### PR TITLE
dependabot: add configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/editoast/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "editoast:"
+  - package-ecosystem: "pip"
+    directory: "/api/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "api:"
+  - package-ecosystem: "pip"
+    directory: "/chartos/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chartos:"
+  - package-ecosystem: "npm"
+    directory: "/front/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "front:"
+  - package-ecosystem: "gradle"
+    directory: "/core/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "core:"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "actions:"


### PR DESCRIPTION
Allow Dependabot to open pull requests automatically.

That used to be the case, but not anymore: https://github.com/DGEXSolutions/osrd/settings/security_analysis