### PR TITLE
core: stdcm: apply mareco to the final envelope

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMPathfinding.java
@@ -74,7 +74,8 @@ public class STDCMPathfinding {
                 rollingStock,
                 timeStep,
                 comfort,
-                maxRunTime
+                maxRunTime,
+                unavailableTimes
         );
     }
 

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMStandardAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/graph/STDCMStandardAllowance.java
@@ -1,0 +1,137 @@
+package fr.sncf.osrd.api.stdcm.graph;
+
+import com.google.common.collect.Multimap;
+import fr.sncf.osrd.api.stdcm.OccupancyBlock;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.PhysicsPath;
+import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.train.RollingStock;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.*;
+
+/** We try to apply the standard allowance as one mareco computation over the whole path.
+ * If it causes conflicts, we split the mareco ranges so that the passage time at the points of conflict
+ * stays the same as the one we expected when exploring the graph. */
+public class STDCMStandardAllowance {
+
+    public static final Logger logger = LoggerFactory.getLogger(STDCMStandardAllowance.class);
+
+    /** Applies the allowance to the final envelope */
+    static Envelope applyAllowance(
+            Envelope envelope,
+            List<Pathfinding.EdgeRange<STDCMEdge>> ranges,
+            AllowanceValue standardAllowance,
+            PhysicsPath physicsPath,
+            RollingStock rollingStock,
+            double timeStep,
+            RollingStock.Comfort comfort,
+            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes,
+            double departureTime
+    ) {
+        if (standardAllowance == null)
+            return envelope; // This isn't just an optimization, it avoids float inaccuracies
+        var rangeTransitions = new TreeSet<Double>();
+        for (int i = 0; i < 10; i++) {
+            var newEnvelope = applyAllowanceWithTransitions(
+                    envelope,
+                    standardAllowance,
+                    physicsPath,
+                    rollingStock,
+                    timeStep,
+                    comfort,
+                    rangeTransitions
+            );
+            var firstConflictOffset = findFirstConflict(
+                    newEnvelope, unavailableTimes, ranges, timeStep, departureTime);
+            if (Double.isNaN(firstConflictOffset))
+                return newEnvelope;
+            logger.info("Conflict in new envelope at offset {}, splitting mareco ranges", firstConflictOffset);
+            assert !rangeTransitions.contains(firstConflictOffset);
+            rangeTransitions.add(firstConflictOffset);
+        }
+        throw new RuntimeException("Couldn't find an envelope that wouldn't cause a conflict");
+    }
+
+    /** Looks for the first conflict that would happen on the given envelope and unavailable times.
+     * If a conflict is founds, returns its offset.
+     * Otherwise, returns NaN. */
+    private static double findFirstConflict(
+            Envelope envelope,
+            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes,
+            List<Pathfinding.EdgeRange<STDCMEdge>> ranges,
+            double timeStep,
+            double departureTime
+    ) {
+        double tolerance = 2 * timeStep;
+        double routeStartOffset = 0;
+        for (var range : ranges) {
+            var blocksOnRoute = unavailableTimes.get(range.edge().route());
+            var firstConflict = Double.POSITIVE_INFINITY;
+            for (var block : blocksOnRoute) {
+                var startOffset = routeStartOffset + block.distanceStart();
+                var endOffset = routeStartOffset + block.distanceEnd();
+                var enterTime = departureTime + envelope.interpolateTotalTimeClamp(startOffset);
+                var exitTime = departureTime + envelope.interpolateTotalTimeClamp(endOffset);
+                if (enterTime < block.timeEnd() - tolerance && exitTime > block.timeStart() + tolerance) {
+                    // Conflict, but we need to find if we were supposed to pass before or after this block
+                    if (range.edge().timeNextOccupancy() == block.timeStart()) {
+                        // We were supposed to pass before, and we leave too late: conflict at the end position
+                        firstConflict = Double.min(firstConflict, endOffset);
+                    } else {
+                        // We were supposed to pass after, and we enter too early: conflict at the start position
+                        firstConflict = Double.min(firstConflict, startOffset);
+                    }
+                }
+            }
+            // We only returns after going through all the blocks for the route, to find the earliest
+            if (Double.isFinite(firstConflict))
+                return firstConflict;
+            routeStartOffset += range.edge().envelope().getEndPos();
+        }
+        return Double.NaN;
+    }
+
+    /** Applies the allowance to the final envelope, with range transitions at the given offsets */
+    private static Envelope applyAllowanceWithTransitions(
+            Envelope envelope,
+            AllowanceValue standardAllowance,
+            PhysicsPath physicsPath,
+            RollingStock rollingStock,
+            double timeStep,
+            RollingStock.Comfort comfort,
+            TreeSet<Double> rangeTransitions
+    ) {
+        var allowance = new MarecoAllowance(
+                new EnvelopeSimContext(rollingStock, physicsPath, timeStep, comfort),
+                0,
+                envelope.getEndPos(),
+                1,
+                makeAllowanceRanges(standardAllowance, envelope.getEndPos(), rangeTransitions)
+        );
+        return allowance.apply(envelope);
+    }
+
+    /** Create the list of `AllowanceRange`, with the given transitions */
+    private static List<AllowanceRange> makeAllowanceRanges(
+            AllowanceValue allowance,
+            double pathLength,
+            SortedSet<Double> rangeTransitions
+    ) {
+        double transition = 0;
+        var res = new ArrayList<AllowanceRange>();
+        for (var end : rangeTransitions) {
+            assert transition < end;
+            res.add(new AllowanceRange(transition, end, allowance));
+            transition = end;
+        }
+        assert transition < pathLength;
+        res.add(new AllowanceRange(transition, pathLength, allowance));
+        return res;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeDebug.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope/EnvelopeDebug.java
@@ -9,21 +9,43 @@ import java.util.ArrayList;
 @ExcludeFromGeneratedCodeCoverage
 public class EnvelopeDebug {
     private static void plotEnvelope(Plot2DPanel plot, Envelope envelope, String envelopeName) {
-        // add a line plot to the PlotPanel
         for (int i = 0; i < envelope.size(); i++) {
             var lineName = String.format("%s.parts[%d]", envelopeName, i);
             var part = envelope.get(i);
             var positions = part.clonePositions();
             var speeds = part.cloneSpeeds();
-            // workaround https://github.com/yannrichet/jmathplot/issues/5
-            if (part.pointCount() == 2) {
-                var newPositions = new double[] { positions[0], speeds[0] };
-                var newSpeeds = new double[] { positions[1], speeds[1] };
-                positions = newPositions;
-                speeds = newSpeeds;
-            }
-            plot.addLinePlot(lineName, positions, speeds);
+            plotArrays(plot, lineName, positions, speeds);
         }
+    }
+
+    private static void plotEnvelopeSpaceTime(
+            Plot2DPanel plot,
+            Envelope envelope,
+            String envelopeName,
+            double startTime
+    ) {
+        for (int i = 0; i < envelope.size(); i++) {
+            var lineName = String.format("%s.parts[%d]", envelopeName, i);
+            var part = envelope.get(i);
+            var positions = part.clonePositions();
+            var times = new double[part.pointCount()];
+            for (int pointIndex = 0; pointIndex < part.pointCount(); pointIndex++)
+                times[pointIndex] = startTime + part.getTotalTimeMS(pointIndex) / 1000.;
+            plotArrays(plot, lineName, times, positions);
+            startTime += part.getTotalTimeMS() / 1000.;
+        }
+    }
+
+    private static void plotArrays(Plot2DPanel plot, String lineName, double[] xs, double[] ys) {
+        // workaround https://github.com/yannrichet/jmathplot/issues/5
+        assert xs.length == ys.length;
+        if (xs.length == 2) {
+            var newXs = new double[] { xs[0], ys[0] };
+            var newYs = new double[] { xs[1], ys[1] };
+            xs = newXs;
+            ys = newYs;
+        }
+        plot.addLinePlot(lineName, xs, ys);
     }
 
     /** Creates a plot panel for this envelope */
@@ -59,11 +81,18 @@ public class EnvelopeDebug {
     public static final class PlotBuilder {
         private final ArrayList<Envelope> envelopes = new ArrayList<>();
         private final ArrayList<String> names = new ArrayList<>();
+        private final ArrayList<Double> departureTimes = new ArrayList<>();
 
         /** Add an envelope to the plot */
         public PlotBuilder add(Envelope envelope, String name) {
+            return add(envelope, name, 0);
+        }
+
+        /** Add an envelope to the plot, specifying start time (only used in space-time charts) */
+        public PlotBuilder add(Envelope envelope, String name, double departureTime) {
             envelopes.add(envelope);
             names.add(name);
+            departureTimes.add(departureTime);
             return this;
         }
 
@@ -73,6 +102,16 @@ public class EnvelopeDebug {
                 var plot = new Plot2DPanel();
                 for (int i = 0; i < envelopes.size(); i++)
                     plotEnvelope(plot, envelopes.get(i), names.get(i));
+                return plot;
+            });
+        }
+
+        /** Build and show the plot, showing time on the horizontal axis and position on the vertical axis */
+        public void plotSpaceTime() {
+            SwingUtils.debugPanel("Envelope", () -> {
+                var plot = new Plot2DPanel();
+                for (int i = 0; i < envelopes.size(); i++)
+                    plotEnvelopeSpaceTime(plot, envelopes.get(i), names.get(i), departureTimes.get(i));
                 return plot;
             });
         }


### PR DESCRIPTION
We try to apply the standard allowance as one mareco computation over the whole path. If it causes conflicts, we split the mareco ranges so that the passage time at the points of conflict stays the same as the one we expected when exploring the graph.

It comes with a few extra tools in `EnvelopeDebug`, to plot space-time charts.