### PR TITLE
front: inject front-end settings after build

### DIFF
--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -109,10 +109,6 @@ services:
       dockerfile: Dockerfile
       args:
         NGINX_CONFIG: "nginx-dev.conf"
-        REACT_APP_LOCAL_BACKEND: "True"
-        REACT_APP_API_URL: "http://localhost:8000"
-        REACT_APP_CHARTIS_URL: "http://localhost:7070"
-        REACT_APP_EDITOAST_URL: "http://localhost:8090"
     restart: unless-stopped
     ports: ["3000:80"]
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,10 +113,6 @@ services:
       dockerfile: Dockerfile
       args:
         NGINX_CONFIG: "nginx-dev.conf"
-        REACT_APP_LOCAL_BACKEND: "True"
-        REACT_APP_API_URL: "http://localhost:8000"
-        REACT_APP_CHARTIS_URL: "http://localhost:7070"
-        REACT_APP_EDITOAST_URL: "http://localhost:8090"
     restart: unless-stopped
     ports: ["3000:80"]
     healthcheck:

--- a/front/.env
+++ b/front/.env
@@ -1,0 +1,4 @@
+REACT_APP_LOCAL_BACKEND=true
+REACT_APP_API_URL=http://localhost:8000
+REACT_APP_CHARTIS_URL=http://localhost:7070
+REACT_APP_EDITOAST_URL=http://localhost:8090

--- a/front/.env.osrd.dev
+++ b/front/.env.osrd.dev
@@ -1,0 +1,5 @@
+REACT_APP_LOCAL_BACKEND=false
+REACT_APP_API_URL=https://gateway.dev.dgexsol.fr/osrd
+REACT_APP_CHARTIS_URL=https://gateway.dev.dgexsol.fr/chartos
+REACT_APP_EDITOAST_URL=https://gateway.dev.dgexsol.fr/editoast
+REACT_APP_KEYCLOAK_REALM=shared

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -22,7 +22,6 @@
 .env.development.local
 .env.test.local
 .env.production.local
-.env
 .cache
 
 npm-debug.log*

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -9,25 +9,9 @@ ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json yarn.lock /app/
 RUN yarn
 
-# setup build options
-ARG REACT_APP_LOCAL_BACKEND
-ARG REACT_APP_API_URL
-ARG REACT_APP_CHARTIS_URL
-ARG REACT_APP_EDITOAST_URL
-ARG REACT_APP_KEYCLOAK_REALM
-ARG REACT_APP_SENTRY_DSN
-ARG REACT_APP_SENTRY_ENVIRONMENT
-
 # build the app
 COPY . /app
-RUN REACT_APP_LOCAL_BACKEND=$REACT_APP_LOCAL_BACKEND \
-    REACT_APP_API_URL=$REACT_APP_API_URL \
-    REACT_APP_CHARTIS_URL=$REACT_APP_CHARTIS_URL \
-    REACT_APP_EDITOAST_URL=$REACT_APP_EDITOAST_URL \
-    REACT_APP_KEYCLOAK_REALM=$REACT_APP_KEYCLOAK_REALM \
-    REACT_APP_SENTRY_DSN=$REACT_APP_SENTRY_DSN \
-    REACT_APP_SENTRY_ENVIRONMENT=$REACT_APP_SENTRY_ENVIRONMENT \
-    yarn build
+RUN yarn build
 
 # Copy & serve app
 FROM nginx:alpine
@@ -37,6 +21,16 @@ COPY --from=build /app/build /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/$NGINX_CONFIG /etc/nginx/conf.d
 
+RUN apk add npm
+
 EXPOSE 80
 
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENV REACT_APP_LOCAL_BACKEND="True"
+ENV REACT_APP_API_URL="http://localhost:8000"
+ENV REACT_APP_CHARTIS_URL="http://localhost:7070"
+ENV REACT_APP_EDITOAST_URL="http://localhost:8090"
+ENV REACT_APP_KEYCLOAK_REALM="shared"
+ENV REACT_APP_SENTRY_DSN=""
+ENV REACT_APP_SENTRY_ENVIRONMENT=""
+
+ENTRYPOINT npx react-inject-env set && nginx -g "daemon off;"

--- a/front/README.md
+++ b/front/README.md
@@ -48,21 +48,18 @@
 
 ### Module editor
 
-# Create-react-app
-
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
-## Available Scripts
-
-In the project directory, you can run:
+# Running the app
 
 ### `yarn start`
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Runs the app in a local development environment. <br />
+This requires the other services (api, core, postgres…) to be running in your local environment as well.
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+See [Main Readme](../README.md) if you need more information to run the docker.
+
+### `yarn start-osrd-dev`
+
+Runs the app in a local environment, using osrd.dev.dgexsol backend services.
 
 ### `yarn test`
 

