### PR TITLE
core: add missing / to railjson endpoint url

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -120,7 +120,7 @@ public class InfraManager extends APIClient {
             DiagnosticRecorder diagnosticRecorder
     ) throws InfraLoadException {
         // create a request
-        var endpointPath = String.format("infra/%s/railjson", infraId);
+        var endpointPath = String.format("infra/%s/railjson/", infraId);
         var request = buildRequest(endpointPath, "exclude_extensions=true");
 
         try {


### PR DESCRIPTION
I've had errors for a little while where it would cause 404 without the `/` when I run the core outside of its docker instance.

I don't exactly know why it fails and why it didn't fail before, but it fixes the problem. And at the very least it's more consistent and matches the openapi.