### PR TITLE
core: infra: fix a bug where graph nodes would be merged

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
@@ -21,19 +21,20 @@ public class ValidateInfra implements CliCommand {
     @Override
     @ExcludeFromGeneratedCodeCoverage
     public int run() {
+        var warningRecorder = new WarningRecorderImpl(false);
         try {
             var rjs = RJSParser.parseRailJSONFromFile(infraPath);
-            var warningRecorder = new WarningRecorderImpl(false);
             SignalingInfraBuilder.fromRJSInfra(
                     rjs,
                     Set.of(new BAL3(warningRecorder)),
                     warningRecorder
             );
-            warningRecorder.report();
             return 0;
         } catch (Exception e) {
             e.printStackTrace();
             return 1;
+        } finally {
+            warningRecorder.report();
         }
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -97,6 +97,7 @@ public class UndirectedInfraBuilder {
 
     /** Creates all the track section links that haven't already been created by switches */
     private void addRemainingLinks(RJSInfra infra) {
+        int generatedID = 0;
         for (var link : infra.trackSectionLinks) {
             var srcID = link.src.track.id.id;
             var dstID = link.dst.track.id.id;
@@ -115,6 +116,10 @@ public class UndirectedInfraBuilder {
                         oldSrcNode,
                         oldDstNode
                 ));
+            }
+            if (link.id == null || link.id.equals("")) {
+                // Forcing a unique ID avoids node equality troubles, and makes debugging easier
+                link.id = String.format("generated_%d", generatedID++);
             }
             var newNode = new TrackNodeImpl.Joint(link.id);
             addNode(srcID, link.src.endpoint, newNode);

--- a/core/src/test/java/fr/sncf/osrd/infra/tracks/undirected/RJSParsingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/infra/tracks/undirected/RJSParsingTests.java
@@ -74,4 +74,13 @@ public class RJSParsingTests {
                 () -> UndirectedInfraBuilder.parseInfra(rjsInfra, new WarningRecorderImpl(true))
         );
     }
+
+    @Test
+    public void testUnlabeledLinks() throws Exception {
+        var rjsInfra = Helpers.getExampleInfra("one_line/infra.json");
+        for (var link : rjsInfra.trackSectionLinks)
+            link.id = null;
+        // We check that no warning or assertion is raised when importing the infra
+        UndirectedInfraBuilder.parseInfra(rjsInfra, new WarningRecorderImpl(true));
+    }
 }


### PR DESCRIPTION
TrackNodeImpl.Joint is a record so the equality is based on its field, when the id isn't specified they are all equal. This causes problems with guava Networks, which uses node equality