### PR TITLE
adapt async logic

### DIFF
--- a/front/src/applications/stdcm/getStdcmTimetable.js
+++ b/front/src/applications/stdcm/getStdcmTimetable.js
@@ -1,0 +1,74 @@
+import { get } from 'common/requests';
+import { setFailure } from 'reducers/main';
+import {
+  updateAllowancesSettings,
+  updateSelectedProjection,
+  updateSelectedTrain,
+  updateSimulation,
+} from 'reducers/osrdsimulation';
+import { trainscheduleURI } from 'applications/osrd/components/Simulation/consts';
+import { timetableURI } from 'applications/osrd/views/OSRDSimulation/OSRDSimulation';
+/**
+ * Recover the time table for all the trains
+ */
+export default async function getStdcmTimetable(
+  simulation,
+  selectedTrain,
+  dispatch,
+  timetableID,
+  allowancesSettings,
+  selectedProjection,
+  t,
+  tempProjectedPathId
+) {
+  try {
+    if (!simulation.trains || !simulation.trains[selectedTrain]) {
+      dispatch(updateSelectedTrain(0));
+    }
+    const timetable = await get(`${timetableURI}${timetableID}/`);
+    /*
+    if (timetable.train_schedules.length > 0) {
+      setIsEmpty(false);
+    }
+    */
+    const trainSchedulesIDs = timetable.train_schedules.map((train) => train.id);
+    const tempSelectedProjection = await get(`${trainscheduleURI}${trainSchedulesIDs[0]}/`);
+    if (!selectedProjection) {
+      dispatch(updateSelectedProjection(tempSelectedProjection));
+    }
+    try {
+      const simulationLocal = await get(`${trainscheduleURI}results/`, {
+        train_ids: trainSchedulesIDs.join(','),
+        path: tempProjectedPathId || tempSelectedProjection.path,
+      });
+      simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);
+      dispatch(updateSimulation({ trains: simulationLocal }));
+
+      // Create margins settings for each train if not set
+      const newAllowancesSettings = { ...allowancesSettings };
+      simulationLocal.forEach((train) => {
+        if (!newAllowancesSettings[train.id]) {
+          newAllowancesSettings[train.id] = {
+            base: true,
+            baseBlocks: true,
+            eco: true,
+            ecoBlocks: false,
+          };
+        }
+      });
+      dispatch(updateAllowancesSettings(newAllowancesSettings));
+    } catch (e) {
+      dispatch(
+        setFailure({
+          name: t('simulation:errorMessages.unableToRetrieveTrainSchedule'),
+          message: `${e.message} `,
+        })
+      );
+      console.log('ERROR', e);
+    }
+  } catch (e) {
+    console.log('ERROR', e);
+  }
+};
+
+

--- a/front/src/applications/stdcm/views/OSRDStdcmResults.js
+++ b/front/src/applications/stdcm/views/OSRDStdcmResults.js
@@ -1,19 +1,13 @@
 import 'applications/osrd/views/OSRDSimulation/OSRDSimulation.scss';
 import 'applications/osrd/views/OSRDConfig/OSRDConfig.scss';
 
-import {
-  KEY_VALUES_FOR_CONSOLIDATED_SIMULATION,
-  timetableURI,
-} from 'applications/osrd/views/OSRDSimulation/OSRDSimulation';
-import { trainscheduleURI } from 'applications/osrd/components/Simulation/consts';
+import { KEY_VALUES_FOR_CONSOLIDATED_SIMULATION } from 'applications/osrd/views/OSRDSimulation/OSRDSimulation';
 
 import React, { useEffect, useState } from 'react';
 import {
-  updateAllowancesSettings,
   updateConsolidatedSimulation,
   updateMustRedraw,
   updateSelectedProjection,
-  updateSelectedTrain,
   updateSimulation,
 } from 'reducers/osrdsimulation';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,72 +16,19 @@ import SpaceTimeChart from 'applications/osrd/views/OSRDSimulation/SpaceTimeChar
 import SpeedSpaceChart from 'applications/osrd/views/OSRDSimulation/SpeedSpaceChart';
 import TimeTable from 'applications/osrd/views/OSRDSimulation/TimeTable';
 import createTrain from 'applications/osrd/components/Simulation/SpaceTimeChart/createTrain';
