### PR TITLE
codeowners: stop using front-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 CODEOWNERS   @DGEXSolutions/osrd-backend-maintainers
-/front       @DGEXSolutions/osrd-front-maintainers
+/front       @nicolaswurtz
 
 
 /core/specifications   @flomonster @DGEXSolutions/osrd-backend-maintainers


### PR DESCRIPTION
Approval can't be given if review from a group which
containers a single user is required.