### PR TITLE
core: ensure http connections always get closed

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -128,17 +128,16 @@ public class InfraManager extends APIClient {
             logger.info("starting to download {}", request.url());
             cacheEntry.transitionTo(InfraStatus.DOWNLOADING);
 
-            var response = httpClient.newCall(request).execute();
-            if (!response.isSuccessful())
-                throw new UnexpectedHttpResponse(response);
-
-            // Parse the response
-            logger.info("parsing the JSON of {}", request.url());
-            cacheEntry.transitionTo(InfraStatus.PARSING_JSON);
-
             RJSInfra rjsInfra;
-            try (var body = response.body()) {
-                rjsInfra = RJSInfra.adapter.fromJson(body.source());
+            try (var response = httpClient.newCall(request).execute()) {
+                if (!response.isSuccessful())
+                    throw new UnexpectedHttpResponse(response);
+
+                // Parse the response
+                logger.info("parsing the JSON of {}", request.url());
+                cacheEntry.transitionTo(InfraStatus.PARSING_JSON);
+
+                rjsInfra = RJSInfra.adapter.fromJson(response.body().source());
             }
 
             if (rjsInfra == null)


### PR DESCRIPTION
Not doing so results in keeping the connection open, which both exhausts the client connection pool and server workers.