### PR TITLE
core: use static initialiser for pathfinding errors hashmap

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
@@ -40,13 +40,16 @@ public class PathfindingRoutesEndpoint implements Take {
     public static final String PATH_FINDING_ELECTRIFICATION_ERROR =
             "No path could be found after loading Electrification constraints";
 
+    static {
+        constraints.put(LoadingGaugeConstraints.class, PATH_FINDING_GAUGE_ERROR);
+        constraints.put(ElectrificationConstraints.class, PATH_FINDING_ELECTRIFICATION_ERROR);
+    }
+
     /**
      * constructor
      */
     public PathfindingRoutesEndpoint(InfraManager infraHandler) {
         this.infraManager = infraHandler;
-        constraints.put(LoadingGaugeConstraints.class, PATH_FINDING_GAUGE_ERROR);
-        constraints.put(ElectrificationConstraints.class, PATH_FINDING_ELECTRIFICATION_ERROR);
     }
 
     @Override
@@ -90,7 +93,7 @@ public class PathfindingRoutesEndpoint implements Take {
             SignalingInfra infra,
             PathfindingWaypoint[][] reqWaypoints,
             Collection<RollingStock> rollingStocks
-    )  throws NoPathFoundError {
+    ) throws NoPathFoundError {
         // parse the waypoints
         var waypoints = new ArrayList<Collection<Pathfinding.EdgeLocation<SignalingRoute>>>();
         for (var step : reqWaypoints) {
@@ -138,14 +141,14 @@ public class PathfindingRoutesEndpoint implements Take {
         // check there is no path without adding constraints
         var possiblePathWithoutErrorNoConstraints =
                 new Pathfinding<>(new GraphAdapter<>(infra.getSignalingRouteGraph()))
-                .setEdgeToLength(route -> route.getInfraRoute().getLength())
-                .setRemainingDistanceEstimator(remainingDistanceEstimator)
-                .runPathfinding(waypoints);
+                    .setEdgeToLength(route -> route.getInfraRoute().getLength())
+                    .setRemainingDistanceEstimator(remainingDistanceEstimator)
+                    .runPathfinding(waypoints);
         if (possiblePathWithoutErrorNoConstraints == null) {
             throw new NoPathFoundError(PATH_FINDING_GENERIC_ERROR);
         }
         // handling errors
-        for (EdgeToRanges<SignalingRoute> currentConstraint: constraintsList) {
+        for (EdgeToRanges<SignalingRoute> currentConstraint : constraintsList) {
             var possiblePathWithoutError = new Pathfinding<>(new GraphAdapter<>(infra.getSignalingRouteGraph()))
                     .setEdgeToLength(route -> route.getInfraRoute().getLength())
                     .addBlockedRangeOnEdges(currentConstraint)


### PR DESCRIPTION
The tests were passing when running the whole project suite, but that was by chance.

The Hashmap is not correctly initialised if the constructor is never called.

It fixes it by using then static initialiser