### PR TITLE
tests: fix and clean up fuzzer script

### DIFF
--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -197,11 +197,15 @@ def make_stdcm_payload(scenario: Scenario, path: List[Tuple[str, float]], rollin
     """
     start_edge, start_offset = path[0]
     last_edge, last_offset = path[1]
-    return {
+    res = {
         "infra": scenario.infra,
         "rolling_stock": rolling_stock,
         "timetable": scenario.timetable,
-        "start_time": 0,
+        "start_time": random.randint(0, 3600 * 24),
+        "maximum_departure_delay": random.randint(0, 3600 * 4),
+        "maximum_relative_run_time": random.random() * 4,
+        "margin_before": random.randint(0, 600),
+        "margin_after": random.randint(0, 600),
         "start_points": [
             {
                 "track_section": start_edge,
@@ -215,6 +219,10 @@ def make_stdcm_payload(scenario: Scenario, path: List[Tuple[str, float]], rollin
             }
         ],
     }
+    allowance_value = make_random_allowance_value(0)
+    if allowance_value["value_type"] != "time" and random.randint(0, 2) == 0:
+        res["standard_allowance"] = allowance_value
+    return res
 
 
 def run(

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -176,8 +176,8 @@ def test_stdcm(
     stdcm_payload = make_stdcm_payload(base_url, scenario, path, rolling_stock)
     r = post_with_timeout(base_url + "stdcm/", json=stdcm_payload)
     if r.status_code // 100 != 2:
-        if r.status_code // 100 == 4:
-            print("ignore: invalid user input")
+        if r.status_code // 100 == 4 and "no_path_found" in r.content.decode("utf-8"):
+            print("ignore: no path found")
             return
         make_error(
             ErrorType.STDCM,


### PR DESCRIPTION
fixes #3191 

Can be reviewed commit per commit, I thought they were small enough not to warrant several PRs (but I can split the PR if that makes it easier).

1. create scenarios when used as a standalone script
2. properly handle and log timeout errors
3. only ignore stdcm 4xx errors when it's a "no path found"
4. update comments and docstrings
5. add optional parameters for stdcm requests