### PR TITLE
stdcm linear allowance

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1057,6 +1057,8 @@ components:
           description: |
             Margin of y seconds after the train passage, which means that the path used by the train should
             be free and available at least y seconds after its passage.
+        standard_allowance:
+          $ref: "#/components/schemas/AllowanceValue"
     Path:
       properties:
         id:

--- a/api/osrd_infra/serializers.py
+++ b/api/osrd_infra/serializers.py
@@ -175,3 +175,4 @@ class STDCMInputSerializer(Serializer):
     speed_limit_composition = serializers.CharField(max_length=255, required=False, allow_null=True)
     margin_before = serializers.FloatField(required=False, allow_null=True)
     margin_after = serializers.FloatField(required=False, allow_null=True)
+    standard_allowance = serializers.JSONField(required=False, allow_null=True)

--- a/api/osrd_infra/views/stdcm.py
+++ b/api/osrd_infra/views/stdcm.py
@@ -91,7 +91,8 @@ def make_stdcm_core_payload(request):
         "maximum_relative_run_time",
         "speed_limit_composition",
         "margin_before",
-        "margin_after"
+        "margin_after",
+        "standard_allowance"
         # Don't forget to add these fields to the serializer
     ]
     for parameter in optional_forwarded_parameters:

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -569,6 +569,8 @@ components:
           description: |
             Margin of y seconds after the train passage, which means that the path used by the train should
             be free and available at least y seconds after its passage.
+        standard_allowance:
+          $ref: "#/components/schemas/AllowanceValue"
     SimulationRequest:
       required:
         - infra
@@ -588,3 +590,37 @@ components:
           minItems: 1
           items:
             $ref: "#/components/schemas/TrainSchedule"
+    AllowanceValue:
+      oneOf:
+        - $ref: "#/components/schemas/TimePerDistanceAllowanceValue"
+        - $ref: "#/components/schemas/TimeAllowanceValue"
+        - $ref: "#/components/schemas/PercentageAllowanceValue"
+      discriminator:
+        propertyName: value_type
+    TimePerDistanceAllowanceValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["time_per_distance"]
+        minutes:
+          type: number
+          format: double
+          description: time to add per 100km in minutes
+    TimeAllowanceValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["time"]
+        seconds:
+          type: number
+          format: double
+          description: time to add over the whole range in seconds
+    PercentageAllowanceValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["percentage"]
+        percentage:
+          type: number
+          format: double
+          description: in %, how much time do we add compared to the fastest run time

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -9,11 +9,13 @@ import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint;
 import fr.sncf.osrd.api.pathfinding.response.NoPathFoundError;
 import fr.sncf.osrd.api.stdcm.graph.STDCMPathfinding;
 import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.railjson.parser.RJSRollingStockParser;
