### PR TITLE
Proposal of new endpoints and API changes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -480,6 +480,30 @@ paths:
                     type: string
                   infra:
                     type: number
+  /timetable/{id}/conflicts/:
+    get:
+      tags:
+        - timetable
+      summary: Retrieve a list of conflicts for the given timetable, with projections on a given path
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Timetable ID
+          required: true
+        - in: query
+          name: path
+          schema:
+            type: integer
+          description: Path id used to project the train path
+      responses:
+        200:
+          description: The list of conflicts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictResponse"
   /train_schedule/standalone_simulation/:
     post:
       tags:
@@ -1064,6 +1088,33 @@ components:
             id:
               type: integer
         - $ref: "#/components/schemas/WritableTrainSchedule"
+    ConflictResponse:
+      type: array
+      items:
+        type: object
+        properties:
+          first_train:
+            type: number
+            description: ID of the train that arrives first in the conflicted area
+          second_train:
+            type: number
+            description: ID of the train that arrives last in the conflicted area
+          time_start:
+            type: number
+            format: float
+            description: Start time of the conflict
+          time_end:
+            type: number
+            format: float
+            description: End time of the conflict
+          position_start:
+            type: number
+            format: float
+            description: The conflict starts at this position. Unspecified if not on the path
+          position_end:
+            type: number
+            format: float
+            description: The conflict ends at this position. Unspecified if not on the path
     StandaloneSimulationParameters:
       properties:
         timetable:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -773,40 +773,10 @@ components:
               time: { type: number, format: float }
               position: { type: number, format: float }
               duration: { type: number, format: float }
+        signal_aspects:
+          $ref: "#/components/schemas/SignalAspectsResult"
         route_aspects:
-          type: array
-          items:
-            type: object
-            properties:
-              signal_id:
-                type: string
-                description: id of the updated signal
-              route_id:
-                type: string
-                description: id of the affected route on the train path
-              time_start:
-                type: number
-                format: float
-                description: the aspect starts being displayed at this time
-              time_end:
-                type: number
-                format: float
-                description: the aspect stops being displayed at this time
-              position_start:
-                type: number
-                format: float
-                description: the route starts at this position on the train path
-              position_end:
-                type: number
-                format: float
-                description: the route ends at this position on the train path
-              color:
-                type: number
-                format: float
-                description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
-              blinking:
-                type: boolean
-                description: true if the signal is blinking
+          $ref: "#/components/schemas/RouteAspectsResult"
         signals:
           type: array
           items:
@@ -827,6 +797,65 @@ components:
                 items: { type: number, format: float }
                 minItems: 2
                 maxItems: 2
+    SignalAspectsResult:
+      type: array
+      description: all signal aspect updates caused by this train
+      items:
+        type: object
+        properties:
+          signal_id:
+            type: string
+            description: id of the updated signal
+          time_start:
+            type: number
+            format: float
+            description: the aspect starts being displayed at this time
+          time_end:
+            type: number
+            format: float
+            description: the aspect stops being displayed at this time
+          color:
+            type: number
+            format: float
+            description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+          blinking:
+            type: boolean
+            description: true if the signal is blinking
+    RouteAspectsResult:
+      description: all route aspect updates on the projected path
+      type: array
+      items:
+        type: object
+        properties:
+          signal_id:
+            type: string
+            description: id of the updated signal
+          route_id:
+            type: string
+            description: id of the affected route on the train path
+          time_start:
+            type: number
+            format: float
+            description: the aspect starts being displayed at this time
+          time_end:
+            type: number
+            format: float
+            description: the aspect stops being displayed at this time
+          position_start:
+            type: number
+            format: float
+            description: the route starts at this position on the train path
+          position_end:
+            type: number
+            format: float
+            description: the route ends at this position on the train path
+          color:
+            type: number
+            format: float
+            description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+          blinking:
+            type: boolean
+            description: true if the signal is blinking
     TrainScheduleResult:
       properties:
         id:


### PR DESCRIPTION
There are two API changes:

* A new endpoint to get a list of conflicts for a given timetable
* More data in the simulation response, needed to display signal updates