### PR TITLE
Cni: front: GET/GEV get coordinated cursors

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers.ts
@@ -295,36 +295,38 @@ export const interpolateOnTime = (
   const positionInterpolated: Record<string, PositionSpeed> = {};
   listValues.forEach((listValue) => {
     let bisection;
-    // If not array of array
-    if (listValue === 'speed' || listValue === 'speeds') {
-      const comparator = dataSimulation?.[listValue] || dataSimulation?.[listValue][0]
-      if (comparator) {
-        const timeBisect = d3.bisector<any, any>((d) => d['time']).left;
-        const index = timeBisect(dataSimulation[listValue], timePositionLocal, 1);
-        bisection = [dataSimulation[listValue][index - 1], dataSimulation[listValue][index]];
-      }
-    } else if (dataSimulation?.[listValue]) {
-      // Array of array
-      dataSimulation[listValue].forEach((section: Position[]) => {
-        const index = bisect(section, timePositionLocal, 1);
-        if (
-          index !== section.length &&
-          section[0] &&
-          timePositionLocal >= (section[0] as any)[keyValues[0]]
-        ) {
-          bisection = [section[index - 1], section[index]];
+    if (dataSimulation?.[listValue]) {
+      // If not array of array
+      if (listValue === 'speed' || listValue === 'speeds') {
+        const comparator = dataSimulation?.[listValue] || dataSimulation?.[listValue][0];
+        if (comparator) {
+          const timeBisect = d3.bisector<any, any>((d) => d['time']).left;
+          const index = timeBisect(dataSimulation[listValue], timePositionLocal, 1);
+          bisection = [dataSimulation[listValue][index - 1], dataSimulation[listValue][index]];
         }
-      });
-    }
-    if (bisection && bisection[1]) {
-      const duration = bisection[1].time - bisection[0].time;
-      const timePositionFromTime = timePositionLocal - bisection[0].time;
-      const proportion = timePositionFromTime / duration;
-      positionInterpolated[listValue] = {
-        position: d3.interpolateNumber(bisection[0].position, bisection[1].position)(proportion),
-        speed: d3.interpolateNumber(bisection[0].speed, bisection[1].speed)(proportion) * 3.6,
-        time: timePositionLocal,
-      };
+      } else {
+        // Array of array
+        dataSimulation[listValue].forEach((section: Position[]) => {
+          const index = bisect(section, timePositionLocal, 1);
+          if (
+            index !== section.length &&
+            section[0] &&
+            timePositionLocal >= (section[0] as any)[keyValues[0]]
+          ) {
+            bisection = [section[index - 1], section[index]];
+          }
+        });
+      }
+      if (bisection && bisection[1]) {
+        const duration = bisection[1].time - bisection[0].time;
+        const timePositionFromTime = timePositionLocal - bisection[0].time;
+        const proportion = timePositionFromTime / duration;
+        positionInterpolated[listValue] = {
+          position: d3.interpolateNumber(bisection[0].position, bisection[1].position)(proportion),
+          speed: d3.interpolateNumber(bisection[0].speed, bisection[1].speed)(proportion) * 3.6,
+          time: timePositionLocal,
+        };
+      }
     }
   });
 

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart.js
@@ -148,7 +148,6 @@ export default function SpaceTimeChart(props) {
           idx === selectedTrain,
           keyValues,
           allowancesSettings,
-          offsetTimeByDragging,
           rotate,
           setDragEnding,
           setDragOffset,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
@@ -143,7 +143,6 @@ export default function SpaceTimeChart(props) {
         dispatchUpdateChart,
         dispatchUpdateContextMenu,
         allowancesSettings,
-        offsetTimeByDragging,
         setSelectedTrain,
         true
       );

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.js
@@ -46,7 +46,7 @@ export default function SpaceTimeChart(props) {
     allowancesSettings,
     positionValues,
     selectedProjection,
-    initialSelectedTrain,
+    inputSelectedTrain,
     timePosition,
     simulation,
     simulationIsPlaying,
@@ -72,7 +72,7 @@ export default function SpaceTimeChart(props) {
   const [dragOffset, setDragOffset] = useState(0);
   // TODO: remove setDragEnding without creating a new error in the console
   const [, setDragEnding] = useState(false);
-  const [selectedTrain, setSelectedTrain] = useState(initialSelectedTrain);
+  const [selectedTrain, setSelectedTrain] = useState(inputSelectedTrain);
   const [heightOfSpaceTimeChart, setHeightOfSpaceTimeChart] = useState(
     initialHeightOfSpaceTimeChart
   );
@@ -155,6 +155,14 @@ export default function SpaceTimeChart(props) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetChart, rotate, selectedTrain, dataSimulation, heightOfSpaceTimeChart]);
+
+  useEffect(() => {
+    // avoid useless re-render if selectedTrain is already correct
+    if (selectedTrain !== inputSelectedTrain) {
+      setSelectedTrain(inputSelectedTrain);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputSelectedTrain]);
 
   // ADN: trigger a redraw on every simulation change. This is the right pattern.
   useEffect(() => {
@@ -288,7 +296,7 @@ SpaceTimeChart.propTypes = {
   allowancesSettings: PropTypes.any,
   positionValues: PropTypes.any,
   selectedProjection: PropTypes.any.isRequired,
-  initialSelectedTrain: PropTypes.any,
+  inputSelectedTrain: PropTypes.any,
   timePosition: PropTypes.any,
   simulation: PropTypes.any,
   simulationIsPlaying: PropTypes.bool,
@@ -309,7 +317,7 @@ SpaceTimeChart.defaultProps = {
   allowancesSettings: ORSD_GET_SAMPLE_DATA.allowancesSettings,
   dispatch: () => {},
   positionValues: ORSD_GET_SAMPLE_DATA.positionValues,
-  initialSelectedTrain: ORSD_GET_SAMPLE_DATA.selectedTrain,
+  inputSelectedTrain: ORSD_GET_SAMPLE_DATA.selectedTrain,
   timePosition: ORSD_GET_SAMPLE_DATA.timePosition,
   onOffsetTimeByDragging: () => {},
   onSetBaseHeightOfSpaceTimeChart: () => {},

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/createChart.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/createChart.ts
@@ -2,7 +2,10 @@ import * as d3 from 'd3';
 import { select as d3select } from 'd3-selection';
 
 import { Chart, SimulationTrain } from 'reducers/osrdsimulation/types';
-import { defineLinear, defineTime } from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers';
+import {
+  defineLinear,
+  defineTime,
+} from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers';
 import defineChart from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/defineChart';
 
 // This is only used by SpaceTimeChart for now.
@@ -56,7 +59,7 @@ export default function createChart(
   const defineY =
     chart === undefined || reset ? defineLinear(dataSimulationLinearMax, 0.05) : chart.y;
 
-    const width = parseInt(d3select(`#container-${chartID}`)?.style('width'), 10);
+  const width = parseInt(d3select(`#container-${chartID}`)?.style('width'), 10);
 
   const chartLocal = defineChart(
     width,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
@@ -72,7 +72,6 @@ const drawAllTrains = (
   dispatchUpdateChart,
   dispatchUpdateContextMenu,
   allowancesSettings,
-  offsetTimeByDragging,
   setSelectedTrain,
   forceRedraw = false
 ) => {
@@ -105,7 +104,6 @@ const drawAllTrains = (
         idx === selectedTrain,
         keyValues,
         allowancesSettings,
-        offsetTimeByDragging,
         rotate,
         setDragEnding,
         setDragOffset,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
@@ -1,10 +1,5 @@
 import drawTrain from 'applications/operationalStudies/components/SimulationResults/SpaceTimeChart/drawTrain';
-
 import createChart from 'applications/operationalStudies/components/SimulationResults/SpaceTimeChart/createChart';
-
-import enableInteractivity from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity';
-
-import { LIST_VALUES_NAME_SPACE_TIME } from 'applications/operationalStudies/components/SimulationResults/simulationResultsConsts';
 
 function drawOPs(chartLocal, selectedTrainSimulation, rotate) {
   const operationalPointsZone = chartLocal.drawZone
@@ -73,6 +68,8 @@ const drawAllTrains = (
   dispatchUpdateContextMenu,
   allowancesSettings,
   setSelectedTrain,
+  simulationIsPlaying,
+  // TODO: romve forceRedraw (same as mustRedraw)
   forceRedraw = false
 ) => {
   const currentDataSimulation = newDataSimulation;
@@ -112,20 +109,6 @@ const drawAllTrains = (
         setSelectedTrain
       );
     });
-    enableInteractivity(
-      chartLocal,
-      currentDataSimulation[selectedTrain],
-      dispatch,
-      keyValues,
-      LIST_VALUES_NAME_SPACE_TIME,
-      positionValues,
-      rotate,
-      setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      zoomLevel
-    );
     setChart(chartLocal);
     dispatchUpdateChart({ ...chartLocal, rotate });
     dispatchUpdateMustRedraw(false);

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/d3Helpers.js
@@ -86,6 +86,7 @@ const drawAllTrains = (
       keyValues,
       ref,
       reset,
+      rotate
     );
 
     chartLocal.svg.on('click', () => {
@@ -130,6 +131,7 @@ const drawAllTrains = (
     setChart(chartLocal);
     dispatchUpdateChart({ ...chartLocal, rotate });
     dispatchUpdateMustRedraw(false);
+    setResetChart(false);
   }
 };
 

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/drawTrain.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/drawTrain.js
@@ -23,7 +23,6 @@ export default function drawTrain(
   isSelected,
   keyValues,
   allowancesSettings,
-  offsetTimeByDragging,
   rotate,
   setDragEnding,
   setDragOffset,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
@@ -71,7 +71,7 @@ const withOSRDData = (Component) =>
         positionValues={positionValues}
         dispatch={dispatch}
         simulation={simulation}
-        initialSelectedTrain={selectedTrain}
+        inputSelectedTrain={selectedTrain}
         selectedProjection={selectedProjection}
         timePosition={timePosition}
         onOffsetTimeByDragging={onOffsetTimeByDragging}

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/withOSRDData.js
@@ -6,16 +6,16 @@ import {
   updateContextMenu,
   updateChart,
   updatePositionValues,
+  updateTimePositionValues,
 } from 'reducers/osrdsimulation/actions';
 import {
   getAllowancesSettings,
-  getMustRedraw,
   getPositionValues,
   getSelectedProjection,
   getSelectedTrain,
   getTimePosition,
-  getConsolidatedSimulation,
   getPresentSimulation,
+  getIsPlaying,
 } from 'reducers/osrdsimulation/selectors';
 import { persistentUpdateSimulation } from 'reducers/osrdsimulation/simulation';
 import SpaceTimeChart from './SpaceTimeChart';
@@ -28,13 +28,12 @@ import SpaceTimeChart from './SpaceTimeChart';
 const withOSRDData = (Component) =>
   function WrapperComponent(props) {
     const allowancesSettings = useSelector(getAllowancesSettings);
-    const mustRedraw = useSelector(getMustRedraw);
     const positionValues = useSelector(getPositionValues);
     const selectedTrain = useSelector(getSelectedTrain);
     const selectedProjection = useSelector(getSelectedProjection);
     const timePosition = useSelector(getTimePosition);
     const simulation = useSelector(getPresentSimulation);
-    const consolidatedSimulation = useSelector(getConsolidatedSimulation);
+    const isPlaying = useSelector(getIsPlaying);
 
     const dispatch = useDispatch();
 
@@ -45,6 +44,11 @@ const withOSRDData = (Component) =>
 
     const dispatchUpdatePositionValues = (newPositionValues) => {
       dispatch(updatePositionValues(newPositionValues));
+    };
+
+    // difference entre TimePositionValues et PositionValues (besoin cruel de typage)
+    const dispatchUpdateTimePositionValues = (newTimePositionValues) => {
+      dispatch(updateTimePositionValues(newTimePositionValues));
     };
 
     const dispatchUpdateMustRedraw = (newMustRedraw) => {
@@ -63,19 +67,19 @@ const withOSRDData = (Component) =>
       <Component
         {...props}
         allowancesSettings={allowancesSettings}
+        simulationIsPlaying={isPlaying}
         positionValues={positionValues}
-        mustRedraw={mustRedraw}
         dispatch={dispatch}
         simulation={simulation}
-        selectedTrain={selectedTrain}
+        initialSelectedTrain={selectedTrain}
         selectedProjection={selectedProjection}
         timePosition={timePosition}
-        consolidatedSimulation={consolidatedSimulation}
         onOffsetTimeByDragging={onOffsetTimeByDragging}
         dispatchUpdateMustRedraw={dispatchUpdateMustRedraw}
         dispatchUpdateContextMenu={dispatchUpdateContextMenu}
         dispatchUpdateChart={dispatchUpdateChart}
         dispatchUpdatePositionValues={dispatchUpdatePositionValues}
+        dispatchUpdateTimePositionValues={dispatchUpdateTimePositionValues}
       />
     );
   };

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.js
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { CgLoadbar } from 'react-icons/cg';
 import { GiResize } from 'react-icons/gi';
 import PropTypes from 'prop-types';
@@ -72,6 +72,62 @@ const CHART_MIN_HEIGHT = 250;
     () => prepareData(simulation, selectedTrain, keyValues),
     [simulation, selectedTrain, keyValues]
   );
+
+  // draw the train
+  const createChartAndTrain = useCallback(() => {
+    const localChart = createChart(
+      CHART_ID,
+      chart,
+      resetChart,
+      dataSimulation,
+      rotate,
+      keyValues,
+      heightOfSpeedSpaceChart,
+      ref,
+      dispatch,
+      setResetChart
+    );
+    setChart(localChart);
+    drawTrain(
+      LIST_VALUES_NAME_SPEED_SPACE,
+      simulation,
+      selectedTrain,
+      dataSimulation,
+      keyValues,
+      positionValues,
+      rotate,
+      localSettings,
+      mustRedraw,
+      setChart,
+      setYPosition,
+      setZoomLevel,
+      yPosition,
+      dispatch,
+      zoomLevel,
+      CHART_ID,
+      localChart,
+      resetChart,
+      heightOfSpeedSpaceChart,
+      ref,
+      setResetChart,
+      true
+    );
+  }, [
+    chart,
+    dataSimulation,
+    dispatch,
+    heightOfSpeedSpaceChart,
+    keyValues,
+    localSettings,
+    mustRedraw,
+    positionValues,
+    resetChart,
+    rotate,
+    selectedTrain,
+    simulation,
+    yPosition,
+    zoomLevel,
+  ]);
 
   // rotation Handle (button on right bottom)
   const toggleRotation = () => {
@@ -151,33 +207,11 @@ const CHART_MIN_HEIGHT = 250;
     );
   }, [chart]);
 
-  // redraw the trains is necessary
+  // redraw the train if necessary
   useEffect(() => {
-    drawTrain(
-      LIST_VALUES_NAME_SPEED_SPACE,
-      simulation,
-      selectedTrain,
-      dataSimulation,
-      keyValues,
-      positionValues,
-      rotate,
-      localSettings,
-      mustRedraw,
-      setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      dispatch,
-      zoomLevel,
-      CHART_ID,
-      chart,
-      resetChart,
-      heightOfSpeedSpaceChart,
-      ref,
-      setResetChart,
-      true
-    );
-  }, [chart, mustRedraw, rotate, consolidatedSimulation, localSettings]);
+    createChartAndTrain();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mustRedraw, rotate, consolidatedSimulation, localSettings]);
 
   // draw or redraw the position line indictator when usefull
   useEffect(() => {
@@ -209,6 +243,12 @@ const CHART_MIN_HEIGHT = 250;
 
   // reset chart
   useEffect(() => resetChartToggle(), [resetChart]);
+
+  // draw the first chart
+  useEffect(() => {
+    createChartAndTrain();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Rnd

--- a/front/src/reducers/osrdsimulation/selectors.ts
+++ b/front/src/reducers/osrdsimulation/selectors.ts
@@ -8,7 +8,10 @@ export const getAllowancesSettings = makeSubSelector<OsrdSimulationState, 'allow
   getOsrdSimulation,
   'allowancesSettings'
 );
-
+export const getIsPlaying = makeSubSelector<OsrdSimulationState, 'isPlaying'>(
+  getOsrdSimulation,
+  'isPlaying'
+);
 export const getMustRedraw = makeSubSelector<OsrdSimulationState, 'mustRedraw'>(
   getOsrdSimulation,
   'mustRedraw'


### PR DESCRIPTION
closes #3099 
Reviewing commit by commit may make the review easier.

Fix bug : the cursors are not coordinated between GET and GEV
[Capture vidéo du 2023-02-16 10-26-39.webm](https://user-images.githubusercontent.com/45000526/219324248-2d6ca5a2-d1f4-4d6f-8d84-08eb25417c36.webm)

Fix bug : the cursor on GEV keeps disappering when we stop moving the mouse
[Capture vidéo du 2023-02-16 10-30-20.webm](https://user-images.githubusercontent.com/45000526/219324972-1045df91-f8ca-41ec-885a-3938439eac26.webm)

Fix bug : when we select the train on the left side of the scenario, the GET is not updated
[Capture vidéo du 2023-02-16 10-32-36.webm](https://user-images.githubusercontent.com/45000526/219325609-912f6e02-c465-4de6-b287-1d0d9e0557d5.webm)