--- a/front/launch_dev_front.sh
+++ b/front/launch_dev_front.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-export REACT_APP_API_URL=https://gateway.dev.dgexsol.fr/osrd
-export REACT_APP_CHARTIS_URL=https://gateway.dev.dgexsol.fr/chartos
-export REACT_APP_EDITOAST_URL=https://gateway.dev.dgexsol.fr/editoast
-yarn start

--- a/front/launch_local_front.sh
+++ b/front/launch_local_front.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-export REACT_APP_LOCAL_BACKEND=true
-export REACT_APP_API_URL=http://localhost:8000
-export REACT_APP_CHARTIS_URL=http://localhost:7070
-export REACT_APP_EDITOAST_URL=http://localhost:8090
-yarn start

--- a/front/package.json
+++ b/front/package.json
@@ -117,6 +117,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "prettier": "^2.7.1",
+    "react-inject-env": "^2.1.0",
     "typescript": "~4.4.2",
     "web-vitals": "^2.1.0"
   },
@@ -127,6 +128,7 @@
   "scripts": {
     "compile": "tsc -b",
     "start": "react-scripts start",
+    "start-osrd-dev": "sh -ac '. ./.env.osrd.dev; react-scripts start'",
     "build": "react-scripts --max_old_space_size=4096 build",
     "test": "react-scripts test",
     "test-coverage": "react-scripts test --watchAll=false --coverage --coverageDirectory=test",

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -26,6 +26,7 @@
     <title>OSRD</title>
   </head>
   <body>
+    <script src='/env.js' async></script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/front/src/config/config.js
+++ b/front/src/config/config.js
@@ -1,7 +1,9 @@
+import { env } from 'env';
+
 export const MAIN_API = {
-  proxy: process.env.REACT_APP_API_URL,
-  proxy_chartis: process.env.REACT_APP_CHARTIS_URL,
-  proxy_editoast: process.env.REACT_APP_EDITOAST_URL,
+  proxy: env.REACT_APP_API_URL,
+  proxy_chartis: env.REACT_APP_CHARTIS_URL,
+  proxy_editoast: env.REACT_APP_EDITOAST_URL,
   version: '0.0.1',
   editor: {
     component_identifier: { database: 'gaia', name: 'Test' },
@@ -9,7 +11,7 @@ export const MAIN_API = {
 };
 
 export const KEYCLOAK_CONFIG = {
-  realm: process.env.REACT_APP_KEYCLOAK_REALM || 'shared', // shared or staging
+  realm: env.REACT_APP_KEYCLOAK_REALM, // shared or staging
   url: 'https://keycloak.shared.dgexsol.fr/auth/',
   'ssl-required': 'external',
   resource: 'gateway',
@@ -19,8 +21,8 @@ export const KEYCLOAK_CONFIG = {
 };
 
 export const SENTRY_CONFIG = {
-  react_sentry_dsn: process.env.REACT_APP_SENTRY_DSN,
-  environment: process.env.REACT_APP_SENTRY_ENVIRONMENT,
+  react_sentry_dsn: env.REACT_APP_SENTRY_DSN,
+  environment: env.REACT_APP_SENTRY_ENVIRONMENT,
 };
 
 export default MAIN_API;

--- a/front/src/env.ts
+++ b/front/src/env.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+declare global {
+  interface Window {
+    env: Env;
+  }
+}
+
+type Env = Record<string, string | undefined>;
+
+export const env: Env = { ...process.env, ...window.env };

--- a/front/src/main/App/index.js
+++ b/front/src/main/App/index.js
@@ -1,21 +1,22 @@
-import 'i18n';
-
-import { unstable_HistoryRouter as HistoryRouter, Route, Routes } from 'react-router-dom';
-import React, { Suspense, useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Route, Routes, unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
 
-import Home from 'main/Home';
-import HomeCarto from 'applications/carto/Home';
-import HomeEditor from 'applications/editor/Home';
-import HomeOSRD from 'applications/osrd/Home';
-import HomeStdcm from 'applications/stdcm/Home';
-import HomeOpenData from 'applications/opendata/Home';
-import HomeCustomGET from 'applications/customget/Home';
-import Loader from 'common/Loader';
-import { attemptLoginOnLaunch } from 'reducers/user';
+import { env } from 'env';
+import 'i18n';
 import { bootstrapOSRDConf } from 'reducers/osrdconf';
 import { getInfraID } from 'reducers/osrdconf/selectors';
-import history from '../history';
+import { attemptLoginOnLaunch } from 'reducers/user';
+
+import HomeCarto from 'applications/carto/Home';
+import HomeCustomGET from 'applications/customget/Home';
+import HomeEditor from 'applications/editor/Home';
+import HomeOpenData from 'applications/opendata/Home';
+import HomeOSRD from 'applications/osrd/Home';
+import HomeStdcm from 'applications/stdcm/Home';
+import Loader from 'common/Loader';
+import history from 'main/history';
+import Home from 'main/Home';
 
 export default function App() {
   const user = useSelector((state) => state.user);
@@ -25,9 +26,10 @@ export default function App() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (process.env.REACT_APP_LOCAL_BACKEND) {
-      console.log('*** USING LOCAL BACKEND ***');
+    if (env.REACT_APP_LOCAL_BACKEND === 'true') {
+      console.info('*** USING LOCAL BACKEND ***');
     } else {
+      console.info('*** USING OSRD.DEV BACKEND ***');
       dispatch(attemptLoginOnLaunch());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -50,7 +52,7 @@ export default function App() {
 
   return (
     <Suspense fallback={<Loader />}>
-      {(user.isLogged || process.env.REACT_APP_LOCAL_BACKEND) && (
+      {(user.isLogged || env.REACT_APP_LOCAL_BACKEND) && (
         <HistoryRouter history={history}>
           <Routes>
             <Route path="/osrd/*" element={<HomeOSRD />} />
@@ -63,7 +65,7 @@ export default function App() {
           </Routes>
         </HistoryRouter>
       )}
-      {!user.isLogged && !process.env.REACT_APP_LOCAL_BACKEND && <Loader />}
+      {!user.isLogged && !env.REACT_APP_LOCAL_BACKEND && <Loader />}
     </Suspense>
   );
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
   integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
 
+"@aelesia/commons@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@aelesia/commons/-/commons-0.5.0.tgz#4c236feeabf15d992482a3d3f11179f853247351"
+  integrity sha512-iaEw3cCgcRmbQEyg8fgAqzxpqXHMYGj7d2k3w17TObtfBRvv4yr19JNWF1QjiU9tQiyN30X95BMNz5URawRXnA==
+  dependencies:
+    dayjs "^1.8.28"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -2162,6 +2169,16 @@
     swagger2openapi "^7.0.7"
     typescript "^4.1.2"
 
+"@rushstack/ts-command-line@^4.9.0":
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.13.1.tgz#148b644b627131480363b4853b558ba5eaa0d75c"
+  integrity sha512-UTQMRyy/jH1IS2U+6pyzyn9xQ2iMcoUKkTcZUzOP/aaMiKlWLwCTDiBVwhw/M1crDx6apF9CwyjuWO9r1SBdJQ==
+  dependencies:
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    colors "~1.2.1"
+    string-argv "~0.3.1"
+
 "@sentry/browser@7.20.1", "@sentry/browser@^7.15.0":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.20.1.tgz#bce606db24fa02fb72e71187e510ff890f8be903"
@@ -3570,6 +3587,11 @@
     "@turf/helpers" "^6.5.0"
     "@turf/meta" "^6.5.0"
 
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -4877,7 +4899,7 @@ are-we-there-yet@^2.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -5997,7 +6019,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -6317,6 +6339,11 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.3"
     color-string "^1.6.0"
+
+colors@~1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+  integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -7363,6 +7390,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.8.28:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -7842,7 +7874,7 @@ dotenv@8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
-dotenv@^8.0.0:
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
@@ -9406,7 +9438,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -10232,6 +10264,11 @@ internmap@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -14677,6 +14714,17 @@ react-infinite-scroll-component@^6.1.0:
   integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
   dependencies:
     throttle-debounce "^2.1.0"
+    
+react-inject-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-inject-env/-/react-inject-env-2.1.0.tgz#8f8da32ca4b5d98d97cca9d6fbe563b5d6fdf20f"
+  integrity sha512-f1j5EV/iOpjtDEV75QEHZ28X6uvbbvIURuMspTwcuyVPKRkcgfxBUDLCF5bNZLilOYfYPCSMlJzcZ8TAa1qhzQ==
+  dependencies:
+    "@aelesia/commons" "^0.5.0"
+    "@rushstack/ts-command-line" "^4.9.0"
+    dotenv "^8.2.0"
+    replace-in-file "^6.3.2"
+    shelljs "^0.8.4"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -14973,6 +15021,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
@@ -15225,6 +15280,15 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+replace-in-file@^6.3.2:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.5.tgz#ff956b0ab5bc96613207d603d197cd209400a654"
+  integrity sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==
+  dependencies:
+    chalk "^4.1.2"
+    glob "^7.2.0"
+    yargs "^17.2.1"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -15315,7 +15379,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.3.2:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -15792,6 +15856,15 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+shelljs@^0.8.4:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -16191,6 +16264,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
+
+string-argv@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -18235,7 +18313,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
+yargs@^17.0.1, yargs@^17.2.1:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==


### PR DESCRIPTION
- Removed sh scripts, config has been moved to .env files. start using :
  - yarn start
  - yarn start-osrd-dev
- congured `react-inject-env`

`react-inject-env` will read from .env file, but can be overriden with shell variables

closes #2492 