### PR TITLE
actions: run the core CI on unmerged PRs 

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # run the CI on the actual latest commit of the PR, not the attempted merge
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -35,6 +39,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
+          # github runs PR workflows on the result of a merge commit.
+          # tell codecov the sha of the unmerged PR https://github.com/codecov/uploader/issues/525
+          override_commit: "${{ github.event.pull_request.head.sha }}"
           name: codecov
           flags: unittests,core
           directory: ./core/build/reports/jacoco/test


### PR DESCRIPTION
By default, github creates a merge commit with the PR target,
and runs actions on this. We can't directly inhibit this behavior, which
confuses codecov (which misattributes coverage data).

This change disables this behavior by checking out the PR head when relevant.