### PR TITLE
core: optimize speed limits loading

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -154,7 +154,7 @@ public class UndirectedInfraBuilder {
             for (var dir : Direction.values()) {
                 var newMap = TreeRangeMap.<Double, SpeedLimits>create();
                 newMap.put(Range.closed(0., track.getLength()),
-                        new SpeedLimits(Double.POSITIVE_INFINITY, ImmutableMap.of()));
+                        new SpeedLimits(Double.POSITIVE_INFINITY, new HashMap<>()));
                 trackSpeedSections.put(dir, newMap);
             }
             track.speedSections = trackSpeedSections;

--- a/core/src/test/java/fr/sncf/osrd/infra/tracks/undirected/SpeedLimitsTests.java
+++ b/core/src/test/java/fr/sncf/osrd/infra/tracks/undirected/SpeedLimitsTests.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.ImmutableMap;
 import fr.sncf.osrd.infra.api.tracks.undirected.SpeedLimits;
 import org.junit.jupiter.api.Test;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class SpeedLimitsTests {
@@ -13,12 +15,12 @@ public class SpeedLimitsTests {
     public void testInfiniteLimit() {
         var infiniteLimit = new SpeedLimits(
                 Double.POSITIVE_INFINITY,
-                ImmutableMap.of("a", 42.));
+                new HashMap<>(Map.of("a", 42.)));
         var otherLimit = new SpeedLimits(
                 10.,
-                ImmutableMap.of("a", 30.));
-        var selfMerge = SpeedLimits.merge(infiniteLimit, infiniteLimit);
-        var otherMerge = SpeedLimits.merge(otherLimit, infiniteLimit);
+                new HashMap<>(Map.of("a", 30.)));
+        var selfMerge = infiniteLimit.merge(infiniteLimit);
+        var otherMerge = otherLimit.merge(infiniteLimit);
         assertEquals(Double.POSITIVE_INFINITY, selfMerge.getSpeedLimit(List.of()));
         assertEquals(10., otherMerge.getSpeedLimit(List.of()));
         assertEquals(30., otherMerge.getSpeedLimit(List.of("a")));
@@ -29,21 +31,20 @@ public class SpeedLimitsTests {
     @Test
     public void testNull() {
         var var = new SpeedLimits(42, ImmutableMap.of());
-        assertEquals(var, SpeedLimits.merge(var, null));
-        assertEquals(var, SpeedLimits.merge(null, var));
+        assertEquals(var, var.merge(null));
     }
 
     @Test
     public void testMerge() {
-        var categoriesA = ImmutableMap.<String, Double>builder();
-        categoriesA.put("x", 10.);
-        categoriesA.put("y", 20.);
-        var categoriesB = ImmutableMap.<String, Double>builder();
-        categoriesB.put("y", 15.);
-        categoriesB.put("z", 25.);
-        var a = new SpeedLimits(42, categoriesA.build());
-        var b = new SpeedLimits(21, categoriesB.build());
-        var merged = SpeedLimits.merge(a, b);
+        var a = new SpeedLimits(42, new HashMap<>(Map.of(
+                "x", 10.,
+                "y", 20.
+        )));
+        var b = new SpeedLimits(21, new HashMap<>(Map.of(
+                "y", 15.,
+                "z", 25.
+        )));
+        var merged = a.merge(b);
         assertEquals(21, merged.getSpeedLimit(Set.of("default")));
         assertEquals(10, merged.getSpeedLimit(Set.of("x")));
         assertEquals(15, merged.getSpeedLimit(Set.of("y")));


### PR DESCRIPTION
Rather than re-creating new objects whenever a speed limit section is modified, we now only update one of the existing objects