-import { get } from 'common/requests';
-import { setFailure } from 'reducers/main';
+
 import { STDCM_REQUEST_STATUS } from 'applications/osrd/consts';
 import { useTranslation } from 'react-i18next';
+import getStdcmTimetable from 'applications/stdcm/getStdcmTimetable';
 
 export default function OSRDStcdmResults(props) {
   const { selectedTrain } = useSelector((state) => state.osrdsimulation);
   const simulation = useSelector((state) => state.osrdsimulation.simulation.present);
   const { timetableID } = useSelector((state) => state.osrdconf);
   const { t } = useTranslation(['translation', 'osrdconf']);
-  const [, setIsEmpty] = useState(true);
   const { currentStdcmRequestStatus } = props;
   const { allowancesSettings, selectedProjection } = useSelector((state) => state.osrdsimulation);
   const dispatch = useDispatch();
-
-  /**
-   * Recover the time table for all the trains
-   */
-  const getTimetable = async () => {
-    try {
-      if (!simulation.trains || !simulation.trains[selectedTrain]) {
-        dispatch(updateSelectedTrain(0));
-      }
-      const timetable = await get(`${timetableURI}${timetableID}/`);
-      if (timetable.train_schedules.length > 0) {
-        setIsEmpty(false);
-      }
-      const trainSchedulesIDs = timetable.train_schedules.map((train) => train.id);
-      const tempSelectedProjection = await get(`${trainscheduleURI}${trainSchedulesIDs[0]}/`);
-      if (!selectedProjection) {
-        dispatch(updateSelectedProjection(tempSelectedProjection));
-      }
-      try {
-        const simulationLocal = await get(`${trainscheduleURI}results/`, {
-          train_ids: trainSchedulesIDs.join(','),
-          path: tempSelectedProjection.path,
-        });
-        simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);
-        dispatch(updateSimulation({ trains: simulationLocal }));
-
-        // Create margins settings for each train if not set
-        const newAllowancesSettings = { ...allowancesSettings };
-        simulationLocal.forEach((train) => {
-          if (!newAllowancesSettings[train.id]) {
-            newAllowancesSettings[train.id] = {
-              base: true,
-              baseBlocks: true,
-              eco: true,
-              ecoBlocks: false,
-            };
-          }
-        });
-        dispatch(updateAllowancesSettings(newAllowancesSettings));
-      } catch (e) {
-        dispatch(
-          setFailure({
-            name: t('simulation:errorMessages.unableToRetrieveTrainSchedule'),
-            message: `${e.message} `,
-          })
-        );
-        console.log('ERROR', e);
-      }
-    } catch (e) {
-      console.log('ERROR', e);
-    }
-  };
 
   // With this hook we update and store
   // the consolidatedSimuation (simualtion stucture for the selected train)
@@ -107,7 +48,15 @@ export default function OSRDStcdmResults(props) {
     // Setup the listener to undi /redo
     // window.addEventListener('keydown', handleKey);
 
-    getTimetable();
+    getStdcmTimetable(
+      simulation,
+      selectedTrain,
+      dispatch,
+      timetableID,
+      allowancesSettings,
+      selectedProjection,
+      t
+    );
     return function cleanup() {
       // window.removeEventListener('keydown', handleKey);
       dispatch(updateSelectedProjection(undefined));

--- a/front/src/applications/stdcm/views/StdcmRequestModal.js
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.js
@@ -75,7 +75,9 @@ export default function StdcmRequestModal(props) {
             })
           );
 
-          const trainSchedulesIDs = simulation.trains.map((train) => train.id);
+          const trainSchedulesIDs = simulation.trains
+            .filter((train) => !train.isStdcm)
+            .map((train) => train.id);
 
           // ask for timetable with the new path
 
