### PR TITLE
core: create new TrainPath / TrackRangeView

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
@@ -24,6 +24,8 @@ public class EnvelopePath implements PhysicsPath {
         assert gradePositions.length == gradeValues.length + 1;
         assert gradePositions[0] == 0.0;
         assert gradePositions[gradePositions.length - 1] == length;
+        for (int i = 0; i < gradePositions.length - 1; i++)
+            assert gradePositions[i] < gradePositions[i + 1];
         this.gradePositions = gradePositions;
         this.gradeValues = gradeValues;
         this.length = length;

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
@@ -4,12 +4,14 @@ import static fr.sncf.osrd.utils.DoubleUtils.clamp;
 
 import com.carrotsearch.hppc.DoubleArrayList;
 import fr.sncf.osrd.envelope_sim.EnvelopePath;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.train.TrackSectionRange;
 import fr.sncf.osrd.train.TrainPath;
 import fr.sncf.osrd.utils.Range;
 import fr.sncf.osrd.utils.graph.EdgeDirection;
 import java.util.List;
 import java.util.NavigableSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class EnvelopeTrainPath {
@@ -65,10 +67,25 @@ public class EnvelopeTrainPath {
             gradePositions.add(length);
             gradeValues.add(0);
         }
+        return new EnvelopePath(length, gradePositions.toArray(), gradeValues.toArray());
+    }
 
-        for (int i = 0; i < gradePositions.size() - 1; i++)
-            assert gradePositions.get(i) < gradePositions.get(i + 1);
+    /** Create EnvelopePath from a list of TrackRangeView */
+    public static EnvelopePath fromNew(List<TrackRangeView> trackSectionPath) {
+        var gradePositions = new DoubleArrayList();
+        gradePositions.add(0);
+        var gradeValues = new DoubleArrayList();
+        var length = 0.;
 
+        for (var range : trackSectionPath) {
+            var grades = range.getGradients().getValuesInRange(0, range.getLength());
+            for (var interval : new TreeSet<>(grades.keySet())) {
+                gradePositions.add(length + interval.getEndPosition());
+                gradeValues.add(grades.get(interval));
+
+            }
+            length += range.getLength();
+        }
         return new EnvelopePath(length, gradePositions.toArray(), gradeValues.toArray());
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/Direction.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/Direction.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.new_infra.api;
 
+import fr.sncf.osrd.utils.graph.EdgeDirection;
+
 /** Encodes a direction in a one dimension space */
 public enum Direction {
     FORWARD(1),
@@ -9,6 +11,13 @@ public enum Direction {
 
     Direction(double sign) {
         this.sign = sign;
+    }
+
+    /** Converts an EdgeDirection into a Direction (START_TO_STOP -> FORWARD) */
+    public static Direction fromEdgeDir(EdgeDirection direction) {
+        if (direction == EdgeDirection.START_TO_STOP)
+            return FORWARD;
+        return BACKWARD;
     }
 
     /** Returns the opposite direction */

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/reservation/ReservationInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/reservation/ReservationInfra.java
@@ -19,4 +19,6 @@ public interface ReservationInfra extends TrackInfra, DiTrackInfra {
     /** Returns the detection routes infrastructure graph */
     ImmutableNetwork<DiDetector, ReservationRoute> getInfraRouteGraph();
 
+    /** Returns a mapping from route ID to route */
+    ImmutableMap<String, ReservationRoute> getReservationRouteMap();
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/reservation/ReservationRoute.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/reservation/ReservationRoute.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.new_infra.api.reservation;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 
 public interface ReservationRoute {
     /** Returns the route id */
@@ -13,5 +15,11 @@ public interface ReservationRoute {
     ImmutableList<Detector> getReleasePoints();
 
     /** Returns the list of conflicting routes */
-    ImmutableList<ReservationRoute> getConflictingRoutes();
+    ImmutableSet<ReservationRoute> getConflictingRoutes();
+
+    /** Returns the list of track ranges on the route*/
+    ImmutableList<TrackRangeView> getTrackRanges();
+
+    /** Returns the route length (m) */
+    double getLength();
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/SignalingInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/SignalingInfra.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.new_infra.api.signaling;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.graph.ImmutableNetwork;
 import fr.sncf.osrd.new_infra.api.reservation.DiDetector;

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackEdge.java
@@ -1,6 +1,9 @@
 package fr.sncf.osrd.new_infra.api.tracks.undirected;
 
 import com.google.common.collect.ImmutableList;
+import fr.sncf.osrd.new_infra.api.Direction;
+import fr.sncf.osrd.utils.DoubleRangeMap;
+import java.util.EnumMap;
 
 /** An undirected track edge, which can either be a branch of a switch, or a track section */
 public sealed interface TrackEdge permits SwitchBranch, TrackSection {
@@ -9,6 +12,12 @@ public sealed interface TrackEdge permits SwitchBranch, TrackSection {
 
     /** List of objects on the track */
     ImmutableList<TrackObject> getTrackObjects();
+
+    /** List of gradients on the track for a given direction (corrected with curves) */
+    EnumMap<Direction, DoubleRangeMap> getGradients();
+
+    /** List of speed sections on the track for a given direction */
+    EnumMap<Direction, DoubleRangeMap> getSpeedSections();
 
     /** Global unique index starting at 0, used for union finds */
     int getIndex();

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackLocation.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackLocation.java
@@ -1,0 +1,3 @@
+package fr.sncf.osrd.new_infra.api.tracks.undirected;
+
+public record TrackLocation(TrackSection track, double offset) {}

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackObject.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/tracks/undirected/TrackObject.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.new_infra.api.tracks.undirected;
 
+import fr.sncf.osrd.new_infra.api.reservation.Detector;
+
 /** An object located on a track section */
 public interface TrackObject {
     /** Returns the track section this object is on */
@@ -13,6 +15,12 @@ public interface TrackObject {
 
     /** Returns the type of the object */
     TrackObjectType getType();
+
+    /** Linked Detector object (null if there isn't any) */
+    Detector getDetector();
+
+    /** Sets the detector */
+    void setDetector(Detector detector);
 
     enum TrackObjectType {
         DETECTOR,

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/DetectorImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/DetectorImpl.java
@@ -46,7 +46,8 @@ public class DetectorImpl implements Detector {
     void setDetectionSection(Direction direction, DetectionSection section) {
         if (direction == Direction.FORWARD)
             nextSection = section;
-        prevSection = section;
+        else
+            prevSection = section;
     }
 
     /**

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/DetectorMaps.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/DetectorMaps.java
@@ -30,6 +30,7 @@ class DetectorMaps {
         for (var track : infra.getTrackGraph().edges()) {
             for (var object : track.getTrackObjects()) {
                 var newDetector = new DetectorImpl(object.getID());
+                object.setDetector(newDetector);
                 detectors.put(object.getID(), newDetector);
                 var diDetectorForward = new DiDetectorImpl(newDetector, Direction.FORWARD);
                 diDetectors.get(Direction.FORWARD).put(object.getID(), diDetectorForward);

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationInfraImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationInfraImpl.java
@@ -14,6 +14,7 @@ public class ReservationInfraImpl extends DiTrackInfraImpl implements Reservatio
     private final ImmutableMap<DiDetector, DetectionSection> sectionMap;
     private final ImmutableNetwork<DiDetector, ReservationRoute> infraRouteGraph;
     private final ImmutableMap<Direction, ImmutableMap<String, DiDetector>> diDetectorMap;
+    private final ImmutableMap<String, ReservationRoute> reservationRouteMap;
 
     /** Constructor */
     public ReservationInfraImpl(
@@ -21,13 +22,15 @@ public class ReservationInfraImpl extends DiTrackInfraImpl implements Reservatio
             ImmutableMap<String, Detector> detectorMap,
             ImmutableMap<Direction, ImmutableMap<String, DiDetector>> diDetectorMap,
             ImmutableMap<DiDetector, DetectionSection> sectionMap,
-            ImmutableNetwork<DiDetector, ReservationRoute> infraRouteGraph
+            ImmutableNetwork<DiDetector, ReservationRoute> infraRouteGraph,
+            ImmutableMap<String, ReservationRoute> reservationRouteMap
     ) {
         super(infra, infra.getDiTrackGraph());
         this.detectorMap = detectorMap;
         this.diDetectorMap = Maps.immutableEnumMap(diDetectorMap);
         this.sectionMap = sectionMap;
         this.infraRouteGraph = infraRouteGraph;
+        this.reservationRouteMap = reservationRouteMap;
     }
 
     @Override
@@ -48,5 +51,10 @@ public class ReservationInfraImpl extends DiTrackInfraImpl implements Reservatio
     @Override
     public ImmutableNetwork<DiDetector, ReservationRoute> getInfraRouteGraph() {
         return infraRouteGraph;
+    }
+
+    @Override
+    public ImmutableMap<String, ReservationRoute> getReservationRouteMap() {
+        return reservationRouteMap;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationRouteImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationRouteImpl.java
@@ -2,17 +2,20 @@ package fr.sncf.osrd.new_infra.implementation.reservation;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import fr.sncf.osrd.new_infra.api.reservation.Detector;
 import fr.sncf.osrd.new_infra.api.reservation.DiDetector;
 import fr.sncf.osrd.new_infra.api.reservation.ReservationRoute;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.Collection;
 
 public class ReservationRouteImpl implements ReservationRoute {
-    private ImmutableList<ReservationRoute> conflictingRoutes;
+    private ImmutableSet<ReservationRoute> conflictingRoutes;
     private final ImmutableList<DiDetector> detectorPath;
     private final ImmutableList<Detector> releasePoints;
     public final String id;
+    private final ImmutableList<TrackRangeView> trackRanges;
 
     @Override
     @ExcludeFromGeneratedCodeCoverage
@@ -21,6 +24,7 @@ public class ReservationRouteImpl implements ReservationRoute {
                 .add("detectorPath", detectorPath)
                 .add("releasePoints", releasePoints)
                 .add("id", id)
+                .add("trackRanges", trackRanges)
                 .toString();
     }
 
@@ -28,10 +32,11 @@ public class ReservationRouteImpl implements ReservationRoute {
     public ReservationRouteImpl(
             ImmutableList<DiDetector> detectorPath,
             ImmutableList<Detector> releasePoints,
-            String id
-    ) {
+            String id,
+            ImmutableList<TrackRangeView> trackRanges) {
         this.detectorPath = detectorPath;
         this.releasePoints = releasePoints;
+        this.trackRanges = trackRanges;
         this.id = id;
     }
 
@@ -51,12 +56,24 @@ public class ReservationRouteImpl implements ReservationRoute {
     }
 
     @Override
-    public ImmutableList<ReservationRoute> getConflictingRoutes() {
+    public ImmutableSet<ReservationRoute> getConflictingRoutes() {
         return conflictingRoutes;
     }
 
     /** Sets the conflicting routes (package private). */
     void setConflictingRoutes(Collection<ReservationRoute> routes) {
-        conflictingRoutes = ImmutableList.copyOf(routes);
+        conflictingRoutes = ImmutableSet.copyOf(routes);
+    }
+
+    @Override
+    public ImmutableList<TrackRangeView> getTrackRanges() {
+        return trackRanges;
+    }
+
+    @Override
+    public double getLength() {
+        return trackRanges.stream()
+                .mapToDouble(TrackRangeView::getLength)
+                .sum();
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/SignalingInfraImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/SignalingInfraImpl.java
@@ -23,8 +23,14 @@ public class SignalingInfraImpl extends ReservationInfraImpl implements Signalin
             ImmutableMultimap<ReservationRoute, SignalingRoute> routeMap,
             ImmutableNetwork<DiDetector, SignalingRoute> signalingRouteGraph
     ) {
-        super(reservationInfra, reservationInfra.getDetectorMap(), reservationInfra.getDiDetectorMap(),
-                reservationInfra.getSectionMap(), reservationInfra.getInfraRouteGraph());
+        super(
+                reservationInfra,
+                reservationInfra.getDetectorMap(),
+                reservationInfra.getDiDetectorMap(),
+                reservationInfra.getSectionMap(),
+                reservationInfra.getInfraRouteGraph(),
+                reservationInfra.getReservationRouteMap()
+        );
         this.signalMap = signalMap;
         this.routeMap = routeMap;
         this.signalingRouteGraph = signalingRouteGraph;

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/DirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/DirectedInfraBuilder.java
@@ -11,7 +11,6 @@ import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackEdge;
 import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackInfra;
 import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackNode;
 import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackNode.Side;
-import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackObject;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.SwitchBranch;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackEdge;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackInfra;

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
@@ -1,0 +1,130 @@
+package fr.sncf.osrd.new_infra.implementation.tracks.directed;
+
+
+import fr.sncf.osrd.new_infra.api.Direction;
+import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackEdge;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackObject;
+import fr.sncf.osrd.utils.DoubleRangeMap;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** An oriented view on a track range. Can be used to iterate over its content */
+public class TrackRangeView {
+    /** Start of the range on the original track (begin < end) */
+    public final double begin;
+    /** End of the range on the original track (begin < end) */
+    public final double end;
+    /** Referenced oriented track. This sets the direction of the range */
+    public final DiTrackEdge track;
+
+    /** A pair containing an element and an offset. The offset is oriented with 0 = start of the range.
+     * The offset contained in the element is based on the track itself, it may be different */
+    public record ElementView<T>(double offset, T element){}
+
+    private static final Comparator<? super ElementView<TrackObject>> comparator
+            = Comparator.comparingDouble(x -> x.offset);
+
+    /** Constructor */
+    public TrackRangeView(double begin, double end, DiTrackEdge track) {
+        if (begin < end) {
+            this.begin = begin;
+            this.end = end;
+        } else {
+            this.begin = end;
+            this.end = begin;
+        }
+        assert end <= track.getEdge().getLength();
+        assert begin >= 0;
+        this.track = track;
+    }
+
+    /** Returns the length of the range */
+    public double getLength() {
+        return end - begin;
+    }
+
+    /** Returns a list of objects on the range (sorted) */
+    public List<ElementView<TrackObject>> getObjects() {
+        return track.getEdge().getTrackObjects().stream()
+                .map(o -> new ElementView<>(convertPosition(o.getOffset()), o))
+                .filter(this::isInRange)
+                .sorted(comparator)
+                .collect(Collectors.toList());
+    }
+
+    /** Returns the speed sections with positions referring to the track range (0 = directed start of the range) */
+    public DoubleRangeMap getSpeedSections() {
+        var originalSpeedSections = track.getEdge().getSpeedSections().get(track.getDirection());
+        return convertMap(originalSpeedSections);
+    }
+
+    /** Returns the gradients with positions referring to the track range (0 = directed start of the range) */
+    public DoubleRangeMap getGradients() {
+        var originalGradients = track.getEdge().getGradients().get(track.getDirection());
+        return convertMap(originalGradients);
+    }
+
+    /** Returns true if the location is included in the range */
+    public boolean contains(TrackLocation location) {
+        return location.track().equals(track.getEdge())
+                && location.offset() >= begin
+                && location.offset() <= end;
+    }
+
+    /** Returns the distance between the start of the range and the given location */
+    public double offsetOf(TrackLocation location) {
+        assert contains(location) : "can't determine the offset of an element not in the range";
+        if (track.getDirection().equals(Direction.FORWARD))
+            return location.offset() - begin;
+        else
+            return end - location.offset();
+    }
+
+    /** Returns a new view where the beginning is truncated until the given offset */
+    public TrackRangeView truncateBegin(double offset) {
+        assert offset >= begin && offset <= end : "truncate location isn't located in the range";
+        if (track.getDirection().equals(Direction.FORWARD))
+            return new TrackRangeView(offset, end, track);
+        else
+            return new TrackRangeView(begin, offset, track);
+    }
+
+    /** Returns a new view where the end is truncated from the given offset */
+    public TrackRangeView truncateEnd(double offset) {
+        assert offset >= begin && offset <= end : "truncate location isn't located in the range";
+        if (track.getDirection().equals(Direction.FORWARD))
+            return new TrackRangeView(begin, offset, track);
+        else
+            return new TrackRangeView(offset, end, track);
+    }
+
+    /** Converts a DoubleRangeMap based on the original track so that the positions refer to the range */
+    private DoubleRangeMap convertMap(DoubleRangeMap map) {
+        var res = new DoubleRangeMap();
+        for (var entry : map.getValuesInRange(begin, end).entrySet()) {
+            var rangeStart = convertPosition(entry.getKey().getBeginPosition());
+            var rangeEnd = convertPosition(entry.getKey().getEndPosition());
+            if (rangeStart > rangeEnd) {
+                var tmp = rangeStart;
+                rangeStart = rangeEnd;
+                rangeEnd = tmp;
+            }
+            res.addRange(rangeStart, rangeEnd, entry.getValue());
+        }
+        return res.simplify();
+    }
+
+    /** Converts a position on the original track to one referring to the range itself.*/
+    private double convertPosition(double position) {
+        if (track.getDirection() == Direction.FORWARD)
+            return position - begin;
+        return end - position;
+    }
+
+    /** Returns true if the element is inside the range */
+    private boolean isInRange(ElementView<?> element) {
+        return element.offset >= 0 && element.offset <= getLength();
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/SwitchBranchImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/SwitchBranchImpl.java
@@ -2,15 +2,25 @@ package fr.sncf.osrd.new_infra.implementation.tracks.undirected;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import fr.sncf.osrd.new_infra.api.Direction;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.Switch;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.SwitchBranch;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackObject;
+import fr.sncf.osrd.utils.DoubleRangeMap;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
+import java.util.EnumMap;
+import java.util.Map;
 
 public class SwitchBranchImpl implements SwitchBranch {
 
     public Switch switchRef;
     int index;
+
+    /** static mapping from direction to empty map. Avoids unnecessary object instantiations */
+    private static final EnumMap<Direction, DoubleRangeMap> emptyMap = new EnumMap<>(Map.of(
+            Direction.FORWARD, new DoubleRangeMap(),
+            Direction.BACKWARD, new DoubleRangeMap()
+    ));
 
     @Override
     @ExcludeFromGeneratedCodeCoverage
@@ -28,6 +38,16 @@ public class SwitchBranchImpl implements SwitchBranch {
     @Override
     public ImmutableList<TrackObject> getTrackObjects() {
         return ImmutableList.of();
+    }
+
+    @Override
+    public EnumMap<Direction, DoubleRangeMap> getGradients() {
+        return emptyMap;
+    }
+
+    @Override
+    public EnumMap<Direction, DoubleRangeMap> getSpeedSections() {
+        return emptyMap;
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/TrackObjectImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/TrackObjectImpl.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.new_infra.implementation.tracks.undirected;
 
 import com.google.common.base.MoreObjects;
+import fr.sncf.osrd.new_infra.api.reservation.Detector;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackObject;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackSection;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
@@ -15,6 +16,8 @@ public class TrackObjectImpl implements TrackObject {
     public final TrackObjectType type;
     /** ID of the object */
     public final String id;
+    /** Detector object corresponding to this track object (if any) */
+    private Detector detector;
 
     @Override
     @ExcludeFromGeneratedCodeCoverage
@@ -53,5 +56,15 @@ public class TrackObjectImpl implements TrackObject {
     @Override
     public TrackObjectType getType() {
         return type;
+    }
+
+    @Override
+    public Detector getDetector() {
+        return detector;
+    }
+
+    @Override
+    public void setDetector(Detector detector) {
+        this.detector = detector;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/TrackSectionImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/undirected/TrackSectionImpl.java
@@ -2,14 +2,19 @@ package fr.sncf.osrd.new_infra.implementation.tracks.undirected;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import fr.sncf.osrd.new_infra.api.Direction;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackObject;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackSection;
+import fr.sncf.osrd.utils.DoubleRangeMap;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
+import java.util.EnumMap;
 
 public class TrackSectionImpl implements TrackSection {
 
     private final double length;
     private final String id;
+    EnumMap<Direction, DoubleRangeMap> speedSections;
+    EnumMap<Direction, DoubleRangeMap> gradients;
     ImmutableList<TrackObject> trackObjects;
     int index;
 
@@ -35,6 +40,16 @@ public class TrackSectionImpl implements TrackSection {
     @Override
     public ImmutableList<TrackObject> getTrackObjects() {
         return trackObjects;
+    }
+
+    @Override
+    public EnumMap<Direction, DoubleRangeMap> getGradients() {
+        return gradients;
+    }
+
+    @Override
+    public EnumMap<Direction, DoubleRangeMap> getSpeedSections() {
+        return speedSections;
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/api/NewTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/api/NewTrainPath.java
@@ -1,0 +1,44 @@
+package fr.sncf.osrd.new_infra_state.api;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import fr.sncf.osrd.new_infra.api.reservation.DetectionSection;
+import fr.sncf.osrd.new_infra.api.reservation.DiDetector;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record NewTrainPath(
+        ImmutableList<LocatedElement<SignalingRoute>> routePath,
+        ImmutableList<LocatedElement<TrackRangeView>> trackRangePath,
+        ImmutableList<LocatedElement<DiDetector>> detectors,
+        ImmutableList<LocatedElement<DetectionSection>> detectionSections,
+        double length
+) {
+
+    /** An element located with the offset from the start of the path.
+     * For ranges and routes, it's the position of the start of the object
+     * (negative if the path start is in the middle of an object). */
+    public record LocatedElement<T>(double pathOffset, T element) {}
+
+    @Override
+    @ExcludeFromGeneratedCodeCoverage
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("routePath", routePath)
+                .add("trackRangePath", trackRangePath)
+                .add("detectors", detectors)
+                .add("detectionSections", detectionSections)
+                .add("length", length)
+                .toString();
+    }
+
+    /** Utility function, converts a list of LocatedElement into a list of element */
+    public static <T> List<T> removeLocation(ImmutableList<LocatedElement<T>> list) {
+        return list.stream()
+                .map(x -> x.element)
+                .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/TrainPathBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/TrainPathBuilder.java
@@ -1,0 +1,215 @@
+package fr.sncf.osrd.new_infra_state.implementation;
+
+import com.google.common.collect.ImmutableList;
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.new_infra.api.Direction;
+import fr.sncf.osrd.new_infra.api.reservation.DetectionSection;
+import fr.sncf.osrd.new_infra.api.reservation.DiDetector;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackObject;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
+import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrainPathBuilder {
+
+    /** Build Train Path from routes, a starting and ending location */
+    public static NewTrainPath from(
+            List<SignalingRoute> routePath,
+            TrackLocation startLocation,
+            TrackLocation endLocation
+    ) throws InvalidSchedule {
+        ImmutableList<NewTrainPath.LocatedElement<TrackRangeView>> trackSectionPath;
+        try {
+            trackSectionPath = createTrackRangePath(routePath, startLocation, endLocation);
+        } catch (RuntimeException e) {
+            throw new InvalidSchedule(e.getMessage());
+        }
+        var detectors = createDetectorPath(trackSectionPath);
+        var length = trackSectionPath.stream()
+                .mapToDouble(x -> x.element().getLength())
+                .sum();
+        var locatedRoutePath = makeLocatedRoutePath(routePath, startLocation);
+        var trainPath = new NewTrainPath(
+                locatedRoutePath,
+                trackSectionPath,
+                detectors,
+                makeDetectionSections(locatedRoutePath, length),
+                length
+        );
+        validate(trainPath);
+        return trainPath;
+    }
+
+    /** Build Train Path from an RailJSON train path */
+    public static NewTrainPath from(SignalingInfra infra, RJSTrainPath rjsTrainPath) throws InvalidSchedule {
+        try {
+            var routePath = new ArrayList<SignalingRoute>();
+            for (var rjsRoutePath : rjsTrainPath.routePath) {
+                var infraRoute = infra.getReservationRouteMap().get(rjsRoutePath.route.id.id);
+                if (infraRoute == null)
+                    throw new InvalidSchedule(String.format("Can't find route %s", rjsRoutePath.route.id.id));
+                var signalingRoutes = infra.getRouteMap().get(infraRoute);
+                // TODO: add an enum to determine the signalization type
+                routePath.add(signalingRoutes.stream().findFirst().orElseThrow());
+            }
+
+            var rjsStartTrackRange = rjsTrainPath.routePath.get(0).trackSections.get(0);
+            var startLocation = new TrackLocation(
+                    infra.getTrackSection(rjsStartTrackRange.track.id.id),
+                    rjsStartTrackRange.begin
+            );
+
+            var rjsEndRoutePath = rjsTrainPath.routePath.get(rjsTrainPath.routePath.size() - 1);
+            var rjsEndTrackRange = rjsEndRoutePath.trackSections.get(rjsEndRoutePath.trackSections.size() - 1);
+            var endLocation = new TrackLocation(
+                    infra.getTrackSection(rjsEndTrackRange.track.id.id),
+                    rjsEndTrackRange.end
+            );
+
+            return from(routePath, startLocation, endLocation);
+        } catch (InvalidInfraException e) {
+            throw new InvalidSchedule(e.getMessage());
+        }
+    }
+
+    /** Creates the list of detection sections on the path */
+    private static ImmutableList<NewTrainPath.LocatedElement<DetectionSection>> makeDetectionSections(
+            ImmutableList<NewTrainPath.LocatedElement<SignalingRoute>> routePath,
+            double pathLength
+    ) {
+        var res = new ArrayList<NewTrainPath.LocatedElement<DetectionSection>>();
+        var offset = routePath.get(0).pathOffset();
+        for (var locatedRoute : routePath) {
+            var route = locatedRoute.element();
+            for (var range : route.getInfraRoute().getTrackRanges()) {
+                for (var object : range.getObjects()) {
+                    var diDetector = objectToDiDetector(object.element(), range.track.getDirection());
+                    if (diDetector == null)
+                        continue;
+                    var detectionSection = diDetector.getDetector().getNextDetectionSection(diDetector.getDirection());
+                    addIfDifferent(res, new NewTrainPath.LocatedElement<>(offset + object.offset(), detectionSection));
+                }
+                offset += range.getLength();
+            }
+        }
+
+        // Remove the first sections until only one start with a negative offset (the one we start on)
+        while (res.size() > 1 && res.get(1).pathOffset() < 0)
+            res.remove(0);
+        // Remove the sections that start after the end of the path
+        res.removeIf(section -> section.pathOffset() >= pathLength);
+
+        return ImmutableList.copyOf(res);
+    }
+
+    /** check that everything make sense */
+    private static void validate(NewTrainPath path) {
+        assert !path.routePath().isEmpty() : "empty route path";
+        assert !path.detectionSections().isEmpty() : "no detection section on path";
+        assert !path.trackRangePath().isEmpty() : "empty track range path";
+        assert Math.abs(path.detectionSections().size() - path.detectors().size()) <= 1
+                : "Detection section size is inconsistent";
+        assert path.length() > 0 : "length must be strictly positive";
+
+        // TODO checks that the track ranges are properly connected
+        // But this would require an actual infra, which technically isn't required otherwise
+    }
+
+    /** Creates the list of located routes */
+    private static ImmutableList<NewTrainPath.LocatedElement<SignalingRoute>> makeLocatedRoutePath(
+            List<SignalingRoute> routePath,
+            TrackLocation startLocation
+    ) {
+        var res = ImmutableList.<NewTrainPath.LocatedElement<SignalingRoute>>builder();
+        var offsetOnFirstRoute = offsetFromStartOfPath(
+                routePath.get(0).getInfraRoute().getTrackRanges(),
+                startLocation
+        );
+        var offset = -offsetOnFirstRoute;
+        if (Math.abs(offset) == 0)
+            offset = 0; // avoids the annoying -0
+        for (var route : routePath) {
+            res.add(new NewTrainPath.LocatedElement<>(offset, route));
+            offset += route.getInfraRoute().getLength();
+        }
+        return res.build();
+    }
+
+    /** Returns the distance between the beginning of the list of ranges and the given location */
+    private static double offsetFromStartOfPath(ImmutableList<TrackRangeView> path, TrackLocation location) {
+        var offset = 0;
+        for (var range : path) {
+            if (range.contains(location))
+                return offset + range.offsetOf(location);
+            offset += range.getLength();
+        }
+        throw new RuntimeException("Location isn't in the given path");
+    }
+
+    /** Creates a list of located directed detectors on the path */
+    private static ImmutableList<NewTrainPath.LocatedElement<DiDetector>> createDetectorPath(
+            ImmutableList<NewTrainPath.LocatedElement<TrackRangeView>> trackSectionPath
+    ) {
+        var res = new ArrayList<NewTrainPath.LocatedElement<DiDetector>>();
+        double offset = 0;
+        for (var range : trackSectionPath) {
+            for (var object : range.element().getObjects()) {
+                var diDetector = objectToDiDetector(object.element(), range.element().track.getDirection());
+                if (diDetector != null)
+                    addIfDifferent(res, new NewTrainPath.LocatedElement<>(offset + object.offset(), diDetector));
+            }
+            offset += range.element().getLength();
+        }
+        return ImmutableList.copyOf(res);
+    }
+
+    /** Get the DiDetector object from a TrackObject and a direction. Null if not applicable */
+    private static DiDetector objectToDiDetector(TrackObject object, Direction direction) {
+        var detector = object.getDetector();
+        if (detector == null)
+            return null;
+        return detector.getDiDetector(direction);
+    }
+
+    /** Creates the lists of track ranges */
+    private static ImmutableList<NewTrainPath.LocatedElement<TrackRangeView>> createTrackRangePath(
+            List<SignalingRoute> routePath,
+            TrackLocation startLocation,
+            TrackLocation endLocation
+    ) {
+        var res = new ArrayList<NewTrainPath.LocatedElement<TrackRangeView>>();
+        double offset = 0;
+        var reachedStart = false;
+        for (int i = 0; i < routePath.size(); i++) {
+            var signalingRoute = routePath.get(i);
+            var route = signalingRoute.getInfraRoute();
+            for (var range : route.getTrackRanges()) {
+                if (!reachedStart) {
+                    if (!range.contains(startLocation))
+                        continue;
+                    reachedStart = true;
+                    range = range.truncateBegin(startLocation.offset());
+                }
+                // We have to check if we're on the last route to avoid problems with looping paths
+                if (i == routePath.size() - 1 && range.contains(endLocation))
+                    range = range.truncateEnd(endLocation.offset());
+                res.add(new NewTrainPath.LocatedElement<>(offset, range));
+                offset += range.getLength();
+            }
+        }
+        return ImmutableList.copyOf(res);
+    }
+
+    /** Adds a located element if it's not already the last on the list */
+    private static <T> void addIfDifferent(List<NewTrainPath.LocatedElement<T>> list,
+                                           NewTrainPath.LocatedElement<T> element) {
+        if (list.isEmpty() || list.get(list.size() - 1).element() != element.element())
+            list.add(element);
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
@@ -26,6 +26,11 @@ public class RJSTrackSection implements Identified {
     public LineString geo;
     public LineString sch;
 
+    public RJSTrackSection(String id, double length) {
+        this.id = id;
+        this.length = length;
+    }
+
     @Override
     public String getID() {
         return id;

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSBufferStop.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSBufferStop.java
@@ -1,3 +1,13 @@
 package fr.sncf.osrd.railjson.schema.infra.trackobjects;
 
-public class RJSBufferStop extends RJSRouteWaypoint {}
+import fr.sncf.osrd.railjson.schema.common.RJSObjectRef;
+import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection;
+
+public class RJSBufferStop extends RJSRouteWaypoint {
+    /** Constructor */
+    public RJSBufferStop(String id, double position, RJSObjectRef<RJSTrackSection> track) {
+        super(id);
+        this.position = position;
+        this.track = track;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSRouteWaypoint.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSRouteWaypoint.java
@@ -6,6 +6,14 @@ import fr.sncf.osrd.utils.graph.IPointValue;
 
 @SuppressFBWarnings({"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
 public class RJSRouteWaypoint extends RJSTrackObject implements Identified, IPointValue<RJSRouteWaypoint> {
+    public RJSRouteWaypoint(String id) {
+        this.id = id;
+    }
+
+    public RJSRouteWaypoint() {
+        this.id = null;
+    }
+
     public String id;
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSTrainDetector.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackobjects/RJSTrainDetector.java
@@ -1,3 +1,13 @@
 package fr.sncf.osrd.railjson.schema.infra.trackobjects;
 
-public class RJSTrainDetector extends RJSRouteWaypoint {}
+import fr.sncf.osrd.railjson.schema.common.RJSObjectRef;
+import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection;
+
+public class RJSTrainDetector extends RJSRouteWaypoint {
+    /** Constructor */
+    public RJSTrainDetector(String id, double position, RJSObjectRef<RJSTrackSection> track) {
+        super(id);
+        this.position = position;
+        this.track = track;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/SingleDirectionalRJSTrackRange.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/SingleDirectionalRJSTrackRange.java
@@ -22,4 +22,16 @@ public class SingleDirectionalRJSTrackRange extends RJSTrackRange {
         this.direction = direction;
         this.track = track;
     }
+
+    /** Constructor */
+    public SingleDirectionalRJSTrackRange(
+            EdgeDirection direction,
+            RJSObjectRef<RJSTrackSection> track,
+            double begin,
+            double end
+    ) {
+        this(direction, track);
+        this.begin = begin;
+        this.end = end;
+    }
 }

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/schedule/RJSTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/schedule/RJSTrainPath.java
@@ -14,7 +14,15 @@ public class RJSTrainPath {
      * Full train path as a list of routes
      */
     @Json(name = "route_paths")
-    public final List<RJSRoutePath> routePath = new ArrayList<>();
+    public final List<RJSRoutePath> routePath;
+
+    public RJSTrainPath(List<RJSRoutePath> path) {
+        this.routePath = path;
+    }
+
+    public RJSTrainPath() {
+        this.routePath = new ArrayList<>();
+    }
 
     public static class RJSRoutePath {
         public final RJSObjectRef<RJSRoute> route;

--- a/core/src/main/java/fr/sncf/osrd/utils/DoubleRangeMap.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/DoubleRangeMap.java
@@ -1,13 +1,13 @@
 package fr.sncf.osrd.utils;
 
-import java.util.HashMap;
-import java.util.TreeMap;
+import java.util.*;
 
 public class DoubleRangeMap extends TreeMap<Double, Double> {
     private static final long serialVersionUID = -4311554160237448509L;
 
     /** Add a value in a given range */
     public void addRange(double begin, double end, double value) {
+        assert begin != end : "Can't add an empty range";
         put(begin, value);
         if (!containsKey(end))
             put(end, 0.);
@@ -35,5 +35,21 @@ public class DoubleRangeMap extends TreeMap<Double, Double> {
 
         res.put(new Range(begin, end), lastValue);
         return res;
+    }
+
+    /** Merges identical adjacent ranges */
+    public DoubleRangeMap simplify() {
+        var entries = new ArrayList<>(entrySet());
+        if (entries.size() == 0)
+            return this;
+        entries.sort(Comparator.comparingDouble(Map.Entry::getKey));
+        var lastValue = entries.get(0).getValue();
+        for (int i = 1; i < entries.size(); i++) {
+            var value = entries.get(i).getValue();
+            if (value.equals(lastValue))
+                remove(entries.get(i).getKey());
+            lastValue = value;
+        }
+        return this;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/utils/Range.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/Range.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.utils;
 
+import com.google.common.base.MoreObjects;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.Objects;
 
 public class Range implements Comparable<Range> {
@@ -64,5 +66,14 @@ public class Range implements Comparable<Range> {
         if (Double.min(begin, end) > position)
             return false;
         return Double.max(begin, end) >= position;
+    }
+
+    @Override
+    @ExcludeFromGeneratedCodeCoverage
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("begin", begin)
+                .add("end", end)
+                .toString();
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/Helpers.java
+++ b/core/src/test/java/fr/sncf/osrd/Helpers.java
@@ -7,6 +7,7 @@ import fr.sncf.osrd.infra.trackgraph.Waypoint;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
 import fr.sncf.osrd.utils.moshi.MoshiUtils;
 import java.io.*;
 import java.net.URISyntaxException;

--- a/core/src/test/java/fr/sncf/osrd/new_infra/reservation/DetectionSectionBuilderTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra/reservation/DetectionSectionBuilderTests.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.new_infra.reservation;
 
 import static fr.sncf.osrd.new_infra.InfraHelpers.makeSwitchInfra;
+import static fr.sncf.osrd.new_infra.InfraHelpers.setTrackObjects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -110,17 +111,9 @@ public class DetectionSectionBuilderTests {
 
     private void setObjects(TrackInfra infra, String tracKID, List<OffsetIDPair> objects) {
         var track = infra.getTrackSection(tracKID);
-        var builder = ImmutableList.<TrackObject>builder();
+        var list = new ArrayList<TrackObject>();
         for (var object : objects)
-            builder.add(new TrackObjectImpl(track, object.offset, TrackObject.TrackObjectType.DETECTOR, object.id));
-        if (track instanceof TrackSectionImpl impl) {
-            try {
-                var field = TrackSectionImpl.class.getDeclaredField("trackObjects");
-                field.setAccessible(true);
-                field.set(impl, builder.build());
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
+            list.add(new TrackObjectImpl(track, object.offset, TrackObject.TrackObjectType.DETECTOR, object.id));
+        setTrackObjects(track, ImmutableList.copyOf(list));
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/new_infra/tracks/directed/DirectedRJSParsingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra/tracks/directed/DirectedRJSParsingTests.java
@@ -1,15 +1,23 @@
 package fr.sncf.osrd.new_infra.tracks.directed;
 
 import static fr.sncf.osrd.new_infra.InfraHelpers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.graph.NetworkBuilder;
 import com.google.common.graph.Traverser;
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.new_infra.api.Direction;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.*;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.DiTrackEdgeImpl;
 import fr.sncf.osrd.new_infra.implementation.tracks.directed.DirectedInfraBuilder;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.new_infra.implementation.tracks.undirected.*;
+import fr.sncf.osrd.utils.DoubleRangeMap;
 import org.junit.jupiter.api.Test;
 import java.util.Set;
+import java.util.*;
 
 public class DirectedRJSParsingTests {
 
@@ -88,5 +96,211 @@ public class DirectedRJSParsingTests {
                 reachableFrom3,
                 Sets.difference(allTrackEnds, reachableFrom3)
         );
+    }
+
+    @Test
+    public void testTrackObjects() {
+        // Build the undirected graph
+        var builder = NetworkBuilder
+                .directed()
+                .<TrackNode, TrackEdge>immutable();
+
+        final var node1 = new SwitchPortImpl("1");
+        final var node2 = new SwitchPortImpl("2");
+        final var node3 = new SwitchPortImpl("3");
+        builder.addNode(node1);
+        builder.addNode(node2);
+        builder.addNode(node3);
+        var edge12 = new TrackSectionImpl(100, "1-2");
+        var edge32 = new TrackSectionImpl(100, "3-2");
+        builder.addEdge(node1, node2, edge12);
+        builder.addEdge(node3, node2, edge32);
+        var detector1 = new TrackObjectImpl(edge12, 30, TrackObject.TrackObjectType.DETECTOR, "d1");
+        var detector2 = new TrackObjectImpl(edge12, 60, TrackObject.TrackObjectType.DETECTOR, "d2");
+        var bs1 = new TrackObjectImpl(edge12, 0, TrackObject.TrackObjectType.BUFFER_STOP, "bs1");
+        var detector3 = new TrackObjectImpl(edge32, 65, TrackObject.TrackObjectType.DETECTOR, "d3");
+        var detector4 = new TrackObjectImpl(edge32, 35, TrackObject.TrackObjectType.DETECTOR, "d4");
+        setTrackObjects(edge12, List.of(
+                detector1,
+                detector2,
+                bs1
+        ));
+        setTrackObjects(edge32, List.of(
+                detector3,
+                detector4
+        ));
+
+        // Converts to directed graph
+        var infra = TrackInfraImpl.from(null, builder.build());
+        var directedInfra = DirectedInfraBuilder.fromUndirected(infra);
+
+        // Tests that we see the waypoints in the right order when going from 1 to 3
+        final var edge1 = directedInfra.getEdge("1-2", Direction.FORWARD);
+        final var edge2 = directedInfra.getEdge("3-2", Direction.BACKWARD);
+        final var edge1View = new TrackRangeView(0, edge1.getEdge().getLength(), edge1);
+        final var edge2View = new TrackRangeView(0, edge1.getEdge().getLength(), edge2);
+        var allObjects = new ArrayList<TrackObject>();
+        for (var object : edge1View.getObjects())
+            allObjects.add(object.element());
+        for (var object : edge2View.getObjects())
+            allObjects.add(object.element());
+        assertEquals(List.of(
+                bs1,
+                detector1,
+                detector2,
+                detector3,
+                detector4
+        ), allObjects);
+    }
+
+    @Test
+    public void trackViewObjectsTest() {
+        var edge1 = new TrackSectionImpl(100, "1");
+        var edge2 = new TrackSectionImpl(100, "2");
+        var detector1 = new TrackObjectImpl(edge1, 30, TrackObject.TrackObjectType.DETECTOR, "d1-30");
+        var detector2 = new TrackObjectImpl(edge1, 60, TrackObject.TrackObjectType.DETECTOR, "d1-60");
+        var detector3 = new TrackObjectImpl(edge2, 65, TrackObject.TrackObjectType.DETECTOR, "d2-65");
+        var detector4 = new TrackObjectImpl(edge2, 35, TrackObject.TrackObjectType.DETECTOR, "d2-35");
+        setTrackObjects(edge1, List.of(
+                detector1,
+                detector2
+        ));
+        setTrackObjects(edge2, List.of(
+                detector3,
+                detector4
+        ));
+        var diEdge1F = new DiTrackEdgeImpl(edge1, Direction.FORWARD);
+        var diEdge1B = new DiTrackEdgeImpl(edge1, Direction.BACKWARD);
+        var diEdge2F = new DiTrackEdgeImpl(edge2, Direction.FORWARD);
+        var diEdge2B = new DiTrackEdgeImpl(edge2, Direction.BACKWARD);
+
+        var path1 = List.of(
+                new TrackRangeView(0, 100, diEdge1F),
+                new TrackRangeView(0, 100, diEdge2F)
+        );
+        var path2 = List.of(
+                new TrackRangeView(0, 50, diEdge1F),
+                new TrackRangeView(50, 100, diEdge1F),
+                new TrackRangeView(0, 15, diEdge2F),
+                new TrackRangeView(15, 100, diEdge2F)
+        );
+        assertEquals(
+                getObjectsOnRanges(path1),
+                getObjectsOnRanges(path2)
+        );
+
+        var path3 = List.of(
+                new TrackRangeView(0, 100, diEdge1B),
+                new TrackRangeView(100, 0, diEdge2B)
+        );
+        var path4 = List.of(
+                new TrackRangeView(50, 100, diEdge1B),
+                new TrackRangeView(50, 0, diEdge1B),
+                new TrackRangeView(15, 100, diEdge2B),
+                new TrackRangeView(15, 0, diEdge2B)
+        );
+        assertEquals(
+                getObjectsOnRanges(path3),
+                getObjectsOnRanges(path4)
+        );
+
+        var path5 = List.of(
+                new TrackRangeView(100, 0, diEdge2B),
+                new TrackRangeView(0, 100, diEdge1B)
+        );
+
+        var objectsForward = getObjectsOnRanges(path1).stream()
+                .map(x -> x.object.getID())
+                .toList();
+
+        var objectsBackward = getObjectsOnRanges(path5).stream()
+                .map(x -> x.object.getID())
+                .toList();
+        assertEquals(objectsForward, Lists.reverse(objectsBackward));
+    }
+
+
+    @Test
+    public void trackViewRangesTest() {
+        final var edge = new TrackSectionImpl(100, "edge");
+        var speedSections = new EnumMap<Direction, DoubleRangeMap>(Direction.class);
+        var map = new DoubleRangeMap();
+        map.addRange(0, 100, 0);
+        map.addRange(0, 30, 30);
+        map.addRange(60, 80, -10);
+        for (var dir : Direction.values())
+            speedSections.put(dir, map);
+        setTrackSpeedSections(edge, speedSections);
+
+        var edgeF = new DiTrackEdgeImpl(edge, Direction.FORWARD);
+        var edgeB = new DiTrackEdgeImpl(edge, Direction.BACKWARD);
+        var path1 = List.of(
+                new TrackRangeView(0, 100, edgeF)
+        );
+        var path2 = List.of(
+                new TrackRangeView(0, 15, edgeF),
+                new TrackRangeView(15, 50, edgeF),
+                new TrackRangeView(50, 90, edgeF),
+                new TrackRangeView(90, 100, edgeF)
+        );
+        assertEquals(
+                getSpeedsOnRange(path1),
+                getSpeedsOnRange(path2)
+        );
+
+        var path3 = List.of(
+                new TrackRangeView(0, 100, edgeB)
+        );
+        var path4 = List.of(
+                new TrackRangeView(90, 100, edgeB),
+                new TrackRangeView(50, 90, edgeB),
+                new TrackRangeView(15, 50, edgeB),
+                new TrackRangeView(0, 15, edgeB)
+        );
+        assertEquals(
+                getSpeedsOnRange(path3),
+                getSpeedsOnRange(path4)
+        );
+
+        var inverted = new DoubleRangeMap();
+        inverted.addRange(0, 100, 0);
+        inverted.addRange(70, 100, 30);
+        inverted.addRange(20, 40, -10);
+        assertEquals(
+                inverted,
+                getSpeedsOnRange(path3)
+        );
+    }
+
+    private record Pair(TrackObject object, double position) {}
+
+    /** Merges all the objects and positions on a list of ranges */
+    private static List<Pair> getObjectsOnRanges(List<TrackRangeView> ranges) {
+        var pos = 0;
+        var res = new ArrayList<Pair>();
+        for (var range : ranges) {
+            var objects = range.getObjects();
+            for (var obj : objects)
+                res.add(new Pair(obj.element(), pos + obj.offset()));
+            pos += range.getLength();
+        }
+        return res;
+    }
+
+    /** Merges all the speed sections on a list of ranges */
+    private static DoubleRangeMap getSpeedsOnRange(List<TrackRangeView> ranges) {
+        var pos = 0;
+        var res = new DoubleRangeMap();
+        for (var range : ranges) {
+            var sections = range.getSpeedSections();
+            for (var section : sections.getValuesInRange(0, range.getLength()).entrySet())
+                res.addRange(
+                        section.getKey().getBeginPosition() + pos,
+                        section.getKey().getEndPosition() + pos,
+                        section.getValue()
+                );
+            pos += range.getLength();
+        }
+        return res.simplify();
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/new_infra_state/TrainPathTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra_state/TrainPathTests.java
@@ -1,0 +1,187 @@
+package fr.sncf.osrd.new_infra_state;
+
+import static fr.sncf.osrd.new_infra.InfraHelpers.*;
+import static fr.sncf.osrd.new_infra.api.Direction.BACKWARD;
+import static fr.sncf.osrd.new_infra.api.Direction.FORWARD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.new_infra.api.Direction;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
+import fr.sncf.osrd.new_infra.implementation.signaling.SignalingInfraBuilder;
+import fr.sncf.osrd.new_infra.implementation.signaling.modules.BAL3;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.DiTrackEdgeImpl;
+import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.new_infra.implementation.tracks.undirected.TrackSectionImpl;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
+import fr.sncf.osrd.new_infra_state.implementation.TrainPathBuilder;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
+import fr.sncf.osrd.utils.DoubleRangeMap;
+import fr.sncf.osrd.utils.graph.EdgeDirection;
+import org.junit.jupiter.api.Test;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Set;
+
+public class TrainPathTests {
+
+    private SignalingRoute getRoute(SignalingInfra infra, String id) {
+        var reservationRoute = infra.getReservationRouteMap().get(id);
+        assert reservationRoute != null;
+        return infra.getRouteMap().get(reservationRoute).stream()
+                .findFirst().orElseThrow();
+    }
+
+    @Test
+    public void testFromRJSTrainPath() {
+        var rjsInfra = makeSingleTrackRJSInfra();
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var rjsPath = new RJSTrainPath(List.of(
+                new RJSTrainPath.RJSRoutePath("route_forward", List.of(
+                        new RJSTrainPath.RJSDirectionalTrackRange("track", 20, 80, EdgeDirection.START_TO_STOP)
+                ))
+        ));
+        var path = TrainPathBuilder.from(infra, rjsPath);
+        assertEquals(60, path.length());
+    }
+
+    @Test
+    public void testSingleTrackInfraSimple() {
+        var rjsInfra = makeSingleTrackRJSInfra();
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var track = infra.getTrackSection("track");
+        var path = TrainPathBuilder.from(
+                List.of(getRoute(infra, "route_forward")),
+                new TrackLocation(track, 0),
+                new TrackLocation(track, 100)
+        );
+
+        assertEquals(100, path.length());
+
+        assertEquals(1, path.routePath().size());
+        assertEquals(0, path.routePath().get(0).pathOffset());
+        assertEquals("route_forward", path.routePath().get(0).element().getInfraRoute().getID());
+
+        assertEquals(4, path.detectors().size());
+        assertEquals(0, path.detectors().get(0).pathOffset());
+        assertEquals(50, path.detectors().get(1).pathOffset());
+        assertEquals(75, path.detectors().get(2).pathOffset());
+        assertEquals(100, path.detectors().get(3).pathOffset());
+        assertEquals("bs_start", path.detectors().get(0).element().getDetector().getID());
+        assertEquals("d1", path.detectors().get(1).element().getDetector().getID());
+        assertEquals("d2", path.detectors().get(2).element().getDetector().getID());
+        assertEquals("bs_end", path.detectors().get(3).element().getDetector().getID());
+        for (var d : path.detectors())
+            assertEquals(FORWARD, d.element().getDirection());
+
+        assertEquals(3, path.detectionSections().size());
+        for (int i = 0; i < 3; i++)
+            assertEquals(
+                    path.detectors().get(i).element().getDetector().getNextDetectionSection(FORWARD),
+                    path.detectionSections().get(i).element()
+            );
+
+        assertEquals(1, path.trackRangePath().size());
+        assertEquals(0, path.trackRangePath().get(0).element().begin);
+        assertEquals(100, path.trackRangePath().get(0).element().end);
+    }
+
+    @Test
+    public void testSingleTrackInfraTwoRoutes() {
+        var rjsInfra = makeSingleTrackRJSInfra();
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var track = infra.getTrackSection("track");
+        var path = TrainPathBuilder.from(
+                List.of(
+                        getRoute(infra, "route_forward_first_half"),
+                        getRoute(infra, "route_forward_second_half")
+                ),
+                new TrackLocation(track, 20),
+                new TrackLocation(track, 80)
+        );
+
+        assertEquals(60, path.length());
+
+        assertEquals(2, path.routePath().size());
+        assertEquals(-20, path.routePath().get(0).pathOffset());
+        assertEquals(30, path.routePath().get(1).pathOffset());
+        assertEquals("route_forward_first_half", path.routePath().get(0).element().getInfraRoute().getID());
+        assertEquals("route_forward_second_half", path.routePath().get(1).element().getInfraRoute().getID());
+
+        assertEquals(2, path.detectors().size());
+        assertEquals(50 - 20, path.detectors().get(0).pathOffset());
+        assertEquals(75 - 20, path.detectors().get(1).pathOffset());
+        assertEquals("d1", path.detectors().get(0).element().getDetector().getID());
+        assertEquals("d2", path.detectors().get(1).element().getDetector().getID());
+        for (var d : path.detectors())
+            assertEquals(FORWARD, d.element().getDirection());
+
+        assertEquals(3, path.detectionSections().size());
+
+        assertEquals(2, path.trackRangePath().size());
+        assertEquals(20, path.trackRangePath().get(0).element().begin);
+        assertEquals(50, path.trackRangePath().get(0).element().end);
+        assertEquals(50, path.trackRangePath().get(1).element().begin);
+        assertEquals(80, path.trackRangePath().get(1).element().end);
+        assertEquals(30, path.trackRangePath().get(1).pathOffset());
+    }
+
+    @Test
+    public void testSingleTrackInfraBackward() {
+        var rjsInfra = makeSingleTrackRJSInfra();
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var track = infra.getTrackSection("track");
+        var path = TrainPathBuilder.from(
+                List.of(getRoute(infra, "route_backward")),
+                new TrackLocation(track, 90),
+                new TrackLocation(track, 10)
+        );
+
+        assertEquals(80, path.length());
+
+        assertEquals(1, path.routePath().size());
+        assertEquals(-10, path.routePath().get(0).pathOffset());
+        assertEquals("route_backward", path.routePath().get(0).element().getInfraRoute().getID());
+
+        assertEquals(2, path.detectors().size());
+        assertEquals(90 - 75, path.detectors().get(0).pathOffset());
+        assertEquals(90 - 50, path.detectors().get(1).pathOffset());
+        assertEquals("d2", path.detectors().get(0).element().getDetector().getID());
+        assertEquals("d1", path.detectors().get(1).element().getDetector().getID());
+        for (var d : path.detectors())
+            assertEquals(BACKWARD, d.element().getDirection());
+
+        assertEquals(3, path.detectionSections().size());
+
+        assertEquals(1, path.trackRangePath().size());
+        assertEquals(10, path.trackRangePath().get(0).element().begin);
+        assertEquals(90, path.trackRangePath().get(0).element().end);
+    }
+
+    @Test
+    public void envelopeTrainPathTests() {
+        var gradients = new EnumMap<Direction, DoubleRangeMap>(Direction.class);
+        var map = new DoubleRangeMap();
+        map.addRange(0, 100, 0);
+        map.addRange(0, 30, 30);
+        map.addRange(60, 80, -10);
+        for (var dir : Direction.values())
+            gradients.put(dir, map);
+        var rjsInfra = makeSingleTrackRJSInfra();
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var track = infra.getTrackSection("track");
+        setGradient(track, gradients);
+        var path = TrainPathBuilder.from(
+                List.of(getRoute(infra, "route_forward")),
+                new TrackLocation(track, 10),
+                new TrackLocation(track, 0)
+        );
+        var envelopePath = EnvelopeTrainPath.fromNew(NewTrainPath.removeLocation(path.trackRangePath()));
+        assertEquals(30, envelopePath.getAverageGrade(0, 20));
+        assertEquals(0, envelopePath.getAverageGrade(20, 50));
+        assertEquals(-10, envelopePath.getAverageGrade(50, 70));
+        assertEquals(0, envelopePath.getAverageGrade(70, 80));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/DGEXSolutions/osrd/issues/688

The idea behind this `TrackRangeView` is to have convenient classes that do most of the logic about ranges (iterate over its content in a direction). We used to do this kind of operations all over the project and it was very difficult to test. 

In a similar way, the new `TrainPath` includes the offset of every object compared to the beginning of the path. 

The PR is quite large, but a lot of this is tests. 