### PR TITLE
editoast: openapi: fix clone name endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -747,7 +747,7 @@ paths:
                     schematic:
                       type: object
                       description: object's schematic in geojson format
-  /infra/{id}/clone:
+  /infra/{id}/clone/:
     post:
       tags:
         - infra


### PR DESCRIPTION
Fix missing trailing slash