### PR TITLE
front: allowances: omit capacity_speed_limit 

### DIFF
--- a/api/osrd_infra/schemas/train_schedule.py
+++ b/api/osrd_infra/schemas/train_schedule.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Literal, Union
+from typing import List, Literal, Union, Optional
 
 from pydantic import BaseModel, Field, constr
 
@@ -94,9 +94,12 @@ class EngineeringAllowance(RangeAllowance):
 
     allowance_type: Literal["engineering"] = Field(default="engineering")
     distribution: AllowanceDistribution = Field(description="The considered distribution of an allowance")
-    capacity_speed_limit: float = Field(
+    capacity_speed_limit: Optional[float] = Field(
         description="Maximum speed measured in meters per second that cannot be exceeded", gt=0
     )
+
+    def dict(self, exclude_none=True, **kwargs):
+        return super.dict(exclude_none=exclude_none, **kwargs)
 
 
 class StandardAllowance(BaseModel):
@@ -110,9 +113,12 @@ class StandardAllowance(BaseModel):
     default_value: AllowanceValue = Field(description="Type of value of the allowance")
     ranges: List[RangeAllowance] = Field(description="List of the different application ranges of the allowances")
     distribution: AllowanceDistribution = Field(description="The considered distribution of an allowance")
-    capacity_speed_limit: float = Field(
+    capacity_speed_limit: Optional[float] = Field(
         description="Maximum speed measured in meters per second that cannot be exceeded", gt=0
     )
+
+    def dict(self, exclude_none=True, **kwargs):
+        return super.dict(exclude_none=exclude_none, **kwargs)
 
 
 class Allowance(BaseModel):

--- a/front/src/applications/osrd/components/Simulation/Allowances/StandardAllowanceDefault.js
+++ b/front/src/applications/osrd/components/Simulation/Allowances/StandardAllowanceDefault.js
@@ -56,7 +56,6 @@ export default function StandardAllowanceDefault(props) {
   const addStandard = async () => {
     const marecoConf = {
       allowance_type: 'standard',
-      capacity_speed_limit: 0,
       distribution: distribution.id,
       default_value: {
         value_type: value.type,

--- a/front/src/applications/osrd/views/OSRDSimulation/Allowances.js
+++ b/front/src/applications/osrd/views/OSRDSimulation/Allowances.js
@@ -42,7 +42,6 @@ const EmptyLine = (props) => {
   const allowanceNewDatas = allowanceType === 'engineering'
     ? {
       allowance_type: 'engineering',
-      capacity_speed_limit: 0,
       distribution: defaultDistributionId,
       begin_position: 0,
       end_position: simulation.trains[selectedTrain].base.stops[
@@ -53,7 +52,6 @@ const EmptyLine = (props) => {
       },
     } : {
       allowance_type: 'standard',
-      capacity_speed_limit: 0,
       distribution: defaultDistributionId,
       begin_position: marecoBeginPosition ?? 0,
       end_position: marecoEndPosition ?? simulation.trains[selectedTrain].base.stops[


### PR DESCRIPTION
This field is optional, and if present, must be >0
I'll open a PR to rename the field, as the current name isn't clear.
It should be called `allowance_speed_floor`