### PR TITLE
core: fix timing of signaling events after a stop

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 
 
 @SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
-public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelope {
+public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelope, EnvelopeTimeInterpolate {
     private final EnvelopePart[] parts;
     public final boolean continuous;
 

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeStopWrapper.java
@@ -1,0 +1,63 @@
+package fr.sncf.osrd.envelope;
+
+import fr.sncf.osrd.train.TrainStop;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnvelopeStopWrapper implements EnvelopeTimeInterpolate {
+    public final Envelope envelope;
+    public final List<TrainStop> stops;
+
+    public EnvelopeStopWrapper(Envelope envelope, List<TrainStop> stops) {
+        this.envelope = envelope;
+        this.stops = stops;
+    }
+
+    @Override
+    public double interpolateTotalTime(double position) {
+        double stopTime = 0;
+        for (var stop : stops) {
+            if (stop.position > position)
+                break;
+            stopTime += stop.duration;
+        }
+        return stopTime + envelope.interpolateTotalTime(position);
+    }
+
+    @Override
+    public double getEndPos() {
+        return envelope.getEndPos();
+    }
+
+    public record CurvePoint(double time, double speed, double position){}
+
+    /** Returns all the points as (time, speed, position), with time adjusted for stop duration */
+    public List<CurvePoint> iterateCurve() {
+        var res = new ArrayList<CurvePoint>();
+        double time = 0;
+        for (var part : envelope) {
+            // Add head position points
+            for (int i = 0; i < part.pointCount(); i++) {
+                var pos = part.getPointPos(i);
+                var speed = part.getPointSpeed(i);
+                res.add(new CurvePoint(time, speed, pos));
+                if (i < part.stepCount())
+                    time += part.getStepTime(i);
+            }
+
+            if (part.getEndSpeed() > 0)
+                continue;
+
+            // Add stop duration
+            for (var stop : stops) {
+                if (stop.duration == 0. || stop.position < part.getEndPos())
+                    continue;
+                if (stop.position > part.getEndPos())
+                    break;
+                time += stop.duration;
+                res.add(new CurvePoint(time, 0, part.getEndPos()));
+            }
+        }
+        return res;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
@@ -1,0 +1,10 @@
+package fr.sncf.osrd.envelope;
+
+public interface EnvelopeTimeInterpolate {
+
+    /** Computes the time required to get to a given point of the envelope */
+    double interpolateTotalTime(double position);
+
+    /** Returns the end position of the envelope */
+    double getEndPos();
+}

--- a/core/src/main/java/fr/sncf/osrd/infra_state/implementation/standalone/StandaloneSignalingSimulation.java
+++ b/core/src/main/java/fr/sncf/osrd/infra_state/implementation/standalone/StandaloneSignalingSimulation.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.infra_state.implementation.standalone;
 
 import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
 import fr.sncf.osrd.infra.api.signaling.Signal;
 import fr.sncf.osrd.infra.api.signaling.SignalState;
 import fr.sncf.osrd.infra_state.api.TrainPath;
@@ -43,7 +44,7 @@ public class StandaloneSignalingSimulation {
             TrainPath path,
             StandaloneState state,
             SignalizationState signalizationState,
-            Envelope trainEnvelope
+            EnvelopeTimeInterpolate trainEnvelope
     ) {
         return runWithoutEnvelope(path, state, signalizationState).stream()
                 .map(event -> addTimeToEvent(trainEnvelope, event))
@@ -51,7 +52,7 @@ public class StandaloneSignalingSimulation {
     }
 
     private static <T extends SignalState> SignalTimedEvent<T> addTimeToEvent(
-            Envelope trainEnvelope,
+            EnvelopeTimeInterpolate trainEnvelope,
             SignalEvent<T> event
     ) {
         return new SignalTimedEvent<>(


### PR DESCRIPTION
This is done by wrapping the envelope in a new object that has stop data. This avoids having to patch every timing info we get from the envelope separately