### PR TITLE
core: switch to gradle java toolchain

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,13 +89,14 @@ dependencies {
     testCompileOnly libs.jcip.annotations
     testCompileOnly libs.spotbugs.annotations
 }
-
 // endregion
 
 // region MAIN
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 application {
@@ -203,11 +204,6 @@ jacocoTestReport {
 
 // region KOTLIN
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
 
 // endregion
 

--- a/core/kt-fast-collections-annotations/build.gradle
+++ b/core/kt-fast-collections-annotations/build.gradle
@@ -6,6 +6,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api libs.kotlin.reflect

--- a/core/kt-fast-collections-generator/build.gradle
+++ b/core/kt-fast-collections-generator/build.gradle
@@ -6,6 +6,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-fast-collections-annotations")

--- a/core/kt-fast-collections/build.gradle
+++ b/core/kt-fast-collections/build.gradle
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(':kt-fast-collections-annotations')
@@ -27,7 +33,6 @@ kotlin {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/kt-osrd-signaling/build.gradle
+++ b/core/kt-osrd-signaling/build.gradle
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-osrd-utils")
@@ -20,7 +26,6 @@ dependencies {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/kt-osrd-sim-infra/build.gradle
+++ b/core/kt-osrd-sim-infra/build.gradle
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
@@ -28,7 +34,6 @@ kotlin {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/kt-osrd-sim-interlocking/build.gradle
+++ b/core/kt-osrd-sim-interlocking/build.gradle
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(":kt-osrd-utils")
@@ -25,7 +31,6 @@ dependencies {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/kt-osrd-sncf-signaling/build.gradle
+++ b/core/kt-osrd-sncf-signaling/build.gradle
@@ -6,6 +6,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     api project(':kt-osrd-signaling')
@@ -16,7 +22,6 @@ dependencies {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/kt-osrd-utils/build.gradle
+++ b/core/kt-osrd-utils/build.gradle
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
@@ -28,7 +34,6 @@ kotlin {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "17"
         freeCompilerArgs += [
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlin.ExperimentalUnsignedTypes",

--- a/core/osrd-railjson/build.gradle
+++ b/core/osrd-railjson/build.gradle
@@ -6,6 +6,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
 


### PR DESCRIPTION
Fixes kotlin and javac having conflicting jvm targets

See https://docs.gradle.org/current/userguide/toolchains.html