### PR TITLE
editoast: add operator =i for case insensitive "strict" equality

### DIFF
--- a/editoast/src/views/search/context.rs
+++ b/editoast/src/views/search/context.rs
@@ -153,7 +153,10 @@ impl QueryContext {
         function_name: &String,
         arglist_types: &[TypeSpec],
     ) -> Result<&QueryFunction> {
-        let functions = self.functions.get(function_name).unwrap();
+        let functions = self
+            .functions
+            .get(function_name)
+            .ok_or_else(|| ProcessingError::UndefinedFunction(function_name.to_owned()))?;
         let function = match functions.len() {
             0 => Err(ProcessingError::UndefinedFunction(function_name.to_owned())),
             1 => {

--- a/editoast/src/views/search/process.rs
+++ b/editoast/src/views/search/process.rs
@@ -90,6 +90,7 @@ impl QueryContext {
 /// - like : string -> (string | null) -> (bool | null)
 /// - ilike : string -> (string | null) -> (bool | null)
 /// - search : string -> (string | null) -> bool
+/// - =i : string -> string -> bool
 pub fn create_processing_context() -> QueryContext {
     let mut context = QueryContext::default();
     context.def_function_1::<dsl::Nullable<dsl::Ersatz<dsl::Boolean>>, dsl::Sql<dsl::Boolean>>(
@@ -163,13 +164,12 @@ pub fn create_processing_context() -> QueryContext {
             })
         }),
     );
-    context
-        .def_function_2::<dsl::Nullable<dsl::Integer>, dsl::Nullable<dsl::Integer>, dsl::Integer>(
-            "*",
-            Rc::new(|left: Option<i64>, right: Option<i64>| {
-                Ok(left.unwrap_or(1) * right.unwrap_or(1))
-            }),
-        );
+    context.def_function_2::<dsl::Ersatz<dsl::String>, dsl::Nullable<dsl::String>, dsl::Sql<dsl::Boolean>>(
+        "=i",
+        Rc::new(|left, right| {
+            Ok(SqlQuery::infix("ILIKE", left, right.into()))
+        })
+    );
     context
 }
 


### PR DESCRIPTION
```json
["=i", "tot", "ToT"]
# but not
["=i", "tot", "toto"] # differs from search
```

Useful for OP search as we want trigram strict equality, but we don't want to bother about the case (otherwise the front would need to known about DB internals).