### PR TITLE
core: uses editoast instead of api

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -44,7 +44,7 @@ You'll need:
 gradlew.bat processTestResources shadowJar
 
 # Run as service
-java -jar build/libs/osrd-all.jar api --url http://localhost:8000/ -p 8080
+java -jar build/libs/osrd-all.jar api --url http://localhost:8090/ -p 8080
 
 # Check that an infra can be loaded
 java -jar build/libs/osrd-all.jar load-infra --path RAILJSON_INFRA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     restart: unless-stopped
     command: "java -ea -jar /app/osrd_core.jar api -p 8080"
     environment:
-      MIDDLEWARE_BASE_URL: "http://localhost:8000"
+      MIDDLEWARE_BASE_URL: "http://localhost:8090"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       start_period: 4s


### PR DESCRIPTION
Since the endpoint to download an infra railjson is deprecated in API. Core should now use editoast.