### PR TITLE
stdcm: refactor of STDCMGraph

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
@@ -1,0 +1,132 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceConvergenceException;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/** This class contains all the methods used to handle allowances.
+ * This is how we add delays in limited ranges of the path.
+ * */
+public class AllowanceManager {
+
+    private final STDCMGraph graph;
+
+    public AllowanceManager(STDCMGraph graph) {
+        this.graph = graph;
+    }
+
+    /** Try to run an engineering allowance on the routes leading to the given edge. Returns null if it failed. */
+    public STDCMEdge tryEngineeringAllowance(
+            STDCMEdge oldEdge
+    ) {
+        var neededDelay = -oldEdge.maximumAddedDelayAfter();
+        assert neededDelay > 0;
+        if (oldEdge.previousNode() == null)
+            return null; // The conflict happens on the first route, we can't add delay here
+        var affectedEdges = findAffectedEdges(
+                oldEdge.previousNode().previousEdge(),
+                oldEdge.addedDelay()
+        );
+        if (affectedEdges.isEmpty())
+            return null; // No space to try the allowance
+        var context = makeAllowanceContext(affectedEdges);
+        var oldEnvelope = STDCMUtils.mergeEnvelopes(affectedEdges);
+        var newEnvelope = findAllowance(context, oldEnvelope, neededDelay);
+        if (newEnvelope == null)
+            return null; // We couldn't find an envelope
+        var newPreviousEdge = makeNewEdges(affectedEdges, newEnvelope);
+        if (newPreviousEdge == null)
+            return null; // The new edges are invalid, conflicts shouldn't happen here but it can be too slow
+        var newPreviousNode = newPreviousEdge.getEdgeEnd(graph);
+        return STDCMEdgeBuilder.fromNode(graph, newPreviousNode, oldEdge.route())
+                .findEdgeSameNextOccupancy(oldEdge.timeNextOccupancy());
+    }
+
+    /** Re-create the edges in order, following the given envelope. */
+    private STDCMEdge makeNewEdges(List<STDCMEdge> edges, Envelope totalEnvelope) {
+        double previousEnd = 0;
+        STDCMEdge prevEdge = null;
+        if (edges.get(0).previousNode() != null)
+            prevEdge = edges.get(0).previousNode().previousEdge();
+        for (var edge : edges) {
+            var end = previousEnd + edge.envelope().getEndPos();
+            var node = prevEdge == null ? null : prevEdge.getEdgeEnd(graph);
+            var maxAddedDelayAfter = edge.maximumAddedDelayAfter() + edge.addedDelay();
+            if (node != null)
+                maxAddedDelayAfter = node.maximumAddedDelay();
+            prevEdge = new STDCMEdgeBuilder(edge.route(), graph)
+                    .setStartTime(node == null ? edge.timeStart() : node.time())
+                    .setStartSpeed(edge.envelope().getBeginSpeed())
+                    .setStartOffset(edge.envelopeStartOffset())
+                    .setPrevMaximumAddedDelay(maxAddedDelayAfter)
+                    .setPrevAddedDelay(node == null ? 0 : node.totalPrevAddedDelay())
+                    .setPrevNode(node)
+                    .setEnvelope(extractEnvelopeSection(totalEnvelope, previousEnd, end))
+                    .setForceMaxDelay(true)
+                    .findEdgeSameNextOccupancy(edge.timeNextOccupancy());
+            if (prevEdge == null)
+                return null;
+            previousEnd = end;
+        }
+        assert Math.abs(previousEnd - totalEnvelope.getEndPos()) < 1e-5;
+        return prevEdge;
+    }
+
+    /** Returns a new envelope with the content of the base envelope from start to end, with 0 as first position */
+    private static Envelope extractEnvelopeSection(Envelope base, double start, double end) {
+        var parts = base.slice(start, end);
+        for (int i = 0; i < parts.length; i++)
+            parts[i] = parts[i].copyAndShift(-start);
+        return Envelope.make(parts);
+    }
+
+    /** Try to apply an allowance on the given envelope to add the given delay */
+    private Envelope findAllowance(EnvelopeSimContext context, Envelope oldEnvelope, double neededDelay) {
+        neededDelay += context.timeStep; // error margin for the dichotomy
+        var ranges = List.of(
+                new AllowanceRange(0, oldEnvelope.getEndPos(), new AllowanceValue.FixedTime(neededDelay))
+        );
+        var allowance = new MarecoAllowance(context, 0, oldEnvelope.getEndPos(), 0, ranges);
+        try {
+            return allowance.apply(oldEnvelope);
+        } catch (AllowanceConvergenceException e) {
+            return null;
+        }
+    }
+
+    /** Creates the EnvelopeSimContext to run an allowance on the given edges */
+    private EnvelopeSimContext makeAllowanceContext(List<STDCMEdge> edges) {
+        var routes = new ArrayList<SignalingRoute>();
+        var firstOffset = edges.get(0).route().getInfraRoute().getLength() - edges.get(0).envelope().getEndPos();
+        for (var edge : edges)
+            routes.add(edge.route());
+        return STDCMUtils.makeSimContext(routes, firstOffset, graph.rollingStock, graph.timeStep);
+    }
+
+    /** Find on which edges to run the allowance */
+    private List<STDCMEdge> findAffectedEdges(STDCMEdge edge, double delayNeeded) {
+        var res = new ArrayDeque<STDCMEdge>();
+        while (true) {
+            var endTime = edge.timeStart() + edge.envelope().getTotalTime();
+            var maxDelayAddedOnEdge = edge.timeNextOccupancy() - endTime;
+            if (delayNeeded > maxDelayAddedOnEdge) {
+                // We can't add delay in this route, the allowance range ends here (excluded)
+                return new ArrayList<>(res);
+            }
+            res.addFirst(edge);
+            if (edge.previousNode() == null) {
+                // We've reached the start of the path, this should only happen because of the max delay parameter
+                return new ArrayList<>(res);
+            }
+            delayNeeded += edge.addedDelay();
+            edge = edge.previousNode().previousEdge();
+        }
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
@@ -1,0 +1,116 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
+import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
+
+import fr.sncf.osrd.api.stdcm.BacktrackingEnvelopeAttr;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder;
+import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
+import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
+import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
+import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
+import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import java.util.List;
+
+/** This class contains all the methods used to backtrack in the graph.
+ * We need to backtrack to remove any kind of speed discontinuity, generally because of deceleration spanning over
+ * several edges.
+ * </p>
+ * A short explanation of how it's done: given nodes a, b, c, d
+ * If we compute the edge "c->d" and see that we need to go slower at the start of the node (e.g. because we stop here)
+ * We instantiate a new edge going from b to c, with the specified end speed. The predecessor of this new "b->c" edge
+ * will be set to be the existing "a->b" edge (if we don't need to backtrack any further).
+ * We can then create a new edge starting at c with the correct speed.
+ * */
+public class BacktrackingManager {
+
+    private final STDCMGraph graph;
+
+    public BacktrackingManager(STDCMGraph graph) {
+        this.graph = graph;
+    }
+
+    /** Given an edge that needs an envelope change in previous edges to avoid a discontinuity,
+     * returns an edge that has no discontinuity, going over the same route using the same opening.
+     * The given edge does not change but the previous ones are new instances with a different envelope.
+     * If no backtracking is needed, nothing is done and the edge is returned as it is.
+     * If the new edge is invalid (for example if it would cause conflicts), returns null. */
+    STDCMEdge backtrack(STDCMEdge e) {
+        if (e.previousNode() == null) {
+            // First edge of the path
+            assert e.envelope().getBeginSpeed() == 0;
+            return e;
+        }
+        if (e.previousNode().speed() == e.envelope().getBeginSpeed()) {
+            // No need to backtrack any further
+            return e;
+        }
+
+        // We try to create a new previous edge with the end speed we need
+        var previousEdge = e.previousNode().previousEdge();
+        var newPreviousEdge = rebuildEdgeBackward(previousEdge, e.envelope().getBeginSpeed());
+        if (newPreviousEdge == null)
+            return null; // No valid result was found
+
+        // Create the new edge
+        var newNode = newPreviousEdge.getEdgeEnd(graph);
+        return STDCMEdgeBuilder.fromNode(graph, newNode, e.route())
+                .setStartOffset(e.envelopeStartOffset())
+                .findEdgeSameNextOccupancy(e.timeNextOccupancy());
+    }
+
+    /** Recreate the edge, but with a different end speed. Returns null if no result is possible.
+     * </p>
+     * The new edge will use the same physical path as the old one, but with a different envelope and times.
+     * The train speed will be continuous from the start of the path,
+     * recursive calls are made when needed (through the EdgeBuilder).
+     * The start time and any data related to delays will be updated accordingly.
+     * */
+    private STDCMEdge rebuildEdgeBackward(STDCMEdge old, double endSpeed) {
+        var newEnvelope = simulateBackwards(old.route(), endSpeed, old.envelopeStartOffset(), old.envelope());
+        var prevNode = old.previousNode();
+        return new STDCMEdgeBuilder(old.route(), graph)
+                .setStartTime(old.timeStart() - old.addedDelay())
+                .setStartOffset(old.envelopeStartOffset())
+                .setPrevMaximumAddedDelay(old.maximumAddedDelayAfter() + old.addedDelay())
+                .setPrevNode(prevNode)
+                .setEnvelope(newEnvelope)
+                .findEdgeSameNextOccupancy(old.timeNextOccupancy());
+    }
+
+    /** Simulates a route that already has an envelope, but with a different end speed */
+    private Envelope simulateBackwards(
+            SignalingRoute route,
+            double endSpeed,
+            double start,
+            Envelope oldEnvelope
+    ) {
+        var context = STDCMUtils.makeSimContext(
+                List.of(route),
+                start,
+                graph.rollingStock,
+                graph.timeStep
+        );
+        var partBuilder = new EnvelopePartBuilder();
+        partBuilder.setAttr(EnvelopeProfile.BRAKING);
+        partBuilder.setAttr(new BacktrackingEnvelopeAttr());
+        var overlayBuilder = new ConstrainedEnvelopePartBuilder(
+                partBuilder,
+                new SpeedConstraint(0, FLOOR),
+                new EnvelopeConstraint(oldEnvelope, CEILING)
+        );
+        EnvelopeDeceleration.decelerate(
+                context,
+                oldEnvelope.getEndPos(),
+                endSpeed,
+                overlayBuilder,
+                -1
+        );
+        var builder = OverlayEnvelopeBuilder.backward(oldEnvelope);
+        builder.addPart(partBuilder.build());
+        return builder.build();
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
@@ -1,0 +1,110 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import com.google.common.collect.Multimap;
+import fr.sncf.osrd.api.stdcm.OccupancyBlock;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import java.util.HashSet;
+import java.util.Set;
+
+/** This class contains all the methods used to handle delays
+ * (how much we can add, how much we need to add, and such)
+ * */
+public class DelayManager {
+
+    public final double minScheduleTimeStart;
+    public final double maxRunTime;
+    private final Multimap<SignalingRoute, OccupancyBlock> unavailableTimes;
+
+    DelayManager(
+            double minScheduleTimeStart,
+            double maxRunTime,
+            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes
+    ) {
+        this.minScheduleTimeStart = minScheduleTimeStart;
+        this.maxRunTime = maxRunTime;
+        this.unavailableTimes = unavailableTimes;
+    }
+
+    /** Returns one value per "opening" (interval between two unavailable times).
+     * Always returns the shortest delay to add to enter this opening. */
+    Set<Double> minimumDelaysPerOpening(SignalingRoute route, double startTime, Envelope envelope) {
+        var res = new HashSet<Double>();
+        res.add(findMinimumAddedDelay(route, startTime, envelope));
+        for (var block : unavailableTimes.get(route)) {
+            var enterTime = STDCMUtils.interpolateTime(envelope, route, block.distanceStart(), startTime);
+            var diff = block.timeEnd() - enterTime;
+            if (diff < 0)
+                continue;
+            var time = diff + findMinimumAddedDelay(route, startTime + diff, envelope);
+            res.add(time);
+        }
+        return res;
+    }
+
+    /** Returns the start time of the next occupancy for the route (does not depend on the envelope) */
+    double findNextOccupancy(SignalingRoute route, double time) {
+        var earliest = Double.POSITIVE_INFINITY;
+        for (var occupancy : unavailableTimes.get(route)) {
+            var occupancyTime = occupancy.timeStart();
+            if (occupancyTime < time)
+                continue;
+            earliest = Math.min(earliest, occupancyTime);
+        }
+        return earliest;
+    }
+
+    /** Returns true if the total run time at the start of the edge is above the specified threshold */
+    boolean isRunTimeTooLong(STDCMEdge edge) {
+        var totalRunTime = edge.timeStart() - edge.totalDepartureTimeShift() - minScheduleTimeStart;
+        // We could use the A* heuristic here, but it would break STDCM on any infra where the
+        // coordinates don't match the actual distance (which is the case when generated).
+        // Ideally we should add a switch in the railjson format
+        return totalRunTime > maxRunTime;
+    }
+
+    /** Returns by how much we can shift this envelope (in time) before causing a conflict.
+     * </p>
+     * e.g. if the train takes 42s to go through the route, enters the route at t=10s,
+     * and we need to leave the route at t=60s, this will return 8s. */
+    double findMaximumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
+        var minValue = Double.POSITIVE_INFINITY;
+        for (var occupancy : unavailableTimes.get(route)) {
+            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
+            var exitTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
+            var margin = occupancy.timeStart() - exitTime;
+            if (margin < 0) {
+                // This occupancy block was before the train passage, we can ignore it
+                continue;
+            }
+            minValue = Math.min(minValue, margin);
+        }
+        return minValue;
+    }
+
+    /** Returns by how much delay we need to add to avoid causing a conflict.
+     * </p>
+     * e.g. if the whole route is occupied from t=0s to t=60s, and we enter the route at t=42s,
+     * this will return 18s. */
+    double findMinimumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
+        double maxValue = 0;
+        if (Double.isInfinite(startTime))
+            return 0;
+        for (var occupancy : unavailableTimes.get(route)) {
+            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
+            var enterTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceStart(), startTime);
+            var exitTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
+            if (enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart())
+                continue;
+            var diff = occupancy.timeEnd() - enterTime;
+            maxValue = Math.max(maxValue, diff);
+        }
+        if (maxValue == 0 || Double.isInfinite(maxValue))
+            return maxValue;
+
+        // We need a recursive call to see if we can fit a curve in the new position,
+        // or if we need to shift it further because of a different occupancy block
+        return maxValue + findMinimumAddedDelay(route, startTime + maxValue, envelope);
+    }
+
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdge.java
@@ -48,4 +48,16 @@ public record STDCMEdge(
                 timeNextOccupancy
         );
     }
+
+    /** Returns the node at the end of this edge */
+    STDCMNode getEdgeEnd(STDCMGraph graph) {
+        return new STDCMNode(
+                envelope().getTotalTime() + timeStart(),
+                envelope().getEndSpeed(),
+                graph.infra.getSignalingRouteGraph().incidentNodes(route()).nodeV(),
+                totalDepartureTimeShift(),
+                maximumAddedDelayAfter(),
+                this
+        );
+    }
 }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdge.java
