### PR TITLE
API Pathfinding Routes: add operational points

### DIFF
--- a/examples/circular_infra/infra.json
+++ b/examples/circular_infra/infra.json
@@ -372,8 +372,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station"
         }
       ],

--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -483,8 +483,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_foo"
         }
       ],
@@ -629,8 +628,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_foo"
         }
       ],
@@ -678,8 +676,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_bar"
         }
       ],

--- a/examples/tiny_infra/infra_optional.json
+++ b/examples/tiny_infra/infra_optional.json
@@ -509,8 +509,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_foo"
         }
       ],
@@ -651,8 +650,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_foo"
         }
       ],
@@ -696,8 +694,7 @@
       "length": 200,
       "operational_points": [
         {
-          "begin": 100,
-          "end": 100,
+          "position": 100,
           "ref": "op.station_bar"
         }
       ],

--- a/src/main/java/fr/sncf/osrd/DebugViewer.java
+++ b/src/main/java/fr/sncf/osrd/DebugViewer.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 // caused by the temporary opRef.begin == opRef.end
-@SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY", "SIC_INNER_SHOULD_BE_STATIC_ANON"})
+@SuppressFBWarnings({"SIC_INNER_SHOULD_BE_STATIC_ANON"})
 public class DebugViewer extends ChangeConsumer {
     static final Logger logger = LoggerFactory.getLogger(DebugViewer.class);
 
@@ -130,20 +130,14 @@ public class DebugViewer extends ChangeConsumer {
                 graph.getNode(endId).setAttribute("y", edge.endpointCoords.get(1).get(1));
             }
 
-            edge.operationalPoints.getAll((opRef) -> {
-                // operational points can be point-like objects, or ranges
-                // !! this check causes a linter warning, which has to be waived for the whole class
-                if (opRef.begin == opRef.end) {
-                    double pos = opRef.begin / edge.length;
-                    var opRefID = encodeSpriteId(opRef.op.id + "@" + edge.id);
-                    var sprite = spriteManager.addSprite(opRefID);
-                    sprite.attachToEdge(edge.id);
-                    sprite.setPosition(pos);
-                    sprite.setAttribute("ui.style", POINT_OP_CSS);
-                    sprite.setAttribute("ui.label", opRef.op.id);
-                } else {
-                    throw new RuntimeException("");
-                }
+            edge.operationalPoints.forEach((opRef) -> {
+                double pos = opRef.position / edge.length;
+                var opRefID = encodeSpriteId(opRef.value.id + "@" + edge.id);
+                var sprite = spriteManager.addSprite(opRefID);
+                sprite.attachToEdge(edge.id);
+                sprite.setPosition(pos);
+                sprite.setAttribute("ui.style", POINT_OP_CSS);
+                sprite.setAttribute("ui.label", opRef.value.id);
             });
 
             for (var signal : edge.signals) {

--- a/src/main/java/fr/sncf/osrd/api/PathfindingEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingEndpoint.java
@@ -52,15 +52,13 @@ public abstract class PathfindingEndpoint implements Take {
     protected static class TrackSectionRangeResult {
         @Json(name = "track_section")
         private final String trackSection;
-        @Json(name = "begin_position")
-        private final double beginPosition;
-        @Json(name = "end_position")
-        private final double endPosition;
+        private final double begin;
+        private final double end;
 
         protected TrackSectionRangeResult(String trackSection, double beginPosition, double endPosition) {
             this.trackSection = trackSection;
-            this.beginPosition = beginPosition;
-            this.endPosition = endPosition;
+            this.begin = beginPosition;
+            this.end = endPosition;
         }
     }
 }

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -6,9 +6,12 @@ import com.squareup.moshi.Moshi;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.infra.OperationalPoint;
 import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra.routegraph.RouteLocation;
+import fr.sncf.osrd.infra.trackgraph.TrackSection;
 import fr.sncf.osrd.train.TrackSectionRange;
+import fr.sncf.osrd.utils.TrackSectionLocation;
 import fr.sncf.osrd.utils.graph.Dijkstra;
 import fr.sncf.osrd.utils.graph.DistCostFunction;
 import fr.sncf.osrd.utils.graph.EdgeDirection;
@@ -23,6 +26,7 @@ import org.takes.rs.RsWithStatus;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
@@ -127,8 +131,7 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
             candidatePaths.add(pathsToGoal.get(pathsToGoal.size() - 1));
         }
 
-        var resRoutes = (ArrayList<Route>[]) new ArrayList[reqWaypoints.length - 1];
-        var resTrackSections = (ArrayList<TrackSectionRange>[]) new ArrayList[reqWaypoints.length - 1];
+        var res = new PathfindingResult[reqWaypoints.length - 1];
 
         for (int i = 0; i < pathsToGoal.size(); i++) {
             var path = FullPathArray.from(pathsToGoal.get(i));
@@ -144,13 +147,22 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                     routes.add(node.edge);
             }
 
-            resRoutes[i] = routes;
-            resTrackSections[i] = Route.routesToTrackSectionRange(routes, beginLoc, endLoc);
+            var entry = new PathfindingResult();
+            for (int j = 0; j < routes.size(); j++) {
+                TrackSectionLocation begin = null;
+                TrackSectionLocation end = null;
+                if (j == 0)
+                    begin = beginLoc;
+                if (j == routes.size() - 1)
+                    end = endLoc;
+                var route = routes.get(i);
+                var trackSections = Route.routesToTrackSectionRange(
+                        Collections.singletonList(route), begin, end);
+                entry.add(route, trackSections);
+            }
+            res[i] = entry;
         }
-        var result = new PathfindingResult[resRoutes.length];
-        for (int i = 0; i < resRoutes.length; i++)
-            result[i] = PathfindingResult.from(resRoutes[i], resTrackSections[i]);
-        return new RsJson(new RsWithBody(adapterResult.toJson(result)));
+        return new RsJson(new RsWithBody(adapterResult.toJson(res)));
     }
 
     @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
@@ -160,24 +172,55 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
 
     @SuppressFBWarnings({"URF_UNREAD_FIELD", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class PathfindingResult {
-        public final List<String> routes;
-        @Json(name = "track_sections")
-        public final List<TrackSectionRangeResult> trackSections;
+        public final List<RouteResult> routes;
+        public final List<OperationalPointResult> operationalPoints;
 
-        private PathfindingResult(List<String> routes, List<TrackSectionRangeResult> trackSections) {
-            this.routes = routes;
-            this.trackSections = trackSections;
+        private PathfindingResult() {
+            routes = new ArrayList<>();
+            operationalPoints = new ArrayList<>();
         }
 
-        static PathfindingResult from(List<Route> routes, List<TrackSectionRange> trackSections) {
-            var resRoutes = new ArrayList<String>();
-            var resTrackSections = new ArrayList<TrackSectionRangeResult>();
-            for (var route : routes)
-                resRoutes.add(route.id);
-            for (var track : trackSections)
-                resTrackSections.add(new TrackSectionRangeResult(
-                        track.edge.id, track.getBeginPosition(), track.getEndPosition()));
-            return new PathfindingResult(resRoutes, resTrackSections);
+        public void add(Route route, List<TrackSectionRange> trackSections) {
+            var routeResult = new RouteResult();
+            routeResult.route = route.id;
+            routeResult.trackSections = new ArrayList<>();
+            for (var trackSection : trackSections) {
+                var trackSectionResult = new TrackSectionRangeResult(trackSection.edge.id,
+                        trackSection.getBeginPosition(),
+                        trackSection.getEndPosition());
+                routeResult.trackSections.add(trackSectionResult);
+                trackSection.edge.operationalPoints.getAll(
+                        op -> operationalPoints.add(new OperationalPointResult(op, trackSection.edge))
+                );
+            }
+            routes.add(routeResult);
+        }
+
+        public static class RouteResult {
+            public String route;
+            @Json(name = "track_sections")
+            public List<TrackSectionRangeResult> trackSections;
+        }
+
+        public static class OperationalPointResult {
+            public String op;
+            public PositionResult position;
+            public OperationalPointResult(OperationalPoint.Ref op, TrackSection trackSection) {
+                this.op = op.op.id;
+                this.position = new PositionResult(trackSection.id, op.begin); // TODO ech: remove op.end
+            }
+        }
+
+        public static class PositionResult {
+            @Json(name = "track_section")
+            public String trackSection;
+
+            public double offset;
+
+            public PositionResult(String trackSection, double offset) {
+                this.offset = offset;
+                this.trackSection = trackSection;
+            }
         }
     }
 }

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -155,7 +155,7 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                     begin = beginLoc;
                 if (j == routes.size() - 1)
                     end = endLoc;
-                var route = routes.get(i);
+                var route = routes.get(j);
                 var trackSections = Route.routesToTrackSectionRange(
                         Collections.singletonList(route), begin, end);
                 entry.add(route, trackSections);

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -190,10 +190,7 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                         trackSection.getEndPosition());
                 routeResult.trackSections.add(trackSectionResult);
                 trackSection.edge.operationalPoints.getAll(op -> {
-                    var lastOpId = "";
-                    if (!operationalPoints.isEmpty())
-                        lastOpId = operationalPoints.get(operationalPoints.size() - 1).op;
-                    if (!lastOpId.equals(op.op.id))
+                    if (trackSection.containsPosition(op.begin))
                         operationalPoints.add(new OperationalPointResult(op, trackSection.edge));
                 });
             }

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -173,11 +173,11 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
 
     @SuppressFBWarnings({"URF_UNREAD_FIELD", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class PathfindingResult {
-        public final List<RouteResult> routes;
+        public final List<RouteResult> path;
         public final List<OperationalPointResult> operationalPoints;
 
         private PathfindingResult() {
-            routes = new ArrayList<>();
+            path = new ArrayList<>();
             operationalPoints = new ArrayList<>();
         }
 
@@ -195,7 +195,7 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                         operationalPoints.add(new OperationalPointResult(op, trackSection.edge));
                 }
             }
-            routes.add(routeResult);
+            path.add(routeResult);
         }
 
         public static class RouteResult {

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -11,6 +11,7 @@ import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra.routegraph.RouteLocation;
 import fr.sncf.osrd.infra.trackgraph.TrackSection;
 import fr.sncf.osrd.train.TrackSectionRange;
+import fr.sncf.osrd.utils.PointValue;
 import fr.sncf.osrd.utils.TrackSectionLocation;
 import fr.sncf.osrd.utils.graph.Dijkstra;
 import fr.sncf.osrd.utils.graph.DistCostFunction;
@@ -189,8 +190,8 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                         trackSection.getBeginPosition(),
                         trackSection.getEndPosition());
                 routeResult.trackSections.add(trackSectionResult);
-                trackSection.edge.operationalPoints.getAll(op -> {
-                    if (trackSection.containsPosition(op.begin))
+                trackSection.edge.operationalPoints.forEach(op -> {
+                    if (trackSection.containsPosition(op.position))
                         operationalPoints.add(new OperationalPointResult(op, trackSection.edge));
                 });
             }
@@ -206,9 +207,9 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
         public static class OperationalPointResult {
             public String op;
             public PositionResult position;
-            public OperationalPointResult(OperationalPoint.Ref op, TrackSection trackSection) {
-                this.op = op.op.id;
-                this.position = new PositionResult(trackSection.id, op.begin); // TODO ech: remove op.end
+            public OperationalPointResult(PointValue<OperationalPoint> op, TrackSection trackSection) {
+                this.op = op.value.id;
+                this.position = new PositionResult(trackSection.id, op.position);
             }
         }
 

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -190,10 +190,10 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                         trackSection.getBeginPosition(),
                         trackSection.getEndPosition());
                 routeResult.trackSections.add(trackSectionResult);
-                trackSection.edge.operationalPoints.forEach(op -> {
+                for (var op : trackSection.edge.operationalPoints) {
                     if (trackSection.containsPosition(op.position))
                         operationalPoints.add(new OperationalPointResult(op, trackSection.edge));
-                });
+                }
             }
             routes.add(routeResult);
         }

--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -189,9 +189,13 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
                         trackSection.getBeginPosition(),
                         trackSection.getEndPosition());
                 routeResult.trackSections.add(trackSectionResult);
