### PR TITLE
stdcm: explore the same route at different times as different edges

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -6,6 +6,7 @@ import fr.sncf.osrd.api.pathfinding.PathfindingResultConverter;
 import fr.sncf.osrd.api.pathfinding.PathfindingRoutesEndpoint;
 import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint;
 import fr.sncf.osrd.api.pathfinding.response.NoPathFoundError;
+import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.PhysicsPath;
 import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
@@ -106,7 +107,7 @@ public class STDCMEndpoint implements Take {
             simResult.baseSimulations.add(ScheduleMetadataExtractor.run(
                     res.envelope(),
                     res.trainPath(),
-                    makeTrainSchedule(res.physicsPath(), rollingStock),
+                    makeTrainSchedule(res.envelope(), rollingStock),
                     infra
             ));
             simResult.ecoSimulations.add(null);
@@ -118,10 +119,10 @@ public class STDCMEndpoint implements Take {
         }
     }
 
-    /** Generate a train schedule matching the envelope path and rolling stock, with one stop at the end */
-    private static StandaloneTrainSchedule makeTrainSchedule(PhysicsPath physicsPath, RollingStock rollingStock) {
+    /** Generate a train schedule matching the envelope and rolling stock, with one stop at the end */
+    private static StandaloneTrainSchedule makeTrainSchedule(Envelope envelope, RollingStock rollingStock) {
         List<TrainStop> trainStops = new ArrayList<>();
-        trainStops.add(new TrainStop(physicsPath.getLength(), 0.1));
+        trainStops.add(new TrainStop(envelope.getEndPos(), 0.1));
         return new StandaloneTrainSchedule(rollingStock, 0., trainStops, List.of(), List.of());
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
@@ -104,7 +104,9 @@ public class STDCMPathfinding {
             offset += edge.edge().envelope().getEndPos();
         }
         var newEnvelope = Envelope.make(parts.toArray(new EnvelopePart[0]));
-        return addBrakingCurves(newEnvelope, rollingStock, physicsPath, timeStep);
+        var finalEnvelope = addBrakingCurves(newEnvelope, rollingStock, physicsPath, timeStep);
+        assert finalEnvelope.continuous;
+        return finalEnvelope;
     }
 
     /** Adds any missing braking curves to the envelope (including the last stop).

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
@@ -98,10 +98,12 @@ public class STDCMPathfinding {
         var parts = new ArrayList<EnvelopePart>();
         double offset = 0;
         for (var edge : edges) {
-            var envelope = Envelope.make(edge.edge().envelope().slice(0, Math.abs(edge.end() - edge.start())));
-            for (var part : envelope)
+            var envelope = edge.edge().envelope();
+            var sliceUntil = Math.min(envelope.getEndPos(), Math.abs(edge.end() - edge.start()));
+            var slicedEnvelope = Envelope.make(envelope.slice(0, sliceUntil));
+            for (var part : slicedEnvelope)
                 parts.add(part.copyAndShift(offset));
-            offset += edge.edge().envelope().getEndPos();
+            offset = parts.get(parts.size() - 1).getEndPos();
         }
         var newEnvelope = Envelope.make(parts.toArray(new EnvelopePart[0]));
         var finalEnvelope = addBrakingCurves(newEnvelope, rollingStock, physicsPath, timeStep);

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/UnavailableSpaceBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/UnavailableSpaceBuilder.java
@@ -9,6 +9,9 @@ import java.util.Collection;
 
 public class UnavailableSpaceBuilder {
 
+    /** Only used when we have missing signal data */
+    private static final double DEFAULT_SIGHT_DISTANCE = 400;
+
     /** Computes the unavailable space for each route, i.e.
      * the times and positions where the *head* of the train cannot be.
      * This considers existing occupancy blocks, the length of the train,
@@ -43,7 +46,9 @@ public class UnavailableSpaceBuilder {
             var predecessorRoutes = routeGraph.inEdges(startRouteNode);
             for (var predecessorRoute : predecessorRoutes) {
                 var preBlockLength = predecessorRoute.getInfraRoute().getLength();
-                var sightDistance = predecessorRoute.getExitSignal().getSightDistance();
+                double sightDistance = DEFAULT_SIGHT_DISTANCE;
+                if (predecessorRoute.getExitSignal() != null)
+                    sightDistance = predecessorRoute.getExitSignal().getSightDistance();
                 var previousBlock = new OccupancyBlock(
                         timeStart,
                         timeEnd,

--- a/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -159,7 +159,7 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
     public long interpolateTotalTimeMS(double position) {
         assert continuous : "interpolating times on a non continuous envelope is a risky business";
         var envelopePartIndex = findLeft(position);
-        assert envelopePartIndex != -1 : "Trying to interpolate time outside of the envelope";
+        assert envelopePartIndex >= 0 : "Trying to interpolate time outside of the envelope";
         var envelopePart = get(envelopePartIndex);
         return getCumulativeTimeMS(envelopePartIndex) + envelopePart.interpolateTotalTimeMS(position);
     }

--- a/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -169,6 +169,13 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
         return ((double) interpolateTotalTimeMS(position)) / 1000;
     }
 
+    /** Computes the time required to get to a given point of the envelope.
+     * The value is clamped to the [0, envelope length] range. */
+    public double interpolateTotalTimeClamp(double position) {
+        position = Math.min(getEndPos(), Math.max(0, position));
+        return ((double) interpolateTotalTimeMS(position)) / 1000;
+    }
+
     // endregion
 
     // region CACHING

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeStopWrapper.java
@@ -25,6 +25,12 @@ public class EnvelopeStopWrapper implements EnvelopeTimeInterpolate {
     }
 
     @Override
+    public double interpolateTotalTimeClamp(double position) {
+        position = Math.max(0, Math.min(envelope.getEndPos(), position));
+        return interpolateTotalTime(position);
+    }
+
+    @Override
     public double getEndPos() {
         return envelope.getEndPos();
     }

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
@@ -5,6 +5,10 @@ public interface EnvelopeTimeInterpolate {
     /** Computes the time required to get to a given point of the envelope */
     double interpolateTotalTime(double position);
 
+    /** Computes the time required to get to a given point of the envelope,
+     * clamping the position to [0, envelope length] first */
+    double interpolateTotalTimeClamp(double position);
+
     /** Returns the end position of the envelope */
     double getEndPos();
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.java
@@ -64,10 +64,10 @@ public class MaxSpeedEnvelope {
             // if the stopPosition is zero, no need to build a deceleration curve
             if (stopPosition == 0.0)
                 continue;
-            if (stopPosition > context.path.getLength())
+            if (stopPosition > curveWithDecelerations.getEndPos())
                 throw new RuntimeException(String.format(
                         "Stop at index %d is out of bounds (position = %f, path length = %f)",
-                        i, stopPosition, context.path.getLength()
+                        i, stopPosition, curveWithDecelerations.getEndPos()
                 ));
             var partBuilder = new EnvelopePartBuilder();
             partBuilder.setAttr(EnvelopeProfile.BRAKING);

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.java
@@ -232,10 +232,10 @@ public class ScheduleMetadataExtractor {
             }
 
             res.put(routeID, new ResultOccupancyTiming(
-                    envelope.interpolateTotalTime(min(occupied, trainPath.length())),
-                    envelope.interpolateTotalTime(min(headFree, trainPath.length())),
-                    envelope.interpolateTotalTime(min(tailOccupied, trainPath.length())),
-                    envelope.interpolateTotalTime(min(free, trainPath.length()))
+                    envelope.interpolateTotalTimeClamp(occupied),
+                    envelope.interpolateTotalTimeClamp(headFree),
+                    envelope.interpolateTotalTimeClamp(tailOccupied),
+                    envelope.interpolateTotalTimeClamp(free)
             ));
         }
         validate(trainPath, res, envelope, trainLength);
@@ -269,15 +269,12 @@ public class ScheduleMetadataExtractor {
 
         // Checks that every route in the path is occupied *at least* when the train is present on it
         for (var route : trainPath.routePath()) {
-            var beginOccupancy = max(0, route.pathOffset());
-            var endOccupancy = min(
-                    route.pathOffset() + route.element().getInfraRoute().getLength() + trainLength,
-                    trainPath.length()
-            );
+            var beginOccupancy = route.pathOffset();
+            var endOccupancy = route.pathOffset() + route.element().getInfraRoute().getLength() + trainLength;
             var time = times.get(route.element().getInfraRoute().getID());
             assert time != null;
-            assert envelope.interpolateTotalTime(beginOccupancy) >= time.timeHeadOccupy;
-            assert envelope.interpolateTotalTime(endOccupancy) <= time.timeTailFree;
+            assert envelope.interpolateTotalTimeClamp(beginOccupancy) >= time.timeHeadOccupy;
+            assert envelope.interpolateTotalTimeClamp(endOccupancy) <= time.timeTailFree;
         }
     }
 

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/EdgeToRanges.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/EdgeToRanges.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 
 /** Function that takes an edge and returns a collection of ranges,
  * used to define blocked ranges on an edge */
+@FunctionalInterface
 public interface EdgeToRanges<EdgeT> {
     Collection<Pathfinding.Range> apply(EdgeT edge);
 }

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TargetsOnEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TargetsOnEdge.java
@@ -1,0 +1,9 @@
+package fr.sncf.osrd.utils.graph.functional_interfaces;
+
+import java.util.Collection;
+
+/** Functions that takes an edge and returns the offset of any target for the current step on the edge */
+@FunctionalInterface
+public interface TargetsOnEdge<EdgeT> {
+    Collection<Double> apply(EdgeT edge);
+}

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DummyRouteGraphBuilder.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DummyRouteGraphBuilder.java
@@ -106,6 +106,11 @@ public class DummyRouteGraphBuilder {
         }
 
         @Override
+        public String toString() {
+            return id;
+        }
+
+        @Override
         public String getID() {
             return id;
         }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm;
 
 import static fr.sncf.osrd.train.TestTrains.*;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
@@ -54,9 +55,9 @@ public class STDCMPathfindingTests {
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
                 firstRoute, new OccupancyBlock(0, 50, 0, 100),
-                firstRoute, new OccupancyBlock(10000, Double.POSITIVE_INFINITY, 0, 100),
+                firstRoute, new OccupancyBlock(10000, POSITIVE_INFINITY, 0, 100),
                 secondRoute, new OccupancyBlock(0, 50, 0, 100),
-                secondRoute, new OccupancyBlock(10000, Double.POSITIVE_INFINITY, 0, 100));
+                secondRoute, new OccupancyBlock(10000, POSITIVE_INFINITY, 0, 100));
         var res = STDCMPathfinding.findPath(
                 infra,
                 REALISTIC_FAST_TRAIN,
@@ -68,7 +69,7 @@ public class STDCMPathfindingTests {
                 2.
         );
         assertNotNull(res);
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
     /** Test that no path is found when the routes aren't connected */
@@ -108,9 +109,9 @@ public class STDCMPathfindingTests {
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
                 firstRoute, new OccupancyBlock(0, 99, 0, 100),
-                firstRoute, new OccupancyBlock(101, Double.POSITIVE_INFINITY, 0, 100),
+                firstRoute, new OccupancyBlock(101, POSITIVE_INFINITY, 0, 100),
                 secondRoute, new OccupancyBlock(0, 50, 0, 100),
-                secondRoute, new OccupancyBlock(1000, Double.POSITIVE_INFINITY, 0, 100));
+                secondRoute, new OccupancyBlock(1000, POSITIVE_INFINITY, 0, 100));
         var res = STDCMPathfinding.findPath(
                 infra,
                 REALISTIC_FAST_TRAIN,
@@ -149,7 +150,7 @@ public class STDCMPathfindingTests {
                 2.
         );
         assertNotNull(res);
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
     /** Tests that an occupied route can cause delays */
@@ -179,7 +180,7 @@ public class STDCMPathfindingTests {
         );
         assertNotNull(res);
         assert res.envelope().getTotalTime() >= 1000;
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
     /** Test that the path can change depending on the occupancy */
@@ -205,10 +206,10 @@ public class STDCMPathfindingTests {
         infraBuilder.addRoute("d", "e");
         var infra = infraBuilder.build();
         var occupancyGraph1 = ImmutableMultimap.of(
-                routeTop, new OccupancyBlock(0, Double.POSITIVE_INFINITY, 0, 100)
+                routeTop, new OccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
         );
         var occupancyGraph2 = ImmutableMultimap.of(
-                routeBottom, new OccupancyBlock(0, Double.POSITIVE_INFINITY, 0, 100)
+                routeBottom, new OccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
         );
 
         var firstRoute = infra.findSignalingRoute("a->b", "BAL3");
@@ -243,11 +244,11 @@ public class STDCMPathfindingTests {
 
         assertFalse(routes1.contains("b->c1"));
         assertTrue(routes1.contains("b->c2"));
-        assertTrue(occupancyTest(res1, occupancyGraph1));
+        occupancyTest(res1, occupancyGraph1);
 
         assertFalse(routes2.contains("b->c2"));
         assertTrue(routes2.contains("b->c1"));
-        assertTrue(occupancyTest(res2, occupancyGraph2));
+        occupancyTest(res2, occupancyGraph2);
     }
 
     /** Test that everything works well when the train is at max speed during route transitions */
@@ -341,7 +342,7 @@ public class STDCMPathfindingTests {
         var secondRouteEntryTime = res.departureTime()
                 + res.envelope().interpolateTotalTime(firstRoute.getInfraRoute().getLength());
         assertTrue(secondRouteEntryTime >= 3600);
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
     /** Test that we can add delays to avoid several occupied blocks */
@@ -375,7 +376,7 @@ public class STDCMPathfindingTests {
                 + res.envelope().interpolateTotalTime(firstRoute.getInfraRoute().getLength());
         assertTrue(secondRouteEntryTime >= 3600);
 
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
     /** Test that we don't add too much delay, crossing over occupied sections in previous routes */
@@ -400,7 +401,7 @@ public class STDCMPathfindingTests {
                 ImmutableMultimap.of(
                         firstRoute, new OccupancyBlock(
                                 firstRouteEnvelope.getTotalTime() + 10,
-                                Double.POSITIVE_INFINITY,
+                                POSITIVE_INFINITY,
                                 0, 100),
                         secondRoute, new OccupancyBlock(0, 3600, 0, 100)
                 ),
@@ -448,23 +449,261 @@ public class STDCMPathfindingTests {
         );
 
         assertNotNull(res);
-        assertTrue(occupancyTest(res, occupancyGraph));
+        occupancyTest(res, occupancyGraph);
     }
 
-    private boolean occupancyTest(STDCMResult res, ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph) {
+    /** This is the same test as the one above, but with the split on the first route. */
+    @Test
+    public void testTwoOpeningsFirstRoute() {
+        /*
+        a --> b --> c
+
+        space
+          ^
+        c |##############   end
+          |##############   /
+        b |##############__/____
+          | x       ##### /
+        a |/________#####/______> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(300, 500, 0, 100),
+                secondRoute, new OccupancyBlock(0, 500, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                100,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 50)),
+                occupancyGraph,
+                2.
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+    }
+
+    /** This is the same test as the one above, but with the split on the last route. */
+    @Test
+    public void testTwoOpeningsLastRoute() {
+        /*
+        a --> b --> c
+
+        space
+          ^
+        c |    x    ##### end
+          |___/_____#####_/_____
+        b |__/______#####/______
+          | /           /
+        a start________/_______> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                secondRoute, new OccupancyBlock(300, 500, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                100,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 50)),
+                occupancyGraph,
+                2.
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+    }
+
+    /** Test that we keep track of how much we can shift the departure time over several routes */
+    @Test
+    public void testMaximumShiftMoreRestrictive() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        e |######################################__/___
+          |###################################### /
+        d |######################################/_____
+          |                                     /
+        c |____________________________________x_______
+          |                     #######################
+        b |_____________________#######################
+          |                                    ########
+        a start________________________________########> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        infraBuilder.addRoute("c", "d", 1); // Very short to prevent slowdowns
+        var forthRoute = infraBuilder.addRoute("d", "e");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(1200, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new OccupancyBlock(600, POSITIVE_INFINITY, 0, 100),
+                forthRoute, new OccupancyBlock(0, 1000, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 1)),
+                occupancyGraph,
+                2.
+        );
+        assertNull(res);
+    }
+
+    /** We shift de departure time a little more at each route,
+     * we test that we still keep track of how much we can shift.
+     * This test may need tweaking / removal once we consider slowdowns. */
+    @Test
+    public void testMaximumShiftWithDelays() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        e |################################ end
+          |################################/__________
+        d |#################### /         /
+          |####################/_________/____________
+        c |############# /              /
+          |#############/______________x______________
+        b |#####  /                ###################
+          |#####/                  ###################
+        a start____________________###################_> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var thirdRoute = infraBuilder.addRoute("c", "d");
+        var forthRoute = infraBuilder.addRoute("d", "e");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(0, 200, 0, 100),
+                firstRoute, new OccupancyBlock(500, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new OccupancyBlock(0, 400, 0, 100),
+                thirdRoute, new OccupancyBlock(0, 600, 0, 100),
+                forthRoute, new OccupancyBlock(0, 800, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 1)),
+                occupancyGraph,
+                2.
+        );
+        assertNull(res);
+    }
+
+    /** Test that we can consider more than two openings */
+    @Test
+    public void testSeveralOpenings() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        d |##########################_______################
+          |##########################  end  ################
+        c |##########################__/____################
+          |   x     ##### x     ##### /     ##### x
+        b |__/______#####/______#####/______#####/__________
+          | /           /                       /
+        a start________/_______________________/_____________> time
+                    |   |       |    |      |    |          |
+                   300 600     900  1200   1500 1800       inf   (s)
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var thirdRoute = infraBuilder.addRoute("c", "d");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                secondRoute, new OccupancyBlock(300, 600, 0, 100),
+                secondRoute, new OccupancyBlock(900, 1200, 0, 100),
+                secondRoute, new OccupancyBlock(1500, 1800, 0, 100),
+                thirdRoute, new OccupancyBlock(0, 1200, 0, 100),
+                thirdRoute, new OccupancyBlock(1500, POSITIVE_INFINITY, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                100,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 1)),
+                occupancyGraph,
+                2.
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+    }
+
+    /** Test that we don't enter infinite loops */
+    @Test
+    public void testImpossiblePathWithLoop() {
+        /*
+        a --> b
+        ^----/
+
+        x --> y
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstLoop = infraBuilder.addRoute("a", "b");
+        infraBuilder.addRoute("b", "a");
+        var disconnectedRoute = infraBuilder.addRoute("x", "y");
+        var infra = infraBuilder.build();
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                100,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstLoop, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(disconnectedRoute, 0)),
+                ImmutableMultimap.of(),
+                2.
+        );
+        assertNull(res);
+    }
+
+    /** Checks that the result don't cross in an occupied section */
+    private void occupancyTest(STDCMResult res, ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph) {
         var routes = res.trainPath().routePath();
-        for (var index = 1; index < routes.size(); index++) {
-            var endRoutePosition = routes.get(index).pathOffset();
-            var startRouteTime = res.departureTime();
-            var endRouteTime = res.departureTime() + res.envelope().interpolateTotalTime(endRoutePosition);
-            var routeOccupancies = occupancyGraph.get(routes.get(index - 1).element());
-            for (var occupancy:routeOccupancies) {
-                if ((occupancy.timeStart() < startRouteTime && startRouteTime < occupancy.timeEnd())
-                        || (occupancy.timeStart() < endRouteTime && endRouteTime < occupancy.timeEnd())) {
-                    return false;
-                }
+        for (var index = 0; index < routes.size(); index++) {
+            var startRoutePosition = routes.get(index).pathOffset();
+            var routeOccupancies = occupancyGraph.get(routes.get(index).element());
+            for (var occupancy : routeOccupancies) {
+                var enterTime = res.departureTime() + res.envelope().interpolateTotalTimeClamp(
+                        startRoutePosition + occupancy.distanceStart()
+                );
+                var exitTime = res.departureTime() + res.envelope().interpolateTotalTimeClamp(
+                        startRoutePosition + occupancy.distanceEnd()
+                );
+                assertTrue(enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart());
             }
         }
-        return true;
     }
 }


### PR DESCRIPTION
List of changes:

* Change generic pathfinding so that objectives can be defined as lambda (edge equality isn't enough anymore)
* Change STDCM graph representation to enable one child edge per "opening" (interval between two occupied blocks)
* Many new tests (most of the diff is located here)
* Change fuzzer to sometimes generate STDCM requests
* Fix bugs detected by the fuzzer (mostly related to float inaccuracies)