### PR TITLE
stdcm: use a smaller abstract interface for conflict detection

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -26,7 +26,7 @@ import fr.sncf.osrd.standalone_sim.ScheduleMetadataExtractor;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.standalone_sim.result.ResultEnvelopePoint;
 import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
-import fr.sncf.osrd.stdcm.UnavailableSpaceBuilder;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
 import fr.sncf.osrd.train.TrainStop;

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -26,6 +26,7 @@ import fr.sncf.osrd.standalone_sim.ScheduleMetadataExtractor;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.standalone_sim.result.ResultEnvelopePoint;
 import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.RouteAvailabilityLegacyAdapter;
 import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
@@ -128,7 +129,7 @@ public class STDCMEndpoint implements Take {
                     endTime,
                     startLocations,
                     endLocations,
-                    unavailableSpace,
+                    new RouteAvailabilityLegacyAdapter(unavailableSpace),
                     request.timeStep,
                     request.maximumDepartureDelay,
                     request.maximumRelativeRunTime * minRunTime,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
@@ -1,11 +1,13 @@
 package fr.sncf.osrd.stdcm.graph;
 
-import com.google.common.collect.Multimap;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
 import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import java.util.HashSet;
-import java.util.Set;
+import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 /** This class contains all the methods used to handle delays
  * (how much we can add, how much we need to add, and such)
@@ -14,53 +16,65 @@ public class DelayManager {
 
     public final double minScheduleTimeStart;
     public final double maxRunTime;
-    private final Multimap<SignalingRoute, OccupancyBlock> unavailableTimes;
+    private final RouteAvailabilityInterface routeAvailability;
     private final STDCMGraph graph;
 
     DelayManager(
             double minScheduleTimeStart,
             double maxRunTime,
-            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes,
+            RouteAvailabilityInterface routeAvailability,
             STDCMGraph graph
     ) {
         this.minScheduleTimeStart = minScheduleTimeStart;
         this.maxRunTime = maxRunTime;
-        this.unavailableTimes = unavailableTimes;
+        this.routeAvailability = routeAvailability;
         this.graph = graph;
     }
 
     /** Returns one value per "opening" (interval between two unavailable times).
      * Always returns the shortest delay to add to enter this opening. */
-    Set<Double> minimumDelaysPerOpening(SignalingRoute route, double startTime, Envelope envelope) {
-        var res = new HashSet<Double>();
-        res.add(findMinimumAddedDelay(route, startTime, envelope));
-        for (var block : unavailableTimes.get(route)) {
-            var enterTime = STDCMSimulations.interpolateTime(
+    NavigableSet<Double> minimumDelaysPerOpening(
+            SignalingRoute route,
+            double startTime,
+            Envelope envelope,
+            double startOffset
+    ) {
+        var res = new TreeSet<Double>();
+        var endOffset = startOffset + envelope.getEndPos();
+        var path = STDCMUtils.makeTrainPath(route, startOffset, endOffset);
+        double time = startTime;
+        while (Double.isFinite(time)) {
+            var availability = getScaledAvailability(
+                    path,
+                    0,
+                    path.length(),
                     envelope,
-                    route,
-                    block.distanceStart(),
-                    startTime,
-                    graph.getStandardAllowanceSpeedRatio(envelope)
+                    time
             );
-            var diff = block.timeEnd() - enterTime;
-            if (diff < 0)
-                continue;
-            var time = diff + findMinimumAddedDelay(route, startTime + diff, envelope);
-            res.add(time);
+            if (availability instanceof RouteAvailabilityInterface.Available available) {
+                res.add(time - startTime);
+                time += available.maximumDelay + 1;
+            } else if (availability instanceof RouteAvailabilityInterface.Unavailable unavailable) {
+                time += unavailable.duration;
+            } else
+                throw new RuntimeException("STDCM lookahead isn't supported yet");
         }
         return res;
     }
 
-    /** Returns the start time of the next occupancy for the route (does not depend on the envelope) */
-    double findNextOccupancy(SignalingRoute route, double time) {
-        var earliest = Double.POSITIVE_INFINITY;
-        for (var occupancy : unavailableTimes.get(route)) {
-            var occupancyTime = occupancy.timeStart();
-            if (occupancyTime < time)
-                continue;
-            earliest = Math.min(earliest, occupancyTime);
-        }
-        return earliest;
+    /** Returns the start time of the next occupancy for the route */
+    double findNextOccupancy(SignalingRoute route, double time, double startOffset, Envelope envelope) {
+        var endOffset = startOffset + envelope.getEndPos();
+        var path = STDCMUtils.makeTrainPath(route, startOffset, endOffset);
+        var availability = getScaledAvailability(
+                path,
+                0,
+                path.length(),
+                envelope,
+                time
+        );
+        assert availability.getClass() == RouteAvailabilityInterface.Available.class;
+        return ((RouteAvailabilityInterface.Available) availability).timeOfNextConflict;
     }
 
     /** Returns true if the total run time at the start of the edge is above the specified threshold */
@@ -76,53 +90,32 @@ public class DelayManager {
      * </p>
      * e.g. if the train takes 42s to go through the route, enters the route at t=10s,
      * and we need to leave the route at t=60s, this will return 8s. */
-    double findMaximumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
-        var minValue = Double.POSITIVE_INFINITY;
-        for (var occupancy : unavailableTimes.get(route)) {
-            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var exitTime = STDCMSimulations.interpolateTime(
-                    envelope,
-                    route,
-                    occupancy.distanceEnd(),
-                    startTime,
-                    graph.getStandardAllowanceSpeedRatio(envelope)
-            );
-            var margin = occupancy.timeStart() - exitTime;
-            if (margin < 0) {
-                // This occupancy block was before the train passage, we can ignore it
-                continue;
-            }
-            minValue = Math.min(minValue, margin);
-        }
-        return minValue;
+    double findMaximumAddedDelay(SignalingRoute route, double startTime, double startOffset, Envelope envelope) {
+        double endOffset = startOffset + envelope.getEndPos();
+        var path = STDCMUtils.makeTrainPath(route, startOffset, endOffset);
+        var availability = getScaledAvailability(
+                path, 0, path.length(), envelope, startTime
+        );
+        assert availability instanceof RouteAvailabilityInterface.Available;
+        return ((RouteAvailabilityInterface.Available) availability).maximumDelay;
     }
 
-    /** Returns by how much delay we need to add to avoid causing a conflict.
-     * </p>
-     * e.g. if the whole route is occupied from t=0s to t=60s, and we enter the route at t=42s,
-     * this will return 18s. */
-    double findMinimumAddedDelay(SignalingRoute route, double startTime, Envelope envelope) {
-        double maxValue = 0;
-        if (Double.isInfinite(startTime))
-            return 0;
-        for (var occupancy : unavailableTimes.get(route)) {
-            var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope);
-            // This loop has a poor complexity, we need to optimize it by the time we handle full timetables
-            var enterTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceStart(),
-                    startTime, speedRatio);
-            var exitTime = STDCMSimulations.interpolateTime(envelope, route, occupancy.distanceEnd(),
-                    startTime, speedRatio);
-            if (enterTime >= occupancy.timeEnd() || exitTime <= occupancy.timeStart())
-                continue;
-            var diff = occupancy.timeEnd() - enterTime;
-            maxValue = Math.max(maxValue, diff);
-        }
-        if (maxValue == 0 || Double.isInfinite(maxValue))
-            return maxValue;
-
-        // We need a recursive call to see if we can fit a curve in the new position,
-        // or if we need to shift it further because of a different occupancy block
-        return maxValue + findMinimumAddedDelay(route, startTime + maxValue, envelope);
+    /** Calls `routeAvailability.getAvailability`, on an envelope scaled to account for the standard allowance. */
+    private RouteAvailabilityInterface.Availability getScaledAvailability(
+            TrainPath path,
+            double startOffset,
+            double endOffset,
+            Envelope envelope,
+            double startTime
+    ) {
+        var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope);
+        var scaledEnvelope = LinearAllowance.scaleEnvelope(envelope, speedRatio);
+        return routeAvailability.getAvailability(
+                path,
+                startOffset,
+                endOffset,
+                scaledEnvelope,
+                startTime
+        );
     }
-
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
@@ -39,6 +39,10 @@ public class DelayManager {
             Envelope envelope,
             double startOffset
     ) {
+        // This is the margin used for the binary search, we need to add
+        // this time before and after the train to avoid problems caused by the error margin
+        double margin = graph.timeStep;
+
         var res = new TreeSet<Double>();
         var endOffset = startOffset + envelope.getEndPos();
         var path = STDCMUtils.makeTrainPath(route, startOffset, endOffset);
@@ -52,10 +56,11 @@ public class DelayManager {
                     time
             );
             if (availability instanceof RouteAvailabilityInterface.Available available) {
-                res.add(time - startTime);
+                if (available.maximumDelay >= margin)
+                    res.add(time - startTime);
                 time += available.maximumDelay + 1;
             } else if (availability instanceof RouteAvailabilityInterface.Unavailable unavailable) {
-                time += unavailable.duration;
+                time += unavailable.duration + margin;
             } else
                 throw new RuntimeException("STDCM lookahead isn't supported yet");
         }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
@@ -1,12 +1,11 @@
 package fr.sncf.osrd.stdcm.graph;
 
-import com.google.common.collect.Multimap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Graph;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -40,7 +39,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
             RollingStock rollingStock,
             RollingStock.Comfort comfort,
             double timeStep,
-            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes,
+            RouteAvailabilityInterface routeAvailability,
             double maxRunTime,
             double minScheduleTimeStart,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
@@ -52,7 +51,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         this.comfort = comfort;
         this.timeStep = timeStep;
         this.endLocations = endLocations;
-        this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, unavailableTimes, this);
+        this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, routeAvailability, this);
         this.allowanceManager = new AllowanceManager(this);
         this.backtrackingManager = new BacktrackingManager(this);
         this.tag = tag;

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
@@ -1,14 +1,13 @@
 package fr.sncf.osrd.stdcm.graph;
 
-import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
 import fr.sncf.osrd.stdcm.STDCMResult;
 import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints;
 import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import fr.sncf.osrd.utils.graph.functional_interfaces.TargetsOnEdge;
@@ -31,7 +30,7 @@ public class STDCMPathfinding {
             double endTime,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> startLocations,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
-            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes,
+            RouteAvailabilityInterface routeAvailability,
             double timeStep,
             double maxDepartureDelay,
             double maxRunTime,
@@ -43,7 +42,7 @@ public class STDCMPathfinding {
                 rollingStock,
                 comfort,
                 timeStep,
-                unavailableTimes,
+                routeAvailability,
                 maxRunTime,
                 startTime,
                 endLocations,
@@ -75,7 +74,7 @@ public class STDCMPathfinding {
                 timeStep,
                 comfort,
                 maxRunTime,
-                unavailableTimes
+                routeAvailability
         );
     }
 

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
@@ -1,14 +1,12 @@
 package fr.sncf.osrd.stdcm.graph;
 
-import com.google.common.collect.Multimap;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
 import fr.sncf.osrd.stdcm.STDCMResult;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
-import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.ArrayDeque;
@@ -29,7 +27,7 @@ public class STDCMPostProcessing {
             double timeStep,
             RollingStock.Comfort comfort,
             double maxRunTime,
-            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes
+            RouteAvailabilityInterface routeAvailability
     ) {
         var ranges = makeEdgeRange(path);
         var routeRanges = ranges.stream()
@@ -49,7 +47,7 @@ public class STDCMPostProcessing {
                 rollingStock,
                 timeStep,
                 comfort,
-                unavailableTimes,
+                routeAvailability,
                 departureTime
         );
         var res = new STDCMResult(

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
@@ -1,0 +1,133 @@
+package fr.sncf.osrd.stdcm.preprocessing.implementation;
+
+import com.google.common.collect.Multimap;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.stdcm.OccupancyBlock;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
+import fr.sncf.osrd.train.TrainStop;
+import java.util.List;
+
+/** This class implements the RouteAvailabilityInterface using the legacy route occupancy data.
+ * It's meant to be removed once the rest of the "signaling sim - stdcm" pipeline is implemented. */
+public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterface {
+
+    private final Multimap<SignalingRoute, OccupancyBlock> unavailableSpace;
+
+    /** Constructor */
+    public RouteAvailabilityLegacyAdapter(
+            Multimap<SignalingRoute, OccupancyBlock> unavailableSpace
+    ) {
+        this.unavailableSpace = unavailableSpace;
+    }
+
+    @Override
+    public Availability getAvailability(
+            TrainPath path,
+            double startOffset,
+            double endOffset,
+            Envelope envelope,
+            double startTime,
+            List<TrainStop> stops
+    ) {
+        var minimumDelay = findMinimumDelay(path, startOffset, endOffset, envelope, startTime);
+        if (minimumDelay > 0)
+            return new UnavailableFor(minimumDelay);
+        return new AvailableFor(findMaximumDelay(path, startOffset, endOffset, envelope, startTime));
+    }
+
+    /** Find the minimum delay needed to avoid any conflict.
+     * Returns 0 if the train isn't currently causing any conflict. */
+    double findMinimumDelay(
+            TrainPath path,
+            double startOffset,
+            double endOffset,
+            Envelope envelope,
+            double startTime
+    ) {
+        double minimumDelay = 0;
+        for (var locatedRoute : iteratePathInRange(path, startOffset, endOffset)) {
+            for (var block : unavailableSpace.get(locatedRoute.element())) {
+                var trainInBlock = timeTrainInBlock(
+                        block,
+                        locatedRoute,
+                        startOffset,
+                        envelope,
+                        startTime
+                );
+                if (trainInBlock.start < block.timeEnd()
+                        && trainInBlock.end > block.timeStart())
+                    minimumDelay = Math.max(minimumDelay, block.timeEnd() - trainInBlock.start);
+            }
+        }
+        if (minimumDelay > 0) {
+            // We need to add delay, a recursive call is needed to detect new conflicts later on
+            return findMinimumDelay(path, startOffset, endOffset, envelope, startTime + minimumDelay);
+        }
+        return minimumDelay;
+    }
+
+    /** Find the maximum amount of delay that can be added to the train without causing conflict.
+     * Cannot be called if the train is currently causing a conflict. */
+    double findMaximumDelay(
+            TrainPath path,
+            double startOffset,
+            double endOffset,
+            Envelope envelope,
+            double startTime
+    ) {
+        double maximumDelay = Double.POSITIVE_INFINITY;
+        for (var locatedRoute : iteratePathInRange(path, startOffset, endOffset)) {
+            for (var block : unavailableSpace.get(locatedRoute.element())) {
+                var trainInBlock = timeTrainInBlock(
+                        block,
+                        locatedRoute,
+                        startOffset,
+                        envelope,
+                        startTime
+                );
+                if (trainInBlock.start > block.timeEnd())
+                    continue; // The block is occupied before we enter it
+                assert trainInBlock.start < block.timeStart();
+                maximumDelay = Math.min(maximumDelay, block.timeStart() - trainInBlock.start);
+            }
+        }
+        return maximumDelay;
+    }
+
+    /** Returns the list of routes in the given interval on the path */
+    private static List<TrainPath.LocatedElement<SignalingRoute>> iteratePathInRange(
+            TrainPath path,
+            double start,
+            double end
+    ) {
+        return path.routePath().stream()
+                .filter(r -> r.pathOffset() < end)
+                .filter(r -> r.pathOffset() + r.element().getInfraRoute().getLength() > start)
+                .toList();
+    }
+
+    /** Returns the time interval during which the train is on the given blocK. */
+    private static TimeInterval timeTrainInBlock(
+            OccupancyBlock block,
+            TrainPath.LocatedElement<SignalingRoute> route,
+            double startOffset,
+            Envelope envelope,
+            double startTime
+    ) {
+        var startRouteOffsetOnEnvelope = route.pathOffset() - startOffset;
+        // Offsets on the envelope
+        var blockEnterOffset = startRouteOffsetOnEnvelope + block.distanceStart();
+        var blockExitOffset = startRouteOffsetOnEnvelope + block.distanceEnd();
+
+        var enterTime = startTime + envelope.interpolateTotalTimeClamp(blockEnterOffset);
+        var exitTime = startTime + envelope.interpolateTotalTimeClamp(blockExitOffset);
+        return new TimeInterval(enterTime, exitTime);
+    }
+
+    private record TimeInterval(
+            double start,
+            double end
+    ) {}
+}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/UnavailableSpaceBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/UnavailableSpaceBuilder.java
@@ -1,10 +1,11 @@
-package fr.sncf.osrd.stdcm;
+package fr.sncf.osrd.stdcm.preprocessing.implementation;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.stdcm.STDCMRequest;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.OccupancyBlock;
 import fr.sncf.osrd.train.RollingStock;
 import java.util.Collection;
 

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
@@ -2,8 +2,6 @@ package fr.sncf.osrd.stdcm.preprocessing.interfaces;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.infra_state.api.TrainPath;
-import fr.sncf.osrd.train.TrainStop;
-import java.util.List;
 
 /** Abstract interface used to request the availability of path sections */
 public interface RouteAvailabilityInterface {
@@ -12,18 +10,22 @@ public interface RouteAvailabilityInterface {
      * <br/>
      * Can return either an instance of either type:
      * <ul>
-     * <li>AvailableUntil: the section is available until the given time (which may be +inf) </li>
-     * <li>UnavailableUntil: the section isn't available until the given time </li>
+     * <li>Available: the section is available </li>
+     * <li>Unavailable: the section isn't available </li>
      * <li>NotEnoughLookahead: the train path needs to extend further, it depends on a directional choice </li>
      * </ul>
+     * More details are given in the instances.
+     * <br/>
+     * Note: every position refers to the position of the head of the train.
+     * The implementation of RouteAvailabilityInterface must account for train length, sight distance,
+     * and similar factors.
      *
      * @param path Path taken by the train
-     * @param startOffset Start of the section to check for availability
-     * @param endOffset End of the section to check for availability
+     * @param startOffset Start of the section to check for availability, as an offset from the start of the path
+     * @param endOffset End of the section to check for availability, as an offset from the start of the path
      * @param envelope Envelope describing the position of the train at any moment.
      *                 Must be exactly `(endOffset - startOffset) long.
      * @param startTime Time at which the train is at `startOffset`.
-     * @param stops Planned stops
      * @return An Availability instance.
      */
     Availability getAvailability(
@@ -31,32 +33,53 @@ public interface RouteAvailabilityInterface {
             double startOffset,
             double endOffset,
             Envelope envelope,
-            double startTime,
-            List<TrainStop> stops
+            double startTime
     );
 
     /** Represents the availability of the requested section */
     abstract sealed class Availability
-        permits AvailableFor, UnavailableFor, NotEnoughLookahead
+            permits Available, Unavailable, NotEnoughLookahead
     {}
 
-    /** The requested section is available until the given time, in seconds. */
-    final class AvailableFor extends Availability {
-        public final double duration;
+    /** The requested section is available.
+     * <br/>
+     * For example: a train enter the section at t=10, sees a signal 42s after entering the section,
+     * and the signal is green until t=100. The result would be:
+     * <ul>
+     * <li>maximumDelay = 100 - 42 - 10 = 48
+     * <li>timeOfNextConflict = 100
+     * </ul>
+     */
+    final class Available extends Availability {
+        /** The train can use the section now and up to `maximumDelay` later without conflict */
+        public final double maximumDelay;
+
+        /** Earliest time any resource used by the train is reused by another one */
+        public final double timeOfNextConflict;
 
         /** Constructor */
-        public AvailableFor(double duration) {
-            this.duration = duration;
+        public Available(double maximumDelay, double timeOfNextConflict) {
+            this.maximumDelay = maximumDelay;
+            this.timeOfNextConflict = timeOfNextConflict;
         }
     }
 
-    /** The requested section isn't available, but will be starting from the given time */
-    final class UnavailableFor extends Availability {
+    /** The requested section isn't available yet */
+    final class Unavailable extends Availability {
+        /** Minimum delay to add to the departure time to avoid any conflict */
         public final double duration;
 
+        /** Exact offset of the first conflict encountered. It's always the offset that marks either the border of an
+         * unavailable section.
+         * <br/>
+         * It's either the offset where we start using a ressource before it's available,
+         * or the offset where the train would have released a ressource it has kept for too long. */
+        public final double firstConflictOffset;
+
         /** Constructor */
-        public UnavailableFor(double duration) {
+        public Unavailable(double duration, double firstConflictOffset) {
             this.duration = duration;
+            this.firstConflictOffset = firstConflictOffset;
         }
     }
 

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
@@ -1,0 +1,67 @@
+package fr.sncf.osrd.stdcm.preprocessing.interfaces;
+
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.train.TrainStop;
+import java.util.List;
+
+/** Abstract interface used to request the availability of path sections */
+public interface RouteAvailabilityInterface {
+
+    /** Request availability information about a section of the path.
+     * <br/>
+     * Can return either an instance of either type:
+     * <ul>
+     * <li>AvailableUntil: the section is available until the given time (which may be +inf) </li>
+     * <li>UnavailableUntil: the section isn't available until the given time </li>
+     * <li>NotEnoughLookahead: the train path needs to extend further, it depends on a directional choice </li>
+     * </ul>
+     *
+     * @param path Path taken by the train
+     * @param startOffset Start of the section to check for availability
+     * @param endOffset End of the section to check for availability
+     * @param envelope Envelope describing the position of the train at any moment.
+     *                 Must be exactly `(endOffset - startOffset) long.
+     * @param startTime Time at which the train is at `startOffset`.
+     * @param stops Planned stops
+     * @return An Availability instance.
+     */
+    Availability getAvailability(
+            TrainPath path,
+            double startOffset,
+            double endOffset,
+            Envelope envelope,
+            double startTime,
+            List<TrainStop> stops
+    );
+
+    /** Represents the availability of the requested section */
+    abstract sealed class Availability
+        permits AvailableFor, UnavailableFor, NotEnoughLookahead
+    {}
+
+    /** The requested section is available until the given time, in seconds. */
+    final class AvailableFor extends Availability {
+        public final double duration;
+
+        /** Constructor */
+        public AvailableFor(double duration) {
+            this.duration = duration;
+        }
+    }
+
+    /** The requested section isn't available, but will be starting from the given time */
+    final class UnavailableFor extends Availability {
+        public final double duration;
+
+        /** Constructor */
+        public UnavailableFor(double duration) {
+            this.duration = duration;
+        }
+    }
+
+    /** The availability of the requested section can't be determined,
+     * the path needs to extend further. The availability depends
+     * on the next routes taken by the train. */
+    final class NotEnoughLookahead extends Availability {}
+}

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
@@ -444,12 +444,14 @@ public class DepartureTimeShiftTests {
         var occupancyGraph = ImmutableMultimap.of(
                 firstRoute, new OccupancyBlock(0, 1000, 0, 100)
         );
+        double timeStep = 2;
         var res1 = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 0)))
                 .setUnavailableTimes(occupancyGraph)
-                .setMaxDepartureDelay(1001)
+                .setTimeStep(timeStep)
+                .setMaxDepartureDelay(1000 + timeStep)
                 .run();
         assertNotNull(res1);
 
@@ -458,7 +460,8 @@ public class DepartureTimeShiftTests {
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 0)))
                 .setUnavailableTimes(occupancyGraph)
-                .setMaxDepartureDelay(999)
+                .setTimeStep(timeStep)
+                .setMaxDepartureDelay(1000 - timeStep)
                 .run();
         assertNull(res2);
     }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -58,7 +58,7 @@ public class EngineeringAllowanceTests {
                 .run();
 
         assertNotNull(res);
-        STDCMHelpers.occupancyTest(res, occupancyGraph);
+        STDCMHelpers.occupancyTest(res, occupancyGraph, 2 * timeStep);
         assertEquals(10, res.departureTime(), 2 * timeStep);
     }
 
@@ -111,7 +111,7 @@ public class EngineeringAllowanceTests {
                 .run();
 
         assertNotNull(res);
-        STDCMHelpers.occupancyTest(res, occupancyGraph);
+        STDCMHelpers.occupancyTest(res, occupancyGraph, 2 * timeStep);
         assertEquals(0, res.departureTime(), 2 * timeStep);
     }
 
@@ -171,7 +171,7 @@ public class EngineeringAllowanceTests {
                 .run();
 
         assertNotNull(res);
-        STDCMHelpers.occupancyTest(res, occupancyGraph);
+        STDCMHelpers.occupancyTest(res, occupancyGraph, 2 * timeStep);
         assertEquals(0, res.departureTime(), 2 * timeStep);
     }
 
@@ -252,14 +252,16 @@ public class EngineeringAllowanceTests {
                 thirdRoute, new OccupancyBlock(0, 1800, 0, 100),
                 forthRoute, new OccupancyBlock(0, 4_000, 0, 100)
         );
+        double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(forthRoute, 1)))
                 .setUnavailableTimes(occupancyGraph)
