### PR TITLE
changeDefaultSettings

### DIFF
--- a/front/src/applications/osrd/views/OSRDSimulation/OSRDSimulation.js
+++ b/front/src/applications/osrd/views/OSRDSimulation/OSRDSimulation.js
@@ -118,9 +118,9 @@ const OSRDSimulation = () => {
           if (!newAllowancesSettings[train.id]) {
             newAllowancesSettings[train.id] = {
               base: true,
-              baseBlocks: false,
+              baseBlocks: true,
               eco: true,
-              ecoBlocks: true,
+              ecoBlocks: false,
             };
           }
         });


### PR DESCRIPTION
We need to have a proper allowance Setting init for new trains now. default is based, not eco. Position one map retrieval use this key and using eco for train which have no eco position lead to crash