### PR TITLE
actions: core: run on dev / release branches

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,7 +5,11 @@ on:
   pull_request:
     paths:
       - core/**
-
+  push:
+    branches:
+      - dev
+      - staging
+      - prod
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codecov previously got very confused when the base branch for a PR had no / partial coverage data