### PR TITLE
fix integration tests on windows

### DIFF
--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -69,6 +69,7 @@ services:
     environment:
       OSRD_DEV: "True"
       OSRD_BACKEND_URL: "http://osrd-core"
+      POSTGRES_HOST: "osrd-postgres"
     command:
       - /bin/sh
       - -c

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -31,7 +31,7 @@ def setup() -> Dict[str, int]:
 
 
 def _load_tiny_infra() -> int:
-    generator = Path(__file__).parents[1] / "core/examples/generated/generate.py"
+    generator = Path(__file__).resolve().parents[1] / "core/examples/generated/generate.py"
     output = Path("/tmp/osrd-generated-examples")
     tiny_infra = output / "tiny_infra/infra.json"
     subprocess.check_call(["python3", str(generator), str(output), "tiny_infra"])


### PR DESCRIPTION
* Set postgres host in the docker-compose file without host networking
* Fix the use of `Path` to find the infra generator script