### PR TITLE
api: pathfinding missing rolling_stocks parameter error

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1095,6 +1095,10 @@ components:
                   nullable: true
 
     PathQuery:
+      required: 
+        - infra
+        - rolling_stocks
+        - steps
       properties:
         infra:
           type: integer

--- a/api/osrd_infra/serializers.py
+++ b/api/osrd_infra/serializers.py
@@ -134,8 +134,7 @@ class PathInputSerializer(Serializer):
     infra = serializers.PrimaryKeyRelatedField(queryset=Infra.objects.all())
     steps = serializers.ListField(min_length=2, child=StepInputSerializer())
     rolling_stocks = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=RollingStock.objects.all()),
-        required=False,
+        child=serializers.PrimaryKeyRelatedField(queryset=RollingStock.objects.all())
     )
 
 

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -388,7 +388,7 @@ def make_payload_path(infra: int, path: List[Tuple[str, float]]) -> Dict:
     :param path: List of steps
     :return: Dict
     """
-    path_payload = {"infra": infra, "name": "foo", "steps": [convert_stop(stop) for stop in path]}
+    path_payload = {"rolling_stocks": [102], "infra": infra, "name": "foo", "steps": [convert_stop(stop) for stop in path]}
     path_payload["steps"][-1]["duration"] = 1
     return path_payload
 

--- a/tests/tests/pathfinding_small_infra.py
+++ b/tests/tests/pathfinding_small_infra.py
@@ -10,6 +10,7 @@ def get_track_section(base_url, infra_id):
 
 def run_pathfinding(base_url, infra_id):
     path_payload = {
+        "rolling_stocks": [102],
         "infra": infra_id,
         "steps": [
             {

--- a/tests/tests/regression_fuzzer_tests/run_all.py
+++ b/tests/tests/regression_fuzzer_tests/run_all.py
@@ -9,6 +9,7 @@ from tests.get_timetable import get_timetable
 
 def pathfinding_with_payload(base_url, payload, infra_id, accept_400):
     payload["infra"] = infra_id
+    payload["rolling_stocks"] = []
     r = requests.post(base_url + "pathfinding/", json=payload)
     if r.status_code // 100 != 2:
         if r.status_code // 100 == 4 and accept_400:

--- a/tests/tests/run_pathfinding.py
+++ b/tests/tests/run_pathfinding.py
@@ -11,6 +11,7 @@ def get_track_section(base_url, infra_id):
 def run_pathfinding(base_url, infra_id):
     track = get_track_section(base_url, infra_id)
     path_payload = {
+        "rolling_stocks": [],
         "infra": infra_id,
         "steps": [
             {

--- a/tests/tests/stdcm/utils.py
+++ b/tests/tests/stdcm/utils.py
@@ -43,6 +43,7 @@ def get_schedule_longest_occupancy(base_url, schedule_id):
 
 def _run_pathfinding(base_url, infra_id, start, stop):
     path_payload = {
+        "rolling_stocks": [],
         "infra": infra_id,
         "steps": [
             {


### PR DESCRIPTION
make rolling_stocks a required field for pathfinding. 
This is already verified on front-end side, but `api` still allowed it