### PR TITLE
Remove typo in `core` and `editoast` openapi description

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: OSRD
-  description: OSRD middleware api documentation
+  description: OSRD middleware api description
   version: 2.0.0
 tags:
   - name: infra

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: OSRD Core
-  description: "OSRD backend api description."
+  description: OSRD backend api description
   termsOfService: http://swagger.io/terms/
   license:
     name: GNU GPLv3

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: OSRD Editoast
-  description: OSRD Edition ervice documentation
+  description: OSRD Edition service documentation
   version: 0.1.0
 
 tags:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: OSRD Editoast
-  description: OSRD Edition service documentation
+  description: OSRD Edition service description
   version: 0.1.0
 
 tags:


### PR DESCRIPTION
This PR is :
- removing useless point and quotes in `core/openapi.yaml`
- fixing typo in `editoast/openapi.yaml`
- using consistent wording between descriptions