### PR TITLE
core: fix error feedback loading infra

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -191,6 +191,9 @@ public class InfraManager {
         } catch (IOException | UnexpectedHttpResponse | JsonDataException e) {
             cacheEntry.registerError(e);
             throw new InfraLoadException("error while loading new infra", cacheEntry.lastStatus, e);
+        } catch (Exception e) {
+            cacheEntry.registerError(e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
This PR fixes a problem I just discovered.

When we load an infra and an `InvalidInfraError` occurs, the cached infra has not been set to `ERROR`. This is a problem for following requests that wait indefinitely for the infra to finish loading.