### PR TITLE
scripts: fix load-database force to restart editoast container

### DIFF
--- a/scripts/load-database.sh
+++ b/scripts/load-database.sh
@@ -13,3 +13,4 @@ docker cp "$1" osrd-postgres:/backup-osrd
 docker exec osrd-postgres pg_restore -d osrd -x -c /backup-osrd || true
 docker exec osrd-api python3 manage.py migrate
 docker exec osrd-editoast editoast generate
+docker restart osrd-editoast


### PR DESCRIPTION
If editoast is not restarted after loading a dump, new infras will not be cached by the service.