### PR TITLE
Query rolling stock effort curves before simulation

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopePath.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.envelope_sim;
 
 import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.RangeMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 
@@ -97,7 +98,7 @@ public class EnvelopePath implements PhysicsPath {
     }
 
     @Override
-    public String getCatenaryProfile(double position) {
-        return catenaryProfiles.get(position);
+    public RangeMap<Double, String> getCatenaryProfileMap() {
+        return catenaryProfiles;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.envelope_sim;
 
+import com.google.common.collect.RangeMap;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.RollingStock.Comfort;
 
@@ -7,7 +8,7 @@ public class EnvelopeSimContext {
     public final PhysicsRollingStock rollingStock;
     public final PhysicsPath path;
     public final double timeStep;
-    public final Comfort comfort;
+    public final RangeMap<Double, PhysicsRollingStock.TractiveEffortPoint[]> tractiveEffortCurveMap;
 
     /** Creates a context suitable to run simulations on envelopes */
     public EnvelopeSimContext(
@@ -19,6 +20,6 @@ public class EnvelopeSimContext {
         this.rollingStock = rollingStock;
         this.path = path;
         this.timeStep = timeStep;
-        this.comfort = comfort;
+        this.tractiveEffortCurveMap = rollingStock.mapTractiveEffortCurves(path, comfort);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsPath.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.envelope_sim;
 
+import com.google.common.collect.RangeMap;
+
 public interface PhysicsPath {
     /** The length of the path, in meters */
     double getLength();
@@ -17,5 +19,5 @@ public interface PhysicsPath {
     double findHighGradePosition(double position, double endPos, double length, double gradeThreshold);
 
     /** The catenary profile on a given position of the path */
-    String getCatenaryProfile(double position);
+    RangeMap<Double, String> getCatenaryProfileMap();
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
@@ -14,6 +14,7 @@ import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim.ImpossibleSimulationError;
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration;
 
 /** Max effort envelope = Max speed envelope + acceleration curves + check maintain speed
@@ -75,8 +76,9 @@ public class MaxEffortEnvelope {
         var cursor = EnvelopeCursor.forward(maxSpeedProfile);
         while (cursor.findPart(MaxEffortEnvelope::maxEffortPlateau)) {
             double speed = cursor.getStepBeginSpeed();
-            var profile = path.getCatenaryProfile(cursor.getPosition());
-            double maxTractionForce = rollingStock.getMaxEffort(speed, profile, context.comfort);
+            var tractiveEffortCurve = context.tractiveEffortCurveMap.get(cursor.getPosition());
+            assert tractiveEffortCurve != null;
+            double maxTractionForce = PhysicsRollingStock.getMaxEffort(speed, tractiveEffortCurve);
             double rollingResistance = rollingStock.getRollingResistance(speed);
             double inertia = rollingStock.getInertia();
             double worstRamp = Math.asin((maxTractionForce - rollingResistance) / inertia / 9.81) * 1000;

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSRollingStockParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSRollingStockParser.java
@@ -164,7 +164,7 @@ public class RJSRollingStockParser {
             if (maxEffort < 0)
                 throw new InvalidRollingStockField(fieldKey, "negative max effort");
             tractiveEffortCurve[i] = new RollingStock.TractiveEffortPoint(speed, maxEffort);
-            assert i == 0 || tractiveEffortCurve[i - 1].speed < speed;
+            assert i == 0 || tractiveEffortCurve[i - 1].speed() < speed;
         }
         return tractiveEffortCurve;
     }

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopePathTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopePathTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeMap;
 import org.junit.jupiter.api.Test;
 
 public class EnvelopePathTest {
@@ -35,8 +36,9 @@ public class EnvelopePathTest {
     void getCatenaryProfile() {
         var path = new EnvelopePath(10, new double[] { 0, 10 }, new double[] { 0 },
                 ImmutableRangeMap.of(Range.closed(3., 7.), "1500"));
-        assertNull(path.getCatenaryProfile(1));
-        assertNull(path.getCatenaryProfile(8));
-        assertEquals("1500", path.getCatenaryProfile(4));
+        var profileMap = path.getCatenaryProfileMap();
+        assertNull(profileMap.get(1.));
+        assertNull(profileMap.get(8.));
+        assertEquals("1500", profileMap.get(4.));
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim/FlatPath.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim/FlatPath.java
@@ -1,5 +1,8 @@
 package fr.sncf.osrd.envelope_sim;
 
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+
 public class FlatPath implements PhysicsPath {
     private final double length;
     private final double slope;
@@ -27,7 +30,7 @@ public class FlatPath implements PhysicsPath {
     }
 
     @Override
-    public String getCatenaryProfile(double position) {
-        return null;
+    public RangeMap<Double, String> getCatenaryProfileMap() {
+        return TreeRangeMap.create();
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.java
+++ b/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.java
@@ -1,0 +1,62 @@
+package fr.sncf.osrd.train;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import fr.sncf.osrd.envelope_sim.EnvelopePath;
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+
+public class TestRollingStock {
+    @Test
+    void testMapTractiveEffortCurve() {
+        var builder = new ImmutableRangeMap.Builder<Double, String>();
+        builder.put(Range.closedOpen(0., 10.), "1500");
+        builder.put(Range.closed(10., 20.), "25000");
+
+        builder.put(Range.closed(30., 50.), "unhandled");
+
+        var path1 = new EnvelopePath(40, new double[]{0, 40}, new double[]{0}, builder.build());
+        var path2 = new EnvelopePath(60, new double[]{0, 60}, new double[]{0}, builder.build());
+        var path3 = new EnvelopePath(50, new double[]{0, 50}, new double[]{0}, ImmutableRangeMap.of());
+
+        var rollingStock = TestTrains.REALISTIC_FAST_TRAIN;
+
+        RangeMap<Double, PhysicsRollingStock.TractiveEffortPoint[]> res = null;
+        for (var path : List.of(path1, path2, path3)) {
+            var tractiveEffortCurveMap = rollingStock.mapTractiveEffortCurves(path, RollingStock.Comfort.STANDARD);
+            if (res == null)
+                res = tractiveEffortCurveMap;
+            testRangeCoverage(tractiveEffortCurveMap, path.getLength());
+            var size = tractiveEffortCurveMap.asMapOfRanges().size();
+            var expectedSize = path != path3 ? 6 : 1;
+            assertEquals(expectedSize, size, "wrong number of ranges");
+        }
+
+        assertEquals(res.get(5.), rollingStock.modes.get("1500").defaultCurve());
+        assertEquals(res.get(15.), rollingStock.modes.get("25000").defaultCurve());
+        assertEquals(res.get(25.), rollingStock.modes.get("thermal").defaultCurve());
+        assertEquals(res.get(40.), rollingStock.modes.get("thermal").defaultCurve());
+    }
+
+    static void testRangeCoverage(RangeMap<Double, PhysicsRollingStock.TractiveEffortPoint[]> map, double length) {
+        var subMap = map.subRangeMap(Range.closed(0., length));
+
+        var span = subMap.span();
+        assertTrue((span.upperEndpoint() - span.lowerEndpoint()) == length, "map does not cover the whole path");
+
+        var entries = subMap.asMapOfRanges().entrySet().iterator();
+        var prev = entries.next();
+        while (entries.hasNext()) {
+            var next = entries.next();
+            assertTrue(prev.getKey().upperEndpoint().equals(next.getKey().lowerEndpoint()),
+                    "ranges are not contiguous");
+            prev = next;
+        }
+    }
+}


### PR DESCRIPTION
Currently we look through the effort curve for the right mode and condition every time we need to get the maxEffort value. 

This can be optimized by querying the curves before hand, because we already know which modes we encounter along the path.

This is not a big optimization as there are only 2 conditions in each list for each mode, but it will be quite an improvement when the electrical profiles are implemented since there will be 30 conditions in each mode.