### PR TITLE
editoast: Parse and expose `chartos.yml`

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_yaml",
  "strum",
  "strum_macros",
  "tempfile",
@@ -1782,6 +1783,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2241,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "url"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -37,3 +37,4 @@ thiserror = "~1.0.37"
 enum-map = "2.4.2"
 tempfile = "3.3.0"
 editoast_derive = { path = "./editoast_derive" }
+serde_yaml = "0.9.16"

--- a/editoast/map_layers.yml
+++ b/editoast/map_layers.yml
@@ -1,0 +1,223 @@
+layers:
+  - name: track_sections
+    table_name: osrd_infra_tracksectionlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: track_section.data
+        exclude_fields: [geo, sch]
+        joins:
+          - inner join osrd_infra_tracksectionmodel track_section on track_section.obj_id = layer.obj_id and track_section.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: track_section.data
+        exclude_fields: [geo, sch]
+        joins:
+          - inner join osrd_infra_tracksectionmodel track_section on track_section.obj_id = layer.obj_id and track_section.infra_id = layer.infra_id
+
+  - name: signals
+    table_name: osrd_infra_signallayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: signal.data
+        joins:
+          - inner join osrd_infra_signalmodel signal on signal.obj_id = layer.obj_id and signal.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: signal.data
+        joins:
+          - inner join osrd_infra_signalmodel signal on signal.obj_id = layer.obj_id and signal.infra_id = layer.infra_id
+
+  - name: speed_sections
+    table_name: osrd_infra_speedsectionlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: speed_section.data
+        joins:
+          - inner join osrd_infra_speedsectionmodel speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
+        where:
+          - not (speed_section.data @? '$.extensions.lpv_sncf.z')
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: speed_section.data
+        joins:
+          - inner join osrd_infra_speedsectionmodel speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
+        where:
+          - not (speed_section.data @? '$.extensions.lpv_sncf.z')
+
+  - name: lpv
+    table_name: osrd_infra_speedsectionlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: speed_section.data
+        joins:
+          - inner join osrd_infra_speedsectionmodel speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
+        where:
+          - speed_section.data @? '$.extensions.lpv_sncf.z'
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: speed_section.data
+        joins:
+          - inner join osrd_infra_speedsectionmodel speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
+        where:
+          - speed_section.data @? '$.extensions.lpv_sncf.z'
+
+  - name: track_section_links
+    table_name: osrd_infra_tracksectionlinklayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: track_section_link.data
+        joins:
+          - inner join osrd_infra_tracksectionlinkmodel track_section_link on track_section_link.obj_id = layer.obj_id and track_section_link.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: track_section_link.data
+        joins:
+          - inner join osrd_infra_tracksectionlinkmodel track_section_link on track_section_link.obj_id = layer.obj_id and track_section_link.infra_id = layer.infra_id
+
+  - name: switches
+    table_name: osrd_infra_switchlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: switch.data
+        joins:
+          - inner join osrd_infra_switchmodel switch on switch.obj_id = layer.obj_id and switch.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: switch.data
+        joins:
+          - inner join osrd_infra_switchmodel switch on switch.obj_id = layer.obj_id and switch.infra_id = layer.infra_id
+
+  - name: detectors
+    table_name: osrd_infra_detectorlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: detector.data
+        joins:
+          - inner join osrd_infra_detectormodel detector on detector.obj_id = layer.obj_id and detector.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: detector.data
+        joins:
+          - inner join osrd_infra_detectormodel detector on detector.obj_id = layer.obj_id and detector.infra_id = layer.infra_id
+
+  - name: buffer_stops
+    table_name: osrd_infra_bufferstoplayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: buffer_stop.data
+        joins:
+          - inner join osrd_infra_bufferstopmodel buffer_stop on buffer_stop.obj_id = layer.obj_id and buffer_stop.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: buffer_stop.data
+        joins:
+          - inner join osrd_infra_bufferstopmodel buffer_stop on buffer_stop.obj_id = layer.obj_id and buffer_stop.infra_id = layer.infra_id
+
+  - name: routes
+    table_name: osrd_infra_routelayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: route.data
+        joins:
+          - inner join osrd_infra_routemodel route on route.obj_id = layer.obj_id and route.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: route.data
+        joins:
+          - inner join osrd_infra_routemodel route on route.obj_id = layer.obj_id and route.infra_id = layer.infra_id
+
+  - name: operational_points
+    table_name: osrd_infra_operationalpointlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: operational_point.data
+        joins:
+          - inner join osrd_infra_operationalpointmodel operational_point on operational_point.obj_id = layer.obj_id and operational_point.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: operational_point.data
+        joins:
+          - inner join osrd_infra_operationalpointmodel operational_point on operational_point.obj_id = layer.obj_id and operational_point.infra_id = layer.infra_id
+
+  - name: catenaries
+    table_name: osrd_infra_catenarylayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: catenary.data
+        joins:
+          - inner join osrd_infra_catenarymodel catenary on catenary.obj_id = layer.obj_id and catenary.infra_id = layer.infra_id
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: catenary.data
+        joins:
+          - inner join osrd_infra_catenarymodel catenary on catenary.obj_id = layer.obj_id and catenary.infra_id = layer.infra_id
+
+  - name: lpv_panels
+    table_name: osrd_infra_lpvpanellayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: layer.data
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: layer.data
+
+  - name: errors
+    table_name: osrd_infra_errorlayer
+    id_field: id
+    views:
+      - name: geo
+        on_field: geographic
+        cache_duration: 3600
+        data_expr: layer.information
+      - name: sch
+        on_field: schematic
+        cache_duration: 3600
+        data_expr: layer.information

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -31,6 +31,17 @@ paths:
                 required:
                   - git_describe
 