-                trackSection.edge.operationalPoints.getAll(
-                        op -> operationalPoints.add(new OperationalPointResult(op, trackSection.edge))
-                );
+                trackSection.edge.operationalPoints.getAll(op -> {
+                    var lastOpId = "";
+                    if (!operationalPoints.isEmpty())
+                        lastOpId = operationalPoints.get(operationalPoints.size() - 1).op;
+                    if (!lastOpId.equals(op.op.id))
+                        operationalPoints.add(new OperationalPointResult(op, trackSection.edge));
+                });
             }
             routes.add(routeResult);
         }

--- a/src/main/java/fr/sncf/osrd/infra/Infra.java
+++ b/src/main/java/fr/sncf/osrd/infra/Infra.java
@@ -133,9 +133,9 @@ public final class Infra {
                 forwardBuilder.add(waypoint.position, waypoint.value);
                 backwardBuilder.add(waypoint.position, waypoint.value);
             }
-            trackSection.operationalPoints.getAll(op -> {
-                        forwardBuilder.add(op.begin, op.op);
-                        backwardBuilder.add(op.end, op.op);
+            trackSection.operationalPoints.forEach(op -> {
+                        forwardBuilder.add(op.position, op.value);
+                        backwardBuilder.add(op.position, op.value);
                     }
             );
             forwardBuilder.build();

--- a/src/main/java/fr/sncf/osrd/infra/OperationalPoint.java
+++ b/src/main/java/fr/sncf/osrd/infra/OperationalPoint.java
@@ -7,10 +7,10 @@ import fr.sncf.osrd.simulation.Simulation;
 import fr.sncf.osrd.train.InteractionType;
 import fr.sncf.osrd.train.InteractionTypeSet;
 import fr.sncf.osrd.train.Train;
-import fr.sncf.osrd.utils.IntervalNode;
+import fr.sncf.osrd.utils.PointSequence;
+import fr.sncf.osrd.utils.PointValue;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class OperationalPoint implements ActionPoint {
     public final String id;
@@ -23,13 +23,12 @@ public class OperationalPoint implements ActionPoint {
     /**
      * Add a reference to an operational point into a track section
      * @param section the track section to reference the op from
-     * @param begin the begin offset
-     * @param end the end offset
+     * @param position the position of the operational point section
+     * @param opBuilder
      */
-    public void addRef(TrackSection section, double begin, double end) {
-        var ref = new Ref(begin, end, this);
+    public void addRef(TrackSection section, double position, PointSequence.Builder<OperationalPoint> opBuilder) {
         this.refs.add(section);
-        section.operationalPoints.insert(ref);
+        opBuilder.add(position, this);
     }
 
     @Override
@@ -46,35 +45,5 @@ public class OperationalPoint implements ActionPoint {
     public void interact(Simulation sim, Train train, InteractionType interactionType) {
         var change = new OperationalPointChange(sim, train, this);
         sim.publishChange(change);
-    }
-
-
-    public static final class Ref extends IntervalNode {
-        public final OperationalPoint op;
-
-        private Ref(double begin, double end, OperationalPoint op) {
-            super(begin, end);
-            this.op = op;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null)
-                return false;
-
-            if (obj.getClass() != Ref.class)
-                return false;
-
-            var o = (Ref) obj;
-            if (o.op != op)
-                return false;
-
-            return super.equals(o);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), System.identityHashCode(op));
-        }
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra/OperationalPoint.java
+++ b/src/main/java/fr/sncf/osrd/infra/OperationalPoint.java
@@ -24,7 +24,7 @@ public class OperationalPoint implements ActionPoint {
      * Add a reference to an operational point into a track section
      * @param section the track section to reference the op from
      * @param position the position of the operational point section
-     * @param opBuilder
+     * @param opBuilder Builder for sequence of operational point, to add the point in it
      */
     public void addRef(TrackSection section, double position, PointSequence.Builder<OperationalPoint> opBuilder) {
         this.refs.add(section);

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/Route.java
@@ -123,28 +123,32 @@ public class Route extends DirNEdge {
         }
 
         // Drop first track sections until the begin location
-        while (true) {
-            if (flattenSections.isEmpty())
-                throw new RuntimeException("Begin position not contained in the route path");
-            var firstTrack = flattenSections.removeFirst();
-            if (firstTrack.containsLocation(beginLocation)) {
-                var newTrackSection = new TrackSectionRange(firstTrack.edge, firstTrack.direction,
-                        beginLocation.offset, firstTrack.getEndPosition());
-                flattenSections.addFirst(newTrackSection);
-                break;
+        if (beginLocation != null) {
+            while (true) {
+                if (flattenSections.isEmpty())
+                    throw new RuntimeException("Begin position not contained in the route path");
+                var firstTrack = flattenSections.removeFirst();
+                if (firstTrack.containsLocation(beginLocation)) {
+                    var newTrackSection = new TrackSectionRange(firstTrack.edge, firstTrack.direction,
+                            beginLocation.offset, firstTrack.getEndPosition());
+                    flattenSections.addFirst(newTrackSection);
+                    break;
+                }
             }
         }
 
         // Drop lasts track sections until the end location
-        while (true) {
-            if (flattenSections.isEmpty())
-                throw new RuntimeException("End position not contained in the route path");
-            var lastTrack = flattenSections.removeLast();
-            if (lastTrack.containsLocation(endLocation)) {
-                var newTrackSection = new TrackSectionRange(lastTrack.edge, lastTrack.direction,
-                        lastTrack.getBeginPosition(), endLocation.offset);
-                flattenSections.addLast(newTrackSection);
-                break;
+        if (endLocation != null) {
+            while (true) {
+                if (flattenSections.isEmpty())
+                    throw new RuntimeException("End position not contained in the route path");
+                var lastTrack = flattenSections.removeLast();
+                if (lastTrack.containsLocation(endLocation)) {
+                    var newTrackSection = new TrackSectionRange(lastTrack.edge, lastTrack.direction,
+                            lastTrack.getBeginPosition(), endLocation.offset);
+                    flattenSections.addLast(newTrackSection);
+                    break;
+                }
             }
         }
 

--- a/src/main/java/fr/sncf/osrd/infra/trackgraph/TrackSection.java
+++ b/src/main/java/fr/sncf/osrd/infra/trackgraph/TrackSection.java
@@ -53,7 +53,7 @@ public final class TrackSection extends BiNEdge<TrackSection> {
     public final DoubleOrientedRangeSequence slope = new DoubleOrientedRangeSequence();
     public final ArrayList<RangeValue<SpeedSection>> forwardSpeedSections = new ArrayList<>();
     public final ArrayList<RangeValue<SpeedSection>> backwardSpeedSections = new ArrayList<>();
-    public final IntervalTree<OperationalPoint.Ref> operationalPoints = new IntervalTree<>();
+    public final PointSequence<OperationalPoint> operationalPoints = new PointSequence<>();
     public final PointSequence<Waypoint> waypoints = new PointSequence<>();
     public final PointSequence<Signal> signals = new PointSequence<>();
     public final PointSequence<ActionPoint> forwardActionPoints = new PointSequence<>();

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailJSONParser.java
@@ -120,12 +120,14 @@ public class RailJSONParser {
             // Parse operational points
             if (trackSection.operationalPoints == null)
                 trackSection.operationalPoints = new ArrayList<>();
+            var opBuilder = infraTrackSection.operationalPoints.builder();
             for (var rjsOp : trackSection.operationalPoints) {
                 var op = trackGraph.operationalPoints.get(rjsOp.ref.id);
                 // add the reference from the OperationalPoint to the TrackSection,
                 // add from the TrackSection to the OperationalPoint
-                op.addRef(infraTrackSection, rjsOp.begin, rjsOp.end);
+                op.addRef(infraTrackSection, rjsOp.position, opBuilder);
             }
+            opBuilder.build();
 
             // Parse speed limits
             if (trackSection.speedSections == null)

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/BiDirectionalRJSTrackObject.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/BiDirectionalRJSTrackObject.java
@@ -3,7 +3,7 @@ package fr.sncf.osrd.railjson.schema.infra.trackobjects;
 import fr.sncf.osrd.utils.graph.ApplicableDirection;
 
 public class BiDirectionalRJSTrackObject extends RJSTrackObject {
-    BiDirectionalRJSTrackObject(double position) {
+    protected BiDirectionalRJSTrackObject(double position) {
         super(position);
     }
 

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
@@ -3,14 +3,15 @@ package fr.sncf.osrd.railjson.schema.infra.trackranges;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPoint;
 import fr.sncf.osrd.railjson.schema.common.ID;
+import fr.sncf.osrd.railjson.schema.infra.trackobjects.BiDirectionalRJSTrackObject;
 
 @SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-public class RJSOperationalPointPart extends BiDirectionalRJSTrackRange {
+public class RJSOperationalPointPart extends BiDirectionalRJSTrackObject {
     /** The identifier of the operational point this belongs to. */
     public ID<RJSOperationalPoint> ref;
 
-    public RJSOperationalPointPart(ID<RJSOperationalPoint> ref, double start, double end) {
-        super(start, end);
+    public RJSOperationalPointPart(ID<RJSOperationalPoint> ref, double position) {
+        super(position);
         this.ref = ref;
     }
 }

--- a/src/main/java/fr/sncf/osrd/railml/RMLOperationalPoint.java
+++ b/src/main/java/fr/sncf/osrd/railml/RMLOperationalPoint.java
@@ -34,7 +34,7 @@ public final class RMLOperationalPoint {
             var hasSpotLocation = SpotLocation.parse(
                     (netElement, appliesTo, pos) -> {
                         var rjsTrackSection = rjsTrackSections.get(netElement.id);
-                        var opPart = new RJSOperationalPointPart(operationalPointID, pos, pos);
+                        var opPart = new RJSOperationalPointPart(operationalPointID, pos);
                         rjsTrackSection.operationalPoints.add(opPart);
                     },
                     netElementMap,
@@ -44,7 +44,10 @@ public final class RMLOperationalPoint {
             var hasLinearLocation = LinearLocation.parse(
                     (netElement, appliesTo, begin, end) -> {
                         var rjsTrackSection = rjsTrackSections.get(netElement.id);
-                        var opPart = new RJSOperationalPointPart(operationalPointID, begin, end);
+
+                        // We don't support range operational point, se we get the middle point
+                        var location = (begin + end) / 2;
+                        var opPart = new RJSOperationalPointPart(operationalPointID, location);
                         rjsTrackSection.operationalPoints.add(opPart);
                     },
                     netElementMap,

--- a/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
+++ b/src/test/java/fr/sncf/osrd/StaticSpeedLimitTest.java
@@ -61,8 +61,10 @@ public class StaticSpeedLimitTest {
         var opStart = new OperationalPoint("start id");
         var opEnd = new OperationalPoint("end id");
 
-        opStart.addRef(edge, 0, 0);
-        opEnd.addRef(edge, edgeLength, edgeLength);
+        var opBuilder = edge.operationalPoints.builder();
+        opStart.addRef(edge, 0, opBuilder);
+        opEnd.addRef(edge, edgeLength, opBuilder);
+        opBuilder.build();
 
         // add the speed limits
         var limits = edge.forwardSpeedSections;

--- a/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -8,6 +8,7 @@ import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
 
 public class PathfindingTest extends ApiTest {
+    /* TODO ech
     @Test
     public void simpleRoutes() throws Exception {
         var waypointStart = new PathfindingEndpoint.PathfindingWaypoint(
@@ -39,6 +40,7 @@ public class PathfindingTest extends ApiTest {
         assertEquals(3, response[0].routes.size());
         assertEquals(3, response[0].trackSections.size());
     }
+     */
 
     @Test
     public void simpleTracks() throws Exception {

--- a/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -32,15 +32,16 @@ public class PathfindingTest extends ApiTest {
                 new PathfindingRoutesEndpoint(infraHandlerMock).act(
                         new RqFake("POST", "/pathfinding/routes", requestBody))
         ).printBody();
+        System.out.println(result);
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
         assertEquals(1, response.length);
 
-        assertEquals(3, response[0].routes.size());
-        assertEquals("rt.buffer_stop_b-C3", response[0].routes.get(0).route);
-        assertEquals("rt.C3-S7", response[0].routes.get(1).route);
-        assertEquals("rt.S7-buffer_stop_c", response[0].routes.get(2).route);
+        assertEquals(3, response[0].path.size());
+        assertEquals("rt.buffer_stop_b-C3", response[0].path.get(0).route);
+        assertEquals("rt.C3-S7", response[0].path.get(1).route);
+        assertEquals("rt.S7-buffer_stop_c", response[0].path.get(2).route);
 
         assertEquals(2, response[0].operationalPoints.size());
         assertEquals("op.station_foo", response[0].operationalPoints.get(0).op);

--- a/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -8,7 +8,6 @@ import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
 
 public class PathfindingTest extends ApiTest {
-    /* TODO ech
     @Test
     public void simpleRoutes() throws Exception {
         var waypointStart = new PathfindingEndpoint.PathfindingWaypoint(
@@ -37,10 +36,16 @@ public class PathfindingTest extends ApiTest {
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
         assertEquals(1, response.length);
+
         assertEquals(3, response[0].routes.size());
-        assertEquals(3, response[0].trackSections.size());
+        assertEquals("rt.buffer_stop_b-C3", response[0].routes.get(0).route);
+        assertEquals("rt.C3-S7", response[0].routes.get(1).route);
+        assertEquals("rt.S7-buffer_stop_c", response[0].routes.get(2).route);
+
+        assertEquals(2, response[0].operationalPoints.size());
+        assertEquals("op.station_foo", response[0].operationalPoints.get(0).op);
+        assertEquals("op.station_bar", response[0].operationalPoints.get(1).op);
     }
-     */
 
     @Test
     public void simpleTracks() throws Exception {


### PR DESCRIPTION
Fixes #63 

Change `pathfinding/routes` endpoint response with the following format:

```json
{
  "path": [
    {
    "route": "route_id_1",
    "track_sections": [{"track_section": "track_id_1", "begin": 30, "end": 45}]
    },
    {
    "route": "route_id_2",
    "track_sections": [{"track_section": "track_id_2", "begin": 30, "end": 45}]
    }
  ],
  "operational_points": [
    {
      "op": "my_operational_point_1",
      "position": {"track_section": "track_1", "offset": 50}
    }
  ]
}
```