### PR TITLE
simulation: fix a corner case and changelog serializer

### DIFF
--- a/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
+++ b/src/main/java/fr/sncf/osrd/api/PathfindingRoutesEndpoint.java
@@ -179,7 +179,7 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
             operationalPoints = new ArrayList<>();
         }
 
-        public void add(Route route, List<TrackSectionRange> trackSections) {
+        void add(Route route, List<TrackSectionRange> trackSections) {
             var routeResult = new RouteResult();
             routeResult.route = route.id;
             routeResult.trackSections = new ArrayList<>();
@@ -205,7 +205,8 @@ public class PathfindingRoutesEndpoint extends PathfindingEndpoint {
         public static class OperationalPointResult {
             public String op;
             public PositionResult position;
-            public OperationalPointResult(PointValue<OperationalPoint> op, TrackSection trackSection) {
+
+            OperationalPointResult(PointValue<OperationalPoint> op, TrackSection trackSection) {
                 this.op = op.value.id;
                 this.position = new PositionResult(trackSection.id, op.position);
             }

--- a/src/main/java/fr/sncf/osrd/simulation/ChangeSerializer.java
+++ b/src/main/java/fr/sncf/osrd/simulation/ChangeSerializer.java
@@ -6,6 +6,7 @@ import com.squareup.moshi.*;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.infra.OperationalPoint;
 import fr.sncf.osrd.infra.TVDSection;
 import fr.sncf.osrd.infra.railscript.value.RSAspectSet;
 import fr.sncf.osrd.infra.railscript.value.RSBool;
@@ -37,7 +38,6 @@ import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
-import java.sql.Time;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -76,6 +76,7 @@ public class ChangeSerializer {
                     .withSubtype(BufferStop.class, "bufferStop")
                     .withSubtype(Detector.class, "detector")
                     .withSubtype(Signal.class, "signal")
+                    .withSubtype(OperationalPoint.class, "operationalPoint")
                     .withSubtype(SignalNavigatePhase.VirtualActionPoint.class, "virtualActionPoint")
             )
             .add(PolymorphicJsonAdapterFactory.of(RSValue.class, "valueType")

--- a/src/main/java/fr/sncf/osrd/speedcontroller/generators/MarginGenerator.java
+++ b/src/main/java/fr/sncf/osrd/speedcontroller/generators/MarginGenerator.java
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.speedcontroller.generators;
 
 import fr.sncf.osrd.TrainSchedule;
-import fr.sncf.osrd.railjson.schema.schedule.RJSRunningTimeParameters;
 import fr.sncf.osrd.railjson.schema.schedule.RJSRunningTimeParameters.Margin.MarginType;
 import fr.sncf.osrd.simulation.Simulation;
 import fr.sncf.osrd.speedcontroller.MapSpeedController;
@@ -9,9 +8,6 @@ import fr.sncf.osrd.speedcontroller.SpeedController;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static fr.sncf.osrd.railjson.schema.schedule.RJSRunningTimeParameters.Margin.MarginType.*;
 
 public class MarginGenerator implements SpeedControllerGenerator {
 

--- a/src/main/java/fr/sncf/osrd/train/phases/SignalNavigatePhase.java
+++ b/src/main/java/fr/sncf/osrd/train/phases/SignalNavigatePhase.java
@@ -284,7 +284,8 @@ public final class SignalNavigatePhase implements Phase {
                         return tvdSectionPath.tvdSection;
                 }
             }
-            throw new RuntimeException("Can't find the waypoint in the planned route path");
+            // No tvd section could be found forward this waypoint
+            return null;
         }
 
         private TVDSection findBackwardTVDSection(Waypoint waypoint) {
@@ -297,7 +298,8 @@ public final class SignalNavigatePhase implements Phase {
                         return tvdSectionPath.tvdSection;
                 }
             }
-            throw new RuntimeException("Can't find the waypoint in the planned route path");
+            // No tvd section could be found behind this waypoint
+            return null;
         }
 
         /** Occupy and free tvd sections given a detector the train is interacting with. */
@@ -317,12 +319,16 @@ public final class SignalNavigatePhase implements Phase {
             // Occupy the next tvdSection
             if (interactionType == InteractionType.HEAD) {
                 var forwardTVDSectionPath = findForwardTVDSection(detector);
+                if (forwardTVDSectionPath == null)
+                    return;
                 var nextTVDSection = sim.infraState.getTvdSectionState(forwardTVDSectionPath.index);
                 nextTVDSection.occupy(sim);
                 return;
             }
             // Doesn't occupy the last tvdSection
             var backwardTVDSectionPath = findBackwardTVDSection(detector);
+            if (backwardTVDSectionPath == null)
+                return;
             var backwardTVDSection = sim.infraState.getTvdSectionState(backwardTVDSectionPath.index);
             backwardTVDSection.unoccupy(sim);
         }


### PR DESCRIPTION
The simulation didn't work with the following corner case:

* The train `initial_position` is exactly at the first waypoint of the first route of his path.