### PR TITLE
Fix pathfinding serialization

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api;
 
+import com.squareup.moshi.Json;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import io.sentry.Sentry;
 import org.takes.Response;
@@ -43,10 +44,15 @@ public class ExceptionHandler {
         public static final String osrdErrorType = "assert_error";
         private static final long serialVersionUID = 1662852082101020410L;
 
+        @Json(name = "assert_message")
+        public final String assertMessage;
+
+        @Json(name = "stack_trace")
         public final List<String> stackTrace;
 
         protected AssertWrapper(AssertionError ex) {
             super(ex.getMessage(), ErrorCause.INTERNAL);
+            this.assertMessage = ex.getMessage();
             stackTrace = convertStackTrace(ex.getStackTrace());
         }
 

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
@@ -43,15 +43,15 @@ public class PathfindingRoutesEndpoint implements Take {
             if (request == null)
                 return new RsWithStatus(new RsText("missing request body"), 400);
 
-            var reqWaypoints = request.waypoints();
+            var reqWaypoints = request.waypoints;
 
             // load infra
-            var infra = infraManager.load(request.infra(), request.expectedVersion(), warningRecorder);
+            var infra = infraManager.load(request.infra, request.expectedVersion, warningRecorder);
 
             // load rolling stocks
             var rollingStocks = List.<RollingStock>of();
-            if (request.rollingStocks() != null)
-                rollingStocks = request.rollingStocks().stream()
+            if (request.rollingStocks != null)
+                rollingStocks = request.rollingStocks.stream()
                         .map(RJSRollingStockParser::parse)
                         .toList();
 
@@ -126,7 +126,7 @@ public class PathfindingRoutesEndpoint implements Take {
                 .collect(Collectors.toSet());
         for (var step : reqWaypoints) {
             assert Arrays.stream(step)
-                    .anyMatch(waypoint -> tracksOnPath.contains(waypoint.trackSection()));
+                    .anyMatch(waypoint -> tracksOnPath.contains(waypoint.trackSection));
         }
     }
 
@@ -136,17 +136,17 @@ public class PathfindingRoutesEndpoint implements Take {
             PathfindingWaypoint waypoint
     ) {
         var res = new HashSet<Pathfinding.EdgeLocation<SignalingRoute>>();
-        var edge = infra.getEdge(waypoint.trackSection(), Direction.fromEdgeDir(waypoint.direction()));
+        var edge = infra.getEdge(waypoint.trackSection, Direction.fromEdgeDir(waypoint.direction));
         if (edge == null)
             throw new InvalidSchedule(
-                    String.format("Track %s referenced in path step does not exist", waypoint.trackSection())
+                    String.format("Track %s referenced in path step does not exist", waypoint.trackSection)
             );
         for (var entry : infra.getRoutesOnEdges().get(edge)) {
             var signalingRoutes = infra.getRouteMap().get(entry.route());
             for (var signalingRoute : signalingRoutes) {
-                var waypointOffsetFromStart = waypoint.offset();
-                if (waypoint.direction().equals(EdgeDirection.STOP_TO_START))
-                    waypointOffsetFromStart = edge.getEdge().getLength() - waypoint.offset();
+                var waypointOffsetFromStart = waypoint.offset;
+                if (waypoint.direction.equals(EdgeDirection.STOP_TO_START))
+                    waypointOffsetFromStart = edge.getEdge().getLength() - waypoint.offset;
                 var offset = waypointOffsetFromStart - entry.startOffset();
                 if (offset >= 0 && offset <= signalingRoute.getInfraRoute().getLength())
                     res.add(new Pathfinding.EdgeLocation<>(signalingRoute, offset));

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/request/PathfindingRequest.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/request/PathfindingRequest.java
@@ -7,24 +7,38 @@ import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock;
 import java.util.List;
 
-/**
- * @param infra The infrastructure identifier
- * @param expectedVersion The expected infrastructure version
- * @param waypoints A list of locations the path must to through. A location is a group of points.
- *     The path only has to go through a single point per location.
- * @param rollingStocks List of rolling stocks that must be able to use this path
- */
-public record PathfindingRequest(
-        PathfindingWaypoint[][] waypoints,
-        String infra,
-        @Json(name = "expected_version")
-        String expectedVersion,
-        @Json(name = "rolling_stocks")
-        List<RJSRollingStock> rollingStocks
-) {
+public class PathfindingRequest {
     public static final JsonAdapter<PathfindingRequest> adapter = new Moshi
             .Builder()
             .add(RJSRollingResistance.adapter)
             .build()
             .adapter(PathfindingRequest.class);
+
+    /** Create a new pathfinding request */
+    public PathfindingRequest(PathfindingWaypoint[][] waypoints, String infra,
+                              String expectedVersion, List<RJSRollingStock> rollingStocks) {
+        this.waypoints = waypoints;
+        this.infra = infra;
+        this.expectedVersion = expectedVersion;
+        this.rollingStocks = rollingStocks;
+    }
+
+    public PathfindingRequest() {
+    }
+
+    /** A list of locations the path must to through. A location is a group of points.
+     *  The path only has to go through a single point per location.
+     */
+    public PathfindingWaypoint[][] waypoints;
+
+    /** The infrastructure identifier */
+    public String infra;
+
+    /** expectedVersion The expected infrastructure version */
+    @Json(name = "expected_version")
+    public String expectedVersion;
+
+    /** List of rolling stocks that must be able to use this path */
+    @Json(name = "rolling_stocks")
+    public List<RJSRollingStock> rollingStocks;
 }

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/request/PathfindingWaypoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/request/PathfindingWaypoint.java
@@ -3,11 +3,23 @@ package fr.sncf.osrd.api.pathfinding.request;
 import com.squareup.moshi.Json;
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
 
-/** Creates a pathfinding waypoint */
-public record PathfindingWaypoint(
-        @Json(name = "track_section")
-        String trackSection,
-        double offset,
-        EdgeDirection direction
-) {
+public final class PathfindingWaypoint {
+    @Json(name = "track_section")
+    public String trackSection;
+    public double offset = Double.NaN;
+    public EdgeDirection direction;
+
+    /** Creates a pathfinding waypoint */
+    public PathfindingWaypoint(
+            String trackSection,
+            double offset,
+            EdgeDirection direction
+    ) {
+        this.trackSection = trackSection;
+        this.offset = offset;
+        this.direction = direction;
+    }
+
+    public PathfindingWaypoint() {
+    }
 }

--- a/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/PathfindingTest.java
@@ -38,9 +38,9 @@ import java.util.stream.Stream;
 public class PathfindingTest extends ApiTest {
     private static PathfindingWaypoint[] makeBidirectionalEndPoint(PathfindingWaypoint point) {
         var waypointInverted = new PathfindingWaypoint(
-                point.trackSection(),
-                point.offset(),
-                point.direction().opposite()
+                point.trackSection,
+                point.offset,
+                point.direction.opposite()
         );
         return new PathfindingWaypoint[]{point, waypointInverted};
     }
@@ -51,11 +51,11 @@ public class PathfindingTest extends ApiTest {
     ) {
         for (var route : result.routePaths) {
             for (var track : route.trackSections) {
-                if (!track.trackSection.id.id.equals(waypoint.trackSection()))
+                if (!track.trackSection.id.id.equals(waypoint.trackSection))
                     continue;
                 final var begin = Math.min(track.getBegin(), track.getEnd());
                 final var end = Math.max(track.getBegin(), track.getEnd());
-                if (begin <= waypoint.offset() && end >= waypoint.offset())
+                if (begin <= waypoint.offset && end >= waypoint.offset)
                     return;
             }
         }
@@ -383,8 +383,8 @@ public class PathfindingTest extends ApiTest {
                     .filter(wp -> !wp.suggestion)
                     .toList();
             assertEquals(1, userDefinedWaypoints.size());
-            var waypointOff = waypoint.offset();
-            var waypointTrack = waypoint.trackSection();
+            var waypointOff = waypoint.offset;
+            var waypointTrack = waypoint.trackSection;
             if (waypointOff <= 0 || waypointOff >= infra.getTrackSection(waypointTrack).getLength()) {
                 // Waypoints placed on track transitions can be on either side
                 continue;
@@ -403,7 +403,7 @@ public class PathfindingTest extends ApiTest {
         );
         var rjsInfra = Helpers.getExampleInfra(infraPath + "/infra.json");
         var infra = infraFromRJS(rjsInfra);
-        for (var waypointList : req.waypoints())
+        for (var waypointList : req.waypoints)
             for (var waypoint : waypointList)
                 testMatchingRouteOffsets(infra, waypoint);
     }


### PR DESCRIPTION
Avoid using records with moshi, as it somehow does not work depending on the build environment (It works inside intellij, not with standalone gradle).
Just use regular classes until we can safely make the switch.