### PR TITLE
build: fix docker-compose-mac.yml for the latest container's versions

### DIFF
--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -57,6 +57,7 @@ services:
   api:
     image: osrd/api
     container_name: osrd-api
+    platform: linux/amd64
     depends_on:
       postgres: {condition: service_healthy}
     restart: unless-stopped


### PR DESCRIPTION
The version of pyscopg2 used since #2957 triggers the following error on M1 macs: "SCRAM authentication requires libpq version 10 or above". Changing the platform seems to solve it. Cf. https://stackoverflow.com/a/70238851
It's not really a satisfying solution because of the performance hit but afaik it is the only solution that works every time. (Note that Rosetta is already required for postgres in order to run OSRD.)