### PR TITLE
editoast: properly clip tile geometry

### DIFF
--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -146,7 +146,7 @@ async fn cache_and_get_mvt_tile(
     .await
     .unwrap()?;
 
-    let mvt_bytes: Vec<u8> = create_and_fill_mvt_tile(z, x, y, layer_slug, records)
+    let mvt_bytes: Vec<u8> = create_and_fill_mvt_tile(layer_slug, records)
         .to_bytes()
         .unwrap();
     set(


### PR DESCRIPTION
The mvt crate does not support geometry clipping. As a result, the transform from WebMercator into tile coordinate space has to be done by PostGIS.

Fixes #3164