### PR TITLE
codeowners: remove front rtk generated files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 
 # --- FRONT ---
 /front                                                   @DGEXSolutions/front-maintainers
+/front/src/config/openapi-editoast-config.ts
+/front/src/config/openapi-middleware-config.ts
 
 # --- EDITOAST ---
 /editoast                                                @DGEXSolutions/editoast-maintainers


### PR DESCRIPTION
The idea is to avoid front-end maintainers to review when you have only modified files generated by rtk. The CI takes care of checking that everything is up to date.