### PR TITLE
front: api: minor fixes on rolling stock selector

### DIFF
--- a/api/osrd_infra/serializers.py
+++ b/api/osrd_infra/serializers.py
@@ -46,7 +46,7 @@ class RollingStockLiverySerializer(NestedHyperlinkedModelSerializer):
 
     class Meta:
         model = RollingStockLivery
-        fields = ["name", "url"]
+        fields = ["name", "id"]
         extra_kwargs = {
             'url': {
                 'view_name': 'rolling_stock_livery-detail',

--- a/front/src/applications/customget/views/TrainDetails.js
+++ b/front/src/applications/customget/views/TrainDetails.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 export default function TrainDetails() {
   const { positionValues, timePosition } = useSelector((state) => state.osrdsimulation);
-  const dispatch = useDispatch();
 
   const { t } = useTranslation(['simulation']);
 

--- a/front/src/applications/opendata/OpenDataImport.js
+++ b/front/src/applications/opendata/OpenDataImport.js
@@ -14,7 +14,7 @@ export default function OpenDataImport() {
 
   async function getRollingStockDB() {
     try {
-      const data = await get(ROLLING_STOCK_URL, { page_size: 1000 });
+      const data = await get(ROLLING_STOCK_URL, { params: { page_size: 1000 } });
       setRollingStockDB(data.results);
     } catch (error) {
       console.log(error);

--- a/front/src/applications/opendata/components/TrainDetail.js
+++ b/front/src/applications/opendata/components/TrainDetail.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import nextId from 'react-id-generator';
 import { seconds2hhmmss } from 'applications/opendata/components/OpenDataHelpers';
 import RollingStock2Img from 'common/RollingStockSelector/RollingStock2Img';
+import { LazyLoadComponent } from 'react-lazy-load-image-component';
 
 export default function TrainDetail(props) {
   const { trainData, idx, rollingStock } = props;
@@ -36,11 +37,13 @@ export default function TrainDetail(props) {
         </span>
         <span className="opendata-traindetail-duration">{seconds2hhmmss(trainData.duree)}</span>
         {rollingStock ? (
-          <span className="opendata-traindetail-rollingstock">
-            <span className="opendata-traindetail-rollingstock-img">
-              <RollingStock2Img rollingStock={rollingStock} />
+          <LazyLoadComponent>
+            <span className="opendata-traindetail-rollingstock">
+              <span className="opendata-traindetail-rollingstock-img">
+                <RollingStock2Img rollingStock={rollingStock} />
+              </span>
             </span>
-          </span>
+          </LazyLoadComponent>
         ) : null}
         <span className="opendata-traindetail-transilien">{trainData.num_transilien}</span>
         <span

--- a/front/src/applications/opendata/components/TrainDetail.js
+++ b/front/src/applications/opendata/components/TrainDetail.js
@@ -39,9 +39,7 @@ export default function TrainDetail(props) {
         {rollingStock ? (
           <LazyLoadComponent>
             <span className="opendata-traindetail-rollingstock">
-              <span className="opendata-traindetail-rollingstock-img">
-                <RollingStock2Img rollingStock={rollingStock} />
-              </span>
+              <RollingStock2Img rollingStock={rollingStock} />
             </span>
           </LazyLoadComponent>
         ) : null}

--- a/front/src/applications/opendata/opendata.scss
+++ b/front/src/applications/opendata/opendata.scss
@@ -186,11 +186,10 @@
             overflow: hidden;
             height: 2rem;
             width: 50%;
-            .opendata-traindetail-rollingstock-img {
-              display: flex;
-              align-items: baseline;
-              transform: scale(.4);
-              transform-origin: top;
+            padding-left: 10%;
+            img {
+              height: 2rem;
+              padding: .25rem 0;
             }
           }
           .opendata-traindetail-transilien {   

--- a/front/src/applications/operationalStudies/components/ManageTrainSchedule/Itinerary/ModalPathJSONDetail.js
+++ b/front/src/applications/operationalStudies/components/ManageTrainSchedule/Itinerary/ModalPathJSONDetail.js
@@ -18,7 +18,7 @@ export default function ModalPathJSONDetail() {
 
   const getPathJSON = async (zoom, params) => {
     try {
-      const pathJSON = await get(`/pathfinding/${pathfindingID}/`, params, {}, true);
+      const pathJSON = await get(`/pathfinding/${pathfindingID}/`, { params });
       setPathJSONDetail(pathJSON);
     } catch (e) {
       dispatch(

--- a/front/src/applications/operationalStudies/components/ManageTrainSchedule/TimetableSelector.js
+++ b/front/src/applications/operationalStudies/components/ManageTrainSchedule/TimetableSelector.js
@@ -24,7 +24,7 @@ export default function TimetableSelector(props) {
   const getTimetable = async (id) => {
     setIsWorking(true);
     try {
-      const timetableQuery = await get(`${timetableURL}${id}/`, {});
+      const timetableQuery = await get(`${timetableURL}${id}/`);
       timetableQuery.train_schedules.sort((a, b) => a.departure_time > b.departure_time);
       setSelectedTimetable(timetableQuery);
       setIsWorking(false);

--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/StandardAllowanceDefault.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/StandardAllowanceDefault.js
@@ -82,8 +82,10 @@ export default function StandardAllowanceDefault(props) {
     newSimulationTrains[selectedTrain] = await get(
       `${trainscheduleURI}${simulation.trains[selectedTrain].id}/result/`,
       {
-        id: simulation.trains[selectedTrain].id,
-        path: selectedProjection.path,
+        params: {
+          id: simulation.trains[selectedTrain].id,
+          path: selectedProjection.path,
+        },
       }
     );
     getAllowances();

--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/withOSRDData.tsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/withOSRDData.tsx
@@ -51,8 +51,10 @@ function withOSRDData<T>(Component: ComponentType<T>) {
         newSimulationTrains[selectedTrain] = await get(
           `${trainscheduleURI}${simulation.trains[selectedTrain].id}/result/`,
           {
-            id: simulation.trains[selectedTrain].id,
-            path: selectedProjection.path,
+            params: {
+              id: simulation.trains[selectedTrain].id,
+              path: selectedProjection.path,
+            },
           }
         );
 

--- a/front/src/applications/operationalStudies/components/TimetableSelector/TimetableSelectorModal.js
+++ b/front/src/applications/operationalStudies/components/TimetableSelector/TimetableSelectorModal.js
@@ -23,7 +23,7 @@ export default function TimetableSelectorModal() {
 
   const getTimetablesList = async () => {
     try {
-      const timetablesListQuery = await get(timetableURL, { infra: infraID });
+      const timetablesListQuery = await get(timetableURL, { params: { infra: infraID } });
       settimetablesList(timetablesListQuery);
     } catch (e) {
       dispatch(

--- a/front/src/applications/stdcm/getStdcmTimetable.js
+++ b/front/src/applications/stdcm/getStdcmTimetable.js
@@ -40,8 +40,10 @@ export default async function getStdcmTimetable(
     }
     try {
       const simulationLocal = await get(`${trainscheduleURI}results/`, {
-        train_ids: trainSchedulesIDs.join(','),
-        path: tempProjectedPathId || tempSelectedProjection.path,
+        params: {
+          train_ids: trainSchedulesIDs.join(','),
+          path: tempProjectedPathId || tempSelectedProjection.path,
+        },
       });
       simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);
       dispatch(updateSimulation({ trains: simulationLocal }));

--- a/front/src/applications/stdcm/views/StdcmRequestModal.js
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.js
@@ -81,8 +81,10 @@ export default function StdcmRequestModal(props) {
           get(`${timetableURI}${osrdconf.timetableID}/`).then((timetable) => {
             const trainIds = timetable.train_schedules.map((train_schedule) => train_schedule.id);
             get(`${trainscheduleURI}results/`, {
-              train_ids: trainIds.join(','),
-              path: result.path.id,
+              params: {
+                train_ids: trainIds.join(','),
+                path: result.path.id,
+              },
             }).then((simulationLocal) => {
               const newSimulation = {};
               newSimulation.trains = [...simulationLocal];

--- a/front/src/common/InfraSelector/InfraSelector.js
+++ b/front/src/common/InfraSelector/InfraSelector.js
@@ -23,7 +23,7 @@ export default function InfraSelector(props) {
 
   const getInfra = async (id) => {
     try {
-      const infraQuery = await get(`${INFRA_URL}${id}/`, {});
+      const infraQuery = await get(`${INFRA_URL}${id}/`);
       setSelectedInfra(infraQuery);
     } catch (e) {
       dispatch(

--- a/front/src/common/InfraSelector/InfraSelectorModal.js
+++ b/front/src/common/InfraSelector/InfraSelectorModal.js
@@ -37,7 +37,7 @@ export default function InfraSelectorModal() {
   const getInfrasList = async () => {
     setIsFetching(true);
     try {
-      const infrasListQuery = await get(INFRA_URL, {});
+      const infrasListQuery = await get(INFRA_URL);
       setInfrasList(infrasListQuery);
       filterInfras(infrasListQuery);
       setIsFetching(false);

--- a/front/src/common/Map/Search/MapSearchSignal.js
+++ b/front/src/common/Map/Search/MapSearchSignal.js
@@ -27,7 +27,7 @@ export default function MapSearchSignal(props) {
 
   const updateSearch = async (params) => {
     try {
-      const data = await get(searchURI, params);
+      const data = await get(searchURI, { params });
       setSearchResults(data);
     } catch (e) {
       console.log(e);

--- a/front/src/common/Map/Search/MapSearchSignalBox.js
+++ b/front/src/common/Map/Search/MapSearchSignalBox.js
@@ -20,7 +20,7 @@ export default function MapSearchSignalBox() {
 
   const updateSearch = async (params) => {
     try {
-      const data = await get(searchURI, params);
+      const data = await get(searchURI, { params });
       setSearchResults(data);
     } catch (e) {
       console.log(e);

--- a/front/src/common/Map/Search/MapSearchStation.js
+++ b/front/src/common/Map/Search/MapSearchStation.js
@@ -23,7 +23,7 @@ export default function MapSearchStation(props) {
 
   const updateSearch = async (params) => {
     try {
-      const data = await get(searchURI, params);
+      const data = await get(searchURI, { params });
       setSearchResults(data);
     } catch (e) {
       console.log(e);

--- a/front/src/common/RollingStockSelector/RollingStock.scss
+++ b/front/src/common/RollingStockSelector/RollingStock.scss
@@ -134,6 +134,9 @@
   width: 100%;
   cursor: pointer;
   border-radius: 4px;
+  &.solid {
+    opacity: 1 !important;
+  }
   &.inactive:not(:hover) {
     transition: .5s;
     opacity: .5;
@@ -220,16 +223,12 @@
   border-right: 2px solid var(--coolgray3);
   .rollingstock-body-img {
     overflow: hidden;
-    .rollingstock-img {
+    img {
       height: 2rem;
-      white-space: nowrap;
-      transform: scale(.4); // Have to scale whole <img> because electric trains with pantograph have taller pictures
-      transform-origin: left;
-      img {
-        display: inline-block;
-        position: relative;
-        vertical-align: baseline;
-      }
+      display: inline-block;
+      padding-top: .75rem;
+      position: relative;
+      vertical-align: baseline;
     }
   }
 }

--- a/front/src/common/RollingStockSelector/RollingStockCard.js
+++ b/front/src/common/RollingStockSelector/RollingStockCard.js
@@ -5,6 +5,7 @@ import { MdLocalGasStation } from 'react-icons/md';
 import { IoIosSpeedometer } from 'react-icons/io';
 import { FaWeightHanging } from 'react-icons/fa';
 import { AiOutlineColumnWidth } from 'react-icons/ai';
+import { LazyLoadComponent } from 'react-lazy-load-image-component';
 import RollingStockCardDetail from './RollingStockCardDetail';
 import RollingStock2Img from './RollingStock2Img';
 import { RollingStockInfos } from './RollingStockHelpers';
@@ -75,13 +76,15 @@ function RollingStockCard(props) {
           setCurvesComfortList={setCurvesComfortList}
         />
       ) : (
-        <div className="rollingstock-body-container-img">
-          <div className="rollingstock-body-img">
-            <div className="rollingstock-img">
-              <RollingStock2Img rollingStock={data} />
+        <LazyLoadComponent>
+          <div className="rollingstock-body-container-img">
+            <div className="rollingstock-body-img">
+              <div className="rollingstock-img">
+                <RollingStock2Img rollingStock={data} />
+              </div>
             </div>
           </div>
-        </div>
+        </LazyLoadComponent>
       )}
       <div className="rollingstock-footer">
         <div className="rollingstock-footer-specs">

--- a/front/src/common/RollingStockSelector/RollingStockCard.js
+++ b/front/src/common/RollingStockSelector/RollingStockCard.js
@@ -18,7 +18,7 @@ function RollingStockCard(props) {
     voltages: [],
   });
   const [curvesComfortList, setCurvesComfortList] = useState();
-  const { data, ref2scroll, setOpenedRollingStockCardId, isOpen } = props;
+  const { data, ref2scroll, setOpenedRollingStockCardId, isOpen, noCardSelected } = props;
   const ref2scrollWhenOpened = useRef();
 
   function displayCardDetail() {
@@ -48,7 +48,9 @@ function RollingStockCard(props) {
 
   return (
     <div
-      className={`rollingstock-container mb-3 ${isOpen ? 'active' : 'inactive'}`}
+      className={`rollingstock-container mb-3 ${isOpen ? 'active' : 'inactive'} ${
+        noCardSelected ? 'solid' : ''
+      }`}
       role="button"
       onClick={displayCardDetail}
       tabIndex={0}
@@ -79,9 +81,7 @@ function RollingStockCard(props) {
         <LazyLoadComponent>
           <div className="rollingstock-body-container-img">
             <div className="rollingstock-body-img">
-              <div className="rollingstock-img">
-                <RollingStock2Img rollingStock={data} />
-              </div>
+              <RollingStock2Img rollingStock={data} />
             </div>
           </div>
         </LazyLoadComponent>
@@ -156,6 +156,7 @@ RollingStockCard.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   setOpenedRollingStockCardId: PropTypes.func.isRequired,
   ref2scroll: PropTypes.object,
+  noCardSelected: PropTypes.bool.isRequired,
 };
 
 const MemoizedRollingStockCard = React.memo(RollingStockCard);

--- a/front/src/common/RollingStockSelector/RollingStockModal.js
+++ b/front/src/common/RollingStockSelector/RollingStockModal.js
@@ -95,7 +95,7 @@ function RollingStockModal(props) {
   const getAllRollingStock = async () => {
     if (rollingStock === undefined) {
       try {
-        const data = await get(ROLLING_STOCK_URL, { page_size: 1000 });
+        const data = await get(ROLLING_STOCK_URL, { params: { page_size: 1000 } });
         setRollingStock(data.results);
       } catch (e) {
         dispatch(

--- a/front/src/common/RollingStockSelector/RollingStockModal.js
+++ b/front/src/common/RollingStockSelector/RollingStockModal.js
@@ -13,6 +13,7 @@ import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import { getRollingStockID } from 'reducers/osrdconf/selectors';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
+import { isEmpty } from 'lodash';
 import RollingStockEmpty from './RollingStockEmpty';
 import RollingStockCard from './RollingStockCard';
 
@@ -24,7 +25,7 @@ function RollingStockModal(props) {
   const { darkmode } = useSelector((state) => state.main);
   const rollingStockID = useSelector(getRollingStockID);
   const { t } = useTranslation(['translation', 'rollingstock']);
-  const [rollingStock, setRollingStock] = useState();
+  const [rollingStocks, setRollingStocks] = useState();
   const [filteredRollingStockList, setFilteredRollingStockList] = useState([]);
   const [filters, setFilters] = useState({
     text: '',
@@ -47,7 +48,7 @@ function RollingStockModal(props) {
   const updateSearch = () => {
     setOpenedRollingStockCardId(undefined);
     // Text filter
-    let filteredRollingStockListNew = rollingStock.filter(
+    let filteredRollingStockListNew = rollingStocks.filter(
       (el) =>
         el.name.toLowerCase().includes(filters.text) ||
         (el.metadata.detail && el.metadata.detail.toLowerCase().includes(filters.text)) ||
@@ -93,10 +94,10 @@ function RollingStockModal(props) {
   };
 
   const getAllRollingStock = async () => {
-    if (rollingStock === undefined) {
+    if (rollingStocks === undefined) {
       try {
         const data = await get(ROLLING_STOCK_URL, { params: { page_size: 1000 } });
-        setRollingStock(data.results);
+        setRollingStocks(data.results);
       } catch (e) {
         dispatch(
           setFailure({
@@ -109,13 +110,14 @@ function RollingStockModal(props) {
     }
   };
 
-  const listOfRollingStock = useMemo(
+  const listOfRollingStocks = useMemo(
     () =>
       filteredRollingStockList.length > 0 ? (
         filteredRollingStockList.map((item) => (
           <RollingStockCard
             data={item}
             key={item.id}
+            noCardSelected={openedRollingStockCardId === undefined}
             isOpen={item.id === openedRollingStockCardId}
             setOpenedRollingStockCardId={setOpenedRollingStockCardId}
             ref2scroll={rollingStockID === item.id ? ref2scroll : undefined}
@@ -133,11 +135,11 @@ function RollingStockModal(props) {
   }, []);
 
   useEffect(() => {
-    if (rollingStock !== undefined) {
+    if (rollingStocks !== undefined) {
       updateSearch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, rollingStock]);
+  }, [filters, rollingStocks]);
 
   return (
     <ModalBodySNCF>
@@ -196,7 +198,7 @@ function RollingStockModal(props) {
             </div>
             <div className="col-md-2 mt-1 ml-auto">
               <small className="">
-                {filteredRollingStockList !== undefined && filteredRollingStockList.length > 0
+                {filteredRollingStockList.length > 0
                   ? `${filteredRollingStockList.length} ${t('rollingstock:resultsFound')}`
                   : t('rollingstock:noResultFound')}
               </small>
@@ -204,8 +206,8 @@ function RollingStockModal(props) {
           </div>
         </div>
         <div className="rollingstock-search-list">
-          {filteredRollingStockList !== undefined && !isFiltering ? (
-            listOfRollingStock
+          {!isEmpty(filteredRollingStockList) && !isFiltering ? (
+            listOfRollingStocks
           ) : (
             <Loader msg={t('rollingstock:waitingLoader')} />
           )}

--- a/front/src/common/requests.ts
+++ b/front/src/common/requests.ts
@@ -18,11 +18,12 @@ function formatPath(path: string): string {
 /**
  * Get the axios configuration for the authentification.
  */
-export function getAuthConfig(): AxiosRequestConfig {
+export function getAuthConfig(otherHeaders?: { [key: string]: unknown }): AxiosRequestConfig {
   return {
     headers: {
       Authorization: `Bearer ${localStorage.getItem('access_token')}`,
     },
+    ...otherHeaders,
   };
 }
 
@@ -65,11 +66,11 @@ function handleAxiosError(e: unknown): Error {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function get<T = any>(path: string, params?: { [key: string]: unknown }): Promise<T> {
-  const config = getAuthConfig();
-  if (params) {
-    config.params = params;
-  }
+export async function get<T = any>(
+  path: string,
+  otherHeaders?: { [key: string]: string | number | boolean | unknown }
+): Promise<T> {
+  const config = getAuthConfig(otherHeaders);
 
   let newPath = '';
   // ULGY HACK https://gateway.dev.dgexsol.fr/osrd

--- a/front/src/reducers/osrdsimulation/simulation.js
+++ b/front/src/reducers/osrdsimulation/simulation.js
@@ -63,8 +63,10 @@ export async function progressiveDuplicateTrain(
   const trainSchedulesIDs = timetable.train_schedules.map((train) => train.id);
   try {
     const simulationLocal = await get(`${trainscheduleURI}results/`, {
-      train_ids: trainSchedulesIDs.join(','),
-      path: selectedProjection.path,
+      params: {
+        train_ids: trainSchedulesIDs.join(','),
+        path: selectedProjection.path,
+      },
     });
     simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);
     dispatch(updateSimulation({ trains: simulationLocal }));


### PR DESCRIPTION
close #3047 
- load the rollingStock image before the render
- remove transform in RollingStock image css
- rolling stocks cards should not be transparent if no rs is selected