### PR TITLE
front: fix #3488

### DIFF
--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -56,10 +56,11 @@ export const FormComponent: React.FC<FieldProps> = (props) => {
 
   // Get the distance of the geometry
   const distance = useMemo(() => {
+    if (!isNil(formContext.length)) {
+      return formContext.length;
+    }
     if (formContext.geometry?.type === 'LineString') {
-      const geoLineLength = getLineStringDistance(formContext.geometry);
-      const inputLength = formContext.length;
-      return fnMax([geoLineLength, inputLength]) as number;
+      return getLineStringDistance(formContext.geometry);
     }
     return 0;
   }, [formContext]);


### PR DESCRIPTION
The length for the linear metadata should always be taken from the length field except if there is no value, then it is computed from the geometry
Fix #3488