### PR TITLE
actions: when a release is published push tagged images to the registry

### DIFF
--- a/.github/workflows/docker-build-push-template.yml
+++ b/.github/workflows/docker-build-push-template.yml
@@ -38,6 +38,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: "${{ inputs.image_name }}"
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
         id: docker_meta
 
       - name: Login to DockerHub

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - dev
+  release:
+    types:
+      - published
 
 jobs:
   build_push_core:


### PR DESCRIPTION
close #1955

This PR adds:

- When we publish a release the ci will be triggered
- All the images of the services will be pushed with their versions as a tag to the registry
  - Let's say the tag is `v1.4.2`. The images tags will be: `1`, `1.4` and `1.4.2`.