+import fr.sncf.osrd.railjson.parser.RJSStandaloneTrainScheduleParser;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidRollingStock;
 import fr.sncf.osrd.railjson.parser.exceptions.InvalidSchedule;
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
@@ -85,6 +87,11 @@ public class STDCMEndpoint implements Take {
             var startLocations = findRoutes(infra, request.startPoints);
             var endLocations = findRoutes(infra, request.endPoints);
             String tag = request.speedLimitComposition;
+            AllowanceValue standardAllowance = null;
+            if (request.standardAllowance != null)
+                standardAllowance = RJSStandaloneTrainScheduleParser.parseAllowanceValue(
+                        request.standardAllowance
+                );
 
             assert Double.isFinite(startTime);
 
@@ -112,7 +119,8 @@ public class STDCMEndpoint implements Take {
                     request.timeStep,
                     request.maximumDepartureDelay,
                     request.maximumRelativeRunTime * minRunTime,
-                    tag
+                    tag,
+                    standardAllowance
             );
             if (res == null) {
                 var error = new NoPathFoundError("No path could be found");

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
@@ -117,6 +117,12 @@ public final class STDCMRequest {
     @Json(name = "margin_after")
     public double gridMarginAfterSTDCM = 0;
 
+    /** Standard allowance to use when adding the new train. If unspecified (null), no allowance is added.
+     * This is only one part of the usual allowance object, because we can't define ranges nor specify
+     * the allowance type (mareco / linear). */
+    @Json(name = "standard_allowance")
+    public RJSAllowanceValue standardAllowance = null;
+
     /**
      * Create a default STDCMRequest
      */

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/AllowanceManager.java
@@ -2,10 +2,6 @@ package fr.sncf.osrd.api.stdcm.graph;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceConvergenceException;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -38,7 +34,7 @@ public class AllowanceManager {
             return null; // No space to try the allowance
         var context = makeAllowanceContext(affectedEdges);
         var oldEnvelope = STDCMUtils.mergeEnvelopes(affectedEdges);
-        var newEnvelope = findAllowance(context, oldEnvelope, neededDelay);
+        var newEnvelope = STDCMSimulations.findEngineeringAllowance(context, oldEnvelope, neededDelay);
         if (newEnvelope == null)
             return null; // We couldn't find an envelope
         var newPreviousEdge = makeNewEdges(affectedEdges, newEnvelope);
@@ -87,29 +83,13 @@ public class AllowanceManager {
         return Envelope.make(parts);
     }
 
-    /** Try to apply an allowance on the given envelope to add the given delay */
-    private Envelope findAllowance(EnvelopeSimContext context, Envelope oldEnvelope, double neededDelay) {
-        neededDelay += context.timeStep; // error margin for the dichotomy
-        var ranges = List.of(
-                new AllowanceRange(0, oldEnvelope.getEndPos(), new AllowanceValue.FixedTime(neededDelay))
-        );
-        var capacitySpeedLimit = 1; // We set a minimum because generating curves at very low speed can cause issues
-        // TODO: add a parameter and set a higher default value once we can handle proper stops
-        var allowance = new MarecoAllowance(context, 0, oldEnvelope.getEndPos(), capacitySpeedLimit, ranges);
-        try {
-            return allowance.apply(oldEnvelope);
-        } catch (AllowanceConvergenceException e) {
-            return null;
-        }
-    }
-
     /** Creates the EnvelopeSimContext to run an allowance on the given edges */
     private EnvelopeSimContext makeAllowanceContext(List<STDCMEdge> edges) {
         var routes = new ArrayList<SignalingRoute>();
         var firstOffset = edges.get(0).route().getInfraRoute().getLength() - edges.get(0).envelope().getEndPos();
         for (var edge : edges)
             routes.add(edge.route());
-        return STDCMUtils.makeSimContext(routes, firstOffset, graph.rollingStock, graph.comfort, graph.timeStep);
+        return STDCMSimulations.makeSimContext(routes, firstOffset, graph.rollingStock, graph.comfort, graph.timeStep);
     }
 
     /** Find on which edges to run the allowance */

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
@@ -71,7 +71,13 @@ public class BacktrackingManager {
      * The start time and any data related to delays will be updated accordingly.
      * */
     private STDCMEdge rebuildEdgeBackward(STDCMEdge old, double endSpeed) {
-        var newEnvelope = simulateBackwards(old.route(), endSpeed, old.envelopeStartOffset(), old.envelope());
+        var newEnvelope = simulateBackwards(
+                old.route(),
+                endSpeed,
+                old.envelopeStartOffset(),
+                old.envelope(),
+                graph
+        );
         var prevNode = old.previousNode();
         return new STDCMEdgeBuilder(old.route(), graph)
                 .setStartTime(old.timeStart() - old.addedDelay())
@@ -84,13 +90,14 @@ public class BacktrackingManager {
     }
 
     /** Simulates a route that already has an envelope, but with a different end speed */
-    private Envelope simulateBackwards(
+    private static Envelope simulateBackwards(
             SignalingRoute route,
             double endSpeed,
             double start,
-            Envelope oldEnvelope
+            Envelope oldEnvelope,
+            STDCMGraph graph
     ) {
-        var context = STDCMUtils.makeSimContext(
+        var context = STDCMSimulations.makeSimContext(
                 List.of(route),
                 start,
                 graph.rollingStock,

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/BacktrackingManager.java
@@ -1,20 +1,5 @@
 package fr.sncf.osrd.api.stdcm.graph;
 
-import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
-import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
-
-import fr.sncf.osrd.api.stdcm.BacktrackingEnvelopeAttr;
-import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder;
-import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
-import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
-import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
-import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
-import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
-import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration;
-import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import java.util.List;
-
 /** This class contains all the methods used to backtrack in the graph.
  * We need to backtrack to remove any kind of speed discontinuity, generally because of deceleration spanning over
  * several edges.
@@ -71,7 +56,7 @@ public class BacktrackingManager {
      * The start time and any data related to delays will be updated accordingly.
      * */
     private STDCMEdge rebuildEdgeBackward(STDCMEdge old, double endSpeed) {
-        var newEnvelope = simulateBackwards(
+        var newEnvelope = STDCMSimulations.simulateBackwards(
                 old.route(),
                 endSpeed,
                 old.envelopeStartOffset(),
@@ -89,38 +74,4 @@ public class BacktrackingManager {
                 .findEdgeSameNextOccupancy(old.timeNextOccupancy());
     }
 
-    /** Simulates a route that already has an envelope, but with a different end speed */
-    private static Envelope simulateBackwards(
-            SignalingRoute route,
-            double endSpeed,
-            double start,
-            Envelope oldEnvelope,
-            STDCMGraph graph
-    ) {
-        var context = STDCMSimulations.makeSimContext(
-                List.of(route),
-                start,
-                graph.rollingStock,
-                graph.comfort,
-                graph.timeStep
-        );
-        var partBuilder = new EnvelopePartBuilder();
-        partBuilder.setAttr(EnvelopeProfile.BRAKING);
-        partBuilder.setAttr(new BacktrackingEnvelopeAttr());
-        var overlayBuilder = new ConstrainedEnvelopePartBuilder(
-                partBuilder,
-                new SpeedConstraint(0, FLOOR),
-                new EnvelopeConstraint(oldEnvelope, CEILING)
-        );
-        EnvelopeDeceleration.decelerate(
-                context,
-                oldEnvelope.getEndPos(),
-                endSpeed,
-                overlayBuilder,
-                -1
-        );
-        var builder = OverlayEnvelopeBuilder.backward(oldEnvelope);
-        builder.addPart(partBuilder.build());
-        return builder.build();
-    }
 }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
@@ -40,7 +40,7 @@ public class DelayManager {
                     route,
                     block.distanceStart(),
                     startTime,
-                    graph.standardAllowanceSpeedRatio
+                    graph.getStandardAllowanceSpeedRatio(envelope, route)
             );
             var diff = block.timeEnd() - enterTime;
             if (diff < 0)
@@ -85,7 +85,7 @@ public class DelayManager {
                     route,
                     occupancy.distanceEnd(),
                     startTime,
-                    graph.standardAllowanceSpeedRatio
+                    graph.getStandardAllowanceSpeedRatio(envelope, route)
             );
             var margin = occupancy.timeStart() - exitTime;
             if (margin < 0) {
@@ -106,11 +106,12 @@ public class DelayManager {
         if (Double.isInfinite(startTime))
             return 0;
         for (var occupancy : unavailableTimes.get(route)) {
+            var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope, route);
             // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
             var enterTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceStart(),
-                    startTime, graph.standardAllowanceSpeedRatio);
+                    startTime, speedRatio);
             var exitTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceEnd(),
-                    startTime, graph.standardAllowanceSpeedRatio);
+                    startTime, speedRatio);
             if (enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart())
                 continue;
             var diff = occupancy.timeEnd() - enterTime;

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/DelayManager.java
@@ -32,7 +32,7 @@ public class DelayManager {
         var res = new HashSet<Double>();
         res.add(findMinimumAddedDelay(route, startTime, envelope));
         for (var block : unavailableTimes.get(route)) {
-            var enterTime = STDCMUtils.interpolateTime(envelope, route, block.distanceStart(), startTime);
+            var enterTime = STDCMSimulations.interpolateTime(envelope, route, block.distanceStart(), startTime);
             var diff = block.timeEnd() - enterTime;
             if (diff < 0)
                 continue;
@@ -71,7 +71,7 @@ public class DelayManager {
         var minValue = Double.POSITIVE_INFINITY;
         for (var occupancy : unavailableTimes.get(route)) {
             // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var exitTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
+            var exitTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
             var margin = occupancy.timeStart() - exitTime;
             if (margin < 0) {
                 // This occupancy block was before the train passage, we can ignore it
@@ -92,8 +92,8 @@ public class DelayManager {
             return 0;
         for (var occupancy : unavailableTimes.get(route)) {
             // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var enterTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceStart(), startTime);
-            var exitTime = STDCMUtils.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
+            var enterTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceStart(), startTime);
+            var exitTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceEnd(), startTime);
             if (enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart())
                 continue;
             var diff = occupancy.timeEnd() - enterTime;

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
@@ -120,7 +120,7 @@ public class STDCMEdgeBuilder {
     /** Creates all edges that can be accessed on the given route, using all the parameters specified. */
     public Collection<STDCMEdge> makeAllEdges() {
         if (envelope == null)
-            envelope = STDCMUtils.simulateRoute(
+            envelope = STDCMSimulations.simulateRoute(
                     route,
                     startSpeed,
                     startOffset,

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
@@ -169,7 +169,7 @@ public class STDCMEdgeBuilder {
                 prevNode,
                 route.getInfraRoute().getLength() - envelope.getEndPos(),
                 (int) (actualStartTime / 60),
-                graph.standardAllowanceSpeedRatio
+                graph.getStandardAllowanceSpeedRatio(envelope, route)
         );
         if (res.maximumAddedDelayAfter() < 0)
             res = graph.allowanceManager.tryEngineeringAllowance(res);

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMEdgeBuilder.java
@@ -168,7 +168,8 @@ public class STDCMEdgeBuilder {
                 prevAddedDelay + delayNeeded,
                 prevNode,
                 route.getInfraRoute().getLength() - envelope.getEndPos(),
-                (int) (actualStartTime / 60)
+                (int) (actualStartTime / 60),
+                graph.standardAllowanceSpeedRatio
         );
         if (res.maximumAddedDelayAfter() < 0)
             res = graph.allowanceManager.tryEngineeringAllowance(res);

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.api.stdcm.graph;
 import com.google.common.collect.Multimap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.train.RollingStock;
@@ -30,6 +31,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
     final AllowanceManager allowanceManager;
     final BacktrackingManager backtrackingManager;
     final String tag;
+    final AllowanceValue standardAllowance;
 
     /** Constructor */
     public STDCMGraph(
@@ -41,13 +43,15 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
             double maxRunTime,
             double minScheduleTimeStart,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
-            String tag
+            String tag,
+            AllowanceValue standardAllowance
     ) {
         this.infra = infra;
         this.rollingStock = rollingStock;
         this.comfort = comfort;
         this.timeStep = timeStep;
         this.endLocations = endLocations;
+        this.standardAllowance = standardAllowance;
         this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, unavailableTimes);
         this.allowanceManager = new AllowanceManager(this);
         this.backtrackingManager = new BacktrackingManager(this);

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMGraph.java
@@ -31,7 +31,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
     final AllowanceManager allowanceManager;
     final BacktrackingManager backtrackingManager;
     final String tag;
-    final AllowanceValue standardAllowance;
+    final double standardAllowanceSpeedRatio;
 
     /** Constructor */
     public STDCMGraph(
@@ -51,11 +51,25 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         this.comfort = comfort;
         this.timeStep = timeStep;
         this.endLocations = endLocations;
-        this.standardAllowance = standardAllowance;
-        this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, unavailableTimes);
+        this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, unavailableTimes, this);
         this.allowanceManager = new AllowanceManager(this);
         this.backtrackingManager = new BacktrackingManager(this);
         this.tag = tag;
+        this.standardAllowanceSpeedRatio = makeStandardAllowanceSpeedRatio(standardAllowance);
+    }
+
+    /** Returns the speed ratio we need to apply to the envelope to apply the given standard allowance */
+    private static double makeStandardAllowanceSpeedRatio(AllowanceValue allowanceValue) {
+        if (allowanceValue == null)
+            return 1;
+
+        // For now only percentage value is supported. Flat time duration can't be supported.
+        // Time per distance could eventually be supported as well but the speed factor would be irregular
+        assert allowanceValue instanceof AllowanceValue.Percentage
+                : "Standard allowance can only be a percentage allowance for STDCM trains";
+
+        var percentAllowance = (AllowanceValue.Percentage) allowanceValue;
+        return 1 / (1 + percentAllowance.percentage / 100);
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -6,21 +6,11 @@ import fr.sncf.osrd.api.stdcm.OccupancyBlock;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
 import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints;
 import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints;
-import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.PhysicsPath;
-import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance;
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
-import fr.sncf.osrd.infra_state.api.TrainPath;
-import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
-import fr.sncf.osrd.utils.graph.Pathfinding.EdgeRange;
 import fr.sncf.osrd.utils.graph.functional_interfaces.TargetsOnEdge;
 import fr.sncf.osrd.utils.graph.functional_interfaces.AStarHeuristic;
 import java.util.*;
@@ -77,20 +67,15 @@ public class STDCMPathfinding {
                 );
         if (path == null)
             return null;
-        var res = makeResult(
+        return STDCMPostProcessing.makeResult(
                 path,
                 startTime,
                 graph.standardAllowance,
                 rollingStock,
                 timeStep,
-                comfort
+                comfort,
+                maxRunTime
         );
-        if (res.envelope().getTotalTime() > maxRunTime) {
-            // This can happen if the destination is one edge away from being reachable in time,
-            // as we only check the time at the start of an edge when exploring the graph
-            return null;
-        }
-        return res;
     }
 
     /** Make the objective function from the edge locations */
@@ -148,160 +133,6 @@ public class STDCMPathfinding {
         });
     }
 
-    /** Builds the actual list of EdgeRange given the raw result of the pathfinding.
-     * We can't use it directly because it can't handle backtracking properly */
-    private static List<EdgeRange<STDCMEdge>> makeEdgeRange(
-            Pathfinding.Result<STDCMEdge> raw
-    ) {
-        var orderedEdges = new ArrayDeque<STDCMEdge>();
-        var firstRange = raw.ranges().get(0);
-        var lastRange = raw.ranges().get(raw.ranges().size() - 1);
-        var current = lastRange.edge();
-        while (true) {
-            orderedEdges.addFirst(current);
-            if (current.previousNode() == null)
-                break;
-            current = current.previousNode().previousEdge();
-        }
-        firstRange = new EdgeRange<>(orderedEdges.removeFirst(), firstRange.start(), firstRange.end());
-        if (lastRange.edge() != firstRange.edge())
-            lastRange = new EdgeRange<>(orderedEdges.removeLast(), lastRange.start(), lastRange.end());
-        var res = new ArrayList<EdgeRange<STDCMEdge>>();
-        res.add(firstRange);
-        for (var edge : orderedEdges)
-            res.add(new EdgeRange<>(edge, 0, edge.route().getInfraRoute().getLength()));
-        if (firstRange.edge() != lastRange.edge())
-            res.add(lastRange);
-        return res;
-    }
-
-    /** Builds the STDCM result object from the raw pathfinding result */
-    private static STDCMResult makeResult(
-            Pathfinding.Result<STDCMEdge> path,
-            double startTime,
-            AllowanceValue standardAllowance,
-            RollingStock rollingStock,
-            double timeStep,
-            RollingStock.Comfort comfort
-    ) {
-        var ranges = makeEdgeRange(path);
-        var routeRanges = ranges.stream()
-                .map(x -> new EdgeRange<>(x.edge().route(), x.start(), x.end()))
-                .toList();
-        var routeWaypoints = path.waypoints().stream()
-                .map(x -> new Pathfinding.EdgeLocation<>(x.edge().route(), x.offset()))
-                .toList();
-        var physicsPath = makePhysicsPath(ranges);
-        var mergedEnvelopes = STDCMUtils.mergeEnvelopeRanges(ranges);
-        var withAllowance = applyAllowance(
-                mergedEnvelopes,
-                ranges,
-                standardAllowance,
-                physicsPath,
-                rollingStock,
-                timeStep,
-                comfort
-        );
-        return new STDCMResult(
-                new Pathfinding.Result<>(routeRanges, routeWaypoints),
-                withAllowance,
-                makeTrainPath(ranges),
-                physicsPath,
-                computeDepartureTime(ranges, startTime)
-        );
-    }
-
-    /** Applies the allowance to the final envelope */
-    private static Envelope applyAllowance(
-            Envelope envelope,
-            List<EdgeRange<STDCMEdge>> ranges,
-            AllowanceValue standardAllowance,
-            PhysicsPath physicsPath,
-            RollingStock rollingStock,
-            double timeStep,
-            RollingStock.Comfort comfort
-    ) {
-        if (standardAllowance == null)
-            return envelope; // This isn't just an optimization, it avoids float inaccuracies
-        var allowance = new LinearAllowance(
-                new EnvelopeSimContext(rollingStock, physicsPath, timeStep, comfort),
-                0,
-                envelope.getEndPos(),
-                1,
-                makeAllowanceRanges(standardAllowance, ranges)
-        );
-        return allowance.apply(envelope);
-    }
-
-    /** Creates the list of allowance ranges for the final standard allowance.
-     * Adjacent ranges with identical values are merged to avoid problems later on. */
-    public static List<AllowanceRange> makeAllowanceRanges(
-            AllowanceValue allowance,
-            List<EdgeRange<STDCMEdge>> ranges
-    ) {
-        double prevPosition = 0;
-        var allowanceRanges = new ArrayList<AllowanceRange>();
-        double prevAllowanceRatio = Double.NaN;
-        for (var range : ranges) {
-            if (range.start() == range.end())
-                continue;
-            var currentAllowanceRatio = allowance.getAllowanceRatio(
-                    range.edge().envelope().getTotalTime(),
-                    range.end() - range.start()
-            );
-            var endPosition = prevPosition + range.end() - range.start();
-            if (prevAllowanceRatio == currentAllowanceRatio) {
-                // Merge with the previous range
-                allowanceRanges.set(allowanceRanges.size() - 1, new AllowanceRange(
-                        allowanceRanges.get(allowanceRanges.size() - 1).beginPos,
-                        endPosition,
-                        allowance
-                ));
-            } else {
-                prevAllowanceRatio = currentAllowanceRatio;
-                allowanceRanges.add(new AllowanceRange(prevPosition, endPosition, allowance));
-            }
-            prevPosition = endPosition;
-        }
-        return allowanceRanges;
-    }
-
-    /** Converts the list of pathfinding edges into a list of TrackRangeView that covers the path exactly */
-    private static List<TrackRangeView> makeTrackRanges(
-            List<EdgeRange<STDCMEdge>> edges
-    ) {
-        var trackRanges = new ArrayList<TrackRangeView>();
-        for (var routeRange : edges) {
-            var infraRoute = routeRange.edge().route().getInfraRoute();
-            trackRanges.addAll(infraRoute.getTrackRanges(routeRange.start(), routeRange.end()));
-        }
-        return trackRanges;
-    }
-
-    /** Builds a PhysicsPath from the pathfinding edges */
-    private static PhysicsPath makePhysicsPath(
-            List<EdgeRange<STDCMEdge>> edges
-    ) {
-        return EnvelopeTrainPath.from(makeTrackRanges(edges));
-    }
-
-    /** Creates a TrainPath instance from the list of pathfinding edges */
-    private static TrainPath makeTrainPath(
-            List<EdgeRange<STDCMEdge>> ranges
-    ) {
-        var routeList = ranges.stream()
-                .map(edge -> edge.edge().route())
-                .toList();
-        var trackRanges = makeTrackRanges(ranges);
-        var lastRange = trackRanges.get(trackRanges.size() - 1);
-        return TrainPathBuilder.from(
-                routeList,
-                trackRanges.get(0).offsetLocation(0),
-                lastRange.offsetLocation(lastRange.getLength())
-        );
-    }
-
-
     /** Converts locations on a SignalingRoute into a location on a STDCMGraph.Edge. */
     private static Set<Pathfinding.EdgeLocation<STDCMEdge>> convertLocations(
             STDCMGraph graph,
@@ -321,13 +152,5 @@ public class STDCMPathfinding {
                 res.add(new Pathfinding.EdgeLocation<>(edge, location.offset()));
         }
         return res;
-    }
-
-    /** Computes the departure time, made of the sum of all delays added over the path */
-    private static double computeDepartureTime(List<EdgeRange<STDCMEdge>> ranges, double startTime) {
-        for (var range : ranges) {
-            startTime += range.edge().addedDelay();
-        }
-        return startTime;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -111,7 +111,7 @@ public class STDCMPathfinding {
             double searchTimeRange
     ) {
         var envelope = range.edge().envelope();
-        var timeEnd = STDCMUtils.interpolateTime(
+        var timeEnd = STDCMSimulations.interpolateTime(
                 envelope, range.edge().route(), range.offset(), range.edge().timeStart()
         );
         var pathDuration = timeEnd - range.edge().totalDepartureTimeShift();

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -7,6 +7,7 @@ import fr.sncf.osrd.api.stdcm.STDCMResult;
 import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints;
 import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints;
 import fr.sncf.osrd.envelope_sim.PhysicsPath;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
@@ -40,7 +41,8 @@ public class STDCMPathfinding {
             double timeStep,
             double maxDepartureDelay,
             double maxRunTime,
-            String tag
+            String tag,
+            AllowanceValue standardAllowance
     ) {
         var graph = new STDCMGraph(
                 infra,
@@ -51,7 +53,8 @@ public class STDCMPathfinding {
                 maxRunTime,
                 startTime,
                 endLocations,
-                tag
+                tag,
+                standardAllowance
         );
 
         // Initializes the constraints

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPostProcessing.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPostProcessing.java
@@ -1,0 +1,185 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import fr.sncf.osrd.api.stdcm.STDCMResult;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.PhysicsPath;
+import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
+import fr.sncf.osrd.train.RollingStock;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+/** This class contains all the static methods used to turn the raw pathfinding result into a full response.
+ * This includes creating the final envelope (merging the parts + applying the allowances) */
+public class STDCMPostProcessing {
+
+    /** Builds the STDCM result object from the raw pathfinding result.
+     * This is the only non-private method of this class, the rest is implementation detail. */
+    static STDCMResult makeResult(
+            Pathfinding.Result<STDCMEdge> path,
+            double startTime,
+            AllowanceValue standardAllowance,
+            RollingStock rollingStock,
+            double timeStep,
+            RollingStock.Comfort comfort,
+            double maxRunTime
+    ) {
+        var ranges = makeEdgeRange(path);
+        var routeRanges = ranges.stream()
+                .map(x -> new Pathfinding.EdgeRange<>(x.edge().route(), x.start(), x.end()))
+                .toList();
+        var routeWaypoints = path.waypoints().stream()
+                .map(x -> new Pathfinding.EdgeLocation<>(x.edge().route(), x.offset()))
+                .toList();
+        var physicsPath = EnvelopeTrainPath.from(makeTrackRanges(ranges));
+        var mergedEnvelopes = STDCMUtils.mergeEnvelopeRanges(ranges);
+        var withAllowance = applyAllowance(
+                mergedEnvelopes,
+                ranges,
+                standardAllowance,
+                physicsPath,
+                rollingStock,
+                timeStep,
+                comfort
+        );
+        var res = new STDCMResult(
+                new Pathfinding.Result<>(routeRanges, routeWaypoints),
+                withAllowance,
+                makeTrainPath(ranges),
+                physicsPath,
+                computeDepartureTime(ranges, startTime)
+        );
+        if (res.envelope().getTotalTime() > maxRunTime) {
+            // This can happen if the destination is one edge away from being reachable in time,
+            // as we only check the time at the start of an edge when exploring the graph
+            return null;
+        }
+        return res;
+    }
+
+    /** Builds the actual list of EdgeRange given the raw result of the pathfinding.
+     * We can't use the pathfinding result directly because we use our own method
+     * to keep track of previous nodes/edges. */
+    private static List<Pathfinding.EdgeRange<STDCMEdge>> makeEdgeRange(
+            Pathfinding.Result<STDCMEdge> raw
+    ) {
+        var orderedEdges = new ArrayDeque<STDCMEdge>();
+        var firstRange = raw.ranges().get(0);
+        var lastRange = raw.ranges().get(raw.ranges().size() - 1);
+        var current = lastRange.edge();
+        while (true) {
+            orderedEdges.addFirst(current);
+            if (current.previousNode() == null)
+                break;
+            current = current.previousNode().previousEdge();
+        }
+        firstRange = new Pathfinding.EdgeRange<>(orderedEdges.removeFirst(), firstRange.start(), firstRange.end());
+        if (lastRange.edge() != firstRange.edge())
+            lastRange = new Pathfinding.EdgeRange<>(orderedEdges.removeLast(), lastRange.start(), lastRange.end());
+        var res = new ArrayList<Pathfinding.EdgeRange<STDCMEdge>>();
+        res.add(firstRange);
+        for (var edge : orderedEdges)
+            res.add(new Pathfinding.EdgeRange<>(edge, 0, edge.route().getInfraRoute().getLength()));
+        if (firstRange.edge() != lastRange.edge())
+            res.add(lastRange);
+        return res;
+    }
+
+    /** Converts the list of pathfinding edges into a list of TrackRangeView that covers the path exactly */
+    private static List<TrackRangeView> makeTrackRanges(
+            List<Pathfinding.EdgeRange<STDCMEdge>> edges
+    ) {
+        var trackRanges = new ArrayList<TrackRangeView>();
+        for (var routeRange : edges) {
+            var infraRoute = routeRange.edge().route().getInfraRoute();
+            trackRanges.addAll(infraRoute.getTrackRanges(routeRange.start(), routeRange.end()));
+        }
+        return trackRanges;
+    }
+
+    /** Applies the allowance to the final envelope */
+    private static Envelope applyAllowance(
+            Envelope envelope,
+            List<Pathfinding.EdgeRange<STDCMEdge>> ranges,
+            AllowanceValue standardAllowance,
+            PhysicsPath physicsPath,
+            RollingStock rollingStock,
+            double timeStep,
+            RollingStock.Comfort comfort
+    ) {
+        if (standardAllowance == null)
+            return envelope; // This isn't just an optimization, it avoids float inaccuracies
+        var allowance = new LinearAllowance(
+                new EnvelopeSimContext(rollingStock, physicsPath, timeStep, comfort),
+                0,
+                envelope.getEndPos(),
+                1,
+                makeAllowanceRanges(standardAllowance, ranges)
+        );
+        return allowance.apply(envelope);
+    }
+
+    /** Creates the list of allowance ranges for the final standard allowance.
+     * Adjacent ranges with identical values are merged to avoid extra binary search and an accumulation of errors. */
+    private static List<AllowanceRange> makeAllowanceRanges(
+            AllowanceValue allowance,
+            List<Pathfinding.EdgeRange<STDCMEdge>> ranges
+    ) {
+        double prevPosition = 0;
+        var allowanceRanges = new ArrayList<AllowanceRange>();
+        double prevAllowanceRatio = Double.NaN;
+        for (var range : ranges) {
+            if (range.start() == range.end())
+                continue;
+            var currentAllowanceRatio = allowance.getAllowanceRatio(
+                    range.edge().envelope().getTotalTime(),
+                    range.end() - range.start()
+            );
+            var endPosition = prevPosition + range.end() - range.start();
+            if (prevAllowanceRatio == currentAllowanceRatio) {
+                // Merge with the previous range
+                allowanceRanges.set(allowanceRanges.size() - 1, new AllowanceRange(
+                        allowanceRanges.get(allowanceRanges.size() - 1).beginPos,
+                        endPosition,
+                        allowance
+                ));
+            } else {
+                prevAllowanceRatio = currentAllowanceRatio;
+                allowanceRanges.add(new AllowanceRange(prevPosition, endPosition, allowance));
+            }
+            prevPosition = endPosition;
+        }
+        return allowanceRanges;
+    }
+
+    /** Creates a TrainPath instance from the list of pathfinding edges */
+    static TrainPath makeTrainPath(
+            List<Pathfinding.EdgeRange<STDCMEdge>> ranges
+    ) {
+        var routeList = ranges.stream()
+                .map(edge -> edge.edge().route())
+                .toList();
+        var trackRanges = makeTrackRanges(ranges);
+        var lastRange = trackRanges.get(trackRanges.size() - 1);
+        return TrainPathBuilder.from(
+                routeList,
+                trackRanges.get(0).offsetLocation(0),
+                lastRange.offsetLocation(lastRange.getLength())
+        );
+    }
+
+    /** Computes the departure time, made of the sum of all delays added over the path */
+    static double computeDepartureTime(List<Pathfinding.EdgeRange<STDCMEdge>> ranges, double startTime) {
+        for (var range : ranges)
+            startTime += range.edge().addedDelay();
+        return startTime;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMSimulations.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMSimulations.java
@@ -1,0 +1,104 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.ImpossibleSimulationError;
+import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceConvergenceException;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
+import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.MRSP;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.train.RollingStock;
+import java.util.ArrayList;
+import java.util.List;
+
+/** This class contains all the methods used to simulate the train behavior.
+ * */
+public class STDCMSimulations {
+    /** Create an EnvelopeSimContext instance from the route and extra parameters */
+    static EnvelopeSimContext makeSimContext(
+            List<SignalingRoute> routes,
+            double offsetFirstRoute,
+            RollingStock rollingStock,
+            RollingStock.Comfort comfort,
+            double timeStep
+    ) {
+        var tracks = new ArrayList<TrackRangeView>();
+        for (var route : routes) {
+            var routeLength = route.getInfraRoute().getLength();
+            tracks.addAll(route.getInfraRoute().getTrackRanges(offsetFirstRoute, routeLength));
+            offsetFirstRoute = 0;
+        }
+        var envelopePath = EnvelopeTrainPath.from(tracks);
+        return new EnvelopeSimContext(rollingStock, envelopePath, timeStep, comfort);
+    }
+
+    /** Returns an envelope matching the given route. The envelope time starts when the train enters the route.
+     *
+     * <p>
+     * Note: there are some approximations made here as we only "see" the tracks on the given routes.
+     * We are missing slopes and speed limits from earlier in the path.
+     * </p>
+     * This is public because it helps when writing unit tests. */
+    public static Envelope simulateRoute(
+            SignalingRoute route,
+            double initialSpeed,
+            double start,
+            RollingStock rollingStock,
+            RollingStock.Comfort comfort,
+            double timeStep,
+            double[] stops,
+            String tag
+    ) {
+        try {
+            var context = makeSimContext(List.of(route), start, rollingStock, comfort, timeStep);
+            var mrsp = MRSP.from(
+                    route.getInfraRoute().getTrackRanges(start, start + context.path.getLength()),
+                    rollingStock,
+                    false,
+                    tag
+            );
+            var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
+            return MaxEffortEnvelope.from(context, initialSpeed, maxSpeedEnvelope);
+        } catch (ImpossibleSimulationError e) {
+            // This can happen when the train can't go through this part,
+            // for example because of high slopes with a "weak" rolling stock
+            return null;
+        }
+    }
+
+    /** Returns the time at which the offset on the given route is reached */
+    public static double interpolateTime(
+            Envelope envelope,
+            SignalingRoute route,
+            double routeOffset,
+            double startTime
+    ) {
+        var routeLength = route.getInfraRoute().getLength();
+        var envelopeStartOffset = routeLength - envelope.getEndPos();
+        var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);
+        assert envelopeOffset <= envelope.getEndPos();
+        return startTime + envelope.interpolateTotalTime(envelopeOffset);
+    }
+
+    /** Try to apply an allowance on the given envelope to add the given delay */
+    static Envelope findEngineeringAllowance(EnvelopeSimContext context, Envelope oldEnvelope, double neededDelay) {
+        neededDelay += context.timeStep; // error margin for the dichotomy
+        var ranges = List.of(
+                new AllowanceRange(0, oldEnvelope.getEndPos(), new AllowanceValue.FixedTime(neededDelay))
+        );
+        var capacitySpeedLimit = 1; // We set a minimum because generating curves at very low speed can cause issues
+        // TODO: add a parameter and set a higher default value once we can handle proper stops
+        var allowance = new MarecoAllowance(context, 0, oldEnvelope.getEndPos(), capacitySpeedLimit, ranges);
+        try {
+            return allowance.apply(oldEnvelope);
+        } catch (AllowanceConvergenceException e) {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMUtils.java
@@ -3,19 +3,10 @@ package fr.sncf.osrd.api.stdcm.graph;
 import com.google.common.primitives.Doubles;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
-import fr.sncf.osrd.envelope_sim.ImpossibleSimulationError;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
-import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
-import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
-import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 public class STDCMUtils {
 
@@ -51,58 +42,6 @@ public class STDCMUtils {
         );
     }
 
-    /** Create an EnvelopeSimContext instance from the route and extra parameters */
-    static EnvelopeSimContext makeSimContext(
-            List<SignalingRoute> routes,
-            double offsetFirstRoute,
-            RollingStock rollingStock,
-            RollingStock.Comfort comfort,
-            double timeStep
-    ) {
-        var tracks = new ArrayList<TrackRangeView>();
-        for (var route : routes) {
-            var routeLength = route.getInfraRoute().getLength();
-            tracks.addAll(route.getInfraRoute().getTrackRanges(offsetFirstRoute, routeLength));
-            offsetFirstRoute = 0;
-        }
-        var envelopePath = EnvelopeTrainPath.from(tracks);
-        return new EnvelopeSimContext(rollingStock, envelopePath, timeStep, comfort);
-    }
-
-    /** Returns an envelope matching the given route. The envelope time starts when the train enters the route.
-     *
-     * <p>
-     * Note: there are some approximations made here as we only "see" the tracks on the given routes.
-     * We are missing slopes and speed limits from earlier in the path.
-     * </p>
-     * This is public because it helps when writing unit tests. */
-    public static Envelope simulateRoute(
-            SignalingRoute route,
-            double initialSpeed,
-            double start,
-            RollingStock rollingStock,
-            RollingStock.Comfort comfort,
-            double timeStep,
-            double[] stops,
-            String tag
-    ) {
-        try {
-            var context = makeSimContext(List.of(route), start, rollingStock, comfort, timeStep);
-            var mrsp = MRSP.from(
-                    route.getInfraRoute().getTrackRanges(start, start + context.path.getLength()),
-                    rollingStock,
-                    false,
-                    tag
-            );
-            var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
-            return MaxEffortEnvelope.from(context, initialSpeed, maxSpeedEnvelope);
-        } catch (ImpossibleSimulationError e) {
-            // This can happen when the train can't go through this part,
-            // for example because of high slopes with a "weak" rolling stock
-            return null;
-        }
-    }
-
     /** Returns the offset of the stops on the given route, starting at startOffset*/
     static double[] getStopsOnRoute(STDCMGraph graph, SignalingRoute route, double startOffset) {
         var res = new ArrayList<Double>();
@@ -116,17 +55,4 @@ public class STDCMUtils {
         return Doubles.toArray(res);
     }
 
-    /** Returns the time at which the offset on the given route is reached */
-    public static double interpolateTime(
-            Envelope envelope,
-            SignalingRoute route,
-            double routeOffset,
-            double startTime
-    ) {
-        var routeLength = route.getInfraRoute().getLength();
-        var envelopeStartOffset = routeLength - envelope.getEndPos();
-        var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);
-        assert envelopeOffset <= envelope.getEndPos();
-        return startTime + envelope.interpolateTotalTime(envelopeOffset);
-    }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -19,7 +19,7 @@ public class EnvelopePhysics {
 
     /** Given a constant acceleration, a last known speed and a position offset, compute the new speed */
     public static double interpolateStepSpeed(double acceleration, double lastSpeed, double positionDelta) {
-        return Math.sqrt(lastSpeed * lastSpeed + 2 * acceleration * positionDelta);
+        return Math.sqrt(Math.max(0, lastSpeed * lastSpeed + 2 * acceleration * positionDelta));
     }
 
     /** Compute the speed at offset positionDelta inside a given step */

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/LinearAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/LinearAllowance.java
@@ -37,25 +37,32 @@ public class LinearAllowance extends AbstractAllowanceWithRanges {
     @Override
     protected Envelope computeCore(Envelope coreBase, double maxSpeed) {
         var ratio = maxSpeed / coreBase.getMaxSpeed();
+        return scaleEnvelope(coreBase, ratio);
+    }
+
+    /** Scale an envelope, new speed = old speed * ratio */
+    public static Envelope scaleEnvelope(Envelope envelope, double ratio) {
         var builder = new EnvelopeBuilder();
-        for (var i = 0; i < coreBase.size(); i++) {
-            var part = coreBase.get(i);
-            var positions = part.clonePositions();
-            var speeds = part.cloneSpeeds();
-            var scaledSpeeds = Arrays.stream(speeds)
-                    .map(x -> x * ratio)
-                    .toArray();
-            var attr = part.getAttr(EnvelopeProfile.class);
-            var attrs = List.<EnvelopeAttr>of();
-            if (attr != null)
-                attrs = List.of(attr);
-            var scaledPart = EnvelopePart.generateTimes(
-                    attrs,
-                    positions,
-                    scaledSpeeds
-            );
-            builder.addPart(scaledPart);
-        }
+        for (var part : envelope)
+            builder.addPart(scalePart(part, ratio));
         return builder.build();
+    }
+
+    /** Scale a single part, new speed = old speed * ratio */
+    private static EnvelopePart scalePart(EnvelopePart part, double ratio) {
+        var positions = part.clonePositions();
+        var speeds = part.cloneSpeeds();
+        var scaledSpeeds = Arrays.stream(speeds)
+                .map(x -> x * ratio)
+                .toArray();
+        var attr = part.getAttr(EnvelopeProfile.class);
+        var attrs = List.<EnvelopeAttr>of();
+        if (attr != null)
+            attrs = List.of(attr);
+        return EnvelopePart.generateTimes(
+                attrs,
+                positions,
+                scaledSpeeds
+        );
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
@@ -144,8 +144,9 @@ public class RJSStandaloneTrainScheduleParser {
         return new AllowanceRange(range.beginPos, range.endPos, parseAllowanceValue(range.value));
     }
 
+    /** Parses the RJSAllowanceValue into an AllowanceValue */
     @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
-    private static AllowanceValue parseAllowanceValue(RJSAllowanceValue rjsValue) throws InvalidSchedule {
+    public static AllowanceValue parseAllowanceValue(RJSAllowanceValue rjsValue) throws InvalidSchedule {
         if (rjsValue.getClass() == RJSAllowanceValue.TimePerDistance.class) {
             var rjsTimePerDist = (RJSAllowanceValue.TimePerDistance) rjsValue;
             if (Double.isNaN(rjsTimePerDist.minutes))

--- a/core/src/main/java/fr/sncf/osrd/utils/SwingUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/SwingUtils.java
@@ -20,6 +20,7 @@ public class SwingUtils {
 
         SwingUtilities.invokeLater(() -> {
             var frame = new JFrame(windowName);
+            frame.setSize(600, 400); // The values are arbitrary, it just prevents a single pixel window
             frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
             frame.setContentPane(panelSupplier.get());
             frame.setVisible(true);

--- a/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMultimap;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
-import fr.sncf.osrd.api.stdcm.graph.STDCMUtils;
+import fr.sncf.osrd.api.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ public class BacktrackingTests {
          */
         var infraBuilder = new DummyRouteGraphBuilder();
         var route = infraBuilder.addRoute("a", "b", 1000);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(route, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(route, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -54,7 +54,7 @@ public class BacktrackingTests {
         infraBuilder.addRoute("b", "c", 10);
         infraBuilder.addRoute("c", "d", 10);
         var lastRoute = infraBuilder.addRoute("d", "e", 10);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -82,7 +82,7 @@ public class BacktrackingTests {
         var infraBuilder = new DummyRouteGraphBuilder();
         var firstRoute = infraBuilder.addRoute("a", "b", 1000);
         var secondRoute = infraBuilder.addRoute("b", "c", 100, 5);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
-import fr.sncf.osrd.api.stdcm.graph.STDCMUtils;
+import fr.sncf.osrd.api.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -179,7 +179,7 @@ public class DepartureTimeShiftTests {
         var firstRoute = infraBuilder.addRoute("a", "b");
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2, new double[]{}, null);
         assert firstRouteEnvelope != null;
         var occupancyGraph = ImmutableMultimap.of(

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
-import fr.sncf.osrd.api.stdcm.graph.STDCMUtils;
+import fr.sncf.osrd.api.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -36,10 +36,10 @@ public class EngineeringAllowanceTests {
         var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 30);
         var secondRoute = infraBuilder.addRoute("b", "c", 10_000, 30);
         var thirdRoute = infraBuilder.addRoute("c", "d", 100, 30);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert secondRouteEnvelope != null;
         var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
@@ -89,10 +89,10 @@ public class EngineeringAllowanceTests {
         infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
@@ -147,10 +147,10 @@ public class EngineeringAllowanceTests {
         final var thirdRoute = infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMUtils.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMUtils.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;

--- a/core/src/test/java/fr/sncf/osrd/stdcm/FullSTDCMTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/FullSTDCMTests.java
@@ -25,19 +25,14 @@ public class FullSTDCMTests {
         var infra = Helpers.infraFromRJS(Helpers.getExampleInfra("tiny_infra/infra.json"));
         var firstRoute = infra.findSignalingRoute("rt.buffer_stop_b->tde.foo_b-switch_foo", "BAL3");
         var secondRoute = infra.findSignalingRoute("rt.tde.foo_b-switch_foo->buffer_stop_c", "BAL3");
-        var res = STDCMPathfinding.findPath(
-                infra,
-                RJSRollingStockParser.parse(parseRollingStockDir(getResourcePath("rolling_stocks/")).get(0)),
-                RollingStock.Comfort.STANDARD,
-                0,
-                0,
-                Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 100)),
-                Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 10125)),
-                ImmutableMultimap.of(),
-                2.,
-                Double.POSITIVE_INFINITY,
-                Double.POSITIVE_INFINITY,
-                null);
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setRollingStock(
+                        RJSRollingStockParser.parse(parseRollingStockDir(getResourcePath("rolling_stocks/")).get(0))
+                )
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 100)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 10125)))
+                .run();
         assertNotNull(res);
     }
 
@@ -54,19 +49,13 @@ public class FullSTDCMTests {
         var occupancies = STDCMHelpers.makeOccupancyFromPath(infra, start, end, 0);
         double minDelay = STDCMHelpers.getMaxOccupancyLength(occupancies); // Eventually we may need to add a % margin
         occupancies.putAll(STDCMHelpers.makeOccupancyFromPath(infra, start, end, minDelay * 2));
-        var res = STDCMPathfinding.findPath(
-                infra,
-                REALISTIC_FAST_TRAIN,
-                RollingStock.Comfort.STANDARD,
-                minDelay,
-                0,
-                start,
-                end,
-                occupancies,
-                2.,
-                3600 * 24,
-                Double.POSITIVE_INFINITY,
-                null);
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartTime(minDelay)
+                .setStartLocations(start)
+                .setEndLocations(end)
+                .setUnavailableTimes(occupancies)
+                .run();
         assertNotNull(res);
     }
 
@@ -80,19 +69,13 @@ public class FullSTDCMTests {
         var end = Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 1137));
         var occupancies = STDCMHelpers.makeOccupancyFromPath(infra, start, end, 0);
         occupancies.putAll(STDCMHelpers.makeOccupancyFromPath(infra, start, end, 600));
-        var res = STDCMPathfinding.findPath(
-                infra,
-                REALISTIC_FAST_TRAIN,
-                RollingStock.Comfort.STANDARD,
-                300,
-                0,
-                start,
-                end,
-                occupancies,
-                2.,
-                7200,
-                Double.POSITIVE_INFINITY,
-                null);
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartTime(300)
+                .setStartLocations(start)
+                .setEndLocations(end)
+                .setUnavailableTimes(occupancies)
+                .run();
         assertNotNull(res);
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -9,7 +9,7 @@ import fr.sncf.osrd.api.stdcm.OccupancyBlock;
 import fr.sncf.osrd.api.stdcm.STDCMRequest;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
 import fr.sncf.osrd.api.stdcm.UnavailableSpaceBuilder;
-import fr.sncf.osrd.api.stdcm.graph.STDCMUtils;
+import fr.sncf.osrd.api.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
@@ -112,7 +112,7 @@ public class STDCMHelpers {
         double time = 0;
         double speed = 0;
         for (var route : routes) {
-            var envelope = STDCMUtils.simulateRoute(route, speed, 0,
+            var envelope = STDCMSimulations.simulateRoute(route, speed, 0,
                     REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
             assert envelope != null;
             time += envelope.getTotalTime();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -123,6 +123,15 @@ public class STDCMHelpers {
 
     /** Checks that the result don't cross in an occupied section */
     static void occupancyTest(STDCMResult res, ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph) {
+        occupancyTest(res, occupancyGraph, 0);
+    }
+
+    /** Checks that the result don't cross in an occupied section, with a certain tolerance for float inaccuracies */
+    static void occupancyTest(
+            STDCMResult res,
+            ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph,
+            double tolerance
+    ) {
         var routes = res.trainPath().routePath();
         for (var index = 0; index < routes.size(); index++) {
             var startRoutePosition = routes.get(index).pathOffset();
@@ -134,7 +143,9 @@ public class STDCMHelpers {
                 var exitTime = res.departureTime() + res.envelope().interpolateTotalTimeClamp(
                         startRoutePosition + occupancy.distanceEnd()
                 );
-                assertTrue(enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart());
+                assertTrue(
+                        enterTime + tolerance >= occupancy.timeEnd() || exitTime - tolerance <= occupancy.timeStart()
+                );
             }
         }
     }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.stdcm.OccupancyBlock;
 import fr.sncf.osrd.api.stdcm.STDCMResult;
 import fr.sncf.osrd.api.stdcm.graph.STDCMPathfinding;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.train.RollingStock;
@@ -36,6 +37,7 @@ public class STDCMPathfindingBuilder {
     double maxDepartureDelay = 3600 * 2;
     double maxRunTime = Double.POSITIVE_INFINITY;
     String tag = "";
+    AllowanceValue standardAllowance;
     // endregion OPTIONAL
 
     // region SETTERS
@@ -77,7 +79,7 @@ public class STDCMPathfindingBuilder {
 
     /** Sets at which times each section of routes are unavailable. By default, everything is available */
     public STDCMPathfindingBuilder setUnavailableTimes(
-            ImmutableMultimap<SignalingRoute, OccupancyBlock> unavailableTimes
+            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes
     ) {
         this.unavailableTimes = unavailableTimes;
         return this;
@@ -107,6 +109,12 @@ public class STDCMPathfindingBuilder {
         return this;
     }
 
+    /** Sets the standard allowance used for the new train. Defaults to null (no allowance) */
+    public STDCMPathfindingBuilder setStandardAllowance(AllowanceValue allowance) {
+        this.standardAllowance = allowance;
+        return this;
+    }
+
     // endregion SETTERS
 
     /** Runs the pathfinding request with the given parameters */
@@ -127,7 +135,8 @@ public class STDCMPathfindingBuilder {
                 timeStep,
                 maxDepartureDelay,
                 maxRunTime,
-                tag
+                tag,
+                standardAllowance
         );
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -1,0 +1,329 @@
+package fr.sncf.osrd.stdcm;
+
+import static fr.sncf.osrd.stdcm.STDCMHelpers.occupancyTest;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.collect.ImmutableMultimap;
+import fr.sncf.osrd.api.stdcm.OccupancyBlock;
+import fr.sncf.osrd.api.stdcm.STDCMResult;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class StandardAllowanceTests {
+
+    private static final double timeStep = 2.;
+
+    /** Contains result with and without allowance, with the method above it makes testing easier */
+    record STDCMAllowanceResults(
+            STDCMResult withAllowance,
+            STDCMResult withoutAllowance
+    ){}
+
+    /** Runs the pathfinding with the given parameters, with and without allowance */
+    private static STDCMAllowanceResults runWithAndWithoutAllowance(STDCMPathfindingBuilder builder) {
+        builder.setTimeStep(timeStep);
+        var resultWithAllowance = builder.run();
+        builder.setStandardAllowance(null);
+        var resultWithoutAllowance = builder.run();
+        return new STDCMAllowanceResults(
+                resultWithAllowance,
+                resultWithoutAllowance
+        );
+    }
+
+    /** Compares the run time with and without allowance, checks that the allowance is properly applied */
+    private static void checkAllowanceResult(STDCMAllowanceResults results, AllowanceValue.Percentage value) {
+        assertEquals(
+                results.withoutAllowance.envelope().getTotalTime() * (1 + value.percentage / 100),
+                results.withAllowance.envelope().getTotalTime(),
+                2 * timeStep
+        );
+    }
+
+
+    /** Test that the path found with a simple allowance is longer than the path we find with no allowance */
+    @Test
+    public void testSimpleStandardAllowance() {
+        /*
+        a --> b --> c --> d
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1_000, 30),
+                infraBuilder.addRoute("b", "c", 1_000, 30),
+                infraBuilder.addRoute("c", "d", 1_000, 30)
+        );
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(10);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 1_000)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withAllowance);
+        assertNotNull(res.withoutAllowance);
+        checkAllowanceResult(res, allowance);
+    }
+
+    /** Same test as the previous one, with a very high allowance value (1000%) */
+    @Test
+    public void testVeryHighStandardAllowance() {
+        /*
+        a --> b --> c --> d
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1_000, 30),
+                infraBuilder.addRoute("b", "c", 1_000, 30),
+                infraBuilder.addRoute("c", "d", 1_000, 30)
+        );
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(1_000);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 1_000)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withAllowance);
+        assertNotNull(res.withoutAllowance);
+        checkAllowanceResult(res, allowance);
+    }
+
+    /** Test that we can add delays to avoid occupied sections with a standard allowance */
+    @Test
+    public void testSimpleDelay() {
+        /*
+        a --> b --> c
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                secondRoute, new OccupancyBlock(0, 3600, 0, 100)
+        );
+        var allowance = new AllowanceValue.Percentage(20);
+
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancyGraph)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 50)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withoutAllowance);
+        assertNotNull(res.withAllowance);
+        var secondRouteEntryTime = res.withAllowance.departureTime()
+                + res.withAllowance.envelope().interpolateTotalTime(firstRoute.getInfraRoute().getLength());
+        assertTrue(secondRouteEntryTime >= 3600 - timeStep);
+        occupancyTest(res.withAllowance, occupancyGraph, timeStep);
+        checkAllowanceResult(res, allowance);
+    }
+
+    /** Test that we can add delays on partial route ranges with a standard allowance */
+    @Test
+    public void testRouteRangeOccupancy() {
+        /*
+        a ------> b
+
+        The route is occupied from a certain point only, we check that we don't add too little or too much delay
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var route = infraBuilder.addRoute("a", "b", 10_000);
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                route, new OccupancyBlock(0, 3600, 5_000, 10_000)
+        );
+        var allowance = new AllowanceValue.Percentage(20);
+
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancyGraph)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 10_000)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withoutAllowance);
+        assertNotNull(res.withAllowance);
+        var timeEnterOccupiedSection = res.withAllowance.departureTime()
+                + res.withAllowance.envelope().interpolateTotalTime(5_000);
+        assertEquals(3600, timeEnterOccupiedSection, timeStep);
+        occupancyTest(res.withAllowance, occupancyGraph, timeStep);
+        checkAllowanceResult(res, allowance);
+    }
+
+    /** Test that we can have both an engineering and a standard allowance */
+    @Test
+    public void testEngineeringWithStandardAllowance() {
+        /*
+        a --> b -----> c --> d
+
+        space
+          ^
+        d |############### end
+          |############### /
+          |###############/
+        c |           ___/
+          |       ___/
+        b |   ___/
+          |  /#################
+        a |_/##################_> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1_000, 30),
+                infraBuilder.addRoute("b", "c", 10_000, 30),
+                infraBuilder.addRoute("c", "d", 1_000, 30)
+        );
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                routes.get(0), new OccupancyBlock(120, POSITIVE_INFINITY, 0, 1_000),
+                routes.get(2), new OccupancyBlock(0, 1000, 0, 1_000)
+        );
+        var allowance = new AllowanceValue.Percentage(20);
+
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancyGraph)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 1_000)))
+                .setStandardAllowance(allowance)
+                .run();
+        occupancyTest(res, occupancyGraph, timeStep);
+
+        var thirdRouteEntryTime = res.departureTime()
+                + res.envelope().interpolateTotalTime(11_000);
+        assertEquals(1000, thirdRouteEntryTime, 2 * timeStep);
+    }
+
+    /** Same test as the previous one, with very short routes at the start and end */
+    @Test
+    public void testEngineeringWithStandardAllowanceSmallRoutes() {
+        /*
+        a -> b -----> c -> d
+
+        space
+          ^
+        d |###############
+          |############### end
+        c |           ___/
+          |       ___/
+        b |   ___/
+          |  /
+        a |_/##################_> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1, 30),
+                infraBuilder.addRoute("b", "c", 10_000, 30),
+                infraBuilder.addRoute("c", "d", 1, 30)
+        );
+        var infra = infraBuilder.build();
+        var occupancyGraph = ImmutableMultimap.of(
+                routes.get(0), new OccupancyBlock(60, POSITIVE_INFINITY, 0, 1),
+                routes.get(2), new OccupancyBlock(0, 1000, 0, 1)
+        );
+        var allowance = new AllowanceValue.Percentage(20);
+
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancyGraph)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 0.1)))
+                .setStandardAllowance(allowance)
+                .run();
+        occupancyTest(res, occupancyGraph, timeStep);
+
+        var thirdRouteEntryTime = res.departureTime()
+                + res.envelope().interpolateTotalTime(10_001);
+        assertEquals(1000, thirdRouteEntryTime, 2 * timeStep);
+    }
+
+
+    /** This test checks that we add the right delay while backtracking several times, by adding mrsp drops */
+    @Test
+    public void testManyMRSPDrops() {
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = new ArrayList<SignalingRoute>();
+        for (int i = 0; i < 10; i++) {
+            routes.add(infraBuilder.addRoute(
+                    Integer.toString(i),
+                    String.format("%d.5", i),
+                    1_000,
+                    50
+            ));
+            routes.add(infraBuilder.addRoute(
+                    String.format("%d.5", i),
+                    Integer.toString(i + 1),
+                    10,
+                    5
+            ));
+        }
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(50);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(routes.size() - 1), 0)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withAllowance);
+        assertNotNull(res.withoutAllowance);
+        checkAllowanceResult(res, allowance);
+    }
+
+    /** We shift de departure time a little more at each route */
+    @Test
+    public void testMaximumShiftWithDelays() {
+        /*
+        a --> b --> c --> d --> e
+
+        space
+          ^
+        e |################################ end
+          |################################/__________
+        d |#################### /         /
+          |####################/_________/____________
+        c |############# /    /         /
+          |#############/____/_________/______________
+        b |#####  /    /    /         /
+          |#####/     /    /         /
+        a start______/____/_________/__________________> time
+
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var thirdRoute = infraBuilder.addRoute("c", "d");
+        var forthRoute = infraBuilder.addRoute("d", "e");
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(100);
+        var occupancyGraph = ImmutableMultimap.of(
+                firstRoute, new OccupancyBlock(0, 200, 0, 100),
+                secondRoute, new OccupancyBlock(0, 600, 0, 100),
+                thirdRoute, new OccupancyBlock(0, 1200, 0, 100),
+                forthRoute, new OccupancyBlock(0, 2000, 0, 100)
+        );
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 1)))
+                .setUnavailableTimes(occupancyGraph)
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withoutAllowance);
+        assertNotNull(res.withAllowance);
+        occupancyTest(res.withAllowance, occupancyGraph, timeStep);
+        checkAllowanceResult(res, allowance);
+    }
+}


### PR DESCRIPTION
This PR adds linear allowance in STDCM requests (back-end only).

We don't directly change the envelopes as we create them, because we need to keep track of the original envelope to properly compute the allowance and handle route transitions.
Instead, we keep track of the speed factor as a new field. We use it whenever we compute the time it takes to go from point A to B.