### PR TITLE
actions: don't run CI on push

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     paths:
       - api/**
-  push:
-    paths:
-      - api/**
 
 jobs:
   test:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     paths:
       - core/**
-  push:
-    paths:
-      - core/**
 
 jobs:
   build:

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     paths:
       - front/**
-  push:
-    paths:
-      - front/**
 
 jobs:
   build:


### PR DESCRIPTION
It messes up path rules when pushing rebased commits.