### PR TITLE
core: stdcm: lazy edge evaluation to avoid computing useless allowances

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
@@ -45,6 +45,8 @@ public class AllowanceManager {
         if (newPreviousEdge == null)
             return null; // The new edges are invalid, conflicts shouldn't happen here but it can be too slow
         var newPreviousNode = newPreviousEdge.getEdgeEnd(graph);
+        if (newPreviousNode == null)
+            return null;
         return STDCMEdgeBuilder.fromNode(graph, newPreviousNode, oldEdge.route())
                 .findEdgeSameNextOccupancy(oldEdge.timeNextOccupancy());
     }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
@@ -57,8 +57,11 @@ public class BacktrackingManager {
 
         // Create the new edge
         var newNode = newPreviousEdge.getEdgeEnd(graph);
+        if (newNode == null)
+            return null;
         return STDCMEdgeBuilder.fromNode(graph, newNode, e.route())
                 .setStartOffset(e.envelopeStartOffset())
+                .setEnvelope(e.envelope())
                 .findEdgeSameNextOccupancy(e.timeNextOccupancy());
     }
 

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
@@ -156,7 +156,7 @@ public class STDCMEdgeBuilder {
                 graph.delayManager.findMaximumAddedDelay(route, startTime + delayNeeded, envelope)
         );
         var actualStartTime = startTime + delayNeeded;
-        var newEdge = new STDCMEdge(
+        return new STDCMEdge(
                 route,
                 envelope,
                 actualStartTime,
@@ -168,16 +168,6 @@ public class STDCMEdgeBuilder {
                 route.getInfraRoute().getLength() - envelope.getEndPos(),
                 (int) (actualStartTime / 60)
         );
-        if (maximumDelay < 0) {
-            // We need to make the train go slower
-            newEdge = graph.allowanceManager.tryEngineeringAllowance(newEdge);
-            if (newEdge == null)
-                return null;
-        }
-        newEdge = graph.backtrackingManager.backtrack(newEdge); // Fixes any speed discontinuity
-        if (newEdge == null || graph.delayManager.isRunTimeTooLong(newEdge))
-            return null;
-        return newEdge;
     }
 
     /** Creates all the edges in the given settings, then look for one that shares the given time of next occupancy.

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -62,7 +62,7 @@ public class STDCMPathfinding {
                 .setEdgeRangeCost(STDCMPathfinding::edgeRangeCost)
                 .runPathfinding(
                         convertLocations(graph, startLocations, startTime, maxDepartureDelay),
-                        makeObjectiveFunction(endLocations)
+                        makeObjectiveFunction(endLocations, graph)
                 );
         if (path == null)
             return null;
@@ -77,13 +77,17 @@ public class STDCMPathfinding {
 
     /** Make the objective function from the edge locations */
     private static List<TargetsOnEdge<STDCMEdge>> makeObjectiveFunction(
-            Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations
+            Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
+            STDCMGraph graph
     ) {
         return List.of(edge -> {
-            var res = new HashSet<Double>();
+            var res = new HashSet<Pathfinding.EdgeLocation<STDCMEdge>>();
+            edge = edge.finishBuildingEdge(graph);
+            if (edge == null)
+                return res;
             for (var loc : endLocations)
                 if (loc.edge().equals(edge.route()))
-                    res.add(loc.offset());
+                    res.add(new Pathfinding.EdgeLocation<>(edge, loc.offset()));
             return res;
         });
     }

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TargetsOnEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TargetsOnEdge.java
@@ -1,9 +1,10 @@
 package fr.sncf.osrd.utils.graph.functional_interfaces;
 
+import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.Collection;
 
 /** Functions that takes an edge and returns the offset of any target for the current step on the edge */
 @FunctionalInterface
 public interface TargetsOnEdge<EdgeT> {
-    Collection<Double> apply(EdgeT edge);
+    Collection<Pathfinding.EdgeLocation<EdgeT>> apply(EdgeT edge);
 }


### PR DESCRIPTION
We avoid computing allowances and backtracking when computing an edge, we only compute this once needed.
This significantly reduces the amount of allowances computed.