### PR TITLE
editor: fixes saving point items

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -68,8 +68,9 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
       state: toolState,
       setState: setToolState,
       switchTool<S extends CommonToolState>(tool: Tool<S>, state?: Partial<S>) {
+        const fullState = { ...tool.getInitialState(), ...(state || {}) };
         activateTool(tool);
-        setToolState({ ...tool.getInitialState(), ...(state || {}) });
+        setToolState(fullState);
       },
     }),
     [activeTool, modal, t, toolState]
@@ -138,8 +139,18 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
     }
   }, [dispatch, infra, infraID, t]);
 
+  // Lifecycle events on tools:
+  useEffect(() => {
+    if (activeTool.onMount) activeTool.onMount(extendedContext);
+
+    return () => {
+      if (activeTool.onUnmount) activeTool.onUnmount(extendedContext);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTool]);
+
   return (
-    <EditorContext.Provider value={context as EditorContextType<unknown>}>
+    <EditorContext.Provider value={extendedContext as EditorContextType<unknown>}>
       <main
         className={`editor-root mastcontainer mastcontainer-map${fullscreen ? ' fullscreen' : ''}`}
       >

--- a/front/src/applications/editor/data/api.ts
+++ b/front/src/applications/editor/data/api.ts
@@ -110,10 +110,7 @@ export async function editorSave(
         operation_type: 'UPDATE',
         obj_id: features.source.id,
         obj_type: features.source.objType,
-        railjson_patch: compare(
-          { ...(features.source.properties || {}), geo: features.source.geometry },
-          { ...(features.target.properties || {}), geo: features.target.geometry }
-        ),
+        railjson_patch: compare(features.source.properties || {}, features.target.properties || {}),
       })
     ),
     ...(operations.delete || []).map(

--- a/front/src/applications/editor/tools/pointEdition/components.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components.tsx
@@ -1,4 +1,3 @@
-import { omit } from 'lodash';
 import React, { FC, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Layer, Source } from 'react-map-gl';
@@ -48,7 +47,18 @@ export const PointEditionLeftPanel: FC = <Entity extends EditorEntity>() => {
       data={state.entity as Entity}
       onSubmit={async (savedEntity) => {
         const res = await dispatch(
-          save({ [state.entity.id ? 'update' : 'create']: [savedEntity] })
+          save(
+            state.entity.id
+              ? {
+                  update: [
+                    {
+                      source: editorState.editorDataIndex[state.entity.id as string],
+                      target: savedEntity,
+                    },
+                  ],
+                }
+              : { create: [savedEntity] }
+          )
         );
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const operation = res[0] as any as CreateEntityOperation;

--- a/front/src/applications/editor/tools/pointEdition/types.ts
+++ b/front/src/applications/editor/tools/pointEdition/types.ts
@@ -7,5 +7,10 @@ export type PointEditionState<E extends EditorEntity> = CommonToolState & {
   initialEntity: MakeOptional<E, 'geometry'>;
   entity: MakeOptional<E, 'geometry'>;
   isHoveringTarget?: boolean;
-  nearestPoint: { feature: Feature<Point>; trackSectionID: string; angle: number } | null;
+  nearestPoint: {
+    feature: Feature<Point>;
+    position: number;
+    trackSectionID: string;
+    angle: number;
+  } | null;
 };

--- a/front/src/applications/editor/tools/selection/components.tsx
+++ b/front/src/applications/editor/tools/selection/components.tsx
@@ -14,7 +14,7 @@ import colors from '../../../../common/Map/Consts/colors';
 import EditorZone from '../../../../common/Map/Layers/EditorZone';
 import EditorForm from '../../components/EditorForm';
 import { save } from '../../../../reducers/editor';
-import { EditorContextType } from '../types';
+import { EditorContextType, ExtendedEditorContextType } from '../types';
 
 export const SelectionMessages: FC = () => {
   const { t, state } = useContext(EditorContext) as EditorContextType<SelectionState>;
@@ -87,7 +87,9 @@ export const SelectionLayers: FC = () => {
 export const SelectionLeftPanel: FC = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const { state, setState } = useContext(EditorContext) as EditorContextType<SelectionState>;
+  const { state, setState, editorState } = useContext(
+    EditorContext
+  ) as ExtendedEditorContextType<SelectionState>;
   const { selection, selectionState } = state;
 
   if (selectionState.type === 'edition') {
@@ -99,7 +101,16 @@ export const SelectionLeftPanel: FC = () => {
         <EditorForm
           data={selection[0]}
           onSubmit={async (savedEntity) => {
-            await dispatch(save({ update: [savedEntity] }));
+            await dispatch(
+              save({
+                update: [
+                  {
+                    source: editorState.editorDataIndex[savedEntity.id as string],
+                    target: savedEntity,
+                  },
+                ],
+              })
+            );
             setState({ ...state, selection: [savedEntity], selectionState: { type: 'single' } });
           }}
         >

--- a/front/src/applications/editor/tools/trackEdition/utils.ts
+++ b/front/src/applications/editor/tools/trackEdition/utils.ts
@@ -1,4 +1,4 @@
-import { TrackSectionEntity } from '../../../../types';
+import { EditorEntity, TrackSectionEntity } from '../../../../types';
 
 // eslint-disable-next-line import/prefer-default-export
 export function getNewLine(points: [number, number][]): TrackSectionEntity {
@@ -10,5 +10,15 @@ export function getNewLine(points: [number, number][]): TrackSectionEntity {
       coordinates: points,
     },
     properties: {},
+  };
+}
+
+export function injectGeometry(track: EditorEntity): EditorEntity {
+  return {
+    ...track,
+    properties: {
+      ...(track.properties || {}),
+      geo: track.geometry,
+    },
   };
 }

--- a/front/src/applications/editor/tools/types.tsx
+++ b/front/src/applications/editor/tools/types.tsx
@@ -97,6 +97,8 @@ export interface Tool<S> {
   getRadius?: (context: ReadOnlyEditorContextType<S>) => number;
 
   // Interactions with Mapbox:
+  onMount?: (context: ExtendedEditorContextType<S>) => void;
+  onUnmount?: (context: ExtendedEditorContextType<S>) => void;
   onClickMap?: (e: MapEvent, context: ExtendedEditorContextType<S>) => void;
   onClickFeature?: (feature: Item, e: MapEvent, context: ExtendedEditorContextType<S>) => void;
   onHover?: (e: MapEvent, context: ExtendedEditorContextType<S>) => void;

--- a/front/src/reducers/editor.ts
+++ b/front/src/reducers/editor.ts
@@ -100,7 +100,7 @@ export type ActionSave = {
 };
 export function save(operations: {
   create?: Array<EditorEntity>;
-  update?: Array<EditorEntity>;
+  update?: Array<{ source: EditorEntity; target: EditorEntity }>;
   delete?: Array<EditorEntity>;
 }): ThunkAction<ActionSave> {
   return async (dispatch, getState) => {
@@ -108,13 +108,7 @@ export function save(operations: {
     dispatch(setLoading());
     try {
       // saving the data
-      const savedFeatures = await editorSave(state.osrdconf.infraID, {
-        ...operations,
-        update: (operations.update || []).map((target) => {
-          const source = state.editor.editorData.find((e) => e.id === target.id);
-          return { source, target };
-        }),
-      });
+      const savedFeatures = await editorSave(state.osrdconf.infraID, operations);
       // reload the zone
       dispatch(selectZone(state.editor.editorZone));
       // success message

--- a/front/src/reducers/editor.ts
+++ b/front/src/reducers/editor.ts
@@ -6,7 +6,6 @@ import { Feature } from 'geojson';
 import { ThunkAction, Zone, EditorSchema, EditorEntity } from '../types';
 import { setLoading, setSuccess, setFailure } from './main';
 import { getEditorSchema, getEditorData, editorSave } from '../applications/editor/data/api';
-import { clip } from '../utils/mapboxHelper';
 
 //
 // Actions
@@ -188,12 +187,23 @@ export default function reducer(inputState: EditorState, action: Actions) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export const dataSelector = (state: EditorState) => state.editorData;
 export const zoneSelector = (state: EditorState) => state.editorZone;
-export const clippedDataSelector = createSelector(dataSelector, zoneSelector, (data, zone) => {
-  let result: Array<EditorEntity> = [];
-  if (zone && data)
-    result = data.map((f) => {
-      const clippedFeature = clip(f, zone);
-      return clippedFeature ? { ...f, geometry: clippedFeature.geometry } : f;
-    });
-  return result;
-});
+export const clippedDataSelector = createSelector(
+  dataSelector,
+  zoneSelector,
+  (
+    data
+    // zone
+  ) => {
+    // [jacomyal]
+    // The following code is commented at least for now, because we need the full
+    // track sections to properly compute point item coordinates from their
+    // positions:
+    // let result: Array<EditorEntity> = [];
+    // if (zone && data)
+    //   result = data.map((f) => {
+    //     const clippedFeature = clip(f, zone);
+    //     return clippedFeature ? { ...f, geometry: clippedFeature.geometry } : f;
+    //   });
+    return data;
+  }
+);

--- a/front/src/types.ts
+++ b/front/src/types.ts
@@ -76,16 +76,21 @@ export interface TrackSectionEntity extends EditorEntity {
 export interface SignalEntity
   extends EditorEntity<
     Point,
-    { track?: { id: string; type: string }; angle_geo?: number; installation_type?: string }
+    {
+      track?: { id: string; type: string };
+      position?: number;
+      angle_geo?: number;
+      installation_type?: string;
+    }
   > {
   objType: 'Signal';
 }
 export interface BufferStopEntity
-  extends EditorEntity<Point, { track?: { id: string; type: string } }> {
+  extends EditorEntity<Point, { track?: { id: string; type: string }; position?: number }> {
   objType: 'BufferStop';
 }
 export interface DetectorEntity
-  extends EditorEntity<Point, { track?: { id: string; type: string } }> {
+  extends EditorEntity<Point, { track?: { id: string; type: string }; position?: number }> {
   objType: 'Detector';
 }
 

--- a/front/src/utils/mapboxHelper.ts
+++ b/front/src/utils/mapboxHelper.ts
@@ -288,7 +288,7 @@ export function getLineGeoJSON(points: Position[]): Feature {
  */
 export function getNearestPoint(lines: Feature<LineString>[], coord: Coord): NearestPoint {
   const nearestPoints: Feature<Point>[] = lines.map((line) => {
-    const point = nearestPointOnLine(line, coord);
+    const point = nearestPointOnLine(line, coord, { units: 'meters' });
     const angle = getAngle(
       line.geometry.coordinates[point.properties.index as number],
       line.geometry.coordinates[(point.properties.index as number) + 1]


### PR DESCRIPTION
This commit addresses issue #1668 - but does not solve it fully yet.
Point items can properly be saved, but we still have a mismatch between
Turf.js position computation and database positions.

Details:
- Removes geometry from data to save in api.ts
- Stores point item position on track section when dropped
- Refreshes point item coordinates when position is updated from the
left panel form
- Displays a warning when positions from database and Turf.js do not
match