### PR TITLE
core: envelope: cleanup the overlay builder API

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -137,6 +137,26 @@ public final class Envelope implements Iterable<EnvelopePart> {
         return -1;
     }
 
+    /** Returns the first envelope part which contains this position. */
+    public int findEnvelopePartIndexLeft(double position) {
+        for (int i = 0; i < parts.length; i++) {
+            var part = parts[i];
+            if (position >= part.getBeginPos() && position <= part.getEndPos())
+                return i;
+        }
+        return -1;
+    }
+
+    /** Returns the last envelope part which contains this position. */
+    public int findEnvelopePartIndexRight(double position) {
+        for (int i = parts.length - 1; i >= 0; i--) {
+            var part = parts[i];
+            if (position >= part.getBeginPos() && position <= part.getEndPos())
+                return i;
+        }
+        return -1;
+    }
+
     // region INTERPOLATION
 
     /** Returns the interpolated speed at a given position */
@@ -211,6 +231,13 @@ public final class Envelope implements Iterable<EnvelopePart> {
      * @return a list of envelope parts spanning from beginPosition to endPosition
      */
     public EnvelopePart[] slice(double beginPosition, double endPosition) {
+        return slice(beginPosition, Double.NaN, endPosition, Double.NaN);
+    }
+
+    /** Cuts an envelope, interpolating new points if required.
+     * @return a list of envelope parts spanning from beginPosition to endPosition
+     */
+    public EnvelopePart[] slice(double beginPosition, double beginSpeed, double endPosition, double endSpeed) {
         int beginIndex = 0;
         var beginPartIndex = 0;
         if (beginPosition != Double.NEGATIVE_INFINITY) {
@@ -226,8 +253,8 @@ public final class Envelope implements Iterable<EnvelopePart> {
             endPart = parts[endPartIndex];
             endIndex = endPart.findStep(endPosition);
         }
-        return slice(beginPartIndex, beginIndex, beginPosition, Double.NaN,
-                endPartIndex, endIndex, endPosition, Double.NaN);
+        return slice(beginPartIndex, beginIndex, beginPosition, beginSpeed,
+                endPartIndex, endIndex, endPosition, endSpeed);
     }
 
     /** Cuts an envelope */

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeBuilder.java
@@ -12,6 +12,12 @@ public final class EnvelopeBuilder {
         parts.add(part);
     }
 
+    /** Adds all parts of an envelope */
+    public void addParts(EnvelopePart[] parts) {
+        for (var part : parts)
+            addPart(part);
+    }
+
     /** Reverses the order of the parts */
     public void reverse() {
         assert parts != null : "build() was already called";

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeCursor.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeCursor.java
@@ -108,22 +108,6 @@ public class EnvelopeCursor {
         }
     }
 
-    /** Cuts the envelope part we're iterating over, taking direction into account */
-    public EnvelopePart[] smartSlice(
-            int beginPartIndex, int beginStepIndex, double beginPosition, double beginSpeed,
-            int endPartIndex, int endStepIndex, double endPosition, double endSpeed
-    ) {
-        if (reverse)
-            return envelope.smartSlice(
-                    endPartIndex, endStepIndex, endPosition, endSpeed,
-                    beginPartIndex, beginStepIndex, beginPosition, beginSpeed
-            );
-        return envelope.smartSlice(
-                beginPartIndex, beginStepIndex, beginPosition, beginSpeed,
-                endPartIndex, endStepIndex, endPosition, endSpeed
-        );
-    }
-
     private double getStepBeginPos(EnvelopePart part, int stepIndex) {
         if (reverse)
             return part.getEndPos(stepIndex);

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeSpeedCap.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeSpeedCap.java
@@ -6,12 +6,14 @@ public class EnvelopeSpeedCap {
     /** Adds a global speed limit to an envelope */
     public static Envelope from(Envelope base, EnvelopePartMeta meta, double speedLimit) {
         var cursor = new EnvelopeCursor(base, false);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(base);
         while (cursor.findSpeed(speedLimit, CmpOperator.STRICTLY_HIGHER)) {
-            var partBuilder = builder.startDiscontinuousOverlay(meta, speedLimit);
+            var partBuilder = OverlayEnvelopePartBuilder.startDiscontinuousOverlay(cursor, meta, speedLimit);
             partBuilder.addPlateau();
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
-        return builder.build();
+        var res = builder.build();
+        assert !base.continuous || res.continuous;
+        return res;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope/OverlayEnvelopeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/OverlayEnvelopeBuilder.java
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.envelope;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.utils.CmpOperator;
+import java.util.ArrayDeque;
 
 /**
  * <p>Creates an overlay over an envelope by combining slices of the base envelope and overlay envelope parts</p>
@@ -19,135 +18,80 @@ import fr.sncf.osrd.utils.CmpOperator;
  * </pre>
  */
 public final class OverlayEnvelopeBuilder {
-    /** Holds the current position inside the envelope */
-    public final EnvelopeCursor cursor;
-
-    /** The location of the end of the last overlay */
-    private int lastOverlayEndPartIndex = -1;
-    /** @see #lastOverlayEndPartIndex */
-    private int lastOverlayEndStepIndex = -1;
-    /** @see #lastOverlayEndPartIndex */
-    private double lastOverlayEndPosition = Double.NaN;
-    /** @see #lastOverlayEndPartIndex */
-    private double lastOverlayEndSpeed = Double.NaN;
-
-    /** The result of the build */
-    private EnvelopeBuilder builder;
+    public final Envelope base;
+    public final boolean reverse;
+    private final ArrayDeque<EnvelopePart> overlayParts;
 
     // region CONSTRUCTORS
-    public OverlayEnvelopeBuilder(EnvelopeCursor cursor) {
-        this.cursor = cursor;
-        this.builder = new EnvelopeBuilder();
+    private OverlayEnvelopeBuilder(Envelope base, boolean reverse) {
+        this.base = base;
+        this.reverse = reverse;
+        this.overlayParts = new ArrayDeque<>();
     }
 
     public static OverlayEnvelopeBuilder withDirection(Envelope base, boolean reverse) {
-        return new OverlayEnvelopeBuilder(new EnvelopeCursor(base, reverse));
+        return new OverlayEnvelopeBuilder(base, reverse);
     }
 
     public static OverlayEnvelopeBuilder forward(Envelope base) {
-        return new OverlayEnvelopeBuilder(new EnvelopeCursor(base, false));
+        return new OverlayEnvelopeBuilder(base, false);
     }
 
     public static OverlayEnvelopeBuilder backward(Envelope base) {
-        return new OverlayEnvelopeBuilder(new EnvelopeCursor(base, true));
+        return new OverlayEnvelopeBuilder(base, true);
     }
     // endregion
 
-    /** Starts an overlay at the given position, speed and threshold */
-    public OverlayEnvelopePartBuilder startDiscontinuousOverlay(
-            EnvelopePartMeta meta,
-            double initialSpeed,
-            double threshold,
-            CmpOperator cmpOperator
-    ) {
-        return OverlayEnvelopePartBuilder.startDiscontinuousOverlay(cursor, meta, initialSpeed, threshold, cmpOperator);
-    }
-
-    /** Starts an overlay at the given position and speed */
-    public OverlayEnvelopePartBuilder startDiscontinuousOverlay(
-            EnvelopePartMeta meta,
-            double initialSpeed
-    ) {
-        return OverlayEnvelopePartBuilder.startDiscontinuousOverlay(cursor, meta, initialSpeed);
-    }
-
-    /** Starts an overlay at the given position and speed threshold, keeping the envelope continuous */
-    public OverlayEnvelopePartBuilder startContinuousOverlay(
-            EnvelopePartMeta meta,
-            double speedThreshold,
-            CmpOperator cmpOperator
-    ) {
-        return OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, meta, speedThreshold, cmpOperator);
-    }
-
-    /** Starts an overlay at the given position, keeping the envelope continuous */
-    public OverlayEnvelopePartBuilder startContinuousOverlay(EnvelopePartMeta meta) {
-        return OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, meta);
-    }
-
-    /** Add parts to the result, taking direction into account */
-    private void addParts(EnvelopePart[] parts) {
-        if (parts == null)
-            return;
-
-        if (cursor.reverse)
-            for (int i = parts.length - 1; i >= 0; i--)
-                builder.addPart(parts[i]);
-        else
-            for (var part : parts)
-                builder.addPart(part);
-    }
-
-    /** Slices the base envelope from the end of the previous overlay to the beginning of current new one,
-     * and adds the resulting envelope parts to the result.
-     * If beginPartIndex is -1, the base envelope is sliced until the end.
-     */
-    private void sliceBaseEnvelope(int beginPartIndex, int beginStepIndex, double beginPosition, double beginSpeed) {
-        addParts(cursor.smartSlice(
-                lastOverlayEndPartIndex, lastOverlayEndStepIndex, lastOverlayEndPosition, lastOverlayEndSpeed,
-                beginPartIndex, beginStepIndex, beginPosition, beginSpeed
-        ));
-    }
-
-    /** Takes an overlay envelope part builder, builds it and adds it to the envelope */
-    @SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})
-    public void addPart(OverlayEnvelopePartBuilder partBuilder) {
-        assert partBuilder.cursor == cursor;
-
-        sliceBaseEnvelope(
-                partBuilder.startPartIndex, partBuilder.startStepIndex,
-                partBuilder.startPosition, partBuilder.startSpeed
-        );
-
-        // ensure the cursor is at the end of the envelope part we're building
-        // this is needed so we can efficiently slice the base envelope
-
-        if (cursor.hasReachedEnd()) {
-            lastOverlayEndPartIndex = cursor.getEnvelopeLastPartIndex();
-            lastOverlayEndStepIndex = cursor.getEnvelopeLastStepIndex();
-            lastOverlayEndPosition = cursor.getEnvelopeEndPos();
-            lastOverlayEndSpeed = cursor.getEnvelopeEndSpeed();
+    /** Adds an overlay envelope part to the builder */
+    public void addPart(EnvelopePart part) {
+        if (reverse) {
+            assert overlayParts.isEmpty() || part.getEndPos() <= overlayParts.getFirst().getBeginPos();
+            overlayParts.addFirst(part);
         } else {
-            lastOverlayEndPartIndex = cursor.getPartIndex();
-            lastOverlayEndStepIndex = cursor.getStepIndex();
-            lastOverlayEndPosition = cursor.getPosition();
-            lastOverlayEndSpeed = cursor.getSpeed();
+            assert overlayParts.isEmpty() || overlayParts.getLast().getEndPos() <= part.getBeginPos();
+            overlayParts.addLast(part);
         }
+    }
 
-        assert lastOverlayEndPosition == partBuilder.getLastPos();
-        builder.addPart(partBuilder.build());
+    /** Slice the base curve between the end of the previous overlay and the beginning of the current one. */
+    private EnvelopePart[] sliceBase(
+            EnvelopePart previousOverlay,
+            EnvelopePart currentOverlay
+    ) {
+        double sliceBeginPos = Double.NEGATIVE_INFINITY;
+        double sliceBeginSpeed = Double.NaN;
+        if (previousOverlay != null) {
+            sliceBeginPos = previousOverlay.getEndPos();
+            int partIndex = base.findEnvelopePartIndexRight(sliceBeginPos);
+            var baseSpeed = base.get(partIndex).interpolateSpeed(sliceBeginPos);
+            if (Math.abs(baseSpeed - previousOverlay.getEndSpeed()) < 1e-6)
+                sliceBeginSpeed = previousOverlay.getEndSpeed();
+        }
+        double sliceEndPos = Double.POSITIVE_INFINITY;
+        double sliceEndSpeed = Double.NaN;
+        if (currentOverlay != null) {
+            sliceEndPos = currentOverlay.getBeginPos();
+            int partIndex = base.findEnvelopePartIndexLeft(sliceEndPos);
+            var baseSpeed = base.get(partIndex).interpolateSpeed(sliceEndPos);
+            if (Math.abs(baseSpeed - currentOverlay.getBeginSpeed()) < 1e-6)
+                sliceEndSpeed = currentOverlay.getBeginSpeed();
+        }
+        return base.slice(sliceBeginPos, sliceBeginSpeed, sliceEndPos, sliceEndSpeed);
     }
 
     /** Create the envelope */
     public Envelope build() {
-        cursor.moveToEnd();
-        sliceBaseEnvelope(-1, -1, Double.NaN, Double.NaN);
-
         // build the final envelope
-        if (cursor.reverse)
-            builder.reverse();
-        var result = builder.build();
-        builder = null;
-        return result;
+        var builder = new EnvelopeBuilder();
+
+        EnvelopePart previousOverlay = null;
+        for (var overlayPart : overlayParts) {
+            builder.addParts(sliceBase(previousOverlay, overlayPart));
+            builder.addPart(overlayPart);
+            previousOverlay = overlayPart;
+        }
+
+        builder.addParts(sliceBase(previousOverlay, null));
+        return builder.build();
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeCoasting.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/overlays/EnvelopeCoasting.java
@@ -1,12 +1,19 @@
 package fr.sncf.osrd.envelope_sim.overlays;
 
+import fr.sncf.osrd.envelope.EnvelopePartMeta;
 import fr.sncf.osrd.envelope.StepConsumer;
 import fr.sncf.osrd.envelope_sim.Action;
 import fr.sncf.osrd.envelope_sim.PhysicsPath;
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator;
+import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
 
 public class EnvelopeCoasting {
+    public static final class CoastingMeta extends EnvelopePartMeta {
+    }
+
+    public static final EnvelopePartMeta COASTING = new CoastingMeta();
+
     /** Generate a coasting curve overlay */
     public static void coast(
             PhysicsRollingStock rollingStock,

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
@@ -62,13 +62,13 @@ public class EnvelopeOverlayTest {
         );
         var constSpeedEnvelope = Envelope.make(constSpeedPart);
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
         cursor.findPosition(3);
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(4, 1));
             assertTrue(partBuilder.addStep(5, 4));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(3, envelope.size());
@@ -87,22 +87,22 @@ public class EnvelopeOverlayTest {
         );
         var constSpeedEnvelope = Envelope.make(constSpeedPart);
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(1, 1));
             assertTrue(partBuilder.addStep(3, 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
         cursor.findPosition(6);
 
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(7, 1));
             assertTrue(partBuilder.addStep(8, 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
         var envelope = builder.build();
@@ -120,21 +120,22 @@ public class EnvelopeOverlayTest {
                 new double[]{2, 2}
         );
         var constSpeedEnvelope = Envelope.make(constSpeedPart);
+        var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
         var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(1, 1));
             assertTrue(partBuilder.addStep(3, 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
-        builder.cursor.findPosition(6);
+        cursor.findPosition(6);
 
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(7, 1));
             assertTrue(partBuilder.addStep(8, 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
         var envelope = builder.build();
@@ -155,13 +156,14 @@ public class EnvelopeOverlayTest {
         );
         double[] overlayPoints = backwardDir ? new double[] {5, 4, 3} : new double[] { 3, 4, 5};
         var constSpeedEnvelope = Envelope.make(constSpeedPart);
+        var cursor = new EnvelopeCursor(constSpeedEnvelope, backwardDir);
         var builder = OverlayEnvelopeBuilder.withDirection(constSpeedEnvelope, backwardDir);
-        builder.cursor.findPosition(overlayPoints[0]);
+        cursor.findPosition(overlayPoints[0]);
         {
-            var partBuilder = builder.startContinuousOverlay(testMeta);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, testMeta);
             assertFalse(partBuilder.addStep(overlayPoints[1], 1));
             assertTrue(partBuilder.addStep(overlayPoints[2], 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
         var envelope = builder.build();
@@ -213,9 +215,10 @@ public class EnvelopeOverlayTest {
         );
 
         var builder = OverlayEnvelopeBuilder.withDirection(baseEnvelope, isBackward);
+        var cursor = new EnvelopeCursor(baseEnvelope, isBackward);
         var positions = new double[] { 3, 4, 6 };
         var speeds = new double[] { 4, 3, 4 };
-        EnvelopeTestUtils.buildContinuous(builder, null, positions, speeds, isBackward);
+        builder.addPart(EnvelopeTestUtils.buildContinuous(cursor, null, positions, speeds, isBackward));
         var envelope = builder.build();
         assertEquals(4, envelope.size());
         assertTrue(envelope.continuous);
@@ -261,13 +264,13 @@ public class EnvelopeOverlayTest {
         );
 
         var cursor = EnvelopeCursor.forward(baseEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(baseEnvelope);
         cursor.findPosition(1);
 
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertTrue(partBuilder.addStep(5, 5));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
 
         var forwardEnvelope = builder.build();
@@ -309,9 +312,10 @@ public class EnvelopeOverlayTest {
         );
 
         var builder = OverlayEnvelopeBuilder.withDirection(baseEnvelope, reverse);
+        var cursor = new EnvelopeCursor(baseEnvelope, reverse);
         var positions = new double[] { 3, 4, 5, 6 };
         var speeds = new double[] { 4, 3, 3, 4 };
-        EnvelopeTestUtils.buildContinuous(builder, null, positions, speeds, reverse);
+        builder.addPart(EnvelopeTestUtils.buildContinuous(cursor, null, positions, speeds, reverse));
         var envelope = builder.build();
         assertEquals(4, envelope.size());
         assertTrue(envelope.continuous);
@@ -325,12 +329,13 @@ public class EnvelopeOverlayTest {
                 new double[]{2, 1, 0}
         ));
 
+        var cursor = EnvelopeCursor.forward(inputEnvelope);
         var builder = OverlayEnvelopeBuilder.forward(inputEnvelope);
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(1, 1));
             assertTrue(partBuilder.addStep(4, 1));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(2, envelope.size());
@@ -345,13 +350,14 @@ public class EnvelopeOverlayTest {
                 new double[]{1, 1, 3}
         ));
 
+        var cursor = EnvelopeCursor.forward(inputEnvelope);
         var builder = OverlayEnvelopeBuilder.forward(inputEnvelope);
-        builder.cursor.findPosition(2);
+        cursor.findPosition(2);
         {
-            var partBuilder = builder.startContinuousOverlay(null);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null);
             assertFalse(partBuilder.addStep(3, 2));
             assertTrue(partBuilder.addStep(4, 3));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(2, envelope.size());

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayThresholdTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayThresholdTest.java
@@ -20,13 +20,13 @@ public class EnvelopeOverlayThresholdTest {
                 new double[]{2, 2}
         ));
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         cursor.findPosition(3);
         {
-            var partBuilder = builder.startContinuousOverlay(null, 1, CmpOperator.LOWER);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null, 1, CmpOperator.LOWER);
             assertTrue(partBuilder.addStep(4, 0));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(1.0, envelope.getMinSpeed());
@@ -47,13 +47,13 @@ public class EnvelopeOverlayThresholdTest {
                 new double[]{2, 2}
         ));
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         cursor.findPosition(3);
         {
-            var partBuilder = builder.startContinuousOverlay(null, 1, CmpOperator.LOWER);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null, 1, CmpOperator.LOWER);
             assertTrue(partBuilder.addStep(4, 1));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(1.0, envelope.getMinSpeed());
@@ -74,13 +74,14 @@ public class EnvelopeOverlayThresholdTest {
                 new double[]{2, 2}
         ));
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         cursor.findPosition(3);
         {
-            var partBuilder = builder.startDiscontinuousOverlay(null, 0, 1, CmpOperator.HIGHER);
+            var partBuilder = OverlayEnvelopePartBuilder.startDiscontinuousOverlay(
+                    cursor, null, 0, 1, CmpOperator.HIGHER);
             assertTrue(partBuilder.addStep(4, 2));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         EnvelopeShape.check(envelope, CONSTANT, INCREASING, CONSTANT);
@@ -100,13 +101,14 @@ public class EnvelopeOverlayThresholdTest {
                 new double[]{2, 2}
         ));
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         cursor.findPosition(3);
         {
-            var partBuilder = builder.startDiscontinuousOverlay(null, 0, 1, CmpOperator.HIGHER);
+            var partBuilder = OverlayEnvelopePartBuilder.startDiscontinuousOverlay(
+                    cursor, null, 0, 1, CmpOperator.HIGHER);
             assertTrue(partBuilder.addStep(4, 1));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         EnvelopeShape.check(envelope, CONSTANT, INCREASING, CONSTANT);
@@ -125,18 +127,18 @@ public class EnvelopeOverlayThresholdTest {
                 new double[]{20, 20}
         ));
         var cursor = EnvelopeCursor.forward(constSpeedEnvelope);
-        var builder = new OverlayEnvelopeBuilder(cursor);
+        var builder = OverlayEnvelopeBuilder.forward(constSpeedEnvelope);
 
         var position = 10.0;
         cursor.findPosition(position);
         var speed = cursor.getSpeed();
         {
-            var partBuilder = builder.startContinuousOverlay(null, 10, CmpOperator.LOWER);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, null, 10, CmpOperator.LOWER);
             do {
                 position++;
                 speed--;
             } while (!partBuilder.addStep(position, speed));
-            builder.addPart(partBuilder);
+            builder.addPart(partBuilder.build());
         }
         var envelope = builder.build();
         assertEquals(10.0, envelope.getMinSpeed());

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
@@ -9,26 +9,26 @@ public class EnvelopeTestUtils {
     public static final class EnvelopeTestMeta extends EnvelopePartMeta {
     }
 
-    static void buildContinuous(
-            OverlayEnvelopeBuilder builder, EnvelopePartMeta meta,
+    static EnvelopePart buildContinuous(
+            EnvelopeCursor cursor, EnvelopePartMeta meta,
             double[] positions, double[] speeds, boolean isBackward
     ) {
         var lastIndex = positions.length - 1;
         if (!isBackward) {
-            builder.cursor.findPosition(positions[0]);
+            cursor.findPosition(positions[0]);
 
-            var partBuilder = builder.startContinuousOverlay(meta);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, meta);
             for (int i = 1; i < positions.length - 1; i++)
                 assertFalse(partBuilder.addStep(positions[i], speeds[i]));
             assertTrue(partBuilder.addStep(positions[lastIndex], speeds[lastIndex]));
-            builder.addPart(partBuilder);
+            return partBuilder.build();
         } else {
-            builder.cursor.findPosition(positions[lastIndex]);
-            var partBuilder = builder.startContinuousOverlay(meta);
+            cursor.findPosition(positions[lastIndex]);
+            var partBuilder = OverlayEnvelopePartBuilder.startContinuousOverlay(cursor, meta);
             for (int i = lastIndex - 1; i > 0; i--)
                 assertFalse(partBuilder.addStep(positions[i], speeds[i]));
             assertTrue(partBuilder.addStep(positions[0], speeds[0]));
-            builder.addPart(partBuilder);
+            return partBuilder.build();
         }
     }
 


### PR DESCRIPTION
This change makes the overlay API easier to use: you can add any EnvelopePart to an OverlayEnvelopeBuilder

PS: it seems like project code coverage decreases because there is less code