### PR TITLE
api: postgres: allow to run `api` tests locally

### DIFF
--- a/api/config/settings.py
+++ b/api/config/settings.py
@@ -128,6 +128,9 @@ DATABASES = {
         "USER": POSTGRES_USER,
         "PASSWORD": POSTGRES_PASSWORD,
         "HOST": POSTGRES_HOST,
+        "TEST": {
+            "TEMPLATE": "template_postgis"
+        }
     },
 }
 

--- a/init_db.sql
+++ b/init_db.sql
@@ -1,4 +1,4 @@
-create user osrd password 'password';
+create user osrd with password 'password' createdb;
 create database osrd;
 
 grant all privileges on database osrd to osrd;


### PR DESCRIPTION
To run the tests in a local environment, the user osrd needs to be able to create and delete a database in postgres. (Django creates a test database when running the tests and delete it at the end).

https://docs.djangoproject.com/en/4.1/topics/testing/overview/#the-test-database

closes #2742