### PR TITLE
api: correctly install `dev` dependencies

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 WORKDIR /home/service
 
-RUN pip install --no-cache-dir poetry>=1.1.14
+RUN pip install --no-cache-dir poetry>=1.2.0
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/api/README.md
+++ b/api/README.md
@@ -10,7 +10,7 @@ Multiple extension are used such as:
 
 ## Getting Started
 
-If you want to contribute to thise service you need:
+If you want to contribute to this service you need:
 
 - A running [postgres](https://www.postgresql.org/) server with [postgis](https://postgis.net/)
 extension.

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -386,19 +386,19 @@ sortedcontainers = ">=2.0,<3.0"
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -418,7 +418,7 @@ files = [
 name = "mock"
 version = "5.0.1"
 description = "Rolling backport of unittest.mock for all Pythons"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1030,4 +1030,4 @@ production = ["gunicorn", "sentry-sdk", "uvloop", "httptools", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "4e721cefe26657918c83d12444851beaea0bfb314d6c0ae2a0ae20a96ae739c3"
+content-hash = "e29fedb7faa03464f74c77d245aece21f2540289d28c08805cf84c024f652945"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -2,10 +2,9 @@
 name = "osrd"
 version = "0.1.0"
 description = ""
-authors = ["DGEX Solutions <contact@dgexsol.fr>"]
+authors = ["DGEX Solutions <contact@osrd.fr>"]
 
 [tool.poetry.dependencies]
-# base
 python = ">=3.9,<3.11"
 django = "4.1.5"
 numpy = "1.24.1"
@@ -27,17 +26,15 @@ uvloop = { version = "0.17.0", optional = true }
 httptools = { version = "0.5.0", optional = true }
 uvicorn = { version = "0.20.0", optional = true }
 
-# tests
-mock = "^5.0.0"
-
 [tool.poetry.extras]
 production = ["gunicorn", "sentry-sdk", "uvloop", "httptools", "uvicorn"]
 
-[tool.poetry.dev-dependencies]
-django-debug-toolbar = "^3.8.1"
+[tool.poetry.group.dev.dependencies]
+mock = "^5.0.1"
 black = "^22.12.0"
-isort = "^5.11.4"
-pyproject-flake8 = "^6.0.0"
+isort = "^5.12.0"
+pyproject-flake8 = "^6.0.0.post1"
+django-debug-toolbar = "^3.8.1"
 django-cors-headers = "^3.13.0"
 
 [tool.flake8]


### PR DESCRIPTION
This PR is:
- moving mock under the `dev` groups as it is only used for tests
- Using the cleanest way to define a dev dependency groups according to poetry documentation : https://python-poetry.org/docs/managing-dependencies/
- Updating poetry version in docker image
- changin contact email to the one define in application readme

close #2937