### PR TITLE
core: stdcm: standard allowance bugfixes

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -105,7 +105,14 @@ public class STDCMEndpoint implements Take {
                     request.gridMarginBeforeSTDCM
             );
             double minRunTime = getMinRunTime(
-                    infra, rollingStock, comfort, startLocations, endLocations, request.timeStep);
+                    infra,
+                    rollingStock,
+                    comfort,
+                    startLocations,
+                    endLocations,
+                    request.timeStep,
+                    standardAllowance
+            );
 
             // Run the STDCM pathfinding
             var res = STDCMPathfinding.findPath(
@@ -156,7 +163,8 @@ public class STDCMEndpoint implements Take {
             RollingStock.Comfort comfort,
             Set<EdgeLocation<SignalingRoute>> startLocations,
             Set<EdgeLocation<SignalingRoute>> endLocations,
-            double timeStep
+            double timeStep,
+            AllowanceValue standardAllowance
     ) {
         var remainingDistanceEstimator = new RemainingDistanceEstimator(endLocations);
         var rawPath = new Pathfinding<>(new GraphAdapter<>(infra.getSignalingRouteGraph()))
@@ -191,7 +199,10 @@ public class STDCMEndpoint implements Take {
                 timeStep
         );
         var headPositions = standaloneResult.baseSimulations.get(0).headPositions;
-        return headPositions.get(headPositions.size() - 1).time;
+        var time = headPositions.get(headPositions.size() - 1).time;
+        if (standardAllowance != null)
+            time += standardAllowance.getAllowanceTime(time, path.length()); // Add allowance time to the shortest time
+        return time;
     }
 
     /** Generate a train schedule matching the envelope and rolling stock, with one stop at the end */

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -228,9 +228,6 @@ public class EnvelopePhysics {
 
         var totalEnergyConsumed = kineticEnergyDelta - workGravity - workDrag;
 
-        // If the train is braking the result should be negative
-        assert !part.hasAttr(EnvelopeProfile.BRAKING) || totalEnergyConsumed <= 0;
-
         return max(0., totalEnergyConsumed);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/utils/AllowanceConvergenceException.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/allowances/utils/AllowanceConvergenceException.java
@@ -8,12 +8,18 @@ public class AllowanceConvergenceException extends OSRDError {
     @Serial
     private static final long serialVersionUID = 2130748645658059205L;
     public static final String osrdErrorType = "allowance_convergence";
-    public final String errorType;
+    public final ErrorType errorType;
+
+    public enum ErrorType {
+        DISCONTINUITY,
+        TOO_MUCH_TIME,
+        NOT_ENOUGH_TIME
+    }
 
     private AllowanceConvergenceException(
             String message,
             ErrorCause cause,
-            String marecoErrorType
+            ErrorType marecoErrorType
     ) {
         super(message, cause);
         this.errorType = marecoErrorType;
@@ -24,7 +30,7 @@ public class AllowanceConvergenceException extends OSRDError {
         return new AllowanceConvergenceException(
                 "Failed to converge when computing allowances because of a discontinuity in the search space",
                 ErrorCause.INTERNAL,
-                "discontinuity"
+                ErrorType.DISCONTINUITY
         );
     }
 
@@ -33,7 +39,7 @@ public class AllowanceConvergenceException extends OSRDError {
         return new AllowanceConvergenceException(
                 "We could not go slow enough in this setting to match the given allowance time",
                 ErrorCause.USER,
-                "too_much_allowance_time"
+                ErrorType.TOO_MUCH_TIME
         );
     }
 
@@ -42,7 +48,7 @@ public class AllowanceConvergenceException extends OSRDError {
         return new AllowanceConvergenceException(
                 "We could not go fast enough in this setting to match the given allowance time",
                 ErrorCause.INTERNAL,
-                "not_enough_allowance_time"
+                ErrorType.NOT_ENOUGH_TIME
         );
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -338,14 +338,14 @@ public class AllowanceTests {
                 testContext, begin, end, 8.33, allowanceValue);
         var marecoThrown =
                 assertThrows(AllowanceConvergenceException.class, () -> marecoAllowance.apply(maxEffortEnvelope));
-        assertEquals("too_much_allowance_time", marecoThrown.errorType);
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, marecoThrown.errorType);
 
         // test linear distribution
         var linearAllowance = makeStandardLinearAllowance(
                 testContext, begin, end, 8.33, allowanceValue);
         var linearThrown =
                 assertThrows(AllowanceConvergenceException.class, () -> linearAllowance.apply(maxEffortEnvelope));
-        assertEquals("too_much_allowance_time", linearThrown.errorType);
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, linearThrown.errorType);
     }
 
     /** Test the engineering allowance with a very short segment, to trigger intersectLeftRightParts method */
@@ -364,14 +364,14 @@ public class AllowanceTests {
                 testContext, begin, end, 8.33, allowanceValue);
         var marecoThrown =
                 assertThrows(AllowanceConvergenceException.class, () -> marecoAllowance.apply(maxEffortEnvelope));
-        assertEquals("too_much_allowance_time", marecoThrown.errorType);
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, marecoThrown.errorType);
 
         // test linear distribution
         var linearAllowance = makeStandardLinearAllowance(
                 testContext, begin, end, 8.33, allowanceValue);
         var linearThrown =
                 assertThrows(AllowanceConvergenceException.class, () -> linearAllowance.apply(maxEffortEnvelope));
-        assertEquals("too_much_allowance_time", linearThrown.errorType);
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, linearThrown.errorType);
     }
 
     private void testEngineeringOnStandardAllowance(Envelope maxEffortEnvelope,
@@ -725,8 +725,7 @@ public class AllowanceTests {
         var marecoException = assertThrows(AllowanceConvergenceException.class, () ->
                 makeSimpleAllowanceEnvelope(testContext, marecoAllowance, 44.4, true)
         );
-        assert marecoException.errorType.equals("too_much_allowance_time");
-        assert marecoException.cause == OSRDError.ErrorCause.USER;
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, marecoException.errorType);
 
         // test linear distribution
         var linearAllowance = makeStandardLinearAllowance(
@@ -735,7 +734,7 @@ public class AllowanceTests {
         var linearException = assertThrows(AllowanceConvergenceException.class, () ->
                 makeSimpleAllowanceEnvelope(testContext, linearAllowance, 44.4, true)
         );
-        assert linearException.errorType.equals("too_much_allowance_time");
+        assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, linearException.errorType);
         assert linearException.cause == OSRDError.ErrorCause.USER;
     }
 

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -382,6 +382,32 @@ public class StandardAllowanceTests {
         assertEquals(1000, thirdRouteEntryTime, 2 * timeStep);
     }
 
+    /** Tests a simple path with no conflict, with a time per distance allowance and very low value */
+    @Test
+    public void testSimplePathTimePerDistanceAllowanceLowValue() {
+        /*
+        a --> b --> c --> d --> e
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        infraBuilder.addRoute("b", "c");
+        infraBuilder.addRoute("c", "d");
+        var forthRoute = infraBuilder.addRoute("d", "e");
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.TimePerDistance(1);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 100)))
+                .setStandardAllowance(allowance)
+        );
+        assertNotNull(res.withoutAllowance);
+        assertNotNull(res.withAllowance);
+
+        // We need a high tolerance because there are several binary searches
+        checkAllowanceResult(res, allowance, 4 * timeStep);
+    }
+
     /** Tests a simple path with no conflict, with a time per distance allowance */
     @Test
     public void testSimplePathTimePerDistanceAllowance() {


### PR DESCRIPTION
* Handle exceptions that happen inside the binary search, when we can handle them
* Use the given standard allowance to consider the fastest run time
* Remove an assert that could be triggered in linear allowances