### PR TITLE
Cni/fix space time chart

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart.js
@@ -68,6 +68,8 @@ export default function SpaceTimeChart(props) {
   const [showModal, setShowModal] = useState('');
   const [dragOffset, setDragOffset] = useState(0);
   const [dragEnding, setDragEnding] = useState(false);
+  // tmpSelectedTrain added for integration, this component should be deprecated soon
+  const [tmpSelectedTrain, setTmpSelectedTrain] = useState(selectedTrain);
 
   const handleKey = ({ key }) => {
     if (['+', '-'].includes(key)) {
@@ -152,7 +154,8 @@ export default function SpaceTimeChart(props) {
           setDragEnding,
           setDragOffset,
           simulation,
-          train.isStdcm
+          train.isStdcm,
+          setTmpSelectedTrain
         );
       });
       enableInteractivity(

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
@@ -7,7 +7,7 @@ import {
   interpolateOnTime,
   timeShiftTrain,
 } from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers';
-import ORSD_GEV_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
+import ORSD_GET_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
 import { CgLoadbar } from 'react-icons/cg';
 import ChartModal from 'applications/operationalStudies/components/SimulationResults/ChartModal';
 import { GiResize } from 'react-icons/gi';
@@ -43,7 +43,7 @@ export default function SpaceTimeChart(props) {
     allowancesSettings,
     positionValues,
     selectedProjection,
-    selectedTrain,
+    initialSelectedTrain,
     timePosition,
     simulation,
     dispatch,
@@ -66,6 +66,7 @@ export default function SpaceTimeChart(props) {
   const [showModal, setShowModal] = useState('');
   const [dragOffset, setDragOffset] = useState(0);
   const [dragEnding, setDragEnding] = useState(false);
+  const [selectedTrain, setSelectedTrain] = useState(initialSelectedTrain);
   const [heightOfSpaceTimeChart, setHeightOfSpaceTimeChart] = useState(
     initialHeightOfSpaceTimeChart
   );
@@ -123,6 +124,7 @@ export default function SpaceTimeChart(props) {
       dispatchUpdateContextMenu,
       allowancesSettings,
       offsetTimeByDragging,
+      setSelectedTrain,
       false
     );
   };
@@ -164,11 +166,12 @@ export default function SpaceTimeChart(props) {
         dispatchUpdateContextMenu,
         allowancesSettings,
         offsetTimeByDragging,
+        setSelectedTrain,
         true
       );
 
       // Reprogram !
-      //handleWindowResize(CHART_ID, dispatch, drawAllTrains, isResizeActive, setResizeActive);
+      // handleWindowResize(CHART_ID, dispatch, drawAllTrains, isResizeActive, setResizeActive);
     }
   }, [rotate, selectedTrain, dataSimulation, heightOfSpaceTimeChart]);
 
