### PR TITLE
core: bump dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -72,10 +72,10 @@ dependencies {
     implementation group: 'io.sentry', name: 'sentry', version: '6.3.+'  // MIT
 
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'  // EPL 2.0
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'  // EPL 2.0
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'  // EPL 2.0
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'  // EPL 2.0
     // Use JUnit Jupiter Engine for testing.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'  // EPL 2.0
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'  // EPL 2.0
     // jqwik for property based testing
     testImplementation 'net.jqwik:jqwik:1.6.5'  // EPL 2.0
     // mockito for mocking
@@ -83,7 +83,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'  // MIT
 
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.8.2'  // EPL 2.0
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.0'  // EPL 2.0
 
     // for linter annotations
     compileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution


### PR DESCRIPTION
- **junit-jupiter-engine** from 5.8.2 to 5.9.0 (close #1544)
- **junit-platform-launcher** from 1.8.2 to 1.9.0 (close #1543)
- **junit-jupiter-params** from 5.8.2 to 5.9.0 (close #1542)
- **junit-jupiter-api** from 5.8.2 to 5.9.0 (close #1541)