@@ -21,7 +21,9 @@ public record STDCMEdge(
         // Total delay we have added by shifting the departure time since the start of the path
         double totalDepartureTimeShift,
         // Node located at the start of this edge, null if this is the first edge
-        STDCMNode previousNode
+        STDCMNode previousNode,
+        // Offset of the envelope if it doesn't start at the beginning of the edge
+        double envelopeStartOffset
 ) {
     @Override
     @SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
@@ -1,0 +1,194 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/** This class handles the creation of new edges, handling the many optional parameters. */
+public class STDCMEdgeBuilder {
+
+    /** STDCM Graph, needed for most operations */
+    private final STDCMGraph graph;
+
+    /** Route considered for the new edge(s) */
+    private final SignalingRoute route;
+
+    /** Start time of the edge */
+    private double startTime = 0;
+
+    /** Start speed, ignored if envelope is specified */
+    private double startSpeed = 0;
+
+    /** Start offset on the given route */
+    private double startOffset = 0;
+
+    /** Maximum delay we can add on any of the previous edges by shifting the departure time,
+     * without causing a conflict */
+    private double prevMaximumAddedDelay = 0;
+
+    /** Sum of all the delay that has been added in the previous edges by shifting the departure time */
+    private double prevAddedDelay = 0;
+
+    /** Previous node, used to compute the final path */
+    private STDCMNode prevNode = null;
+
+    /** Envelope to use on the edge, if unspecified we try to go at maximum allowed speed */
+    private Envelope envelope = null;
+
+    /** If set to true, we add the maximum amount of delay allowed by shifting the departure time.
+     * Used when computing allowances  */
+    private boolean forceMaxDelay = false;
+
+    // region CONSTRUCTORS
+
+    STDCMEdgeBuilder(SignalingRoute route, STDCMGraph graph) {
+        this.route = route;
+        this.graph = graph;
+    }
+
+    static STDCMEdgeBuilder fromNode(STDCMGraph graph, STDCMNode node, SignalingRoute route) {
+        assert route.getInfraRoute().getEntryDetector().equals(node.detector());
+        var builder = new STDCMEdgeBuilder(route, graph);
+        builder.startTime = node.time();
+        builder.startSpeed = node.speed();
+        builder.prevMaximumAddedDelay = node.maximumAddedDelay();
+        builder.prevAddedDelay = node.totalPrevAddedDelay();
+        builder.prevNode = node;
+        return builder;
+    }
+
+    // endregion CONSTRUCTORS
+
+    // region SETTERS
+
+    /** Sets the start time of the edge */
+    public STDCMEdgeBuilder setStartTime(double startTime) {
+        this.startTime = startTime;
+        return this;
+    }
+
+    /** Sets the start speed, ignored if the envelope has been specified */
+    public STDCMEdgeBuilder setStartSpeed(double startSpeed) {
+        this.startSpeed = startSpeed;
+        return this;
+    }
+
+    /** Start offset on the given route */
+    public STDCMEdgeBuilder setStartOffset(double startOffset) {
+        this.startOffset = startOffset;
+        return this;
+    }
+
+    /** Sets the maximum delay we can add on any of the previous edges by shifting the departure time */
+    public STDCMEdgeBuilder setPrevMaximumAddedDelay(double prevMaximumAddedDelay) {
+        this.prevMaximumAddedDelay = prevMaximumAddedDelay;
+        return this;
+    }
+
+    /** Sets the sum of all the delay that has been added in the previous edges by shifting the departure time */
+    public STDCMEdgeBuilder setPrevAddedDelay(double prevAddedDelay) {
+        this.prevAddedDelay = prevAddedDelay;
+        return this;
+    }
+
+    /** Sets the previous node, used to compute the final path */
+    public STDCMEdgeBuilder setPrevNode(STDCMNode prevNode) {
+        this.prevNode = prevNode;
+        return this;
+    }
+
+    /** Sets the envelope to use on the edge, if unspecified we try to go at maximum allowed speed */
+    public STDCMEdgeBuilder setEnvelope(Envelope envelope) {
+        this.envelope = envelope;
+        return this;
+    }
+
+    /** If set to true, we add the maximum amount of delay allowed by shifting the departure time.
+     * Used when computing allowances  */
+    public STDCMEdgeBuilder setForceMaxDelay(boolean forceMaxDelay) {
+        this.forceMaxDelay = forceMaxDelay;
+        return this;
+    }
+
+    // endregion SETTERS
+
+    // region BUILDERS
+
+    /** Creates all edges that can be accessed on the given route, using all the parameters specified. */
+    public Collection<STDCMEdge> makeAllEdges() {
+        if (envelope == null)
+            envelope = STDCMUtils.simulateRoute(
+                    route,
+                    startSpeed,
+                    startOffset,
+                    graph.rollingStock,
+                    graph.timeStep,
+                    STDCMUtils.getStopsOnRoute(graph, route, startOffset)
+            );
+        if (envelope == null)
+            return List.of();
+        var res = new ArrayList<STDCMEdge>();
+        Set<Double> delaysPerOpening;
+        if (forceMaxDelay)
+            delaysPerOpening = Set.of(Math.min(
+                    prevMaximumAddedDelay,
+                    graph.delayManager.findMaximumAddedDelay(route, startTime, envelope))
+            );
+        else
+            delaysPerOpening = graph.delayManager.minimumDelaysPerOpening(route, startTime, envelope);
+        for (var delayNeeded : delaysPerOpening) {
+            var newEdge = makeSingleEdge(delayNeeded);
+            if (newEdge != null)
+                res.add(newEdge);
+        }
+        return res;
+    }
+
+    /** Creates a single STDCM edge, adding the given amount of delay */
+    private STDCMEdge makeSingleEdge(double delayNeeded) {
+        if (Double.isInfinite(delayNeeded))
+            return null;
+        var maximumDelay = Math.min(
+                prevMaximumAddedDelay - delayNeeded,
+                graph.delayManager.findMaximumAddedDelay(route, startTime + delayNeeded, envelope)
+        );
+        var newEdge = new STDCMEdge(
+                route,
+                envelope,
+                startTime + delayNeeded,
+                maximumDelay,
+                delayNeeded,
+                graph.delayManager.findNextOccupancy(route, startTime + delayNeeded),
+                prevAddedDelay + delayNeeded,
+                prevNode,
+                route.getInfraRoute().getLength() - envelope.getEndPos()
+        );
+        if (maximumDelay < 0) {
+            // We need to make the train go slower
+            newEdge = graph.allowanceManager.tryEngineeringAllowance(newEdge);
+            if (newEdge == null)
+                return null;
+        }
+        newEdge = graph.backtrackingManager.backtrack(newEdge); // Fixes any speed discontinuity
+        if (newEdge == null || graph.delayManager.isRunTimeTooLong(newEdge))
+            return null;
+        return newEdge;
+    }
+
+    /** Creates all the edges in the given settings, then look for one that shares the given time of next occupancy.
+     * This is used to identify the "openings" between two occupancies,
+     * it is used to ensure we use the same one when re-building edges. */
+    STDCMEdge findEdgeSameNextOccupancy(double timeNextOccupancy) {
+        var newEdges = makeAllEdges();
+        // We look for an edge that uses the same opening, identified by the next occupancy
+        for (var newEdge : newEdges)
+            if (newEdge.timeNextOccupancy() == timeNextOccupancy)
+                return newEdge;
+        return null; // No result was found
+    }
+
+    // endregion BUILDERS
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
@@ -1,53 +1,33 @@
 package fr.sncf.osrd.api.stdcm.graph;
 
-import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
-import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
-
 import com.google.common.collect.Multimap;
-import com.google.common.primitives.Doubles;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.api.stdcm.BacktrackingEnvelopeAttr;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
-import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder;
-import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
-import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
-import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
-import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
-import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.ImpossibleSimulationError;
-import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceConvergenceException;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
-import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
-import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Graph;
 import fr.sncf.osrd.utils.graph.Pathfinding;
-import java.util.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 
-/** This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding implementation. */
+/** This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding implementation.
+ * Most of the logic has been delegated to helper classes in this module:
+ * AllowanceManager handles adding delays using allowances,
+ * BacktrackingManager handles backtracking to fix speed discontinuities,
+ * DelayManager handles how much delay we can and need to add to avoid conflicts,
+ * STDCMEdgeBuilder handles the creation of new STDCMEdge instances */
 @SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})
 public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
 
     public final SignalingInfra infra;
     public final RollingStock rollingStock;
     public final double timeStep;