+                .setTimeStep(timeStep)
                 .run();
         assertNotNull(res);
-        STDCMHelpers.occupancyTest(res, occupancyGraph);
+        STDCMHelpers.occupancyTest(res, occupancyGraph, 2 * timeStep);
     }
 
     /** Test that we return null with no crash when we can't slow down fast enough */

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -83,6 +83,7 @@ public class EngineeringAllowanceTests {
         a |/_##################_> time
 
          */
+        final double timeStep = 2;
         final var infraBuilder = new DummyRouteGraphBuilder();
         final var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 20);
         final var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 20);
@@ -98,10 +99,10 @@ public class EngineeringAllowanceTests {
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime(), POSITIVE_INFINITY, 0, 1_000),
+                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
+                        POSITIVE_INFINITY, 0, 1_000),
                 lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000)
         );
-        double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
@@ -141,6 +142,7 @@ public class EngineeringAllowanceTests {
         But another solution exists: keeping the allowance in the "d->e" route (leftmost curve)
 
          */
+        final double timeStep = 2;
         final var infraBuilder = new DummyRouteGraphBuilder();
         final var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 20);
         final var secondRoute = infraBuilder.addRoute("b", "c", 1_000, 20);
@@ -157,11 +159,11 @@ public class EngineeringAllowanceTests {
         var timeThirdRouteOccupied = firstRouteEnvelope.getTotalTime() + 5 + secondRouteEnvelope.getTotalTime() * 2;
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime(), POSITIVE_INFINITY, 0, 1_000),
+                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
+                        POSITIVE_INFINITY, 0, 1_000),
                 lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000),
                 thirdRoute, new OccupancyBlock(timeThirdRouteOccupied, POSITIVE_INFINITY, 0, 1_000)
         );