@@ -85,10 +87,6 @@ export default function StdcmRequestModal(props) {
           }).then((simulationLocal) => {
             const newSimulation = {};
             newSimulation.trains = [...simulationLocal];
-            const indexOfExistingStdcm = newSimulation.trains.findIndex(
-              (train) => train.id === fakedNewTrain.id
-            );
-            if (indexOfExistingStdcm !== -1) newSimulation.trains.splice(indexOfExistingStdcm, 1);
             newSimulation.trains = [...newSimulation.trains, fakedNewTrain];
             const consolidatedSimulation = createTrain(
               dispatch,

--- a/front/src/applications/stdcm/views/StdcmRequestModal.js
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { get } from 'common/requests';
 // osrd Redux reducers
 import {
   updateAllowancesSettings,
@@ -27,6 +28,7 @@ import { setFailure } from 'reducers/main';
 import { STDCM_REQUEST_STATUS } from 'applications/osrd/consts';
 import { updateItinerary } from 'reducers/osrdconf';
 import { useTranslation } from 'react-i18next';
+import { trainscheduleURI } from 'applications/osrd/components/Simulation/consts';
 
 export default function StdcmRequestModal(props) {
   const { t } = useTranslation(['translation', 'osrdconf']);
@@ -73,45 +75,52 @@ export default function StdcmRequestModal(props) {
             })
           );
 
-          const newSimulation = { ...simulation };
-          newSimulation.trains = [...simulation.trains];
+          const trainSchedulesIDs = simulation.trains.map((train) => train.id);
 
-          const indexOfExistingStdcm = newSimulation.trains.findIndex(
-            (train) => train.id === fakedNewTrain.id
-          );
-          if (indexOfExistingStdcm !== -1) newSimulation.trains.splice(indexOfExistingStdcm, 1);
-          newSimulation.trains = [...newSimulation.trains, fakedNewTrain];
+          // ask for timetable with the new path
 
-          const newAllowancesSettings = { ...allowancesSettings };
+          get(`${trainscheduleURI}results/`, {
+            train_ids: trainSchedulesIDs.join(','),
+            path: result.path.id,
+          }).then((simulationLocal) => {
+            const newSimulation = {};
+            newSimulation.trains = [...simulationLocal];
+            const indexOfExistingStdcm = newSimulation.trains.findIndex(
+              (train) => train.id === fakedNewTrain.id
+            );
+            if (indexOfExistingStdcm !== -1) newSimulation.trains.splice(indexOfExistingStdcm, 1);
+            newSimulation.trains = [...newSimulation.trains, fakedNewTrain];
+            const consolidatedSimulation = createTrain(
+              dispatch,
+              KEY_VALUES_FOR_CONSOLIDATED_SIMULATION,
+              newSimulation.trains,
+              t
+            );
+            dispatch(updateConsolidatedSimulation(consolidatedSimulation));
+            dispatch(updateSimulation(newSimulation));
+            dispatch(updateSelectedTrain(newSimulation.trains.length - 1));
 
-          if (!newAllowancesSettings[fakedNewTrain.id]) {
-            newAllowancesSettings[fakedNewTrain.id] = {
-              base: true,
-              baseBlocks: true,
-              eco: true,
-              ecoBlocks: false,
-            };
-            dispatch(updateAllowancesSettings(newAllowancesSettings));
-          }
+            const newAllowancesSettings = { ...allowancesSettings };
 
-          dispatch(updateMustRedraw(true));
+            if (!newAllowancesSettings[fakedNewTrain.id]) {
+              newAllowancesSettings[fakedNewTrain.id] = {
+                base: true,
+                baseBlocks: true,
+                eco: true,
+                ecoBlocks: false,
+              };
+              dispatch(updateAllowancesSettings(newAllowancesSettings));
+            }
 
-          const consolidatedSimulation = createTrain(
-            dispatch,
-            KEY_VALUES_FOR_CONSOLIDATED_SIMULATION,
-            newSimulation.trains,
-            t
-          );
-          dispatch(updateConsolidatedSimulation(consolidatedSimulation));
-          dispatch(updateSimulation(newSimulation));
-          dispatch(updateSelectedTrain(newSimulation.trains.length - 1));
+            dispatch(
+              updateSelectedProjection({
+                id: fakedNewTrain.id,
+                path: result.path,
+              })
+            );
 
-          dispatch(
-            updateSelectedProjection({
-              id: fakedNewTrain.id,
-              path: result.path,
-            })
-          );
+            dispatch(updateMustRedraw(true));
+          });
         })
         .catch((e) => {
           // Update simu in redux with data;


### PR DESCRIPTION
After creating a stdcm on a different path: the projection on GET is correct

warning: range on GEV is not ok, refresh manually. It was a preexisting bug, prefer to isolate the component first