-    public final double maxRunTime;
-    public final double minScheduleTimeStart;
-    private final Multimap<SignalingRoute, OccupancyBlock> unavailableTimes;
-    private final Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations;
+    final Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations;
+    final DelayManager delayManager;
+    final AllowanceManager allowanceManager;
+    final BacktrackingManager backtrackingManager;
 
     /** Constructor */
     public STDCMGraph(
@@ -62,22 +42,15 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         this.infra = infra;
         this.rollingStock = rollingStock;
         this.timeStep = timeStep;
-        this.unavailableTimes = unavailableTimes;
-        this.maxRunTime = maxRunTime;
-        this.minScheduleTimeStart = minScheduleTimeStart;
         this.endLocations = endLocations;
+        this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, unavailableTimes);
+        this.allowanceManager = new AllowanceManager(this);
+        this.backtrackingManager = new BacktrackingManager(this);
     }
 
     @Override
     public STDCMNode getEdgeEnd(STDCMEdge edge) {
-        return new STDCMNode(
-                edge.envelope().getTotalTime() + edge.timeStart(),
-                edge.envelope().getEndSpeed(),
-                infra.getSignalingRouteGraph().incidentNodes(edge.route()).nodeV(),
-                edge.totalDepartureTimeShift(),
-                edge.maximumAddedDelayAfter(),
-                edge
-        );
+        return edge.getEdgeEnd(this);
     }
 
     @Override
