### PR TITLE
api: Remove unused `timetable` endpoints

### DIFF
--- a/front/src/common/api/osrdMiddlewareApi.ts
+++ b/front/src/common/api/osrdMiddlewareApi.ts
@@ -91,27 +91,8 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/light_rolling_stock/${queryArg.id}/` }),
     }),
-    getTimetable: build.query<GetTimetableApiResponse, GetTimetableApiArg>({
-      query: (queryArg) => ({
-        url: `/timetable/`,
-        params: { infra: queryArg.infra, page: queryArg.page, page_size: queryArg.pageSize },
-      }),
-    }),
-    postTimetable: build.mutation<PostTimetableApiResponse, PostTimetableApiArg>({
-      query: (queryArg) => ({ url: `/timetable/`, method: 'POST', body: queryArg.body }),
-    }),
     getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
       query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
-    }),
-    deleteTimetableById: build.mutation<DeleteTimetableByIdApiResponse, DeleteTimetableByIdApiArg>({
-      query: (queryArg) => ({ url: `/timetable/${queryArg.id}/`, method: 'DELETE' }),
-    }),
-    putTimetableById: build.mutation<PutTimetableByIdApiResponse, PutTimetableByIdApiArg>({
-      query: (queryArg) => ({
-        url: `/timetable/${queryArg.id}/`,
-        method: 'PUT',
-        body: queryArg.body,
-      }),
     }),
     postTrainScheduleStandaloneSimulation: build.mutation<
       PostTrainScheduleStandaloneSimulationApiResponse,
@@ -455,44 +436,10 @@ export type GetLightRollingStockByIdApiArg = {
   /** Rolling Stock ID */
   id: number;
 };
-export type GetTimetableApiResponse = /** status 200 The timetable list */ {
-  count?: number;
-  next?: any;
-  previous?: any;
-  results?: {
-    id?: number;
-    name?: string;
-    infra?: number;
-  }[];
-};
-export type GetTimetableApiArg = {
-  /** Filter timetable by infra */
-  infra?: number;
-  /** Page number */
-  page?: number;
-  /** Number of elements by page */
-  pageSize?: number;
-};
-export type PostTimetableApiResponse = /** status 201 The timetable created */ {
-  id?: number;
-  name?: string;
-  infra?: number;
-  electrical_profile_set?: number | null;
-};
-export type PostTimetableApiArg = {
-  /** Infrastructure id and waypoints */
-  body: {
-    infra: number;
-    electrical_profile_set?: number | null;
-    name: string;
-  };
-};
 export type GetTimetableByIdApiResponse = /** status 200 The timetable content */ {
   id?: number;
   name?: string;
-  infra?: number;
-  electrical_profile_set?: number | null;
-  train_schedule?: {
+  train_schedules?: {
     id?: number;
     train_name?: string;
     departure_time?: number;
@@ -502,26 +449,6 @@ export type GetTimetableByIdApiResponse = /** status 200 The timetable content *
 export type GetTimetableByIdApiArg = {
   /** Timetable ID */
   id: number;
-};
-export type DeleteTimetableByIdApiResponse = unknown;
-export type DeleteTimetableByIdApiArg = {
-  /** Timetable ID */
-  id: number;
-};
-export type PutTimetableByIdApiResponse = /** status 200 The timetable updated */ {
-  id?: number;
-  name?: string;
-  infra?: number;
-};
-export type PutTimetableByIdApiArg = {
-  /** Timetable ID */
-  id: number;
-  /** Infrastructure id and waypoints */
-  body: {
-    infra: number;
-    name: string;
-    electrical_profile_set?: number | null;
-  };
 };
 export type PostTrainScheduleStandaloneSimulationApiResponse =
   /** status 201 The ids of the train_schedules created */ {

--- a/python/api/openapi.yaml
+++ b/python/api/openapi.yaml
@@ -455,93 +455,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LightRollingStock"
-  /timetable/:
-    get:
-      tags:
-        - timetable
-      summary: Paginated list of timetable
-      parameters:
-        - in: query
-          name: infra
-          schema:
-            type: integer
-          description: Filter timetable by infra
-        - in: query
-          name: page
-          schema:
-            type: integer
-            minimum: 0
-          description: Page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            maximum: 10000
-            minimum: 1
-            default: 100
-          description: Number of elements by page
-      responses:
-        200:
-          description: The timetable list
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: number
-                        name:
-                          type: string
-                        infra:
-                          type: number
-    post:
-      tags:
-        - timetable
-      summary: Create a timetable
-      requestBody:
-        description: Infrastructure id and waypoints
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                infra:
-                  type: number
-                electrical_profile_set:
-                  type: number
-                  nullable: true
-                  description: Electrical profile set id (if any)
-                name:
-                  type: string
-              required:
-                - infra
-                - name
-      responses:
-        201:
-          description: The timetable created
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: number
-                  name:
-                    type: string
-                  infra:
-                    type: number
-                  electrical_profile_set:
-                    type: number
-                    nullable: true
   /timetable/{id}/:
     get:
       tags:
@@ -566,12 +479,7 @@ paths:
                     type: number
                   name:
                     type: string
-                  infra:
-                    type: number
-                  electrical_profile_set:
-                    type: number
-                    nullable: true
-                  train_schedule:
+                  train_schedules:
                     type: array
                     items:
                       type: object
@@ -584,62 +492,6 @@ paths:
                           type: number
                         train_path:
                           type: number
-    delete:
-      tags:
-        - timetable
-      summary: Delete a timetable and its train schedules
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Timetable ID
-          required: true
-      responses:
-        204:
-          description: No content
-    put:
-      tags:
-        - timetable
-      summary: Update a timetable
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Timetable ID
-          required: true
-      requestBody:
-        description: Infrastructure id and waypoints
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                infra:
-                  type: number
-                name:
-                  type: string
-                electrical_profile_set:
-                  type: number
-                  nullable: true
-              required:
-                - infra
-                - name
-      responses:
-        200:
-          description: The timetable updated
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: number
-                  name:
-                    type: string
-                  infra:
-                    type: number
   /train_schedule/standalone_simulation/:
     post:
       tags:

--- a/python/api/osrd_infra/views/timetable.py
+++ b/python/api/osrd_infra/views/timetable.py
@@ -8,22 +8,12 @@ from osrd_infra.views.pagination import CustomPageNumberPagination
 
 
 class TimetableView(
-    mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.ListModelMixin,
     GenericViewSet,
 ):
     serializer_class = TimetableSerializer
     pagination_class = CustomPageNumberPagination
-
-    def get_queryset(self):
-        queryset = Timetable.objects.order_by("-pk")
-        infra = self.request.query_params.get("infra")
-        if infra is not None:
-            queryset = queryset.filter(infra__pk=infra)
-        return queryset
+    queryset = Timetable.objects.order_by("-pk")
 
     def retrieve(self, request, pk):
         timetable = self.get_object()


### PR DESCRIPTION
Removing the unused and bugged endpoint from the `openapi` and code

close #3510