### PR TITLE
Bugfix: fix a crash when a train path contains the same track section twice in both directions

### DIFF
--- a/src/main/java/fr/sncf/osrd/train/TrainPositionTracker.java
+++ b/src/main/java/fr/sncf/osrd/train/TrainPositionTracker.java
@@ -115,7 +115,9 @@ public final class TrainPositionTracker implements Cloneable, DeepComparable<Tra
                 nextTrackSection = null;
                 var currentEdge = curTrackSectionPos.edge;
                 for (int i = 1; i < trackSectionPath.size(); i++) {
-                    if (trackSectionPath.get(i - 1).edge.id.equals(currentEdge.id)) {
+                    var prevRange = trackSectionPath.get(i - 1);
+                    if (prevRange.edge.id.equals(currentEdge.id)
+                            && prevRange.direction.equals(curTrackSectionPos.direction)) {
                         nextTrackSection = trackSectionPath.get(i).edge;
                         break;
                     }


### PR DESCRIPTION
* Fix a crash when a train path contains the same track section twice in both directions