### PR TITLE
core: fix pathfinding

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/reporting/ErrorContext.java
+++ b/core/src/main/java/fr/sncf/osrd/reporting/ErrorContext.java
@@ -2,8 +2,10 @@ package fr.sncf.osrd.reporting;
 
 import com.squareup.moshi.Json;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
+import java.io.Serial;
+import java.io.Serializable;
 
-public class ErrorContext {
+public class ErrorContext implements Serializable {
 
     public static final PolymorphicJsonAdapterFactory<ErrorContext> adapter = (
             PolymorphicJsonAdapterFactory.of(ErrorContext.class, "type")
@@ -11,8 +13,12 @@ public class ErrorContext {
                     .withSubtype(Allowance.class, "allowance")
                     .withSubtype(Signal.class, "signal")
     );
+    @Serial
+    private static final long serialVersionUID = 2059829018182790086L;
 
     public static class Train extends ErrorContext {
+        @Serial
+        private static final long serialVersionUID = 806035086782570303L;
         public final String id;
 
         public Train(String id) {
@@ -21,6 +27,8 @@ public class ErrorContext {
     }
 
     public static class Allowance extends ErrorContext {
+        @Serial
+        private static final long serialVersionUID = 6574267112831336260L;
         public final int index;
 
         public Allowance(int index) {
@@ -29,6 +37,8 @@ public class ErrorContext {
     }
 
     public static class Signal extends ErrorContext {
+        @Serial
+        private static final long serialVersionUID = 1307122869428730982L;
         @Json(name = "signal_id")
         public final String signalID;
 

--- a/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -147,14 +147,25 @@ public class PathfindingTest extends ApiTest {
         var res = readHeadResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
                 new RqFake("POST", "/pathfinding/routes", requestBody)
         ));
-        var contains400 = false;
-        for (var header : res) {
-            if (header.contains("400")) {
-                contains400 = true;
-                break;
-            }
-        }
-        assertTrue(contains400);
+        assert contains400(res);
+    }
+
+    @Test
+    public void missingTrackTest() throws IOException {
+        var waypoint = new PathfindingWaypoint(
+                "this_track_does_not_exist",
+                0,
+                EdgeDirection.STOP_TO_START
+        );
+        var waypoints = new PathfindingWaypoint[2][1];
+        waypoints[0][0] = waypoint;
+        waypoints[1][0] = waypoint;
+        var requestBody = PathfindingEndpoint.adapterRequest.toJson(
+                new PathfindingEndpoint.PathfindingRequest(waypoints, "tiny_infra/infra.json", "1"));
+        var res = readHeadResponse(new PathfindingRoutesEndpoint(infraHandlerMock).act(
+                new RqFake("POST", "/pathfinding/routes", requestBody)
+        ));
+        assert contains400(res);
     }
 
     @Test
@@ -391,5 +402,17 @@ public class PathfindingTest extends ApiTest {
     @MethodSource("provideInfraParameters")
     public void testMachingRouteOffsets(String path, boolean inverted) throws Exception {
         testAllMatchingRouteOffsets(path, inverted);
+    }
+
+    /** Returns true if the response is a 400 */
+    private static boolean contains400(List<String> res) {
+        var contains400 = false;
+        for (var header : res) {
+            if (header.contains("400")) {
+                contains400 = true;
+                break;
+            }
+        }
+        return contains400;
     }
 }


### PR DESCRIPTION
We had errors when the path starts or ends on the exact edge of a track because 0 length track ranges were not included in the path. This means we couldn't find the waypoint track in the path. We now include those track ranges. 