### PR TITLE
core: fix bugs where we would fetch data an epsilon too far

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.envelope_sim;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
@@ -88,6 +90,8 @@ public class EnvelopeSimPath implements PhysicsPath {
     }
 
     private double getCumGrade(double position) {
+        if (position > length && Math.abs(position - length) < POSITION_EPSILON)
+            position = length;
         assert position <= length && position >= 0;
         var pointIndex = Arrays.binarySearch(gradePositions, position);
         if (pointIndex >= 0)

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.stdcm.graph;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+
 import com.google.common.primitives.Doubles;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -60,6 +62,14 @@ public class STDCMUtils {
 
     /** Builds a train path from a route, and offset from its start, and an envelope. */
     static TrainPath makeTrainPath(SignalingRoute route, double startOffset, double endOffset) {
+        var routeLength = route.getInfraRoute().getLength();
+        if (endOffset > routeLength) {
+            assert Math.abs(endOffset - routeLength) < POSITION_EPSILON;
+            endOffset = routeLength;
+        }
+        assert 0 <= startOffset && startOffset <= routeLength;
+        assert 0 <= endOffset && endOffset <= routeLength;
+        assert startOffset <= endOffset;
         var infraRoute = route.getInfraRoute();
         var start = TrackRangeView.getLocationFromList(infraRoute.getTrackRanges(), startOffset);
         var end = TrackRangeView.getLocationFromList(infraRoute.getTrackRanges(), endOffset);

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -258,7 +258,7 @@ def run(
                 print(e)
                 log_folder.mkdir(exist_ok=True)
                 with open(str(log_folder / f"{i}.json"), "w") as f:
-                    print(json.dumps(e.args[0]), file=f)
+                    print(json.dumps(e.args[0], indent=4), file=f)
 
 
 def get_random_rolling_stock(base_url: str) -> int:

--- a/tests/tests/regression_tests_data/envelope_sim_path_out_of_range.json
+++ b/tests/tests/regression_tests_data/envelope_sim_path_out_of_range.json
@@ -1,0 +1,33 @@
+{
+    "error_type": "STDCM",
+    "code": 500,
+    "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"stack_trace\":[\"EnvelopeSimPath.java:91\",\"EnvelopeSimPath.java:109\",\"EnvelopePhysics.java:209\",\"EnvelopePhysics.java:192\",\"ScheduleMetadataExtractor.java:50\",\"STDCMEndpoint.java:149\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}",
+    "infra_name": "small_infra",
+    "path_payload": {},
+    "stdcm_payload": {
+        "infra": 4,
+        "rolling_stock": 68,
+        "timetable": 119,
+        "start_time": 21958,
+        "maximum_departure_delay": 963,
+        "maximum_relative_run_time": 1.136604311134589,
+        "margin_before": 594,
+        "margin_after": 236,
+        "start_points": [
+            {
+                "track_section": "TA0",
+                "offset": 7.398875175310682
+            }
+        ],
+        "end_points": [
+            {
+                "track_section": "TA0",
+                "offset": 612.5908071738528
+            }
+        ],
+        "standard_allowance": {
+            "value_type": "time_per_distance",
+            "minutes": 3.721996485553568
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3509 

Only one of the two bugs has been reproduced in a fuzzer regression test. The other can easily be reproduced on France (and has properly been fixed), but it doesn't seem to appear on a generated infra. I suspect it only happens on very long paths, in which case we should eventually add a generated infra with extremely long tracks for better tests.