### PR TITLE
core: dockerfile: fix copy

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -6,5 +6,5 @@ RUN gradle shadowJar --no-daemon
 
 FROM amazoncorretto:11
 
-COPY --from=build /home/gradle/src/build/libs/*.jar /app/osrd_core.jar
+COPY --from=build /home/gradle/src/build/libs/osrd-all.jar /app/osrd_core.jar
 CMD ["java", "-ea", "-jar", "/app/osrd_core.jar", "api"]


### PR DESCRIPTION
Globbing doesn't work when there are multiple produced jar files