### PR TITLE
New RailScript primitive and RouteStatus for CBTC compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,15 @@ gradlew*
 *.jar
 .jqwik-database
 
+# vscode
+
+.vscode
+.class
+bin
+.project
+.classpath
+.settings
+
 # avoid mistakenly adding proprietary files
 *.rsl
 *.xml

--- a/examples/circular_infra/infra.json
+++ b/examples/circular_infra/infra.json
@@ -1,6 +1,11 @@
 {
   "aspects": [
     {
+      "id": "WHITE_CROSS",
+      "color": "#ffffff",
+      "constraints": []
+    },
+    {
       "id": "GREEN",
       "color": "#2a850c",
       "constraints": []
@@ -143,19 +148,19 @@
         "type": "condition",
         "if": {
           "type": "aspect_set_contains",
-          "aspect_set": {
-            "type": "argument_ref",
-            "argument_name": "aspects"
-          },
-          "aspect": "RED"
+            "aspect_set": {
+              "type": "argument_ref",
+              "argument_name": "aspects"
+            },
+            "aspect": "WHITE_CROSS"
         },
         "then": {
           "type": "aspect_set",
-          "members": [
-            {
-              "aspect": "RED"
-            }
-          ]
+            "members": [
+              {
+                "aspect": "WHITE_CROSS"
+              }
+            ]
         },
         "else": {
           "type": "condition",
@@ -165,19 +170,38 @@
               "type": "argument_ref",
               "argument_name": "aspects"
             },
-            "aspect": "YELLOW"
+            "aspect": "RED"
           },
           "then": {
             "type": "aspect_set",
             "members": [
               {
-                "aspect": "YELLOW"
+                "aspect": "RED"
               }
             ]
           },
           "else": {
-            "type": "argument_ref",
-            "argument_name": "aspects"
+            "type": "condition",
+            "if": {
+              "type": "aspect_set_contains",
+              "aspect_set": {
+                "type": "argument_ref",
+                "argument_name": "aspects"
+              },
+              "aspect": "YELLOW"
+            },
+            "then": {
+              "type": "aspect_set",
+              "members": [
+                {
+                  "aspect": "YELLOW"
+                }
+              ]
+            },
+            "else": {
+              "type": "argument_ref",
+              "argument_name": "aspects"
+            }
           }
         }
       }
