### PR TITLE
core: use a library catalog (libs.versions.toml)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,35 +1,15 @@
-// this project is licensed under LGPLv3.
-// DO NOT ADD any dependency which isn't compatible with LGPLv3, such as:
-//  - GPLv2, GPLv2+
-//  - GPLv3, GPLv3+
-//  - EPL 1.0
-//
-// The following licenses were checked for compatibility for use as libraries:
-//  - Apache 2.0
-//  - MIT
-//  - BSD licenses
-//  - EPL2.0 (see https://www.eclipse.org/legal/epl-2.0/faq.php#h.hsnsfg4e0htq)
-//  - LGPLv2, LGPLv2+, LGPLv3
-//  - GPLv2 with classpath exception
-//  - CC Attribution
-
 import static org.apache.tools.ant.taskdefs.condition.Os.*
 
 plugins {
     id 'java'
-    // must be kept in sync with kotlin_version below
-    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
-    id 'com.google.devtools.ksp' version '1.7.21-1.0.8' apply false
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp) apply false
     id 'application'
     id 'checkstyle'
-    id 'com.github.spotbugs' version '5.0.+'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    alias(libs.plugins.spotbugs)
+    alias(libs.plugins.shadow)
     id 'jacoco'
 }
-
-// must be kept in sync across all modules
-def kotlin_version = '1.7.21'
-
 
 // region DEPENDENCIES
 
@@ -38,73 +18,75 @@ repositories {
 }
 
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
+
     implementation project(':osrd-railjson')
 
     // kotlin
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.+'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-test', version: '1.6.+'  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
+    testImplementation libs.kotlin.test
+    testImplementation libs.kotlinx.coroutines.test
 
     implementation project(':kt-osrd-signaling')
     implementation project(":kt-osrd-sim-interlocking")
     implementation project(":kt-osrd-sim-infra")
 
     // base primitives
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'  // Apache 2.0
+    implementation libs.guava
 
     // command line parsing
-    implementation group: 'com.beust', name: 'jcommander', version: '1.82'  // Apache 2.0
+    implementation libs.jcommander
 
     // fast primitive collections
-    implementation group: 'com.carrotsearch', name: 'hppc', version: '0.9.1'  // Apache 2.0
+    implementation libs.hppc
 
     // JSON parsing
-    implementation 'com.squareup.moshi:moshi:1.14.0' // Apache 2.0
-    implementation 'com.squareup.moshi:moshi-adapters:1.14.0'  // Apache 2.0
+    implementation libs.moshi
+    implementation libs.moshi.adapters
 
     // HTTP server framework
-    implementation group: 'org.takes', name: 'takes', version: '1.24.+'  // MIT
-    implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'  // GPLv2 with classpath exemption
+    implementation libs.takes
+    implementation libs.javax.json.api
 
     // HTTP client
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0' // Apache 2.0
+    implementation libs.okhttp
 
     // ClassGraph (FastClasspathScanner)
-    implementation group: 'io.github.classgraph', name: 'classgraph', version: '4.8.+' // MIT
+    implementation libs.classgraph
 
     // for debug UI
-    implementation 'com.github.yannrichet:JMathPlot:1.0.1' // BSD
+    implementation libs.jmathplot
 
     // the logging API stub
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.+'  // MIT
+    implementation libs.slf4j
 
     // the logging API implementation
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.+'  // EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.+'
+    implementation libs.logback.core
+    implementation libs.logback.classic
 
     // Sentry
-    implementation group: 'io.sentry', name: 'sentry', version: '6.8.+'  // MIT
+    implementation libs.sentry
 
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.+'  // EPL 2.0
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.+'  // EPL 2.0
+    testImplementation libs.junit.jupiter.api
+    testImplementation libs.junit.jupiter.params
     // Use JUnit Jupiter Engine for testing.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.+'  // EPL 2.0
+    testRuntimeOnly libs.junit.jupiter.engine
     // jqwik for property based testing
-    testImplementation 'net.jqwik:jqwik:1.7.+'  // EPL 2.0
+    testImplementation libs.jqwik
     // mockito for mocking
-    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.9.+'  // MIT
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.9.+'  // MIT
+    testImplementation libs.mockito.inline
+    testImplementation libs.mockito.junit.jupiter
 
     // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.+'  // EPL 2.0
+    testRuntimeOnly libs.junit.platform.launcher
 
     // for linter annotations
-    compileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.+'  // LGPLv2.1
-    testCompileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    testCompileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.+'  // LGPLv2.1
+    compileOnly libs.jcip.annotations
+    compileOnly libs.spotbugs.annotations
+    testCompileOnly libs.jcip.annotations
+    testCompileOnly libs.spotbugs.annotations
 }
 
 // endregion

