### PR TITLE
core: debug pathfinding to find the shortest path

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // Sentry
     implementation libs.sentry
 
+    // Geographic computations
+    implementation libs.geodesy
+
     // Use JUnit Jupiter API for testing.
     testImplementation libs.junit.jupiter.api
     testImplementation libs.junit.jupiter.params

--- a/core/libs.versions.toml
+++ b/core/libs.versions.toml
@@ -58,6 +58,8 @@ mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.9.+' }  # EPL 2.0
 jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' }  # CC Attribution
 spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.7.+' }  # LGPLv2.1
+geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' }  # Apache 2.0
+
 
 [plugins]
 # kotlin

--- a/core/osrd-railjson/build.gradle
+++ b/core/osrd-railjson/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation libs.moshi
     implementation libs.moshi.adapters
 
+    // Geographic computations
+    implementation libs.geodesy
+
     // for linter annotations
     compileOnly libs.jcip.annotations
     compileOnly libs.spotbugs.annotations

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/geom/LineString.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/geom/LineString.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 public class LineString {
 
-    /** A list of N coordinates (X component) */
+    /** A list of N coordinates (X component, longitude) */
     private final double[] bufferX;
-    /** A list of N coordinates (Y component) */
+    /** A list of N coordinates (Y component, latitude) */
     private final double[] bufferY;
     /** A cumulative list of N-1 distances between coordinates */
     private final double[] cumulativeLengths;

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/geom/Point.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/geom/Point.java
@@ -2,8 +2,14 @@ package fr.sncf.osrd.railjson.schema.geom;
 
 import com.squareup.moshi.*;
 import java.io.IOException;
+import org.gavaghan.geodesy.*;
 
-public record Point (double x, double y) {
+public record Point (
+        // Longitude
+        double x,
+        // Latitude
+        double y
+) {
 
     public static class Adapter extends JsonAdapter<Point> {
 
@@ -65,13 +71,13 @@ public record Point (double x, double y) {
         }
     }
 
-    /** Returns the distance between this point and another in meters, assuming x and y are latitude and longitude.
-     * This is an approximation. */
+    /** Returns the distance between this point and another in meters,
+     * assuming x = longitude and y = latitude */
     public double distanceAsMeters(Point other) {
-        var mPerLatDeg = 111132.954 - 559.822 * Math.cos(2.0 * x) + 1.175 * Math.cos(4.0 * x);
-        var mPerLonDeg = (Math.PI / 180) * 6367449 * Math.cos(x);
-        var latDistance = (x - other.x) * mPerLatDeg;
-        var lonDistance = (y - other.y) * mPerLonDeg;
-        return Math.sqrt(latDistance * latDistance + lonDistance * lonDistance);
+        GeodeticCalculator geoCalc = new GeodeticCalculator();
+        Ellipsoid reference = Ellipsoid.WGS84;
+        GlobalPosition thisPosition = new GlobalPosition(y, x, 0.0);
+        GlobalPosition otherPosition = new GlobalPosition(other.y, other.x, 0.0);
+        return geoCalc.calculateGeodeticCurve(reference, thisPosition, otherPosition).getEllipsoidalDistance();
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/Pathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/Pathfinding.java
@@ -155,7 +155,7 @@ public class Pathfinding<NodeT, EdgeT> {
     ) {
         checkParameters();
         for (var location : starts) {
-            var startRange = new EdgeRange<>(location.edge, location.offset, edgeToLength.apply(location.edge));
+            var startRange = new EdgeRange<>(location.edge, location.offset, location.offset);
             registerStep(startRange, null, 0, 0, List.of(location));
         }
         while (true) {

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/PathfindingTests.java
@@ -566,6 +566,41 @@ public class PathfindingTests {
         assertNull(res);
     }
 
+    @Test
+    public void pathfindingDisjointedPaths() {
+        /* Two disjointed paths, top one is direct and fastest, bottom one is split
+
+        0 -> B1 ------> E1 -> 1
+        2 -> B2 -> 3 -> 4 -> E2 -> 5
+         */
+        var builder = new SimpleGraphBuilder();
+        builder.makeNodes(6);
+        builder.makeEdge(0, 1, 10_000);
+        builder.makeEdge(2, 3, 1_000);
+        builder.makeEdge(3, 4, 1_000);
+        builder.makeEdge(4, 5, 1_000);
+        var g = builder.build();
+        var res = new Pathfinding<>(g)
+                .setEdgeToLength(edge -> edge.length)
+                .runPathfindingEdgesOnly(List.of(
+                        List.of(
+                                builder.getEdgeLocation("0-1", 5_000),
+                                builder.getEdgeLocation("2-3")
+                        ),
+                        List.of(
+                                builder.getEdgeLocation("0-1", 6_999),
+                                builder.getEdgeLocation("4-5", 1_000)
+                        )
+                ));
+        var resIDs = res.stream().map(x -> x.label).toList();
+        assertEquals(
+                List.of(
+                        "0-1"
+                ),
+                resIDs
+        );
+    }
+
     private static List<SimpleRange> convertRes(Pathfinding.Result<SimpleGraphBuilder.Edge> res) {
         return res.ranges().stream()
                 .map(x -> new SimpleRange(x.edge().label, x.start(), x.end()))


### PR DESCRIPTION
Fix #3319 

* Fix a bug where the shortest path could have an invalid weight if the destination is on the same edge as the origin
* Use geodesy to compute geographic distances