### PR TITLE
front: fix-bug: set default standard allowance type to percentage instead of time

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/allowancesConsts.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/allowancesConsts.jsx
@@ -9,3 +9,9 @@ export const TYPES_UNITS = {
   percentage: 'percentage',
   time_per_distance: 'minutes',
 };
+
+export const ALLOWANCE_UNIT_TYPES = {
+  TIME: 'time',
+  PERCENTAGE: 'percentage',
+  TIME_PER_DISTANCE: 'time_per_distance',
+};

--- a/front/src/applications/stdcm/formatStcmConf.ts
+++ b/front/src/applications/stdcm/formatStcmConf.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from 'redux';
 import { TFunction } from 'i18next';
 
-import { TYPES_UNITS } from 'applications/operationalStudies/components/SimulationResults/Allowances/allowancesConsts';
+import { ALLOWANCE_UNIT_TYPES, TYPES_UNITS } from 'applications/operationalStudies/components/SimulationResults/Allowances/allowancesConsts';
 import { STDCM_MODES, OsrdConfState } from 'applications/operationalStudies/consts';
 import { time2sec } from 'utils/timeManipulation';
 import { makeEnumBooleans } from 'utils/constants';
@@ -108,7 +108,7 @@ export default function formatStdcmConf(
 
   if (!error) {
     const standardAllowanceType: string =
-      (osrdconf.standardStdcmAllowance?.type as string) || 'time';
+      (osrdconf.standardStdcmAllowance?.type as string) || ALLOWANCE_UNIT_TYPES.PERCENTAGE;
     const standardAllowanceValue: number = osrdconf.standardStdcmAllowance?.value || 0;
     const standardAllowance: { [index: string]: any } = {};
     const typeUnitTanslationIndex: { [index: string]: any } = TYPES_UNITS;


### PR DESCRIPTION
Fixes #3151 

When the STDCM tab is opened from a fresh environment and the standard allowance parameters aren't modified, the front sends a request with a standard allowance of "0 seconds". This is invalid because it's a flat time. It should be either unspecified or set to a percentage value.

The flat time option can't be manually selected anymore, but it's still the default value.

I have modified the default valut to 0%.