### PR TITLE
core: standalone: use signaling for block occupancy

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
@@ -6,6 +6,8 @@ import com.squareup.moshi.Moshi;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
+import fr.sncf.osrd.new_infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.railjson.parser.RJSRollingStockParser;
 import fr.sncf.osrd.railjson.parser.RJSStandaloneTrainScheduleParser;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
@@ -29,7 +31,7 @@ import java.util.*;
 
 
 public class StandaloneSimulationEndpoint implements Take {
-    private final InfraManager infraManager;
+    private final NewInfraManager infraManager;
 
     public static final JsonAdapter<StandaloneSimulationRequest> adapterRequest = new Moshi
             .Builder()
@@ -40,7 +42,7 @@ public class StandaloneSimulationEndpoint implements Take {
             .build()
             .adapter(StandaloneSimulationRequest.class);
 
-    public StandaloneSimulationEndpoint(InfraManager infraManager) {
+    public StandaloneSimulationEndpoint(NewInfraManager infraManager) {
         this.infraManager = infraManager;
     }
 
@@ -65,8 +67,8 @@ public class StandaloneSimulationEndpoint implements Take {
                 rollingStocks.put(rjsRollingStock.id, RJSRollingStockParser.parse(rjsRollingStock));
 
             // Parse trainsPath
-            var trainsPath = TrainPath.from(infra, request.trainsPath);
-            var envelopePath = EnvelopeTrainPath.from(trainsPath);
+            var trainsPath = TrainPathBuilder.from(infra, request.trainsPath);
+            var envelopePath = EnvelopeTrainPath.fromNew(trainsPath);
 
             // Parse train schedules
             var trainSchedules = new ArrayList<StandaloneTrainSchedule>();

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -58,6 +58,7 @@ public final class ApiServerCommand implements CliCommand {
         FbSentry.init();
         var authorizationToken = System.getenv("FETCH_INFRA_AUTHORIZATION");
         var infraManager = new InfraManager(getMiddlewareBaseUrl(), authorizationToken);
+        var newInfraManager = new NewInfraManager(getMiddlewareBaseUrl(), authorizationToken);
 
         try {
             // the list of endpoints
@@ -65,7 +66,7 @@ public final class ApiServerCommand implements CliCommand {
                     new FkRegex("/health", ""),
                     new FkRegex("/pathfinding/routes", new PathfindingRoutesEndpoint(infraManager)),
                     new FkRegex("/pathfinding/tracks", new PathfindingTracksEndpoint(infraManager)),
-                    new FkRegex("/standalone_simulation", new StandaloneSimulationEndpoint(infraManager)),
+                    new FkRegex("/standalone_simulation", new StandaloneSimulationEndpoint(newInfraManager)),
                     new FkRegex("/cache_status", new InfraCacheStatusEndpoint(infraManager))
             );
 

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
@@ -35,7 +35,7 @@ public class EnvelopePath implements PhysicsPath {
     private double[] initCumSum(double[] gradePositions, double[] gradeValues) {
         var result = new double[gradePositions.length];
         result[0] = 0.0;
-        var cumSum = 0;
+        double cumSum = 0;
         for (int i = 0; i < gradePositions.length - 1; i++) {
             var rangeLength = gradePositions[i + 1] - gradePositions[i];
             cumSum += gradeValues[i] * rangeLength;

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
@@ -76,7 +76,7 @@ public class EnvelopeTrainPath {
         var gradePositions = new DoubleArrayList();
         gradePositions.add(0);
         var gradeValues = new DoubleArrayList();
-        var length = 0.;
+        double length = 0;
 
         for (var range : trackSectionPath) {
             if (range.getLength() > 0) {

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
@@ -5,6 +5,7 @@ import static fr.sncf.osrd.utils.DoubleUtils.clamp;
 import com.carrotsearch.hppc.DoubleArrayList;
 import fr.sncf.osrd.envelope_sim.EnvelopePath;
 import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
 import fr.sncf.osrd.train.TrackSectionRange;
 import fr.sncf.osrd.train.TrainPath;
 import fr.sncf.osrd.utils.Range;
@@ -78,14 +79,21 @@ public class EnvelopeTrainPath {
         var length = 0.;
 
         for (var range : trackSectionPath) {
-            var grades = range.getGradients().getValuesInRange(0, range.getLength());
-            for (var interval : new TreeSet<>(grades.keySet())) {
-                gradePositions.add(length + interval.getEndPosition());
-                gradeValues.add(grades.get(interval));
+            if (range.getLength() > 0) {
+                var grades = range.getGradients().getValuesInRange(0, range.getLength());
+                for (var interval : new TreeSet<>(grades.keySet())) {
+                    gradePositions.add(length + interval.getEndPosition());
+                    gradeValues.add(grades.get(interval));
 
+                }
+                length += range.getLength();
             }
-            length += range.getLength();
         }
         return new EnvelopePath(length, gradePositions.toArray(), gradeValues.toArray());
+    }
+
+    /** Create EnvelopePath from a train path */
+    public static EnvelopePath fromNew(NewTrainPath trainsPath) {
+        return fromNew(NewTrainPath.removeLocation(trainsPath.trackRangePath()));
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/infra/SpeedSection.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/SpeedSection.java
@@ -3,12 +3,12 @@ package fr.sncf.osrd.infra;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.train.RollingStock;
 
+@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
 public class SpeedSection {
     /**
      * Whether there are signals on the track telling the driver about this speed limit.
      * If there aren't, the driver must make sure the speed limit is taken care of anyway.
      */
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public final boolean isSignalized;
 
     public final double speedLimit;

--- a/core/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/routegraph/RouteGraph.java
@@ -68,7 +68,7 @@ public class RouteGraph extends DirNGraph<Route, Waypoint> {
             try {
                 var tvdSectionsPath = generatePath(id, entryPoint, exitPoint, entryDirection, switchesGroup);
 
-                var length = 0;
+                double length = 0;
                 for (var tvdSectionPath : tvdSectionsPath)
                     length += tvdSectionPath.length;
 

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/Signal.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/Signal.java
@@ -24,4 +24,7 @@ public interface Signal<StateT extends SignalState> {
 
     /** Returns the signal ID */
     String getID();
+
+    /** Returns a set of routes protected by this signal. May be empty if the signal isn't linked to a detector */
+    Set<ReservationRoute> getProtectedRoutes();
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/SignalState.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/api/signaling/SignalState.java
@@ -6,4 +6,7 @@ import com.google.errorprone.annotations.Immutable;
 public interface SignalState {
     /** Returns the RGB Color for this signal state, as encoded by {@link java.awt.Color#getRGB}. */
     int getRGBColor();
+
+    /** Returns true if the protected route is completely free: the train can go at full speed */
+    boolean isFree();
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationInfraBuilder.java
@@ -79,8 +79,9 @@ public class ReservationInfraBuilder {
         var routes = new ArrayList<ReservationRouteImpl>();
         for (var rjsRoute : rjsInfra.routes) {
             var trackRanges = makeTrackRanges(rjsRoute);
+            var length = trackRanges.stream().mapToDouble(TrackRangeView::getLength).sum();
             var route = new ReservationRouteImpl(detectorsOnRoute(rjsRoute), releasePoints(rjsRoute),
-                    rjsRoute.id, trackRanges, isRouteControlled(trackRanges));
+                    rjsRoute.id, trackRanges, isRouteControlled(trackRanges), length);
             routes.add(route);
             for (var section : sectionsOnRoute(rjsRoute)) {
                 routesPerSection.put(section, route);

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationRouteImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/reservation/ReservationRouteImpl.java
@@ -9,7 +9,6 @@ import fr.sncf.osrd.new_infra.api.tracks.undirected.Detector;
 import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 public class ReservationRouteImpl implements ReservationRoute {
     private ImmutableSet<ReservationRoute> conflictingRoutes = ImmutableSet.of();
@@ -18,17 +17,14 @@ public class ReservationRouteImpl implements ReservationRoute {
     public final String id;
     private final ImmutableList<TrackRangeView> trackRanges;
     private final boolean isControlled;
+    private final double length;
 
     @Override
     @ExcludeFromGeneratedCodeCoverage
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("detectorPath", detectorPath)
-                .add("releasePoints", releasePoints)
                 .add("id", id)
-                .add("trackRanges", trackRanges)
-                .add("conflictingRoutes", conflictingRoutes.stream()
-                        .map(ReservationRoute::getID).collect(Collectors.toList()))
+                .add("length", length)
                 .toString();
     }
 
@@ -38,13 +34,14 @@ public class ReservationRouteImpl implements ReservationRoute {
             ImmutableList<Detector> releasePoints,
             String id,
             ImmutableList<TrackRangeView> trackRanges,
-            boolean isControlled
-    ) {
+            boolean isControlled,
+            double length) {
         this.detectorPath = detectorPath;
         this.releasePoints = releasePoints;
         this.trackRanges = trackRanges;
         this.id = id;
         this.isControlled = isControlled;
+        this.length = length;
     }
 
     @Override
@@ -79,9 +76,7 @@ public class ReservationRouteImpl implements ReservationRoute {
 
     @Override
     public double getLength() {
-        return trackRanges.stream()
-                .mapToDouble(TrackRangeView::getLength)
-                .sum();
+        return length;
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/modules/bal3/BAL3Signal.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/modules/bal3/BAL3Signal.java
@@ -11,6 +11,7 @@ import fr.sncf.osrd.new_infra_state.api.SignalizationStateView;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class BAL3Signal implements Signal<BAL3SignalState> {
 
@@ -85,5 +86,12 @@ public class BAL3Signal implements Signal<BAL3SignalState> {
     @Override
     public String getID() {
         return id;
+    }
+
+    @Override
+    public Set<ReservationRoute> getProtectedRoutes() {
+        return protectedRoutes.stream()
+                .map(BAL3.BAL3Route::getInfraRoute)
+                .collect(Collectors.toSet());
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/modules/bal3/BAL3SignalState.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/signaling/modules/bal3/BAL3SignalState.java
@@ -23,6 +23,11 @@ public class BAL3SignalState implements SignalState {
     }
 
     @Override
+    public boolean isFree() {
+        return aspect.equals(BAL3.Aspect.GREEN);
+    }
+
+    @Override
     @ExcludeFromGeneratedCodeCoverage
     public String toString() {
         return MoreObjects.toStringHelper(this)

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
@@ -6,6 +6,7 @@ import fr.sncf.osrd.new_infra.api.Direction;
 import fr.sncf.osrd.new_infra.api.tracks.directed.DiTrackEdge;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.Detector;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackSection;
 import fr.sncf.osrd.utils.DoubleRangeMap;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.Comparator;
@@ -94,6 +95,16 @@ public class TrackRangeView {
             return end - location.offset();
     }
 
+    /** Returns the location of the given offset on the range */
+    public TrackLocation locationOfOffset(double offset) {
+        assert track.getEdge() instanceof TrackSection;
+        var trackSection = (TrackSection) track.getEdge();
+        if (track.getDirection().equals(Direction.FORWARD))
+            return new TrackLocation(trackSection, begin + offset);
+        else
+            return new TrackLocation(trackSection, end - offset);
+    }
+
     /** Returns a new view where the beginning is truncated until the given offset */
     public TrackRangeView truncateBegin(double offset) {
         assert offset >= begin && offset <= end : "truncate location isn't located in the range";
@@ -123,7 +134,8 @@ public class TrackRangeView {
                 rangeStart = rangeEnd;
                 rangeEnd = tmp;
             }
-            res.addRange(rangeStart, rangeEnd, entry.getValue());
+            if (rangeStart != rangeEnd)
+                res.addRange(rangeStart, rangeEnd, entry.getValue());
         }
         return res.simplify();
     }

--- a/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra/implementation/tracks/directed/TrackRangeView.java
@@ -96,7 +96,7 @@ public class TrackRangeView {
     }
 
     /** Returns the location of the given offset on the range */
-    public TrackLocation locationOfOffset(double offset) {
+    public TrackLocation offsetLocation(double offset) {
         assert track.getEdge() instanceof TrackSection;
         var trackSection = (TrackSection) track.getEdge();
         if (track.getDirection().equals(Direction.FORWARD))

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/api/NewTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/api/NewTrainPath.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import fr.sncf.osrd.new_infra.api.reservation.DetectionSection;
 import fr.sncf.osrd.new_infra.api.reservation.DiDetector;
 import fr.sncf.osrd.new_infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.SwitchBranch;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.new_infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
@@ -77,8 +78,11 @@ public record NewTrainPath(
 
     /** Returns the location at the given offset */
     public TrackLocation findLocation(double pathOffset) {
-        assert pathOffset <= length;
         var element = getLastLocatedElementBefore(trackRangePath, pathOffset);
-        return element.element.locationOfOffset(pathOffset - element.pathOffset);
+        if (element.element.track.getEdge() instanceof SwitchBranch) {
+            // This case can happen when pathOffset is exactly on a switch, we want the next range in that case
+            element = trackRangePath.get(trackRangePath.indexOf(element) + 1);
+        }
+        return element.element.offsetLocation(pathOffset - element.pathOffset);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/SignalizationEngine.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/SignalizationEngine.java
@@ -98,14 +98,14 @@ public class SignalizationEngine implements SignalizationState {
             HashSet<Signal<?>> updated
     ) {
         try {
-            if (modifiedSignalsInCurrentUpdate.contains(signal))
-                throw new SignalizationError(
-                        "Infinite loop in signal dependency updates",
-                        OSRDError.ErrorCause.USER // This would be caused by invalid infrastructures
-                );
-            modifiedSignalsInCurrentUpdate.add(signal);
             var newSignalState = signal.processDependencyUpdate(infraState, this);
             if (!newSignalState.equals(signalStates.get(signal))) {
+                if (modifiedSignalsInCurrentUpdate.contains(signal))
+                    throw new SignalizationError(
+                            "Infinite loop in signal dependency updates",
+                            OSRDError.ErrorCause.USER // This would be caused by invalid infrastructures
+                    );
+                modifiedSignalsInCurrentUpdate.add(signal);
                 updated.add(signal);
                 signalStates.put(signal, newSignalState);
                 for (var otherSignal : signalSubscribers.get(signal))

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/standalone/StandaloneSignalingSimulation.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/standalone/StandaloneSignalingSimulation.java
@@ -25,8 +25,6 @@ public class StandaloneSignalingSimulation {
     ) {
         var res = new ArrayList<SignalEvent<?>>();
         for (var position : state.updatePositions) {
-            if (position >= path.length())
-                break;
             state.moveTrain(position);
             var updatedSignals = new HashSet<Signal<?>>();
             for (var route : state.routeUpdatePositions.get(position)) {
@@ -58,7 +56,7 @@ public class StandaloneSignalingSimulation {
     ) {
         return new SignalTimedEvent<>(
                 event.position,
-                trainEnvelope.interpolateTotalTime(event.position),
+                trainEnvelope.interpolateTotalTime(Math.min(trainEnvelope.getEndPos(), event.position)),
                 event.signal,
                 event.state
         );

--- a/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/standalone/StandaloneState.java
+++ b/core/src/main/java/fr/sncf/osrd/new_infra_state/implementation/standalone/StandaloneState.java
@@ -113,7 +113,8 @@ public class StandaloneState implements InfraStateView {
                             otherRoute
                     );
             }
-            return new StandaloneReservationRouteState(ReservationRouteState.Summary.FREE, null, route);
+            return new StandaloneReservationRouteState(ReservationRouteState.Summary.RESERVED,
+                    new StandaloneReservationTrain(), route);
         }
     }
 

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
@@ -35,7 +35,7 @@ public class RJSStandaloneTrainScheduleParser {
         if (rollingStock == null)
             throw new UnknownRollingStock(rollingStockID);
 
-        var stops = (ArrayList<TrainStop>) RJSStopsParser.parseNew(rjsTrainSchedule.stops, infra, trainPath);
+        var stops = RJSStopsParser.parseNew(rjsTrainSchedule.stops, infra, trainPath);
 
         var initialSpeed = rjsTrainSchedule.initialSpeed;
         if (Double.isNaN(initialSpeed) || initialSpeed < 0)
@@ -71,7 +71,8 @@ public class RJSStandaloneTrainScheduleParser {
                 throw new InvalidSchedule("missing construction allowance end_position");
             return new MarecoAllowance(
                     new EnvelopeSimContext(rollingStock, envelopePath, timeStep),
-                    rjsConstruction.beginPosition, rjsConstruction.endPosition,
+                    rjsConstruction.beginPosition,
+                    Math.min(envelopePath.length, rjsConstruction.endPosition),
                     getPositiveDoubleOrDefault(rjsConstruction.capacitySpeedLimit, 30 / 3.6),
                     List.of(
                             new AllowanceRange(

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
@@ -7,7 +7,8 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceDistribution;
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue;
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
 import fr.sncf.osrd.envelope_sim.allowances.*;
-import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.railjson.parser.exceptions.UnknownRollingStock;
 import fr.sncf.osrd.railjson.schema.schedule.*;
@@ -22,11 +23,11 @@ import java.util.stream.Collectors;
 public class RJSStandaloneTrainScheduleParser {
     /** Parses a RailJSON standalone train schedule */
     public static StandaloneTrainSchedule parse(
-            Infra infra,
+            SignalingInfra infra,
             double timeStep,
             Function<String, RollingStock> rollingStockGetter,
             RJSStandaloneTrainSchedule rjsTrainSchedule,
-            TrainPath trainPath,
+            NewTrainPath trainPath,
             EnvelopePath envelopePath
     ) throws InvalidSchedule {
         var rollingStockID = rjsTrainSchedule.rollingStock;
@@ -34,7 +35,7 @@ public class RJSStandaloneTrainScheduleParser {
         if (rollingStock == null)
             throw new UnknownRollingStock(rollingStockID);
 
-        var stops = (ArrayList<TrainStop>) RJSStopsParser.parse(rjsTrainSchedule.stops, infra, trainPath);
+        var stops = (ArrayList<TrainStop>) RJSStopsParser.parseNew(rjsTrainSchedule.stops, infra, trainPath);
 
         var initialSpeed = rjsTrainSchedule.initialSpeed;
         if (Double.isNaN(initialSpeed) || initialSpeed < 0)

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
@@ -51,6 +51,17 @@ public class RJSStopsParser {
                 position = stop.position;
             else
                 position = path.convertTrackLocation(RJSTrackLocationParser.parseNew(infra, stop.location));
+
+            if (position > path.length()) {
+                // As we use different TrainPath classes for pathfinding and simulation (for now),
+                // we can have small float inaccuracies for the path length, causing errors on the last stop
+                // (this is temporary)
+                if (position <= path.length() + 1e-5)
+                    position = path.length();
+                else
+                    throw new InvalidSchedule("Stop position is outside of the path");
+            }
+
             res.add(new TrainStop(position, stop.duration));
         }
         for (var stop : res)

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.railjson.parser;
 
 import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop;
 import fr.sncf.osrd.train.TrainPath;
@@ -30,6 +32,30 @@ public class RJSStopsParser {
         for (var stop : res)
             if (stop.position < 0)
                 stop.position = path.length;
+        res.sort(Comparator.comparingDouble(stop -> stop.position));
+        return res;
+    }
+
+    /** Parse a list of RJS stops given an infra and a path */
+    public static List<TrainStop> parseNew(RJSTrainStop[] stops, SignalingInfra infra, NewTrainPath path)
+            throws InvalidSchedule {
+        var res = new ArrayList<TrainStop>();
+        if (stops == null) {
+            throw new InvalidSchedule("The train schedule must have at least one train stop");
+        }
+        for (var stop : stops) {
+            if ((stop.position == null) == (stop.location == null))
+                throw new InvalidSchedule("Train stop must specify exactly one of position or location");
+            double position;
+            if (stop.position != null)
+                position = stop.position;
+            else
+                position = path.convertTrackLocation(RJSTrackLocationParser.parseNew(infra, stop.location));
+            res.add(new TrainStop(position, stop.duration));
+        }
+        for (var stop : res)
+            if (stop.position < 0)
+                stop.position = path.length();
         res.sort(Comparator.comparingDouble(stop -> stop.position));
         return res;
     }

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSTrackLocationParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSTrackLocationParser.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.railjson.parser;
 
 import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackInfra;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.railjson.parser.exceptions.UnknownTrackSection;
 import fr.sncf.osrd.railjson.schema.common.RJSTrackLocation;
@@ -17,5 +19,18 @@ public class RJSTrackLocationParser {
         if (offset < 0 || offset > trackSection.length)
             throw new InvalidSchedule("invalid track section offset");
         return new TrackSectionLocation(trackSection, offset);
+    }
+
+    /** Parse RJS track location */
+    public static TrackLocation parseNew(TrackInfra infra, RJSTrackLocation location)
+            throws InvalidSchedule {
+        var trackSectionID = location.trackSection.id;
+        var trackSection = infra.getTrackSection(trackSectionID);
+        if (trackSection == null)
+            throw new UnknownTrackSection("unknown section", trackSectionID);
+        var offset = location.offset;
+        if (offset < 0 || offset > trackSection.getLength())
+            throw new InvalidSchedule("invalid track section offset");
+        return new TrackLocation(trackSection, offset);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSApplicableDirectionsTrackRange.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSApplicableDirectionsTrackRange.java
@@ -10,7 +10,8 @@ public class RJSApplicableDirectionsTrackRange extends RJSTrackRange {
     @Json(name = "applicable_directions")
     public ApplicableDirection applicableDirections;
 
-    RJSApplicableDirectionsTrackRange(
+    /** Constructor */
+    public RJSApplicableDirectionsTrackRange(
             RJSObjectRef<RJSTrackSection> track,
             ApplicableDirection applicableDirections,
             double begin,

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSSpeedSection.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSSpeedSection.java
@@ -13,7 +13,8 @@ public class RJSSpeedSection implements Identified {
     @Json(name = "track_ranges")
     public List<RJSApplicableDirectionsTrackRange> trackRanges;
 
-    RJSSpeedSection(
+    /** Constructor */
+    public RJSSpeedSection(
             String id,
             double speed,
             List<RJSApplicableDirectionsTrackRange> trackRanges

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
@@ -1,29 +1,33 @@
 package fr.sncf.osrd.standalone_sim;
 
+import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.infra.Infra;
 import fr.sncf.osrd.infra.InvalidInfraException;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
+import fr.sncf.osrd.new_infra_state.api.ReservationRouteState;
+import fr.sncf.osrd.new_infra_state.implementation.SignalizationEngine;
+import fr.sncf.osrd.new_infra_state.implementation.standalone.StandaloneSignalingSimulation;
+import fr.sncf.osrd.new_infra_state.implementation.standalone.StandaloneState;
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
 import fr.sncf.osrd.standalone_sim.result.*;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
-import fr.sncf.osrd.train.TrainPath;
 import fr.sncf.osrd.utils.CurveSimplification;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 
 public class ScheduleMetadataExtractor {
     /** Use an already computed envelope to extract various metadata about a trip. */
     public static ResultTrain run(
             Envelope envelope,
-            TrainPath trainPath,
+            NewTrainPath trainPath,
             RJSTrainPath rjsTrainPath,
             StandaloneTrainSchedule schedule,
-            Infra infra
+            SignalingInfra infra
     ) throws InvalidInfraException {
         assert envelope.continuous;
         // Compute speeds, head and tail positions
-        var trainLength = schedule.rollingStock.length;
+        final var trainLength = schedule.rollingStock.length;
         var speeds = new ArrayList<ResultSpeed>();
         var headPositions = new ArrayList<ResultPosition>();
         double time = 0;
@@ -62,35 +66,94 @@ public class ScheduleMetadataExtractor {
             var stopTime = ResultPosition.interpolateTime(stop.position, headPositions);
             stops.add(new ResultStops(stopTime, stop.position, stop.duration));
         }
+        return new ResultTrain(speeds, headPositions, stops,
+                makeRouteOccupancy(infra, envelope, trainPath, trainLength));
+    }
 
-        // Compute routeOccupancy
-        var routeOccupancies = new HashMap<String, ResultOccupancyTiming>();
-        double lastPosition = 0;
-        for (var routePath : rjsTrainPath.routePath) {
-            var route = routePath.route.getRoute(infra.routeGraph.routeMap);
-            var conflictedRoutes = route.getConflictedRoutes();
-            var newPosition = lastPosition;
-            for (var trackRange : routePath.trackSections)
-                newPosition += Math.abs(trackRange.end - trackRange.begin);
-            var routeOccupancy =
-                    ResultOccupancyTiming.fromPositions(lastPosition, newPosition, headPositions, trainLength);
+    /** Generates the ResultOccupancyTiming objects for each route */
+    public static Map<String, ResultOccupancyTiming> makeRouteOccupancy(
+            SignalingInfra infra,
+            Envelope envelope,
+            NewTrainPath trainPath,
+            double trainLength
+    ) {
+        // Earliest position at which the route is occupied
+        var routeOccupied = new HashMap<String, Double>();
+        // Latest position at which the route is freed
+        var routeFree = new HashMap<String, Double>();
 
-            for (var conflictedRoute : conflictedRoutes) {
-                if (!routeOccupancies.containsKey(conflictedRoute.id)) {
-                    routeOccupancies.put(conflictedRoute.id, routeOccupancy);
-                    continue;
-                }
-                var oldOccupancy = routeOccupancies.get(conflictedRoute.id);
-                var newOccupancy = new ResultOccupancyTiming(
-                        oldOccupancy.timeHeadOccupy,
-                        routeOccupancy.timeHeadFree,
-                        oldOccupancy.timeTailOccupy,
-                        routeOccupancy.timeTailFree);
-                routeOccupancies.replace(conflictedRoute.id, newOccupancy);
+        var infraState = StandaloneState.from(trainPath, trainLength);
+
+        // Add routes that are directly occupied by the train (handles routes not protected by signals)
+        for (var entry : infraState.routeUpdatePositions.entries()) {
+            var position = entry.getKey();
+            var route = entry.getValue();
+            if (position >= trainPath.length())
+                continue;
+            infraState.moveTrain(position);
+            for (var r : Sets.union(route.getConflictingRoutes(), Set.of(route))) {
+                addUpdate(
+                        routeOccupied,
+                        routeFree,
+                        infraState.getState(r).summarize().equals(ReservationRouteState.Summary.FREE),
+                        r.getID(),
+                        position,
+                        trainPath.length()
+                );
             }
-            lastPosition = newPosition;
         }
-        return new ResultTrain(speeds, headPositions, stops, routeOccupancies);
+
+        // Add signal updates: a route is "occupied" when a signal protecting it isn't green
+        var signalizationEngine = SignalizationEngine.from(infra, infraState);
+        var events = StandaloneSignalingSimulation.runWithoutEnvelope(trainPath, infraState, signalizationEngine);
+        for (var e : events) {
+            var routes = e.signal().getProtectedRoutes();
+            for (var r : routes) {
+                addUpdate(
+                        routeOccupied,
+                        routeFree,
+                        e.state().isFree(),
+                        r.getID(),
+                        e.position(),
+                        trainPath.length()
+                );
+            }
+        }
+
+        // Builds the results, converting positions into times
+        var res = new HashMap<String, ResultOccupancyTiming>();
+        for (var route : Sets.union(routeFree.keySet(), routeOccupied.keySet())) {
+            var occupied = routeOccupied.getOrDefault(route, 0.);
+            var free = routeFree.getOrDefault(route, trainPath.length());
+
+            // Get the points where the route is freed by the head and occupied by the tail
+            // TODO: either remove the need for this, or add comments that explain why it's needed
+            var headFree = Math.min(occupied + trainLength, trainPath.length());
+            var tailOccupied = Math.max(free - trainLength, 0);
+
+            res.put(route, new ResultOccupancyTiming(
+                    envelope.interpolateTotalTime(occupied),
+                    envelope.interpolateTotalTime(headFree),
+                    envelope.interpolateTotalTime(tailOccupied),
+                    envelope.interpolateTotalTime(free)
+            ));
+        }
+        return res;
+    }
+
+    /** Adds a route update to the maps */
+    private static void addUpdate(
+            Map<String, Double> routeOccupied,
+            Map<String, Double> routeFree,
+            boolean isFree,
+            String id,
+            double position,
+            double pathLength
+    ) {
+        if (isFree)
+            routeFree.put(id, Math.max(position, routeOccupied.getOrDefault(id, 0.)));
+        else
+            routeOccupied.put(id, Math.min(position, routeOccupied.getOrDefault(id, pathLength)));
     }
 
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -47,7 +47,6 @@ public class StandaloneSim {
                 var simResultTrain = ScheduleMetadataExtractor.run(
                         envelope,
                         trainsPath,
-                        rjsTrainsPath,
                         trainSchedule,
                         infra);
                 cacheMaxEffort.put(trainSchedule, simResultTrain);
@@ -58,7 +57,6 @@ public class StandaloneSim {
                     var simEcoResultTrain = ScheduleMetadataExtractor.run(
                             ecoEnvelope,
                             trainsPath,
-                            rjsTrainsPath,
                             trainSchedule,
                             infra);
                     cacheEco.put(trainSchedule, simEcoResultTrain);

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -9,11 +9,11 @@ import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.exceptions.ErrorContext;
 import fr.sncf.osrd.exceptions.OSRDError;
-import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainPath;
 import fr.sncf.osrd.standalone_sim.result.*;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
-import fr.sncf.osrd.train.TrainPath;
 import java.util.HashMap;
 import java.util.List;
 
@@ -23,13 +23,13 @@ public class StandaloneSim {
      * Interactions between trains are ignored.
      */
     public static StandaloneSimResult run(
-            Infra infra,
+            SignalingInfra infra,
             RJSTrainPath rjsTrainsPath,
-            TrainPath trainsPath,
+            NewTrainPath trainsPath,
             List<StandaloneTrainSchedule> schedules,
             double timeStep
     ) {
-        var envelopePath = EnvelopeTrainPath.from(trainsPath);
+        var envelopePath = EnvelopeTrainPath.fromNew(trainsPath);
 
         // Compute envelopes
         var result = new StandaloneSimResult();

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultPosition.java
@@ -2,7 +2,7 @@ package fr.sncf.osrd.standalone_sim.result;
 
 import com.squareup.moshi.Json;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.train.TrainPath;
+import fr.sncf.osrd.new_infra_state.api.NewTrainPath;
 import java.util.ArrayList;
 
 @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
@@ -21,9 +21,9 @@ public class ResultPosition {
         this.offset = offset;
     }
 
-    public static ResultPosition from(double time, double pathOffset, TrainPath path) {
+    public static ResultPosition from(double time, double pathOffset, NewTrainPath path) {
         var location = path.findLocation(pathOffset);
-        return new ResultPosition(time, pathOffset, location.edge.id, location.offset);
+        return new ResultPosition(time, pathOffset, location.track().getID(), location.offset());
     }
 
     /** Interpolate in a list of positions the time associated to a given position.

--- a/core/src/main/java/fr/sncf/osrd/train/StandaloneTrainSchedule.java
+++ b/core/src/main/java/fr/sncf/osrd/train/StandaloneTrainSchedule.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.train;
 import com.carrotsearch.hppc.DoubleArrayList;
 import fr.sncf.osrd.envelope_sim.allowances.Allowance;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class StandaloneTrainSchedule {
@@ -11,16 +12,16 @@ public class StandaloneTrainSchedule {
 
     public final double initialSpeed;
 
-    public final ArrayList<TrainStop> stops;
+    public final List<TrainStop> stops;
 
-    public final ArrayList<? extends Allowance> allowances;
+    public final List<? extends Allowance> allowances;
 
     /** Standalone Train Schedule constructor */
     public StandaloneTrainSchedule(
             RollingStock rollingStock,
             double initialSpeed,
-            ArrayList<TrainStop> stops,
-            ArrayList<? extends Allowance> allowances
+            List<TrainStop> stops,
+            List<? extends Allowance> allowances
     ) {
         this.rollingStock = rollingStock;
         this.initialSpeed = initialSpeed;

--- a/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
@@ -1,21 +1,28 @@
 package fr.sncf.osrd.api;
 
+import static fr.sncf.osrd.infra.Infra.parseRailJSONFromFile;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.api.InfraManager.InfraLoadException;
 import fr.sncf.osrd.infra.Infra;
+import fr.sncf.osrd.new_infra.implementation.signaling.SignalingInfraBuilder;
+import fr.sncf.osrd.new_infra.implementation.signaling.modules.bal3.BAL3;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
 public class ApiTest {
     @Mock
     static InfraManager infraHandlerMock;
+    @Mock
+    static NewInfraManager newInfraHandlerMock;
 
     /**
      * Setup infra handler mock
@@ -23,10 +30,18 @@ public class ApiTest {
     @BeforeEach
     public void setUp() throws InfraLoadException, InterruptedException {
         ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
-        when(infraHandlerMock.load(argument.capture(), any())).thenAnswer(
+        lenient().when(infraHandlerMock.load(argument.capture(), any())).thenAnswer(
                 invocation ->
                         Infra.parseFromFile(
                                 Helpers.getResourcePath(argument.getValue()).toString()
+                        )
+        );
+        lenient().when(newInfraHandlerMock.load(argument.capture(), any())).thenAnswer(
+                invocation ->
+                        SignalingInfraBuilder.fromRJSInfra(
+                                parseRailJSONFromFile(
+                                        Helpers.getResourcePath(argument.getValue()).toString()
+                                ), Set.of(new BAL3())
                         )
         );
     }

--- a/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
@@ -48,7 +48,7 @@ class StandaloneSimulationTest extends ApiTest {
         var requestBody = StandaloneSimulationEndpoint.adapterRequest.toJson(request);
 
         // process it
-        var rawResponse = new RsPrint(new StandaloneSimulationEndpoint(infraHandlerMock)
+        var rawResponse = new RsPrint(new StandaloneSimulationEndpoint(newInfraHandlerMock)
                 .act(new RqFake("POST", "/standalone_simulation", requestBody))
         ).printBody();
 

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 public class MaxEffortEnvelopeTest {
     /** Builds max effort envelope with the specified stops, on a flat MRSP */
-    static Envelope makeSimpleMaxEffortEnvelope(
+    public static Envelope makeSimpleMaxEffortEnvelope(
             EnvelopeSimContext context,
             double speed,
             double[] stops

--- a/core/src/test/java/fr/sncf/osrd/new_infra/tracks/directed/DirectedRJSParsingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra/tracks/directed/DirectedRJSParsingTests.java
@@ -276,7 +276,7 @@ public class DirectedRJSParsingTests {
 
     /** Merges all the detectors and positions on a list of ranges */
     private static List<Pair> getDetectorsOnRanges(List<TrackRangeView> ranges) {
-        var pos = 0;
+        var pos = 0.;
         var res = new ArrayList<Pair>();
         for (var range : ranges) {
             var detectors = range.getDetectors();
@@ -289,7 +289,7 @@ public class DirectedRJSParsingTests {
 
     /** Merges all the speed sections on a list of ranges */
     private static DoubleRangeMap getSpeedsOnRange(List<TrackRangeView> ranges) {
-        var pos = 0;
+        var pos = 0.;
         var res = new DoubleRangeMap();
         for (var range : ranges) {
             var sections = range.getSpeedSections();

--- a/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneSignalingSimulationTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneSignalingSimulationTests.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.new_infra_state;
 
 import static fr.sncf.osrd.new_infra.InfraHelpers.getSignalingRoute;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.envelope.Envelope;
@@ -52,7 +53,11 @@ public class StandaloneSignalingSimulationTests {
                         new SignalUpdateID(175, "il.sig.C2", BAL3.Aspect.RED),
                         new SignalUpdateID(175 + length, "il.sig.S7", BAL3.Aspect.GREEN),
                         new SignalUpdateID(10175, "il.sig.C6", BAL3.Aspect.RED),
-                        new SignalUpdateID(10175 + length, "il.sig.C2", BAL3.Aspect.YELLOW)
+                        new SignalUpdateID(10175 + length, "il.sig.C2", BAL3.Aspect.YELLOW),
+                        new SignalUpdateID(path.length() + length, "il.sig.C2", BAL3.Aspect.GREEN),
+                        new SignalUpdateID(path.length() + length, "il.sig.C3", BAL3.Aspect.GREEN),
+                        new SignalUpdateID(path.length() + length, "il.sig.C6", BAL3.Aspect.GREEN),
+                        new SignalUpdateID(path.length() + length, "il.sig.C1", BAL3.Aspect.GREEN)
                 ),
                 convertEventList(events)
         );
@@ -70,7 +75,7 @@ public class StandaloneSignalingSimulationTests {
         var path = TrainPathBuilder.from(
                 routes,
                 new TrackLocation(infra.getTrackSection("track.0"), 0),
-                new TrackLocation(infra.getTrackSection("track.9"), 1000)
+                new TrackLocation(infra.getTrackSection("track.9"), 0)
         );
         var length = 100;
         var infraState = StandaloneState.from(path, length);
@@ -84,7 +89,7 @@ public class StandaloneSignalingSimulationTests {
                 if (bal3State.aspect.equals(BAL3.Aspect.RED))
                     redSignals.add(e.signal().getID());
         for (var signal : infra.getSignalMap().values())
-            assert redSignals.contains(signal.getID());
+            assertTrue(redSignals.contains(signal.getID()));
     }
 
     @Test
@@ -99,7 +104,7 @@ public class StandaloneSignalingSimulationTests {
         var path = TrainPathBuilder.from(
                 routes,
                 new TrackLocation(infra.getTrackSection("track.0"), 0),
-                new TrackLocation(infra.getTrackSection("track.9"), 1000)
+                new TrackLocation(infra.getTrackSection("track.9"), 0)
         );
         var speed = 10;
         var envelope = makeConstantSpeedEnvelope(path.length(), speed);
@@ -108,7 +113,7 @@ public class StandaloneSignalingSimulationTests {
         var signalizationEngine = SignalizationEngine.from(infra, infraState);
         var events = StandaloneSignalingSimulation.run(path, infraState, signalizationEngine, envelope);
         for (var e : events)
-            assertEquals(e.position() / speed, e.time());
+            assertTrue(e.position() / speed >= e.time());
     }
 
     /** Converts a list of event into a set of simpler record structure, for easier equality testing */

--- a/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneSignalingSimulationTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneSignalingSimulationTests.java
@@ -55,9 +55,7 @@ public class StandaloneSignalingSimulationTests {
                         new SignalUpdateID(10175, "il.sig.C6", BAL3.Aspect.RED),
                         new SignalUpdateID(10175 + length, "il.sig.C2", BAL3.Aspect.YELLOW),
                         new SignalUpdateID(path.length() + length, "il.sig.C2", BAL3.Aspect.GREEN),
-                        new SignalUpdateID(path.length() + length, "il.sig.C3", BAL3.Aspect.GREEN),
-                        new SignalUpdateID(path.length() + length, "il.sig.C6", BAL3.Aspect.GREEN),
-                        new SignalUpdateID(path.length() + length, "il.sig.C1", BAL3.Aspect.GREEN)
+                        new SignalUpdateID(path.length() + length, "il.sig.C6", BAL3.Aspect.GREEN)
                 ),
                 convertEventList(events)
         );

--- a/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneStateTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra_state/StandaloneStateTests.java
@@ -68,7 +68,7 @@ public class StandaloneStateTests {
                 Set.of(
                         new RouteUpdate(0, ReservationRouteState.Summary.OCCUPIED, firstRoute),
                         new RouteUpdate(50, ReservationRouteState.Summary.OCCUPIED, secondRoute),
-                        new RouteUpdate(50 + length, ReservationRouteState.Summary.FREE, firstRoute)
+                        new RouteUpdate(50 + length, ReservationRouteState.Summary.RESERVED, firstRoute)
                 ),
                 routeUpdates
         );

--- a/core/src/test/java/fr/sncf/osrd/new_infra_state/TrainPathTests.java
+++ b/core/src/test/java/fr/sncf/osrd/new_infra_state/TrainPathTests.java
@@ -164,7 +164,7 @@ public class TrainPathTests {
         var path = TrainPathBuilder.from(
                 List.of(getSignalingRoute(infra, "route_forward")),
                 new TrackLocation(track, 10),
-                new TrackLocation(track, 0)
+                new TrackLocation(track, 100)
         );
         var envelopePath = EnvelopeTrainPath.fromNew(NewTrainPath.removeLocation(path.trackRangePath()));
         assertEquals(30, envelopePath.getAverageGrade(0, 20));

--- a/core/src/test/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorTests.java
+++ b/core/src/test/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorTests.java
@@ -8,12 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.new_infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.new_infra.implementation.signaling.SignalingInfraBuilder;
 import fr.sncf.osrd.new_infra.implementation.signaling.modules.bal3.BAL3;
 import fr.sncf.osrd.new_infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.train.TestTrains;
 import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -69,5 +71,79 @@ public class ScheduleMetadataExtractorTests {
                     timings.get(route.getID()).timeTailFree
             );
         }
+    }
+
+    @Test
+    public void tinyInfraEndsInMiddleRoutesTests() throws Exception {
+        var rjsInfra = Helpers.getExampleInfra("tiny_infra/infra.json");
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var barA = infra.getTrackSection("ne.micro.bar_a");
+        var fooA = infra.getTrackSection("ne.micro.foo_a");
+        var path = TrainPathBuilder.from(
+                List.of(
+                        getSignalingRoute(infra, "rt.buffer_stop_c->tde.track-bar"),
+                        getSignalingRoute(infra, "rt.tde.track-bar->tde.switch_foo-track"),
+                        getSignalingRoute(infra, "rt.tde.switch_foo-track->buffer_stop_a")
+                ),
+                new TrackLocation(barA, 100),
+                new TrackLocation(fooA, 100)
+        );
+        var testRollingStock = TestTrains.REALISTIC_FAST_TRAIN;
+        var testContext = new EnvelopeSimContext(testRollingStock, EnvelopeTrainPath.fromNew(path), TIME_STEP);
+        var envelope = makeSimpleMaxEffortEnvelope(
+                testContext,
+                testRollingStock.maxSpeed, new double[]{}
+        );
+        // We only check that no assertion is thrown in the validation
+        ScheduleMetadataExtractor.makeRouteOccupancy(infra, envelope, path, testRollingStock.length);
+    }
+
+    @Test
+    public void veryLongTrainTests() throws Exception {
+        var rjsInfra = Helpers.getExampleInfra("tiny_infra/infra.json");
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var barA = infra.getTrackSection("ne.micro.bar_a");
+        var fooA = infra.getTrackSection("ne.micro.foo_a");
+        var path = TrainPathBuilder.from(
+                List.of(
+                        getSignalingRoute(infra, "rt.buffer_stop_c->tde.track-bar"),
+                        getSignalingRoute(infra, "rt.tde.track-bar->tde.switch_foo-track"),
+                        getSignalingRoute(infra, "rt.tde.switch_foo-track->buffer_stop_a")
+                ),
+                new TrackLocation(barA, 100),
+                new TrackLocation(fooA, 100)
+        );
+        var testRollingStock = TestTrains.VERY_LONG_FAST_TRAIN;
+        var testContext = new EnvelopeSimContext(testRollingStock, EnvelopeTrainPath.fromNew(path), TIME_STEP);
+        var envelope = makeSimpleMaxEffortEnvelope(
+                testContext,
+                testRollingStock.maxSpeed, new double[]{}
+        );
+        // We only check that no assertion is thrown in the validation
+        ScheduleMetadataExtractor.makeRouteOccupancy(infra, envelope, path, testRollingStock.length);
+    }
+
+    @Test
+    public void oneLineInfraTests() throws Exception {
+        var rjsInfra = Helpers.getExampleInfra("one_line/infra.json");
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var routes = new ArrayList<SignalingRoute>();
+        routes.add(getSignalingRoute(infra, "rt.buffer_stop.0->detector.0"));
+        for (int i = 0; i < 9; i++)
+            routes.add(getSignalingRoute(infra, String.format("rt.detector.%d->detector.%d", i, i + 1)));
+        routes.add(getSignalingRoute(infra, "rt.detector.9->buffer_stop.1"));
+        var path = TrainPathBuilder.from(
+                routes,
+                new TrackLocation(infra.getTrackSection("track.0"), 0),
+                new TrackLocation(infra.getTrackSection("track.9"), 0)
+        );
+        var testRollingStock = TestTrains.REALISTIC_FAST_TRAIN;
+        var testContext = new EnvelopeSimContext(testRollingStock, EnvelopeTrainPath.fromNew(path), TIME_STEP);
+        var envelope = makeSimpleMaxEffortEnvelope(
+                testContext,
+                testRollingStock.maxSpeed, new double[]{}
+        );
+        // We only check that no assertion is thrown in the validation
+        ScheduleMetadataExtractor.makeRouteOccupancy(infra, envelope, path, testRollingStock.length);
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorTests.java
+++ b/core/src/test/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorTests.java
@@ -1,0 +1,73 @@
+package fr.sncf.osrd.standalone_sim;
+
+import static fr.sncf.osrd.envelope_sim.MaxEffortEnvelopeTest.makeSimpleMaxEffortEnvelope;
+import static fr.sncf.osrd.envelope_sim.MaxSpeedEnvelopeTest.TIME_STEP;
+import static fr.sncf.osrd.new_infra.InfraHelpers.getSignalingRoute;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fr.sncf.osrd.Helpers;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.new_infra.api.tracks.undirected.TrackLocation;
+import fr.sncf.osrd.new_infra.implementation.signaling.SignalingInfraBuilder;
+import fr.sncf.osrd.new_infra.implementation.signaling.modules.bal3.BAL3;
+import fr.sncf.osrd.new_infra_state.implementation.TrainPathBuilder;
+import fr.sncf.osrd.train.TestTrains;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.Set;
+
+public class ScheduleMetadataExtractorTests {
+
+    @Test
+    public void tinyInfraTests() throws Exception {
+        var rjsInfra = Helpers.getExampleInfra("tiny_infra/infra.json");
+        var infra = SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3()));
+        var barA = infra.getTrackSection("ne.micro.bar_a");
+        var fooA = infra.getTrackSection("ne.micro.foo_a");
+        var path = TrainPathBuilder.from(
+                List.of(
+                        getSignalingRoute(infra, "rt.buffer_stop_c->tde.track-bar"),
+                        getSignalingRoute(infra, "rt.tde.track-bar->tde.switch_foo-track"),
+                        getSignalingRoute(infra, "rt.tde.switch_foo-track->buffer_stop_a")
+                ),
+                new TrackLocation(barA, 200),
+                new TrackLocation(fooA, 0)
+        );
+        var testRollingStock = TestTrains.REALISTIC_FAST_TRAIN;
+        var testContext = new EnvelopeSimContext(testRollingStock, EnvelopeTrainPath.fromNew(path), TIME_STEP);
+        var envelope = makeSimpleMaxEffortEnvelope(
+                testContext,
+                testRollingStock.maxSpeed, new double[]{}
+        );
+        var timings = ScheduleMetadataExtractor.makeRouteOccupancy(infra, envelope, path, testRollingStock.length);
+
+        var routePath = path.routePath();
+        for (int i = 0; i < routePath.size(); i++) {
+            var signalingRoute = routePath.get(i).element();
+            var route = signalingRoute.getInfraRoute();
+            var offset = routePath.get(i).pathOffset();
+            var occupiedPosition = Math.max(0, offset);
+            assertEquals(
+                    envelope.interpolateTotalTime(occupiedPosition),
+                    timings.get(route.getID()).timeHeadOccupy
+            );
+            var freePosition = Math.min(path.length(), offset + route.getLength() + testRollingStock.length);
+            if (i < routePath.size() - 1 && signalingRoute instanceof BAL3.BAL3Route bal3Route) {
+                if (bal3Route.entrySignal() != null) {
+                    var nextRoute = routePath.get(i + 1);
+                    freePosition = Math.min(
+                            path.length(),
+                            nextRoute.pathOffset()
+                                    + nextRoute.element().getInfraRoute().getLength()
+                                    + testRollingStock.length
+                    );
+                }
+            }
+            assertEquals(
+                    envelope.interpolateTotalTime(freePosition),
+                    timings.get(route.getID()).timeTailFree
+            );
+        }
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
+++ b/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
@@ -24,6 +24,7 @@ public class TestTrains {
     public static final RollingStock REALISTIC_FAST_TRAIN;
     public static final RollingStock REALISTIC_FAST_TRAIN_MAX_DEC_TYPE;
     public static final RollingStock VERY_SHORT_FAST_TRAIN;
+    public static final RollingStock VERY_LONG_FAST_TRAIN;
 
 
     static {
@@ -45,6 +46,22 @@ public class TestTrains {
                 "fast train source",
                 "fast train verbose name",
                 1, trainMass, 1.05, (0.65 * trainMass) / 100,
+                ((0.008 * trainMass) / 100) * 3.6,
+                (((0.00012 * trainMass) / 100) * 3.6) * 3.6,
+                maxSpeed,
+                30,
+                0.05,
+                0.25,
+                0.5,
+                RollingStock.GammaType.CONST,
+                tractiveEffortCurve.toArray(new RollingStock.TractiveEffortPoint[0])
+        );
+
+        VERY_LONG_FAST_TRAIN = new RollingStock(
+                "fast train",
+                "fast train source",
+                "fast train verbose name",
+                100000, trainMass, 1.05, (0.65 * trainMass) / 100,
                 ((0.008 * trainMass) / 100) * 3.6,
                 (((0.00012 * trainMass) / 100) * 3.6) * 3.6,
                 maxSpeed,

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -9,7 +9,7 @@ import requests
 from pathlib import Path
 
 URL = "http://127.0.0.1:8000/"
-TIMEOUT = 10
+TIMEOUT = 15
 
 
 """


### PR DESCRIPTION
Integrates signaling to compute block occupancy for standalone sim. Fixes https://github.com/DGEXSolutions/osrd/issues/693.

It's a draft because it's barely tested yet.

There is a good amount of duplicated code, the old version will be removed once https://github.com/DGEXSolutions/osrd/issues/721 is done. 