### PR TITLE
Front: fix missing  allowances (simulation)

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/Allowances.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/Allowances.jsx
@@ -209,8 +209,7 @@ function EmptyLine(props) {
 }
 
 function Allowance(props) {
-  const { data, delAllowance, idx, selectedTrain, simulation } = props;
-  const { t } = useTranslation(['allowances']);
+  const { data, delAllowance, idx, selectedTrain, simulation, t} = props;
 
   const position2name = (position) => {
     const place = simulation.trains[selectedTrain].base.stops.find(
@@ -265,6 +264,7 @@ export default function Allowances(props) {
     mutateAllowances,
     getAllowances,
     trainDetail,
+    getAllowanceTypes
   } = props;
 
   const [allowances, setAllowances] = useState([]);
@@ -379,6 +379,7 @@ export default function Allowances(props) {
               simulation={simulation}
               t={t}
               dispatch={dispatch}
+              getAllowanceTypes={getAllowanceTypes}
             />
             <button
               type="button"
@@ -396,6 +397,7 @@ export default function Allowances(props) {
             .find((a) => a.ranges)
             ?.ranges?.map((allowance, idx) => (
               <Allowance
+                t={t}
                 data={allowance}
                 delAllowance={delAllowance}
                 idx={idx}

--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/StandardAllowanceDefault.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/StandardAllowanceDefault.jsx
@@ -43,6 +43,7 @@ export default function StandardAllowanceDefault(props) {
       unit: ALLOWANCE_UNITS_KEYS.percentage,
     },
   ]);
+
   const [distribution, setDistribution] = useState(distributionsTypes[0]);
 
   const debouncedChangeType = useMemo(

--- a/front/src/applications/operationalStudies/components/SimulationResults/Allowances/withOSRDData.tsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/Allowances/withOSRDData.tsx
@@ -8,6 +8,8 @@ import { trainscheduleURI } from 'applications/operationalStudies/components/Sim
 import { setFailure, setSuccess } from 'reducers/main';
 import Allowances from './Allowances';
 
+import { ALLOWANCE_UNITS_KEYS } from './allowancesConsts';
+
 // Initialy try to implement https://react-typescript-cheatsheet.netlify.app/docs/hoc/, no success
 
 function withOSRDData<T>(Component: ComponentType<T>) {
@@ -37,6 +39,26 @@ function withOSRDData<T>(Component: ComponentType<T>) {
         );
       }
     };
+
+    const allowanceTypes = [
+      {
+        id: 'time',
+        label: t('allowanceTypes.time'),
+        unit: ALLOWANCE_UNITS_KEYS.time,
+      },
+      {
+        id: 'percentage',
+        label: t('allowanceTypes.percentage'),
+        unit: ALLOWANCE_UNITS_KEYS.percentage,
+      },
+      {
+        id: 'time_per_distance',
+        label: t('allowanceTypes.time_per_distance'),
+        unit: ALLOWANCE_UNITS_KEYS.time_per_distance,
+      },
+    ];
+
+    const getAllowanceTypes = () => allowanceTypes;
 
     // Alowance mutation in REST strat
     const mutateAllowances = async (newAllowances: any) => {
@@ -95,6 +117,7 @@ function withOSRDData<T>(Component: ComponentType<T>) {
         selectedTrain={selectedTrain} // To be removed
         trainDetail={trainDetail}
         persistentAllowances={trainDetail.allowances}
+        getAllowanceTypes={getAllowanceTypes}
       />
     );
   };


### PR DESCRIPTION
![Capture d’écran 2023-03-09 à 16 55 13](https://user-images.githubusercontent.com/765626/224078686-8dcade90-dc12-4828-89d1-e55e73e491b1.png)

Restore correct os units in Simulation standard margin set