### PR TITLE
front: Limit layers to be searched for SnappedMarker

### DIFF
--- a/front/src/applications/operationalStudies/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/applications/operationalStudies/components/ManageTrainSchedule/Map.tsx
@@ -75,9 +75,17 @@ function Map() {
       pitch: 0,
     });
   };
+  
+  const getTrackLayerName = () => {
+    const layerNames = {
+      geographic: ['chartis/tracks-geo/main'],
+      schematic: ['chartis/tracks-sch/main'],
+    };
+    return layerNames[mapTrackSources];
+  };
 
   const onFeatureClick = (e: MapLayerMouseEvent) => {
-    const result = getMapMouseEventNearestFeature(e);
+    const result = getMapMouseEventNearestFeature(e, { layersId: getTrackLayerName() });
     if (
       result &&
       result.feature.properties &&
@@ -102,7 +110,7 @@ function Map() {
   };
 
   const onMoveGetFeature = (e: MapLayerMouseEvent) => {
-    const result = getMapMouseEventNearestFeature(e);
+    const result = getMapMouseEventNearestFeature(e, { layersId: getTrackLayerName() });
     if (
       result &&
       result.feature.properties &&


### PR DESCRIPTION
This will limit the searching only for the track section layers when moving mouse over map and searching the coordinates for `SnappedMarker`.

Unless this causes some unwanted side-effects which I didn't notice, this should fix #2927, #3162 and #3150.