### PR TITLE
front: fix-bug: write unit in lowercase in RollingStock selector

### DIFF
--- a/front/src/common/RollingStockSelector/RollingStockCard.jsx
+++ b/front/src/common/RollingStockSelector/RollingStockCard.jsx
@@ -115,22 +115,19 @@ function RollingStockCard(props) {
             <div className="col-2">
               <div className="rollingstock-size text-nowrap">
                 <AiOutlineColumnWidth />
-                {data.length}
-                <small>M</small>
+                {data.length}m
               </div>
             </div>
             <div className="col-2">
               <div className="rollingstock-weight text-nowrap">
                 <FaWeightHanging />
-                {Math.round(data.mass / 1000)}
-                <small>T</small>
+                {Math.round(data.mass / 1000)}t
               </div>
             </div>
             <div className="col-3">
               <div className="rollingstock-speed text-nowrap">
                 <IoIosSpeedometer />
-                {Math.round(data.max_speed * 3.6)}
-                <small>KM/H</small>
+                {Math.round(data.max_speed * 3.6)}km/h
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #3269 

Current rs selector:
![image](https://user-images.githubusercontent.com/45000526/220674527-c14351cf-5b8d-497d-af2d-9d08273f5dad.png)


After modifications
![image](https://user-images.githubusercontent.com/45000526/220674380-4576b751-7664-4341-976f-8690f9baa9ce.png)
