### PR TITLE
core: suppress warnings appearing in newer jdk versions

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
@@ -41,6 +41,7 @@ public class ExceptionHandler {
     }
 
     /** Wraps an assertion error as an OSRDError, to report the stack trace with the same formatting as other errors */
+    @SuppressWarnings("serial") // Removes the warning about List not being serializable
     public static class AssertWrapper extends OSRDError {
         public static final String osrdErrorType = "assert_error";
         private static final long serialVersionUID = 1662852082101020410L;

--- a/core/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
+++ b/core/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.reporting.exceptions;
 import com.squareup.moshi.JsonAdapter;
 import fr.sncf.osrd.reporting.ErrorContext;
 import fr.sncf.osrd.utils.Reflection;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +24,10 @@ import java.util.List;
  * }
  * </pre>
  */
+@SuppressWarnings("serial") // Removes the warning about List not being serializable (moshi doesn't support ArrayList)
 public abstract class OSRDError extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1197516372515951853L;
 
     public static final String osrdErrorType = "core";

--- a/core/src/main/java/fr/sncf/osrd/reporting/warnings/DiagnosticError.java
+++ b/core/src/main/java/fr/sncf/osrd/reporting/warnings/DiagnosticError.java
@@ -4,6 +4,7 @@ import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import java.io.Serial;
 import java.util.List;
 
+@SuppressWarnings("serial") // Removes the warning about List not being serializable (moshi doesn't support ArrayList)
 public class DiagnosticError extends OSRDError {
     @Serial
     private static final long serialVersionUID = -6160787914977591307L;


### PR DESCRIPTION
This causes errors in newer versions of JDKs, Lists are not serializable anymore but ArrayLists are