### PR TITLE
Add primitives and Optional to railscript

### DIFF
--- a/examples/tiny_infra/config_railjson_optional.json
+++ b/examples/tiny_infra/config_railjson_optional.json
@@ -1,0 +1,9 @@
+{
+  "simulation_time_step": 1,
+  "infra_path": "infra_optional.json",
+  "simulation_path": "simulation.json",
+  "show_viewer": true,
+  "realtime_viewer": true,
+  "change_replay_check": true,
+  "simulation_step_pause": 0.2
+}

--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -53,6 +53,9 @@
   "routes": [
     {
       "id": "rt.buffer_stop_a-C1",
+      "entry_signal": "",
+      "signals": [
+      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_a"
@@ -69,6 +72,9 @@
     },
     {
       "id": "rt.buffer_stop_b-C3",
+      "entry_signal": "",
+      "signals": [
+      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_b"
@@ -85,6 +91,13 @@
     },
     {
       "id": "rt.C1-S7",
+      "entry_signal": "il.sig.C1",
+      "signals": [
+        "il.sig.C6",
+        "il.sig.W4",
+        "il.sig.W5",
+        "il.sig.S7"
+      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -108,6 +121,9 @@
     },
     {
       "id": "rt.C3-S7",
+      "entry_signal": "il.sig.C3",
+      "signals": [
+      ],
       "switches_position": {
         "il.switch_foo": "LEFT"
       },
@@ -131,6 +147,9 @@
     },
     {
       "id": "rt.S7-buffer_stop_c",
+      "entry_signal": "il.sig.S7",
+      "signals": [
+      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -147,6 +166,9 @@
     },
     {
       "id": "rt.buffer_stop_c-C2",
+      "entry_signal": "",
+      "signals": [
+      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -163,6 +185,9 @@
     },
     {
       "id": "rt.C2-C6",
+      "entry_signal": "il.sig.C2",
+      "signals": [
+      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.track"
@@ -179,6 +204,9 @@
     },
     {
       "id": "rt.C6-buffer_stop_a",
+      "entry_signal": "il.sig.C6",
+      "signals": [
+      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -202,6 +230,9 @@
     },
     {
       "id": "rt.C6-buffer_stop_b",
+      "entry_signal": "il.sig.C6",
+      "signals": [
+      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },

--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -54,8 +54,6 @@
     {
       "id": "rt.buffer_stop_a-C1",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_a"
@@ -73,8 +71,6 @@
     {
       "id": "rt.buffer_stop_b-C3",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_b"
@@ -92,12 +88,6 @@
     {
       "id": "rt.C1-S7",
       "entry_signal": "il.sig.C1",
-      "signals": [
-        "il.sig.C6",
-        "il.sig.W4",
-        "il.sig.W5",
-        "il.sig.S7"
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -122,8 +112,6 @@
     {
       "id": "rt.C3-S7",
       "entry_signal": "il.sig.C3",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "LEFT"
       },
@@ -148,8 +136,6 @@
     {
       "id": "rt.S7-buffer_stop_c",
       "entry_signal": "il.sig.S7",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -167,8 +153,6 @@
     {
       "id": "rt.buffer_stop_c-C2",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -186,8 +170,6 @@
     {
       "id": "rt.C2-C6",
       "entry_signal": "il.sig.C2",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.track"
@@ -205,8 +187,6 @@
     {
       "id": "rt.C6-buffer_stop_a",
       "entry_signal": "il.sig.C6",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -231,8 +211,6 @@
     {
       "id": "rt.C6-buffer_stop_b",
       "entry_signal": "il.sig.C6",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -607,7 +607,7 @@
             "arguments": [
               {
                 "type": "signal",
-                "signal": "il.sig.W5"
+                "signal": "il.sig.C3"
               }
             ]
           },
@@ -746,7 +746,7 @@
             "arguments": [
               {
                 "type": "signal",
-                "signal": "il.sig.W5"
+                "signal": "il.sig.C1"
               }
             ]
           },
@@ -790,7 +790,7 @@
             "arguments": [
               {
                 "type": "signal",
-                "signal": "il.sig.W4"
+                "signal": "il.sig.C2"
               }
             ]
           },

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -54,8 +54,6 @@
     {
       "id": "rt.buffer_stop_a-C1",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_a"
@@ -73,8 +71,6 @@
     {
       "id": "rt.buffer_stop_b-C3",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.foo_b"
@@ -92,12 +88,6 @@
     {
       "id": "rt.C1-S7",
       "entry_signal": "il.sig.C1",
-      "signals": [
-        "il.sig.C6",
-        "il.sig.W4",
-        "il.sig.W5",
-        "il.sig.S7"
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -122,8 +112,6 @@
     {
       "id": "rt.C3-S7",
       "entry_signal": "il.sig.C3",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "LEFT"
       },
@@ -148,8 +136,6 @@
     {
       "id": "rt.S7-buffer_stop_c",
       "entry_signal": "il.sig.S7",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -167,8 +153,6 @@
     {
       "id": "rt.buffer_stop_c-C2",
       "entry_signal": "",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.bar_a"
@@ -186,8 +170,6 @@
     {
       "id": "rt.C2-C6",
       "entry_signal": "il.sig.C2",
-      "signals": [
-      ],
       "switches_position": {},
       "tvd_sections": [
         "tvd.track"
@@ -205,8 +187,6 @@
     {
       "id": "rt.C6-buffer_stop_a",
       "entry_signal": "il.sig.C6",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },
@@ -231,8 +211,6 @@
     {
       "id": "rt.C6-buffer_stop_b",
       "entry_signal": "il.sig.C6",
-      "signals": [
-      ],
       "switches_position": {
         "il.switch_foo": "RIGHT"
       },

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -414,14 +414,11 @@
         "type": "optional_match",
         "name": "reserved_route",
         "expr": {
-          "type": "call",
-          "function": "reserved_route",
-          "arguments": [
-            {
-              "type": "argument_ref",
-              "argument_name": "master_signal"
-            }
-          ]
+          "type": "reserved_route",
+          "signal": {
+            "type": "argument_ref",
+            "argument_name": "master_signal"
+          }
         },
         "case_none": {
           "type": "aspect_set",
@@ -435,18 +432,15 @@
           "type": "optional_match",
           "name": "next_signal",
           "expr": {
-            "type": "call",
-            "function": "next_signal",
-            "arguments": [
-              {
-                "type": "optional_match_ref",
-                "match_name": "reserved_route"
-              },
-              {
-                "type": "argument_ref",
-                "argument_name": "master_signal"
-              }
-            ]
+            "type": "next_signal",
+            "route": {
+              "type": "optional_match_ref",
+              "match_name": "reserved_route"
+            },
+            "signal": {
+              "type": "argument_ref",
+              "argument_name": "master_signal"
+            }
           },
           "case_none": {
             "type": "aspect_set",

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -630,10 +630,6 @@
               {
                 "type": "signal",
                 "signal": "il.sig.W5"
-              },
-              {
-                "type": "route",
-                "route": "rt.C3-S7"
               }
             ]
           },
@@ -773,10 +769,6 @@
               {
                 "type": "signal",
                 "signal": "il.sig.W5"
-              },
-              {
-                "type": "route",
-                "route": "rt.C1-S7"
               }
             ]
           },
@@ -821,10 +813,6 @@
               {
                 "type": "signal",
                 "signal": "il.sig.W4"
-              },
-              {
-                "type": "route",
-                "route": "rt.C2-C6"
               }
             ]
           },

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -1,0 +1,898 @@
+{
+  "aspects": [
+    {
+      "id": "GREEN",
+      "color": "#2a850c",
+      "constraints": []
+    },
+    {
+      "id": "YELLOW",
+      "color": "#f08a05",
+      "constraints": [
+        {
+          "type": "speed_limit",
+          "speed": 8.33333333333333,
+          "applies_at": {
+            "element": "NEXT_SIGNAL",
+            "offset": -100
+          },
+          "until": {
+            "element": "NEXT_SIGNAL",
+            "offset": 0
+          }
+        }
+      ]
+    },
+    {
+      "id": "RED",
+      "color": "#db0c04",
+      "constraints": [
+        {
+          "type": "speed_limit",
+          "speed": 0,
+          "applies_at": {
+            "element": "CURRENT_SIGNAL",
+            "offset": -5
+          },
+          "until": {
+            "element": "END",
+            "offset": 0
+          }
+        }
+      ]
+    }
+  ],
+  "operational_points": [
+    {
+      "id": "op.station_foo"
+    },
+    {
+      "id": "op.station_bar"
+    }
+  ],
+  "routes": [
+    {
+      "id": "rt.buffer_stop_a-C1",
+      "entry_signal": "",
+      "signals": [
+      ],
+      "switches_position": {},
+      "tvd_sections": [
+        "tvd.foo_a"
+      ],
+      "release_groups": [
+        [
+          "tvd.foo_a"
+        ]
+      ],
+      "waypoints": [
+        "buffer_stop_a",
+        "tde.foo_a-switch_foo"
+      ]
+    },
+    {
+      "id": "rt.buffer_stop_b-C3",
+      "entry_signal": "",
+      "signals": [
+      ],
+      "switches_position": {},
+      "tvd_sections": [
+        "tvd.foo_b"
+      ],
+      "release_groups": [
+        [
+          "tvd.foo_b"
+        ]
+      ],
+      "waypoints": [
+        "buffer_stop_b",
+        "tde.foo_b-switch_foo"
+      ]
+    },
+    {
+      "id": "rt.C1-S7",
+      "entry_signal": "il.sig.C1",
+      "signals": [
+        "il.sig.C6",
+        "il.sig.W4",
+        "il.sig.W5",
+        "il.sig.S7"
+      ],
+      "switches_position": {
+        "il.switch_foo": "RIGHT"
+      },
+      "tvd_sections": [
+        "tvd.switch_foo",
+        "tvd.track"
+      ],
+      "release_groups": [
+        [
+          "tvd.track"
+        ],
+        [
+          "tvd.switch_foo"
+        ]
+      ],
+      "waypoints": [
+        "tde.foo_a-switch_foo",
+        "tde.switch_foo-track",
+        "tde.track-bar"
+      ]
+    },
+    {
+      "id": "rt.C3-S7",
+      "entry_signal": "il.sig.C3",
+      "signals": [
+      ],
+      "switches_position": {
+        "il.switch_foo": "LEFT"
+      },
+      "tvd_sections": [
+        "tvd.switch_foo",
+        "tvd.track"
+      ],
+      "release_groups": [
+        [
+          "tvd.track"
+        ],
+        [
+          "tvd.switch_foo"
+        ]
+      ],
+      "waypoints": [
+        "tde.foo_b-switch_foo",
+        "tde.switch_foo-track",
+        "tde.track-bar"
+      ]
+    },
+    {
+      "id": "rt.S7-buffer_stop_c",
+      "entry_signal": "il.sig.S7",
+      "signals": [
+      ],
+      "switches_position": {},
+      "tvd_sections": [
+        "tvd.bar_a"
+      ],
+      "release_groups": [
+        [
+          "tvd.bar_a"
+        ]
+      ],
+      "waypoints": [
+        "tde.track-bar",
+        "buffer_stop_c"
+      ]
+    },
+    {
+      "id": "rt.buffer_stop_c-C2",
+      "entry_signal": "",
+      "signals": [
+      ],
+      "switches_position": {},
+      "tvd_sections": [
+        "tvd.bar_a"
+      ],
+      "release_groups": [
+        [
+          "tvd.bar_a"
+        ]
+      ],
+      "waypoints": [
+        "buffer_stop_c",
+        "tde.track-bar"
+      ]
+    },
+    {
+      "id": "rt.C2-C6",
+      "entry_signal": "il.sig.C2",
+      "signals": [
+      ],
+      "switches_position": {},
+      "tvd_sections": [
+        "tvd.track"
+      ],
+      "release_groups": [
+        [
+          "tvd.track"
+        ]
+      ],
+      "waypoints": [
+        "tde.track-bar",
+        "tde.switch_foo-track"
+      ]
+    },
+    {
+      "id": "rt.C6-buffer_stop_a",
+      "entry_signal": "il.sig.C6",
+      "signals": [
+      ],
+      "switches_position": {
+        "il.switch_foo": "RIGHT"
+      },
+      "tvd_sections": [
+        "tvd.switch_foo",
+        "tvd.foo_a"
+      ],
+      "release_groups": [
+        [
+          "tvd.switch_foo"
+        ],
+        [
+          "tvd.foo_a"
+        ]
+      ],
+      "waypoints": [
+        "tde.switch_foo-track",
+        "tde.foo_a-switch_foo",
+        "buffer_stop_a"
+      ]
+    },
+    {
+      "id": "rt.C6-buffer_stop_b",
+      "entry_signal": "il.sig.C6",
+      "signals": [
+      ],
+      "switches_position": {
+        "il.switch_foo": "RIGHT"
+      },
+      "tvd_sections": [
+        "tvd.switch_foo",
+        "tvd.foo_b"
+      ],
+      "release_groups": [
+        [
+          "tvd.switch_foo"
+        ],
+        [
+          "tvd.foo_b"
+        ]
+      ],
+      "waypoints": [
+        "tde.switch_foo-track",
+        "tde.foo_b-switch_foo",
+        "buffer_stop_b"
+      ]
+    }
+  ],
+  "script_functions": [
+    {
+      "name": "sncf_filter",
+      "arguments": [
+        {
+          "type": "ASPECT_SET",
+          "name": "aspects"
+        }
+      ],
+      "return_type": "ASPECT_SET",
+      "body": {
+        "type": "condition",
+        "if": {
+          "type": "aspect_set_contains",
+          "aspect_set": {
+            "type": "argument_ref",
+            "argument_name": "aspects"
+          },
+          "aspect": "RED"
+        },
+        "then": {
+          "type": "aspect_set",
+          "members": [
+            {
+              "aspect": "RED"
+            }
+          ]
+        },
+        "else": {
+          "type": "condition",
+          "if": {
+            "type": "aspect_set_contains",
+            "aspect_set": {
+              "type": "argument_ref",
+              "argument_name": "aspects"
+            },
+            "aspect": "YELLOW"
+          },
+          "then": {
+            "type": "aspect_set",
+            "members": [
+              {
+                "aspect": "YELLOW"
+              }
+            ]
+          },
+          "else": {
+            "type": "argument_ref",
+            "argument_name": "aspects"
+          }
+        }
+      }
+    },
+    {
+      "name": "warn_signal",
+      "arguments": [
+        {
+          "type": "SIGNAL",
+          "name": "master_signal"
+        }
+      ],
+      "return_type": "ASPECT_SET",
+      "body": {
+        "type": "call",
+        "function": "sncf_filter",
+        "arguments": [
+          {
+            "type": "aspect_set",
+            "members": [
+              {
+                "aspect": "YELLOW",
+                "condition": {
+                  "type": "signal_has_aspect",
+                  "signal": {
+                    "type": "argument_ref",
+                    "argument_name": "master_signal"
+                  },
+                  "aspect": "RED"
+                }
+              },
+              {
+                "aspect": "GREEN"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "check_route",
+      "arguments": [
+        {
+          "type": "ROUTE",
+          "name": "route"
+        }
+      ],
+      "return_type": "ASPECT_SET",
+      "body": {
+        "type": "condition",
+        "if": {
+          "type": "or",
+          "exprs": [
+            {
+              "type": "route_has_state",
+              "route": {
+                "type": "argument_ref",
+                "argument_name": "route"
+              },
+              "state": "OCCUPIED"
+            },
+            {
+              "type": "route_has_state",
+              "route": {
+                "type": "argument_ref",
+                "argument_name": "route"
+              },
+              "state": "REQUESTED"
+            },
+            {
+              "type": "route_has_state",
+              "route": {
+                "type": "argument_ref",
+                "argument_name": "route"
+              },
+              "state": "CONFLICT"
+            }
+          ]
+        },
+        "then": {
+          "type": "aspect_set",
+          "members": [
+            {
+              "aspect": "RED"
+            }
+          ]
+        },
+        "else": {
+          "type": "aspect_set",
+          "members": [
+            {
+              "aspect": "YELLOW"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "bal3_line_signal",
+      "arguments": [
+        {
+          "type": "SIGNAL",
+          "name": "master_signal"
+        }
+      ],
+      "return_type": "ASPECT_SET",
+      "body": {
+        "type": "optional_match",
+        "name": "reserved_route",
+        "expr": {
+          "type": "call",
+          "function": "reserved_route",
+          "arguments": [
+            {
+              "type": "argument_ref",
+              "argument_name": "master_signal"
+            }
+          ]
+        },
+        "case_none": {
+          "type": "aspect_set",
+          "members": [
+            {
+              "aspect": "RED"
+            }
+          ]
+        },
+        "case_some": {
+          "type": "optional_match",
+          "name": "next_signal",
+          "expr": {
+            "type": "call",
+            "function": "next_signal",
+            "arguments": [
+              {
+                "type": "optional_match_ref",
+                "match_name": "reserved_route"
+              },
+              {
+                "type": "argument_ref",
+                "argument_name": "master_signal"
+              }
+            ]
+          },
+          "case_none": {
+            "type": "aspect_set",
+            "members": [
+              {
+                "aspect": "YELLOW"
+              }
+            ]
+          },
+          "case_some": {
+            "type": "condition",
+            "if": {
+              "type": "signal_has_aspect",
+              "signal": {
+                "type": "optional_match_ref",
+                "match_name": "next_signal"
+              },
+              "aspect": "RED"
+            },
+            "then": {
+              "type": "aspect_set",
+              "members": [
+                {
+                  "aspect": "YELLOW"
+                }
+              ]
+            },
+            "else": {
+              "type": "aspect_set",
+              "members": [
+                {
+                  "aspect": "GREEN"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "switch_signal",
+      "arguments": [
+        {
+          "type": "SWITCH",
+          "name": "switch"
+        },
+        {
+          "type": "ROUTE",
+          "name": "left_route"
+        },
+        {
+          "type": "ROUTE",
+          "name": "right_route"
+        }
+      ],
+      "return_type": "ASPECT_SET",
+      "body": {
+        "type": "match",
+        "expr": {
+          "type": "argument_ref",
+          "argument_name": "switch"
+        },
+        "branches": {
+          "LEFT": {
+            "type": "call",
+            "function": "check_route",
+            "arguments": [
+              {
+                "type": "argument_ref",
+                "argument_name": "left_route"
+              }
+            ]
+          },
+          "RIGHT": {
+            "type": "call",
+            "function": "check_route",
+            "arguments": [
+              {
+                "type": "argument_ref",
+                "argument_name": "right_route"
+              }
+            ]
+          },
+          "MOVING": {
+            "type": "aspect_set",
+            "members": [
+              {
+                "aspect": "RED"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "speed_sections": [
+    {
+      "id": "speedsection.mid_limit",
+      "is_signalized": false,
+      "speed": 16.666666666666668
+    }
+  ],
+  "switches": [
+    {
+      "base": {
+        "endpoint": "BEGIN",
+        "section": "ne.micro.foo_to_bar"
+      },
+      "id": "il.switch_foo",
+      "position_change_delay": 6,
+      "left": {
+        "endpoint": "END",
+        "section": "ne.micro.foo_b"
+      },
+      "right": {
+        "endpoint": "END",
+        "section": "ne.micro.foo_a"
+      }
+    }
+  ],
+  "track_section_links": [
+    {
+      "begin": {
+        "endpoint": "END",
+        "section": "ne.micro.foo_a"
+      },
+      "end": {
+        "endpoint": "BEGIN",
+        "section": "ne.micro.foo_to_bar"
+      },
+      "navigability": "BOTH"
+    },
+    {
+      "begin": {
+        "endpoint": "END",
+        "section": "ne.micro.foo_b"
+      },
+      "end": {
+        "endpoint": "BEGIN",
+        "section": "ne.micro.foo_to_bar"
+      },
+      "navigability": "BOTH"
+    },
+    {
+      "begin": {
+        "endpoint": "END",
+        "section": "ne.micro.foo_to_bar"
+      },
+      "end": {
+        "endpoint": "BEGIN",
+        "section": "ne.micro.bar_a"
+      },
+      "navigability": "BOTH"
+    }
+  ],
+  "track_sections": [
+    {
+      "id": "ne.micro.foo_b",
+      "length": 200,
+      "operational_points": [
+        {
+          "begin": 100,
+          "end": 100,
+          "ref": "op.station_foo"
+        }
+      ],
+      "route_waypoints": [
+        {
+          "type": "buffer_stop",
+          "application_directions": "REVERSE",
+          "id": "buffer_stop_b",
+          "position": 0
+        },
+        {
+          "type": "detector",
+          "application_directions": "BOTH",
+          "id": "tde.foo_b-switch_foo",
+          "position": 175
+        }
+      ],
+      "signals": [
+        {
+          "expr": {
+            "type": "call",
+            "function": "bal3_line_signal",
+            "arguments": [
+              {
+                "type": "signal",
+                "signal": "il.sig.W5"
+              },
+              {
+                "type": "route",
+                "route": "rt.C3-S7"
+              }
+            ]
+          },
+          "id": "il.sig.C3",
+          "navigability": "NORMAL",
+          "position": 150,
+          "sightDistance": 400
+        }
+      ],
+      "speed_sections": []
+    },
+    {
+      "id": "ne.micro.foo_to_bar",
+      "length": 10000,
+      "operational_points": [],
+      "route_waypoints": [
+        {
+          "type": "detector",
+          "application_directions": "BOTH",
+          "id": "tde.switch_foo-track",
+          "position": 25
+        }
+      ],
+      "signals": [
+        {
+          "expr": {
+            "type": "call",
+            "function": "warn_signal",
+            "arguments": [
+              {
+                "type": "signal",
+                "signal": "il.sig.C6"
+              }
+            ]
+          },
+          "id": "il.sig.W4",
+          "navigability": "REVERSE",
+          "position": 1025,
+          "sightDistance": 400
+        },
+        {
+          "expr": {
+            "type": "call",
+            "function": "warn_signal",
+            "arguments": [
+              {
+                "type": "signal",
+                "signal": "il.sig.S7"
+              }
+            ]
+          },
+          "id": "il.sig.W5",
+          "navigability": "NORMAL",
+          "position": 8975,
+          "sightDistance": 400
+        },
+        {
+          "expr": {
+            "type": "call",
+            "function": "switch_signal",
+            "arguments": [
+              {
+                "type": "switch",
+                "switch": "il.switch_foo"
+              },
+              {
+                "type": "route",
+                "route": "rt.C6-buffer_stop_a"
+              },
+              {
+                "type": "route",
+                "route": "rt.C6-buffer_stop_b"
+              }
+            ]
+          },
+          "id": "il.sig.C6",
+          "navigability": "REVERSE",
+          "position": 50,
+          "sightDistance": 400
+        },
+        {
+          "expr": {
+            "type": "call",
+            "function": "check_route",
+            "arguments": [
+              {
+                "type": "route",
+                "route": "rt.S7-buffer_stop_c"
+              }
+            ]
+          },
+          "id": "il.sig.S7",
+          "navigability": "NORMAL",
+          "position": 9975,
+          "sightDistance": 400
+        }
+      ],
+      "speed_sections": [
+        {
+          "applicable_direction": "BOTH",
+          "begin": 2000,
+          "end": 8000,
+          "ref": "speedsection.mid_limit"
+        }
+      ]
+    },
+    {
+      "id": "ne.micro.foo_a",
+      "length": 200,
+      "operational_points": [
+        {
+          "begin": 100,
+          "end": 100,
+          "ref": "op.station_foo"
+        }
+      ],
+      "route_waypoints": [
+        {
+          "type": "buffer_stop",
+          "application_directions": "REVERSE",
+          "id": "buffer_stop_a",
+          "position": 0
+        },
+        {
+          "type": "detector",
+          "application_directions": "BOTH",
+          "id": "tde.foo_a-switch_foo",
+          "position": 175
+        }
+      ],
+      "signals": [
+        {
+          "expr": {
+            "type": "call",
+            "function": "bal3_line_signal",
+            "arguments": [
+              {
+                "type": "signal",
+                "signal": "il.sig.W5"
+              },
+              {
+                "type": "route",
+                "route": "rt.C1-S7"
+              }
+            ]
+          },
+          "id": "il.sig.C1",
+          "navigability": "NORMAL",
+          "position": 150,
+          "sightDistance": 400
+        }
+      ],
+      "speed_sections": []
+    },
+    {
+      "id": "ne.micro.bar_a",
+      "length": 200,
+      "operational_points": [
+        {
+          "begin": 100,
+          "end": 100,
+          "ref": "op.station_bar"
+        }
+      ],
+      "route_waypoints": [
+        {
+          "type": "detector",
+          "application_directions": "BOTH",
+          "id": "tde.track-bar",
+          "position": 0
+        },
+        {
+          "type": "buffer_stop",
+          "application_directions": "NORMAL",
+          "id": "buffer_stop_c",
+          "position": 200
+        }
+      ],
+      "signals": [
+        {
+          "expr": {
+            "type": "call",
+            "function": "bal3_line_signal",
+            "arguments": [
+              {
+                "type": "signal",
+                "signal": "il.sig.W4"
+              },
+              {
+                "type": "route",
+                "route": "rt.C2-C6"
+              }
+            ]
+          },
+          "id": "il.sig.C2",
+          "navigability": "REVERSE",
+          "position": 25,
+          "sightDistance": 400
+        }
+      ],
+      "speed_sections": []
+    }
+  ],
+  "tvd_sections": [
+    {
+      "buffer_stops": [
+        "buffer_stop_a"
+      ],
+      "id": "tvd.foo_a",
+      "is_berthing_track": true,
+      "train_detectors": [
+        "tde.foo_a-switch_foo"
+      ]
+    },
+    {
+      "buffer_stops": [
+        "buffer_stop_b"
+      ],
+      "id": "tvd.foo_b",
+      "is_berthing_track": true,
+      "train_detectors": [
+        "tde.foo_b-switch_foo"
+      ]
+    },
+    {
+      "buffer_stops": [],
+      "id": "tvd.switch_foo",
+      "is_berthing_track": false,
+      "train_detectors": [
+        "tde.foo_b-switch_foo",
+        "tde.foo_a-switch_foo",
+        "tde.switch_foo-track"
+      ]
+    },
+    {
+      "buffer_stops": [],
+      "id": "tvd.track",
+      "is_berthing_track": false,
+      "train_detectors": [
+        "tde.track-bar",
+        "tde.switch_foo-track"
+      ]
+    },
+    {
+      "buffer_stops": [
+        "buffer_stop_c"
+      ],
+      "id": "tvd.bar_a",
+      "is_berthing_track": true,
+      "train_detectors": [
+        "tde.track-bar"
+      ]
+    }
+  ],
+  "version": 1
+}

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -412,7 +412,7 @@
       "return_type": "ASPECT_SET",
       "body": {
         "type": "optional_match",
-        "name": "reserved_route",
+        "name": "route",
         "expr": {
           "type": "reserved_route",
           "signal": {
@@ -430,12 +430,12 @@
         },
         "case_some": {
           "type": "optional_match",
-          "name": "next_signal",
+          "name": "signal",
           "expr": {
             "type": "next_signal",
             "route": {
               "type": "optional_match_ref",
-              "match_name": "reserved_route"
+              "match_name": "route"
             },
             "signal": {
               "type": "argument_ref",
@@ -456,7 +456,7 @@
               "type": "signal_has_aspect",
               "signal": {
                 "type": "optional_match_ref",
-                "match_name": "next_signal"
+                "match_name": "signal"
               },
               "aspect": "RED"
             },

--- a/src/main/java/fr/sncf/osrd/infra/Infra.java
+++ b/src/main/java/fr/sncf/osrd/infra/Infra.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.infra;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.config.JsonConfig;
+import fr.sncf.osrd.infra.railscript.DependencyBinder;
 import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra_state.InfraState;
 import fr.sncf.osrd.railjson.parser.RailJSONParser;
@@ -137,6 +138,7 @@ public final class Infra {
         }
 
         routeGraph.routeMap.values().forEach(Route::resolveSignals);
+        signals.forEach(signal -> DependencyBinder.bind(signal, infra));
 
         // Evaluate initial aspects of signals
         var topologicalSignalOrder = buildTopologicalSignalOrder(signals);

--- a/src/main/java/fr/sncf/osrd/infra/Infra.java
+++ b/src/main/java/fr/sncf/osrd/infra/Infra.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.infra;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.config.JsonConfig;
+import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra_state.InfraState;
 import fr.sncf.osrd.railjson.parser.RailJSONParser;
 import fr.sncf.osrd.infra.routegraph.RouteGraph;
@@ -134,6 +135,8 @@ public final class Infra {
             forwardBuilder.build();
             backwardBuilder.build();
         }
+
+        routeGraph.routeMap.values().forEach(Route::resolveSignals);
 
         // Evaluate initial aspects of signals
         var topologicalSignalOrder = buildTopologicalSignalOrder(signals);

--- a/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
@@ -187,9 +187,12 @@ public class DependencyBinder extends RSExprVisitor {
         for (var val : possibleSignals) {
             assert val instanceof Signal;
             var signal = (Signal) val;
-            infra.routeGraph.routeMap.values().stream()
-                    .filter(x -> x.signalsWithEntry.contains(signal))
-                    .forEach(possibleValues::add);
+            for (Route route : infra.routeGraph.routeMap.values()) {
+                if (route.signalsWithEntry.contains(signal)) {
+                    possibleValues.add(route);
+                    reservedRoute.routeCandidates.add(route);
+                }
+            }
         }
         lastExprPossibleValues = possibleValues;
     }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
@@ -23,8 +23,7 @@ public class DependencyBinder extends RSExprVisitor {
     /** The set of all routes used to evaluate the visited expression. */
     public final Set<Route> routeDependencies = new HashSet<>();
 
-    /** The set of all switches used to evaluate the visited expression.
-     * NOTE: For now, this is always empty. No expression takes a switch state as input.*/
+    /** The set of all switches used to evaluate the visited expression. */
     public final Set<Switch> switchDependencies = new HashSet<>();
 
     /** Contains the possible values of arguments of each function calls before visiting its body */
@@ -127,6 +126,14 @@ public class DependencyBinder extends RSExprVisitor {
     /** Visit method */
     public void visit(RSExpr.EnumMatch<?, ?> expr) throws InvalidInfraException {
         expr.expr.accept(this);
+        for (var possibleValue : lastExprPossibleValues) {
+            if (possibleValue instanceof Switch) {
+                switchDependencies.add((Switch) possibleValue);
+            }
+            else if (possibleValue instanceof Route) {
+                routeDependencies.add((Route) possibleValue);
+            }
+        }
         var possibleValues = new HashSet<>();
         for (var branch : expr.branches) {
             branch.accept(this);

--- a/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
@@ -1,0 +1,193 @@
+package fr.sncf.osrd.infra.railscript;
+
+import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.infra.routegraph.Route;
+import fr.sncf.osrd.infra.signaling.Signal;
+import fr.sncf.osrd.infra.trackgraph.Switch;
+import fr.sncf.osrd.infra_state.RouteState;
+import fr.sncf.osrd.infra_state.SignalState;
+
+import java.util.*;
+
+public class DependencyBinder extends RSExprVisitor {
+    private Set<Object> lastExprPossibleValues;
+    public final Set<Signal> signalDependencies = new HashSet<>();
+    public final Set<Route> routeDependencies = new HashSet<>();
+    public final Set<Switch> switchDependencies = new HashSet<>();
+    private final Stack<ArrayList<Set<Object>>> argsPossibleValues = new Stack<>();
+    private final HashMap<String, Set<Object>> matchRefPossibleValues = new HashMap<>();
+    private final Infra infra;
+
+    public DependencyBinder(Infra infra) {
+        this.infra = infra;
+    }
+
+    public static void bind(Signal signal, Infra infra) {
+        var visitor = new DependencyBinder(infra);
+        var expr = signal.expr.rootExpr;
+        try {
+            expr.accept(visitor);
+        } catch (InvalidInfraException e) {
+            assert false; // this visitor cannot throw
+        }
+        for (var s : visitor.signalDependencies)
+            s.signalSubscribers.add(signal);
+        for (var route : visitor.routeDependencies)
+            route.signalSubscribers.add(signal);
+        for (var s : visitor.switchDependencies)
+            s.signalSubscribers.add(signal);
+    }
+
+    public void visit(RSExpr.Or expr) throws InvalidInfraException {
+        var possibleValues = new HashSet<>();
+        for (var e : expr.expressions) {
+            e.accept(this);
+            possibleValues.addAll(lastExprPossibleValues);
+        }
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.And expr) throws InvalidInfraException {
+        var possibleValues = new HashSet<>();
+        for (var e : expr.expressions) {
+            e.accept(this);
+            possibleValues.addAll(lastExprPossibleValues);
+        }
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.SignalRef expr) throws InvalidInfraException {
+        lastExprPossibleValues = new HashSet<>();
+        lastExprPossibleValues.add(expr.signal);
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.RouteRef expr) throws InvalidInfraException {
+        lastExprPossibleValues = new HashSet<>();
+        lastExprPossibleValues.add(expr.route);
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.SwitchRef expr) throws InvalidInfraException {
+        lastExprPossibleValues = new HashSet<>();
+        lastExprPossibleValues.add(expr.switchRef);
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.If<?> expr) throws InvalidInfraException {
+        expr.ifExpr.accept(this);
+        expr.thenExpr.accept(this);
+        var possibleValues = new HashSet<>(lastExprPossibleValues);
+        expr.elseExpr.accept(this);
+        possibleValues.addAll(lastExprPossibleValues);
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.Call<?> expr) throws InvalidInfraException {
+        var argValues = new ArrayList<Set<Object>>();
+        for (var arg : expr.arguments) {
+            arg.accept(this);
+            argValues.add(lastExprPossibleValues);
+        }
+        this.argsPossibleValues.push(argValues);
+        expr.function.body.accept(this);
+        this.argsPossibleValues.pop();
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.ArgumentRef<?> expr) {
+        lastExprPossibleValues = argsPossibleValues.peek().get(expr.slotIndex);
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.EnumMatch<?, ?> expr) throws InvalidInfraException {
+        expr.expr.accept(this);
+        var possibleValues = new HashSet<>();
+        for (var branch : expr.branches) {
+            branch.accept(this);
+            possibleValues.addAll(lastExprPossibleValues);
+        }
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.SignalAspectCheck expr) throws InvalidInfraException {
+        expr.signalExpr.accept(this);
+        for (var possibleValue : lastExprPossibleValues) {
+            assert possibleValue instanceof Signal;
+            signalDependencies.add((Signal) possibleValue);
+        }
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.RouteStateCheck expr) throws InvalidInfraException {
+        expr.routeExpr.accept(this);
+        for (var possibleValue : lastExprPossibleValues) {
+            assert possibleValue instanceof Route;
+            routeDependencies.add((Route) possibleValue);
+        }
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.OptionalMatch<?> expr) throws InvalidInfraException {
+        expr.expr.accept(this);
+        matchRefPossibleValues.put(expr.name, lastExprPossibleValues);
+        expr.caseSome.accept(this);
+        var possibleValues = new HashSet<>(lastExprPossibleValues);
+        expr.caseNone.accept(this);
+        possibleValues.addAll(lastExprPossibleValues);
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.OptionalMatchRef<?> expr) {
+        lastExprPossibleValues = matchRefPossibleValues.get(expr.name);
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.ReservedRoute reservedRoute) throws InvalidInfraException {
+        var possibleValues = new HashSet<>();
+        reservedRoute.signal.accept(this);
+        var possibleSignals = lastExprPossibleValues;
+        for (var val : possibleSignals) {
+            assert val instanceof Signal;
+            var signal = (Signal) val;
+            signalDependencies.add(signal);
+            infra.routeGraph.routeMap.values().stream()
+                    .filter(x -> x.signalsWithEntry.contains(signal))
+                    .forEach(possibleValues::add);
+        }
+        lastExprPossibleValues = possibleValues;
+    }
+
+    /** Visit method */
+    public void visit(RSExpr.NextSignal nextSignal) throws InvalidInfraException {
+        var possibleValues = new HashSet<>();
+        nextSignal.signal.accept(this);
+        var possibleSignals = lastExprPossibleValues;
+        nextSignal.route.accept(this);
+        var possibleRoutes = lastExprPossibleValues;
+        for (var currentRouteState : possibleRoutes) {
+            assert currentRouteState instanceof Route;
+            var currentRoute = (Route) currentRouteState;
+
+            for (var currentSignalState : possibleSignals) {
+                assert currentSignalState instanceof Signal;
+                var currentSignal = (Signal) currentSignalState;
+
+                for (int i = 0; i < currentRoute.signalsWithEntry.size() - 1; i++) {
+                    if (currentRoute.signalsWithEntry.get(i).equals(currentSignal)) {
+                        var resSignal = currentRoute.signalsWithEntry.get(i + 1);
+                        possibleValues.add(resSignal);
+                        routeDependencies.add(currentRoute);
+                    }
+                }
+            }
+        }
+        lastExprPossibleValues = possibleValues;
+    }
+}

--- a/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/DependencyBinder.java
@@ -5,8 +5,6 @@ import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra.signaling.Signal;
 import fr.sncf.osrd.infra.trackgraph.Switch;
-import fr.sncf.osrd.infra_state.RouteState;
-import fr.sncf.osrd.infra_state.SignalState;
 
 import java.util.*;
 
@@ -156,7 +154,6 @@ public class DependencyBinder extends RSExprVisitor {
         for (var val : possibleSignals) {
             assert val instanceof Signal;
             var signal = (Signal) val;
-            signalDependencies.add(signal);
             infra.routeGraph.routeMap.values().stream()
                     .filter(x -> x.signalsWithEntry.contains(signal))
                     .forEach(possibleValues::add);

--- a/src/main/java/fr/sncf/osrd/infra/railscript/PrettyPrinter.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/PrettyPrinter.java
@@ -77,23 +77,7 @@ public class PrettyPrinter extends RSExprVisitor {
     }
 
     private void print(RSType type) {
-        switch (type) {
-            case BOOLEAN:
-                out.print("bool");
-                break;
-            case ASPECT_SET:
-                out.print("AspectSet");
-                break;
-            case SIGNAL:
-                out.print("Signal");
-                break;
-            case ROUTE:
-                out.print("Route");
-                break;
-            case SWITCH:
-                out.print("Switch");
-                break;
-        }
+        out.print(type);
     }
 
     /** Display the tab matching the current indentation */
@@ -162,6 +146,36 @@ public class PrettyPrinter extends RSExprVisitor {
             expr.expressions[i].accept(this);
         }
         out.print(")");
+    }
+
+    @Override
+    public void visit(RSExpr.OptionalMatch<?> expr) throws InvalidInfraException {
+        out.print("match ");
+        expr.expr.accept(this);
+        out.println(" {");
+        inctab();
+
+        out.print("Some(");
+        out.print(expr.name);
+        out.println("): ");
+        inctab();
+        expr.caseSome.accept(this);
+        out.println();
+        dectab();
+
+        out.print("None: ");
+        out.println();
+        inctab();
+        expr.caseNone.accept(this);
+        dectab();
+        out.println();
+        dectab();
+        out.println("}");
+    }
+
+    @Override
+    public void visit(RSExpr.OptionalMatchRef<?> expr) {
+        out.print(expr.name);
     }
 
     @Override
@@ -295,5 +309,21 @@ public class PrettyPrinter extends RSExprVisitor {
             functions.put(expr.function.functionName, expr.function);
             expr.function.body.accept(this);
         }
+    }
+
+    @Override
+    public void visit(RSExpr.ReservedRoute reservedRoute) throws InvalidInfraException {
+        out.print("reserved_route(");
+        reservedRoute.signal.accept(this);
+        out.print(")");
+    }
+
+    @Override
+    public void visit(RSExpr.NextSignal nextSignal) throws InvalidInfraException {
+        out.print("next_signal(");
+        nextSignal.route.accept(this);
+        out.print(", ");
+        nextSignal.signal.accept(this);
+        out.print(")");
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -390,9 +390,45 @@ public abstract class RSExpr<T extends RSValue> {
         }
     }
 
+    public static final class OptionalMatch<T extends RSValue> extends RSExpr<T> {
+        public final RSExpr<RSOptional<T>> expr;
+        public final RSExpr<T> caseNone;
+        public final RSExpr<T> caseSome;
+        public final String name;
+
+        public OptionalMatch(RSExpr<RSOptional<T>> expr, RSExpr<T> caseNone, RSExpr<T> caseSome, String name) {
+            this.expr = expr;
+            this.caseNone = caseNone;
+            this.caseSome = caseSome;
+            this.name = name;
+        }
+
+        @Override
+        public T evaluate(RSExprState<?> state) {
+            var optional = expr.evaluate(state);
+            // TODO somehow bind everything
+            var caseNoneResult = caseNone.evaluate(state);
+            if (optional.value == null)
+                return caseNoneResult;
+            else
+                // NOTE: we can't run this branch in all cases, so delays here will not work
+                return caseSome.evaluate(state);
+        }
+
+        @Override
+        public RSType getType(RSType[] argumentTypes) {
+            return caseNone.getType(argumentTypes);
+        }
+
+        @Override
+        public void accept(RSExprVisitor visitor) throws InvalidInfraException {
+            visitor.visit(this);
+        }
+    }
+
     // endregion
 
-    // region FUNCTION_SPECIFIC
+    // region REFERENCES
 
     public static final class ArgumentRef<T extends RSValue> extends RSExpr<T> {
         public final int slotIndex;
@@ -410,6 +446,31 @@ public abstract class RSExpr<T extends RSValue> {
         @Override
         public RSType getType(RSType[] argumentTypes) {
             return argumentTypes[slotIndex];
+        }
+
+        @Override
+        public void accept(RSExprVisitor visitor) {
+            visitor.visit(this);
+        }
+    }
+
+    public static final class OptionalMatchRef<T extends RSValue> extends RSExpr<T> {
+        public final String name;
+
+        public OptionalMatchRef(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public T evaluate(RSExprState<?> state) {
+            // TODO
+            return null;
+        }
+
+        @Override
+        public RSType getType(RSType[] argumentTypes) {
+            // TODO
+            return RSType.BOOLEAN;
         }
 
         @Override

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -615,5 +615,55 @@ public abstract class RSExpr<T extends RSValue> {
         }
     }
 
+    public static final class ReservedRoute extends RSExpr<RSOptional<RouteState>> {
+        public final RSExpr<SignalState> signal;
+
+        public ReservedRoute(RSExpr<SignalState> signal) {
+            this.signal = signal;
+        }
+
+        @Override
+        public RSOptional<RouteState> evaluate(RSExprState<?> state) {
+            // TODO
+            return new RSOptional<>(null);
+        }
+
+        @Override
+        public RSType getType(RSType[] argumentTypes) {
+            return RSType.OPTIONAL;
+        }
+
+        @Override
+        public void accept(RSExprVisitor visitor) throws InvalidInfraException {
+            visitor.visit(this);
+        }
+    }
+
+    public static final class NextSignal extends RSExpr<RSOptional<SignalState>> {
+        public final RSExpr<SignalState> signal;
+        public final RSExpr<RouteState> route;
+
+        public NextSignal(RSExpr<SignalState> signal, RSExpr<RouteState> route) {
+            this.signal = signal;
+            this.route = route;
+        }
+
+        @Override
+        public RSOptional<SignalState> evaluate(RSExprState<?> state) {
+            // TODO
+            return new RSOptional<>(null);
+        }
+
+        @Override
+        public RSType getType(RSType[] argumentTypes) {
+            return RSType.OPTIONAL;
+        }
+
+        @Override
+        public void accept(RSExprVisitor visitor) throws InvalidInfraException {
+            visitor.visit(this);
+        }
+    }
+
     // endregion
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -648,7 +648,6 @@ public abstract class RSExpr<T extends RSValue> {
                     .filter(x -> x.route.signalsWithEntry.contains(currentSignal))
                     .findFirst()
                     .orElse(null);
-            System.out.println(currentSignal.id);
             return new RSOptional<>(route);
         }
 

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -11,7 +11,6 @@ import fr.sncf.osrd.infra_state.RouteState;
 import fr.sncf.osrd.infra_state.SignalState;
 import fr.sncf.osrd.infra_state.SwitchState;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -398,6 +397,7 @@ public abstract class RSExpr<T extends RSValue> {
         public final RSExpr<T> caseSome;
         public final String name;
 
+        /** Matches an optional expression with an expression depending on its content */
         public OptionalMatch(RSExpr<RSOptional<T>> expr, RSExpr<T> caseNone, RSExpr<T> caseSome, String name) {
             this.expr = expr;
             this.caseNone = caseNone;
@@ -466,6 +466,7 @@ public abstract class RSExpr<T extends RSValue> {
         public final String name;
         public final RSType type;
 
+        /** Refers to the content of an optional, in a "some" expression */
         public OptionalMatchRef(String name, HashMap<String, RSType> varTypes) throws InvalidInfraException {
             this.name = name;
             if (! varTypes.containsKey(name))

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -407,13 +407,19 @@ public abstract class RSExpr<T extends RSValue> {
         @Override
         public T evaluate(RSExprState<?> state) {
             var optional = expr.evaluate(state);
-            // TODO somehow bind everything
             var caseNoneResult = caseNone.evaluate(state);
             if (optional.value == null)
                 return caseNoneResult;
-            else
+            else {
+                state.variablesInScope.put(name, optional);
+
                 // NOTE: we can't run this branch in all cases, so delays here will not work
-                return caseSome.evaluate(state);
+                // TODO validate the absence of delays here at init
+                var res = caseSome.evaluate(state);
+
+                state.variablesInScope.remove(name);
+                return res;
+            }
         }
 
         @Override
@@ -467,9 +473,9 @@ public abstract class RSExpr<T extends RSValue> {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public T evaluate(RSExprState<?> state) {
-            // TODO
-            return null;
+            return (T) state.variablesInScope.get(name);
         }
 
         @Override

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -398,7 +398,8 @@ public abstract class RSExpr<T extends RSValue> {
         public final String name;
 
         /** Matches an optional expression with an expression depending on its content */
-        public OptionalMatch(RSExpr<RSOptional<T>> expr, RSExpr<T> caseNone, RSExpr<T> caseSome, String name) throws InvalidInfraException {
+        public OptionalMatch(RSExpr<RSOptional<T>> expr, RSExpr<T> caseNone, RSExpr<T> caseSome, String name)
+                throws InvalidInfraException {
             this.expr = expr;
             this.caseNone = caseNone;
             this.caseSome = caseSome;

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -646,9 +646,7 @@ public abstract class RSExpr<T extends RSValue> {
 
         @Override
         public RSType getType(RSType[] argumentTypes) {
-            var res = RSType.OPTIONAL;
-            res.optionalContentType = RSType.ROUTE;
-            return res;
+            return RSType.OPTIONAL_ROUTE;
         }
 
         @Override
@@ -683,9 +681,7 @@ public abstract class RSExpr<T extends RSValue> {
 
         @Override
         public RSType getType(RSType[] argumentTypes) {
-            var res = RSType.OPTIONAL;
-            res.optionalContentType = RSType.SIGNAL;
-            return res;
+            return RSType.OPTIONAL_SIGNAL;
         }
 
         @Override

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -11,6 +11,7 @@ import fr.sncf.osrd.infra_state.RouteState;
 import fr.sncf.osrd.infra_state.SignalState;
 import fr.sncf.osrd.infra_state.SwitchState;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class RSExpr<T extends RSValue> {
@@ -456,9 +457,13 @@ public abstract class RSExpr<T extends RSValue> {
 
     public static final class OptionalMatchRef<T extends RSValue> extends RSExpr<T> {
         public final String name;
+        public final RSType type;
 
-        public OptionalMatchRef(String name) {
+        public OptionalMatchRef(String name, HashMap<String, RSType> varTypes) throws InvalidInfraException {
             this.name = name;
+            if (! varTypes.containsKey(name))
+                throw new InvalidInfraException("can't find matching optional for name " + name);
+            type = varTypes.get(name);
         }
 
         @Override
@@ -469,8 +474,7 @@ public abstract class RSExpr<T extends RSValue> {
 
         @Override
         public RSType getType(RSType[] argumentTypes) {
-            // TODO
-            return RSType.BOOLEAN;
+            return type;
         }
 
         @Override
@@ -630,7 +634,9 @@ public abstract class RSExpr<T extends RSValue> {
 
         @Override
         public RSType getType(RSType[] argumentTypes) {
-            return RSType.OPTIONAL;
+            var res = RSType.OPTIONAL;
+            res.optionalContentType = RSType.ROUTE;
+            return res;
         }
 
         @Override
@@ -656,7 +662,9 @@ public abstract class RSExpr<T extends RSValue> {
 
         @Override
         public RSType getType(RSType[] argumentTypes) {
-            return RSType.OPTIONAL;
+            var res = RSType.OPTIONAL;
+            res.optionalContentType = RSType.SIGNAL;
+            return res;
         }
 
         @Override

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -416,7 +416,7 @@ public abstract class RSExpr<T extends RSValue> {
             if (optional.value == null)
                 return caseNoneResult;
             else {
-                state.variablesInScope.put(name, optional);
+                state.variablesInScope.put(name, optional.value);
                 var res = caseSome.evaluate(state);
                 state.variablesInScope.remove(name);
                 return res;
@@ -648,6 +648,7 @@ public abstract class RSExpr<T extends RSValue> {
                     .filter(x -> x.route.signalsWithEntry.contains(currentSignal))
                     .findFirst()
                     .orElse(null);
+            System.out.println(currentSignal.id);
             return new RSOptional<>(route);
         }
 

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprState.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprState.java
@@ -5,6 +5,7 @@ import fr.sncf.osrd.infra_state.InfraState;
 import fr.sncf.osrd.utils.DeepComparable;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 public class RSExprState<T extends RSValue> implements DeepComparable<RSExprState<?>> {
     @Override
@@ -33,6 +34,7 @@ public class RSExprState<T extends RSValue> implements DeepComparable<RSExprStat
     transient InfraState infraState;
     transient RSExprEvalMode evalMode = RSExprEvalMode.INITIALIZE;
     final transient RSValue[] argStates;
+    final transient HashMap<String, RSValue> variablesInScope;
     transient int argScopeOffset = 0;
     transient int delayScopeOffset = 0;
     private transient int lastUpdatedDelaySlot = -1;
@@ -93,6 +95,7 @@ public class RSExprState<T extends RSValue> implements DeepComparable<RSExprStat
         this.argStates = new RSValue[argSlotCount];
         this.delayCurrentStates = new RSValue[delaySlotCount];
         this.delayLaggingStates = new RSValue[delaySlotCount];
+        variablesInScope = new HashMap<>();
     }
 
     private T eval(InfraState infraState, RSDelayHandler delayHandler, RSExprEvalMode evalMode) {

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
@@ -89,9 +89,12 @@ public class RSExprVisitor {
     public void visit(RSExpr.OptionalMatchRef<?> tOptionalMatchRef) {
     }
 
-    public void visit(RSExpr.ReservedRoute reservedRoute) {
+    public void visit(RSExpr.ReservedRoute reservedRoute) throws InvalidInfraException {
+        reservedRoute.signal.accept(this);
     }
 
-    public void visit(RSExpr.NextSignal nextSignal) {
+    public void visit(RSExpr.NextSignal nextSignal) throws InvalidInfraException {
+        nextSignal.signal.accept(this);
+        nextSignal.route.accept(this);
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
@@ -88,4 +88,10 @@ public class RSExprVisitor {
 
     public void visit(RSExpr.OptionalMatchRef<?> tOptionalMatchRef) {
     }
+
+    public void visit(RSExpr.ReservedRoute reservedRoute) {
+    }
+
+    public void visit(RSExpr.NextSignal nextSignal) {
+    }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
@@ -1,27 +1,31 @@
 package fr.sncf.osrd.infra.railscript;
 
 import fr.sncf.osrd.infra.InvalidInfraException;
-import fr.sncf.osrd.infra.railscript.value.RSValue;
 
 public class RSExprVisitor {
 
+    /** Visit method */
     public void visit(RSExpr.Or expr) throws InvalidInfraException {
         for (var e : expr.expressions)
             e.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.And expr) throws InvalidInfraException {
         for (var e : expr.expressions)
             e.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.Not expr) throws InvalidInfraException {
         expr.expr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.True expr) {
     }
 
+    /** Visit method */
     public void visit(RSExpr.False expr) {
     }
 
@@ -33,12 +37,15 @@ public class RSExprVisitor {
         }
     }
 
+    /** Visit method */
     public void visit(RSExpr.SignalRef expr) throws InvalidInfraException {
     }
 
+    /** Visit method */
     public void visit(RSExpr.RouteRef expr) throws InvalidInfraException {
     }
 
+    /** Visit method */
     public void visit(RSExpr.SwitchRef expr) throws InvalidInfraException {
     }
 
@@ -49,6 +56,7 @@ public class RSExprVisitor {
         expr.elseExpr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.Call<?> expr) throws InvalidInfraException {
         for (var arg : expr.arguments)
             arg.accept(this);
@@ -61,38 +69,47 @@ public class RSExprVisitor {
             branch.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.ArgumentRef<?> expr) {
     }
 
+    /** Visit method */
     public void visit(RSExpr.Delay<?> expr) throws InvalidInfraException {
         expr.expr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.SignalAspectCheck expr) throws InvalidInfraException {
         expr.signalExpr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.RouteStateCheck expr) throws InvalidInfraException {
         expr.routeExpr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.AspectSetContains expr) throws InvalidInfraException {
         expr.expr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.OptionalMatch<?> expr) throws InvalidInfraException {
         expr.caseSome.accept(this);
         expr.caseNone.accept(this);
         expr.expr.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.OptionalMatchRef<?> tOptionalMatchRef) {
     }
 
+    /** Visit method */
     public void visit(RSExpr.ReservedRoute reservedRoute) throws InvalidInfraException {
         reservedRoute.signal.accept(this);
     }
 
+    /** Visit method */
     public void visit(RSExpr.NextSignal nextSignal) throws InvalidInfraException {
         nextSignal.signal.accept(this);
         nextSignal.route.accept(this);

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.infra.railscript;
 
 import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.infra.railscript.value.RSValue;
 
 public class RSExprVisitor {
 
@@ -77,5 +78,14 @@ public class RSExprVisitor {
 
     public void visit(RSExpr.AspectSetContains expr) throws InvalidInfraException {
         expr.expr.accept(this);
+    }
+
+    public void visit(RSExpr.OptionalMatch<?> expr) throws InvalidInfraException {
+        expr.caseSome.accept(this);
+        expr.caseNone.accept(this);
+        expr.expr.accept(this);
+    }
+
+    public void visit(RSExpr.OptionalMatchRef<?> tOptionalMatchRef) {
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
@@ -2,7 +2,7 @@ package fr.sncf.osrd.infra.railscript.value;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public class RSOptional<T extends RSValue> implements RSValue{
+public class RSOptional<T extends RSValue> implements RSValue {
 
     public T value;
 

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
@@ -1,0 +1,14 @@
+package fr.sncf.osrd.infra.railscript.value;
+
+public class RSOptional<T extends RSValue> implements RSValue{
+
+    public T value;
+
+    @Override
+    public boolean deepEquals(RSValue other) {
+        if (other.getClass() != RSOptional.class)
+            return false;
+        var otherOptional = (RSOptional<?>) other;
+        return value.deepEquals(otherOptional.value);
+    }
+}

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.infra.railscript.value;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class RSOptional<T extends RSValue> implements RSValue{
 
     public T value;
@@ -9,6 +11,7 @@ public class RSOptional<T extends RSValue> implements RSValue{
     }
 
     @Override
+    @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
     public boolean deepEquals(RSValue other) {
         if (other.getClass() != RSOptional.class)
             return false;

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSOptional.java
@@ -4,6 +4,10 @@ public class RSOptional<T extends RSValue> implements RSValue{
 
     public T value;
 
+    public RSOptional(T value) {
+        this.value = value;
+    }
+
     @Override
     public boolean deepEquals(RSValue other) {
         if (other.getClass() != RSOptional.class)

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -19,6 +19,7 @@ public enum RSType {
         this.enumClass = enumClass;
     }
 
+    /** Converts the value to the matching string */
     public String toString() {
         switch (this) {
             case BOOLEAN:
@@ -40,6 +41,7 @@ public enum RSType {
         }
     }
 
+    /** Returns the subtype if this is an optional */
     public RSType subType() throws InvalidInfraException {
         switch (this) {
             case OPTIONAL_ROUTE:

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -8,6 +8,7 @@ public enum RSType {
     ASPECT_SET(null),
     SIGNAL(null),
     ROUTE(RouteStatus.class),
+    OPTIONAL(null),
     SWITCH(SwitchPosition.class);
 
     public final Class<? extends Enum<?>> enumClass;

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -41,14 +41,14 @@ public enum RSType {
         }
     }
 
-    /** Returns the subtype if this is an optional */
-    public RSType subType() throws InvalidInfraException {
+    /** Returns the content type if this is an optional */
+    public RSType contentType() throws InvalidInfraException {
         switch (this) {
             case OPTIONAL_ROUTE:
                 return ROUTE;
             case OPTIONAL_SIGNAL:
                 return SIGNAL;
         }
-        throw new InvalidInfraException("Can't call subtype on a type that is not an optional");
+        throw new InvalidInfraException("Can't call contained type on a type that is not an optional");
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -17,4 +17,23 @@ public enum RSType {
     RSType(Class<? extends Enum<?>> enumClass) {
         this.enumClass = enumClass;
     }
+
+    public String toString() {
+        switch (this) {
+            case BOOLEAN:
+                return "bool";
+            case ASPECT_SET:
+                return "AspectSet";
+            case SIGNAL:
+                return "Signal";
+            case ROUTE:
+                return "Route";
+            case SWITCH:
+                return "Switch";
+            case OPTIONAL:
+                return String.format("Optional<%s>", optionalContentType);
+            default:
+                return "";
+        }
+    }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -12,6 +12,7 @@ public enum RSType {
     SWITCH(SwitchPosition.class);
 
     public final Class<? extends Enum<?>> enumClass;
+    public RSType optionalContentType = null;
 
     RSType(Class<? extends Enum<?>> enumClass) {
         this.enumClass = enumClass;

--- a/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/value/RSType.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.infra.railscript.value;
 
+import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.infra_state.RouteStatus;
 import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
 
@@ -8,11 +9,11 @@ public enum RSType {
     ASPECT_SET(null),
     SIGNAL(null),
     ROUTE(RouteStatus.class),
-    OPTIONAL(null),
+    OPTIONAL_SIGNAL(null),
+    OPTIONAL_ROUTE(null),
     SWITCH(SwitchPosition.class);
 
     public final Class<? extends Enum<?>> enumClass;
-    public RSType optionalContentType = null;
 
     RSType(Class<? extends Enum<?>> enumClass) {
         this.enumClass = enumClass;
@@ -30,10 +31,22 @@ public enum RSType {
                 return "Route";
             case SWITCH:
                 return "Switch";
-            case OPTIONAL:
-                return String.format("Optional<%s>", optionalContentType);
+            case OPTIONAL_ROUTE:
+                return "Optional route";
+            case OPTIONAL_SIGNAL:
+                return "Optional signal";
             default:
                 return "";
         }
+    }
+
+    public RSType subType() throws InvalidInfraException {
+        switch (this) {
+            case OPTIONAL_ROUTE:
+                return ROUTE;
+            case OPTIONAL_SIGNAL:
+                return SIGNAL;
+        }
+        throw new InvalidInfraException("Can't call subtype on a type that is not an optional");
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
@@ -87,8 +87,10 @@ public class Route extends DirNEdge {
         if (entrySignal != null)
             signalsWithEntry.add(entrySignal);
         for (var actionPoint : getActionPoints())
-            if (actionPoint instanceof Signal)
-                signalsWithEntry.add((Signal) actionPoint);
+            if (actionPoint instanceof Signal) {
+                var signal = (Signal) actionPoint;
+                signalsWithEntry.add(signal);
+            }
     }
 
     /** Build track section path. Need to concatenate all track section of all TvdSectionPath.

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
@@ -22,6 +22,7 @@ public class Route extends DirNEdge {
     public final HashMap<Switch, SwitchPosition> switchesPosition;
     public final Signal entrySignal;
     public final List<Signal> signals;
+    public final List<Signal> signalsWithEntry;
     public ArrayList<Signal> signalSubscribers;
 
     Route(
@@ -49,6 +50,11 @@ public class Route extends DirNEdge {
         graph.registerEdge(this);
         this.tvdSectionsPaths = tvdSectionsPaths;
         this.signalSubscribers = new ArrayList<>();
+
+        signalsWithEntry = new ArrayList<>();
+        if (entrySignal != null)
+            signalsWithEntry.add(entrySignal);
+        signalsWithEntry.addAll(signals);
     }
 
     /** Build track section path. Need to concatenate all track section of all TvdSectionPath.

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
@@ -20,8 +20,6 @@ public class Route extends DirNEdge {
     public final List<EdgeDirection> tvdSectionsPathDirections;
     public final List<SortedArraySet<TVDSection>> releaseGroups;
     public final HashMap<Switch, SwitchPosition> switchesPosition;
-    public final Signal entrySignal;
-    public final List<Signal> signals;
     public final List<Signal> signalsWithEntry;
     public ArrayList<Signal> signalSubscribers;
 
@@ -45,8 +43,6 @@ public class Route extends DirNEdge {
         this.releaseGroups = releaseGroups;
         this.tvdSectionsPathDirections = tvdSectionsPathDirections;
         this.switchesPosition = switchesPosition;
-        this.entrySignal = entrySignal;
-        this.signals = signals;
         graph.registerEdge(this);
         this.tvdSectionsPaths = tvdSectionsPaths;
         this.signalSubscribers = new ArrayList<>();

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
@@ -1,6 +1,5 @@
 package fr.sncf.osrd.infra.routegraph;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.TVDSection;
 import fr.sncf.osrd.infra.signaling.Signal;
 import fr.sncf.osrd.infra.trackgraph.Switch;
@@ -9,14 +8,10 @@ import fr.sncf.osrd.infra.waypointgraph.TVDSectionPath;
 import fr.sncf.osrd.train.TrackSectionRange;
 import fr.sncf.osrd.utils.SortedArraySet;
 import fr.sncf.osrd.utils.TrackSectionLocation;
-import fr.sncf.osrd.utils.graph.BiNEdge;
 import fr.sncf.osrd.utils.graph.DirNEdge;
 import fr.sncf.osrd.utils.graph.EdgeDirection;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 public class Route extends DirNEdge {
     public final String id;
@@ -25,6 +20,8 @@ public class Route extends DirNEdge {
     public final List<EdgeDirection> tvdSectionsPathDirections;
     public final List<SortedArraySet<TVDSection>> releaseGroups;
     public final HashMap<Switch, SwitchPosition> switchesPosition;
+    public final Signal entrySignal;
+    public final List<Signal> signals;
     public ArrayList<Signal> signalSubscribers;
 
     Route(
@@ -34,8 +31,8 @@ public class Route extends DirNEdge {
             List<SortedArraySet<TVDSection>> releaseGroups,
             List<TVDSectionPath> tvdSectionsPaths,
             List<EdgeDirection> tvdSectionsPathDirections,
-            HashMap<Switch, SwitchPosition> switchesPosition
-    ) {
+            HashMap<Switch, SwitchPosition> switchesPosition,
+            Signal entrySignal, List<Signal> signals) {
         super(
                 graph.nextEdgeIndex(),
                 tvdSectionsPaths.get(0).getStartNode(tvdSectionsPathDirections.get(0)),
@@ -47,6 +44,8 @@ public class Route extends DirNEdge {
         this.releaseGroups = releaseGroups;
         this.tvdSectionsPathDirections = tvdSectionsPathDirections;
         this.switchesPosition = switchesPosition;
+        this.entrySignal = entrySignal;
+        this.signals = signals;
         graph.registerEdge(this);
         this.tvdSectionsPaths = tvdSectionsPaths;
         this.signalSubscribers = new ArrayList<>();

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
@@ -51,8 +51,7 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
                 SortedArraySet<TVDSection> tvdSections,
                 List<SortedArraySet<TVDSection>> releaseGroups,
                 HashMap<Switch, SwitchPosition> switchesPosition,
-                Signal entrySignal,
-                List<Signal> signals) throws InvalidInfraException {
+                Signal entrySignal) throws InvalidInfraException {
             if (waypoints.size() < 2) {
                 throw new InvalidInfraException(String.format("Route '%s' doesn't contains enough waypoints", id));
             }
@@ -105,8 +104,7 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
                     tvdSectionsPath,
                     tvdSectionsPathDirection,
                     switchesPosition,
-                    entrySignal,
-                    signals);
+                    entrySignal);
 
             routeGraph.routeMap.put(id, route);
 

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.infra.routegraph;
 
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.infra.TVDSection;
+import fr.sncf.osrd.infra.signaling.Signal;
 import fr.sncf.osrd.infra.trackgraph.Switch;
 import fr.sncf.osrd.infra.trackgraph.SwitchPosition;
 import fr.sncf.osrd.infra.trackgraph.TrackSection;
@@ -14,6 +15,7 @@ import fr.sncf.osrd.infra.waypointgraph.WaypointGraph;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 public class RouteGraph extends DirNGraph<Route, Waypoint> {
     public final HashMap<String, Route> routeMap = new HashMap<>();
@@ -48,8 +50,9 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
                 List<Waypoint> waypoints,
                 SortedArraySet<TVDSection> tvdSections,
                 List<SortedArraySet<TVDSection>> releaseGroups,
-                HashMap<Switch, SwitchPosition> switchesPosition
-        ) throws InvalidInfraException {
+                HashMap<Switch, SwitchPosition> switchesPosition,
+                Signal entrySignal,
+                List<Signal> signals) throws InvalidInfraException {
             if (waypoints.size() < 2) {
                 throw new InvalidInfraException(String.format("Route '%s' doesn't contains enough waypoints", id));
             }
@@ -101,8 +104,9 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
                     releaseGroups,
                     tvdSectionsPath,
                     tvdSectionsPathDirection,
-                    switchesPosition
-            );
+                    switchesPosition,
+                    entrySignal,
+                    signals);
 
             routeGraph.routeMap.put(id, route);
 

--- a/src/main/java/fr/sncf/osrd/infra/signaling/Signal.java
+++ b/src/main/java/fr/sncf/osrd/infra/signaling/Signal.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.infra.signaling;
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.infra.railscript.*;
 import fr.sncf.osrd.infra.railscript.value.RSAspectSet;
+import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra_state.InfraState;
 import fr.sncf.osrd.simulation.*;
 import fr.sncf.osrd.train.InteractionType;
@@ -11,6 +12,9 @@ import fr.sncf.osrd.train.InteractionTypeSet;
 import fr.sncf.osrd.utils.graph.ApplicableDirections;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Stack;
 
 public class Signal implements ActionPoint {
     public final int index;
@@ -65,31 +69,5 @@ public class Signal implements ActionPoint {
     @Override
     public String toString() {
         return String.format("Signal { id=%s }", id);
-    }
-
-    public static class DependenciesFinder extends RSExprVisitor {
-        final Signal signal;
-
-        public DependenciesFinder(Signal signal) {
-            this.signal = signal;
-        }
-
-        @Override
-        public void visit(RSExpr.SignalRef expr) throws InvalidInfraException {
-            expr.signal.signalSubscribers.add(signal);
-            super.visit(expr);
-        }
-
-        @Override
-        public void visit(RSExpr.RouteRef expr) throws InvalidInfraException {
-            expr.route.signalSubscribers.add(signal);
-            super.visit(expr);
-        }
-
-        @Override
-        public void visit(RSExpr.SwitchRef expr) throws InvalidInfraException {
-            expr.switchRef.signalSubscribers.add(signal);
-            super.visit(expr);
-        }
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/InfraState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/InfraState.java
@@ -5,6 +5,9 @@ import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.utils.DeepComparable;
 import fr.sncf.osrd.utils.DeepEqualsUtils;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 public final class InfraState implements DeepComparable<InfraState> {
     private final SignalState[] signalSignalStates;
     private final RouteState[] routeStates;
@@ -30,6 +33,10 @@ public final class InfraState implements DeepComparable<InfraState> {
 
     public RouteState getRouteState(int routeIndex) {
         return routeStates[routeIndex];
+    }
+
+    public Stream<RouteState> getRoutesStream() {
+        return Arrays.stream(routeStates);
     }
 
     public SwitchState getSwitchState(int switchIndex) {

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -195,6 +195,11 @@ public class RailJSONParser {
             tvdSectionsMap.put(tvd.id, tvd);
         }
 
+        // build name maps to prepare resolving names in expressions
+        var signalNames = new HashMap<String, Signal>();
+        for (var signal : signals)
+            signalNames.put(signal.id, signal);
+
         // Build waypoint Graph
         var waypointGraph = Infra.buildWaypointGraph(trackGraph, tvdSectionsMap);
 
@@ -232,18 +237,10 @@ public class RailJSONParser {
                 switchesPosition.put(switchRef, position);
             }
 
-            var entrySignal = signals.stream()
-                    .filter(x -> x.id.equals(rjsRoute.entrySignal.id))
-                    .findFirst()
-                    .orElse(null);
+            var entrySignal = signalNames.getOrDefault(rjsRoute.entrySignal.id, null);
 
             routeGraph.makeRoute(rjsRoute.id, waypoints, tvdSections, releaseGroups, switchesPosition, entrySignal);
         }
-
-        // build name maps to prepare resolving names in expressions
-        var signalNames = new HashMap<String, Signal>();
-        for (var signal : signals)
-            signalNames.put(signal.id, signal);
 
         var routeNames = new HashMap<String, Route>();
         for (var route : routeGraph.routeGraph.iterEdges())

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -4,6 +4,7 @@ import static fr.sncf.osrd.infra.trackgraph.TrackSection.linkEdges;
 
 import com.squareup.moshi.*;
 import fr.sncf.osrd.infra.*;
+import fr.sncf.osrd.infra.railscript.DependencyBinder;
 import fr.sncf.osrd.railjson.schema.common.ID;
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSBufferStop;
@@ -269,12 +270,6 @@ public class RailJSONParser {
             function.body.accept(nameResolver);
         for (var signal : signals)
             signal.expr.accept(nameResolver);
-
-        // Fill signals dependencies
-        for (var signal : signals) {
-            var dependenciesFinder = new Signal.DependenciesFinder(signal);
-            signal.expr.accept(dependenciesFinder);
-        }
 
         return Infra.build(trackGraph, waypointGraph, routeGraph.build(),
                 tvdSectionsMap, aspectsMap, signals, switches);

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -231,7 +231,21 @@ public class RailJSONParser {
                 switchesPosition.put(switchRef, position);
             }
 
-            routeGraph.makeRoute(rjsRoute.id, waypoints, tvdSections, releaseGroups, switchesPosition);
+            var entrySignal = signals.stream()
+                    .filter(x -> x.id.equals(rjsRoute.entrySignal.id))
+                    .findFirst()
+                    .orElse(null);
+            var signalsOnRoute = new ArrayList<Signal>();
+            for (var signalId : rjsRoute.signals) {
+                var signal = signals.stream()
+                        .filter(x -> x.id.equals(signalId.id))
+                        .findFirst()
+                        .orElseThrow(() -> new InvalidInfraException("Invalid signal reference " + signalId.id));
+                signalsOnRoute.add(signal);
+            }
+
+            routeGraph.makeRoute(rjsRoute.id, waypoints, tvdSections, releaseGroups, switchesPosition,
+                    entrySignal, signalsOnRoute);
         }
 
         // build name maps to prepare resolving names in expressions

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -235,17 +235,8 @@ public class RailJSONParser {
                     .filter(x -> x.id.equals(rjsRoute.entrySignal.id))
                     .findFirst()
                     .orElse(null);
-            var signalsOnRoute = new ArrayList<Signal>();
-            for (var signalId : rjsRoute.signals) {
-                var signal = signals.stream()
-                        .filter(x -> x.id.equals(signalId.id))
-                        .findFirst()
-                        .orElseThrow(() -> new InvalidInfraException("Invalid signal reference " + signalId.id));
-                signalsOnRoute.add(signal);
-            }
 
-            routeGraph.makeRoute(rjsRoute.id, waypoints, tvdSections, releaseGroups, switchesPosition,
-                    entrySignal, signalsOnRoute);
+            routeGraph.makeRoute(rjsRoute.id, waypoints, tvdSections, releaseGroups, switchesPosition, entrySignal);
         }
 
         // build name maps to prepare resolving names in expressions

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
@@ -266,8 +266,8 @@ public class RailScriptExprParser {
         var noneExpr = parse(optionalMatchExpr.caseNone);
         var contentExpr = parseOptionalExpr(optionalMatchExpr.expr);
         var type = contentExpr.getType(argTypes);
-        var subType = type.subType();
-        varTypes.put(name, subType);
+        var contentType = type.contentType();
+        varTypes.put(name, contentType);
         var someExpr = parse(optionalMatchExpr.caseSome);
         varTypes.remove(name);
 

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
@@ -267,8 +267,7 @@ public class RailScriptExprParser {
         var noneExpr = parse(optionalMatchExpr.caseNone);
         var contentExpr = parseOptionalExpr(optionalMatchExpr.expr);
         var type = contentExpr.getType(argTypes);
-        assert type == RSType.OPTIONAL;
-        var subType = type.optionalContentType;
+        var subType = type.subType();
         varTypes.put(name, subType);
         var someExpr = parse(optionalMatchExpr.caseSome);
         varTypes.remove(name);
@@ -358,7 +357,10 @@ public class RailScriptExprParser {
     @SuppressWarnings("unchecked")
     private RSExpr<RSOptional<?>> parseOptionalExpr(RJSRSExpr rjsExpr) throws InvalidInfraException {
         var expr = parse(rjsExpr);
-        checkExprType(RSType.OPTIONAL, expr);
+        var exprType = expr.getType(argTypes);
+        if (exprType != RSType.OPTIONAL_ROUTE && exprType != RSType.OPTIONAL_SIGNAL)
+            throw new InvalidInfraException(String.format(
+                    "type mismatch: expected an optional, got %s", exprType.toString()));
         return (RSExpr<RSOptional<?>>) expr;
     }
 

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
@@ -271,6 +271,9 @@ public class RailScriptExprParser {
         var someExpr = parse(optionalMatchExpr.caseSome);
         varTypes.remove(name);
 
+        if (noneExpr.getType(argTypes) != someExpr.getType(argTypes))
+            throw new InvalidInfraException("Mismatched types in optional branches");
+
         @SuppressWarnings({"unchecked", "rawtypes"})
         var res = new RSExpr.OptionalMatch(contentExpr, noneExpr, someExpr, name);
         return res;

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
@@ -15,7 +15,6 @@ import fr.sncf.osrd.infra.railscript.RSStatefulExpr;
 import fr.sncf.osrd.infra_state.RouteStatus;
 import fr.sncf.osrd.infra.signaling.Aspect;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 
 public class RailScriptExprParser {

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
@@ -38,8 +38,7 @@ public class RJSRoute implements Identified {
             Map<ID<RJSSwitch>, RJSSwitch.Position> switchesPosition,
             List<ID<RJSRouteWaypoint>> waypoints,
             List<Set<ID<RJSTVDSection>>> releaseGroups,
-            ID<RJSSignal> entrySignal,
-            List<ID<RJSSignal>> signals
+            ID<RJSSignal> entrySignal
     ) {
         this.id = id;
         this.tvdSections = tvdSections;

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
@@ -31,10 +31,6 @@ public class RJSRoute implements Identified {
     @Json(name = "entry_signal")
     public ID<RJSSignal> entrySignal;
 
-    /** List of the signals placed on the route, does not include entrySignal */
-    @Json(name = "signals")
-    public List<ID<RJSSignal>> signals;
-
     /** Routes are described as a list of waypoints, TVD Sections and Switches in specific positions */
     public RJSRoute(
             String id,
@@ -51,7 +47,6 @@ public class RJSRoute implements Identified {
         this.waypoints = waypoints;
         this.releaseGroups = releaseGroups;
         this.entrySignal = entrySignal;
-        this.signals = signals;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json;
 import fr.sncf.osrd.railjson.schema.common.ID;
 import fr.sncf.osrd.railjson.schema.common.Identified;
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSRouteWaypoint;
+import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal;
 
 import java.util.Map;
 import java.util.List;
@@ -26,19 +27,31 @@ public class RJSRoute implements Identified {
     @Json(name = "release_groups")
     public List<Set<ID<RJSTVDSection>>> releaseGroups;
 
+    /** Signal placed just before the route, may be empty if no entry signal */
+    @Json(name = "entry_signal")
+    public ID<RJSSignal> entrySignal;
+
+    /** List of the signals placed on the route, does not include entrySignal */
+    @Json(name = "signals")
+    public List<ID<RJSSignal>> signals;
+
     /** Routes are described as a list of waypoints, TVD Sections and Switches in specific positions */
     public RJSRoute(
             String id,
             List<ID<RJSTVDSection>> tvdSections,
             Map<ID<RJSSwitch>, RJSSwitch.Position> switchesPosition,
             List<ID<RJSRouteWaypoint>> waypoints,
-            List<Set<ID<RJSTVDSection>>> releaseGroups
+            List<Set<ID<RJSTVDSection>>> releaseGroups,
+            ID<RJSSignal> entrySignal,
+            List<ID<RJSSignal>> signals
     ) {
         this.id = id;
         this.tvdSections = tvdSections;
         this.switchesPosition = switchesPosition;
         this.waypoints = waypoints;
         this.releaseGroups = releaseGroups;
+        this.entrySignal = entrySignal;
+        this.signals = signals;
     }
 
     @Override

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
@@ -254,14 +254,15 @@ public abstract class RJSRSExpr {
     public static final class OptionalMatch extends RJSRSExpr implements Identified {
         public RJSRSExpr expr;
 
-        @Json(name="case_none")
+        @Json(name = "case_none")
         public RJSRSExpr caseNone;
 
-        @Json(name="case_some")
+        @Json(name = "case_some")
         public RJSRSExpr caseSome;
 
         public String name;
 
+        /** Matches an optional with an expression, depending on its content */
         public OptionalMatch(
                 RJSRSExpr expr,
                 RJSRSExpr caseNone,
@@ -294,7 +295,7 @@ public abstract class RJSRSExpr {
     }
 
     public static final class OptionalMatchRef extends RJSRSExpr {
-        @Json(name="match_name")
+        @Json(name = "match_name")
         public ID<OptionalMatch> optionalMatchName;
 
         public OptionalMatchRef(ID<OptionalMatch> optionalMatchName) {

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.common.ID;
+import fr.sncf.osrd.railjson.schema.common.Identified;
 import fr.sncf.osrd.railjson.schema.infra.RJSRoute;
 import fr.sncf.osrd.railjson.schema.infra.RJSSwitch;
 import fr.sncf.osrd.railjson.schema.infra.signaling.RJSAspect;
@@ -104,8 +105,10 @@ public abstract class RJSRSExpr {
                     .withSubtype(If.class, "condition")
                     .withSubtype(Call.class, "call")
                     .withSubtype(EnumMatch.class, "match")
-                    // function-specific
+                    .withSubtype(OptionalMatch.class, "optional_match")
+                    // references
                     .withSubtype(ArgumentRef.class, "argument_ref")
+                    .withSubtype(OptionalMatchRef.class, "optional_match_ref")
                     // primitives
                     .withSubtype(Delay.class, "delay")
                     .withSubtype(SignalAspectCheck.class, "signal_has_aspect")
@@ -247,9 +250,38 @@ public abstract class RJSRSExpr {
         }
     }
 
+    public static final class OptionalMatch extends RJSRSExpr implements Identified {
+        public RJSRSExpr expr;
+
+        @Json(name="case_none")
+        public RJSRSExpr caseNone;
+
+        @Json(name="case_some")
+        public RJSRSExpr caseSome;
+
+        public String name;
+
+        public OptionalMatch(
+                RJSRSExpr expr,
+                RJSRSExpr caseNone,
+                RJSRSExpr caseSome,
+                String name
+        ) {
+            this.expr = expr;
+            this.caseNone = caseNone;
+            this.caseSome = caseSome;
+            this.name = name;
+        }
+
+        @Override
+        public String getID() {
+            return name;
+        }
+    }
+
     // endregion
 
-    // region FUNCTION_SPECIFIC
+    // region REFERENCES
 
     public static final class ArgumentRef extends RJSRSExpr {
         @Json(name = "argument_name")
@@ -257,6 +289,15 @@ public abstract class RJSRSExpr {
 
         public ArgumentRef(String argumentName) {
             this.argumentName = argumentName;
+        }
+    }
+
+    public static final class OptionalMatchRef extends RJSRSExpr {
+        @Json(name="optional_match_name")
+        public ID<OptionalMatch> optionalMatchName;
+
+        public OptionalMatchRef(ID<OptionalMatch> optionalMatchName) {
+            this.optionalMatchName = optionalMatchName;
         }
     }
 

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
@@ -2,7 +2,6 @@ package fr.sncf.osrd.railjson.schema.infra.railscript;
 
 import com.squareup.moshi.Json;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.common.ID;
 import fr.sncf.osrd.railjson.schema.common.Identified;
 import fr.sncf.osrd.railjson.schema.infra.RJSRoute;
@@ -114,6 +113,8 @@ public abstract class RJSRSExpr {
                     .withSubtype(SignalAspectCheck.class, "signal_has_aspect")
                     .withSubtype(RouteStateCheck.class, "route_has_state")
                     .withSubtype(AspectSetContains.class, "aspect_set_contains")
+                    .withSubtype(ReservedRoute.class, "reserved_route")
+                    .withSubtype(NextSignal.class, "next_signal")
     );
 
     // region BOOLEAN_LOGIC
@@ -293,7 +294,7 @@ public abstract class RJSRSExpr {
     }
 
     public static final class OptionalMatchRef extends RJSRSExpr {
-        @Json(name="optional_match_name")
+        @Json(name="match_name")
         public ID<OptionalMatch> optionalMatchName;
 
         public OptionalMatchRef(ID<OptionalMatch> optionalMatchName) {
@@ -370,6 +371,40 @@ public abstract class RJSRSExpr {
         public AspectSetContains(RJSRSExpr aspectSet, ID<RJSAspect> aspect) {
             this.aspectSet = aspectSet;
             this.aspect = aspect;
+        }
+    }
+
+    /**
+     * Returns the current reserved route containing the signal, if any
+     */
+    public static final class ReservedRoute extends RJSRSExpr {
+        /**
+         * The expression giving the signal to look for.
+         */
+        public RJSRSExpr signal;
+
+        public ReservedRoute(RJSRSExpr signal) {
+            this.signal = signal;
+        }
+    }
+
+    /**
+     * Returns the next signal on the given route, if any
+     */
+    public static final class NextSignal extends RJSRSExpr {
+        /**
+         * The expression giving the signal used as reference, assumed to be on the route.
+         */
+        public RJSRSExpr signal;
+
+        /**
+         * The expression giving the route to follow.
+         */
+        public RJSRSExpr route;
+
+        public NextSignal(RJSRSExpr signal, RJSRSExpr route) {
+            this.signal = signal;
+            this.route = route;
         }
     }
     // endregion

--- a/src/main/java/fr/sncf/osrd/railml/RMLRoute.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLRoute.java
@@ -61,11 +61,20 @@ public class RMLRoute {
                     false, route, rmlRouteGraph, rjsTrackSections, graph, signalTrackNetElementMap);
             var rmlRouteWaypoints = computeRouteWaypoints(entryWaypoint, exitWaypoint, rmlRouteGraph);
             var routeWaypoints = rmlToRjsWaypoints(rmlRouteWaypoints, rjsWaypointsMap);
+            var entrySignal = parseEntrySignal(route, signalTrackNetElementMap);
 
-            res.add(new RJSRoute(id, tvdSections, switchesPosition, routeWaypoints, releaseGroups,
-                    null, new ArrayList<>()));
+            res.add(new RJSRoute(id, tvdSections, switchesPosition, routeWaypoints, releaseGroups, entrySignal));
         }
         return res;
+    }
+
+    private static ID<RJSSignal> parseEntrySignal(Element route, HashMap<String, TrackNetElement> signalTrackNets) {
+        var entryElement = route.element("routeEntry").element("refersTo").attributeValue("ref");
+        var isSignal = signalTrackNets.keySet().contains(entryElement);
+        if (isSignal)
+            return new ID<>(entryElement);
+        else
+            return new ID<>("");
     }
 
     private static List<Set<ID<RJSTVDSection>>> parseReleaseGroups(

--- a/src/main/java/fr/sncf/osrd/railml/RMLRoute.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLRoute.java
@@ -62,7 +62,8 @@ public class RMLRoute {
             var rmlRouteWaypoints = computeRouteWaypoints(entryWaypoint, exitWaypoint, rmlRouteGraph);
             var routeWaypoints = rmlToRjsWaypoints(rmlRouteWaypoints, rjsWaypointsMap);
 
-            res.add(new RJSRoute(id, tvdSections, switchesPosition, routeWaypoints, releaseGroups));
+            res.add(new RJSRoute(id, tvdSections, switchesPosition, routeWaypoints, releaseGroups,
+                    null, new ArrayList<>()));
         }
         return res;
     }

--- a/src/main/java/fr/sncf/osrd/utils/SortedSequence.java
+++ b/src/main/java/fr/sncf/osrd/utils/SortedSequence.java
@@ -86,7 +86,10 @@ public abstract class SortedSequence<E> {
                 throw new NoSuchElementException();
 
             var res = data.get(i);
-            return new PointValue<E>(translator.applyAsDouble(res.position), res.value);
+            var position = res.position;
+            if (translator != null)
+                position = translator.applyAsDouble(position);
+            return new PointValue<E>(position, res.value);
         }
 
         @Override
@@ -120,7 +123,10 @@ public abstract class SortedSequence<E> {
                 throw new NoSuchElementException();
 
             var res = data.get(i);
-            return new PointValue<E>(translator.applyAsDouble(res.position), res.value);
+            var position = res.position;
+            if (translator != null)
+                position = translator.applyAsDouble(position);
+            return new PointValue<E>(position, res.value);
         }
 
         @Override

--- a/src/test/java/fr/sncf/osrd/Helpers.java
+++ b/src/test/java/fr/sncf/osrd/Helpers.java
@@ -139,9 +139,14 @@ public class Helpers {
 
     /** Generates the defaults infra from tiny_infra/infra.json, to be edited for each test */
     public static RJSInfra getBaseInfra() {
+        return getBaseInfra("tiny_infra/infra.json");
+    }
+
+    /** Generates the defaults infra from the specified path */
+    public static RJSInfra getBaseInfra(String path) {
         try {
             ClassLoader classLoader = Helpers.class.getClassLoader();
-            var infraPath = classLoader.getResource("tiny_infra/infra.json");
+            var infraPath = classLoader.getResource(path);
             assert infraPath != null;
             var fileSource = Okio.source(Path.of(infraPath.getFile()));
             var bufferedSource = Okio.buffer(fileSource);

--- a/src/test/java/fr/sncf/osrd/Helpers.java
+++ b/src/test/java/fr/sncf/osrd/Helpers.java
@@ -159,9 +159,9 @@ public class Helpers {
     }
 
     /** Generates the defaults config from tiny_infra/config_railjson.json */
-    public static Config getBaseConfig() {
+    public static Config getBaseConfig(String path) {
         ClassLoader classLoader = Helpers.class.getClassLoader();
-        var configPath = classLoader.getResource("tiny_infra/config_railjson.json");
+        var configPath = classLoader.getResource(path);
         assert configPath != null;
         try {
             return Config.readFromFile(Path.of(configPath.getFile()));
@@ -169,6 +169,11 @@ public class Helpers {
             fail(e);
             return null;
         }
+    }
+
+    /** Generates the defaults config from tiny_infra/config_railjson.json */
+    public static Config getBaseConfig() {
+        return getBaseConfig("tiny_infra/config_railjson.json");
     }
 
     /** Go through all the events in the simulation, fails if an exception is thrown */

--- a/src/test/java/fr/sncf/osrd/RouteGraphTest.java
+++ b/src/test/java/fr/sncf/osrd/RouteGraphTest.java
@@ -60,8 +60,7 @@ public class RouteGraphTest {
             releaseGroups.add(releaseGroup);
         }
 
-        return builder.makeRoute(id, waypoints, tvdSections, releaseGroups, null, null,
-                new ArrayList<>());
+        return builder.makeRoute(id, waypoints, tvdSections, releaseGroups, null, null);
     }
 
     /**

--- a/src/test/java/fr/sncf/osrd/RouteGraphTest.java
+++ b/src/test/java/fr/sncf/osrd/RouteGraphTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Optional;
 
 public class RouteGraphTest {
 
@@ -59,7 +60,8 @@ public class RouteGraphTest {
             releaseGroups.add(releaseGroup);
         }
 
-        return builder.makeRoute(id, waypoints, tvdSections, releaseGroups, null);
+        return builder.makeRoute(id, waypoints, tvdSections, releaseGroups, null, null,
+                new ArrayList<>());
     }
 
     /**

--- a/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
+++ b/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
@@ -88,8 +88,7 @@ public class StaticSpeedLimitTest {
         releaseGroup.add(tvdSection);
         releaseGroups.add(releaseGroup);
         var route = routeGraphBuilder.makeRoute(
-                "R1", waypointsAB, tvdSectionsR1, releaseGroups, new HashMap<>(), null,
-                new ArrayList<>());
+                "R1", waypointsAB, tvdSectionsR1, releaseGroups, new HashMap<>(), null);
 
         final var infra = Infra.build(trackGraph, waypointGraph, routeGraphBuilder.build(),
                 tvdSections, new HashMap<>(), new ArrayList<>(), new ArrayList<>());

--- a/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
+++ b/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -87,7 +88,8 @@ public class StaticSpeedLimitTest {
         releaseGroup.add(tvdSection);
         releaseGroups.add(releaseGroup);
         var route = routeGraphBuilder.makeRoute(
-                "R1", waypointsAB, tvdSectionsR1, releaseGroups, new HashMap<>());
+                "R1", waypointsAB, tvdSectionsR1, releaseGroups, new HashMap<>(), null,
+                new ArrayList<>());
 
         final var infra = Infra.build(trackGraph, waypointGraph, routeGraphBuilder.build(),
                 tvdSections, new HashMap<>(), new ArrayList<>(), new ArrayList<>());

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/DependencyResolutionTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/DependencyResolutionTests.java
@@ -1,0 +1,37 @@
+package fr.sncf.osrd.railjson.schema.infra.railscript;
+
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.railjson.parser.RailJSONParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static fr.sncf.osrd.Helpers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DependencyResolutionTests {
+
+    @Test
+    public void testDependencyResolution() throws InvalidInfraException {
+        var infra = getBaseInfra("tiny_infra/infra_optional.json");
+        assert infra != null;
+        var config = getBaseConfig("tiny_infra/config_railjson_optional.json");
+        assert config != null;
+
+        var signals = RailJSONParser.parse(infra).signals;
+        var expectedMap = new HashMap<String, HashSet<String>>();
+        expectedMap.put("il.sig.C1", new HashSet<>());
+        expectedMap.put("il.sig.C2", new HashSet<>());
+        expectedMap.put("il.sig.C3", new HashSet<>());
+        expectedMap.put("il.sig.C6", new HashSet<>(Collections.singletonList("il.sig.W4")));
+        expectedMap.put("il.sig.S7", new HashSet<>(Collections.singletonList("il.sig.W5")));
+        expectedMap.put("il.sig.W4", new HashSet<>(Collections.singletonList("il.sig.C2")));
+        expectedMap.put("il.sig.W5", new HashSet<>(Arrays.asList("il.sig.C3", "il.sig.C1")));
+        for (var s : signals) {
+            var res = s.signalSubscribers.stream().map(x -> x.id).collect(Collectors.toSet());
+            assertEquals(expectedMap.get(s.id), res);
+        }
+    }
+
+}

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/DependencyResolutionTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/DependencyResolutionTests.java
@@ -1,14 +1,14 @@
 package fr.sncf.osrd.railjson.schema.infra.railscript;
 
+import static fr.sncf.osrd.Helpers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.railjson.parser.RailJSONParser;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static fr.sncf.osrd.Helpers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DependencyResolutionTests {
 
@@ -19,7 +19,6 @@ public class DependencyResolutionTests {
         var config = getBaseConfig("tiny_infra/config_railjson_optional.json");
         assert config != null;
 
-        var signals = RailJSONParser.parse(infra).signals;
         var expectedMap = new HashMap<String, HashSet<String>>();
         expectedMap.put("il.sig.C1", new HashSet<>());
         expectedMap.put("il.sig.C2", new HashSet<>());
@@ -28,7 +27,7 @@ public class DependencyResolutionTests {
         expectedMap.put("il.sig.S7", new HashSet<>(Collections.singletonList("il.sig.W5")));
         expectedMap.put("il.sig.W4", new HashSet<>(Collections.singletonList("il.sig.C2")));
         expectedMap.put("il.sig.W5", new HashSet<>(Arrays.asList("il.sig.C3", "il.sig.C1")));
-        for (var s : signals) {
+        for (var s : RailJSONParser.parse(infra).signals) {
             var res = s.signalSubscribers.stream().map(x -> x.id).collect(Collectors.toSet());
             assertEquals(expectedMap.get(s.id), res);
         }

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
@@ -1,0 +1,62 @@
+package fr.sncf.osrd.railjson.schema.infra.railscript;
+
+import static fr.sncf.osrd.Helpers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.railjson.parser.RailJSONParser;
+import fr.sncf.osrd.railjson.parser.RailScriptExprParser;
+import fr.sncf.osrd.railjson.schema.common.ID;
+import fr.sncf.osrd.railjson.schema.infra.RJSSwitch;
+import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal;
+import fr.sncf.osrd.simulation.Simulation;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+public class OptionalTests {
+
+    @Test
+    public void testSignalsFunctionWithOptionals() throws InvalidInfraException {
+        var infra = getBaseInfra("tiny_infra/infra_optional.json");
+        assert infra != null;
+        var config = getBaseConfig();
+        assert config != null;
+
+        // We force a (very long) switch change, to make sure signals are necessary
+        infra.routes.forEach((route) -> {
+            var positions = route.switchesPosition;
+            positions.replaceAll((k, v) -> RJSSwitch.Position.RIGHT);
+        });
+        infra.switches.iterator().next().positionChangeDelay = 42;
+
+        var sim = Simulation.createFromInfra(RailJSONParser.parse(infra), 0, null);
+        run(sim, config);
+    }
+
+    @Test
+    void testThrowOnInvalidDelay() throws InvalidInfraException {
+        var infra = getBaseInfra("tiny_infra/infra_optional.json");
+        assert infra != null;
+        var sim = Simulation.createFromInfra(RailJSONParser.parse(infra), 0, null);
+        var trueExpr = new RJSRSExpr.True();
+        var delay = new RJSRSExpr.Delay(0, trueExpr);
+        var signalId = new ID<RJSSignal>(sim.infraState.getSignalState(0).signal.id);
+        var optional = new RJSRSExpr.ReservedRoute(new RJSRSExpr.SignalRef(signalId));
+
+
+        assertThrows(InvalidInfraException.class,
+                () -> tryInstanciate(sim, new RJSRSExpr.OptionalMatch(optional, trueExpr, delay, "foo")),
+                "Expected an invalid infra because of the delay in the match expression"
+        );
+        // but no exception here (delays are in the other branches)
+        tryInstanciate(sim, new RJSRSExpr.OptionalMatch(optional, delay, trueExpr, "foo"));
+        tryInstanciate(sim, new RJSRSExpr.OptionalMatch(
+                new RJSRSExpr.Delay(0, optional), trueExpr, trueExpr, "foo")
+        );
+    }
+
+    static void tryInstanciate(Simulation sim, RJSRSExpr expr) throws InvalidInfraException {
+        new RailScriptExprParser(sim.infra.aspects, new HashMap<>()).parse(expr);
+    }
+}

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
@@ -21,7 +21,7 @@ public class OptionalTests {
     public void testSignalsFunctionWithOptionals() throws InvalidInfraException {
         var infra = getBaseInfra("tiny_infra/infra_optional.json");
         assert infra != null;
-        var config = getBaseConfig();
+        var config = getBaseConfig("tiny_infra/config_railjson_optional.json");
         assert config != null;
 
         // We force a (very long) switch change, to make sure signals are necessary
@@ -40,7 +40,7 @@ public class OptionalTests {
         // Other half the test above: we check that invalid signals would have failed
         var infra = getBaseInfra("tiny_infra/infra_optional.json");
         assert infra != null;
-        var config = getBaseConfig();
+        var config = getBaseConfig("tiny_infra/config_railjson_optional.json");
         assert config != null;
 
         var functions = infra.scriptFunctions;

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/OptionalTests.java
@@ -44,7 +44,6 @@ public class OptionalTests {
         var signalId = new ID<RJSSignal>(sim.infraState.getSignalState(0).signal.id);
         var optional = new RJSRSExpr.ReservedRoute(new RJSRSExpr.SignalRef(signalId));
 
-
         assertThrows(InvalidInfraException.class,
                 () -> tryInstanciate(sim, new RJSRSExpr.OptionalMatch(optional, trueExpr, delay, "foo")),
                 "Expected an invalid infra because of the delay in the match expression"

--- a/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/RailScriptTests.java
+++ b/src/test/java/fr/sncf/osrd/railjson/schema/infra/railscript/RailScriptTests.java
@@ -165,7 +165,9 @@ public class RailScriptTests extends RSHelpers {
         var m = sim.infra.aspects;
         RSExpr<?> rsMatch = new RailScriptExprParser(m, RJSGenerator.functions).parse(matchExpr);
         assert rsMatch instanceof RSExpr.OptionalMatch;
-        var rsExpr = ((RSExpr.OptionalMatch<?>) rsMatch).expr;
+
+        @SuppressWarnings("unchecked")
+        RSExpr<RSOptional<RouteState>> rsExpr = ((RSExpr.OptionalMatch<RouteState>) rsMatch).expr;
         assert rsExpr instanceof RSExpr.ReservedRoute;
         var signalRef = ((RSExpr.ReservedRoute) rsExpr).signal;
         assert signalRef instanceof RSExpr.SignalRef;

--- a/src/test/java/fr/sncf/osrd/simulation/TrainReactionTest.java
+++ b/src/test/java/fr/sncf/osrd/simulation/TrainReactionTest.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.simulation;
 
 import static fr.sncf.osrd.Helpers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import fr.sncf.osrd.infra.InvalidInfraException;
@@ -46,12 +47,10 @@ public class TrainReactionTest {
             var train = sim.trains.values().iterator().next();
             assert train.lastScheduledEvent == null;
         });
-        try {
-            runWithExceptions(sim);
-        } catch (SimulationError e) {
-            return;
-        }
-        fail("With all lights green, we expected a simulation error (train didn't wait for the switch)");
+        assertThrows(SimulationError.class,
+                () -> runWithExceptions(sim),
+                "Expected a simulation error once the train goes through the switch"
+        );
     }
 
     @Test


### PR DESCRIPTION
Fixes #33 

Add primitives to simplify railscript

 - [x] Add signal list for routes.
   - [x] Add it to the infra.
   - [x] Add it in railjson.
   - [x] Parse it from railml.
 - [x] Add `Optional` type
 - [x] Add `reserved_route(Signal) -> Optional<Route>` primitive
 - [x] Add `next_signal(Signal, Route) -> Optional<Signal>` primitive
 - [x] Handle the dependencies resolution
 - [x] Document everything
 - [x] Add static checks wherever possible (like delays in optional "some" branches)
 - [x] Test everything

Example of matched Optional:

```rust
match Some("test") {
    Some(signal): AspectSet { GREEN },
    None: AspectSet { RED }
}
```
```rust
match reserved_route(current_signal) {
    Some(route): AspectSet {
        match next_signal(current_signal) {
            Some(signal): AspectSet {
                GREEN,
                YELLOW if signal_has_aspect(signal, RED)
            },
            None: AspectSet { YELLOW }
        }
    },
    None: AspectSet { RED }
}
```
