### PR TITLE
core: bump dependencies

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: corretto
       - uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,10 +17,10 @@ import static org.apache.tools.ant.taskdefs.condition.Os.*
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.6.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.7.0'
     id 'application'
     id 'checkstyle'
-    id 'com.github.spotbugs' version '5.0.6'
+    id 'com.github.spotbugs' version '5.0.8'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'jacoco'
 }
@@ -34,30 +34,30 @@ repositories {
 dependencies {
     // kotlin
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.1'  // Apache 2.0
+    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.3'  // Apache 2.0
 
     // base primitives
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'  // Apache 2.0
 
     // command line parsing
-    implementation group: 'com.beust', name: 'jcommander', version: '1.78'  // Apache 2.0
+    implementation group: 'com.beust', name: 'jcommander', version: '1.82'  // Apache 2.0
 
     // fast primitive collections
-    implementation group: 'com.carrotsearch', name: 'hppc', version: '0.9.0'  // Apache 2.0
+    implementation group: 'com.carrotsearch', name: 'hppc', version: '0.9.1'  // Apache 2.0
 
     // JSON parsing
     implementation 'com.squareup.moshi:moshi:1.13.0' // Apache 2.0
     implementation 'com.squareup.moshi:moshi-adapters:1.13.0'  // Apache 2.0
 
     // HTTP server framework
-    implementation group: 'org.takes', name: 'takes', version: '1.19'  // MIT
+    implementation group: 'org.takes', name: 'takes', version: '1.20'  // MIT
     implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'  // GPLv2 with classpath exemption
 
     // HTTP client
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.1' // Apache 2.0
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0' // Apache 2.0
 
     // ClassGraph (FastClasspathScanner)
-    implementation group: 'io.github.classgraph', name: 'classgraph', version: '4.8.102' // MIT
+    implementation group: 'io.github.classgraph', name: 'classgraph', version: '4.8.+' // MIT
 
     // for debug UI
     implementation 'com.github.yannrichet:JMathPlot:1.0.1' // BSD
@@ -65,8 +65,8 @@ dependencies {
     // the logging API stub
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.+'  // MIT
     // the logging API implementation
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.3'  // EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.11'  // EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
 
     // Sentry
     implementation group: 'io.sentry', name: 'sentry', version: '6.1.3'  // MIT
@@ -77,19 +77,19 @@ dependencies {
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'  // EPL 2.0
     // jqwik for property based testing
-    testImplementation 'net.jqwik:jqwik:1.6.3'  // EPL 2.0
+    testImplementation 'net.jqwik:jqwik:1.6.5'  // EPL 2.0
     // mockito for mocking
-    testImplementation 'org.mockito:mockito-inline:4.3.1'  // MIT
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.3.1'  // MIT
+    testImplementation 'org.mockito:mockito-inline:4.6.1'  // MIT
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'  // MIT
 
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.2'  // EPL 2.0
 
     // for linter annotations
     compileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.5.3'  // LGPLv2.1
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.0'  // LGPLv2.1
     testCompileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    testCompileOnly 'com.github.spotbugs:spotbugs-annotations:4.5.3'  // LGPLv2.1
+    testCompileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.0'  // LGPLv2.1
 }
 
 // endregion

--- a/core/config/spotbugs/exclude.xml
+++ b/core/config/spotbugs/exclude.xml
@@ -1,6 +1,6 @@
 <FindBugsFilter>
   <Match>
-    <Bug code="EI2,EI" />
+    <Bug code="EI2,EI,THROWS" />
   </Match>
   <Match>
     <Source name="~.*\.kt"/>

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
@@ -72,6 +72,7 @@ public class EnvelopePath implements PhysicsPath {
     }
 
     @Override
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public double findHighGradePosition(double position, double endPos, double length, double gradeThreshold) {
         // TODO: skip sections which don't have high enough slopes
         while (position <= endPos) {

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.envelope_sim.allowances;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.*;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim.allowances.mareco_impl.AcceleratingSlopeCoast;
@@ -47,6 +48,7 @@ public class MarecoAllowance extends AbstractAllowanceWithRanges {
     /** Compute the initial high bound for the binary search
      *  The high bound ensures that the speed vf will be higher than the max speed of the envelope */
     @Override
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     protected double computeInitialHighBound(Envelope envelopeSection) {
         var sectionMaxSpeed = envelopeSection.getMaxSpeed();
         var maxSpeed = sectionMaxSpeed;

--- a/core/src/main/java/fr/sncf/osrd/utils/takes/TakesUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/takes/TakesUtils.java
@@ -1,0 +1,24 @@
+package fr.sncf.osrd.utils.takes;
+
+import org.takes.Response;
+import org.takes.rs.RsPrint;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TakesUtils {
+    /** Read a `takes` body response and returns it as a String */
+    public static String readBodyResponse(Response res) throws IOException {
+        return new String(new RsPrint(res).body().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    /** Read a `takes` header response and returns it as a list of String */
+    public static List<String> readHeadResponse(Response res) throws IOException {
+        var header = new ArrayList<String>();
+        for (var head : res.head()) {
+            header.add(head);
+        }
+        return header;
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/Helpers.java
+++ b/core/src/test/java/fr/sncf/osrd/Helpers.java
@@ -40,18 +40,18 @@ public class Helpers {
         return parseRollingStockDir(getResourcePath("rolling_stocks/"));
     }
 
-    public static RJSInfra getExampleInfra(String infraPath) throws Exception {
+    public static RJSInfra getExampleInfra(String infraPath) throws IOException, URISyntaxException {
         return deserializeResource(RJSInfra.adapter, infraPath);
     }
 
     private static <T> T deserializeResource(
             JsonAdapter<T> adapter,
             String resourcePath
-    ) throws Exception {
+    ) throws IOException, URISyntaxException {
         ClassLoader loader = Helpers.class.getClassLoader();
         var resourceURL = loader.getResource(resourcePath);
         if (resourceURL == null)
-            throw new Exception("can't find resource " + resourcePath);
+            throw new IOException("can't find resource " + resourcePath);
         return MoshiUtils.deserialize(adapter, Paths.get(resourceURL.toURI()));
     }
 

--- a/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -3,6 +3,8 @@ package fr.sncf.osrd.api;
 import static fr.sncf.osrd.Helpers.getResourcePath;
 import static fr.sncf.osrd.Helpers.infraFromRJS;
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+import static fr.sncf.osrd.utils.takes.TakesUtils.readBodyResponse;
+import static fr.sncf.osrd.utils.takes.TakesUtils.readHeadResponse;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fr.sncf.osrd.Helpers;
@@ -24,7 +26,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.takes.rq.RqFake;
-import org.takes.rs.RsPrint;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
@@ -73,10 +74,10 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json", "1"));
 
-        var result = new RsPrint(
+        var result = readBodyResponse(
                 new PathfindingRoutesEndpoint(infraHandlerMock).act(
                         new RqFake("POST", "/pathfinding/routes", requestBody))
-        ).printBody();
+        );
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
@@ -114,10 +115,8 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json", "1"));
 
-        var result = new RsPrint(
-                new PathfindingRoutesEndpoint(infraHandlerMock).act(
-                        new RqFake("POST", "/pathfinding/routes", requestBody))
-        ).printBody();
+        var result = readBodyResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
+                        new RqFake("POST", "/pathfinding/routes", requestBody)));
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
@@ -145,10 +144,17 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json", "1"));
 
-        var res = new RsPrint(new PathfindingRoutesEndpoint(infraHandlerMock).act(
+        var res =  readHeadResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
                 new RqFake("POST", "/pathfinding/routes", requestBody)
         ));
-        assertTrue(res.printHead().contains("400"));
+        var contains400 = false;
+        for (var header : res) {
+            if (header.contains("400")) {
+                contains400 = true;
+                break;
+            }
+        }
+        assertTrue(contains400);
     }
 
     @Test
@@ -219,10 +225,10 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json"));
 
-        var result = new RsPrint(
+        var result = readBodyResponse(
                 new PathfindingRoutesEndpoint(infraHandlerMock).act(
                         new RqFake("POST", "/pathfinding/routes", requestBody))
-        ).printBody();
+        );
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
@@ -257,10 +263,10 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json"));
 
-        var result = new RsPrint(
+        var result = readBodyResponse(
                 new PathfindingRoutesEndpoint(infraHandlerMock).act(
                         new RqFake("POST", "/pathfinding/routes", requestBody))
-        ).printBody();
+        );
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;
@@ -277,10 +283,10 @@ public class PathfindingTest extends ApiTest {
         );
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(req);
 
-        var result = new RsPrint(
+        var result = readBodyResponse(
                 new PathfindingRoutesEndpoint(infraHandlerMock).act(
                         new RqFake("POST", "/pathfinding/routes", requestBody))
-        ).printBody();
+        );
 
         var response = PathfindingRoutesEndpoint.adapterResult.fromJson(result);
         assert response != null;

--- a/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -144,7 +144,7 @@ public class PathfindingTest extends ApiTest {
         var requestBody = PathfindingEndpoint.adapterRequest.toJson(
                 new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json", "1"));
 
-        var res =  readHeadResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
+        var res = readHeadResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
                 new RqFake("POST", "/pathfinding/routes", requestBody)
         ));
         var contains400 = false;

--- a/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
@@ -1,10 +1,10 @@
 package fr.sncf.osrd.api;
 
 import static fr.sncf.osrd.Helpers.getExampleRollingStocks;
+import static fr.sncf.osrd.utils.takes.TakesUtils.readBodyResponse;
 import static org.junit.jupiter.api.Assertions.*;
 
 import fr.sncf.osrd.api.StandaloneSimulationEndpoint.StandaloneSimulationRequest;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
@@ -14,7 +14,6 @@ import fr.sncf.osrd.standalone_sim.result.ResultSpeed;
 import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
 import org.junit.jupiter.api.Test;
 import org.takes.rq.RqFake;
-import org.takes.rs.RsPrint;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -51,9 +50,9 @@ class StandaloneSimulationTest extends ApiTest {
         var requestBody = StandaloneSimulationEndpoint.adapterRequest.toJson(request);
 
         // process it
-        var rawResponse = new RsPrint(new StandaloneSimulationEndpoint(infraHandlerMock)
+        var rawResponse = readBodyResponse(new StandaloneSimulationEndpoint(infraHandlerMock)
                 .act(new RqFake("POST", "/standalone_simulation", requestBody))
-        ).printBody();
+        );
 
         // parse the response
         var response = StandaloneSimResult.adapter.fromJson(rawResponse);

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -7,6 +7,7 @@ import static fr.sncf.osrd.envelope_sim.MaxSpeedEnvelopeTest.TIME_STEP;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.carrotsearch.hppc.DoubleArrayList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeShape;
 import fr.sncf.osrd.envelope.EnvelopeTransitions;
@@ -67,6 +68,7 @@ public class AllowanceTests {
     }
 
     /** Test the continuity of the binary search */
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     private void testBinarySearchContinuity(Envelope maxEffortEnvelope,
                                             AbstractAllowanceWithRanges allowance,
                                             double lowSpeed,
@@ -514,6 +516,7 @@ public class AllowanceTests {
 
     /** Test standard mareco allowance with different accelerating slopes*/
     @Test
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public void testMarecoAcceleratingSlopes() {
         double length = 100_000;
         var gradeValues = new DoubleArrayList();

--- a/core/src/test/java/fr/sncf/osrd/infra_state/StandaloneStateTests.java
+++ b/core/src/test/java/fr/sncf/osrd/infra_state/StandaloneStateTests.java
@@ -5,6 +5,7 @@ import static fr.sncf.osrd.infra.InfraHelpers.getSignalingRoute;
 import static fr.sncf.osrd.infra.InfraHelpers.makeSingleTrackRJSInfra;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.api.reservation.DetectionSection;
 import fr.sncf.osrd.infra.api.reservation.ReservationRoute;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackLocation;
@@ -94,6 +95,7 @@ public class StandaloneStateTests {
     }
 
     @Test
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public void stateWithStepsTest() {
         var rjsInfra = makeSingleTrackRJSInfra();
         var infra = infraFromRJS(rjsInfra);
@@ -129,6 +131,7 @@ public class StandaloneStateTests {
     }
 
     @Test
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public void conflictingRoutesTests() {
         var rjsInfra = makeSingleTrackRJSInfra();
         var infra = infraFromRJS(rjsInfra);

--- a/core/src/test/java/fr/sncf/osrd/utils/CurveSimplificationTest.java
+++ b/core/src/test/java/fr/sncf/osrd/utils/CurveSimplificationTest.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +56,7 @@ class CurveSimplificationTest {
     }
 
     @Test
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public void complexSimplification() {
         var points = new ArrayList<Point>();
         for (double x = 0; x < 1000; x += 0.5)
@@ -65,6 +67,7 @@ class CurveSimplificationTest {
     }
 
     @Test
+    @SuppressFBWarnings("FL_FLOATS_AS_LOOP_COUNTERS")
     public void complexNoSimplification() {
         var points = new ArrayList<Point>();
         for (double x = 0; x < 1000; x += 0.5)


### PR DESCRIPTION
core: bump dependencies

- **kotlinx-coroutines-core** from 1.6.1 to 1.6.3 (close #1239)
- **com.github.spotbugs** from 5.0.6 to 5.0.8 (close #1238)
- **okhttp** from 4.9.1 to 4.10.0 (close #1237)
- **jcommander** from 1.78 to 1.82 (close #1236)
- **classgraph** from 4.8.102 to 4.8.147 (close #1235)
- **takes** from 1.19 to 1.20 (close #1234)
- **hppc** from 0.9.0 to 0.9.1 (close #1233)
- **spotbugs-annotations** from 4.5.3 to 4.7.0 (close #1232)
- **jqwik** from 1.6.3 to 1.6.5 (close #1231)
- **mockito-inline** from 4.3.1 to 4.6.1 (close #1223)
- **logback-core** from 1.2.3 to 1.2.11 (close #1212)
- **mockito-junit-jupiter** from 4.3.1 to 4.6.1 (close #1211)
- **logback-classic** from 1.2.3 to 1.2.11 (close #1209)
- **org.jetbrains.kotlin.jvm** from 1.6.10 to 1.7.0 (close #1208)