### PR TITLE
core: bump dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,7 +34,7 @@ repositories {
 dependencies {
     // kotlin
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.3'  // Apache 2.0
+    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.+'  // Apache 2.0
 
     // base primitives
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'  // Apache 2.0
@@ -50,7 +50,7 @@ dependencies {
     implementation 'com.squareup.moshi:moshi-adapters:1.13.0'  // Apache 2.0
 
     // HTTP server framework
-    implementation group: 'org.takes', name: 'takes', version: '1.21'  // MIT
+    implementation group: 'org.takes', name: 'takes', version: '1.21.+'  // MIT
     implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'  // GPLv2 with classpath exemption
 
     // HTTP client
@@ -69,7 +69,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
 
     // Sentry
-    implementation group: 'io.sentry', name: 'sentry', version: '6.1.+'  // MIT
+    implementation group: 'io.sentry', name: 'sentry', version: '6.2.+'  // MIT
 
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'  // EPL 2.0


### PR DESCRIPTION
- **takes** from 1.21 to 1.21.+ (close #1485)
- **kotlinx-coroutines-core** from 1.6.3 to 1.6.+ (close #1448)
- **sentry** from 6.1.+ to 6.2.+ (close #1436)