+  /layers/info/:
+    get:
+      summary: Get layers descriptions
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema: 
+                type: array
+
   /infra/:
     get:
       tags:

--- a/editoast/src/chartos/map_layers.rs
+++ b/editoast/src/chartos/map_layers.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use serde_yaml::{self};
+
+// select C.stuff from A inner join B C on C.id = C.id;
+//                       \___________________________/
+//                             a join expression
+//                            C is an alias for B
+type JoinExpr = String;
+
+/// Layer view description
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct View {
+    pub name: String,
+    pub on_field: String,
+    pub data_expr: String,
+    #[serde(default)]
+    pub exclude_fields: Vec<String>,
+    #[serde(default)]
+    pub joins: Vec<JoinExpr>,
+    pub cache_duration: u32,
+    #[serde(rename = "where", default)]
+    pub where_expr: Vec<String>,
+}
+
+/// Layer description
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct Layer {
+    pub name: String,
+    pub table_name: String,
+    pub views: Vec<View>,
+    #[serde(default)]
+    pub id_field: Option<String>,
+    #[serde(default)]
+    pub attribution: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct MapLayers {
+    pub layers: Vec<Layer>,
+}
+
+impl MapLayers {
+    /// Parses file containing layers' description into MapLayers struct
+    pub fn parse() -> MapLayers {
+        serde_yaml::from_str(include_str!("../../map_layers.yml")).unwrap()
+    }
+}

--- a/editoast/src/chartos/mod.rs
+++ b/editoast/src/chartos/mod.rs
@@ -1,8 +1,9 @@
 mod bounding_box;
 mod layer_cache;
+mod map_layers;
 
-pub use bounding_box::BoundingBox;
-pub use bounding_box::InvalidationZone;
+pub use bounding_box::{BoundingBox, InvalidationZone};
+pub use map_layers::MapLayers;
 
 use reqwest::Client;
 use serde_json::json;

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -15,6 +15,7 @@ mod schema;
 mod tables;
 mod views;
 
+use chartos::MapLayers;
 use chashmap::CHashMap;
 use clap::Parser;
 use client::{
@@ -94,7 +95,8 @@ pub fn create_server(
         .attach(RedisPool::init())
         .attach(cors::Cors)
         .manage(Arc::<CHashMap<i32, InfraCache>>::default())
-        .manage(chartos_config);
+        .manage(chartos_config)
+        .manage(MapLayers::parse());
 
     // Mount routes
     for (base, routes) in views::routes() {

--- a/editoast/src/views/layers/info.rs
+++ b/editoast/src/views/layers/info.rs
@@ -1,0 +1,24 @@
+use crate::api_error::ApiResult;
+use crate::chartos::MapLayers;
+use rocket::serde::json::{json, Value as JsonValue};
+
+use rocket::State;
+
+/// Returns all defined layers description in a json format
+#[get("/info")]
+pub async fn info_route(map_layers: &State<MapLayers>) -> ApiResult<JsonValue> {
+    Ok(json!(map_layers.layers))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::views::tests::create_test_client;
+    use rocket::http::Status;
+
+    #[test]
+    fn info() {
+        let client = create_test_client();
+        let response = client.get("/layers/info").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+    }
+}

--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -1,0 +1,8 @@
+mod info;
+
+use info::info_route;
+use rocket::{routes, Route};
+
+pub fn routes() -> Vec<Route> {
+    routes![info_route]
+}

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -1,4 +1,5 @@
 mod infra;
+mod layers;
 use rocket::serde::json::Value as JsonValue;
 use rocket_db_pools::deadpool_redis;
 pub mod pagination;
@@ -15,6 +16,7 @@ pub fn routes() -> HashMap<&'static str, Vec<Route>> {
     HashMap::from([
         ("/", routes![health, version, opt::all_options]),
         ("/infra", infra::routes()),
+        ("/layers", layers::routes()),
     ])
 }
 


### PR DESCRIPTION
This PR is:
- adding `serde_yaml` dependency to editoast
- creating `layers` views
- exposing the content of `chartos.yml` on the `layers/info` endpoint
- renaming `chartos.yml` -> `map_layers.yml`

close #2830