### PR TITLE
front: fixes dynamic signals rendering in maps

### DIFF
--- a/front/src/common/Map/Layers/geoSignalsLayers.ts
+++ b/front/src/common/Map/Layers/geoSignalsLayers.ts
@@ -257,13 +257,12 @@ export function getSignalALayerProps(
   const { yellowSignalIds = [] } = changeSignalContext;
   const angleName = getAngleName(sourceLayer);
   const typeFilter = _type.split(' ')[0];
-  let filter: LayerProps['filter'] = ['==', 'extensions_sncf_installation_type', typeFilter];
-  if (yellowSignalIds.length) filter = ['all', filter, ['in', 'id'].concat(yellowSignalIds)];
+  const filterA = ['in', 'id'].concat(yellowSignalIds);
 
   const props: LayerProps = {
     type: 'symbol',
     minzoom: 12,
-    filter,
+    filter: ['all', ['==', 'extensions_sncf_installation_type', typeFilter], filterA],
     layout: {
       'text-field': '{extensions_sncf_label}',
       'text-font': ['SNCF'],
@@ -358,13 +357,12 @@ export function getSignalStopLayerProps(
   const { redSignalIds = [] } = changeSignalContext;
   const angleName = getAngleName(sourceLayer);
   const typeFilter = _type.split(' ')[0];
-  let filter: LayerProps['filter'] = ['==', 'extensions_sncf_installation_type', typeFilter];
-  if (redSignalIds.length) filter = ['all', filter, ['in', 'id'].concat(redSignalIds)];
+  const filterA = ['in', 'id'].concat(redSignalIds);
 
   const props: LayerProps = {
     type: 'symbol',
     minzoom: 12,
-    filter,
+    filter: ['all', ['==', 'extensions_sncf_installation_type', typeFilter], filterA],
     layout: {
       'text-field': '{extensions_sncf_label}',
       'text-font': ['SNCF'],


### PR DESCRIPTION
I mistakenly pushed earlier some unwanted modifications on the filters for red and yellow lights rendering, in commit:
42a04cc39e8fc9cd18575da924f67367726f530f

This commit reverts only those very modifications.