### PR TITLE
core: bump dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,8 +18,8 @@ import static org.apache.tools.ant.taskdefs.condition.Os.*
 plugins {
     id 'java'
     // must be kept in sync with kotlin_version below
-    id 'org.jetbrains.kotlin.jvm' version '1.7.10'
-    id 'com.google.devtools.ksp' version '1.7.10-1.0.6' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+    id 'com.google.devtools.ksp' version '1.7.21-1.0.8' apply false
     id 'application'
     id 'checkstyle'
     id 'com.github.spotbugs' version '5.0.+'
@@ -28,7 +28,7 @@ plugins {
 }
 
 // must be kept in sync across all modules
-def kotlin_version = '1.7.10'
+def kotlin_version = '1.7.21'
 
 
 // region DEPENDENCIES
@@ -82,7 +82,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.+'
 
     // Sentry
-    implementation group: 'io.sentry', name: 'sentry', version: '6.5.+'  // MIT
+    implementation group: 'io.sentry', name: 'sentry', version: '6.8.+'  // MIT
 
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.+'  // EPL 2.0
@@ -92,8 +92,8 @@ dependencies {
     // jqwik for property based testing
     testImplementation 'net.jqwik:jqwik:1.7.+'  // EPL 2.0
     // mockito for mocking
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.8.+'  // MIT
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.8.+'  // MIT
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.9.+'  // MIT
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.9.+'  // MIT
 
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.+'  // EPL 2.0


### PR DESCRIPTION
- **sentry** from 6.5.+ to 6.8.0 (close #2381)
- **mockito-inline** from 4.8.+ to 4.9.0 (close #2347)
- **kotlin-reflect** from 1.7.10 to 1.7.21 (close #2346)
- **com.google.devtools.ksp** from 1.7.10-1.0.6 to 1.7.21-1.0.8 (close #2345)
- **symbol-processing-api** from 1.7.10-1.0.6 to 1.7.21-1.0.8 (close #2344)
- **mockito-junit-jupiter** from 4.8.+ to 4.9.0 (close #2343)
- **org.jetbrains.kotlin.jvm** from 1.7.10 to 1.7.21 (close #2342)