### PR TITLE
CI: editoast check format

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   test:
+    name: Run tests
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,12 +43,30 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Build
-        run: |
-          cd editoast
-          cargo build --verbose
-
       - name: Test
         run: |
           cd editoast
           cargo test --verbose
+
+  linter:
+    name: Check format and run linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # run the CI on the actual latest commit of the PR, not the attempted merge
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+          override: true
+      - name: Format check
+        run: |
+          cd editoast
+          cargo fmt --check
+      - name: Clippy linter
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --manifest-path=editoast/Cargo.toml

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -160,15 +160,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -238,9 +238,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -296,9 +296,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -612,10 +612,11 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -884,9 +885,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
  "version_check 0.9.4",
 ]
 
@@ -896,7 +897,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
  "version_check 0.9.4",
 ]
@@ -912,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -934,7 +935,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
 ]
 
 [[package]]
@@ -1017,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1157,9 +1158,9 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1188,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -1244,11 +1245,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
  "unicode-xid 0.2.2",
 ]
@@ -1283,9 +1284,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "quote 1.0.17",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -3,6 +3,7 @@ name = "editoast"
 version = "0.1.0"
 edition = "2021"
 authors = ["Florian Amsallem <florian.amsallem@epita.fr>"]
+license = "LGPL-3.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -14,10 +14,22 @@ It will apply modification and update generated data such as object geometry.
 
 ```sh
 # Install nightly rust toolchain
-$ rustup toolchain install nightly 
+$ rustup toolchain install nightly
 # Set nightly as default for the project
 $ rustup override set nightly
 # Build and run
 $ cargo build
 $ cargo run -- runserver
 ```
+
+## Useful tools
+
+Here a list of components to help you in your development:
+
+ - [rustfmt](https://github.com/rust-lang/rust-clippy): Format the whole code `cargo fmt`
+ - [clippy](): Run a powerful linter `cargo clippy`
+
+To install them simply run:
+ ```
+ $ rustup component add rustfmt clippy
+ ```

--- a/editoast/src/infra_cache.rs
+++ b/editoast/src/infra_cache.rs
@@ -26,27 +26,27 @@ struct ObjRefLink {
 }
 
 impl InfraCache {
-    fn add_tracks_refs(&mut self, refs: &Vec<ObjRefLink>, obj_type: ObjectType) {
+    fn add_tracks_refs(&mut self, refs: &[ObjRefLink], obj_type: ObjectType) {
         for link in refs.iter() {
             self.track_sections_refs
                 .entry(link.ref_id.clone())
-                .or_insert(Default::default())
+                .or_default()
                 .insert(ObjectRef::new(obj_type, link.obj_id.clone()));
         }
     }
 
-    fn add_signal_dependencies(&mut self, refs: &Vec<ObjRefLink>) {
+    fn add_signal_dependencies(&mut self, refs: &[ObjRefLink]) {
         for link in refs.iter() {
             self.signal_dependencies
                 .insert(link.obj_id.clone(), link.ref_id.clone());
         }
     }
 
-    fn add_speed_section_dependencies(&mut self, refs: &Vec<ObjRefLink>) {
+    fn add_speed_section_dependencies(&mut self, refs: &[ObjRefLink]) {
         for link in refs.iter() {
             self.speed_section_dependencies
                 .entry(link.obj_id.clone())
-                .or_insert(Default::default())
+                .or_default()
                 .push(link.ref_id.clone());
         }
     }

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-static RAILJSON_VERSION: &'static str = "2.2.0";
+static RAILJSON_VERSION: &str = "2.2.0";
 
 #[derive(Clone, QueryableByName, Queryable, Debug, Serialize)]
 #[table_name = "osrd_infra_infra"]

--- a/editoast/src/models/signal_layer.rs
+++ b/editoast/src/models/signal_layer.rs
@@ -1,5 +1,5 @@
 use crate::infra_cache::InfraCache;
-use crate::railjson::operation::{Operation, RailjsonObject, UpdateOperation};
+use crate::railjson::operation::{Operation, UpdateOperation};
 use crate::railjson::{ObjectRef, ObjectType};
 use crate::schema::osrd_infra_signallayer;
 use crate::schema::osrd_infra_signallayer::dsl::*;
@@ -10,7 +10,6 @@ use diesel::{delete, sql_query};
 use itertools::Itertools;
 use serde::Serialize;
 use std::collections::HashSet;
-use std::ops::Deref;
 
 #[derive(QueryableByName, Queryable, Debug, Serialize)]
 #[table_name = "osrd_infra_signallayer"]
@@ -67,24 +66,34 @@ impl SignalLayer {
             });
     }
 
+    /// Search and update all signals that needs to be refreshed given a list of operation.
     pub fn update(
         conn: &PgConnection,
         infra: i32,
         operations: &Vec<Operation>,
         infra_cache: &mut InfraCache,
     ) -> Result<(), Error> {
-        // Search all signals that needs to be refreshed
         let mut obj_ids = HashSet::new();
         for op in operations {
             match op {
-                Operation::Create(RailjsonObject::TrackSection { railjson }) => {
-                    Self::fill_signal_track_refs(infra_cache.deref(), &railjson.id, &mut obj_ids)
-                }
+                Operation::Create(rjs_obj) => match rjs_obj.get_obj_type() {
+                    ObjectType::TrackSection => {
+                        Self::fill_signal_track_refs(
+                            infra_cache,
+                            &rjs_obj.get_obj_id(),
+                            &mut obj_ids,
+                        );
+                    }
+                    ObjectType::Signal => {
+                        obj_ids.insert(rjs_obj.get_obj_id().clone());
+                    }
+                    _ => (),
+                },
                 Operation::Update(UpdateOperation {
                     obj_id: track_id,
                     obj_type: ObjectType::TrackSection,
                     ..
-                }) => Self::fill_signal_track_refs(infra_cache.deref(), track_id, &mut obj_ids),
+                }) => Self::fill_signal_track_refs(infra_cache, track_id, &mut obj_ids),
                 Operation::Delete(ObjectRef {
                     obj_id: signal_id,
                     obj_type: ObjectType::Signal,
@@ -99,7 +108,6 @@ impl SignalLayer {
                 _ => (),
             }
         }
-        // Update layer
         Self::update_list(conn, infra, &obj_ids)
     }
 }

--- a/editoast/src/railjson/operation/mod.rs
+++ b/editoast/src/railjson/operation/mod.rs
@@ -19,7 +19,7 @@ pub use update::UpdateOperation;
 #[serde(tag = "operation_type", deny_unknown_fields)]
 pub enum Operation {
     #[serde(rename = "CREATE")]
-    Create(RailjsonObject),
+    Create(Box<RailjsonObject>),
     #[serde(rename = "UPDATE")]
     Update(UpdateOperation),
     #[serde(rename = "DELETE")]
@@ -103,7 +103,7 @@ impl Operation {
             }
             Operation::Create(railjson_object) => {
                 create::apply_create_operation(railjson_object, infra_id, conn)?;
-                Ok(OperationResult::Create(railjson_object.clone()))
+                Ok(OperationResult::Create(*railjson_object.clone()))
             }
             Operation::Update(update) => {
                 let obj_railjson = update.apply(infra_id, conn)?;


### PR DESCRIPTION
close #760 

This PR does multiple things:

- Add format check to the CI
- Add clippy check to  the CI (warnings doesn't block the merge)
- Fixing clippy warnings
- Fix update of signal and speed section layers (missing object creation case)