### PR TITLE
core: introduce a switch initialization policy

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/SimInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/SimInfra.kt
@@ -22,7 +22,6 @@ interface MovableElementsInfra {
     val movableElements: StaticIdxSpace<MovableElement>
     fun getMovableElementConfigs(movableElement: MovableElementId): StaticIdxSpace<MovableElementConfig>
     fun getMovableElementDelay(movableElement: MovableElementId): Duration
-    fun getMovableElementDefaultConfig(movableElement: MovableElementId): MovableElementConfigId
     fun getMovableElementConfigName(movableElement: MovableElementId, config: MovableElementConfigId): String
 }
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/SimInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/SimInfraBuilder.kt
@@ -8,16 +8,13 @@ import kotlin.time.Duration
 class MovableElementDescriptorBuilder @PublishedApi internal constructor (
     private val delay: Duration,
     private val configs: StaticPool<MovableElementConfig, MovableElementConfigDescriptor>,
-    var defaultConfig: MovableElementConfigId?
 ) {
     fun config(name: String): MovableElementConfigId {
         return configs.add(MovableElementConfigDescriptor(name))
     }
 
     @PublishedApi internal fun build(): MovableElementDescriptor {
-        if (defaultConfig == null)
-            throw RuntimeException("invalid MovableElement: there must be a default config")
-        return MovableElementDescriptor(delay, configs, defaultConfig!!)
+        return MovableElementDescriptor(delay, configs)
     }
 }
 
@@ -43,7 +40,7 @@ class SimInfraBuilder @PublishedApi internal constructor(
     )
 
     inline fun movableElement(delay: Duration, init: MovableElementDescriptorBuilder.() -> Unit): MovableElementId {
-        val movableElementBuilder = MovableElementDescriptorBuilder(delay, StaticPool(), null)
+        val movableElementBuilder = MovableElementDescriptorBuilder(delay, StaticPool())
         movableElementBuilder.init()
         val movableElement = movableElementBuilder.build()
         return movableElementPool.add(movableElement)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/SimInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/SimInfraImpl.kt
@@ -11,7 +11,6 @@ value class MovableElementConfigDescriptor(val name: String)
 class MovableElementDescriptor(
     val delay: Duration,
     val configs: StaticPool<MovableElementConfig, MovableElementConfigDescriptor>,
-    val defaultConfig: StaticIdx<MovableElementConfig>
 )
 
 @JvmInline
@@ -64,10 +63,6 @@ class SimInfraImpl(
 
     override fun getMovableElementDelay(movableElement: MovableElementId): Duration {
         return movableElementPool[movableElement].delay
-    }
-
-    override fun getMovableElementDefaultConfig(movableElement: MovableElementId): MovableElementConfigId {
-        return movableElementPool[movableElement].defaultConfig
     }
 
     override fun getMovableElementConfigName(

--- a/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/InterlockingSim.kt
+++ b/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/InterlockingSim.kt
@@ -9,8 +9,14 @@ import kotlin.contracts.contract
 
 // region MOVABLE ELEMENTS
 
+/** Defines how movable elements are initialized */
+enum class MovableElementInitPolicy {
+    OPTIMISTIC,
+    PESSIMISTIC,
+}
+
 interface MovableElementSim {
-    fun watchMovableElement(movable: MovableElementId): StateFlow<MovableElementConfigId>
+    fun watchMovableElement(movable: MovableElementId): StateFlow<MovableElementConfigId?>
     suspend fun move(movable: MovableElementId, config: MovableElementConfigId)
     suspend fun lockMovableElement(movable: MovableElementId)
     suspend fun unlockMovableElement(movable: MovableElementId)

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
@@ -20,7 +20,7 @@ class TestLocation {
         val infra = simInfra {
             // create a test switch
             val switchA = movableElement(delay = 42L.milliseconds) {
-                defaultConfig = config("a")
+                config("a")
                 config("b")
             }
 

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.sim
 
+import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.impl.MovableElementSimImpl
 import fr.sncf.osrd.sim.interlocking.api.withLock
 import fr.sncf.osrd.sim_infra.impl.simInfra
@@ -17,12 +18,12 @@ class TestMovableElements {
         // setup test data
         val infra = simInfra {
             movableElement(delay = 42L.milliseconds) {
-                defaultConfig = config("a")
+                config("a")
                 config("b")
             }
         }
 
-        val sim = MovableElementSimImpl(infra)
+        val sim = MovableElementSimImpl(infra, MovableElementInitPolicy.PESSIMISTIC)
         val movableElement = infra.movableElements[0]
         val configs = infra.getMovableElementConfigs(movableElement)
 

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -39,7 +39,7 @@ class TestReservation {
         // region build the test infrastructure
         val builder = SimInfraBuilder()
         val switch = builder.movableElement(delay = 42L.milliseconds) {
-            defaultConfig = config("a")
+            config("a")
             config("b")
         }
 

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.sim
 
 import fr.sncf.osrd.sim.interlocking.api.Train
+import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.impl.LocationSimImpl
 import fr.sncf.osrd.sim.interlocking.impl.movableElementSim
 import fr.sncf.osrd.sim.interlocking.impl.reservationSim
@@ -42,7 +43,7 @@ class TestRouting {
         val builder = SimInfraBuilder()
         // region switches
         val switch = builder.movableElement(delay = 10L.milliseconds) {
-            defaultConfig = config("xy")
+            config("xy")
             config("vy")
         }
 
@@ -105,7 +106,7 @@ class TestRouting {
         val locationSim = LocationSimImpl(infra)
         val simJob = Job()
         val reservationScope = CoroutineScope(coroutineContext + simJob)
-        val movableElementSim = movableElementSim(infra)
+        val movableElementSim = movableElementSim(infra, MovableElementInitPolicy.OPTIMISTIC)
         val reservationSim = reservationSim(infra, locationSim, reservationScope)
         val routingSim = routingSim(infra, movableElementSim, reservationSim, reservationScope)
 


### PR DESCRIPTION
This initialization policy replaces the default switch configuration:
- switches do not all have a default configuration
- we may need to make pessimistic or optimistic assumptions, depending on the context