### PR TITLE
api: add missing optional values in stdcm serializer

### DIFF
--- a/api/osrd_infra/serializers.py
+++ b/api/osrd_infra/serializers.py
@@ -160,3 +160,6 @@ class STDCMInputSerializer(Serializer):
     )
     rolling_stock = serializers.PrimaryKeyRelatedField(queryset=RollingStock.objects.all())
     comfort = serializers.ChoiceField(choices=[(x.value, x.name) for x in ComfortType], default=ComfortType.STANDARD)
+    maximum_departure_delay = serializers.FloatField(required=False, allow_null=True)
+    maximum_relative_run_time = serializers.FloatField(required=False, allow_null=True)
+    speed_limit_composition = serializers.CharField(max_length=255, required=False, allow_null=True)

--- a/api/osrd_infra/views/stdcm.py
+++ b/api/osrd_infra/views/stdcm.py
@@ -89,7 +89,8 @@ def make_stdcm_core_payload(request):
     optional_forwarded_parameters = [
         "maximum_departure_delay",
         "maximum_relative_run_time",
-        "speed_limit_composition"
+        "speed_limit_composition",
+        # Don't forget to add these fields to the serializer
     ]
     for parameter in optional_forwarded_parameters:
         if parameter in request:


### PR DESCRIPTION
Fixes #2422 