### PR TITLE
core: envelope: use binary search in envelope parts

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -183,8 +183,7 @@ public final class Envelope implements Iterable<EnvelopePart> {
         var envelopePartIndex = findEnvelopePartIndex(position);
         assert envelopePartIndex != -1 : "Trying to interpolate time outside of the envelope";
         var envelopePart = get(envelopePartIndex);
-        var stepIndex = envelopePart.findStep(position);
-        return getCumulativeTimeMS(envelopePartIndex) + envelopePart.interpolateTotalTimeMS(stepIndex, position);
+        return getCumulativeTimeMS(envelopePartIndex) + envelopePart.interpolateTotalTimeMS(position);
     }
 
     /** Computes the time required to get to a given point of the envelope */
@@ -253,7 +252,7 @@ public final class Envelope implements Iterable<EnvelopePart> {
         if (beginPosition != Double.NEGATIVE_INFINITY) {
             beginPartIndex = findEnvelopePartIndex(beginPosition);
             var beginPart = parts[beginPartIndex];
-            beginIndex = beginPart.findStep(beginPosition);
+            beginIndex = beginPart.findStepRight(beginPosition);
         }
         var endPartIndex = parts.length - 1;
         var endPart = parts[endPartIndex];
@@ -261,7 +260,7 @@ public final class Envelope implements Iterable<EnvelopePart> {
         if (endPosition != Double.POSITIVE_INFINITY) {
             endPartIndex = findEnvelopePartIndex(endPosition);
             endPart = parts[endPartIndex];
-            endIndex = endPart.findStep(endPosition);
+            endIndex = endPart.findStepLeft(endPosition);
         }
         return slice(beginPartIndex, beginIndex, beginPosition, beginSpeed,
                 endPartIndex, endIndex, endPosition, endSpeed);

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -91,8 +91,8 @@ public class EnvelopePhysics {
 
     /** @see #intersectSteps(EnvelopePart, int, EnvelopePart, int) */
     public static EnvelopePoint intersectSteps(EnvelopePart a, EnvelopePart b, double position) {
-        var stepIndexA = a.findStep(position);
-        var stepIndexB = b.findStep(position);
+        var stepIndexA = a.findStepLeft(position);
+        var stepIndexB = b.findStepLeft(position);
         return intersectSteps(a, stepIndexA, b, stepIndexB);
     }
 

--- a/core/src/main/java/fr/sncf/osrd/envelope/MaxEnvelopeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/MaxEnvelopeBuilder.java
@@ -108,7 +108,8 @@ public final class MaxEnvelopeBuilder {
         for (var part : activeParts) {
             var speed = part.interpolateSpeed(position);
             if (Math.abs(speed - currentMaxSpeed) < 1E-6) {
-                var acceleration = part.interpolateAcceleration(position);
+                var stepIndex = part.findStepRight(position);
+                var acceleration = part.interpolateAcceleration(stepIndex, position);
                 if (acceleration <= currentMaxAcceleration)
                     continue;
                 currentMaxAcceleration = acceleration;

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
@@ -74,7 +74,7 @@ public class EnvelopeOverlayTest {
         assertEquals(3, envelope.size());
         assertTrue(envelope.continuous);
 
-        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStep(3), 3, Double.NaN);
+        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStepLeft(3), 3, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedFirst, envelope.get(0));
     }
 
@@ -170,7 +170,7 @@ public class EnvelopeOverlayTest {
         assertEquals(3, envelope.size());
         assertTrue(envelope.continuous);
 
-        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStep(3), 3, Double.NaN);
+        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStepLeft(3), 3, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedFirst, envelope.get(0));
         var expectedMid = EnvelopePart.generateTimes(
                 testMeta,
@@ -178,7 +178,7 @@ public class EnvelopeOverlayTest {
                 new double[]{2, 1, 2}
         );
         EnvelopeTestUtils.assertEquals(expectedMid, envelope.get(1));
-        var expectedLast = constSpeedPart.sliceEnd(constSpeedPart.findStep(5), 5, Double.NaN);
+        var expectedLast = constSpeedPart.sliceEnd(constSpeedPart.findStepRight(5), 5, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedLast, envelope.get(2));
     }
 

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -19,18 +19,29 @@ class EnvelopePartTest {
     }
 
     @Test
-    void getRangeIndex() {
+    void findStep() {
         var ep = EnvelopePart.generateTimes(
                 null,
                 new double[] {1.5, 3, 5},
                 new double[] {3, 4, 4}
         );
-        assertEquals(0, ep.findStep(1.5));
-        assertEquals(0, ep.findStep(3));
-        assertEquals(1, ep.findStep(3.5));
-        assertEquals(1, ep.findStep(5));
-        assertThrows(AssertionError.class, () -> ep.findStep(1));
-        assertThrows(AssertionError.class, () -> ep.findStep(5.1));
+
+        assertEquals(0, ep.findStepLeft(1.5));
+        assertEquals(0, ep.findStepRight(1.5));
+
+        assertEquals(0, ep.findStepLeft(3));
+        assertEquals(1, ep.findStepRight(3));
+
+        assertEquals(1, ep.findStepLeft(3.5));
+        assertEquals(1, ep.findStepRight(3.5));
+
+        assertEquals(1, ep.findStepLeft(5));
+        assertEquals(1, ep.findStepRight(5));
+
+        assertThrows(AssertionError.class, () -> ep.findStepLeft(1));
+        assertThrows(AssertionError.class, () -> ep.findStepLeft(5.1));
+        assertThrows(AssertionError.class, () -> ep.findStepRight(1));
+        assertThrows(AssertionError.class, () -> ep.findStepRight(5.1));
     }
 
     @Test

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
@@ -48,7 +48,7 @@ public class EnvelopeTest {
         var partB = EnvelopePart.generateTimes(null, new double[] { 2, 4 }, new double[] { 1, 1 });
         var envelope = Envelope.make(partA, partB);
 
-        assertEquals(1, partA.interpolateTotalTime(0, 1));
+        assertEquals(1, partA.interpolateTotalTime(1));
 
         assertEquals(1, envelope.interpolateTotalTime(1));
         assertEquals(2, envelope.interpolateTotalTime(2));


### PR DESCRIPTION
Replace findStep by findStepLeft and findStepRight, which specifies which step is chosen on intermediary point boundaries.