### PR TITLE
editoast: fix db connections pool size

### DIFF
--- a/editoast/README.md
+++ b/editoast/README.md
@@ -30,7 +30,6 @@ $ cargo run -- runserver
 
 ```sh
 # limit threads to avoid test errors with database connections
-export RUST_TEST_THREADS=2
 cargo test
 ```
 

--- a/editoast/src/client/postgres_config.rs
+++ b/editoast/src/client/postgres_config.rs
@@ -20,6 +20,9 @@ pub struct PostgresConfig {
     #[derivative(Default(value = "5432"))]
     #[clap(long, env, default_value_t = 5432)]
     pub psql_port: u16,
+    #[derivative(Default(value = "32"))]
+    #[clap(long, env, default_value_t = 32)]
+    pub pool_size: u16,
 }
 
 impl PostgresConfig {

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -58,6 +58,7 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
         Commands::ImportRailjson(args) => import_railjson(args, pg_config),
     }
 }
+/// Create a rocket server given the config
 pub fn create_server(
     runserver_config: &RunserverArgs,
     pg_config: &PostgresConfig,
@@ -68,6 +69,7 @@ pub fn create_server(
         .merge(("port", runserver_config.port))
         .merge(("address", runserver_config.address.clone()))
         .merge(("databases.postgres.url", pg_config.url()))
+        .merge(("databases.postgres.pool_size", pg_config.pool_size))
         .merge(("limits.json", 250 * 1024 * 1024)) // Set limits to 250MiB
     ;
 
@@ -98,6 +100,7 @@ pub fn create_server(
     rocket
 }
 
+/// Create and run the server
 async fn runserver(
     args: RunserverArgs,
     pg_config: PostgresConfig,

--- a/editoast/src/schema/signal.rs
+++ b/editoast/src/schema/signal.rs
@@ -36,7 +36,7 @@ pub struct Signal {
     pub extensions: SignalExtensions,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct LogicalSignal {
     pub signaling_system: String,
     pub next_signaling_systems: Vec<String>,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -247,28 +247,23 @@ async fn unlock(infra: i32, conn: DBConnection) -> ApiResult<Custom<JsonValue>> 
 
 #[cfg(test)]
 mod tests {
-    use crate::create_server;
     use crate::infra::Infra;
     use crate::schema::operation::{Operation, RailjsonObject};
     use crate::schema::SwitchType;
+    use crate::views::tests::create_test_client;
     use rocket::http::{ContentType, Status};
-    use rocket::local::blocking::Client;
     use serde::Deserialize;
 
     #[test]
     fn infra_list() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let client = create_test_client();
         let response = client.get("/infra").dispatch();
         assert_eq!(response.status(), Status::Ok);
     }
 
     #[test]
     fn infra_create_delete() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let client = create_test_client();
         let create_infra_response = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -289,9 +284,7 @@ mod tests {
 
     #[test]
     fn infra_get() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let client = create_test_client();
         let create_infra_response = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -317,8 +310,7 @@ mod tests {
 
     #[test]
     fn infra_rename() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -342,10 +334,7 @@ mod tests {
 
     #[test]
     fn infra_refresh() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra_response = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -378,10 +367,7 @@ mod tests {
 
     #[test]
     fn infra_refresh_force() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -413,10 +399,7 @@ mod tests {
 
     #[test]
     fn infra_get_switch_types() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -459,10 +442,7 @@ mod tests {
 
     #[test]
     fn infra_lock() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -129,25 +129,16 @@ pub async fn get_objects(
 
 #[cfg(test)]
 mod tests {
-    use rocket::{
-        http::{ContentType, Status},
-        local::blocking::Client,
-    };
+    use rocket::http::{ContentType, Status};
 
-    use crate::{
-        create_server,
-        infra::Infra,
-        schema::{
-            operation::{Operation, RailjsonObject},
-            SwitchType,
-        },
-    };
+    use crate::infra::Infra;
+    use crate::schema::operation::{Operation, RailjsonObject};
+    use crate::schema::SwitchType;
+    use crate::views::tests::create_test_client;
+
     #[test]
     fn check_invalid_ids() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -167,10 +158,7 @@ mod tests {
     }
     #[test]
     fn get_objects_no_ids() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -191,10 +179,7 @@ mod tests {
 
     #[test]
     fn get_objects_duplicate_ids() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)
@@ -215,10 +200,7 @@ mod tests {
 
     #[test]
     fn get_switch_types() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-
-        let client = Client::tracked(rocket).expect("valid rocket instance");
-
+        let client = create_test_client();
         let create_infra = client
             .post("/infra")
             .header(ContentType::JSON)

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -22,14 +22,25 @@ pub async fn health(conn: DBConnection) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use crate::client::PostgresConfig;
     use crate::create_server;
     use rocket::http::Status;
     use rocket::local::blocking::Client;
 
+    /// Create a test editoast client
+    /// This client create a single new connection to the database
+    pub fn create_test_client() -> Client {
+        let pg_config = PostgresConfig {
+            pool_size: 1,
+            ..Default::default()
+        };
+        let rocket = create_server(&Default::default(), &pg_config, Default::default());
+        Client::tracked(rocket).expect("valid rocket instance")
+    }
+
     #[test]
     fn health() {
-        let rocket = create_server(&Default::default(), &Default::default(), Default::default());
-        let client = Client::tracked(rocket).expect("valid rocket instance");
+        let client = create_test_client();
         let response = client.get("/health").dispatch();
         assert_eq!(response.status(), Status::Ok);
     }


### PR DESCRIPTION
By default:

- diesel create a pool of `nb_worker * 4` connections 
- rocket instantiates `threads * 2` worker

On my machine, I had `64` connections created.

This is an issue cause we can easily reach postgresql limit (around 200). 
I suspect that this is the cause of issues within the github CI