### PR TITLE
editor: forces reloading tiles after deleting data (related to #3323)

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -43,6 +43,10 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
     tool: TOOLS[0],
     state: TOOLS[0].getInitialState({ osrdConf }),
   });
+  const [renderingFingerprint, setRenderingFingerprint] = useState(Date.now());
+  const forceRender = useCallback(() => {
+    setRenderingFingerprint(Date.now());
+  }, [setRenderingFingerprint]);
 
   const switchTool = useCallback(
     <S extends CommonToolState>(tool: Tool<S>, partialState?: Partial<S>) => {
@@ -69,7 +73,8 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
   const resetState = useCallback(() => {
     switchTool(TOOLS[0]);
     dispatch(reset());
-  }, [dispatch, switchTool]);
+    forceRender();
+  }, [dispatch, switchTool, forceRender]);
 
   const { infra } = useParams<{ infra?: string }>();
   const { mapStyle, viewport } = useSelector(
@@ -91,8 +96,19 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
       state: toolAndState.state,
       setState: setToolState,
       switchTool,
+      forceRender,
+      renderingFingerprint,
     }),
-    [setToolState, toolAndState, openModal, closeModal, osrdConf, t]
+    [
+      setToolState,
+      toolAndState,
+      openModal,
+      closeModal,
+      osrdConf,
+      t,
+      forceRender,
+      renderingFingerprint,
+    ]
   );
   const extendedContext = useMemo<ExtendedEditorContextType<CommonToolState>>(
     () => ({

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -1,11 +1,10 @@
 import React, { FC, PropsWithChildren, useContext, useMemo, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import ReactMapGL, { AttributionControl, ScaleControl } from 'react-map-gl';
+import ReactMapGL, { AttributionControl, MapRef, ScaleControl } from 'react-map-gl';
 import { withTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 import maplibregl from 'maplibre-gl';
 import { isEmpty, isEqual } from 'lodash';
-import mapboxgl from 'mapbox-gl';
 
 import VirtualLayers from 'applications/operationalStudies/components/SimulationResults/SimulationResultsMap/VirtualLayers';
 import colors from 'common/Map/Consts/colors';
@@ -66,7 +65,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
   children,
 }) => {
   const dispatch = useDispatch();
-  const map = useRef(null);
+  const mapRef = useRef<MapRef>(null);
   const [mapState, setMapState] = useState<MapState>({
     isLoaded: true,
     isDragging: false,
@@ -112,7 +111,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
       >
         <ReactMapGL
           {...viewport}
-          ref={map}
+          ref={mapRef}
           key={activeTool.id}
           mapLib={maplibregl}
           style={{ width: '100%', height: '100%' }}
@@ -262,9 +261,8 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
           />
 
           {/* Tool specific layers */}
-          {activeTool.layersComponent && map.current && (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            <activeTool.layersComponent map={(map.current as any).getMap() as mapboxgl.Map} />
+          {activeTool.layersComponent && mapRef.current && (
+            <activeTool.layersComponent map={mapRef.current.getMap()} />
           )}
         </ReactMapGL>
       </div>

--- a/front/src/applications/editor/tools/pointEdition/components.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components.tsx
@@ -305,6 +305,7 @@ export const BasePointEditionLayers: FC<{
   interactiveLayerIDRegex?: RegExp;
 }> = ({ mergeEntityWithNearestPoint, interactiveLayerIDRegex }) => {
   const {
+    renderingFingerprint,
     state: { nearestPoint, mousePosition, entity, objType },
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<PointEditionState<EditorEntity>>;
@@ -370,6 +371,7 @@ export const BasePointEditionLayers: FC<{
         colors={colors[mapStyle]}
         hidden={entity.properties.id !== NEW_ENTITY_ID ? [entity.properties.id] : undefined}
         layers={editorLayers}
+        fingerprint={renderingFingerprint}
       />
 
       {/* Edited entity */}

--- a/front/src/applications/editor/tools/routeEdition/components.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components.tsx
@@ -27,6 +27,7 @@ export const RouteEditionLeftPanel: FC = () => {
 export const RouteEditionLayers: FC = () => {
   const {
     state,
+    renderingFingerprint,
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<RouteEditionState>;
   const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
@@ -40,7 +41,12 @@ export const RouteEditionLayers: FC = () => {
        (a fake selection must be given to grey everything, else the component
        will consider nothing is selected and nothing must be greyed)
        */}
-      <GeoJSONs selection={['placeholder']} colors={colors[mapStyle]} layers={editorLayers} />
+      <GeoJSONs
+        selection={['placeholder']}
+        colors={colors[mapStyle]}
+        layers={editorLayers}
+        fingerprint={renderingFingerprint}
+      />
       {state.type === 'editRoutePath' ? (
         <EditRoutePathEditionLayers key="editRoutePath" state={state} />
       ) : (

--- a/front/src/applications/editor/tools/routeEdition/components/EditRouteMetadata.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/EditRouteMetadata.tsx
@@ -33,7 +33,7 @@ export const EditRouteMetadataPanel: FC<{ state: EditRouteMetadataState }> = ({ 
   const { t } = useTranslation();
   const { initialRouteEntity, routeEntity } = state;
   const { entry_point, entry_point_direction, exit_point } = routeEntity.properties;
-  const { setState, openModal } = useContext(
+  const { setState, openModal, closeModal } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<RouteEditionState>;
   const osrdConf = useSelector(({ osrdconf }: { osrdconf: OSRDConf }) => osrdconf);
@@ -93,15 +93,22 @@ export const EditRouteMetadataPanel: FC<{ state: EditRouteMetadataState }> = ({ 
             openModal(
               <ConfirmModal
                 title={t('Editor.tools.routes-edition.delete-route')}
-                onConfirm={async () => {
+                onConfirm={async (setDisabled) => {
                   setIsLoading(true);
-                  await dispatch(save({ delete: [initialRouteEntity] as EditorEntity[] }));
-                  setIsLoading(false);
-                  addNotification({
-                    type: 'success',
-                    text: t('Editor.tools.routes-edition.delete-route-success'),
-                  });
-                  setState(getEmptyCreateRouteState());
+                  setDisabled(true);
+
+                  try {
+                    await dispatch(save({ delete: [initialRouteEntity] as EditorEntity[] }));
+                    setIsLoading(false);
+                    addNotification({
+                      type: 'success',
+                      text: t('Editor.tools.routes-edition.delete-route-success'),
+                    });
+                    setState(getEmptyCreateRouteState());
+                    closeModal();
+                  } catch (e: unknown) {
+                    setDisabled(false);
+                  }
                 }}
               >
                 <p>{t('Editor.tools.routes-edition.confirm-delete-route')}</p>

--- a/front/src/applications/editor/tools/selection/components.tsx
+++ b/front/src/applications/editor/tools/selection/components.tsx
@@ -37,6 +37,7 @@ export const SelectionLayers: FC = () => {
   const {
     state,
     editorState: { editorLayers },
+    renderingFingerprint,
   } = useContext(EditorContext) as ExtendedEditorContextType<SelectionState>;
   const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
     mapStyle: string;
@@ -67,6 +68,7 @@ export const SelectionLayers: FC = () => {
         colors={colors[mapStyle]}
         selection={state.selection.map((e) => e.properties.id)}
         layers={editorLayers}
+        fingerprint={renderingFingerprint}
       />
       <SelectionZone newZone={selectionZone} />
       {state.mousePosition && state.selectionState.type === 'single' && state.hovered && (

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -159,13 +159,20 @@ const SelectionTool: Tool<SelectionState> = {
         isDisabled({ state }) {
           return !state.selection.length;
         },
-        onClick({ openModal, state, setState, dispatch, t }) {
+        onClick({ openModal, closeModal, forceRender, state, setState, dispatch, t }) {
           openModal(
             <ConfirmModal
               title={t('Editor.tools.select-items.actions.delete-selection')}
-              onConfirm={async () => {
-                await dispatch<ReturnType<typeof save>>(save({ delete: state.selection }));
-                setState({ ...state, selection: [] });
+              onConfirm={async (setDisabled) => {
+                setDisabled(true);
+                try {
+                  await dispatch<ReturnType<typeof save>>(save({ delete: state.selection }));
+                  setState({ ...state, selection: [] });
+                  closeModal();
+                  forceRender();
+                } catch (e: unknown) {
+                  setDisabled(true);
+                }
               }}
             >
               <p>{t('Editor.tools.select-items.actions.confirm-delete-selection')}</p>

--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -310,6 +310,7 @@ export const SwitchEditionLayers: FC = () => {
   const [showPopup, setShowPopup] = useState(true);
   const osrdConf = useSelector(({ osrdconf }: { osrdconf: OSRDConf }) => osrdconf);
   const {
+    renderingFingerprint,
     state: { entity, hovered, portEditionState, mousePosition },
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<SwitchEditionState>;
@@ -417,6 +418,7 @@ export const SwitchEditionLayers: FC = () => {
         colors={colors[mapStyle]}
         hidden={entity?.properties?.id ? [entity.properties.id] : undefined}
         layers={editorLayers}
+        fingerprint={renderingFingerprint}
       />
 
       {/* Edited switch */}

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -25,6 +25,7 @@ const TRACK_STYLE = { 'line-color': TRACK_COLOR, 'line-dasharray': [2, 1], 'line
 export const TrackEditionLayers: FC = () => {
   const {
     state,
+    renderingFingerprint,
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<TrackEditionState>;
   const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
@@ -75,6 +76,7 @@ export const TrackEditionLayers: FC = () => {
         colors={colors[mapStyle]}
         hidden={state.track.properties.id ? [state.track.properties.id] : undefined}
         layers={editorLayers}
+        fingerprint={renderingFingerprint}
       />
 
       {/* Track path */}

--- a/front/src/applications/editor/tools/types.ts
+++ b/front/src/applications/editor/tools/types.ts
@@ -78,6 +78,11 @@ export type EditorContextType<S = any> = {
     tool: Tool<NewToolState>,
     state?: Partial<NewToolState>
   ) => void;
+
+  // Listen to this number's updates to rerender on specific cases, such as data
+  // suppression:
+  forceRender: () => void;
+  renderingFingerprint: number;
 } & Pick<ModalContextType, 'openModal' | 'closeModal'>;
 
 export interface ExtendedEditorContextType<S> extends EditorContextType<S> {

--- a/front/src/common/BootstrapSNCF/ModalSNCF/ConfirmModal.tsx
+++ b/front/src/common/BootstrapSNCF/ModalSNCF/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useContext } from 'react';
+import React, { FC, PropsWithChildren, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ModalContext } from './ModalProvider';
@@ -8,7 +8,7 @@ export interface ConfirmModalProps {
   title?: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  onConfirm: () => void | Promise<void>;
+  onConfirm: (setDisabled: (disabled: boolean) => void) => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
 }
 
@@ -22,6 +22,7 @@ export const ConfirmModal: FC<PropsWithChildren<ConfirmModalProps>> = ({
 }) => {
   const { t } = useTranslation();
   const { closeModal } = useContext(ModalContext);
+  const [disabled, setDisabled] = useState(false);
 
   return (
     <Modal title={title}>
@@ -32,10 +33,16 @@ export const ConfirmModal: FC<PropsWithChildren<ConfirmModalProps>> = ({
           type="button"
           className="btn btn-danger mr-2"
           onClick={() => (onCancel ? onCancel() : closeModal())}
+          disabled={disabled}
         >
           {cancelLabel || t('common.cancel')}
         </button>
-        <button type="button" className="btn btn-primary" onClick={() => onConfirm()}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => onConfirm(setDisabled)}
+          disabled={disabled}
+        >
           {confirmLabel || t('common.confirm')}
         </button>
       </div>

--- a/front/src/common/BootstrapSNCF/ModalSNCF/ModalProvider.tsx
+++ b/front/src/common/BootstrapSNCF/ModalSNCF/ModalProvider.tsx
@@ -35,9 +35,7 @@ export interface ModalContextType {
 const initialModalContext: ModalContextType = {
   isOpen: false,
   content: null,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   openModal: noop,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeModal: noop,
 };
 


### PR DESCRIPTION
editor: forces reloading tiles after deleting data
    
This commit should partially solve issue #3323.
However, there appear to be some issue backend side, that could still make the item reappear in some tiles. This is being investigated.
    
Details:
  - Adds a fingerprint in the editor context, and a method to force regenerating this fingerprint
  - Propagates the fingerprint to the GeoJSONs module
  - Remounts sources in GeoJSONs on fingerprint updates
  - Fixes ConfirmModal not auto closing