### PR TITLE
remove handleSymbol

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
@@ -534,9 +534,6 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
             />
           ))}
       </ReactMapGL>
-      <div className="handle-tab-resize">
-        <CgLoadbar />
-      </div>
     </>
   );
 };


### PR DESCRIPTION
Remove a useless symbol under the simulation results map
closes #3239 