### PR TITLE
fix ChangeSerializer to support TrainDecisionMaker

### DIFF
--- a/src/main/java/fr/sncf/osrd/simulation/ChangeSerializer.java
+++ b/src/main/java/fr/sncf/osrd/simulation/ChangeSerializer.java
@@ -26,6 +26,10 @@ import fr.sncf.osrd.simulation.changelog.ChangeLog;
 import fr.sncf.osrd.speedcontroller.*;
 import fr.sncf.osrd.train.TrackSectionRange;
 import fr.sncf.osrd.train.Train.*;
+import fr.sncf.osrd.train.decisions.InteractiveInput;
+import fr.sncf.osrd.train.decisions.KeyboardInput;
+import fr.sncf.osrd.train.decisions.TrainDecisionMaker;
+import fr.sncf.osrd.train.decisions.TrainDecisionMaker.DefaultTrainDecisionMaker;
 import fr.sncf.osrd.train.phases.Phase;
 import fr.sncf.osrd.train.phases.PhaseState;
 import fr.sncf.osrd.train.phases.SignalNavigatePhase;
@@ -85,6 +89,13 @@ public class ChangeSerializer {
                     .withSubtype(SignalState.class, "signal")
                     .withSubtype(RouteState.class, "route")
                     .withSubtype(SwitchState.class, "switch")
+            )
+            .add(PolymorphicJsonAdapterFactory.of(TrainDecisionMaker.class, "trainDecisionMakerType")
+                    .withSubtype(DefaultTrainDecisionMaker.class, "defaultTrainDecisionMakerType")
+                    .withSubtype(InteractiveInput.class, "interactiveInput")
+            )
+            .add(PolymorphicJsonAdapterFactory.of(InteractiveInput.class, "interactiveInputType")
+                .withSubtype(KeyboardInput.class, "keyboardInputType")
             )
             .add(adaptPolymorphicType(SpeedController.class, "controllerType"))
             .build()


### PR DESCRIPTION
Ajout d'un serializer json pour TrainDecisionMaker, DefaultTrainDecisionMaker.class, InteractiveInput, KeyboardInput (crash la simulation à la fin)