### PR TITLE
front: rollbacks react-error-overlay to v6.0.9

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -136,7 +136,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jsdoc": "^3.6.11",
     "prettier": "^2.7.1",
-    "react-error-overlay": "6.0.11",
+    "react-error-overlay": "6.0.9",
     "typescript": "~4.8.2"
   },
   "resolutions": {
@@ -149,7 +149,7 @@
     "nth-check": ">=2.0.1",
     "node-forge": ">=1.0.0",
     "semver-regex": ">=4.0.5",
-    "react-error-overlay": "6.0.11",
+    "react-error-overlay": "6.0.9",
     "postcss": "^7.0.0",
     "browserslist": "^4.20.0",
     "marked": ">=4.0.10",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -12991,10 +12991,10 @@ react-draggable@4.4.4:
     clsx "^1.1.1"
     prop-types "^15.6.0"
 
-react-error-overlay@6.0.11, react-error-overlay@^6.0.11, react-error-overlay@^6.0.9:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.11, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-flatpickr@^3.10.13:
   version "3.10.13"


### PR DESCRIPTION
This should fix #1837.
Also, to better understand the context, please read:
https://github.com/facebook/create-react-app/issues/11773#issuecomment-995933869