@@ -277,22 +280,31 @@ export default function SpaceTimeChart(props) {
 }
 
 SpaceTimeChart.propTypes = {
-  heightOfSpaceTimeChart: PropTypes.number.isRequired,
+  allowancesSettings: PropTypes.any,
+  positionValues: PropTypes.any,
+  selectedProjection: PropTypes.any.isRequired,
+  initialSelectedTrain: PropTypes.any,
+  timePosition: PropTypes.any,
+  simulation: PropTypes.any,
+  dispatch: PropTypes.any,
   onOffsetTimeByDragging: PropTypes.func,
+  onSetBaseHeightOfSpaceTimeChart: PropTypes.any,
   dispatchUpdateMustRedraw: PropTypes.func,
+  dispatchUpdatePositionValues: PropTypes.any,
+  dispatchUpdateChart: PropTypes.any,
+  dispatchUpdateContextMenu: PropTypes.any,
+  initialHeightOfSpaceTimeChart: PropTypes.any.isRequired,
 };
 
 SpaceTimeChart.defaultProps = {
-  heightOfSpeedSpaceChart: 250,
-  simulation: ORSD_GEV_SAMPLE_DATA.simulation.present,
-  allowancesSettings: ORSD_GEV_SAMPLE_DATA.allowancesSettings,
+  simulation: ORSD_GET_SAMPLE_DATA.simulation.present,
+  allowancesSettings: ORSD_GET_SAMPLE_DATA.allowancesSettings,
   dispatch: () => {},
-  positionValues: ORSD_GEV_SAMPLE_DATA.positionValues,
-  selectedTrain: ORSD_GEV_SAMPLE_DATA.selectedTrain,
-  timePosition: ORSD_GEV_SAMPLE_DATA.timePosition,
-  onOffsetTimeByDragging: ({ ...args }) => {},
-  onSetBaseHeightOfSpaceTimeChart: ({ ...args }) => {},
-  onDragEnding: () => {},
+  positionValues: ORSD_GET_SAMPLE_DATA.positionValues,
+  initialSelectedTrain: ORSD_GET_SAMPLE_DATA.selectedTrain,
+  timePosition: ORSD_GET_SAMPLE_DATA.timePosition,
+  onOffsetTimeByDragging: () => {},
+  onSetBaseHeightOfSpaceTimeChart: () => {},
   dispatchUpdateMustRedraw: () => {},
   dispatchUpdateChart: () => {},
   dispatchUpdatePositionValues: () => {},

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
@@ -2,9 +2,7 @@ import drawTrain from 'applications/operationalStudies/components/SimulationResu
 
 import createChart from 'applications/operationalStudies/components/SimulationResults/SpaceTimeChart/createChart';
 
-import enableInteractivity, {
-  traceVerticalLine,
-} from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity';
+import enableInteractivity from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity';
 
 import { LIST_VALUES_NAME_SPACE_TIME } from 'applications/operationalStudies/components/SimulationResults/simulationResultsConsts';
 
@@ -75,9 +73,10 @@ const drawAllTrains = (
   dispatchUpdateContextMenu,
   allowancesSettings,
   offsetTimeByDragging,
-  forceRedraw = false,
+  setSelectedTrain,
+  forceRedraw = false
 ) => {
-  const currentDataSimulation = newDataSimulation || dataSimulation;
+  const currentDataSimulation = newDataSimulation;
   if (mustRedraw || forceRedraw) {
     const chartLocal = createChart(
       chart,
@@ -111,7 +110,8 @@ const drawAllTrains = (
         setDragEnding,
         setDragOffset,
         simulation,
-        train.isStdcm
+        train.isStdcm,
+        setSelectedTrain
       );
     });
     enableInteractivity(

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
@@ -4,9 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   updateMustRedraw,
   updateContextMenu,
-  updateSpeedSpaceSettings,
   updateChart,
-  updatePositionValues
+  updatePositionValues,
 } from 'reducers/osrdsimulation/actions';
 import {
   getAllowancesSettings,
@@ -18,7 +17,6 @@ import {
   getConsolidatedSimulation,
   getPresentSimulation,
 } from 'reducers/osrdsimulation/selectors';
-import { changeTrain } from 'applications/operationalStudies/components/SimulationResults/simulationResultsHelpers';
 import { persistentUpdateSimulation } from 'reducers/osrdsimulation/simulation';
 import SpaceTimeChart from './SpaceTimeChart';
 
@@ -40,32 +38,9 @@ const withOSRDData = (Component) =>
 
     const dispatch = useDispatch();
 
-    const toggleSetting = (settingName) => {
-      dispatch(
-        updateSpeedSpaceSettings({
-          ...speedSpaceSettings,
-          [settingName]: !speedSpaceSettings[settingName],
-        })
-      );
-      dispatch(updateMustRedraw(true));
-    };
-
     // Consequence of direct actions by component
     const onOffsetTimeByDragging = (trains) => {
       dispatch(persistentUpdateSimulation({ ...simulation, trains }));
-    };
-
-    const onDragEnding = (dragEnding, setDragEnding) => {
-      if (dragEnding) {
-        // NO TRIGGER, use event status
-        changeTrain(
-          {
-            departure_time: simulation.trains[selectedTrain].base.stops[0].time,
-          },
-          simulation.trains[selectedTrain].id
-        );
-        setDragEnding(false);
-      }
     };
 
     const dispatchUpdatePositionValues = (newPositionValues) => {
@@ -97,7 +72,6 @@ const withOSRDData = (Component) =>
         timePosition={timePosition}
         consolidatedSimulation={consolidatedSimulation}
         onOffsetTimeByDragging={onOffsetTimeByDragging}
-        onDragEnding={onDragEnding}
         dispatchUpdateMustRedraw={dispatchUpdateMustRedraw}
         dispatchUpdateContextMenu={dispatchUpdateContextMenu}
         dispatchUpdateChart={dispatchUpdateChart}

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -141,7 +141,6 @@ export default function SimulationResults() {
           <TimeLine />
 
           {/* SIMULATION : SPACE TIME CHART */}
-
           <div className="osrd-simulation-container d-flex mb-2">
             <div
               className="spacetimechart-container"

--- a/front/src/common/ReleaseInformations/ReleaseInformations.tsx
+++ b/front/src/common/ReleaseInformations/ReleaseInformations.tsx
@@ -1,7 +1,7 @@
 // React Component displaying different applications versions
 // List of applications : Editoast, Core, Api
 
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { env } from 'env';
 

--- a/front/src/stories/SpaceTimeChart.stories.tsx
+++ b/front/src/stories/SpaceTimeChart.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ComponentStory } from '@storybook/react';
 import SpaceTimeChart from 'applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart';
 import 'styles/main.css';
 import ORSD_GEV_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';


### PR DESCRIPTION
fixes #3100, fixes #3019 

- in storybook, we can now select a train on click (run `yarn storybook` to launch storybook)
- fix  the following issue : drag and drop 1 train affects all the trains
- fix the following issue : select a train AND drag and drop it, the train jumps in time