### PR TITLE
editoast: fix endpoint that retrieve infra errors

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -665,20 +665,20 @@ components:
       type: object
       description: An infra error or warning
       properties:
-        obj_id:
-          type: string
-          example: 8979e17f-6704-49f6-b63e-98f68ba2d086
-          description: Id of the object linked to the error
-        obj_type:
-          $ref: "#/components/schemas/ObjectType"
-          example: Signal
+        geographic:
+          nullable: true
+          type: object
+          description: Geojson of the geographic geometry of the error
+        schematic:
+          nullable: true
+          type: object
+          description: Geojson of the schematic geometry of the error
         information:
           type: object
-          description: Information about the erorr (check schema documentation for more details)
+          description: Information about the error (check schema documentation for more details)
           example:
             error_type: invalid_reference
             field: track
             is_warning: false
-            reference:
-              id: 61205924-6667-11e3-81ff-01f464e0362d
-              type: TrackSection
+            obj_id: 61205924-6667-11e3-81ff-01f464e0362d
+            obj_type: TrackSection

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -1,6 +1,6 @@
 use crate::api_error::ApiError;
 use crate::views::pagination::{paginate, PaginationError};
-use diesel::sql_types::{BigInt, Integer, Json, Text};
+use diesel::sql_types::{BigInt, Integer, Json, Nullable, Text};
 use diesel::{PgConnection, RunQueryDsl};
 use serde::Serialize;
 use serde_json::Value;
@@ -11,10 +11,10 @@ struct InfraErrorQueryable {
     pub count: i64,
     #[sql_type = "Json"]
     pub information: Value,
-    #[sql_type = "Json"]
-    pub geographic: Value,
-    #[sql_type = "Json"]
-    pub schematic: Value,
+    #[sql_type = "Nullable<Json>"]
+    pub geographic: Option<Value>,
+    #[sql_type = "Nullable<Json>"]
+    pub schematic: Option<Value>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, FromFormField)]
@@ -29,8 +29,8 @@ pub enum Level {
 #[serde(deny_unknown_fields)]
 pub struct InfraErrorModel {
     pub information: Value,
-    pub geographic: Value,
-    pub schematic: Value,
+    pub geographic: Option<Value>,
+    pub schematic: Option<Value>,
 }
 
 impl From<InfraErrorQueryable> for InfraErrorModel {


### PR DESCRIPTION
A diesel error occurred when there was no geometry of the error.