### PR TITLE
core: stdcm fixes

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
@@ -40,7 +40,7 @@ public class DelayManager {
                     route,
                     block.distanceStart(),
                     startTime,
-                    graph.getStandardAllowanceSpeedRatio(envelope, route)
+                    graph.getStandardAllowanceSpeedRatio(envelope)
             );
             var diff = block.timeEnd() - enterTime;
             if (diff < 0)
@@ -85,7 +85,7 @@ public class DelayManager {
                     route,
                     occupancy.distanceEnd(),
                     startTime,
-                    graph.getStandardAllowanceSpeedRatio(envelope, route)
+                    graph.getStandardAllowanceSpeedRatio(envelope)
             );
             var margin = occupancy.timeStart() - exitTime;
             if (margin < 0) {
@@ -106,7 +106,7 @@ public class DelayManager {
         if (Double.isInfinite(startTime))
             return 0;
         for (var occupancy : unavailableTimes.get(route)) {
-            var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope, route);
+            var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope);
             // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
             var enterTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceStart(),
                     startTime, speedRatio);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
@@ -169,7 +169,7 @@ public class STDCMEdgeBuilder {
                 prevNode,
                 route.getInfraRoute().getLength() - envelope.getEndPos(),
                 (int) (actualStartTime / 60),
-                graph.getStandardAllowanceSpeedRatio(envelope, route)
+                graph.getStandardAllowanceSpeedRatio(envelope)
         );
         if (res.maximumAddedDelayAfter() < 0)
             res = graph.allowanceManager.tryEngineeringAllowance(res);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
@@ -62,17 +62,15 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
                 : "Standard allowance cannot be a flat time for STDCM trains";
     }
 
-    /** Returns the speed ratio we need to apply to the envelope to follow the given standard allowance.
-     * We need to know the envelope and route in case of a "time per distance" allowance. */
+    /** Returns the speed ratio we need to apply to the envelope to follow the given standard allowance. */
     public double getStandardAllowanceSpeedRatio(
-            Envelope envelope,
-            SignalingRoute route
+            Envelope envelope
     ) {
         if (standardAllowance == null)
             return 1;
 
         var runTime = envelope.getTotalTime();
-        var distance = route.getInfraRoute().getLength();
+        var distance = envelope.getTotalDistance();
         var allowanceRatio = standardAllowance.getAllowanceRatio(runTime, distance);
         return 1 / (1 + allowanceRatio);
     }


### PR DESCRIPTION
* We need more accuracy when finding accelerating stops (EDIT: reverted because it's not that easy: https://github.com/DGEXSolutions/osrd/issues/3140)
* Fix a "typo" / small mistake, the wrong distance value was used to evaluate standard allowance time