### PR TITLE
core: bump dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,7 +17,7 @@ import static org.apache.tools.ant.taskdefs.condition.Os.*
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.7.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.7.+'
     id 'application'
     id 'checkstyle'
     id 'com.github.spotbugs' version '5.0.+'
@@ -46,8 +46,8 @@ dependencies {
     implementation group: 'com.carrotsearch', name: 'hppc', version: '0.9.1'  // Apache 2.0
 
     // JSON parsing
-    implementation 'com.squareup.moshi:moshi:1.13.0' // Apache 2.0
-    implementation 'com.squareup.moshi:moshi-adapters:1.13.0'  // Apache 2.0
+    implementation 'com.squareup.moshi:moshi:1.14.0' // Apache 2.0
+    implementation 'com.squareup.moshi:moshi-adapters:1.14.0'  // Apache 2.0
 
     // HTTP server framework
     implementation group: 'org.takes', name: 'takes', version: '1.24.+'  // MIT
@@ -69,27 +69,27 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.+'
 
     // Sentry
-    implementation group: 'io.sentry', name: 'sentry', version: '6.4.+'  // MIT
+    implementation group: 'io.sentry', name: 'sentry', version: '6.5.+'  // MIT
 
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'  // EPL 2.0
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'  // EPL 2.0
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.+'  // EPL 2.0
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.+'  // EPL 2.0
     // Use JUnit Jupiter Engine for testing.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'  // EPL 2.0
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.+'  // EPL 2.0
     // jqwik for property based testing
-    testImplementation 'net.jqwik:jqwik:1.6.5'  // EPL 2.0
+    testImplementation 'net.jqwik:jqwik:1.7.+'  // EPL 2.0
     // mockito for mocking
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.7.+'  // MIT
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.7.+'  // MIT
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.8.+'  // MIT
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.8.+'  // MIT
 
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.0'  // EPL 2.0
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.+'  // EPL 2.0
 
     // for linter annotations
     compileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
     compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.+'  // LGPLv2.1
     testCompileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.0'  // LGPLv2.1
+    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.+'  // LGPLv2.1
 }
 
 // endregion


### PR DESCRIPTION
- **sentry** from 6.4.+ to 6.5.0 (close #2084)
- **jqwik** from 1.6.5 to 1.7.0 (close #2002)
- **org.jetbrains.kotlin.jvm** from 1.7.10 to 1.7.20 (close #1995)
- **junit-jupiter-engine** from 5.9.0 to 5.9.1 (close #1941)
- **junit-platform-launcher** from 1.9.0 to 1.9.1 (close #1940)
- **junit-jupiter-api** from 5.9.0 to 5.9.1 (close #1939)
- **junit-jupiter-params** from 5.9.0 to 5.9.1 (close #1938)
- **moshi-adapters** from 1.13.0 to 1.14.0 (close #1852)
- **mockito-inline** from 4.7.+ to 4.8.0 (close #1851)
- **mockito-junit-jupiter** from 4.7.+ to 4.8.0 (close #1850)
- **moshi** from 1.13.0 to 1.14.0 (close #1849)
- **spotbugs-annotations** from 4.7.+ to 4.7.2 (close #1832)