### PR TITLE
core: envelope: search for envelope parts using binary search

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePart.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePart.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
  *  <li>each segment of the line is thus a step over space, which is indexed from 0 to stepCount()</li>
  * </ul>
  */
-public final class EnvelopePart {
+public final class EnvelopePart implements SearchableEnvelope {
     // region INTRINSIC DATA FIELDS
 
     /** Metadata about this envelope part */
@@ -347,54 +347,14 @@ public final class EnvelopePart {
 
     // region FIND
 
-    /** Find the leftmost step (with the lowest position) which contains the given position */
-    public int findStepLeft(double position) {
-        assert position >= getBeginPos();
-        assert position <= getEndPos();
-        var pointIndex = Arrays.binarySearch(positions, position);
-        // if the position matches one of the data points, return the range on the left, if any
-        if (pointIndex >= 0) {
-            if (pointIndex == 0)
-                return 0;
-            return pointIndex - 1;
-        }
-
-        // when the position isn't found, binarySearch returns -(insertion point) - 1
-        var insertionPoint = -(pointIndex + 1);
-        // the index of the step is the index of the point which starts the range
-        return insertionPoint - 1;
+    @Override
+    public int binarySearchPositions(double position) {
+        return Arrays.binarySearch(positions, position);
     }
 
-    /** Find the leftmost step (with the lowest position) which contains the given position */
-    public int findStepRight(double position) {
-        assert position >= getBeginPos();
-        assert position <= getEndPos();
-        var pointIndex = Arrays.binarySearch(positions, position);
-        // if the position matches one of the data points, return the range on the left, if any
-        if (pointIndex >= 0) {
-            if (pointIndex == positions.length - 1)
-                return pointIndex - 1;
-            return pointIndex;
-        }
-
-        // when the position isn't found, binarySearch returns -(insertion point) - 1
-        var insertionPoint = -(pointIndex + 1);
-        // the index of the step is the index of the point which starts the range
-        return insertionPoint - 1;
-    }
-
-    /** Returns the first step which contains a position along a given direction */
-    public int findStepLeftDir(double position, double direction) {
-        if (direction < 0)
-            return findStepRight(position);
-        return findStepLeft(position);
-    }
-
-    /** Returns the last step which contains a position along a given direction */
-    public int findStepRightDir(double position, double direction) {
-        if (direction < 0)
-            return findStepLeft(position);
-        return findStepRight(position);
+    @Override
+    public int positionPointsCount() {
+        return positions.length;
     }
 
     // endregion
@@ -568,12 +528,12 @@ public final class EnvelopePart {
         if (beginPosition <= getBeginPos())
             beginPosition = Double.NEGATIVE_INFINITY;
         if (beginPosition != Double.NEGATIVE_INFINITY)
-            beginIndex = findStepRight(beginPosition);
+            beginIndex = findRight(beginPosition);
         int endIndex = stepCount() - 1;
         if (endPosition >= getEndPos())
             endPosition = Double.POSITIVE_INFINITY;
         if (endPosition != Double.POSITIVE_INFINITY)
-            endIndex = findStepLeft(endPosition);
+            endIndex = findLeft(endPosition);
         return slice(beginIndex, beginPosition, endIndex, endPosition);
     }
 

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -91,8 +91,8 @@ public class EnvelopePhysics {
 
     /** @see #intersectSteps(EnvelopePart, int, EnvelopePart, int) */
     public static EnvelopePoint intersectSteps(EnvelopePart a, EnvelopePart b, double position) {
-        var stepIndexA = a.findStepLeft(position);
-        var stepIndexB = b.findStepLeft(position);
+        var stepIndexA = a.findLeft(position);
+        var stepIndexB = b.findLeft(position);
         return intersectSteps(a, stepIndexA, b, stepIndexB);
     }
 

--- a/core/src/main/java/fr/sncf/osrd/envelope/MaxEnvelopeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/MaxEnvelopeBuilder.java
@@ -106,7 +106,7 @@ public final class MaxEnvelopeBuilder {
         for (var part : activeParts) {
             var speed = part.interpolateSpeed(position);
             if (Math.abs(speed - currentMaxSpeed) < 1E-6) {
-                var stepIndex = part.findStepRight(position);
+                var stepIndex = part.findRight(position);
                 var acceleration = part.interpolateAcceleration(stepIndex, position);
                 if (acceleration <= currentMaxAcceleration)
                     continue;

--- a/core/src/main/java/fr/sncf/osrd/envelope/OverlayEnvelopeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/OverlayEnvelopeBuilder.java
@@ -62,7 +62,7 @@ public final class OverlayEnvelopeBuilder {
         double sliceBeginSpeed = Double.NaN;
         if (previousOverlay != null) {
             sliceBeginPos = previousOverlay.getEndPos();
-            int partIndex = base.findEnvelopePartIndexRight(sliceBeginPos);
+            int partIndex = base.findRight(sliceBeginPos);
             var baseSpeed = base.get(partIndex).interpolateSpeed(sliceBeginPos);
             if (Math.abs(baseSpeed - previousOverlay.getEndSpeed()) < 1e-6)
                 sliceBeginSpeed = previousOverlay.getEndSpeed();
@@ -71,7 +71,7 @@ public final class OverlayEnvelopeBuilder {
         double sliceEndSpeed = Double.NaN;
         if (currentOverlay != null) {
             sliceEndPos = currentOverlay.getBeginPos();
-            int partIndex = base.findEnvelopePartIndexLeft(sliceEndPos);
+            int partIndex = base.findLeft(sliceEndPos);
             var baseSpeed = base.get(partIndex).interpolateSpeed(sliceEndPos);
             if (Math.abs(baseSpeed - currentOverlay.getBeginSpeed()) < 1e-6)
                 sliceEndSpeed = currentOverlay.getBeginSpeed();

--- a/core/src/main/java/fr/sncf/osrd/envelope/SearchableEnvelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/SearchableEnvelope.java
@@ -1,0 +1,70 @@
+package fr.sncf.osrd.envelope;
+
+/**
+ * <p>A utility class to search envelope positions, both on envelopes and envelope parts.
+ * It performs the search on the position of points if on envelope parts, and on the position of
+ * envelope parts if on envelopes.</p>
+ *
+ * <p>The position arrays encodes a 1D monotonic polyline:</p>
+ * <pre>
+ *     +------------+--------+----------+
+ *     0            1        2          3
+ * </pre>
+ */
+interface SearchableEnvelope {
+    /** Runs a binary search on the positions array */
+    int binarySearchPositions(double position);
+
+    /** Returns the number of positions */
+    int positionPointsCount();
+
+    /** Find the leftmost segment (with the lowest position) which contains the given position */
+    default int findLeft(double position) {
+        var pointIndex = binarySearchPositions(position);
+        // if the position matches one of the data points, return the range on the left, if any
+        if (pointIndex >= 0) {
+            if (pointIndex == 0)
+                return 0;
+            return pointIndex - 1;
+        }
+
+        // when the position isn't found, binarySearch returns -(insertion point) - 1
+        var insertionPoint = -(pointIndex + 1);
+        if (insertionPoint == 0 || insertionPoint == positionPointsCount())
+            return -insertionPoint - 1;
+        // the index of the step is the index of the point which starts the range
+        return insertionPoint - 1;
+    }
+
+    /** Find the leftmost index (with the lowest position) which contains the given position */
+    default int findRight(double position) {
+        var pointIndex = binarySearchPositions(position);
+        // if the position matches one of the data points, return the range on the left, if any
+        if (pointIndex >= 0) {
+            if (pointIndex == positionPointsCount() - 1)
+                return pointIndex - 1;
+            return pointIndex;
+        }
+
+        // when the position isn't found, binarySearch returns -(insertion point) - 1
+        var insertionPoint = -(pointIndex + 1);
+        if (insertionPoint == 0 || insertionPoint == positionPointsCount())
+            return -insertionPoint - 1;
+        // the index of the step is the index of the point which starts the range
+        return insertionPoint - 1;
+    }
+
+    /** Returns the first index which contains a position along a given direction */
+    default int findLeftDir(double position, double direction) {
+        if (direction < 0)
+            return findRight(position);
+        return findLeft(position);
+    }
+
+    /** Returns the last index which contains a position along a given direction */
+    default int findRightDir(double position, double direction) {
+        if (direction < 0)
+            return findLeft(position);
+        return findRight(position);
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/envelope/constraint/EnvelopeCeiling.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/constraint/EnvelopeCeiling.java
@@ -15,14 +15,14 @@ public class EnvelopeCeiling implements EnvelopePartConstraint {
 
     @Override
     public boolean initCheck(double direction, double position, double speed) {
-        var partIndex = envelope.findEnvelopePartIndexRightDir(position, direction);
+        var partIndex = envelope.findRightDir(position, direction);
 
         // if the position is off the envelope, fail
         if (partIndex == -1)
             return false;
 
         var part = envelope.get(partIndex);
-        var stepIndex = part.findStepRightDir(position, direction);
+        var stepIndex = part.findRightDir(position, direction);
         var envelopeSpeed = part.interpolateSpeed(stepIndex, position);
         cursor = new EnvelopeCursor(envelope, direction < 0, partIndex, stepIndex, position);
         return envelopeSpeed >= speed;

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
@@ -242,7 +242,8 @@ public class MarecoAllowance implements Allowance {
             List<Double> endOfCoastingPositions
     ) {
         for (var position : endOfCoastingPositions) {
-            var part = envelope.getEnvelopePartLeft(position);
+            var partIndex = envelope.findLeft(position);
+            var part = partIndex < 0 ? null : envelope.get(partIndex);
             if (part == null || (part.hasAttr(EnvelopeProfile.ACCELERATING) && part.getBeginPos() < position))
                 continue; // Starting a coasting curve in an acceleration part would stop instantly and trigger asserts
 
@@ -327,7 +328,7 @@ public class MarecoAllowance implements Allowance {
     /** Moves the position forward until it's not in a braking section,
      * returns -1 if it reaches the end of the path*/
     private double moveForwardUntilNotBraking(Envelope base, double position) {
-        var envelopeIndex = base.findEnvelopePartIndexLeft(position);
+        var envelopeIndex = base.findLeft(position);
         while (envelopeIndex < base.size() && isBraking(base.get(envelopeIndex)))
             envelopeIndex++;
         if (envelopeIndex >= base.size())
@@ -339,7 +340,7 @@ public class MarecoAllowance implements Allowance {
     /** Moves the position backwards until it's not in an accelerating section,
      * returns -1 if it reaches the beginning of the path*/
     private double moveBackwardsUntilNotAccelerating(Envelope base, double position) {
-        var envelopeIndex = base.findEnvelopePartIndexLeft(position);
+        var envelopeIndex = base.findLeft(position);
         while (envelopeIndex >= 0 && base.get(envelopeIndex).hasAttr(EnvelopeProfile.ACCELERATING))
             envelopeIndex--;
         if (envelopeIndex < 0)

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
-import java.util.Map;
 
 public class EnvelopeOverlayTest {
     @ParameterizedTest
@@ -77,7 +76,7 @@ public class EnvelopeOverlayTest {
         assertEquals(2, envelope.get(1).getMaxSpeed());
         assertTrue(envelope.continuous);
 
-        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStepLeft(3), 3, Double.NaN);
+        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findLeft(3), 3, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedFirst, envelope.get(0));
     }
 
@@ -144,7 +143,7 @@ public class EnvelopeOverlayTest {
         assertEquals(3, envelope.size());
         assertTrue(envelope.continuous);
 
-        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findStepLeft(3), 3, Double.NaN);
+        var expectedFirst = constSpeedPart.sliceBeginning(constSpeedPart.findLeft(3), 3, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedFirst, envelope.get(0));
         var expectedMid = EnvelopePart.generateTimes(
                 List.of(TestAttr.A),
@@ -152,7 +151,7 @@ public class EnvelopeOverlayTest {
                 new double[]{2, 1, 2}
         );
         EnvelopeTestUtils.assertEquals(expectedMid, envelope.get(1));
-        var expectedLast = constSpeedPart.sliceEnd(constSpeedPart.findStepRight(5), 5, Double.NaN);
+        var expectedLast = constSpeedPart.sliceEnd(constSpeedPart.findRight(5), 5, Double.NaN);
         EnvelopeTestUtils.assertEquals(expectedLast, envelope.get(2));
     }
 

--- a/core/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.envelope;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.sncf.osrd.envelope.EnvelopeTestUtils.TestAttr;
 import org.junit.jupiter.api.Test;
@@ -45,22 +46,22 @@ class EnvelopePartTest {
                 new double[] {3, 4, 4}
         );
 
-        assertEquals(0, ep.findStepLeft(1.5));
-        assertEquals(0, ep.findStepRight(1.5));
+        assertEquals(0, ep.findLeft(1.5));
+        assertEquals(0, ep.findRight(1.5));
 
-        assertEquals(0, ep.findStepLeft(3));
-        assertEquals(1, ep.findStepRight(3));
+        assertEquals(0, ep.findLeft(3));
+        assertEquals(1, ep.findRight(3));
 
-        assertEquals(1, ep.findStepLeft(3.5));
-        assertEquals(1, ep.findStepRight(3.5));
+        assertEquals(1, ep.findLeft(3.5));
+        assertEquals(1, ep.findRight(3.5));
 
-        assertEquals(1, ep.findStepLeft(5));
-        assertEquals(1, ep.findStepRight(5));
+        assertEquals(1, ep.findLeft(5));
+        assertEquals(1, ep.findRight(5));
 
-        assertThrows(AssertionError.class, () -> ep.findStepLeft(1));
-        assertThrows(AssertionError.class, () -> ep.findStepLeft(5.1));
-        assertThrows(AssertionError.class, () -> ep.findStepRight(1));
-        assertThrows(AssertionError.class, () -> ep.findStepRight(5.1));
+        assertEquals(-1,  ep.findLeft(1));
+        assertEquals(-4,  ep.findLeft(5.1));
+        assertEquals(-1,  ep.findRight(1));
+        assertEquals(-4, ep.findRight(5.1));
     }
 
     @Test


### PR DESCRIPTION
This previously was not possible, as envelope parts were not guaranteed to be contiguous.