@@ -237,6 +261,16 @@
           {
             "type": "aspect_set",
             "members": [
+              {
+                "aspect": "WHITE_CROSS",
+                "condition": {
+                  "type": "is_incoming_route_cbtc",
+                  "route": {
+                    "type": "argument_ref",
+                    "argument_name": "route"
+                  }
+                }
+              },
               {
                 "aspect": "RED",
                 "condition": {

--- a/examples/tiny_infra/infra.json
+++ b/examples/tiny_infra/infra.json
@@ -1,6 +1,11 @@
 {
   "aspects": [
     {
+      "id": "WHITE_CROSS",
+      "color": "#ffffff",
+      "constraints": []
+    },
+    {
       "id": "GREEN",
       "color": "#2a850c",
       "constraints": []
@@ -176,19 +181,19 @@
         "type": "condition",
         "if": {
           "type": "aspect_set_contains",
-          "aspect_set": {
-            "type": "argument_ref",
-            "argument_name": "aspects"
-          },
-          "aspect": "RED"
+            "aspect_set": {
+              "type": "argument_ref",
+              "argument_name": "aspects"
+            },
+            "aspect": "WHITE_CROSS"
         },
         "then": {
           "type": "aspect_set",
-          "members": [
-            {
-              "aspect": "RED"
-            }
-          ]
+            "members": [
+              {
+                "aspect": "WHITE_CROSS"
+              }
+            ]
         },
         "else": {
           "type": "condition",
@@ -198,19 +203,38 @@
               "type": "argument_ref",
               "argument_name": "aspects"
             },
-            "aspect": "YELLOW"
+            "aspect": "RED"
           },
           "then": {
             "type": "aspect_set",
             "members": [
               {
-                "aspect": "YELLOW"
+                "aspect": "RED"
               }
             ]
           },
           "else": {
-            "type": "argument_ref",
-            "argument_name": "aspects"
+            "type": "condition",
+            "if": {
+              "type": "aspect_set_contains",
+              "aspect_set": {
+                "type": "argument_ref",
+                "argument_name": "aspects"
+              },
+              "aspect": "YELLOW"
+            },
+            "then": {
+              "type": "aspect_set",
+              "members": [
+                {
+                  "aspect": "YELLOW"
+                }
+              ]
+            },
+            "else": {
+              "type": "argument_ref",
+              "argument_name": "aspects"
+            }
           }
         }
       }
@@ -328,6 +352,16 @@
           {
             "type": "aspect_set",
             "members": [
+              {
+                "aspect": "WHITE_CROSS",
+                "condition": {
+                  "type": "is_incoming_route_cbtc",
+                  "route": {
+                    "type": "argument_ref",
+                    "argument_name": "route"
+                  }
+                }
+              },
               {
                 "aspect": "RED",
                 "condition": {

--- a/src/main/java/fr/sncf/osrd/infra/railscript/PrettyPrinter.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/PrettyPrinter.java
@@ -326,4 +326,11 @@ public class PrettyPrinter extends RSExprVisitor {
         nextSignal.signal.accept(this);
         out.print(")");
     }
+
+    @Override
+    public void visit(RSExpr.IsIncomingRouteCBTC expr) throws InvalidInfraException {
+        out.print("is_incoming_route_cbtc(");
+        expr.routeExpr.accept(this);
+        out.print(")");
+    }
 }

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExpr.java
@@ -13,6 +13,7 @@ import fr.sncf.osrd.infra_state.SwitchState;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 public abstract class RSExpr<T extends RSValue> {
@@ -694,6 +695,35 @@ public abstract class RSExpr<T extends RSValue> {
         @Override
         public RSType getType(RSType[] argumentTypes) {
             return RSType.OPTIONAL_SIGNAL;
+        }
+
+        @Override
+        public void accept(RSExprVisitor visitor) throws InvalidInfraException {
+            visitor.visit(this);
+        }
+    }
+
+    public static final class IsIncomingRouteCBTC extends RSExpr<RSBool> {
+        public final RSExpr<RouteState> routeExpr;
+
+        public IsIncomingRouteCBTC(RSExpr<RouteState> routeExpr) {
+            this.routeExpr = routeExpr;
+        }
+
+        @Override
+        public RSBool evaluate(RSExprState<?> state) {
+            List<Route> routes = state.infraState.getInfra().routeGraph.getIncomingNeighbors(routeExpr.evaluate(state).route);
+            for(Route route : routes) {
+                if(state.infraState.getRouteState(route.index).hasCBTCStatus()) {
+                    return RSBool.from(true);
+                }
+            }
+            return RSBool.from(false);
+        }
+
+        @Override
+        public RSType getType(RSType[] argumentTypes) {
+            return RSType.BOOLEAN;
         }
 
         @Override

--- a/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
+++ b/src/main/java/fr/sncf/osrd/infra/railscript/RSExprVisitor.java
@@ -114,4 +114,9 @@ public class RSExprVisitor {
         nextSignal.signal.accept(this);
         nextSignal.route.accept(this);
     }
+
+    /** Visit method */
+    public void visit(RSExpr.IsIncomingRouteCBTC expr) throws InvalidInfraException {
+        expr.routeExpr.accept(this);
+    }
 }

--- a/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
+++ b/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
@@ -30,6 +30,16 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
         return node.getRouteNeighbors(nodeDirection);
     }
 
+    /** Return the neighbors of the route at the start node */
+    public List<Route> getIncomingNeighbors(Route route) {
+        var firstTvdSectionPathIndex = 0;
+        var firstTvdSectionPath = route.tvdSectionsPaths.get(firstTvdSectionPathIndex);
+        var firstTvdSectionPathDir = route.tvdSectionsPathDirections.get(firstTvdSectionPathIndex);
+        var node = getNode(firstTvdSectionPath.getStartNode(firstTvdSectionPathDir));
+        var nodeDirection = firstTvdSectionPath.nodeDirection(firstTvdSectionPathDir, EdgeEndpoint.BEGIN);
+        return node.getIncomingRouteNeighbors(nodeDirection);
+    }
+
     public static class Builder {
         public RouteGraph routeGraph = new RouteGraph();
         public final WaypointGraph waypointGraph;
@@ -114,6 +124,13 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
             var startWaypoint = waypointGraph.getNode(firstTVDSectionPath.getStartNode(firstTVDSectionPathDir));
             var waypointDirection = firstTVDSectionPath.nodeDirection(firstTVDSectionPathDir, EdgeEndpoint.BEGIN);
             startWaypoint.getRouteNeighbors(waypointDirection).add(route);
+
+            // Link route to the ending waypoint
+            var lastTVDSectionPath = tvdSectionsPath.get(0);
+            var lastTVDSectionPathDir = tvdSectionsPathDirection.get(0);
+            var endWaypoint = waypointGraph.getNode(lastTVDSectionPath.getEndNode(lastTVDSectionPathDir));
+            var endWaypointDirection = lastTVDSectionPath.nodeDirection(lastTVDSectionPathDir, EdgeEndpoint.END);
+            endWaypoint.getIncomingRouteNeighbors(endWaypointDirection).add(route);
 
             // Link route to track sections and tvd sections
             double routeOffset = 0;

--- a/src/main/java/fr/sncf/osrd/infra/trackgraph/Waypoint.java
+++ b/src/main/java/fr/sncf/osrd/infra/trackgraph/Waypoint.java
@@ -20,8 +20,14 @@ public abstract class Waypoint extends Node implements ActionPoint {
     /** List of neighbors seen when moving across the detector from the end of the track section to the beginning */
     public final ArrayList<Route> startToStopRoutes = new ArrayList<>();
 
+    /** List of routes that can be left when moving across the detector from the end of the track section to the beginning */
+    public final ArrayList<Route> incomingStartToStopRoutes = new ArrayList<>();
+
     /** List of neighbors seen when moving across the detector from the beginning of the track section to the end */
     public final ArrayList<Route> stopToStartRoutes = new ArrayList<>();
+
+    /** List of routes that can be left when moving across the detector from the beginning of the track section to the end */
+    public final ArrayList<Route> incomingStopToStartRoutes = new ArrayList<>();
 
     public Waypoint(int index, String id) {
         super(index);
@@ -40,5 +46,12 @@ public abstract class Waypoint extends Node implements ActionPoint {
         if (dir == EdgeDirection.START_TO_STOP)
             return startToStopRoutes;
         return stopToStartRoutes;
+    }
+
+    /** Returns adjacent route list, given a direction */
+    public ArrayList<Route> getIncomingRouteNeighbors(EdgeDirection dir) {
+        if (dir == EdgeDirection.START_TO_STOP)
+            return incomingStartToStopRoutes;
+        return incomingStopToStartRoutes;
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/InfraState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/InfraState.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 public final class InfraState implements DeepComparable<InfraState> {
+    private final Infra infra;
     private final SignalState[] signalSignalStates;
     private final RouteState[] routeStates;
     private final SwitchState[] switchStates;
@@ -16,11 +17,13 @@ public final class InfraState implements DeepComparable<InfraState> {
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private InfraState(
+            Infra infra,
             SignalState[] signalSignalStates,
             RouteState[] routeStates,
             SwitchState[] switchStates,
             TVDSectionState[] tvdSectionStates
     ) {
+        this.infra = infra;
         this.signalSignalStates = signalSignalStates;
         this.routeStates = routeStates;
         this.switchStates = switchStates;
@@ -45,6 +48,10 @@ public final class InfraState implements DeepComparable<InfraState> {
 
     public TVDSectionState getTvdSectionState(int tvdSectionIndex) {
         return tvdSectionStates[tvdSectionIndex];
+    }
+
+    public Infra getInfra() {
+        return infra;
     }
 
     @Override
@@ -81,6 +88,6 @@ public final class InfraState implements DeepComparable<InfraState> {
         for (var tvdSection : infra.tvdSections.values())
             tvdSectionStates[tvdSection.index] = new TVDSectionState(tvdSection);
 
-        return new InfraState(signalStates, routeStates, switchStates, tvdSectionStates);
+        return new InfraState(infra, signalStates, routeStates, switchStates, tvdSectionStates);
     }
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteState.java
@@ -231,4 +231,9 @@ public final class RouteState implements RSMatchable {
             return String.format("RouteStatusChange { route: %d, status: %s }", routeIndex, newStatus);
         }
     }
+
+    public boolean hasCBTCStatus() {
+        return status == RouteStatus.CBTC_OCCUPIED || status == RouteStatus.CBTC_RESERVED
+                || status == RouteStatus.CBTC_REQUESTED;
+    }
 }

--- a/src/main/java/fr/sncf/osrd/infra_state/RouteStatus.java
+++ b/src/main/java/fr/sncf/osrd/infra_state/RouteStatus.java
@@ -4,6 +4,9 @@ public enum RouteStatus {
    FREE,
    RESERVED,
    OCCUPIED,
+   REQUESTED,
+   CBTC_RESERVED,
+   CBTC_OCCUPIED,
+   CBTC_REQUESTED,
    CONFLICT,
-   REQUESTED
 }

--- a/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
+++ b/src/main/java/fr/sncf/osrd/railjson/parser/RailScriptExprParser.java
@@ -222,6 +222,11 @@ public class RailScriptExprParser {
             var routeExpr = parseRouteExpr(nextSignalExpr.route);
             return new RSExpr.NextSignal(signalExpr, routeExpr);
         }
+        if (type == RJSRSExpr.IsIncomingRouteCBTC.class) {
+            var incomingRouteExpr = (RJSRSExpr.IsIncomingRouteCBTC) expr;
+            var route = parseRouteExpr(incomingRouteExpr.route);
+            return new RSExpr.IsIncomingRouteCBTC(route);
+        }
 
         throw new InvalidInfraException(String.format("'%s' unsupported signal expression", type));
     }

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSRoute.java
@@ -45,7 +45,10 @@ public class RJSRoute implements Identified {
         FREE,
         RESERVED,
         OCCUPIED,
+        REQUESTED,
+        CBTC_RESERVED,
+        CBTC_OCCUPIED,
+        CBTC_REQUESTED,
         CONFLICT,
-        REQUESTED
     }
 }

--- a/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
+++ b/src/main/java/fr/sncf/osrd/railjson/schema/infra/railscript/RJSRSExpr.java
@@ -115,6 +115,7 @@ public abstract class RJSRSExpr {
                     .withSubtype(AspectSetContains.class, "aspect_set_contains")
                     .withSubtype(ReservedRoute.class, "reserved_route")
                     .withSubtype(NextSignal.class, "next_signal")
+                    .withSubtype(IsIncomingRouteCBTC.class, "is_incoming_route_cbtc")
     );
 
     // region BOOLEAN_LOGIC
@@ -405,6 +406,21 @@ public abstract class RJSRSExpr {
 
         public NextSignal(RJSRSExpr signal, RJSRSExpr route) {
             this.signal = signal;
+            this.route = route;
+        }
+    }
+
+    /**
+     * Returns whether a route preceding the given one is CBTC_RESERVED or
+     * CBTC_REQUESTED or CBTC OCCUPIED.
+     */
+    public static final class IsIncomingRouteCBTC extends RJSRSExpr {
+        /**
+         * The signal the condition checks for.
+         */
+        public RJSRSExpr route;
+
+        public IsIncomingRouteCBTC(RJSRSExpr route) {
             this.route = route;
         }
     }


### PR DESCRIPTION
The `infra.json` files have been modified to take into account the CBTC in some functions. However, others may need to be modified (`check-route` ?).  This modifications are supposed to be 100% compatible with BAL3.

The `cbtcReserve` function is not used yet and will probably be modified - or even deleted - with the merge of switch-post.

It may also be necessary to modify the class `DependencyBinder` to complete a correct implementation of the `is_incoming_route_cbtc` primitive.