--- a/core/kt-fast-collections-annotations/build.gradle
+++ b/core/kt-fast-collections-annotations/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.kotlin.jvm)
 }
 
 repositories {
@@ -7,6 +7,7 @@ repositories {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
+    api libs.kotlin.reflect
 }
 

--- a/core/kt-fast-collections-generator/build.gradle
+++ b/core/kt-fast-collections-generator/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.kotlin.jvm)
 }
 
 repositories {
@@ -7,7 +7,8 @@ repositories {
 }
 
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-fast-collections-annotations")
-    implementation 'com.google.devtools.ksp:symbol-processing-api:1.7.10-1.0.6'
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
+    implementation libs.ksp.symbol.processing.api
+    implementation libs.kotlin.reflect
 }

--- a/core/kt-fast-collections/build.gradle
+++ b/core/kt-fast-collections/build.gradle
@@ -1,21 +1,20 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp'
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(':kt-fast-collections-annotations')
     ksp project(':kt-fast-collections-generator')
 
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    api group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.+'  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.stdlib
+    api libs.kotlinx.coroutines.core
+    testImplementation libs.kotlin.test
 }
 
 // to get KSP generated-stuff to be recognised

--- a/core/kt-osrd-signaling/build.gradle
+++ b/core/kt-osrd-signaling/build.gradle
@@ -1,22 +1,21 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp'
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-osrd-utils")
     api project(':kt-osrd-sim-infra')
     api project(":osrd-railjson")
 
-    implementation group: 'io.github.microutils', name: 'kotlin-logging', version: '3.0.4'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.logging
+    implementation libs.kotlin.stdlib
+    testImplementation libs.kotlin.test
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/core/kt-osrd-sim-infra/build.gradle
+++ b/core/kt-osrd-sim-infra/build.gradle
@@ -1,22 +1,21 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp'
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
     ksp project(':kt-fast-collections-generator')
 
     api project(":kt-osrd-utils")
     api project(":osrd-railjson")
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.stdlib
+    testImplementation libs.kotlin.test
 }
 
 // to get KSP generated-stuff to be recognised

--- a/core/kt-osrd-sim-interlocking/build.gradle
+++ b/core/kt-osrd-sim-interlocking/build.gradle
@@ -1,27 +1,26 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp'
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-osrd-utils")
     api project(':kt-osrd-sim-infra')
-    api group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.+'  // Apache 2.0
+    api libs.kotlinx.coroutines.core
 
-    implementation group: 'io.github.microutils', name: 'kotlin-logging', version: '3.0.4'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-test', version: '1.6.+'  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.logging
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.test
+    testImplementation libs.kotlin.test
 
     // the logging API implementation is only needed during testing, as this is a library
-    testRuntimeOnly group: 'ch.qos.logback', name: 'logback-core', version: '1.4.+'  // EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
-    testRuntimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.+'
+    testRuntimeOnly libs.logback.core
+    testRuntimeOnly libs.logback.classic
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/core/kt-osrd-sncf-signaling/build.gradle
+++ b/core/kt-osrd-sncf-signaling/build.gradle
@@ -1,18 +1,17 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.kotlin.jvm)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(':kt-osrd-signaling')
 
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    implementation libs.kotlin.stdlib
+    testImplementation libs.kotlin.test
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/core/kt-osrd-utils/build.gradle
+++ b/core/kt-osrd-utils/build.gradle
@@ -1,22 +1,22 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp'
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
 }
 
 repositories {
     mavenCentral()
 }
 
-def kotlin_version = '1.7.10'
-
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
     ksp project(':kt-fast-collections-generator')
 
-    api group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '1.6.+'  // Apache 2.0
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version  // Apache 2.0
-    testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-test', version: kotlin_version  // Apache 2.0
+    api libs.kotlinx.coroutines.core
+    implementation libs.kotlin.stdlib
+    testImplementation libs.kotlin.test
 }