-        double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
@@ -332,15 +334,17 @@ public class EngineeringAllowanceTests {
                 routes.get(0), new OccupancyBlock(300, 3600, 0, 1),
                 routes.get(2), new OccupancyBlock(0, 3600, 0, 1)
         );
+        double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 100)))
                 .setUnavailableTimes(occupancyGraph)
+                .setTimeStep(timeStep)
                 .run();
 
         assertNotNull(res);
         STDCMHelpers.occupancyTest(res, occupancyGraph);
-        assertEquals(3600, res.departureTime());
+        assertEquals(3600, res.departureTime(), timeStep);
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -14,6 +14,7 @@ import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
 import fr.sncf.osrd.train.TrainStop;

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
@@ -6,6 +6,7 @@ import fr.sncf.osrd.stdcm.graph.STDCMPathfinding;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.RouteAvailabilityLegacyAdapter;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.TestTrains;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -129,7 +130,7 @@ public class STDCMPathfindingBuilder {
                 0,
                 startLocations,
                 endLocations,
-                unavailableTimes,
+                new RouteAvailabilityLegacyAdapter(unavailableTimes),
                 timeStep,
                 maxDepartureDelay,
                 maxRunTime,

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -335,6 +335,7 @@ public class STDCMPathfindingTests {
         /*
         a --> b
          */
+        final double timeStep = 2;
         var infraBuilder = new DummyRouteGraphBuilder();
         var route = infraBuilder.addRoute("a", "b");
         var infra = infraBuilder.build();
@@ -345,8 +346,9 @@ public class STDCMPathfindingTests {
                 .setUnavailableTimes(ImmutableMultimap.of(
                         route, new OccupancyBlock(0, 1000, 0, 100)
                 ))
-                .setMaxDepartureDelay(1000)
+                .setMaxDepartureDelay(1000 + timeStep)
                 .setMaxRunTime(100)
+                .setTimeStep(timeStep)
                 .run();
         assertNotNull(res);
     }

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMultimap;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.utils.graph.Pathfinding;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -481,8 +482,9 @@ public class StandardAllowanceTests {
         checkAllowanceResult(res, allowance, 4 * timeStep);
     }
 
-    /** The path we find must pass through an exact space-time point at the middle of the path,
+    /** The path we find must pass through an (almost) exact space-time point at the middle of the path,
      * we check that we can still do this with mareco */
+    @Disabled
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testMarecoSingleSpaceTimePoint(boolean isTimePerDistance) {
@@ -508,8 +510,8 @@ public class StandardAllowanceTests {
         if (isTimePerDistance)
             allowance = new AllowanceValue.TimePerDistance(120);
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(2_000, POSITIVE_INFINITY, 0, 1_000),
-                secondRoute, new OccupancyBlock(0, 2_000, 0, 1_000)
+                firstRoute, new OccupancyBlock(2_000 + timeStep, POSITIVE_INFINITY, 0, 1_000),
+                secondRoute, new OccupancyBlock(0, 2_000 - timeStep, 0, 1_000)
         );
         var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
                 .setInfra(infra)

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -166,8 +166,8 @@ public class StandardAllowanceTests {
         assertNotNull(res.withAllowance);
         var timeEnterOccupiedSection = res.withAllowance.departureTime()
                 + res.withAllowance.envelope().interpolateTotalTime(5_000);
-        assertEquals(3600, timeEnterOccupiedSection, timeStep);
-        occupancyTest(res.withAllowance, occupancyGraph, timeStep);
+        assertEquals(3600, timeEnterOccupiedSection, 2 * timeStep);
+        occupancyTest(res.withAllowance, occupancyGraph, 2 * timeStep);
         checkAllowanceResult(res, allowance);
     }
 
@@ -213,7 +213,7 @@ public class StandardAllowanceTests {
 
         var thirdRouteEntryTime = res.departureTime()
                 + res.envelope().interpolateTotalTime(11_000);
-        assertEquals(1000, thirdRouteEntryTime, 2 * timeStep);
+        assertEquals(1000, thirdRouteEntryTime, 4 * timeStep); // Errors build up, we need a high delta
     }
 
     /** Same test as the previous one, with very short routes at the start and end */
@@ -484,7 +484,6 @@ public class StandardAllowanceTests {
 
     /** The path we find must pass through an (almost) exact space-time point at the middle of the path,
      * we check that we can still do this with mareco */
-    @Disabled
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testMarecoSingleSpaceTimePoint(boolean isTimePerDistance) {

--- a/core/src/test/java/fr/sncf/osrd/stdcm/UnavailableSpaceBuilderTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/UnavailableSpaceBuilderTests.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm;
 
-import static fr.sncf.osrd.stdcm.UnavailableSpaceBuilder.computeUnavailableSpace;
+import static fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder.computeUnavailableSpace;
 import static fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
* Create a new interface to request the availability of a path
* Replace the old multimap of blocked sections with this interface
* Add a placeholder implementation of the interface using the old multimap


This interface is just an intermediate step in the stdcm <=> signaling module pipeline.
I wished "available until / unavailable until" were enough, but we sometimes need a little more details to properly avoid conflicts.

We don't support the lookahead problem yet, but there's plans for that.