### PR TITLE
editoast: handle secret key

### DIFF
--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -132,6 +132,7 @@ services:
     restart: unless-stopped
     ports: ["8090:8090"]
     environment:
+      ROCKET_ENV: dev
       PSQL_HOST: "postgres"
       CHARTOS_URL: http://chartos/
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,8 @@ services:
       context: editoast
       dockerfile: Dockerfile
     restart: unless-stopped
+    environment:
+      ROCKET_ENV: dev
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
       start_period: 4s

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -36,3 +36,9 @@ pub struct GenerateArgs {
     #[clap(short, long, help = "Force refresh")]
     pub force: bool,
 }
+
+/// Retrieve the secret key from the environment variable `SECRET_KEY`.
+/// Return `None` if the environment variable is not set.
+pub fn get_secret_key() -> Option<String> {
+    std::env::var("SECRET_KEY").ok()
+}

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -70,6 +70,17 @@ pub fn create_server(
     // Set limits to 250MiB
     config.set_limits(Limits::default().limit("json", 250 * 1024 * 1024));
 
+    // Set secret key
+    if let Some(secret_key) = client::get_secret_key() {
+        config.set_secret_key(secret_key).unwrap();
+    } else if !config.environment.is_dev() {
+        eprintln!(
+            "{}",
+            "Error: No secret key set. This is a security risk!".red()
+        );
+        exit(1);
+    }
+
     // Setup CORS
     let cors = CorsOptions::default().to_cors().unwrap();
 

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -9,8 +9,8 @@ from typing import Tuple, Dict, List
 import requests
 
 
-URL = "http://127.0.0.1:8000/"
-EDITOAST_URL = "http://127.0.0.1:8090/"
+URL = "http://localhost:8000/"
+EDITOAST_URL = "http://localhost:8090/"
 
 
 def setup() -> Dict[str, int]:


### PR DESCRIPTION
I found out that we don't have a secret key in production.
This PR forces to have a secret key when running in production