### PR TITLE
Add delays for switch position changes

### DIFF
--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -467,6 +467,7 @@
         "section": "ne.micro.foo_to_bar"
       },
       "id": "il.switch_foo",
+      "position_change_delay": 6,
       "left": {
         "endpoint": "END",
         "section": "ne.micro.foo_b"

--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -448,6 +448,14 @@
                 "argument_name": "right_route"
               }
             ]
+          },
+          "MOVING": {
+            "type": "aspect_set",
+            "members": [
+              {
+                "aspect": "RED"
+              }
+            ]
           }
         }
       }

--- a/src/main/java/fr/sncf/osrd/infra/trackgraph/Switch.java
+++ b/src/main/java/fr/sncf/osrd/infra/trackgraph/Switch.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 public class Switch extends TrackNode {
     public final int switchIndex;
+    public final double positionChangeDelay;
     public TrackSection leftTrackSection;
     public TrackSection rightTrackSection;
     public ArrayList<Signal> signalSubscribers;
@@ -14,10 +15,11 @@ public class Switch extends TrackNode {
             TrackGraph graph,
             int index,
             String id,
-            int switchIndex
-    ) {
+            int switchIndex,
+            double positionChangeDelay) {
         super(index, id);
         this.switchIndex = switchIndex;
+        this.positionChangeDelay = positionChangeDelay;
         this.signalSubscribers = new ArrayList<>();
         graph.registerNode(this);
     }

--- a/src/main/java/fr/sncf/osrd/infra/trackgraph/SwitchPosition.java
+++ b/src/main/java/fr/sncf/osrd/infra/trackgraph/SwitchPosition.java
@@ -2,5 +2,6 @@ package fr.sncf.osrd.infra.trackgraph;
 
 public enum SwitchPosition {
     LEFT,
-    RIGHT
+    RIGHT,
+    MOVING
 }

--- a/src/main/java/fr/sncf/osrd/infra/trackgraph/TrackGraph.java
+++ b/src/main/java/fr/sncf/osrd/infra/trackgraph/TrackGraph.java
@@ -33,9 +33,9 @@ public final class TrackGraph extends BiNGraph<TrackSection, TrackNode> {
     public Switch makeSwitchNode(
             int index,
             String id,
-            int switchIndex
-    ) {
-        var node = new Switch(this, index, id, switchIndex);
+            int switchIndex,
+            double positionChangeDelay) {
+        var node = new Switch(this, index, id, switchIndex, positionChangeDelay);
         trackNodeMap.put(node.id, node);
         return node;
     }

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
@@ -113,9 +113,11 @@ public final class RouteState implements RSMatchable {
         movingSwitchesLeft = 0;
         for (var switchPos : route.switchesPosition.entrySet()) {
             var switchState = sim.infraState.getSwitchState(switchPos.getKey().switchIndex);
-            boolean isMoving = switchState.requestPositionChange(sim, switchPos.getValue(), this);
-            if (isMoving)
+            boolean isRightPosition = switchState.getPosition().equals(switchPos.getValue());
+            if (!isRightPosition) {
                 movingSwitchesLeft++;
+                switchState.requestPositionChange(sim, switchPos.getValue(), this);
+            }
         }
     }
 

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
@@ -98,10 +98,6 @@ public final class RouteState implements RSMatchable {
     /** Reserve a route and his tvd sections. Routes that share tvd sections will have the status CONFLICT */
     public void reserve(Simulation sim) {
         assert status == RouteStatus.FREE;
-        var change = new RouteStatusChange(sim, this, RouteStatus.REQUESTED);
-        change.apply(sim, this);
-        sim.publishChange(change);
-        notifySignals(sim);
 
         // Reserve the tvd sections
         for (var tvdSectionPath : route.tvdSectionsPaths) {
@@ -119,6 +115,14 @@ public final class RouteState implements RSMatchable {
                 switchState.requestPositionChange(sim, switchPos.getValue(), this);
             }
         }
+
+        RouteStatus newStatus = movingSwitchesLeft > 0 ? RouteStatus.REQUESTED : RouteStatus.RESERVED;
+
+        var change = new RouteStatusChange(sim, this, newStatus);
+        change.apply(sim, this);
+        sim.publishChange(change);
+        notifySignals(sim);
+
     }
 
     /** Should be called when a switch is done moving and is in the position we requested */

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
@@ -121,10 +121,10 @@ public final class RouteState implements RSMatchable {
         }
     }
 
+    /** Should be called when a switch is done moving and is in the position we requested */
     public void notifySwitchHasMoved(Simulation sim) {
         movingSwitchesLeft--;
-        if (movingSwitchesLeft == 0)
-        {
+        if (movingSwitchesLeft == 0) {
             var change = new RouteStatusChange(sim, this, RouteStatus.RESERVED);
             change.apply(sim, this);
             sim.publishChange(change);

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteStatus.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteStatus.java
@@ -4,5 +4,6 @@ public enum RouteStatus {
    FREE,
    RESERVED,
    OCCUPIED,
-   CONFLICT
+   CONFLICT,
+   REQUESTED
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
@@ -54,14 +54,11 @@ public final class SwitchState implements RSMatchable {
 
 
     /**
-     * Starts a switch change if needed
+     * Starts a switch change that will happen after the switch's delay
      */
-    public boolean requestPositionChange(Simulation sim, SwitchPosition position, RouteState requestingRoute) {
-        // if (this.position == position)
-            // return false;
+    public void requestPositionChange(Simulation sim, SwitchPosition position, RouteState requestingRoute) {
         var delay = switchRef.positionChangeDelay;
         SwitchMoveEvent.plan(sim, sim.getTime() + delay, position, this, requestingRoute);
-        return true;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
@@ -8,6 +8,7 @@ import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
 import fr.sncf.osrd.infra.trackgraph.TrackSection;
 import fr.sncf.osrd.simulation.EntityChange;
 import fr.sncf.osrd.simulation.Simulation;
+import fr.sncf.osrd.infra_state.events.SwitchMoveEvent;
 
 /**
  * The state of the route is the actual entity which interacts with the rest of the infrastructure
@@ -49,6 +50,17 @@ public final class SwitchState implements RSMatchable {
                 signalState.notifyChange(sim);
             }
         }
+    }
+
+
+    /**
+     * Starts a switch change if needed
+     */
+    public boolean requestPositionChange(Simulation sim, SwitchPosition position, RouteState requestingRoute) {
+        // if (this.position == position)
+            // return false;
+        SwitchMoveEvent.plan(sim, sim.getTime() + 6 /* FIXME */, position, this, requestingRoute);
+        return true;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
@@ -59,7 +59,8 @@ public final class SwitchState implements RSMatchable {
     public boolean requestPositionChange(Simulation sim, SwitchPosition position, RouteState requestingRoute) {
         // if (this.position == position)
             // return false;
-        SwitchMoveEvent.plan(sim, sim.getTime() + 6 /* FIXME */, position, this, requestingRoute);
+        var delay = switchRef.positionChangeDelay;
+        SwitchMoveEvent.plan(sim, sim.getTime() + delay, position, this, requestingRoute);
         return true;
     }
 

--- a/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/SwitchState.java
@@ -57,8 +57,11 @@ public final class SwitchState implements RSMatchable {
      * Starts a switch change that will happen after the switch's delay
      */
     public void requestPositionChange(Simulation sim, SwitchPosition position, RouteState requestingRoute) {
-        var delay = switchRef.positionChangeDelay;
-        SwitchMoveEvent.plan(sim, sim.getTime() + delay, position, this, requestingRoute);
+        if (this.position != position) {
+            var delay = switchRef.positionChangeDelay;
+            SwitchMoveEvent.plan(sim, sim.getTime() + delay, position, this, requestingRoute);
+            setPosition(sim, SwitchPosition.MOVING);
+        }
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
@@ -1,0 +1,92 @@
+package fr.sncf.osrd.infra_state.events;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
+import fr.sncf.osrd.infra_state.RouteState;
+import fr.sncf.osrd.infra_state.SwitchState;
+import fr.sncf.osrd.simulation.Simulation;
+import fr.sncf.osrd.simulation.SimulationError;
+import fr.sncf.osrd.simulation.TimelineEvent;
+import fr.sncf.osrd.simulation.TimelineEventId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SwitchMoveEvent extends TimelineEvent {
+    static final Logger logger = LoggerFactory.getLogger(SwitchMoveEvent.class);
+    private final SwitchPosition newPosition;
+    private final SwitchState switchState;
+    private final RouteState routeState;
+
+    private SwitchMoveEvent(TimelineEventId eventId, SwitchPosition newPosition, SwitchState switchState, RouteState routeState) {
+        super(eventId);
+        this.newPosition = newPosition;
+        this.switchState = switchState;
+        this.routeState = routeState;
+    }
+
+    @Override
+    protected void onOccurrence(Simulation sim) throws SimulationError {
+        logger.info(String.format("hello from %s, moving to %s", switchState.switchRef.id, newPosition));
+        routeState.notifySwitchHasMoved(sim);
+    }
+
+    @Override
+    protected void onCancellation(Simulation sim) throws SimulationError {
+        throw new SimulationError("cancelling a switch move isn't supported");
+    }
+
+    @Override
+    @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
+    public boolean deepEquals(TimelineEvent other) {
+        if (other.getClass() != SwitchMoveEvent.class)
+            return false;
+        var o = (SwitchMoveEvent) other;
+        return o.newPosition == newPosition && o.switchState.equals(switchState) && o.routeState.equals(routeState);
+    }
+
+    /** Plan a SwitchMoveEvent creating a change that schedule it */
+    public static SwitchMoveEvent plan(Simulation sim,
+                                       double moveTime,
+                                       SwitchPosition newPosition,
+                                       SwitchState switchState,
+                                       RouteState routeState) {
+        var change = new SwitchMovePlanned(sim, moveTime, newPosition, switchState, routeState);
+        var event = change.apply(sim);
+        sim.publishChange(change);
+        return event;
+    }
+
+    public static class SwitchMovePlanned extends Simulation.TimelineEventCreated {
+
+        private final SwitchPosition newPosition;
+        private final SwitchState switchState;
+        private final RouteState routeState;
+
+        private SwitchMovePlanned(Simulation sim,
+                                  double moveTime,
+                                  SwitchPosition newPosition,
+                                  SwitchState switchState,
+                                  RouteState routeState) {
+            super(sim, moveTime);
+            this.newPosition = newPosition;
+            this.switchState = switchState;
+            this.routeState = routeState;
+        }
+
+        private SwitchMoveEvent apply(Simulation sim) {
+            var event = new SwitchMoveEvent(eventId, newPosition, switchState, routeState);
+            super.scheduleEvent(sim, event);
+            return event;
+        }
+
+        @Override
+        public void replay(Simulation sim) {
+            apply(sim);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("SwitchChangePlanned { newPosition=%s, switchId=%s }", newPosition, switchState.switchRef.id);
+        }
+    }
+}

--- a/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
@@ -17,7 +17,10 @@ public class SwitchMoveEvent extends TimelineEvent {
     private final SwitchState switchState;
     private final RouteState routeState;
 
-    private SwitchMoveEvent(TimelineEventId eventId, SwitchPosition newPosition, SwitchState switchState, RouteState routeState) {
+    private SwitchMoveEvent(TimelineEventId eventId,
+                            SwitchPosition newPosition,
+                            SwitchState switchState,
+                            RouteState routeState) {
         super(eventId);
         this.newPosition = newPosition;
         this.switchState = switchState;
@@ -86,7 +89,8 @@ public class SwitchMoveEvent extends TimelineEvent {
 
         @Override
         public String toString() {
-            return String.format("SwitchChangePlanned { newPosition=%s, switchId=%s }", newPosition, switchState.switchRef.id);
+            return String.format("SwitchChangePlanned { newPosition=%s, switchId=%s }",
+                    newPosition, switchState.switchRef.id);
         }
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/events/SwitchMoveEvent.java
@@ -26,7 +26,7 @@ public class SwitchMoveEvent extends TimelineEvent {
 
     @Override
     protected void onOccurrence(Simulation sim) throws SimulationError {
-        logger.info(String.format("hello from %s, moving to %s", switchState.switchRef.id, newPosition));
+        switchState.setPosition(sim, newPosition);
         routeState.notifySwitchHasMoved(sim);
     }
 

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -68,7 +68,8 @@ public class RailJSONParser {
         var switchIndex = 0;
         for (var rjsSwitch : railJSON.switches) {
             var index = nodeIDs.get(rjsSwitch.base);
-            switchNames.put(rjsSwitch.id, trackGraph.makeSwitchNode(index, rjsSwitch.id, switchIndex++, rjsSwitch.positionChangeDelay));
+            switchNames.put(rjsSwitch.id, trackGraph.makeSwitchNode(index, rjsSwitch.id, switchIndex++,
+                    rjsSwitch.positionChangeDelay));
         }
         final var switches = new ArrayList<>(switchNames.values());
 

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 
 public class RailJSONParser {
     /**
@@ -69,7 +68,7 @@ public class RailJSONParser {
         var switchIndex = 0;
         for (var rjsSwitch : railJSON.switches) {
             var index = nodeIDs.get(rjsSwitch.base);
-            switchNames.put(rjsSwitch.id, trackGraph.makeSwitchNode(index, rjsSwitch.id, switchIndex++));
+            switchNames.put(rjsSwitch.id, trackGraph.makeSwitchNode(index, rjsSwitch.id, switchIndex++, rjsSwitch.positionChangeDelay));
         }
         final var switches = new ArrayList<>(switchNames.values());
 

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
@@ -14,6 +14,8 @@ public class RJSSwitch implements Identified {
     public final RJSTrackSection.EndpointID left;
     /** The track section linked to the base if the switch is in RIGHT position */
     public final RJSTrackSection.EndpointID right;
+    /** The time it takes for the switch to change position in milliseconds */
+    public long position_change_delay;
 
     /**
      * Create a new serialized switch
@@ -21,17 +23,20 @@ public class RJSSwitch implements Identified {
      * @param base the base branch
      * @param left the left branch
      * @param right the right branch
+     * @param position_change_delay the delay when changing position
      */
     public RJSSwitch(
             String id,
             RJSTrackSection.EndpointID base,
             RJSTrackSection.EndpointID left,
-            RJSTrackSection.EndpointID right
+            RJSTrackSection.EndpointID right,
+            long position_change_delay
     ) {
         this.id = id;
         this.base = base;
         this.left = left;
         this.right = right;
+        this.position_change_delay = position_change_delay;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
@@ -15,9 +15,9 @@ public class RJSSwitch implements Identified {
     public final RJSTrackSection.EndpointID left;
     /** The track section linked to the base if the switch is in RIGHT position */
     public final RJSTrackSection.EndpointID right;
-    /** The time it takes for the switch to change position in milliseconds */
+    /** The time it takes for the switch to change position in seconds */
     @Json(name = "position_change_delay")
-    public final long positionChangeDelay;
+    public final double positionChangeDelay;
 
     /**
      * Create a new serialized switch
@@ -25,14 +25,14 @@ public class RJSSwitch implements Identified {
      * @param base the base branch
      * @param left the left branch
      * @param right the right branch
-     * @param positionChangeDelay the delay when changing position
+     * @param positionChangeDelay the delay when changing position in seconds
      */
     public RJSSwitch(
             String id,
             RJSTrackSection.EndpointID base,
             RJSTrackSection.EndpointID left,
             RJSTrackSection.EndpointID right,
-            long positionChangeDelay
+            double positionChangeDelay
     ) {
         this.id = id;
         this.base = base;

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.railjson.schema.infra;
 
+import com.squareup.moshi.Json;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
 import fr.sncf.osrd.railjson.schema.common.Identified;
@@ -15,7 +16,8 @@ public class RJSSwitch implements Identified {
     /** The track section linked to the base if the switch is in RIGHT position */
     public final RJSTrackSection.EndpointID right;
     /** The time it takes for the switch to change position in milliseconds */
-    public long position_change_delay;
+    @Json(name = "position_change_delay")
+    public final long positionChangeDelay;
 
     /**
      * Create a new serialized switch
@@ -23,20 +25,20 @@ public class RJSSwitch implements Identified {
      * @param base the base branch
      * @param left the left branch
      * @param right the right branch
-     * @param position_change_delay the delay when changing position
+     * @param positionChangeDelay the delay when changing position
      */
     public RJSSwitch(
             String id,
             RJSTrackSection.EndpointID base,
             RJSTrackSection.EndpointID left,
             RJSTrackSection.EndpointID right,
-            long position_change_delay
+            long positionChangeDelay
     ) {
         this.id = id;
         this.base = base;
         this.left = left;
         this.right = right;
-        this.position_change_delay = position_change_delay;
+        this.positionChangeDelay = positionChangeDelay;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSSwitch.java
@@ -17,7 +17,7 @@ public class RJSSwitch implements Identified {
     public final RJSTrackSection.EndpointID right;
     /** The time it takes for the switch to change position in seconds */
     @Json(name = "position_change_delay")
-    public final double positionChangeDelay;
+    public double positionChangeDelay;
 
     /**
      * Create a new serialized switch

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
@@ -11,26 +11,22 @@ import java.util.HashMap;
 // https://wiki3.railml.org/index.php?title=IL:switchIL
 public class RMLSwitchIL {
 
-    static void parse(
+    static ArrayList<RJSSwitch> parse(
             Document document,
-            ArrayList<RJSSwitch> switches
+            HashMap<String, RMLSwitchIS> switchesIS
     ) throws InvalidInfraException {
-
-        var switch_per_id = new HashMap<String, RJSSwitch>();
-        for (var s : switches) {
-            switch_per_id.put(s.id, s);
-        }
-
         var xpath = "/railML/interlocking/assetsForIL/switchesIL/switchIL";
+        var res = new ArrayList<RJSSwitch>();
         for (var switchNode : document.selectNodes(xpath)) {
             var switchIL = (Element) switchNode;
             var throwTime_iso8601 = switchIL.attributeValue("typicalThrowTime", "PT0S");
             var throwTime = java.time.Duration.parse(throwTime_iso8601).toMillis();
             var id = switchIL.attributeValue("id");
-            var switchIS = switch_per_id.get(id);
+            var switchIS = switchesIS.get(id);
             if (switchIS == null)
                 throw new InvalidInfraException(String.format("Invalid XML, switchIL %s has no matching switchIS", id));
-            switchIS.position_change_delay = throwTime;
+            res.add(new RJSSwitch(id, switchIS.base, switchIS.left, switchIS.right, throwTime));
         }
+        return res;
     }
 }

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
@@ -1,0 +1,36 @@
+package fr.sncf.osrd.railml;
+
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.railjson.schema.infra.RJSSwitch;
+import org.dom4j.Document;
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+// https://wiki3.railml.org/index.php?title=IL:switchIL
+public class RMLSwitchIL {
+
+    static void parse(
+            Document document,
+            ArrayList<RJSSwitch> switches
+    ) throws InvalidInfraException {
+
+        var switch_per_id = new HashMap<String, RJSSwitch>();
+        for (var s : switches) {
+            switch_per_id.put(s.id, s);
+        }
+
+        var xpath = "/railML/interlocking/assetsForIL/switchesIL/switchIL";
+        for (var switchNode : document.selectNodes(xpath)) {
+            var switchIL = (Element) switchNode;
+            var throwTime_iso8601 = switchIL.attributeValue("typicalThrowTime", "PT0S");
+            var throwTime = java.time.Duration.parse(throwTime_iso8601).toMillis();
+            var id = switchIL.attributeValue("id");
+            var switchIS = switch_per_id.get(id);
+            if (switchIS == null)
+                throw new InvalidInfraException(String.format("Invalid XML, switchIL %s has no matching switchIS", id));
+            switchIS.position_change_delay = throwTime;
+        }
+    }
+}

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
@@ -20,12 +20,13 @@ public class RMLSwitchIL {
         for (var switchNode : document.selectNodes(xpath)) {
             var switchIL = (Element) switchNode;
             var throwTime_iso8601 = switchIL.attributeValue("typicalThrowTime", "PT0S");
-            var throwTime = java.time.Duration.parse(throwTime_iso8601).toMillis();
+            double throwTime = java.time.Duration.parse(throwTime_iso8601).toMillis();
+            double throwTimeSeconds = throwTime / 1000;
             var id = switchIL.attributeValue("id");
             var switchIS = switchesIS.get(id);
             if (switchIS == null)
                 throw new InvalidInfraException(String.format("Invalid XML, switchIL %s has no matching switchIS", id));
-            res.add(new RJSSwitch(id, switchIS.base, switchIS.left, switchIS.right, throwTime));
+            res.add(new RJSSwitch(id, switchIS.base, switchIS.left, switchIS.right, throwTimeSeconds));
         }
         return res;
     }

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
@@ -23,9 +23,11 @@ public class RMLSwitchIL {
             double throwTime = java.time.Duration.parse(throwTimeIso8601).toMillis();
             double throwTimeSeconds = throwTime / 1000.;
             var id = switchIL.attributeValue("id");
-            var switchIS = switchesIS.get(id);
+            var refSwitchIS = switchIL.element("refersTo").attributeValue("ref");
+            var switchIS = switchesIS.get(refSwitchIS);
             if (switchIS == null)
-                throw new InvalidInfraException(String.format("Invalid XML, switchIL %s has no matching switchIS", id));
+                throw new InvalidInfraException(
+                        String.format("Invalid XML, switchIL %s has no matching switchIS %s", id, refSwitchIS));
             res.add(new RJSSwitch(id, switchIS.base, switchIS.left, switchIS.right, throwTimeSeconds));
         }
         return res;

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIL.java
@@ -19,9 +19,9 @@ public class RMLSwitchIL {
         var res = new ArrayList<RJSSwitch>();
         for (var switchNode : document.selectNodes(xpath)) {
             var switchIL = (Element) switchNode;
-            var throwTime_iso8601 = switchIL.attributeValue("typicalThrowTime", "PT0S");
-            double throwTime = java.time.Duration.parse(throwTime_iso8601).toMillis();
-            double throwTimeSeconds = throwTime / 1000;
+            var throwTimeIso8601 = switchIL.attributeValue("typicalThrowTime", "PT0S");
+            double throwTime = java.time.Duration.parse(throwTimeIso8601).toMillis();
+            double throwTimeSeconds = throwTime / 1000.;
             var id = switchIL.attributeValue("id");
             var switchIS = switchesIS.get(id);
             if (switchIS == null)

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
@@ -9,9 +9,23 @@ import org.dom4j.Document;
 import org.dom4j.Element;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class RMLSwitchIS {
+
+    final RJSTrackSection.EndpointID base;
+    final RJSTrackSection.EndpointID left;
+    final RJSTrackSection.EndpointID right;
+
+    private RMLSwitchIS(RJSTrackSection.EndpointID base,
+                        RJSTrackSection.EndpointID left,
+                        RJSTrackSection.EndpointID right) {
+        this.base = base;
+        this.left = left;
+        this.right = right;
+    }
+
     private static RJSTrackSection.EndpointID parseSwitchBranch(
             Map<String, RJSTrackSectionLink> netRelations,
             RJSTrackSection.EndpointID baseBranch,
@@ -37,12 +51,12 @@ public final class RMLSwitchIS {
                 branchName, switchElement.attributeValue("id")));
     }
 
-    static ArrayList<RJSSwitch> parse(
+    static HashMap<String, RMLSwitchIS> parse(
             Map<String, NetElement> netElements,
             Map<String, RJSTrackSectionLink> netRelations,
             Document document
     ) throws InvalidInfraException {
-        var res = new ArrayList<RJSSwitch>();
+        var res = new HashMap<String, RMLSwitchIS>();
         var xpath = "/railML/infrastructure/functionalInfrastructure/switchesIS/switchIS";
         for (var switchISNode :  document.selectNodes(xpath)) {
             var switchIS = (Element) switchISNode;
@@ -50,7 +64,7 @@ public final class RMLSwitchIS {
             var baseBranch = ParsingUtils.parseLocationEndpointID(netElements, switchIS);
             var leftBranch = parseSwitchBranch(netRelations, baseBranch, switchIS, "leftBranch");
             var rightBranch = parseSwitchBranch(netRelations, baseBranch, switchIS, "rightBranch");
-            res.add(new RJSSwitch(id, baseBranch, leftBranch, rightBranch, 0));
+            res.put(id, new RMLSwitchIS(baseBranch, leftBranch, rightBranch));
         }
         return res;
     }

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
@@ -1,14 +1,12 @@
 package fr.sncf.osrd.railml;
 
 import fr.sncf.osrd.infra.InvalidInfraException;
-import fr.sncf.osrd.railjson.schema.infra.RJSSwitch;
 import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection;
 import fr.sncf.osrd.railjson.schema.infra.RJSTrackSectionLink;
 import fr.sncf.osrd.railml.tracksectiongraph.NetElement;
 import org.dom4j.Document;
 import org.dom4j.Element;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLSwitchIS.java
@@ -50,7 +50,7 @@ public final class RMLSwitchIS {
             var baseBranch = ParsingUtils.parseLocationEndpointID(netElements, switchIS);
             var leftBranch = parseSwitchBranch(netRelations, baseBranch, switchIS, "leftBranch");
             var rightBranch = parseSwitchBranch(netRelations, baseBranch, switchIS, "rightBranch");
-            res.add(new RJSSwitch(id, baseBranch, leftBranch, rightBranch));
+            res.add(new RJSSwitch(id, baseBranch, leftBranch, rightBranch, 0));
         }
         return res;
     }

--- a/src/main/java/fr/sncf/osrd/railml/RailMLParser.java
+++ b/src/main/java/fr/sncf/osrd/railml/RailMLParser.java
@@ -71,8 +71,8 @@ public final class RailMLParser {
         final var rjsOperationalPoints = RMLOperationalPoint.parse(netElements, document, rjsTrackSections);
         final var rjsSpeedSections = RMLSpeedSection.parse(netElements, document, rjsTrackSections);
         final var rjsTvdSections = RMLTVDSection.parse(netElements, document, rjsTrackSections);
-        final var rjsSwitches = RMLSwitchIS.parse(netElements, netRelations, document);
-        RMLSwitchIL.parse(document, rjsSwitches);
+        final var rmlSwitchesIS = RMLSwitchIS.parse(netElements, netRelations, document);
+        final var rjsSwitches = RMLSwitchIL.parse(document, rmlSwitchesIS);
         RMLTrainDetectionElement.parse(netElements, document, rjsTrackSections);
         RMLBufferStop.parse(netElements, document, rjsTrackSections);
         final var rmlSignalsIS = RMLSignalIS.parse(netElements, document, rjsTrackSections);

--- a/src/main/java/fr/sncf/osrd/railml/RailMLParser.java
+++ b/src/main/java/fr/sncf/osrd/railml/RailMLParser.java
@@ -72,6 +72,7 @@ public final class RailMLParser {
         final var rjsSpeedSections = RMLSpeedSection.parse(netElements, document, rjsTrackSections);
         final var rjsTvdSections = RMLTVDSection.parse(netElements, document, rjsTrackSections);
         final var rjsSwitches = RMLSwitchIS.parse(netElements, netRelations, document);
+        RMLSwitchIL.parse(document, rjsSwitches);
         RMLTrainDetectionElement.parse(netElements, document, rjsTrackSections);
         RMLBufferStop.parse(netElements, document, rjsTrackSections);
         final var rmlSignalsIS = RMLSignalIS.parse(netElements, document, rjsTrackSections);

--- a/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
+++ b/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
@@ -7,7 +7,6 @@ import fr.sncf.osrd.config.Config;
 import fr.sncf.osrd.config.JsonConfig;
 import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.infra.InvalidInfraException;
-import fr.sncf.osrd.infra.trackgraph.Switch;
 import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
@@ -21,12 +20,15 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 public class SwitchEventsTest {
 
+    /** Generates the defaults infra from tiny_infra/infra.json, to be edited for each test */
     public Infra getBaseInfra() {
         try {
             ClassLoader classLoader = getClass().getClassLoader();
@@ -39,6 +41,7 @@ public class SwitchEventsTest {
         }
     }
 
+    /** Go through all the events in the simulation */
     public ArrayList<TimelineEvent> run(Simulation sim) {
         ClassLoader classLoader = getClass().getClassLoader();
         var configPath = classLoader.getResource("tiny_infra/config_railjson.json");
@@ -57,15 +60,35 @@ public class SwitchEventsTest {
         }
     }
 
+    /** Generates an event that runs an assertion at a certain point in the simulation */
     public void makeAssertEvent(Simulation sim, double time, Function<Simulation, Boolean> predicate) {
         BiConsumer<Simulation, SimulationTest.TestEvent> consumer = (s, test) -> assertTrue(predicate.apply(s));
         SimulationTest.TestEvent.plan(sim, time, null, consumer);
+    }
+
+    /** Sets a field in an object, bypassing `final`.
+     * This is used to make small changes in the infra for each test
+     * */
+    public void setField(Object o, String fieldName, Object value) {
+
+        try {
+            Field field = o.getClass().getDeclaredField(fieldName);
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                field.setAccessible(true);
+                return null;
+            });
+            field.set(o, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(e);
+        }
     }
 
     @Test
     public void testSwitchNoMove() {
         var infra = getBaseInfra();
         var sim = Simulation.createFromInfra(infra, 0, null);
+        RouteState routeState = sim.infraState.getRouteState(3);
+        makeAssertEvent(sim, 21, (s) -> routeState.status == RouteStatus.RESERVED);
         var events = run(sim);
 
         // The switch starts in the correct position, no switch move event should happen
@@ -75,7 +98,7 @@ public class SwitchEventsTest {
     }
 
     @Test
-    public void testSimpleSwitch() throws NoSuchFieldException, IllegalAccessException {
+    public void testSimpleSwitch() {
         var infra = getBaseInfra();
 
         // Set all the switch expected positions to RIGHT, to trigger a change
@@ -85,10 +108,7 @@ public class SwitchEventsTest {
             positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
         });
 
-        Switch mainSwitch = infra.switches.get(0);
-        Field delayField = Switch.class.getDeclaredField("positionChangeDelay");
-        delayField.setAccessible(true);
-        delayField.set(mainSwitch, 6);
+        setField(infra.switches.get(0), "positionChangeDelay", 6);
 
         var sim = Simulation.createFromInfra(infra, 0, null);
 
@@ -104,7 +124,7 @@ public class SwitchEventsTest {
     }
 
     @Test
-    public void testSwitchLongerDelay() throws NoSuchFieldException, IllegalAccessException {
+    public void testSwitchLongerDelay() {
         var infra = getBaseInfra();
 
         // Set all the switch expected positions to RIGHT, to trigger a change
@@ -114,10 +134,7 @@ public class SwitchEventsTest {
             positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
         });
 
-        Switch mainSwitch = infra.switches.get(0);
-        Field delayField = Switch.class.getDeclaredField("positionChangeDelay");
-        delayField.setAccessible(true);
-        delayField.set(mainSwitch, 10);
+        setField(infra.switches.get(0), "positionChangeDelay", 10);
 
         var sim = Simulation.createFromInfra(infra, 0, null);
 

--- a/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
+++ b/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
@@ -1,0 +1,134 @@
+package fr.sncf.osrd.infra_state;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import fr.sncf.osrd.SimulationTest;
+import fr.sncf.osrd.config.Config;
+import fr.sncf.osrd.config.JsonConfig;
+import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.infra.trackgraph.Switch;
+import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
+import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
+import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
+import fr.sncf.osrd.simulation.Simulation;
+import fr.sncf.osrd.simulation.SimulationError;
+import fr.sncf.osrd.simulation.TimelineEvent;
+import fr.sncf.osrd.infra_state.events.SwitchMoveEvent;
+import fr.sncf.osrd.train.events.TrainCreatedEvent;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class SwitchEventsTest {
+
+    public Infra getBaseInfra() {
+        try {
+            ClassLoader classLoader = getClass().getClassLoader();
+            var infraPath = classLoader.getResource("tiny_infra/infra.json");
+            assert infraPath != null;
+            return Infra.parseFromFile(JsonConfig.InfraType.UNKNOWN, infraPath.getFile());
+        } catch (IOException | InvalidInfraException e) {
+            fail(e);
+            return null;
+        }
+    }
+
+    public ArrayList<TimelineEvent> run(Simulation sim) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        var configPath = classLoader.getResource("tiny_infra/config_railjson.json");
+        assert configPath != null;
+        var events = new ArrayList<TimelineEvent>();
+        try {
+            Config config = Config.readFromFile(Path.of(configPath.getFile()));
+            for (var trainSchedule : config.trainSchedules)
+                TrainCreatedEvent.plan(sim, trainSchedule);
+            while (!sim.isSimulationOver())
+                events.add(sim.step());
+            return events;
+        } catch (IOException | InvalidInfraException | InvalidRollingStock | InvalidSchedule | SimulationError e) {
+            fail(e);
+            return null;
+        }
+    }
+
+    public void makeAssertEvent(Simulation sim, double time, Function<Simulation, Boolean> predicate) {
+        BiConsumer<Simulation, SimulationTest.TestEvent> consumer = (s, test) -> assertTrue(predicate.apply(s));
+        SimulationTest.TestEvent.plan(sim, time, null, consumer);
+    }
+
+    @Test
+    public void testSwitchNoMove() {
+        var infra = getBaseInfra();
+        var sim = Simulation.createFromInfra(infra, 0, null);
+        var events = run(sim);
+
+        // The switch starts in the correct position, no switch move event should happen
+        for (var e : events) {
+            assertNotEquals(SwitchMoveEvent.class, e.getClass());
+        }
+    }
+
+    @Test
+    public void testSimpleSwitch() throws NoSuchFieldException, IllegalAccessException {
+        var infra = getBaseInfra();
+
+        // Set all the switch expected positions to RIGHT, to trigger a change
+        var routes = infra.routeGraph.routeMap;
+        routes.forEach((key, route) -> {
+            var positions = route.switchesPosition;
+            positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
+        });
+
+        Switch mainSwitch = infra.switches.get(0);
+        Field delayField = Switch.class.getDeclaredField("positionChangeDelay");
+        delayField.setAccessible(true);
+        delayField.set(mainSwitch, 6);
+
+        var sim = Simulation.createFromInfra(infra, 0, null);
+
+        SwitchState switchState = sim.infraState.getSwitchState(0);
+        RouteState routeState = sim.infraState.getRouteState(3);
+        makeAssertEvent(sim, 19, (s) -> switchState.getPosition() == SwitchPosition.LEFT);
+        makeAssertEvent(sim, 21, (s) -> switchState.getPosition() == SwitchPosition.MOVING);
+        makeAssertEvent(sim, 21, (s) -> routeState.status == RouteStatus.REQUESTED);
+        makeAssertEvent(sim, 27, (s) -> switchState.getPosition() == SwitchPosition.RIGHT);
+        makeAssertEvent(sim, 27, (s) -> routeState.status == RouteStatus.RESERVED);
+
+        run(sim);
+    }
+
+    @Test
+    public void testSwitchLongerDelay() throws NoSuchFieldException, IllegalAccessException {
+        var infra = getBaseInfra();
+
+        // Set all the switch expected positions to RIGHT, to trigger a change
+        var routes = infra.routeGraph.routeMap;
+        routes.forEach((key, route) -> {
+            var positions = route.switchesPosition;
+            positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
+        });
+
+        Switch mainSwitch = infra.switches.get(0);
+        Field delayField = Switch.class.getDeclaredField("positionChangeDelay");
+        delayField.setAccessible(true);
+        delayField.set(mainSwitch, 10);
+
+        var sim = Simulation.createFromInfra(infra, 0, null);
+
+        SwitchState switchState = sim.infraState.getSwitchState(0);
+        RouteState routeState = sim.infraState.getRouteState(3);
+        makeAssertEvent(sim, 19, (s) -> switchState.getPosition() == SwitchPosition.LEFT);
+        makeAssertEvent(sim, 25, (s) -> switchState.getPosition() == SwitchPosition.MOVING);
+        makeAssertEvent(sim, 25, (s) -> routeState.status == RouteStatus.REQUESTED);
+        makeAssertEvent(sim, 31, (s) -> switchState.getPosition() == SwitchPosition.RIGHT);
+        makeAssertEvent(sim, 31, (s) -> routeState.status == RouteStatus.RESERVED);
+
+        run(sim);
+    }
+}

--- a/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
+++ b/src/test/java/fr/sncf/osrd/infra_state/SwitchEventsTest.java
@@ -2,26 +2,26 @@ package fr.sncf.osrd.infra_state;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.squareup.moshi.JsonReader;
 import fr.sncf.osrd.SimulationTest;
 import fr.sncf.osrd.config.Config;
-import fr.sncf.osrd.config.JsonConfig;
-import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
+import fr.sncf.osrd.railjson.parser.RailJSONParser;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
+import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
+import fr.sncf.osrd.railjson.schema.infra.RJSSwitch;
 import fr.sncf.osrd.simulation.Simulation;
 import fr.sncf.osrd.simulation.SimulationError;
 import fr.sncf.osrd.simulation.TimelineEvent;
 import fr.sncf.osrd.infra_state.events.SwitchMoveEvent;
 import fr.sncf.osrd.train.events.TrainCreatedEvent;
+import okio.Okio;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -29,13 +29,16 @@ import java.util.function.Function;
 public class SwitchEventsTest {
 
     /** Generates the defaults infra from tiny_infra/infra.json, to be edited for each test */
-    public Infra getBaseInfra() {
+    public RJSInfra getBaseInfra() {
         try {
             ClassLoader classLoader = getClass().getClassLoader();
             var infraPath = classLoader.getResource("tiny_infra/infra.json");
             assert infraPath != null;
-            return Infra.parseFromFile(JsonConfig.InfraType.UNKNOWN, infraPath.getFile());
-        } catch (IOException | InvalidInfraException e) {
+            var fileSource = Okio.source(Path.of(infraPath.getFile()));
+            var bufferedSource = Okio.buffer(fileSource);
+            var jsonReader = JsonReader.of(bufferedSource);
+            return RJSInfra.adapter.fromJson(jsonReader);
+        } catch (IOException e) {
             fail(e);
             return null;
         }
@@ -66,27 +69,10 @@ public class SwitchEventsTest {
         SimulationTest.TestEvent.plan(sim, time, null, consumer);
     }
 
-    /** Sets a field in an object, bypassing `final`.
-     * This is used to make small changes in the infra for each test
-     * */
-    public void setField(Object o, String fieldName, Object value) {
-
-        try {
-            Field field = o.getClass().getDeclaredField(fieldName);
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                field.setAccessible(true);
-                return null;
-            });
-            field.set(o, value);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            fail(e);
-        }
-    }
-
     @Test
-    public void testSwitchNoMove() {
+    public void testSwitchNoMove() throws InvalidInfraException {
         var infra = getBaseInfra();
-        var sim = Simulation.createFromInfra(infra, 0, null);
+        var sim = Simulation.createFromInfra(RailJSONParser.parse(infra), 0, null);
         RouteState routeState = sim.infraState.getRouteState(3);
         makeAssertEvent(sim, 21, (s) -> routeState.status == RouteStatus.RESERVED);
         var events = run(sim);
@@ -98,19 +84,18 @@ public class SwitchEventsTest {
     }
 
     @Test
-    public void testSimpleSwitch() {
+    public void testSimpleSwitch() throws InvalidInfraException {
         var infra = getBaseInfra();
 
         // Set all the switch expected positions to RIGHT, to trigger a change
-        var routes = infra.routeGraph.routeMap;
-        routes.forEach((key, route) -> {
+        infra.routes.forEach((route) -> {
             var positions = route.switchesPosition;
-            positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
+            positions.replaceAll((k, v) -> RJSSwitch.Position.RIGHT);
         });
 
-        setField(infra.switches.get(0), "positionChangeDelay", 6);
+        infra.switches.iterator().next().positionChangeDelay = 6;
 
-        var sim = Simulation.createFromInfra(infra, 0, null);
+        var sim = Simulation.createFromInfra(RailJSONParser.parse(infra), 0, null);
 
         SwitchState switchState = sim.infraState.getSwitchState(0);
         RouteState routeState = sim.infraState.getRouteState(3);
@@ -124,19 +109,18 @@ public class SwitchEventsTest {
     }
 
     @Test
-    public void testSwitchLongerDelay() {
+    public void testSwitchLongerDelay() throws InvalidInfraException {
         var infra = getBaseInfra();
 
         // Set all the switch expected positions to RIGHT, to trigger a change
-        var routes = infra.routeGraph.routeMap;
-        routes.forEach((key, route) -> {
+        infra.routes.forEach((route) -> {
             var positions = route.switchesPosition;
-            positions.replaceAll((k, v) -> SwitchPosition.RIGHT);
+            positions.replaceAll((k, v) -> RJSSwitch.Position.RIGHT);
         });
 
-        setField(infra.switches.get(0), "positionChangeDelay", 10);
+        infra.switches.iterator().next().positionChangeDelay = 10;
 
-        var sim = Simulation.createFromInfra(infra, 0, null);
+        var sim = Simulation.createFromInfra(RailJSONParser.parse(infra), 0, null);
 
         SwitchState switchState = sim.infraState.getSwitchState(0);
         RouteState routeState = sim.infraState.getRouteState(3);

--- a/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
+++ b/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
@@ -1,0 +1,26 @@
+package fr.sncf.osrd.railml;
+
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RMLSwitchILTest {
+
+    @Test
+    public void testRealData() {
+        String inputPath = "examples/tiny_infra/infra.xml";
+        RJSInfra infra = null;
+        try {
+            infra = RailMLParser.parse(inputPath);
+        } catch (InvalidInfraException e) {
+            fail("XML reading should not have failed");
+        }
+        var switches = infra.switches;
+        assertEquals(1, switches.size());
+        var s = switches.iterator().next();
+        assertEquals(6000, s.positionChangeDelay);
+        assertEquals("il.switch_foo", s.id);
+    }
+}

--- a/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
+++ b/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
@@ -24,7 +24,7 @@ public class RMLSwitchILTest {
         var switches = infra.switches;
         assertEquals(1, switches.size());
         var s = switches.iterator().next();
-        assertEquals(6000, s.positionChangeDelay);
+        assertEquals(6, s.positionChangeDelay);
         assertEquals("il.switch_foo", s.id);
     }
 }

--- a/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
+++ b/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
@@ -1,10 +1,11 @@
 package fr.sncf.osrd.railml;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class RMLSwitchILTest {
 
@@ -14,12 +15,15 @@ public class RMLSwitchILTest {
         try {
             ClassLoader classLoader = getClass().getClassLoader();
             var resource = classLoader.getResource("tiny_infra/infra.xml");
-            if (resource == null)
+            if (resource == null) {
                 fail("Can't load test resource");
+                return;
+            }
             var infraPath = resource.toString();
             infra = RailMLParser.parse(infraPath);
         } catch (InvalidInfraException e) {
             fail("XML reading should not have failed", e);
+            return;
         }
         var switches = infra.switches;
         assertEquals(1, switches.size());

--- a/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
+++ b/src/test/java/fr/sncf/osrd/railml/RMLSwitchILTest.java
@@ -10,12 +10,16 @@ public class RMLSwitchILTest {
 
     @Test
     public void testRealData() {
-        String inputPath = "examples/tiny_infra/infra.xml";
         RJSInfra infra = null;
         try {
-            infra = RailMLParser.parse(inputPath);
+            ClassLoader classLoader = getClass().getClassLoader();
+            var resource = classLoader.getResource("tiny_infra/infra.xml");
+            if (resource == null)
+                fail("Can't load test resource");
+            var infraPath = resource.toString();
+            infra = RailMLParser.parse(infraPath);
         } catch (InvalidInfraException e) {
-            fail("XML reading should not have failed");
+            fail("XML reading should not have failed", e);
         }
         var switches = infra.switches;
         assertEquals(1, switches.size());


### PR DESCRIPTION
Fixes #23 

TODO:

- [x] add the position_change_delay field to RailJSON
- [x] add the REQUESTED RouteStatus, which applies while the switches are moving
- [x] add a MOVING member to the SwitchState enum
- [x] create a new event corresponding to the successful position change of a switch
- [x] when the event completes, tell the route so it can lock itself if all switches are ready (doing nothing otherwise)
- [x] test everything