### PR TITLE
editor: allows user to select which layers to show

### DIFF
--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -28,11 +28,23 @@
   "Editor": {
     "title": "Éditeur",
     "tool-help": "Voir la description de l'outil actif",
+    "layers": {
+      "track_sections": "Sections de lignes",
+      "signals": "Signaux",
+      "buffer_stops": "Heurtoirs",
+      "detectors": "Détecteurs",
+      "switches": "Aiguillages"
+    },
     "nav": {
       "recenter": "Recentrer la carte",
-      "toggle-layers": "[TODO] Choisir les couches à afficher",
+      "toggle-layers": "Choisir les types d'éléments à afficher",
       "select-infra": "Choisir l'infrastructure à éditer",
       "infra-changed": "Vous éditez maintenant l'infra \"{{label}}\" (id \"{{id}}\")."
+    },
+    "layers-modal": {
+      "layer-selected-items_one": "Un élément sera désélectionné",
+      "layer-selected-items_other": "{{count}} éléments seront désélectionnés",
+      "frozen-layer": "ne peut pas être caché pour le moment"
     },
     "errors": {
       "infra-not-found": "L'infrastructure {{id}} non trouvée",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -42,9 +42,11 @@
       "infra-changed": "Vous éditez maintenant l'infra \"{{label}}\" (id \"{{id}}\")."
     },
     "layers-modal": {
-      "layer-selected-items_one": "Un élément sera désélectionné",
-      "layer-selected-items_other": "{{count}} éléments seront désélectionnés",
-      "frozen-layer": "ne peut pas être caché pour le moment"
+      "layer-selected-items_one": "Un élément sélectionné",
+      "layer-selected-items_other": "{{count}} éléments sélectionnés",
+      "selection-warning_one": "Un élément sera désélectionné lors de la confirmation.",
+      "selection-warning_other": "{{count}} éléments seront désélectionnés lors de la confirmation.",
+      "frozen-layer": "nécessaire pour l'outil actif"
     },
     "errors": {
       "infra-not-found": "L'infrastructure {{id}} non trouvée",

--- a/front/src/applications/editor/Editor.scss
+++ b/front/src/applications/editor/Editor.scss
@@ -2,7 +2,7 @@
   $blue: var(--primary);
   $blue-dark: var(--primary-dark);
   $white: var(--white);
-  $gray: var(--gray);
+  $gray: var(--coolgray5);
 
   padding-top: 3.75rem; // Header height
 

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -294,7 +294,10 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
                           )}
                           onClick={() => {
                             if (onClick) {
-                              onClick({ dispatch, setViewport, viewport, openModal }, editorState);
+                              onClick(
+                                { dispatch, setViewport, viewport, openModal, editorState },
+                                { activeTool, toolState, setToolState }
+                              );
                             }
                           }}
                           disabled={isDisabled && isDisabled(editorState)}

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { TFunction } from 'i18next';
 import { withTranslation } from 'react-i18next';
 import { ViewportProps } from 'react-map-gl';
+import { useNavigate } from 'react-router';
 import cx from 'classnames';
 
 import 'common/Map/Map.scss';
@@ -34,6 +35,7 @@ import TOOLS from './tools/list';
 
 const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const osrdConf = useSelector((state: { osrdconf: OSRDConf }) => state.osrdconf);
   const editorState = useSelector((state: { editor: EditorState }) => state.editor);
   const { fullscreen } = useSelector((state: { main: MainState }) => state.main);
