### PR TITLE
editor: improves transition between tools

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -112,7 +112,6 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
         <ReactMapGL
           {...viewport}
           ref={mapRef}
-          key={activeTool.id}
           mapLib={maplibregl}
           style={{ width: '100%', height: '100%' }}
           mapStyle={osmBlankStyle}

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -254,7 +254,7 @@ const GeoJSONs: FC<{
 
   // This flag is used to unmount sources before mounting the new ones, when
   // fingerprint is updated;
-  const [skipSources, setSkipSources] = useState(false);
+  const [skipSources, setSkipSources] = useState(true);
   useEffect(() => {
     setSkipSources(true);
     const timeout = setTimeout(() => setSkipSources(false), 0);


### PR DESCRIPTION
This commit fixes issue #2734.

Details:
- Removes ReactMapGL key, preventing it to fully remount on each new tool
- Stops rendering GeoJSONs on its first frame, so that when it remounts it necessarily skips a frame, so that react-mapgl does not have to reconciliate layers