@@ -85,514 +58,11 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         var res = new ArrayList<STDCMEdge>();
         var neighbors = infra.getSignalingRouteGraph().outEdges(node.detector());
         for (var neighbor : neighbors) {
-            res.addAll(makeEdges(
-                    neighbor,
-                    node.time(),
-                    node.speed(),
-                    0,
-                    node.maximumAddedDelay(),
-                    node.totalPrevAddedDelay(),
-                    node,
-                    null,
-                    false
-            ));
+            res.addAll(
+                    STDCMEdgeBuilder.fromNode(this, node, neighbor)
+                            .makeAllEdges()
+            );
         }
         return res;
     }
-
-    /** Creates all edges that can be accessed from a given route and start time/speed.
-     * This is public because it is used to initialize the first edges for the pathfinding */
-    public Collection<STDCMEdge> makeEdges(
-            SignalingRoute route,
-            double startTime,
-            double startSpeed,
-            double start,
-            double prevMaximumAddedDelay,
-            double prevAddedDelay,
-            STDCMNode node,
-            Envelope envelope,
-            boolean forceMaxDelay
-    ) {
-        if (envelope == null)
-            envelope = simulateRoute(route, startSpeed, start, rollingStock, timeStep, getStopsOnRoute(route, start));
-        if (envelope == null)
-            return List.of();
-        var res = new ArrayList<STDCMEdge>();
-        Set<Double> delaysPerOpening;
-        if (forceMaxDelay)
-            delaysPerOpening = Set.of(Math.min(
-                    prevMaximumAddedDelay,
-                    findMaximumAddedDelay(route, startTime, envelope))
-            );
-        else
-            delaysPerOpening = minimumDelaysPerOpening(route, startTime, envelope);
-        for (var delayNeeded : delaysPerOpening) {
-            var newEdge = createSingleEdge(
-                    prevMaximumAddedDelay,
-                    prevAddedDelay,
-                    node,
-                    delayNeeded,
-                    route,
-                    envelope,
-                    startTime
-            );
-            if (newEdge != null)
-                res.add(newEdge);
-        }
-        return res;
-    }
-
-    /** Creates an STDCM edge */
-    private STDCMEdge createSingleEdge(
-            double prevMaximumAddedDelay,
-            double prevAddedDelay,
-            STDCMNode node,
-            Double delayNeeded,
-            SignalingRoute route,
-            Envelope envelope,
-            double startTime
-    ) {
-        if (delayNeeded.isInfinite())
-            return null;
-        var maximumDelay = Math.min(
-                prevMaximumAddedDelay - delayNeeded,
-                findMaximumAddedDelay(route, startTime + delayNeeded, envelope)
-        );
-        var newEdge = new STDCMEdge(
-                route,
-                envelope,
-                startTime + delayNeeded,
-                maximumDelay,
-                delayNeeded,
-                findNextOccupancy(route, startTime + delayNeeded),
-                prevAddedDelay + delayNeeded,
-                node,
-                route.getInfraRoute().getLength() - envelope.getEndPos()
-        );
-        if (maximumDelay < 0) {
-            // We need to make the train go slower
-            newEdge = tryEngineeringAllowance(newEdge);
-            if (newEdge == null)
-                return null;
-        }
-        newEdge = backtrack(newEdge); // Fixes any speed discontinuity
-        if (newEdge == null || isRunTimeTooLong(newEdge))
-            return null;
-        return newEdge;
-    }
-
-    // region DELAY MANAGEMENT
-
-    /** Returns one value per "opening" (interval between two unavailable times).
-     * Always returns the shortest delay to add to enter this opening. */
-    private Set<Double> minimumDelaysPerOpening(SignalingRoute route, double startTime, Envelope envelope) {
-        var res = new HashSet<Double>();
-        res.add(findMinimumAddedDelay(route, startTime, envelope));
-        for (var block : unavailableTimes.get(route)) {
-            var enterTime = interpolateTime(envelope, route, block.distanceStart(), startTime);
-            var diff = block.timeEnd() - enterTime;
-            if (diff < 0)
-                continue;
-            var time = diff + findMinimumAddedDelay(route, startTime + diff, envelope);
-            res.add(time);
-        }
-        return res;
-    }
-
-    /** Returns the start time of the next occupancy for the route (does not depend on the envelope) */
-    private double findNextOccupancy(SignalingRoute route, double time) {
-        var earliest = Double.POSITIVE_INFINITY;
-        for (var occupancy : unavailableTimes.get(route)) {
-            var occupancyTime = occupancy.timeStart();
-            if (occupancyTime < time)
-                continue;
-            earliest = Math.min(earliest, occupancyTime);
-        }
-        return earliest;
-    }
-
-    /** Returns true if the total run time at the start of the edge is above the specified threshold */
-    private boolean isRunTimeTooLong(STDCMEdge edge) {
-        var totalRunTime = edge.timeStart() - edge.totalDepartureTimeShift() - minScheduleTimeStart;
-        // We could use the A* heuristic here, but it would break STDCM on any infra where the
-        // coordinates don't match the actual distance (which is the case when generated).
-        // Ideally we should add a switch in the railjson format
-        return totalRunTime > maxRunTime;
-    }
-
-    /** Returns by how much we can shift this envelope (in time) before causing a conflict.
-     * </p>
-     * e.g. if the train takes 42s to go through the route, enters the route at t=10s,
-     * and we need to leave the route at t=60s, this will return 8s. */
-    private double findMaximumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
-        var minValue = Double.POSITIVE_INFINITY;
-        for (var occupancy : unavailableTimes.get(route)) {
-            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var exitTime = interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
-            var margin = occupancy.timeStart() - exitTime;
-            if (margin < 0) {
-                // This occupancy block was before the train passage, we can ignore it
-                continue;
-            }
-            minValue = Math.min(minValue, margin);
-        }
-        return minValue;
-    }
-
-    /** Returns by how much delay we need to add to avoid causing a conflict.
-     * </p>
-     * e.g. if the whole route is occupied from t=0s to t=60s, and we enter the route at t=42s,
-     * this will return 18s. */
-    private double findMinimumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
-        double maxValue = 0;
-        if (Double.isInfinite(startTime))
-            return 0;
-        for (var occupancy : unavailableTimes.get(route)) {
-            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var enterTime = interpolateTime(envelope, route, occupancy.distanceStart(), startTime);
-            var exitTime = interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
-            if (enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart())
-                continue;
-            var diff = occupancy.timeEnd() - enterTime;
-            maxValue = Math.max(maxValue, diff);
-        }
-        if (maxValue == 0 || Double.isInfinite(maxValue))
-            return maxValue;
-
-        // We need a recursive call to see if we can fit a curve in the new position,
-        // or if we need to shift it further because of a different occupancy block
-        return maxValue + findMinimumAddedDelay(route, startTime + maxValue, envelope);
-    }
-
-    // endregion // DELAY MANAGEMENT
-
-    // region BACKTRACKING
-
-    /** Given an edge that needs an envelope change in previous edges to avoid a discontinuity,
-     * returns an edge that has no discontinuity.
-     * The given edge does not change but the previous ones are new instances with a different envelope.
-     * If no backtracking is needed, nothing is done and the edge is returned as it is.
-     * If the new edge is invalid, returns null. */
-    private STDCMEdge backtrack(STDCMEdge e) {
-        if (e.previousNode() == null) {
-            // First edge of the path
-            assert e.envelope().getBeginSpeed() == 0;
-            return e;
-        }
-        if (e.previousNode().speed() == e.envelope().getBeginSpeed()) {
-            // No need to backtrack any further
-            return e;
-        }
-
-        // We try to create a new previous edge with the end speed we need
-        var previousEdge = e.previousNode().previousEdge();
-        var newPreviousEdge = rebuildEdgeBackward(previousEdge, e.envelope().getBeginSpeed());
-        if (newPreviousEdge == null)
-            return null; // No valid result was found
-
-        // Create the new edge
-        var newNode = getEdgeEnd(newPreviousEdge);
-        return findEdgeSameNextOccupancy(
-                e.route(),
-                newNode.time(),
-                newNode.speed(),
-                e.envelopeStartOffset(),
-                newNode.maximumAddedDelay(),
-                newNode.totalPrevAddedDelay(),
-                newNode,
-                null,
-                e.timeNextOccupancy(),
-                false
-        );
-    }
-
-    /** Recreate the edge, but with a different end speed. Returns null if no result is possible.
-     * </p>
-     * The new edge will use the same physical path as the old one, but with a different envelope and times.
-     * The train speed will be continuous from the start of the path,
-     * recursive calls are made when needed (through makeEdges).
-     * The start time and any data related to delays will be updated accordingly.
-     * */
-    private STDCMEdge rebuildEdgeBackward(STDCMEdge old, double endSpeed) {
-        var newEnvelope = simulateBackwards(old.route(), endSpeed, old.envelopeStartOffset(), old.envelope());
-        var prevNode = old.previousNode();
-        return findEdgeSameNextOccupancy(
-                old.route(),
-                old.timeStart() - old.addedDelay(),
-                Double.NaN,
-                old.envelopeStartOffset(),
-                old.maximumAddedDelayAfter() + old.addedDelay(),
-                prevNode == null ? 0 : prevNode.totalPrevAddedDelay(),
-                prevNode,
-                newEnvelope,
-                old.timeNextOccupancy(),
-                false
-        );
-    }
-
-    /** Simulates a route that already has an envelope, but with a different end speed */
-    private Envelope simulateBackwards(
-            SignalingRoute route,
-            double endSpeed,
-            double start,
-            Envelope oldEnvelope
-    ) {
-        var context = makeSimContext(List.of(route), start, rollingStock, timeStep);
-        var partBuilder = new EnvelopePartBuilder();
-        partBuilder.setAttr(EnvelopeProfile.BRAKING);
-        partBuilder.setAttr(new BacktrackingEnvelopeAttr());
-        var overlayBuilder = new ConstrainedEnvelopePartBuilder(
-                partBuilder,
-                new SpeedConstraint(0, FLOOR),
-                new EnvelopeConstraint(oldEnvelope, CEILING)
-        );
-        EnvelopeDeceleration.decelerate(
-                context,
-                oldEnvelope.getEndPos(),
-                endSpeed,
-                overlayBuilder,
-                -1
-        );
-        var builder = OverlayEnvelopeBuilder.backward(oldEnvelope);
-        builder.addPart(partBuilder.build());
-        return builder.build();
-    }
-
-    // endregion // BACKTRACKING
-
-    // region UTILS
-
-    /** Create an EnvelopeSimContext instance from the route and extra parameters */
-    private static EnvelopeSimContext makeSimContext(
-            List<SignalingRoute> routes,
-            double offsetFirstRoute,
-            RollingStock rollingStock,
-            double timeStep
-    ) {
-        var tracks = new ArrayList<TrackRangeView>();
-        for (var route : routes) {
-            var routeLength = route.getInfraRoute().getLength();
-            tracks.addAll(route.getInfraRoute().getTrackRanges(offsetFirstRoute, routeLength));
-            offsetFirstRoute = 0;
-        }
-        var envelopePath = EnvelopeTrainPath.from(tracks);
-        return new EnvelopeSimContext(rollingStock, envelopePath, timeStep);
-    }
-
-    /** Returns an envelope matching the given route. The envelope time starts when the train enters the route.
-     *
-     * </p>
-     * Note: there are some approximations made here as we only "see" the tracks on the given routes.
-     * We are missing slopes and speed limits from earlier in the path.
-     * </p>
-     * This is public because it helps when writing unit tests. */
-    public static Envelope simulateRoute(
-            SignalingRoute route,
-            double initialSpeed,
-            double start,
-            RollingStock rollingStock,
-            double timeStep,
-            double[] stops
-    ) {
-        try {
-            var context = makeSimContext(List.of(route), start, rollingStock, timeStep);
-            var mrsp = MRSP.from(
-                    route.getInfraRoute().getTrackRanges(start, start + context.path.getLength()),
-                    rollingStock,
-                    false,
-                    Set.of()
-            );
-            var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
-            return MaxEffortEnvelope.from(context, initialSpeed, maxSpeedEnvelope);
-        } catch (ImpossibleSimulationError e) {
-            // This can happen when the train can't go through this part,
-            // for example because of high slopes with a "weak" rolling stock
-            return null;
-        }
-    }
-
-    /** Returns the offset of the stops on the given route, starting at startOffset*/
-    private double[] getStopsOnRoute(SignalingRoute route, double startOffset) {
-        var res = new ArrayList<Double>();
-        for (var endLocation : endLocations) {
-            if (endLocation.edge() == route) {
-                var offset = endLocation.offset() - startOffset;
-                if (offset >= 0)
-                    res.add(offset);
-            }
-        }
-        return Doubles.toArray(res);
-    }
-
-    /** Returns the time at which the offset on the given route is reached */
-    public static double interpolateTime(
-            Envelope envelope,
-            SignalingRoute route,
-            double routeOffset,
-            double startTime
-    ) {
-        var routeLength = route.getInfraRoute().getLength();
-        var envelopeStartOffset = routeLength - envelope.getEndPos();
-        var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);
-        assert envelopeOffset <= envelope.getEndPos();
-        return startTime + envelope.interpolateTotalTime(envelopeOffset);
-    }
-
-    /** Calls `makeEdges` with the same parameters, and look for a result with the specified time of next occupancy */
-    private STDCMEdge findEdgeSameNextOccupancy(
-            SignalingRoute route,
-            double startTime,
-            double startSpeed,
-            double start,
-            double prevMaximumAddedDelay,
-            double prevAddedDelay,
-            STDCMNode node,
-            Envelope envelope,
-            double timeNextOccupancy,
-            boolean forceMaxDelay
-    ) {
-        var newEdges = makeEdges(
-                route,
-                startTime,
-                startSpeed,
-                start,
-                prevMaximumAddedDelay,
-                prevAddedDelay,
-                node,
-                envelope,
-                forceMaxDelay
-        );
-        // We look for an edge that uses the same opening, identified by the next occupancy
-        for (var newEdge : newEdges)
-            if (newEdge.timeNextOccupancy() == timeNextOccupancy)
-                return newEdge;
-        return null; // No result was found
-    }
-
-    // endregion // UTILS
-
-    // region ALLOWANCES
-
-    /** Try to run an engineering allowance on the routes leading to the given edge. Returns null if it failed. */
-    public STDCMEdge tryEngineeringAllowance(
-            STDCMEdge oldEdge
-    ) {
-        var neededDelay = -oldEdge.maximumAddedDelayAfter();
-        assert neededDelay > 0;
-        if (oldEdge.previousNode() == null)
-            return null; // The conflict happens on the first route, we can't add delay here
-        var affectedEdges = findAffectedEdges(
-                oldEdge.previousNode().previousEdge(),
-                oldEdge.addedDelay()
-        );
-        if (affectedEdges.isEmpty())
-            return null; // No space to try the allowance
-        var context = makeAllowanceContext(affectedEdges);
-        var oldEnvelope = STDCMUtils.mergeEnvelopes(affectedEdges);
-        var newEnvelope = findAllowance(context, oldEnvelope, neededDelay);
-        if (newEnvelope == null)
-            return null; // We couldn't find an envelope
-        var newPreviousEdge = makeNewEdges(affectedEdges, newEnvelope);
-        if (newPreviousEdge == null)
-            return null; // The new edges are invalid, conflicts shouldn't happen here but it can be too slow
-        var newPreviousNode = getEdgeEnd(newPreviousEdge);
-        return findEdgeSameNextOccupancy(
-                oldEdge.route(),
-                newPreviousNode.time(),
-                oldEdge.previousNode().speed(),
-                0,
-                oldEdge.maximumAddedDelayAfter() + oldEdge.addedDelay(),
-                oldEdge.previousNode().totalPrevAddedDelay(),
-                newPreviousNode,
-                null,
-                oldEdge.timeNextOccupancy(),
-                false
-        );
-    }
-
-    /** Re-create the edges in order, following the given envelope. */
-    private STDCMEdge makeNewEdges(List<STDCMEdge> edges, Envelope totalEnvelope) {
-        double previousEnd = 0;
-        STDCMEdge prevEdge = null;
-        if (edges.get(0).previousNode() != null)
-            prevEdge = edges.get(0).previousNode().previousEdge();
-        for (var edge : edges) {
-            var end = previousEnd + edge.envelope().getEndPos();
-            var node = prevEdge == null ? null : getEdgeEnd(prevEdge);
-            var maxAddedDelayAfter = edge.maximumAddedDelayAfter() + edge.addedDelay();
-            if (node != null)
-                maxAddedDelayAfter = node.maximumAddedDelay();
-            prevEdge = findEdgeSameNextOccupancy(
-                    edge.route(),
-                    node == null ? edge.timeStart() : node.time(),
-                    edge.envelope().getBeginSpeed(),
-                    edge.envelopeStartOffset(),
-                    maxAddedDelayAfter,
-                    node == null ? 0 : node.totalPrevAddedDelay(),
-                    node,
-                    extractEnvelopeSection(totalEnvelope, previousEnd, end),
-                    edge.timeNextOccupancy(),
-                    true
-            );
-            if (prevEdge == null)
-                return null;
-            previousEnd = end;
-        }
-        assert Math.abs(previousEnd - totalEnvelope.getEndPos()) < 1e-5;
-        return prevEdge;
-    }
-
-    /** Returns a new envelope with the content of the base envelope from start to end, with 0 as first position */
-    private static Envelope extractEnvelopeSection(Envelope base, double start, double end) {
-        var parts = base.slice(start, end);
-        for (int i = 0; i < parts.length; i++)
-            parts[i] = parts[i].copyAndShift(-start);
-        return Envelope.make(parts);
-    }
-
-    /** Try to apply an allowance on the given envelope to add the given delay */
-    private Envelope findAllowance(EnvelopeSimContext context, Envelope oldEnvelope, double neededDelay) {
-        neededDelay += context.timeStep; // error margin for the dichotomy
-        var ranges = List.of(
-                new AllowanceRange(0, oldEnvelope.getEndPos(), new AllowanceValue.FixedTime(neededDelay))
-        );
-        var allowance = new MarecoAllowance(context, 0, oldEnvelope.getEndPos(), 0, ranges);
-        try {
-            return allowance.apply(oldEnvelope);
-        } catch (AllowanceConvergenceException e) {
-            return null;
-        }
-    }
-
-    /** Creates the EnvelopeSimContext to run an allowance on the given edges */
-    private EnvelopeSimContext makeAllowanceContext(List<STDCMEdge> edges) {
-        var routes = new ArrayList<SignalingRoute>();
-        var firstOffset = edges.get(0).route().getInfraRoute().getLength() - edges.get(0).envelope().getEndPos();
-        for (var edge : edges)
-            routes.add(edge.route());
-        return makeSimContext(routes, firstOffset, rollingStock, timeStep);
-    }
-
-    /** Find on which edges to run the allowance */
-    private List<STDCMEdge> findAffectedEdges(STDCMEdge edge, double delayNeeded) {
-        var res = new ArrayDeque<STDCMEdge>();
-        while (true) {
-            var endTime = edge.timeStart() + edge.envelope().getTotalTime();
-            var maxDelayAddedOnEdge = edge.timeNextOccupancy() - endTime;
-            if (delayNeeded > maxDelayAddedOnEdge) {
-                // We can't add delay in this route, the allowance range ends here (excluded)
-                return new ArrayList<>(res);
-            }
-            res.addFirst(edge);
-            if (edge.previousNode() == null) {
-                // We've reached the start of the path, this should only happen because of the max delay parameter
-                return new ArrayList<>(res);
-            }
-            delayNeeded += edge.addedDelay();
-            edge = edge.previousNode().previousEdge();
-        }
-    }
-
-    // endregion // ALLOWANCES
-
 }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -4,8 +4,6 @@ import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
