### PR TITLE
build: switch from jcenter to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
JCenter will soon stop working https://blog.gradle.org/jcenter-shutdown