### PR TITLE
core: fix rjs speed sections parsing

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/infra/api/tracks/undirected/SpeedLimits.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/api/tracks/undirected/SpeedLimits.java
@@ -21,7 +21,7 @@ public class SpeedLimits {
     /** Directly creates a SpeedLimits instance from the railjson dict */
     public static SpeedLimits from(RJSSpeedSection rjsSpeedSection) {
         return new SpeedLimits(
-                rjsSpeedSection.speedLimit,
+                rjsSpeedSection.getSpeedLimit(),
                 ImmutableMap.copyOf(rjsSpeedSection.speedLimitByTag)
         );
     }

--- a/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSSpeedSection.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSSpeedSection.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public class RJSSpeedSection implements Identified {
     public String id;
     @Json(name = "speed_limit")
-    public double speedLimit = Double.POSITIVE_INFINITY;
+    private Double speedLimit = null;
     @Json(name = "speed_limit_by_tag")
     public Map<String, Double> speedLimitByTag;
 
@@ -32,6 +32,13 @@ public class RJSSpeedSection implements Identified {
 
     /** Create an uninitialized speed section (used by the deserializer). */
     public RJSSpeedSection() {
+    }
+
+    /** Retrieve default speed limit*/
+    public double getSpeedLimit() {
+        if (speedLimit == null)
+            return Double.POSITIVE_INFINITY;
+        return speedLimit;
     }
 
     @Override


### PR DESCRIPTION
Moshi failed to parse speed sections when `speed_limit` field was `null`.
I had to adapt the railjson field and add a wrapper to retrieve the speed limit.