### PR TITLE
core: optimize infra loading and standalone simulation

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/infra/api/reservation/DetectionSection.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/api/reservation/DetectionSection.java
@@ -6,4 +6,7 @@ import com.google.common.collect.ImmutableSet;
 public interface DetectionSection {
     /** Returns all the detectors bordering the section. The direction points toward the inside of the section */
     ImmutableSet<DiDetector> getDetectors();
+
+    /** Returns all the routes crossing over this section */
+    ImmutableSet<ReservationRoute> getRoutes();
 }

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/DetectionSectionImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/DetectionSectionImpl.java
@@ -4,11 +4,13 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import fr.sncf.osrd.infra.api.reservation.DetectionSection;
 import fr.sncf.osrd.infra.api.reservation.DiDetector;
+import fr.sncf.osrd.infra.api.reservation.ReservationRoute;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 
 public class DetectionSectionImpl implements DetectionSection {
 
     private final ImmutableSet<DiDetector> detectors;
+    private ImmutableSet<ReservationRoute> routes;
 
     /** Constructor */
     public DetectionSectionImpl(ImmutableSet<DiDetector> detectors) {
@@ -18,6 +20,15 @@ public class DetectionSectionImpl implements DetectionSection {
     @Override
     public ImmutableSet<DiDetector> getDetectors() {
         return detectors;
+    }
+
+    @Override
+    public ImmutableSet<ReservationRoute> getRoutes() {
+        return routes;
+    }
+
+    void setRoutes(ImmutableSet<ReservationRoute> routes) {
+        this.routes = routes;
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -25,7 +25,7 @@ public class UndirectedInfraBuilder {
 
     private final HashMap<String, TrackNode> beginEndpoints = new HashMap<>();
     private final HashMap<String, TrackNode> endEndpoints = new HashMap<>();
-    private final HashMap<TrackSectionImpl, ArrayList<Detector>> detectorLists = new HashMap<>();
+    private final IdentityHashMap<TrackSectionImpl, ArrayList<Detector>> detectorLists = new IdentityHashMap<>();
     private final ImmutableNetwork.Builder<TrackNode, TrackEdge> builder;
     private final Multimap<String, OperationalPoint> operationalPointsPerTrack = ArrayListMultimap.create();
 


### PR DESCRIPTION
We spent a lot of time building the route conflicts over all of the infra. It works roughly the same way now, but with lazy evaluation. 

It is still slower than the previous version, but I don't see any easy shortcut anymore when running a profiler. 


I also optimized the standalone signaling engine