@@ -137,24 +139,26 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
   // we call the api to find the latest infrastructure modified
   useEffect(() => {
     if (infra && parseInt(infra, 10) > 0) {
-      getInfrastructure(parseInt(infra, 10))
-        .then((infrastructure) => {
-          dispatch(updateInfraID(infrastructure.id));
+      const infraID = parseInt(infra, 10);
+      getInfrastructure(infraID)
+        .then(() => {
           resetState();
         })
         .catch(() => {
           dispatch(setFailure(new Error(t('Editor.errors.infra-not-found', { id: infra }))));
-          dispatch(updateViewport({}, `/editor/`, false));
+        })
+        .finally(() => {
+          dispatch(updateInfraID(infraID));
         });
     } else if (osrdConf.infraID) {
-      dispatch(updateViewport({}, `/editor/${osrdConf.infraID}`, false));
+      navigate(`/editor/${osrdConf.infraID}`);
     } else {
       getInfrastructures()
         .then((infras) => {
           if (infras && infras.length > 0) {
             const infrastructure = infras[0];
             dispatch(updateInfraID(infrastructure.id));
-            dispatch(updateViewport({}, `/editor/${infrastructure.id}`, false));
+            navigate(`/editor/${infrastructure.id}`);
           } else {
             dispatch(setFailure(new Error(t('Editor.errors.no-infra-available'))));
           }

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -296,7 +296,11 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
                             if (onClick) {
                               onClick(
                                 { dispatch, setViewport, viewport, openModal, editorState },
-                                { activeTool, toolState, setToolState }
+                                {
+                                  activeTool: toolAndState.tool,
+                                  toolState: toolAndState.state,
+                                  setToolState,
+                                }
                               );
                             }
                           }}

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -11,7 +11,7 @@ import './Editor.scss';
 
 import { LoaderState } from '../../common/Loader';
 import { NotificationsState } from '../../common/Notifications';
-import { EditorState, loadDataModel, reset } from '../../reducers/editor';
+import { loadDataModel, reset } from '../../reducers/editor';
 import { MainState, setFailure } from '../../reducers/main';
 import { updateViewport } from '../../reducers/map';
 import { updateInfraID } from '../../reducers/osrdconf';
@@ -23,6 +23,7 @@ import { EditorContext } from './context';
 import {
   CommonToolState,
   EditorContextType,
+  EditorState,
   ExtendedEditorContextType,
   FullTool,
   ModalRequest,

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -14,11 +14,11 @@ import Hillshade from '../../common/Map/Layers/Hillshade';
 import Platform from '../../common/Map/Layers/Platform';
 import osmBlankStyle from '../../common/Map/Layers/osmBlankStyle';
 
-import { EditorState } from '../../reducers/editor';
 import { EditorContext } from './context';
 import {
   CommonToolState,
   EditorContextType,
+  EditorState,
   ExtendedEditorContextType,
   OSRDConf,
   Tool,

--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -6,9 +6,9 @@ import { JSONSchema7 } from 'json-schema';
 
 import './EditorForm.scss';
 import { EditorEntity } from '../../../types';
-import { EditorState } from '../../../reducers/editor';
 import { FormComponent, FormLineStringLength } from './LinearMetadata';
 import { getJsonSchemaForLayer, getLayerForObjectType } from '../data/utils';
+import { EditorState } from '../tools/types';
 
 const fields = {
   ArrayField: FormComponent,

--- a/front/src/applications/editor/components/LayersModal.tsx
+++ b/front/src/applications/editor/components/LayersModal.tsx
@@ -1,0 +1,104 @@
+import React, { FC, useContext, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { groupBy, mapValues } from 'lodash';
+
+import bufferStopIcon from 'assets/pictures/layersicons/bufferstop.svg';
+import switchesIcon from 'assets/pictures/layersicons/switches.svg';
+import detectorsIcon from 'assets/pictures/layersicons/detectors.svg';
+import trackSectionsIcon from 'assets/pictures/layersicons/layer_adv.svg';
+import signalsIcon from 'assets/pictures/layersicons/layer_signal.svg';
+
+import SwitchSNCF from 'common/BootstrapSNCF/SwitchSNCF/SwitchSNCF';
+import { EditorContext } from '../context';
+import Modal from './Modal';
+import { LayerType, ModalProps } from '../tools/types';
+import { selectLayers } from '../../../reducers/editor';
+import { EditorEntity } from '../../../types';
+
+const LAYERS: { id: LayerType; icon: string }[] = [
+  { id: 'track_sections', icon: trackSectionsIcon },
+  { id: 'signals', icon: signalsIcon },
+  { id: 'buffer_stops', icon: bufferStopIcon },
+  { id: 'detectors', icon: detectorsIcon },
+  { id: 'switches', icon: switchesIcon },
+];
+
+const LayersModal: FC<
+  ModalProps<{
+    initialLayers: Set<LayerType>;
+    selection?: EditorEntity[];
+    frozenLayers?: Set<LayerType>;
+  }>
+> = ({ arguments: { initialLayers, selection, frozenLayers }, cancel, submit }) => {
+  const dispatch = useDispatch();
+  const { t } = useContext(EditorContext);
+  const [selectedLayers, setSelectedLayers] = useState<Set<LayerType>>(initialLayers);
+  const selectionCounts = useMemo(
+    () => (selection ? mapValues(groupBy(selection, 'objType'), (values) => values.length) : {}),
+    [selection]
+  );
+
+  return (
+    <Modal onClose={cancel} title={t('Editor.nav.toggle-layers')}>
+      <div className="container-fluid">
+        <div className="row">
+          {LAYERS.map(({ id, icon }) => (
+            <div className="col-lg-6" key={id}>
+              <div className="d-flex align-items-center mt-2">
+                <SwitchSNCF
+                  type="switch"
+                  onChange={() =>
+                    setSelectedLayers((set) => {
+                      const newSet = new Set(set);
+                      if (newSet.has(id)) newSet.delete(id);
+                      else newSet.add(id);
+                      return newSet;
+                    })
+                  }
+                  name={`editor-layer-${id}`}
+                  id={`editor-layer-${id}`}
+                  checked={selectedLayers.has(id)}
+                  disabled={frozenLayers && frozenLayers.has(id)}
+                />
+                <img className="mx-2" src={icon} alt="" height="20" />
+                <div>
+                  <p>{t(`Editor.layers.${id}`)}</p>
+                  {!!selectionCounts[id] && (
+                    <p className="small text-muted font-italic">
+                      {t('Editor.layers-modal.layer-selected-items', {
+                        count: selectionCounts[id],
+                      })}
+                    </p>
+                  )}
+                  {frozenLayers && frozenLayers.has(id) && (
+                    <p className="small text-muted font-italic">
+                      {t('Editor.layers-modal.frozen-layer')}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="text-right">
+        <button type="button" className="btn btn-danger mr-2" onClick={cancel}>
+          {t('common.cancel')}
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => {
+            dispatch(selectLayers(selectedLayers));
+            submit({});
+          }}
+        >
+          {t('common.confirm')}
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default LayersModal;

--- a/front/src/applications/editor/nav.ts
+++ b/front/src/applications/editor/nav.ts
@@ -6,9 +6,10 @@ import { FiLayers, FiZoomIn, FiZoomOut } from 'react-icons/fi';
 import { LinearInterpolator, ViewportProps } from 'react-map-gl';
 
 import { getZoneViewport } from '../../utils/mapboxHelper';
-import { EditorState, ModalRequest } from './tools/types';
+import { EditorState, ModalRequest, OBJTYPE_TO_LAYER_DICT, Tool } from './tools/types';
 import InfraSelectionModal from './components/InfraSelectionModal';
 import LayersModal from './components/LayersModal';
+import { SelectionState } from './tools/selection/types';
 
 const ZOOM_DEFAULT = 5;
 const ZOOM_DELTA = 1.5;
@@ -29,16 +30,21 @@ export interface NavButton {
   isHidden?: (editorState: EditorState) => boolean;
   isDisabled?: (editorState: EditorState) => boolean;
   // On click button:
-  onClick?: (
+  onClick?: <S = unknown>(
     context: {
       dispatch: Dispatch;
       viewport: ViewportProps;
+      editorState: EditorState;
       setViewport: (newViewport: ViewportProps) => void;
       openModal: <ArgumentsType, SubmitArgumentsType>(
         request: ModalRequest<ArgumentsType, SubmitArgumentsType>
       ) => void;
     },
-    editorState: EditorState
+    toolContext: {
+      activeTool: Tool<S>;
+      toolState: S;
+      setToolState: (newState: S) => void;
+    }
   ) => void;
 }
 
@@ -76,7 +82,7 @@ const NavButtons: NavButton[][] = [
       id: 'recenter',
       icon: BiTargetLock,
       labelTranslationKey: 'Editor.nav.recenter',
-      onClick({ setViewport, viewport }, editorState) {
+      onClick({ setViewport, viewport, editorState }) {
         const newViewport = editorState.editorZone
           ? getZoneViewport(editorState.editorZone, {
               width: +(viewport.width || 1),
@@ -99,10 +105,28 @@ const NavButtons: NavButton[][] = [
       id: 'layers',
       icon: FiLayers,
       labelTranslationKey: 'Editor.nav.toggle-layers',
-      onClick({ openModal }, editorState) {
+      onClick({ openModal, editorState }, { activeTool, toolState, setToolState }) {
         openModal({
           component: LayersModal,
-          arguments: { initialLayers: editorState.editorLayers },
+          arguments: {
+            initialLayers: editorState.editorLayers,
+            frozenLayers: activeTool.requiredLayers,
+            selection:
+              activeTool.id === 'select-items'
+                ? (toolState as SelectionState).selection
+                : undefined,
+          },
+          beforeSubmit({ newLayers }) {
+            if (activeTool.id === 'select-items') {
+              const currentState = toolState as SelectionState;
+              (setToolState as (newState: SelectionState) => void)({
+                ...currentState,
+                selection: currentState.selection.filter((entity) =>
+                  newLayers.has(OBJTYPE_TO_LAYER_DICT[entity.objType])
+                ),
+              } as SelectionState);
+            }
+          },
         });
       },
     },

--- a/front/src/applications/editor/nav.ts
+++ b/front/src/applications/editor/nav.ts
@@ -5,10 +5,10 @@ import { BsMap } from 'react-icons/bs';
 import { FiLayers, FiZoomIn, FiZoomOut } from 'react-icons/fi';
 import { LinearInterpolator, ViewportProps } from 'react-map-gl';
 
-import { EditorState } from '../../reducers/editor';
 import { getZoneViewport } from '../../utils/mapboxHelper';
-import { ModalRequest } from './tools/types';
+import { EditorState, ModalRequest } from './tools/types';
 import InfraSelectionModal from './components/InfraSelectionModal';
+import LayersModal from './components/LayersModal';
 
 const ZOOM_DEFAULT = 5;
 const ZOOM_DELTA = 1.5;
@@ -99,8 +99,11 @@ const NavButtons: NavButton[][] = [
       id: 'layers',
       icon: FiLayers,
       labelTranslationKey: 'Editor.nav.toggle-layers',
-      onClick() {
-        // TODO
+      onClick({ openModal }, editorState) {
+        openModal({
+          component: LayersModal,
+          arguments: { initialLayers: editorState.editorLayers },
+        });
       },
     },
     {

--- a/front/src/applications/editor/tools/pointEdition/tools.ts
+++ b/front/src/applications/editor/tools/pointEdition/tools.ts
@@ -6,7 +6,7 @@ import { BufferStopEntity, DetectorEntity, SignalEntity } from '../../../../type
 import { BufferStopEditionLayers, DetectorEditionLayers, SignalEditionLayers } from './components';
 
 export const SignalEditionTool = getPointEditionTool<SignalEntity>({
-  id: 'signal',
+  layer: 'signals',
   icon: FaMapSigns,
   getNewEntity: getNewSignal,
   layersComponent: SignalEditionLayers,
@@ -14,14 +14,14 @@ export const SignalEditionTool = getPointEditionTool<SignalEntity>({
 });
 
 export const DetectorEditionTool = getPointEditionTool<DetectorEntity>({
-  id: 'detector',
+  layer: 'detectors',
   icon: MdSensors,
   getNewEntity: getNewDetector,
   layersComponent: DetectorEditionLayers,
 });
 
 export const BufferStopEditionTool = getPointEditionTool<BufferStopEntity>({
-  id: 'buffer-stop',
+  layer: 'buffer_stops',
   icon: BsSkipEnd,
   getNewEntity: getNewBufferStop,
   layersComponent: BufferStopEditionLayers,

--- a/front/src/applications/editor/tools/selection/tool.ts
+++ b/front/src/applications/editor/tools/selection/tool.ts
@@ -194,7 +194,7 @@ const SelectionTool: Tool<SelectionState> = {
     let { selection } = state;
     const isAlreadySelected = selection.find((item) => item.id === feature.id);
 
-    const current = editorState.editorData.find((item) => item.id === feature.id);
+    const current = editorState.editorDataIndex[feature.id];
     if (current) {
       if (!isAlreadySelected) {
         if (e.srcEvent.ctrlKey) {
@@ -227,11 +227,10 @@ const SelectionTool: Tool<SelectionState> = {
             selectionState: { ...state.selectionState, rectangleTopLeft: null },
           });
         } else {
-          // TODO remove the layer static variable
           setState({
             ...state,
             selectionState: { ...state.selectionState, rectangleTopLeft: null },
-            selection: selectInZone(editorState.editorData, {
+            selection: selectInZone(editorState.editorDataArray, {
               type: 'rectangle',
               points: [state.selectionState.rectangleTopLeft, position],
             }),
@@ -256,7 +255,7 @@ const SelectionTool: Tool<SelectionState> = {
               ...state.selectionState,
               polygonPoints: [],
             },
-            selection: selectInZone(editorState.editorData, {
+            selection: selectInZone(editorState.editorDataArray, {
               type: 'polygon',
               points,
             }),
@@ -275,8 +274,8 @@ const SelectionTool: Tool<SelectionState> = {
   },
 
   // Layers:
-  getInteractiveLayers({ editorState: { editorData } }) {
-    const symbolTypes = getSymbolTypes(editorData);
+  getInteractiveLayers({ editorState: { editorDataArray } }) {
+    const symbolTypes = getSymbolTypes(editorDataArray);
     return symbolTypes
       .map((type) => `editor/geo/signal-${type}`)
       .concat([

--- a/front/src/applications/editor/tools/switchEdition/tool.ts
+++ b/front/src/applications/editor/tools/switchEdition/tool.ts
@@ -11,6 +11,14 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
   id: 'switch-edition',
   icon: TbSwitch2,
   labelTranslationKey: 'Editor.tools.switch-edition.label',
+  requiredLayers: new Set(['switches', 'track_sections']),
+  isDisabled({ editorState }) {
+    return (
+      !editorState.editorZone ||
+      !editorState.editorLayers.has('switches') ||
+      !editorState.editorLayers.has('track_sections')
+    );
+  },
 
   getInitialState({ osrdConf }) {
     if (!osrdConf.switchTypes?.length) throw new Error('There is no switch type yet.');

--- a/front/src/applications/editor/tools/trackEdition/tool.ts
+++ b/front/src/applications/editor/tools/trackEdition/tool.ts
@@ -31,7 +31,7 @@ const TrackEditionTool: Tool<TrackEditionState> = {
   icon: MdShowChart,
   labelTranslationKey: 'Editor.tools.track-edition.label',
   isDisabled({ editorState }) {
-    return !editorState.editorZone;
+    return !editorState.editorZone || !editorState.editorLayers.has('track_sections');
   },
   getRadius() {
     return 20;

--- a/front/src/applications/editor/tools/trackEdition/tool.ts
+++ b/front/src/applications/editor/tools/trackEdition/tool.ts
@@ -30,6 +30,7 @@ const TrackEditionTool: Tool<TrackEditionState> = {
   id: 'track-edition',
   icon: MdShowChart,
   labelTranslationKey: 'Editor.tools.track-edition.label',
+  requiredLayers: new Set(['track_sections']),
   isDisabled({ editorState }) {
     return !editorState.editorZone || !editorState.editorLayers.has('track_sections');
   },

--- a/front/src/applications/editor/tools/types.tsx
+++ b/front/src/applications/editor/tools/types.tsx
@@ -31,6 +31,14 @@ export const LAYERS = [
 ] as const;
 export type LayerType = typeof LAYERS[number];
 
+export const OBJTYPE_TO_LAYER_DICT: Record<string, LayerType> = {
+  TrackSection: 'track_sections',
+  Signal: 'signals',
+  BufferStop: 'buffer_stops',
+  Detector: 'detectors',
+  Switch: 'switches',
+};
+
 export interface MapState {
   mapStyle: string;
   viewport: ViewportProps;
@@ -124,6 +132,7 @@ export interface Tool<S> {
   labelTranslationKey: string;
   actions: ToolAction<S>[][];
   getInitialState: (context: { osrdConf: OSRDConf }) => S;
+  requiredLayers?: Set<LayerType>;
   isDisabled?: (context: ReadOnlyEditorContextType<S>) => boolean;
   getRadius?: (context: ReadOnlyEditorContextType<S>) => number;
 
@@ -141,7 +150,6 @@ export interface Tool<S> {
   ) => string;
 
   // Display:
-  getRequiredLayers?: (context: ReadOnlyEditorContextType<S>) => Set<LayerType>;
   getInteractiveLayers?: (context: ReadOnlyEditorContextType<S>) => string[];
   layersComponent?: ComponentType;
   leftPanelComponent?: ComponentType;

--- a/front/src/applications/editor/tools/types.tsx
+++ b/front/src/applications/editor/tools/types.tsx
@@ -4,8 +4,32 @@ import { MapEvent, ViewportProps } from 'react-map-gl';
 import { IconType } from 'react-icons/lib/esm/iconBase';
 import { TFunction } from 'i18next';
 
-import { Item, PositionnedItem, SwitchType } from '../../../types';
-import { EditorState } from '../../../reducers/editor';
+import {
+  EditorEntity,
+  EditorSchema,
+  Item,
+  PositionnedItem,
+  SwitchType,
+  Zone,
+} from '../../../types';
+
+export interface EditorState {
+  editorSchema: EditorSchema;
+  editorLayers: Set<LayerType>;
+  editorZone: Zone | null;
+  editorData: Partial<Record<LayerType, EditorEntity[]>>;
+  editorDataArray: EditorEntity[];
+  editorDataIndex: Record<string, EditorEntity>;
+}
+
+export const LAYERS = [
+  'track_sections',
+  'signals',
+  'buffer_stops',
+  'detectors',
+  'switches',
+] as const;
+export type LayerType = typeof LAYERS[number];
 
 export interface MapState {
   mapStyle: string;
@@ -16,7 +40,7 @@ export interface OSRDConf {
   switchTypes: SwitchType[] | null;
 }
 
-export interface ModalProps<ArgumentsType, SubmitArgumentsType = Record<string, unknown>> {
+export interface ModalProps<ArgumentsType = {}, SubmitArgumentsType = Record<string, unknown>> {
   arguments: ArgumentsType;
   cancel: () => void;
   submit: (args: SubmitArgumentsType) => void;
@@ -117,6 +141,7 @@ export interface Tool<S> {
   ) => string;
 
   // Display:
+  getRequiredLayers?: (context: ReadOnlyEditorContextType<S>) => Set<LayerType>;
   getInteractiveLayers?: (context: ReadOnlyEditorContextType<S>) => string[];
   layersComponent?: ComponentType;
   leftPanelComponent?: ComponentType;

--- a/front/src/common/Map/Layers/EditorZone.tsx
+++ b/front/src/common/Map/Layers/EditorZone.tsx
@@ -2,9 +2,9 @@ import { Layer, Source } from 'react-map-gl';
 import { useSelector } from 'react-redux';
 import React, { FC } from 'react';
 
-import { EditorState } from '../../../reducers/editor';
 import { zoneToFeature } from '../../../utils/mapboxHelper';
 import { Zone } from '../../../types';
+import { EditorState } from '../../../applications/editor/tools/types';
 
 const EditorZone: FC<{ newZone?: Zone }> = ({ newZone }) => {
   const { editorZone } = useSelector((state: { editor: EditorState }) => state.editor);
@@ -12,7 +12,7 @@ const EditorZone: FC<{ newZone?: Zone }> = ({ newZone }) => {
   return (
     <>
       {editorZone ? (
-        <Source type="geojson" data={zoneToFeature(editorZone, true)}>
+        <Source type="geojson" data={zoneToFeature(editorZone, true)} key="editor-zone">
           <Layer
             type="line"
             paint={{ 'line-color': '#333', 'line-width': 2, 'line-dasharray': [3, 3] }}
@@ -20,7 +20,7 @@ const EditorZone: FC<{ newZone?: Zone }> = ({ newZone }) => {
         </Source>
       ) : null}
       {newZone ? (
-        <Source type="geojson" data={zoneToFeature(newZone)}>
+        <Source type="geojson" data={zoneToFeature(newZone)} key="new-zone">
           <Layer type="line" paint={{ 'line-color': '#666', 'line-dasharray': [3, 3] }} />
         </Source>
       ) : null}

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -7,11 +7,12 @@ import storage from 'redux-persist/lib/storage'; // defaults to localStorage
 import mainReducer, { MainActions } from './main';
 import userReducer from './user';
 import mapReducer, { MapState } from './map';
-import editorReducer, { EditorState, EditorActions } from './editor';
+import editorReducer, { EditorActions } from './editor';
 
 import osrdconfReducer from './osrdconf';
 import osrdsimulationReducer, { OsrdSimulationState } from './osrdsimulation';
 import rollingStockReducer from './rollingstock';
+import { EditorState } from '../applications/editor/tools/types';
 
 const compressor = createCompressor({
   whitelist: ['rollingstock'],


### PR DESCRIPTION
This PR should close issue #1987. Also, it depends on PR #2069 (related to issue #1986), that should be merged first.

Details (preparing the feature):
- Moves EditorState definition from editor reducer to editor types file
- Improves editorState.editorLayers typing with an enforced list of available layers (and spreads this type through the whole editor codebase)
- Now indexes both the array of entities and them grouped per objType in editor state, to facilitate working with those data
- Improves disabled button display

Details directly related to #1987:
- Adds new LayersModal, accessible from a new button in the right, to select which layers to show or hide
- Slightly refactors actions in editor reducer so that data are reloaded when the zone or the layers are updated
- Some layers can be disabled in the layers modal, if they are required for the current tool.
- When using the selection tool, unchecking a layer will unselect items of that type.