+
 
 // to get KSP generated-stuff to be recognised
 kotlin {

--- a/core/libs.versions.toml
+++ b/core/libs.versions.toml
@@ -1,0 +1,68 @@
+# this project is licensed under LGPLv3.
+# DO NOT ADD any dependency which isn't compatible with LGPLv3, such as:
+#  - GPLv2, GPLv2+
+#  - GPLv3, GPLv3+
+#  - EPL 1.0
+#
+# The following licenses were checked for compatibility for use as libraries:
+#  - Apache 2.0
+#  - MIT
+#  - BSD licenses
+#  - EPL2.0 (see https://www.eclipse.org/legal/epl-2.0/faq.php#h.hsnsfg4e0htq)
+#  - LGPLv2, LGPLv2+, LGPLv3
+#  - GPLv2 with classpath exception
+#  - CC Attribution
+
+[versions]
+kotlin = '1.7.10'
+ksp = '1.7.10-1.0.6'
+kotlinx-coroutines = '1.6.+'
+logback = '1.4.+'
+moshi = '1.14.0'
+junit = '5.9.+'
+
+[libraries]
+# kotlin stuff
+kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib', version.ref = 'kotlin' }  # Apache 2.0
+kotlin-logging = { module = 'io.github.microutils:kotlin-logging', version = '3.0.4' }  # Apache 2.0
+kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' }  # Apache 2.0
+kotlin-test = { module = 'org.jetbrains.kotlin:kotlin-test', version.ref = 'kotlin' }  # Apache 2.0
+kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' }  # Apache 2.0
+kotlinx-coroutines-test = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-test', version.ref = 'kotlinx-coroutines' }  # Apache 2.0
+ksp-symbol-processing-api = { module = 'com.google.devtools.ksp:symbol-processing-api', version.ref = 'ksp' }  # Apache 2.0
+
+# common
+logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback' }  # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
+logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback' }  # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
+
+# java stuff
+guava = { module = 'com.google.guava:guava', version = '31.1-jre' }  # Apache 2.0
+jcommander = { module = 'com.beust:jcommander', version = '1.82' }  # Apache 2.0
+hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' }  # Apache 2.0
+moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' }  # Apache 2.0
+moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' }  # Apache 2.0
+takes = { module = 'org.takes:takes', version = '1.24.+' }  # MIT
+javax-json-api = { module = 'javax.json:javax.json-api', version = '1.1.4' }  # GPLv2 with classpath exemption
+okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.10.0' }  # Apache 2.0
+classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' }  # MIT
+jmathplot = { module = 'com.github.yannrichet:JMathPlot', version = '1.0.1' }  # BSD
+slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' }  # MIT
+sentry = { module = 'io.sentry:sentry', version = '6.8.+' }  # MIT
+junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }  # EPL 2.0
+junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' }  # EPL 2.0
+junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }  # EPL 2.0
+jqwik = { module = 'net.jqwik:jqwik', version = '1.7.+' }  # EPL 2.0
+mockito-inline = { module = 'org.mockito:mockito-inline', version = '4.9.+' }  # MIT
+mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version = '4.9.+' }  # MIT
+junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.9.+' }  # EPL 2.0
+jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' }  # CC Attribution
+spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.7.+' }  # LGPLv2.1
+
+[plugins]
+# kotlin
+ksp = { id = 'com.google.devtools.ksp', version.ref = 'ksp' }
+kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
+
+# java
+spotbugs = { id = 'com.github.spotbugs', version = '5.0.+' }
+shadow = { id = 'com.github.johnrengelman.shadow', version = '7.1.2' }

--- a/core/osrd-railjson/build.gradle
+++ b/core/osrd-railjson/build.gradle
@@ -7,20 +7,22 @@ repositories {
 }
 
 dependencies {
+    // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
+
     // fast primitive collections
-    implementation group: 'com.carrotsearch', name: 'hppc', version: '0.9.1'  // Apache 2.0
+    implementation libs.hppc
 
     // JSON parsing
-    implementation 'com.squareup.moshi:moshi:1.14.0' // Apache 2.0
-    implementation 'com.squareup.moshi:moshi-adapters:1.14.0'  // Apache 2.0
+    implementation libs.moshi
+    implementation libs.moshi.adapters
 
     // for linter annotations
-    compileOnly 'net.jcip:jcip-annotations:1.0'  // CC Attribution
-    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.+'  // LGPLv2.1
+    compileOnly libs.jcip.annotations
+    compileOnly libs.spotbugs.annotations
 
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.+'  // EPL 2.0
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.+'  // EPL 2.0
+    testImplementation libs.junit.jupiter.api
+    testImplementation libs.junit.jupiter.params
     // Use JUnit Jupiter Engine for testing.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.+'  // EPL 2.0
+    testRuntimeOnly libs.junit.jupiter.engine
 }

--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -8,3 +8,12 @@ include 'kt-osrd-signaling'
 include 'kt-osrd-sim-infra'
 include 'kt-osrd-sim-interlocking'
 include 'osrd-railjson'
+
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("./libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
Currently, we need to manually sync dependency versions between modules. Using a centralized dependency catalog enables easier upgrades. https://docs.gradle.org/current/userguide/platforms.html