### PR TITLE
editoast: fix tiles eviction

### DIFF
--- a/editoast/src/map/layer_cache.rs
+++ b/editoast/src/map/layer_cache.rs
@@ -3,6 +3,7 @@ use core::f64::consts::PI;
 use super::BoundingBox;
 
 /// Web mercator coordinates
+#[derive(Debug, Clone, Copy)]
 pub struct Tile {
     pub x: u64,
     pub y: u64,
@@ -10,6 +11,7 @@ pub struct Tile {
 }
 
 /// North-West and South-East web mercator coordinates
+#[derive(Debug, Clone, Copy)]
 struct NwSeCoordinates {
     nw_x: u64,
     nw_y: u64,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -35,14 +35,13 @@ pub async fn edit<'a>(
     })
     .await
     .unwrap()?;
-
     let mut conn = redis_client.get_tokio_connection_manager().await.unwrap();
     map::invalidate_zone(
         &mut conn,
         &map_layers.layers.keys().cloned().collect(),
         infra,
         &invalid_zone,
-        map_layers_config.max_tiles,
+        &map_layers_config,
     )
     .await?;
 


### PR DESCRIPTION
close #3485

The function used to select tiles in a given bbox didn't used a fixed max_zoom instead of the one define in the configuration.