### PR TITLE
core: bugfix: fix race condition on route free/reserve

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/infra_state/TVDSectionState.java
+++ b/core/src/main/java/fr/sncf/osrd/infra_state/TVDSectionState.java
@@ -2,8 +2,6 @@ package fr.sncf.osrd.infra_state;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.TVDSection;
-import fr.sncf.osrd.infra.routegraph.Route;
-import fr.sncf.osrd.infra_state.routes.RouteState;
 import fr.sncf.osrd.simulation.EntityChange;
 import fr.sncf.osrd.simulation.Simulation;
 import fr.sncf.osrd.simulation.SimulationError;
@@ -52,6 +50,7 @@ public class TVDSectionState implements DeepComparable<TVDSectionState> {
             var routeState = sim.infraState.getRouteState(route.index);
             routeState.onTvdSectionFreed(sim);
         }
+        sim.infraState.towerState.checkForTVDUpdates(sim, tvdSection);
     }
 
     /**

--- a/core/src/main/java/fr/sncf/osrd/infra_state/regulator/TowerState.java
+++ b/core/src/main/java/fr/sncf/osrd/infra_state/regulator/TowerState.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.infra_state.regulator;
 
+import fr.sncf.osrd.infra.TVDSection;
 import fr.sncf.osrd.infra.routegraph.Route;
 import fr.sncf.osrd.infra_state.routes.RouteStatus;
 import fr.sncf.osrd.simulation.EntityChange;
@@ -98,8 +99,15 @@ public class TowerState {
         request.getRouteState(sim).reserve(sim);
     }
 
-    /** Notify the towerState that a TVDSection is released and that he can try to process some waiting requests */
-    public void notifyRouteFreed(Simulation sim, Route route) throws SimulationError {
+    /** Checks for updates after a tvd section has been freed */
+    public void checkForTVDUpdates(Simulation sim, TVDSection tvd) throws SimulationError {
+        for (var route : tvd.routeSubscribers)
+            checkForRouteUpdates(sim, route);
+    }
+
+    /** Checks if the route has been freed and if new requests can be processed
+     * To be called once a tvd section has been freed, after all the route updates have been processed */
+    private void checkForRouteUpdates(Simulation sim, Route route) throws SimulationError {
         for (var switchRef : route.switchesGroup.keySet()) {
             if (checkWaitingList(sim, switchRef.id))
                 return;

--- a/core/src/main/java/fr/sncf/osrd/infra_state/routes/RouteState.java
+++ b/core/src/main/java/fr/sncf/osrd/infra_state/routes/RouteState.java
@@ -60,8 +60,6 @@ public abstract class RouteState implements RSMatchable {
             change.apply(sim, this);
             sim.publishChange(change);
             updateStatus(sim, FREE);
-            // Notify Tower State that the route is free
-            sim.infraState.towerState.notifyRouteFreed(sim, route);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/DGEXSolutions/osrd/issues/508

The issue was that we reserved the route for the new train before all the routes has been notified from the first train leaving the tvd section