### PR TITLE
core: stdcm: use the path with shortest arrival time

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMGraph.java
@@ -244,7 +244,12 @@ public class STDCMGraph implements Graph<STDCMGraph.Node, STDCMGraph.Edge> {
     }
 
     /** Returns the time at which the offset on the given route is reached */
-    private double interpolateTime(Envelope envelope, SignalingRoute route, double routeOffset, double startTime) {
+    public static double interpolateTime(
+            Envelope envelope,
+            SignalingRoute route,
+            double routeOffset,
+            double startTime
+    ) {
         var routeLength = route.getInfraRoute().getLength();
         var envelopeStartOffset = routeLength - envelope.getEndPos();
         var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMPathfinding.java
@@ -70,7 +70,7 @@ public class STDCMPathfinding {
         var envelope = range.edge().envelope();
         var timeStart = STDCMGraph.interpolateTime(envelope, range.edge().route(), range.start(), 0);
         var timeEnd = STDCMGraph.interpolateTime(envelope, range.edge().route(), range.end(), 0);
-        return timeEnd - timeStart;
+        return timeEnd - timeStart + range.edge().addedDelay();
     }
 
     private static AStarHeuristic<STDCMGraph.Edge> makeAStarHeuristic(

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/EdgeRangeCost.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/EdgeRangeCost.java
@@ -1,0 +1,8 @@
+package fr.sncf.osrd.utils.graph.functional_interfaces;
+
+import fr.sncf.osrd.utils.graph.Pathfinding;
+
+@FunctionalInterface
+public interface EdgeRangeCost<EdgeT> {
+    double apply(Pathfinding.EdgeRange<EdgeT> range);
+}


### PR DESCRIPTION
* Add a parameter to the generic pathfiding, letting us changing how we define the cost of an edge
* Set this parameter in the STDCM call to use time instead of distance
* Adapt the A* heuristic to use time
* Add a couple tests