-import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.PhysicsPath;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
@@ -82,8 +80,8 @@ public class STDCMPathfinding {
 
     private static double edgeRangeCost(EdgeRange<STDCMEdge> range) {
         var envelope = range.edge().envelope();
-        var timeStart = STDCMGraph.interpolateTime(envelope, range.edge().route(), range.start(), 0);
-        var timeEnd = STDCMGraph.interpolateTime(envelope, range.edge().route(), range.end(), 0);
+        var timeStart = STDCMUtils.interpolateTime(envelope, range.edge().route(), range.start(), 0);
+        var timeEnd = STDCMUtils.interpolateTime(envelope, range.edge().route(), range.end(), 0);
         return timeEnd - timeStart + range.edge().addedDelay();
     }
 
@@ -193,17 +191,11 @@ public class STDCMPathfinding {
         var res = new HashSet<Pathfinding.EdgeLocation<STDCMEdge>>();
         for (var location : locations) {
             var start = location.offset();
-            var edges = graph.makeEdges(
-                    location.edge(),
-                    startTime,
-                    0,
-                    start,
-                    maxDepartureDelay,
-                    0,
-                    null,
-                    null,
-                    false
-            );
+            var edges = new STDCMEdgeBuilder(location.edge(), graph)
+                    .setStartTime(startTime)
+                    .setStartOffset(start)
+                    .setPrevMaximumAddedDelay(maxDepartureDelay)
+                    .makeAllEdges();
             for (var edge : edges)
                 res.add(new Pathfinding.EdgeLocation<>(edge, location.offset()));
         }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
@@ -1,0 +1,42 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.ArrayList;
+import java.util.List;
+
+public class STDCMUtils {
+
+    /** Combines all the envelopes in the given edge ranges */
+    public static Envelope mergeEnvelopeRanges(
+            List<Pathfinding.EdgeRange<STDCMEdge>> edges
+    ) {
+        var parts = new ArrayList<EnvelopePart>();
+        double offset = 0;
+        for (var edge : edges) {
+            var envelope = edge.edge().envelope();
+            var sliceUntil = Math.min(envelope.getEndPos(), Math.abs(edge.end() - edge.start()));
+            if (sliceUntil == 0)
+                continue;
+            var slicedEnvelope = Envelope.make(envelope.slice(0, sliceUntil));
+            for (var part : slicedEnvelope)
+                parts.add(part.copyAndShift(offset));
+            offset = parts.get(parts.size() - 1).getEndPos();
+        }
+        var newEnvelope = Envelope.make(parts.toArray(new EnvelopePart[0]));
+        assert newEnvelope.continuous;
+        return newEnvelope;
+    }
+
+    /** Combines all the envelopes in the given edges */
+    public static Envelope mergeEnvelopes(
+            List<STDCMEdge> edges
+    ) {
+        return mergeEnvelopeRanges(
+                edges.stream()
+                        .map(e -> new Pathfinding.EdgeRange<>(e, 0, e.route().getInfraRoute().getLength()))
+                        .toList()
+        );
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
@@ -1,10 +1,21 @@
 package fr.sncf.osrd.api.stdcm.graph;
 
+import com.google.common.primitives.Doubles;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.ImpossibleSimulationError;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.MRSP;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class STDCMUtils {
 
@@ -38,5 +49,81 @@ public class STDCMUtils {
                         .map(e -> new Pathfinding.EdgeRange<>(e, 0, e.route().getInfraRoute().getLength()))
                         .toList()
         );
+    }
+
+    /** Create an EnvelopeSimContext instance from the route and extra parameters */
+    static EnvelopeSimContext makeSimContext(
+            List<SignalingRoute> routes,
+            double offsetFirstRoute,
+            RollingStock rollingStock,
+            double timeStep
+    ) {
+        var tracks = new ArrayList<TrackRangeView>();
+        for (var route : routes) {
+            var routeLength = route.getInfraRoute().getLength();
+            tracks.addAll(route.getInfraRoute().getTrackRanges(offsetFirstRoute, routeLength));
+            offsetFirstRoute = 0;
+        }
+        var envelopePath = EnvelopeTrainPath.from(tracks);
+        return new EnvelopeSimContext(rollingStock, envelopePath, timeStep);
+    }
+
+    /** Returns an envelope matching the given route. The envelope time starts when the train enters the route.
+     *
+     * </p>
+     * Note: there are some approximations made here as we only "see" the tracks on the given routes.
+     * We are missing slopes and speed limits from earlier in the path.
+     * </p>
+     * This is public because it helps when writing unit tests. */
+    public static Envelope simulateRoute(
+            SignalingRoute route,
+            double initialSpeed,
+            double start,
+            RollingStock rollingStock,
+            double timeStep,
+            double[] stops
+    ) {
+        try {
+            var context = makeSimContext(List.of(route), start, rollingStock, timeStep);
+            var mrsp = MRSP.from(
+                    route.getInfraRoute().getTrackRanges(start, start + context.path.getLength()),
+                    rollingStock,
+                    false,
+                    Set.of()
+            );
+            var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
+            return MaxEffortEnvelope.from(context, initialSpeed, maxSpeedEnvelope);
+        } catch (ImpossibleSimulationError e) {
+            // This can happen when the train can't go through this part,
+            // for example because of high slopes with a "weak" rolling stock
+            return null;
+        }
+    }
+
+    /** Returns the offset of the stops on the given route, starting at startOffset*/
+    static double[] getStopsOnRoute(STDCMGraph graph, SignalingRoute route, double startOffset) {
+        var res = new ArrayList<Double>();
+        for (var endLocation : graph.endLocations) {
+            if (endLocation.edge() == route) {
+                var offset = endLocation.offset() - startOffset;
+                if (offset >= 0)
+                    res.add(offset);
+            }
+        }
+        return Doubles.toArray(res);
+    }
+
+    /** Returns the time at which the offset on the given route is reached */
+    public static double interpolateTime(
+            Envelope envelope,
+            SignalingRoute route,
+            double routeOffset,
+            double startTime
+    ) {
+        var routeLength = route.getInfraRoute().getLength();
+        var envelopeStartOffset = routeLength - envelope.getEndPos();
+        var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);
+        assert envelopeOffset <= envelope.getEndPos();
+        return startTime + envelope.interpolateTotalTime(envelopeOffset);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
@@ -9,10 +9,7 @@ import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
-import fr.sncf.osrd.envelope_sim.Action;
-import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator;
+import fr.sncf.osrd.envelope_sim.*;
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeCoasting;
 
 public final class CoastingGenerator {
@@ -31,7 +28,8 @@ public final class CoastingGenerator {
         );
         var speed = envelope.interpolateSpeed(startPos);
         EnvelopeCoasting.coast(context, startPos, speed, constrainedBuilder, 1);
-        assert constrainedBuilder.lastIntersection == 1;
+        if (constrainedBuilder.lastIntersection == 0)
+            throw new ImpossibleSimulationError(); // We reached a stop while coasting
         if (partBuilder.isEmpty())
             return null;
         return partBuilder.build();

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/DetectorImpl.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/DetectorImpl.java
@@ -34,8 +34,9 @@ public class DetectorImpl implements fr.sncf.osrd.infra.api.tracks.undirected.De
     @Override
     @ExcludeFromGeneratedCodeCoverage
     public String toString() {
+        var trackID = trackSection == null ? "null" : trackSection.getID();
         return MoreObjects.toStringHelper(this)
-                .add("trackSection", trackSection.getID())
+                .add("trackSection", trackID)
                 .add("offset", offset)
                 .add("id", id)
                 .toString();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.*;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
-import fr.sncf.osrd.api.stdcm.graph.STDCMGraph;
 import fr.sncf.osrd.api.stdcm.graph.STDCMPathfinding;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
+import fr.sncf.osrd.api.stdcm.graph.STDCMUtils;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.train.RollingStock;
@@ -518,7 +518,7 @@ public class STDCMPathfindingTests {
         var firstRoute = infraBuilder.addRoute("a", "b");
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2, new double[]{});
         assert firstRouteEnvelope != null;
         var res = STDCMPathfinding.findPath(
@@ -964,7 +964,7 @@ public class STDCMPathfindingTests {
          */
         var infraBuilder = new DummyRouteGraphBuilder();
         var route = infraBuilder.addRoute("a", "b", 1000);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(route, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(route, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -1000,7 +1000,7 @@ public class STDCMPathfindingTests {
         infraBuilder.addRoute("b", "c", 10);
         infraBuilder.addRoute("c", "d", 10);
         var lastRoute = infraBuilder.addRoute("d", "e", 10);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -1034,7 +1034,7 @@ public class STDCMPathfindingTests {
         var infraBuilder = new DummyRouteGraphBuilder();
         var firstRoute = infraBuilder.addRoute("a", "b", 1000);
         var secondRoute = infraBuilder.addRoute("b", "c", 100, 5);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -1169,10 +1169,10 @@ public class STDCMPathfindingTests {
         var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 30);
         var secondRoute = infraBuilder.addRoute("b", "c", 10_000, 30);
         var thirdRoute = infraBuilder.addRoute("c", "d", 100, 30);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert secondRouteEnvelope != null;
         var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
@@ -1227,10 +1227,10 @@ public class STDCMPathfindingTests {
         infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
@@ -1290,10 +1290,10 @@ public class STDCMPathfindingTests {
         final var thirdRoute = infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, 2., new double[]{});
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
@@ -1427,7 +1427,7 @@ public class STDCMPathfindingTests {
         double time = 0;
         double speed = 0;
         for (var route : routes) {
-            var envelope = STDCMGraph.simulateRoute(route, speed, 0,
+            var envelope = STDCMUtils.simulateRoute(route, speed, 0,
                     rollingStock, 2., new double[]{});
             assert envelope != null;
             time += envelope.getTotalTime();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -11,10 +11,12 @@ import fr.sncf.osrd.api.stdcm.graph.STDCMPathfinding;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -1144,6 +1146,294 @@ public class STDCMPathfindingTests {
                 POSITIVE_INFINITY
         );
         assertNotNull(res);
+    }
+
+    /** Test that we can add an engineering allowance to avoid an occupied section */
+    @Test
+    public void testSlowdown() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        d |######### end
+          |######### /
+        c |#########/
+          |     __/
+        b |  __/
+          | /##################
+        a |/_##################_> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 30);
+        var secondRoute = infraBuilder.addRoute("b", "c", 10_000, 30);
+        var thirdRoute = infraBuilder.addRoute("c", "d", 100, 30);
+        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+                REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert firstRouteEnvelope != null;
+        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+                0, REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert secondRouteEnvelope != null;
+        var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + 10, POSITIVE_INFINITY, 0, 1_000),
+                thirdRoute, new OccupancyBlock(0, timeThirdRouteFree + 30, 0, 100)
+        );
+        double timeStep = 2;
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 0)),
+                occupancyGraph,
+                timeStep,
+                3600 * 2,
+                POSITIVE_INFINITY
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+        assertEquals(10, res.departureTime(), 2 * timeStep);
+    }
+
+    /** Test that we can add an engineering allowance over several routes to avoid an occupied section */
+    @Test
+    public void testSlowdownSeveralRoutes() {
+        /*
+        a --> b --> c --> d --> e --> f
+
+        space
+          ^
+        f |##################### end
+          |##################### /
+        e |#####################/
+          |                 __/
+        d |              __/
+          |           __/
+        c |        __/
+          |     __/
+        b |  __/
+          | /##################
+        a |/_##################_> time
+
+         */
+        final var infraBuilder = new DummyRouteGraphBuilder();
+        final var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 20);
+        final var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 20);
+        infraBuilder.addRoute("c", "d", 1_000, 20);
+        infraBuilder.addRoute("d", "e", 1_000, 20);
+        var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
+        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+                REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert firstRouteEnvelope != null;
+        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+                0, REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert secondRouteEnvelope != null;
+        var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime(), POSITIVE_INFINITY, 0, 1_000),
+                lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000)
+        );
+        double timeStep = 2;
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 1_000)),
+                occupancyGraph,
+                timeStep,
+                3600 * 2,
+                POSITIVE_INFINITY
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+        assertEquals(0, res.departureTime(), 2 * timeStep);
+    }
+
+    /** Test that allowances don't cause new conflicts */
+    @Test
+    public void testSlowdownWithConflicts() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        f |##################### end
+          |##################### /
+        e |#####################/
+          |             ______/
+        d |       _____/ __/
+          |     / ####__/######
+        c |    /  #__/#########
+          |   / __/
+        b |  __/
+          | /##################
+        a |/_##################_> time
+
+        A naive allowance extending until we reach the constraints on either side
+        would cross the occupancy in the "d->d" route (rightmost curve).
+
+        But another solution exists: keeping the allowance in the "d->e" route (leftmost curve)
+
+         */
+        final var infraBuilder = new DummyRouteGraphBuilder();
+        final var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 20);
+        final var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 20);
+        final var thirdRoute = infraBuilder.addRoute("c", "d", 1_000, 20);
+        infraBuilder.addRoute("d", "e", 1_000, 20);
+        var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
+        var firstRouteEnvelope = STDCMGraph.simulateRoute(firstRoute, 0, 0,
+                REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert firstRouteEnvelope != null;
+        var secondRouteEnvelope = STDCMGraph.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+                0, REALISTIC_FAST_TRAIN, 2., new double[]{});
+        assert secondRouteEnvelope != null;
+        var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
+        var timeThirdRouteOccupied = firstRouteEnvelope.getTotalTime() + 5 + secondRouteEnvelope.getTotalTime() * 2;
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime(), POSITIVE_INFINITY, 0, 1_000),
+                lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000),
+                thirdRoute, new OccupancyBlock(timeThirdRouteOccupied, POSITIVE_INFINITY, 0, 1_000)
+        );
+        double timeStep = 2;
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 1_000)),
+                occupancyGraph,
+                timeStep,
+                3600 * 2,
+                POSITIVE_INFINITY
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+        assertEquals(0, res.departureTime(), 2 * timeStep);
+    }
+
+    /** Test that we can add the max delay by shifting the departure time, then add more delay by slowing down */
+    @Test
+    public void testMaxDepartureTimeShift() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        d |###############
+          |###############
+        c |###############x end
+          |            __/
+        b |         __/
+          |      __/
+        a |_____/____________________> time
+          |-----|
+             ^
+     max delay at departure time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 30);
+        var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 30);
+        var thirdRoute = infraBuilder.addRoute("c", "d", 1, 30);
+        var lastRouteEntryTime = getRoutesRunTime(List.of(firstRoute, secondRoute), REALISTIC_FAST_TRAIN);
+        var timeThirdRouteFree = lastRouteEntryTime + 3600 * 2 + 60;
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                thirdRoute, new OccupancyBlock(0, timeThirdRouteFree, 0, 1)
+        );
+        double timeStep = 2;
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 0)),
+                occupancyGraph,
+                timeStep,
+                3600 * 2,
+                POSITIVE_INFINITY
+        );
+
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+        assertEquals(3600 * 2, res.departureTime(), 2 * timeStep);
+        assertTrue(res.departureTime() <= 3600 * 2);
+    }
+
+    /** The allowance happens in an area where we have added delay by shifting the departure time */
+    @Test
+    public void testAllowanceWithDepartureTimeShift() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        e |##########################     ###### end
+          |##########################     ######/__________
+        d |#################### /              /
+          |####################/_____     ____/____________
+        c |############# /           [...]   /
+          |#############/____________     __x______________
+        b |#####  /                ##     #################
+          |#####/                  ##     #################
+        a start____________________##     #################_> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 20);
+        var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 20);
+        var thirdRoute = infraBuilder.addRoute("c", "d", 1_000, 20);
+        var forthRoute = infraBuilder.addRoute("d", "e", 1_000, 20);
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(0, 600, 0, 100),
+                firstRoute, new OccupancyBlock(2_000, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new OccupancyBlock(0, 1200, 0, 100),
+                thirdRoute, new OccupancyBlock(0, 1800, 0, 100),
+                forthRoute, new OccupancyBlock(0, 10_000, 0, 100)
+        );
+        var res = STDCMPathfinding.findPath(
+                infra,
+                REALISTIC_FAST_TRAIN,
+                0,
+                0,
+                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)),
+                Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 1)),
+                occupancyGraph,
+                2.,
+                3600 * 2,
+                POSITIVE_INFINITY
+        );
+        assertNotNull(res);
+        occupancyTest(res, occupancyGraph);
+    }
+
+    /** Returns the time it takes to reach the end of the last routes,
+     * starting at speed 0 at the start of the first route*/
+    private double getRoutesRunTime(List<SignalingRoute> routes, RollingStock rollingStock) {
+        double time = 0;
+        double speed = 0;
+        for (var route : routes) {
+            var envelope = STDCMGraph.simulateRoute(route, speed, 0,
+                    rollingStock, 2., new double[]{});
+            assert envelope != null;
+            time += envelope.getTotalTime();
+            speed = envelope.getEndSpeed();
+        }
+        return time;
     }
 
     /** Checks that the result don't cross in an occupied section */


### PR DESCRIPTION
This integrates the changes of https://github.com/DGEXSolutions/osrd/pull/2273 first (which I've closed as this is more readable, but the diff there can show the changes specific to allowances)

`STDCMGraph` had many methods and did too many things, it also had several methods with way too many parameters.

The main change is the creation of `STDCMEdgeBuilder`, which takes care of all the optional parameters when creating edges.
Most methods have then been moved away from `STDCMGraph` into classes that handle specific parts of the problem.