### PR TITLE
docker: front: Run dependabot only for security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "front:"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "area:front"


### PR DESCRIPTION
As explained in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit, `. Use open-pull-requests-limit to change this limit. This also provides a simple way to temporarily disable version updates for a package manager. This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.`

close https://github.com/DGEXSolutions/osrd/issues/2968