### PR TITLE
editoast: fix pathfinding to create routes

### DIFF
--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -187,8 +187,14 @@ fn compute_path(
     let get_length = |track: &String| track_sections[track].unwrap_track_section().length;
     let success = |step: &PathfindingStep| step.found;
     let successors = |step: &PathfindingStep| {
-        // The successor is our ending location
+        // The successor is our on ending track
         if step.track == input.ending.track.0 {
+            // If we aren't in the good direction to reach the ending position, it's a dead end
+            if step.direction == Direction::StartToStop && step.position > input.ending.position
+                || step.direction == Direction::StopToStart && step.position < input.ending.position
+            {
+                return vec![];
+            }
             return vec![(
                 PathfindingStep::new(
                     step.track.clone(),


### PR DESCRIPTION
close #3322 

Handling of cases where the arrival point cannot be reached because the direction is not right.

## Example

If we have a single track. When trying to create a route on it only one is suggested instead of two.

![2023-03-03-150840_1836x801_scrot](https://user-images.githubusercontent.com/15349030/222742883-9ccaeacf-b873-4f4a-a026-0fc7b76fd4d4.png)
