### PR TITLE
doc: add contributing code of conduct

### DIFF
--- a/contributing/code_of_conduct.md
+++ b/contributing/code_of_conduct.md
@@ -1,0 +1,89 @@
+_This code-of-conduct is common to the following projects:_
+* _[Pagerfanta](https://github.com/whiteoctober/Pagerfanta)_
+* _[Pagerfanta Bundle](https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle)_
+* _[SwiftMailerDBBundle](https://github.com/whiteoctober/WhiteOctoberSwiftMailerDBBundle)_
+* _[BreadcrumbsBundle](https://github.com/whiteoctober/breadcrumbsbundle)_
+* _[TCPDFBundle](https://github.com/whiteoctober/WhiteOctoberTCPDFBundle)_
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at contact@osrd.fr. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project contributors who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by 
+members of the project's leadership.
+
+Actions we may take in such instances include (but are not limited to) the following:
+
+* [Locking conversations](https://help.github.com/articles/locking-conversations/)
+* [Blocking users](https://github.com/blog/2146-organizations-can-now-block-abusive-users)
+* [Reporting users to Github](https://help.github.com/articles/reporting-abuse-or-spam/)
+
+As an individual user on Github, you also have the option to [block a user from your personal account](https://help.github.com/articles/blocking-a-user-from-your-personal-account/) or to [report a user to Github](https://help.github.com/articles/reporting-abuse-or-spam/) yourself, but the existence of these functions will not be used as a reason for inaction on our part.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
So that we can use free open source tools for doc editing like Gitbook for example.