### PR TITLE
Move EnvelopeSimContext out of Allowances initialization

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/Allowance.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/Allowance.java
@@ -1,7 +1,8 @@
 package fr.sncf.osrd.envelope_sim.allowances;
 
 import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 
 public interface Allowance {
-    Envelope apply(Envelope base);
+    Envelope apply(Envelope base, EnvelopeSimContext context);
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/LinearAllowance.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/LinearAllowance.java
@@ -4,6 +4,7 @@ import fr.sncf.osrd.envelope.*;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
 import java.util.*;
 
@@ -11,13 +12,12 @@ public class LinearAllowance extends AbstractAllowanceWithRanges {
 
     /** Constructor */
     public LinearAllowance(
-            EnvelopeSimContext context,
             double beginPos,
             double endPos,
             double capacitySpeedLimit,
             List<AllowanceRange> ranges
     ) {
-        super(context, beginPos, endPos, capacitySpeedLimit, ranges);
+        super(beginPos, endPos, capacitySpeedLimit, ranges);
     }
 
     /** Compute the initial low bound for the binary search */
@@ -28,14 +28,14 @@ public class LinearAllowance extends AbstractAllowanceWithRanges {
 
     /** Compute the initial high bound for the binary search */
     @Override
-    protected double computeInitialHighBound(Envelope envelopeSection) {
+    protected double computeInitialHighBound(Envelope envelopeSection, PhysicsRollingStock rollingStock) {
         return envelopeSection.getMaxSpeed();
     }
 
     /** Compute the core of linear allowance algorithm.
      *  This algorithm consists of a ratio that scales speeds */
     @Override
-    protected Envelope computeCore(Envelope coreBase, double maxSpeed) {
+    protected Envelope computeCore(Envelope coreBase, EnvelopeSimContext context, double maxSpeed) {
         var ratio = maxSpeed / coreBase.getMaxSpeed();
         return scaleEnvelope(coreBase, ratio);
     }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -100,13 +100,7 @@ class EnvelopePartTest {
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, 4, testEffortCurveMap);
         var allowanceValue = new AllowanceValue.Percentage(10);
 
-        var marecoAllowance = AllowanceTests.makeStandardMarecoAllowance(
-                testContext,
-                0,
-                length,
-                0,
-                allowanceValue
-        );
+        var marecoAllowance = AllowanceTests.makeStandardMarecoAllowance(0, length, 0, allowanceValue);
         var envelopeAllowance = AllowanceTests.makeSimpleAllowanceEnvelope(testContext, marecoAllowance, 44.4, false);
 
         for (var i = 0; i < envelopeAllowance.size(); i++) {

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
@@ -36,10 +36,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(0, 0.3 * path.getLength(), value1),
                 new AllowanceRange(0.3 * path.getLength(), path.getLength(), value2)
         );
-        var allowance = new MarecoAllowance(
-                context,
-                0, path.getLength(), 0, ranges);
-        return allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, path.getLength(), 0, ranges);
+        return allowance.apply(maxEffortEnvelope, context);
     }
 
     public static double getDistance(MarecoAllowance allowance) {
@@ -74,10 +72,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(0, rangesTransition, value1),
                 new AllowanceRange(rangesTransition, length, value2)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 30 / 3.6, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 30 / 3.6, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var baseTime1 = maxEffortEnvelope.getTimeBetween(0, rangesTransition);
         var baseTime2 = maxEffortEnvelope.getTimeBetween(rangesTransition, length);
         var totalBaseTime = maxEffortEnvelope.getTotalTime();
@@ -107,10 +103,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(rangesTransitions[1], rangesTransitions[2], value2),
                 new AllowanceRange(rangesTransitions[2], rangesTransitions[3], value3)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 30 / 3.6, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 30 / 3.6, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var baseTime1 = maxEffortEnvelope.getTimeBetween(rangesTransitions[0], rangesTransitions[1]);
         var baseTime2 = maxEffortEnvelope.getTimeBetween(rangesTransitions[1], rangesTransitions[2]);
         var baseTime3 = maxEffortEnvelope.getTimeBetween(rangesTransitions[2], rangesTransitions[3]);
@@ -143,10 +137,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(rangesTransitions[1], rangesTransitions[2], value2),
                 new AllowanceRange(rangesTransitions[2], rangesTransitions[3], value3)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 30 / 3.6, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 30 / 3.6, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var baseTime1 = maxEffortEnvelope.getTimeBetween(rangesTransitions[0], rangesTransitions[1]);
         var baseTime2 = maxEffortEnvelope.getTimeBetween(rangesTransitions[1], rangesTransitions[2]);
         var baseTime3 = maxEffortEnvelope.getTimeBetween(rangesTransitions[2], rangesTransitions[3]);
@@ -179,10 +171,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(rangesTransitions[1], rangesTransitions[2], value2),
                 new AllowanceRange(rangesTransitions[2], rangesTransitions[3], value3)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 1, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 1, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
 
         // Check that we lose as much time as specified
         assertEquals(
@@ -222,10 +212,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(rangesTransitions[0], rangesTransitions[1], value1),
                 new AllowanceRange(rangesTransitions[1], rangesTransitions[2], value2)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 30 / 3.6, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 30 / 3.6, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var baseTime1 = maxEffortEnvelope.getTimeBetween(rangesTransitions[0], rangesTransitions[1]);
         var baseTime2 = maxEffortEnvelope.getTimeBetween(rangesTransitions[1], rangesTransitions[2]);
         var totalBaseTime = maxEffortEnvelope.getTotalTime();
@@ -254,10 +242,8 @@ public class AllowanceRangesTests {
                 new AllowanceRange(rangesTransitions[1], rangesTransitions[2], value2),
                 new AllowanceRange(rangesTransitions[2], rangesTransitions[3], value3)
         );
-        var allowance = new MarecoAllowance(
-                testContext, 0, length, 30 / 3.6, ranges
-        );
-        var marecoEnvelope = allowance.apply(maxEffortEnvelope);
+        var allowance = new MarecoAllowance(0, length, 30 / 3.6, ranges);
+        var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var baseTime1 = maxEffortEnvelope.getTimeBetween(rangesTransitions[0], rangesTransitions[1]);
         var baseTime2 = maxEffortEnvelope.getTimeBetween(rangesTransitions[1], rangesTransitions[2]);
         var baseTime3 = maxEffortEnvelope.getTimeBetween(rangesTransitions[2], rangesTransitions[3]);
@@ -288,10 +274,9 @@ public class AllowanceRangesTests {
         var ranges = List.of(
                 new AllowanceRange(rangesTransitions[0], rangesTransitions[1], value1)
         );
-        var allowance = new LinearAllowance(
-                testContext, rangesTransitions[0], rangesTransitions[1], 0, ranges
+        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 0, ranges
         );
-        applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope);
+        applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope, testContext);
     }
 
     /** Test with an allowance range that starts very slightly after the path start, and ends around the end
@@ -309,10 +294,8 @@ public class AllowanceRangesTests {
         var ranges = List.of(
                 new AllowanceRange(rangesTransitions[0], rangesTransitions[1], value1)
         );
-        var allowance = new LinearAllowance(
-                testContext, rangesTransitions[0], rangesTransitions[1], 0, ranges
-        );
-        applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope);
+        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 0, ranges);
+        applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope, testContext);
     }
 
     /** Regression test: reproduces <a href="https://github.com/DGEXSolutions/osrd/issues/3199">this bug</a>.
@@ -328,9 +311,7 @@ public class AllowanceRangesTests {
         var stops = new double[]{300};
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
-        var allowance = new LinearAllowance(
-                testContext,
-                0,
+        var allowance = new LinearAllowance(0,
                 testPath.getLength(),
                 1.5,
                 List.of(
@@ -339,14 +320,15 @@ public class AllowanceRangesTests {
                 )
         );
         var maxEffortEnvelope = makeSimpleMaxEffortEnvelope(testContext, 80, stops);
-        var err = assertThrows(AllowanceConvergenceException.class, () -> allowance.apply(maxEffortEnvelope));
+        var err = assertThrows(AllowanceConvergenceException.class,
+                () -> allowance.apply(maxEffortEnvelope, testContext));
         assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, err.errorType);
     }
 
     /** Applies the allowance to the envelope. Any user error (impossible margin) is ignored */
-    private void applyAllowanceIgnoringUserError(Allowance allowance, Envelope envelope) {
+    private void applyAllowanceIgnoringUserError(Allowance allowance, Envelope envelope, EnvelopeSimContext context) {
         try {
-            allowance.apply(envelope);
+            allowance.apply(envelope, context);
         } catch (AllowanceConvergenceException e) {
             assertEquals(OSRDError.ErrorCause.USER, e.cause);
         }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MarecoDecelerationTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MarecoDecelerationTests.java
@@ -41,10 +41,10 @@ public class MarecoDecelerationTests {
         EnvelopeDeceleration.decelerate(context, 100_000, 0, overlayBuilder, -1);
         var envelope = builder.build();
 
-        var allowance = new MarecoAllowance(context, startOffset, endOffset, 0,
+        var allowance = new MarecoAllowance(startOffset, endOffset, 0,
                 List.of(new AllowanceRange(startOffset, endOffset, new AllowanceValue.Percentage(50))));
         try {
-            allowance.apply(envelope);
+            allowance.apply(envelope, context);
         } catch (AllowanceConvergenceException err) {
             assertEquals(AllowanceConvergenceException.ErrorType.TOO_MUCH_TIME, err.errorType);
         }

--- a/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/StandaloneSimulationEndpoint.java
@@ -96,7 +96,7 @@ public class StandaloneSimulationEndpoint implements Take {
             var trainSchedules = new ArrayList<StandaloneTrainSchedule>();
             for (var rjsTrainSchedule : request.trainSchedules)
                 trainSchedules.add(RJSStandaloneTrainScheduleParser.parse(
-                        infra, request.timeStep, rollingStocks::get, rjsTrainSchedule, trainPath, envelopePath));
+                        infra, rollingStocks::get, rjsTrainSchedule, trainPath, envelopePath));
 
             // Compute envelopes and extract metadata
             DriverBehaviour driverBehaviour = new DriverBehaviour();

--- a/core/src/main/java/fr/sncf/osrd/cli/StandaloneSimulationCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/StandaloneSimulationCommand.java
@@ -114,7 +114,7 @@ public class StandaloneSimulationCommand implements CliCommand {
                 // Parse train schedules (from RJSStandaloneTrainSchedule to StandaloneTrainSchedule)
                 var trainSchedules = new ArrayList<StandaloneTrainSchedule>();
                 trainSchedules.add(RJSStandaloneTrainScheduleParser.parse(
-                        signalingInfra, 2.0, rollingStocks::get, standSched, trainsPath, envelopePath));
+                        signalingInfra, rollingStocks::get, standSched, trainsPath, envelopePath));
 
                 // Calculate the result for the given train path and schedules
                 DriverBehaviour driverBehaviour = new DriverBehaviour();

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeSimContextBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeSimContextBuilder.java
@@ -10,23 +10,11 @@ public class EnvelopeSimContextBuilder {
             RollingStock rollingStock,
             EnvelopeSimPath path,
             double timeStep,
-            RollingStock.Comfort comfort,
-            boolean ignoreElectricalProfiles
-    ) {
-        var powerClass = ignoreElectricalProfiles ? null : rollingStock.powerClass;
-        var modeAndProfileMap = path.getModeAndProfileMap(powerClass);
-        var curvesAndConditions = rollingStock.mapTractiveEffortCurves(modeAndProfileMap, comfort, path.getLength());
-        return new EnvelopeSimContext(rollingStock, path, timeStep, curvesAndConditions.curves());
-    }
-
-    /** Computes the rolling stock effort curves that will be used and creates a context */
-    public static EnvelopeSimContext build(
-            RollingStock rollingStock,
-            EnvelopeSimPath path,
-            double timeStep,
             RollingStock.Comfort comfort
     ) {
-        return build(rollingStock, path, timeStep, comfort, false);
+        var modeAndProfileMap = path.getModeAndProfileMap(null); // Only modes
+        var curvesAndConditions = rollingStock.mapTractiveEffortCurves(modeAndProfileMap, comfort, path.getLength());
+        return new EnvelopeSimContext(rollingStock, path, timeStep, curvesAndConditions.curves());
     }
 
 }

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStandaloneTrainScheduleParser.java
@@ -25,7 +25,6 @@ public class RJSStandaloneTrainScheduleParser {
     /** Parses a RailJSON standalone train schedule */
     public static StandaloneTrainSchedule parse(
             SignalingInfra infra,
-            double timeStep,
             Function<String, RollingStock> rollingStockGetter,
             RJSStandaloneTrainSchedule rjsTrainSchedule,
             TrainPath trainPath,
@@ -51,10 +50,7 @@ public class RJSStandaloneTrainScheduleParser {
         if (rjsTrainSchedule.allowances != null)
             for (int i = 0; i < rjsTrainSchedule.allowances.length; i++) {
                 var rjsAllowance = rjsTrainSchedule.allowances[i];
-                allowances.add(
-                        parseAllowance(timeStep, rollingStock, envelopeSimPath, rjsAllowance, comfort,
-                                options.ignoreElectricalProfiles)
-                );
+                allowances.add(parseAllowance(envelopeSimPath, rjsAllowance));
             }
 
         var tag = rjsTrainSchedule.tag;
@@ -70,12 +66,8 @@ public class RJSStandaloneTrainScheduleParser {
 
     @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
     private static Allowance parseAllowance(
-            double timeStep,
-            RollingStock rollingStock,
             EnvelopeSimPath envelopeSimPath,
-            RJSAllowance rjsAllowance,
-            RollingStock.Comfort comfort,
-            boolean ignoreElectricalProfiles
+            RJSAllowance rjsAllowance
     ) throws InvalidSchedule {
 
         var allowanceDistribution = rjsAllowance.distribution;
@@ -94,19 +86,15 @@ public class RJSStandaloneTrainScheduleParser {
         } else {
             throw new RuntimeException("unknown allowance type");
         }
-        var context = EnvelopeSimContextBuilder.build(rollingStock, envelopeSimPath, timeStep, comfort,
-                ignoreElectricalProfiles);
         // parse allowance distribution
         return switch (allowanceDistribution) {
             case MARECO -> new MarecoAllowance(
-                    context,
                     beginPos,
                     endPos,
                     getPositiveDoubleOrDefault(rjsAllowance.capacitySpeedLimit, 30 / 3.6),
                     ranges
             );
             case LINEAR -> new LinearAllowance(
-                    context,
                     beginPos,
                     endPos,
                     getPositiveDoubleOrDefault(rjsAllowance.capacitySpeedLimit, 30 / 3.6),

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -67,7 +67,7 @@ public class StandaloneSim {
 
                 // Eco
                 if (!trainSchedule.allowances.isEmpty()) {
-                    var ecoEnvelope = applyAllowances(envelope, trainSchedule.allowances);
+                    var ecoEnvelope = applyAllowances(context, envelope, trainSchedule.allowances);
                     var simEcoResultTrain = ScheduleMetadataExtractor.run(
                             ecoEnvelope,
                             trainPath,
@@ -102,13 +102,14 @@ public class StandaloneSim {
      * Apply a list of allowances, in order
      */
     public static Envelope applyAllowances(
+            EnvelopeSimContext context,
             Envelope maxEffortEnvelope,
             List<? extends Allowance> allowances
     ) {
         var result = maxEffortEnvelope;
         for (int i = 0; i < allowances.size(); i++) {
             try {
-                result = allowances.get(i).apply(result);
+                result = allowances.get(i).apply(result, context);
             } catch (OSRDError e) {
                 throw e.withContext(new ErrorContext.Allowance(i));
             }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
@@ -108,9 +108,9 @@ public class STDCMSimulations {
         );
         var capacitySpeedLimit = 1; // We set a minimum because generating curves at very low speed can cause issues
         // TODO: add a parameter and set a higher default value once we can handle proper stops
-        var allowance = new MarecoAllowance(context, 0, oldEnvelope.getEndPos(), capacitySpeedLimit, ranges);
+        var allowance = new MarecoAllowance(0, oldEnvelope.getEndPos(), capacitySpeedLimit, ranges);
         try {
-            return allowance.apply(oldEnvelope);
+            return allowance.apply(oldEnvelope, context);
         } catch (AllowanceConvergenceException e) {
             return null;
         }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
@@ -91,13 +91,13 @@ public class STDCMStandardAllowance {
     ) {
 
         var allowance = new MarecoAllowance(
-                EnvelopeSimContextBuilder.build(rollingStock, envelopeSimPath, timeStep, comfort),
                 0,
                 envelope.getEndPos(),
                 1,
                 makeAllowanceRanges(standardAllowance, envelope.getEndPos(), rangeTransitions)
         );
-        return allowance.apply(envelope);
+        return allowance.apply(envelope,
+                EnvelopeSimContextBuilder.build(rollingStock, envelopeSimPath, timeStep, comfort));
     }
 
     /** Create the list of `AllowanceRange`, with the given transitions */


### PR DESCRIPTION
Doing this refactor has several advantages:

* We avoid duplication of the context (namely in `RJSStandaloneTrainScheduleParser`), since we always build a `EnvelopeSimContext` in `StandaloneSim.run` . 
* With power restrictions, `EnvelopeSimContext` init is also going to get slower, so avoid duplication has twice the benefits.
* The context isn't semantically linked to the `Allowance` classes.
* `EnvelopeSimContext` initialisation is going to get a bit more complex, so avoiding to maintain a custom building method is preferable