### PR TITLE
core: reorganize the standalone sim endpoint

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
@@ -1,21 +1,10 @@
 package fr.sncf.osrd.api;
 
-import static fr.sncf.osrd.api.StandaloneSimulationEndpoint.SimulationResultPosition.interpolateTime;
-
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope_sim.EnvelopePath;
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
-import fr.sncf.osrd.envelope_sim_infra.MRSP;
-import fr.sncf.osrd.exceptions.OSRDError;
-import fr.sncf.osrd.exceptions.ErrorContext;
-import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.railjson.parser.RJSRollingStockParser;
 import fr.sncf.osrd.railjson.parser.RJSStandaloneTrainScheduleParser;
@@ -25,8 +14,9 @@ import fr.sncf.osrd.railjson.schema.common.ID;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock;
 import fr.sncf.osrd.railjson.schema.schedule.*;
+import fr.sncf.osrd.standalone_sim.StandaloneSim;
+import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
 import fr.sncf.osrd.train.*;
-import fr.sncf.osrd.utils.CurveSimplification;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -35,7 +25,6 @@ import org.takes.rs.RsJson;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithBody;
 import org.takes.rs.RsWithStatus;
-import java.io.IOException;
 import java.util.*;
 
 
@@ -51,18 +40,12 @@ public class StandaloneSimulationEndpoint implements Take {
             .build()
             .adapter(StandaloneSimulationRequest.class);
 
-    public static final JsonAdapter<StandaloneSimulationResult> adapterResult = new Moshi
-            .Builder()
-            .build()
-            .adapter(StandaloneSimulationResult.class);
-
     public StandaloneSimulationEndpoint(InfraManager infraManager) {
         this.infraManager = infraManager;
     }
 
     @Override
     public Response act(Request req) throws
-            IOException,
             InvalidRollingStock,
             InvalidSchedule,
             InvalidInfraException {
@@ -85,80 +68,25 @@ public class StandaloneSimulationEndpoint implements Take {
             var trainsPath = TrainPath.from(infra, request.trainsPath);
             var envelopePath = EnvelopeTrainPath.from(trainsPath);
 
-            // Compute envelopes
-            var result = new StandaloneSimulationResult();
-            var cacheMRSP = new HashMap<StandaloneTrainSchedule, List<MRSPPointResult>>();
-            var cacheMaxEffort = new HashMap<StandaloneTrainSchedule, SimulationResultTrain>();
-            var cacheEco = new HashMap<StandaloneTrainSchedule, SimulationResultTrain>();
-            for (var rjsTrainSchedule : request.trainSchedules) {
-                var trainSchedule = RJSStandaloneTrainScheduleParser.parse(
-                        infra, request.timeStep, rollingStocks::get, rjsTrainSchedule, trainsPath, envelopePath);
+            // Parse train schedules
+            var trainSchedules = new ArrayList<StandaloneTrainSchedule>();
+            for (var rjsTrainSchedule : request.trainSchedules)
+                trainSchedules.add(RJSStandaloneTrainScheduleParser.parse(
+                        infra, request.timeStep, rollingStocks::get, rjsTrainSchedule, trainsPath, envelopePath));
 
-                if (!cacheMaxEffort.containsKey(trainSchedule)) {
-                    // MRSP
-                    var mrsp = MRSP.from(trainsPath, trainSchedule.rollingStock);
-                    cacheMRSP.put(trainSchedule, MRSPPointResult.from(mrsp));
+            // Compute envelopes and extract metadata
+            var result = StandaloneSim.run(
+                    infra,
+                    request.trainsPath,
+                    trainsPath,
+                    trainSchedules,
+                    request.timeStep
+            );
 
-                    // Base
-                    var envelope = computeMaxEffortEnvelope(mrsp, request.timeStep, envelopePath, trainSchedule);
-                    var simResultTrain = SimulationResultTrain.from(
-                            envelope,
-                            trainsPath,
-                            request.trainsPath,
-                            trainSchedule,
-                            infra);
-                    cacheMaxEffort.put(trainSchedule, simResultTrain);
-
-                    // Eco
-                    if (!trainSchedule.allowances.isEmpty()) {
-                        var ecoEnvelope = applyAllowances(envelope, trainSchedule);
-                        var simEcoResultTrain = SimulationResultTrain.from(
-                                ecoEnvelope,
-                                trainsPath,
-                                request.trainsPath,
-                                trainSchedule,
-                                infra);
-                        cacheEco.put(trainSchedule, simEcoResultTrain);
-                    }
-                }
-
-                result.mrsps.add(cacheMRSP.get(trainSchedule));
-                result.baseSimulations.add(cacheMaxEffort.get(trainSchedule));
-                result.ecoSimulations.add(cacheEco.getOrDefault(trainSchedule, null));
-            }
-
-            return new RsJson(new RsWithBody(adapterResult.toJson(result)));
+            return new RsJson(new RsWithBody(StandaloneSimResult.adapter.toJson(result)));
         } catch (Throwable ex) {
             return ExceptionHandler.handle(ex);
         }
-    }
-
-    private static Envelope computeMaxEffortEnvelope(
-            Envelope mrsp,
-            double timeStep,
-            EnvelopePath envelopePath,
-            StandaloneTrainSchedule schedule
-    ) {
-        final var rollingStock = schedule.rollingStock;
-        final var stops = schedule.getStopsPositions();
-        final var context = new EnvelopeSimContext(rollingStock, envelopePath, timeStep);
-        final var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
-        return MaxEffortEnvelope.from(context, schedule.initialSpeed, maxSpeedEnvelope);
-    }
-
-    private static Envelope applyAllowances(
-            Envelope maxEffortEnvelope,
-            StandaloneTrainSchedule schedule
-    ) {
-        var result = maxEffortEnvelope;
-        for (int i = 0; i < schedule.allowances.size(); i++) {
-            try {
-                result = schedule.allowances.get(i).apply(result);
-            } catch (OSRDError e) {
-                throw e.withContext(new ErrorContext.Allowance(i));
-            }
-        }
-        return result;
     }
 
     @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
@@ -211,277 +139,6 @@ public class StandaloneSimulationEndpoint implements Take {
             this.rollingStocks = rollingStocks;
             this.trainSchedules = trainSchedules;
             this.trainsPath = trainsPath;
-        }
-    }
-
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
-    private static ArrayList<SimulationResultPosition> simplifyPositions(
-            ArrayList<SimulationResultPosition> positions) {
-        return CurveSimplification.rdp(
-                positions,
-                5.,
-                (point, start, end) -> {
-                    if (Math.abs(start.time - end.time) < 0.000001)
-                        return Math.abs(point.pathOffset - start.pathOffset);
-                    var proj = start.pathOffset + (point.time - start.time)
-                            * (end.pathOffset - start.pathOffset) / (end.time - start.time);
-                    return Math.abs(point.pathOffset - proj);
-                }
-        );
-    }
-
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
-    private static ArrayList<SimulationResultSpeed> simplifySpeeds(ArrayList<SimulationResultSpeed> speeds) {
-        return CurveSimplification.rdp(
-                speeds,
-                0.2,
-                (point, start, end) -> {
-                    if (Math.abs(start.position - end.position) < 0.000001)
-                        return Math.abs(point.speed - start.speed);
-                    var proj = start.speed + (point.position - start.position)
-                            * (end.speed - start.speed) / (end.position - start.position);
-                    return Math.abs(point.speed - proj);
-                }
-        );
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class StandaloneSimulationResult {
-        @Json(name = "base_simulations")
-        public List<SimulationResultTrain> baseSimulations = new ArrayList<>();
-        @Json(name = "eco_simulations")
-        public List<SimulationResultTrain> ecoSimulations = new ArrayList<>();
-        public List<List<MRSPPointResult>> mrsps = new ArrayList<>();
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class SimulationResultTrain {
-        public final List<SimulationResultSpeed> speeds;
-        @Json(name = "head_positions")
-        public final List<SimulationResultPosition> headPositions;
-        public final List<SimulationResultStops> stops;
-        @Json(name = "route_occupancies")
-        public final Map<String, SimulationResultRouteOccupancy> routeOccupancies;
-
-        SimulationResultTrain(
-                List<SimulationResultSpeed> speeds,
-                List<SimulationResultPosition> headPositions,
-                List<SimulationResultStops> stops, Map<String,
-                SimulationResultRouteOccupancy> routeOccupancies
-        ) {
-            this.speeds = speeds;
-            this.headPositions = headPositions;
-            this.stops = stops;
-            this.routeOccupancies = routeOccupancies;
-        }
-
-        static SimulationResultTrain from(
-                Envelope envelope,
-                TrainPath trainPath,
-                RJSTrainPath rjsTrainPath,
-                StandaloneTrainSchedule schedule,
-                Infra infra
-        ) throws InvalidInfraException {
-            assert envelope.continuous;
-            // Compute speeds, head and tail positions
-            var trainLength = schedule.rollingStock.length;
-            var speeds = new ArrayList<SimulationResultSpeed>();
-            var headPositions = new ArrayList<SimulationResultPosition>();
-            double time = 0;
-            for (var part : envelope) {
-                // Add head position points
-                for (int i = 0; i < part.pointCount(); i++) {
-                    var pos = part.getPointPos(i);
-                    var speed = part.getPointSpeed(i);
-                    speeds.add(new SimulationResultSpeed(time, speed, pos));
-                    headPositions.add(new SimulationResultPosition(time, pos, trainPath));
-                    if (i < part.stepCount())
-                        time += part.getStepTime(i);
-                }
-
-                if (part.getEndSpeed() > 0)
-                    continue;
-
-                // Add stop duration
-                for (var stop : schedule.stops) {
-                    if (stop.duration == 0. || stop.position < part.getEndPos())
-                        continue;
-                    if (stop.position > part.getEndPos())
-                        break;
-                    time += stop.duration;
-                    headPositions.add(new SimulationResultPosition(time, part.getEndPos(), trainPath));
-                }
-            }
-
-            // Simplify data
-            speeds = simplifySpeeds(speeds);
-            headPositions = simplifyPositions(headPositions);
-
-            // Compute stops
-            var stops = new ArrayList<SimulationResultStops>();
-            for (var stop : schedule.stops) {
-                var stopTime = interpolateTime(stop.position, headPositions);
-                stops.add(new SimulationResultStops(stopTime, stop.position, stop.duration));
-            }
-
-            // Compute routeOccupancy
-            var routeOccupancies = new HashMap<String, SimulationResultRouteOccupancy>();
-            double lastPosition = 0;
-            for (var routePath : rjsTrainPath.routePath) {
-                var route = routePath.route.getRoute(infra.routeGraph.routeMap);
-                var conflictedRoutes = route.getConflictedRoutes();
-                var newPosition = lastPosition;
-                for (var trackRange : routePath.trackSections)
-                    newPosition += Math.abs(trackRange.end - trackRange.begin);
-                var routeOccupancy =
-                        SimulationResultRouteOccupancy.from(lastPosition, newPosition, headPositions, trainLength);
-
-                for (var conflictedRoute : conflictedRoutes) {
-                    if (!routeOccupancies.containsKey(conflictedRoute.id)) {
-                        routeOccupancies.put(conflictedRoute.id, routeOccupancy);
-                        continue;
-                    }
-                    var oldOccupancy = routeOccupancies.get(conflictedRoute.id);
-                    var newOccupancy = new SimulationResultRouteOccupancy(
-                            oldOccupancy.timeHeadOccupy,
-                            routeOccupancy.timeHeadFree,
-                            oldOccupancy.timeTailOccupy,
-                            routeOccupancy.timeTailFree);
-                    routeOccupancies.replace(conflictedRoute.id, newOccupancy);
-                }
-                lastPosition = newPosition;
-            }
-            return new SimulationResultTrain(speeds, headPositions, stops, routeOccupancies);
-        }
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class SimulationResultSpeed {
-        public final double time;
-        public final double position;
-        public final double speed;
-
-        SimulationResultSpeed(double time, double speed, double position) {
-            this.time = time;
-            this.speed = speed;
-            this.position = position;
-        }
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class SimulationResultPosition {
-        public final double time;
-        @Json(name = "track_section")
-        public final String trackSection;
-        public final double offset;
-        @Json(name = "path_offset")
-        public final double pathOffset;
-
-        SimulationResultPosition(double time, double pathOffset, TrainPath trainPath) {
-            this.time = time;
-            this.pathOffset = pathOffset;
-            var location = trainPath.findLocation(pathOffset);
-            this.trackSection = location.edge.id;
-            this.offset = location.offset;
-        }
-
-        /** Interpolate in a list of positions the time associated to a given position.
-         * Note: Using envelope is not possible since the stop duration is not taken into account in envelopes.
-         * @param position between 0 and last position
-         * @param headPositions list of positions
-         */
-        public static double interpolateTime(double position, ArrayList<SimulationResultPosition> headPositions) {
-            int leftIndex = 0;
-            int rightIndex = headPositions.size() - 1;
-            assert position >= 0;
-            assert position <= headPositions.get(rightIndex).pathOffset;
-            // Binary search to find the interval to use for interpolation
-            while (rightIndex - leftIndex > 1) {
-                int median = (rightIndex + leftIndex) / 2;
-                if (position > headPositions.get(median).pathOffset)
-                    leftIndex = median;
-                else
-                    rightIndex = median;
-            }
-
-            var a = headPositions.get(leftIndex);
-            var b = headPositions.get(rightIndex);
-            return a.time + (position - a.pathOffset) * (b.time - a.time) / (b.pathOffset - a.pathOffset);
-        }
-
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class SimulationResultStops {
-        public final double time;
-        public final double position;
-        public final double duration;
-
-        SimulationResultStops(double time, double position, double duration) {
-            this.time = time;
-            this.position = position;
-            this.duration = duration;
-        }
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    public static class SimulationResultRouteOccupancy {
-        @Json(name = "time_head_occupy")
-        public final double timeHeadOccupy;
-        @Json(name = "time_head_free")
-        public final double timeHeadFree;
-        @Json(name = "time_tail_occupy")
-        public final double timeTailOccupy;
-        @Json(name = "time_tail_free")
-        public final double timeTailFree;
-
-        SimulationResultRouteOccupancy(
-                double timeHeadOccupy,
-                double timeHeadFree,
-                double timeTailOccupy,
-                double timeTailFree
-        ) {
-            this.timeHeadOccupy = timeHeadOccupy;
-            this.timeHeadFree = timeHeadFree;
-            this.timeTailOccupy = timeTailOccupy;
-            this.timeTailFree = timeTailFree;
-        }
-
-        static SimulationResultRouteOccupancy from(
-                double startPosition,
-                double endPosition,
-                ArrayList<SimulationResultPosition> headPositions,
-                double trainLength
-        ) {
-            var timeHeadFree = interpolateTime(endPosition, headPositions);
-            var timeHeadOccupy = interpolateTime(startPosition, headPositions);
-            var pathLength = headPositions.get(headPositions.size() - 1).pathOffset;
-            var timeTailFree = interpolateTime(Math.min(pathLength, endPosition + trainLength), headPositions);
-            double timeTailOccupy = 0;
-            // Special case for first route
-            if (startPosition > 0)
-                timeTailOccupy = interpolateTime(Math.min(pathLength, startPosition + trainLength), headPositions);
-            return new SimulationResultRouteOccupancy(timeHeadOccupy, timeHeadFree, timeTailOccupy, timeTailFree);
-        }
-    }
-
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-    private static class MRSPPointResult {
-        public final double position;
-        public final double speed;
-
-        public MRSPPointResult(double position, double speed) {
-            this.position = position;
-            this.speed = speed;
-        }
-
-        public static List<MRSPPointResult> from(Envelope mrsp) {
-            var res = new ArrayList<MRSPPointResult>();
-            for (var mrspPart : mrsp) {
-                for (int i = 0; i < mrspPart.pointCount(); i++)
-                    res.add(new MRSPPointResult(mrspPart.getPointPos(i), mrspPart.getPointSpeed(i)));
-            }
-            return res;
         }
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
@@ -1,0 +1,126 @@
+package fr.sncf.osrd.standalone_sim;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
+import fr.sncf.osrd.standalone_sim.result.*;
+import fr.sncf.osrd.train.StandaloneTrainSchedule;
+import fr.sncf.osrd.train.TrainPath;
+import fr.sncf.osrd.utils.CurveSimplification;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ScheduleMetadataExtractor {
+    /** Use an already computed envelope to extract various metadata about a trip. */
+    public static ResultTrain run(
+            Envelope envelope,
+            TrainPath trainPath,
+            RJSTrainPath rjsTrainPath,
+            StandaloneTrainSchedule schedule,
+            Infra infra
+    ) throws InvalidInfraException {
+        assert envelope.continuous;
+        // Compute speeds, head and tail positions
+        var trainLength = schedule.rollingStock.length;
+        var speeds = new ArrayList<ResultSpeed>();
+        var headPositions = new ArrayList<ResultPosition>();
+        double time = 0;
+        for (var part : envelope) {
+            // Add head position points
+            for (int i = 0; i < part.pointCount(); i++) {
+                var pos = part.getPointPos(i);
+                var speed = part.getPointSpeed(i);
+                speeds.add(new ResultSpeed(time, speed, pos));
+                headPositions.add(ResultPosition.from(time, pos, trainPath));
+                if (i < part.stepCount())
+                    time += part.getStepTime(i);
+            }
+
+            if (part.getEndSpeed() > 0)
+                continue;
+
+            // Add stop duration
+            for (var stop : schedule.stops) {
+                if (stop.duration == 0. || stop.position < part.getEndPos())
+                    continue;
+                if (stop.position > part.getEndPos())
+                    break;
+                time += stop.duration;
+                headPositions.add(ResultPosition.from(time, part.getEndPos(), trainPath));
+            }
+        }
+
+        // Simplify data
+        speeds = simplifySpeeds(speeds);
+        headPositions = simplifyPositions(headPositions);
+
+        // Compute stops
+        var stops = new ArrayList<ResultStops>();
+        for (var stop : schedule.stops) {
+            var stopTime = ResultPosition.interpolateTime(stop.position, headPositions);
+            stops.add(new ResultStops(stopTime, stop.position, stop.duration));
+        }
+
+        // Compute routeOccupancy
+        var routeOccupancies = new HashMap<String, ResultOccupancyTiming>();
+        double lastPosition = 0;
+        for (var routePath : rjsTrainPath.routePath) {
+            var route = routePath.route.getRoute(infra.routeGraph.routeMap);
+            var conflictedRoutes = route.getConflictedRoutes();
+            var newPosition = lastPosition;
+            for (var trackRange : routePath.trackSections)
+                newPosition += Math.abs(trackRange.end - trackRange.begin);
+            var routeOccupancy =
+                    ResultOccupancyTiming.fromPositions(lastPosition, newPosition, headPositions, trainLength);
+
+            for (var conflictedRoute : conflictedRoutes) {
+                if (!routeOccupancies.containsKey(conflictedRoute.id)) {
+                    routeOccupancies.put(conflictedRoute.id, routeOccupancy);
+                    continue;
+                }
+                var oldOccupancy = routeOccupancies.get(conflictedRoute.id);
+                var newOccupancy = new ResultOccupancyTiming(
+                        oldOccupancy.timeHeadOccupy,
+                        routeOccupancy.timeHeadFree,
+                        oldOccupancy.timeTailOccupy,
+                        routeOccupancy.timeTailFree);
+                routeOccupancies.replace(conflictedRoute.id, newOccupancy);
+            }
+            lastPosition = newPosition;
+        }
+        return new ResultTrain(speeds, headPositions, stops, routeOccupancies);
+    }
+
+    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
+    private static ArrayList<ResultPosition> simplifyPositions(
+            ArrayList<ResultPosition> positions) {
+        return CurveSimplification.rdp(
+                positions,
+                5.,
+                (point, start, end) -> {
+                    if (Math.abs(start.time - end.time) < 0.000001)
+                        return Math.abs(point.pathOffset - start.pathOffset);
+                    var proj = start.pathOffset + (point.time - start.time)
+                            * (end.pathOffset - start.pathOffset) / (end.time - start.time);
+                    return Math.abs(point.pathOffset - proj);
+                }
+        );
+    }
+
+    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
+    private static ArrayList<ResultSpeed> simplifySpeeds(ArrayList<ResultSpeed> speeds) {
+        return CurveSimplification.rdp(
+                speeds,
+                0.2,
+                (point, start, end) -> {
+                    if (Math.abs(start.position - end.position) < 0.000001)
+                        return Math.abs(point.speed - start.speed);
+                    var proj = start.speed + (point.position - start.position)
+                            * (end.speed - start.speed) / (end.position - start.position);
+                    return Math.abs(point.speed - proj);
+                }
+        );
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -1,0 +1,102 @@
+package fr.sncf.osrd.standalone_sim;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopePath;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.MRSP;
+import fr.sncf.osrd.exceptions.ErrorContext;
+import fr.sncf.osrd.exceptions.OSRDError;
+import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
+import fr.sncf.osrd.standalone_sim.result.*;
+import fr.sncf.osrd.train.StandaloneTrainSchedule;
+import fr.sncf.osrd.train.TrainPath;
+import java.util.HashMap;
+import java.util.List;
+
+public class StandaloneSim {
+    /**
+     * Runs a batch of standalone simulations for multiple trains.
+     * Interactions between trains are ignored.
+     */
+    public static StandaloneSimResult run(
+            Infra infra,
+            RJSTrainPath rjsTrainsPath,
+            TrainPath trainsPath,
+            List<StandaloneTrainSchedule> schedules,
+            double timeStep
+    ) {
+        var envelopePath = EnvelopeTrainPath.from(trainsPath);
+
+        // Compute envelopes
+        var result = new StandaloneSimResult();
+        var cacheMRSP = new HashMap<StandaloneTrainSchedule, List<ResultEnvelopePoint>>();
+        var cacheMaxEffort = new HashMap<StandaloneTrainSchedule, ResultTrain>();
+        var cacheEco = new HashMap<StandaloneTrainSchedule, ResultTrain>();
+        for (var trainSchedule : schedules) {
+            if (!cacheMaxEffort.containsKey(trainSchedule)) {
+                // MRSP
+                var mrsp = MRSP.from(trainsPath, trainSchedule.rollingStock);
+                cacheMRSP.put(trainSchedule, ResultEnvelopePoint.from(mrsp));
+
+                // Base
+                var envelope = computeMaxEffortEnvelope(mrsp, timeStep, envelopePath, trainSchedule);
+                var simResultTrain = ScheduleMetadataExtractor.run(
+                        envelope,
+                        trainsPath,
+                        rjsTrainsPath,
+                        trainSchedule,
+                        infra);
+                cacheMaxEffort.put(trainSchedule, simResultTrain);
+
+                // Eco
+                if (!trainSchedule.allowances.isEmpty()) {
+                    var ecoEnvelope = applyAllowances(envelope, trainSchedule);
+                    var simEcoResultTrain = ScheduleMetadataExtractor.run(
+                            ecoEnvelope,
+                            trainsPath,
+                            rjsTrainsPath,
+                            trainSchedule,
+                            infra);
+                    cacheEco.put(trainSchedule, simEcoResultTrain);
+                }
+            }
+
+            result.mrsps.add(cacheMRSP.get(trainSchedule));
+            result.baseSimulations.add(cacheMaxEffort.get(trainSchedule));
+            result.ecoSimulations.add(cacheEco.getOrDefault(trainSchedule, null));
+        }
+        return result;
+    }
+
+    private static Envelope computeMaxEffortEnvelope(
+            Envelope mrsp,
+            double timeStep,
+            EnvelopePath envelopePath,
+            StandaloneTrainSchedule schedule
+    ) {
+        final var rollingStock = schedule.rollingStock;
+        final var stops = schedule.getStopsPositions();
+        final var context = new EnvelopeSimContext(rollingStock, envelopePath, timeStep);
+        final var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
+        return MaxEffortEnvelope.from(context, schedule.initialSpeed, maxSpeedEnvelope);
+    }
+
+    private static Envelope applyAllowances(
+            Envelope maxEffortEnvelope,
+            StandaloneTrainSchedule schedule
+    ) {
+        var result = maxEffortEnvelope;
+        for (int i = 0; i < schedule.allowances.size(); i++) {
+            try {
+                result = schedule.allowances.get(i).apply(result);
+            } catch (OSRDError e) {
+                throw e.withContext(new ErrorContext.Allowance(i));
+            }
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultEnvelopePoint.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultEnvelopePoint.java
@@ -1,0 +1,19 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.envelope.Envelope;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public record ResultEnvelopePoint(double position, double speed) {
+    /** Serializes an envelope as a list of points, regardless of part boundaries. */
+    public static List<ResultEnvelopePoint> from(Envelope envelope) {
+        var res = new ArrayList<ResultEnvelopePoint>();
+        for (var part : envelope) {
+            for (int i = 0; i < part.pointCount(); i++)
+                res.add(new ResultEnvelopePoint(part.getPointPos(i), part.getPointSpeed(i)));
+        }
+        return res;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultOccupancyTiming.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultOccupancyTiming.java
@@ -1,0 +1,57 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import static fr.sncf.osrd.standalone_sim.result.ResultPosition.interpolateTime;
+
+import com.squareup.moshi.Json;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public class ResultOccupancyTiming {
+    @Json(name = "time_head_occupy")
+    public final double timeHeadOccupy;
+    @Json(name = "time_head_free")
+    public final double timeHeadFree;
+    @Json(name = "time_tail_occupy")
+    public final double timeTailOccupy;
+    @Json(name = "time_tail_free")
+    public final double timeTailFree;
+
+    /** Directly create an occupancy timing */
+    public ResultOccupancyTiming(
+            double timeHeadOccupy,
+            double timeHeadFree,
+            double timeTailOccupy,
+            double timeTailFree
+    ) {
+        this.timeHeadOccupy = timeHeadOccupy;
+        this.timeHeadFree = timeHeadFree;
+        this.timeTailOccupy = timeTailOccupy;
+        this.timeTailFree = timeTailFree;
+    }
+
+    /**
+     * Finds the occupancy on a given section
+     * @param startPosition the start of the target region
+     * @param endPosition the end of the target region
+     * @param headPositions the envelope of the head of the train
+     * @param trainLength the length of the train
+     * @return the occupancy times for this section
+     */
+    public static ResultOccupancyTiming fromPositions(
+            double startPosition,
+            double endPosition,
+            ArrayList<ResultPosition> headPositions,
+            double trainLength
+    ) {
+        var timeHeadFree = interpolateTime(endPosition, headPositions);
+        var timeHeadOccupy = interpolateTime(startPosition, headPositions);
+        var pathLength = headPositions.get(headPositions.size() - 1).pathOffset;
+        var timeTailFree = interpolateTime(Math.min(pathLength, endPosition + trainLength), headPositions);
+        double timeTailOccupy = 0;
+        // Special case for first route
+        if (startPosition > 0)
+            timeTailOccupy = interpolateTime(Math.min(pathLength, startPosition + trainLength), headPositions);
+        return new ResultOccupancyTiming(timeHeadOccupy, timeHeadFree, timeTailOccupy, timeTailFree);
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.java
@@ -1,0 +1,54 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import com.squareup.moshi.Json;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.train.TrainPath;
+import java.util.ArrayList;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public class ResultPosition {
+    public final double time;
+    @Json(name = "track_section")
+    public final String trackSection;
+    public final double offset;
+    @Json(name = "path_offset")
+    public final double pathOffset;
+
+    private ResultPosition(double time, double pathOffset, String trackSection, double offset) {
+        this.time = time;
+        this.pathOffset = pathOffset;
+        this.trackSection = trackSection;
+        this.offset = offset;
+    }
+
+    public static ResultPosition from(double time, double pathOffset, TrainPath path) {
+        var location = path.findLocation(pathOffset);
+        return new ResultPosition(time, pathOffset, location.edge.id, location.offset);
+    }
+
+    /** Interpolate in a list of positions the time associated to a given position.
+     * Note: Using envelope is not possible since the stop duration is not taken into account in envelopes.
+     * @param position between 0 and last position
+     * @param headPositions list of positions
+     */
+    public static double interpolateTime(double position, ArrayList<ResultPosition> headPositions) {
+        int leftIndex = 0;
+        int rightIndex = headPositions.size() - 1;
+        assert position >= 0;
+        assert position <= headPositions.get(rightIndex).pathOffset;
+        // Binary search to find the interval to use for interpolation
+        while (rightIndex - leftIndex > 1) {
+            int median = (rightIndex + leftIndex) / 2;
+            if (position > headPositions.get(median).pathOffset)
+                leftIndex = median;
+            else
+                rightIndex = median;
+        }
+
+        var a = headPositions.get(leftIndex);
+        var b = headPositions.get(rightIndex);
+        return a.time + (position - a.pathOffset) * (b.time - a.time) / (b.pathOffset - a.pathOffset);
+    }
+}
+
+

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultSpeed.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultSpeed.java
@@ -1,0 +1,17 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public class ResultSpeed {
+    public final double time;
+    public final double position;
+    public final double speed;
+
+    /** A space time sample */
+    public ResultSpeed(double time, double speed, double position) {
+        this.time = time;
+        this.speed = speed;
+        this.position = position;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultStops.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultStops.java
@@ -1,0 +1,7 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public record ResultStops(double time, double position, double duration) {
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
@@ -1,0 +1,29 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import com.squareup.moshi.Json;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Map;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public class ResultTrain {
+    public final List<ResultSpeed> speeds;
+    @Json(name = "head_positions")
+    public final List<ResultPosition> headPositions;
+    public final List<ResultStops> stops;
+    @Json(name = "route_occupancies")
+    public final Map<String, ResultOccupancyTiming> routeOccupancies;
+
+    /** Creates the serializable result for a given train */
+    public ResultTrain(
+            List<ResultSpeed> speeds,
+            List<ResultPosition> headPositions,
+            List<ResultStops> stops, Map<String,
+            ResultOccupancyTiming> routeOccupancies
+    ) {
+        this.speeds = speeds;
+        this.headPositions = headPositions;
+        this.stops = stops;
+        this.routeOccupancies = routeOccupancies;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/StandaloneSimResult.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/StandaloneSimResult.java
@@ -1,0 +1,22 @@
+package fr.sncf.osrd.standalone_sim.result;
+
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+public class StandaloneSimResult {
+    public static final JsonAdapter<StandaloneSimResult> adapter = new Moshi
+            .Builder()
+            .build()
+            .adapter(StandaloneSimResult.class);
+
+    @Json(name = "base_simulations")
+    public List<ResultTrain> baseSimulations = new ArrayList<>();
+    @Json(name = "eco_simulations")
+    public List<ResultTrain> ecoSimulations = new ArrayList<>();
+    public List<List<ResultEnvelopePoint>> mrsps = new ArrayList<>();
+}

--- a/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
@@ -4,11 +4,13 @@ import static fr.sncf.osrd.Helpers.getExampleRollingStocks;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fr.sncf.osrd.api.StandaloneSimulationEndpoint.StandaloneSimulationRequest;
-import fr.sncf.osrd.api.StandaloneSimulationEndpoint.StandaloneSimulationResult;
 import fr.sncf.osrd.infra.InvalidInfraException;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.railjson.schema.schedule.*;
+import fr.sncf.osrd.standalone_sim.result.ResultPosition;
+import fr.sncf.osrd.standalone_sim.result.ResultSpeed;
+import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
 import fr.sncf.osrd.utils.graph.EdgeDirection;
 import org.junit.jupiter.api.Test;
 import org.takes.rq.RqFake;
@@ -37,7 +39,7 @@ class StandaloneSimulationTest extends ApiTest {
         return trainPath;
     }
 
-    public static StandaloneSimulationResult runStandaloneSimulation(StandaloneSimulationRequest request) throws
+    public static StandaloneSimResult runStandaloneSimulation(StandaloneSimulationRequest request) throws
             InvalidRollingStock,
             InvalidSchedule,
             IOException,
@@ -51,7 +53,7 @@ class StandaloneSimulationTest extends ApiTest {
         ).printBody();
 
         // parse the response
-        var response =  StandaloneSimulationEndpoint.adapterResult.fromJson(rawResponse);
+        var response = StandaloneSimResult.adapter.fromJson(rawResponse);
         assertNotNull(response);
         return response;
     }
@@ -80,12 +82,12 @@ class StandaloneSimulationTest extends ApiTest {
         var trainResult = simResult.baseSimulations.get(0);
 
         // ensure the position of the head and the tail of the train are always increasing
-        var positions = trainResult.headPositions.toArray(new StandaloneSimulationEndpoint.SimulationResultPosition[0]);
+        var positions = trainResult.headPositions.toArray(new ResultPosition[0]);
         for (int i = 1; i < positions.length; i++)
             assertTrue(positions[i - 1].time <= positions[i].time);
 
         // ensure the speed is always increasing
-        var speeds = trainResult.speeds.toArray(new StandaloneSimulationEndpoint.SimulationResultSpeed[0]);
+        var speeds = trainResult.speeds.toArray(new ResultSpeed[0]);
         for (int i = 1; i < speeds.length; i++)
             assertTrue(speeds[i - 1].position <= speeds[i].position);
         assertEquals(8, trainResult.routeOccupancies.size());


### PR DESCRIPTION
This change splits the huge lump of core of the standalone endpoint into more manageable bits. It does not do much to make it truly independent from the rest of the code base. I've refrained from doing that for now, as it will be easier to review in a later PR.