### PR TITLE
editoast: front: Migrate timetable endpoints to editoast

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9,6 +9,8 @@ tags:
     description: Infra
   - name: routes
     description: Operations related to infra routes
+  - name: timetable
+    description: Timetable
   - name: pathfinding
     description: Pathfinding operations
   - name: layers
@@ -1190,6 +1192,44 @@ paths:
       responses:
         204:
           description: No content
+
+  /timetable/{id}/:
+    get:
+      tags:
+        - timetable
+      summary: Retrieve a timetable and its train schedules
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Timetable ID
+          required: true
+      responses:
+        200:
+          description: The timetable content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: number
+                  name:
+                    type: string
+                  train_schedules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                        train_name:
+                          type: string
+                        departure_time:
+                          type: number
+                        train_path:
+                          type: number
 
   /projects/{project_id}/studies/:
     post:

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -1,6 +1,8 @@
 mod documents;
 mod projects;
 mod study;
+mod timetable;
+mod train_schedule;
 
 use crate::error::Result;
 use crate::DbPool;
@@ -11,6 +13,8 @@ use diesel::PgConnection;
 pub use documents::Document;
 pub use projects::{Project, ProjectWithStudies};
 pub use study::{Study, StudyWithScenarios};
+pub use timetable::Timetable;
+pub use train_schedule::TrainSchedule;
 
 /// Trait to implement the `create` and `create_conn` methods.
 /// This trait is automatically implemented by the `#[derive(Model)]` macro.

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -1,0 +1,37 @@
+use super::{Retrieve, TrainSchedule};
+use crate::error::Result;
+use crate::tables::osrd_infra_timetable;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use editoast_derive::Model;
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Queryable, Identifiable, Serialize, Selectable, Model)]
+#[model(table = "osrd_infra_timetable")]
+#[model(retrieve)]
+#[diesel(table_name = osrd_infra_timetable)]
+pub struct Timetable {
+    #[diesel(deserialize_as = i64)]
+    pub id: i64,
+    #[diesel(deserialize_as = String)]
+    pub name: String,
+}
+
+impl Timetable {
+    /// Retrieves timetable with a specific id and its associated train schedules
+    pub fn with_train_schedules(
+        conn: &mut PgConnection,
+        timetable_id: i64,
+    ) -> Result<Option<(Timetable, Vec<TrainSchedule>)>> {
+        let timetable = match Timetable::retrieve_conn(conn, timetable_id)? {
+            Some(timetable) => timetable,
+            None => return Ok(None),
+        };
+
+        let train_schedules = TrainSchedule::belonging_to(&timetable)
+            .select(TrainSchedule::as_select())
+            .load::<TrainSchedule>(conn)?;
+        Ok(Some((timetable, train_schedules)))
+    }
+}

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -1,0 +1,24 @@
+use crate::models::Timetable;
+use crate::tables::osrd_infra_trainschedule;
+use diesel::prelude::*;
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+#[derive(Queryable, Selectable, Identifiable, Associations, Serialize, Debug, PartialEq)]
+#[diesel(belongs_to(Timetable))]
+#[diesel(table_name = osrd_infra_trainschedule)]
+pub struct TrainSchedule {
+    pub id: i64,
+    pub train_name: String,
+    pub labels: JsonValue,
+    pub departure_time: f64,
+    pub initial_speed: f64,
+    pub allowances: JsonValue,
+    pub comfort: String,
+    pub speed_limit_tags: Option<String>,
+    pub power_restriction_ranges: Option<JsonValue>,
+    pub options: Option<JsonValue>,
+    pub path_id: i64,
+    pub rolling_stock_id: i64,
+    pub timetable_id: i64,
+}

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -294,3 +294,32 @@ table! {
         order -> Nullable<BigInt>,
     }
 }
+
+table! {
+    osrd_infra_timetable(id) {
+        id -> BigInt,
+        name -> Text,
+    }
+}
+
+table! {
+    osrd_infra_trainschedule(id) {
+        id -> BigInt,
+        train_name -> Text,
+        labels -> Jsonb,
+        departure_time -> Double,
+        initial_speed -> Double,
+        allowances -> Jsonb,
+        comfort -> Text,
+        speed_limit_tags -> Nullable<Text>,
+        power_restriction_ranges -> Nullable<Jsonb>,
+        options -> Nullable<Jsonb>,
+        path_id -> BigInt,
+        rolling_stock_id -> BigInt,
+        timetable_id -> BigInt,
+    }
+}
+
+joinable!(  osrd_infra_trainschedule -> osrd_infra_timetable (timetable_id));
+
+allow_tables_to_appear_in_same_query!(osrd_infra_trainschedule, osrd_infra_timetable);

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -9,6 +9,8 @@ pub mod projects;
 pub mod rolling_stocks;
 pub mod search;
 pub mod study;
+pub mod timetable;
+pub mod train_schedule;
 
 use crate::client::get_app_version;
 use crate::error::Result;
@@ -30,6 +32,7 @@ pub fn routes() -> impl HttpServiceFactory {
         electrical_profiles::routes(),
         projects::routes(),
         study::routes(),
+        timetable::routes(),
         documents::routes(),
         rolling_stocks::routes(),
         light_rolling_stocks::routes(),

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,0 +1,56 @@
+use crate::error::Result;
+use crate::models::Timetable;
+use crate::DbPool;
+use actix_web::dev::HttpServiceFactory;
+use actix_web::get;
+use actix_web::web::{self, block, Data, Json, Path};
+use editoast_derive::EditoastError;
+use serde::Serialize;
+use thiserror::Error;
+
+use super::train_schedule::TrainScheduleDetails;
+
+pub fn routes() -> impl HttpServiceFactory {
+    web::scope("/timetable/{timetable_id}").service(get)
+}
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "timetable")]
+enum TimetableError {
+    #[error("Timetable '{timetable_id}', could not be found")]
+    #[editoast_error(status = 404)]
+    NotFound { timetable_id: i64 },
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct TimetableWithSchedules {
+    #[serde(flatten)]
+    pub timetable: Timetable,
+    pub train_schedules: Vec<TrainScheduleDetails>,
+}
+
+/// Return a specific timetable with its associated schedules
+#[get("")]
+async fn get(
+    db_pool: Data<DbPool>,
+    timetable_id: Path<i64>,
+) -> Result<Json<TimetableWithSchedules>> {
+    let timetable_id = timetable_id.into_inner();
+    block(move || {
+        let mut conn = db_pool.get().expect("Failed to get DB connection");
+        Ok(Json(
+            match Timetable::with_train_schedules(&mut conn, timetable_id)? {
+                Some((timetable, schedules)) => TimetableWithSchedules {
+                    timetable,
+                    train_schedules: schedules
+                        .into_iter()
+                        .map(|schedule| schedule.into())
+                        .collect(),
+                },
+                None => return Err(TimetableError::NotFound { timetable_id }.into()),
+            },
+        ))
+    })
+    .await
+    .unwrap()
+}

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+use crate::models::TrainSchedule;
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct TrainScheduleDetails {
+    pub id: i64,
+    pub train_name: String,
+    pub departure_time: f64,
+    pub train_path: i64,
+}
+
+impl From<TrainSchedule> for TrainScheduleDetails {
+    fn from(value: TrainSchedule) -> Self {
+        TrainScheduleDetails {
+            id: value.id,
+            train_name: value.train_name.clone(),
+            departure_time: value.departure_time,
+            train_path: value.path_id,
+        }
+    }
+}

--- a/front/src/applications/operationalStudies/components/SimulationResults/simulationResultsConsts.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/simulationResultsConsts.ts
@@ -25,6 +25,6 @@ export const SIGNAL_BASE_DEFAULT = 'BAL3';
 
 export const LIST_VALUES_SIGNAL_BASE = ['BAL3'];
 
-export const timetableURI = '/timetable/';
+export const timetableURI = '/editoast/timetable/';
 export const trainscheduleURI = '/train_schedule/';
 export const scheduleURL = '/train_schedule/standalone_simulation/';

--- a/front/src/applications/stdcm/views/StdcmRequestModal.jsx
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.jsx
@@ -32,7 +32,7 @@ import { updateItinerary } from 'reducers/osrdconf';
 import { useTranslation } from 'react-i18next';
 import { Spinner } from 'common/Loader';
 
-const timetableURI = '/timetable/';
+const timetableURI = '/editoast/timetable/';
 
 export default function StdcmRequestModal(props) {
   const { t } = useTranslation(['translation', 'operationalStudies/manageTrainSchedule']);

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -251,6 +251,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/projects/${queryArg.projectId}/`, method: 'DELETE' }),
     }),
+    getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
+      query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
+    }),
     postProjectsByProjectIdStudies: build.mutation<
       PostProjectsByProjectIdStudiesApiResponse,
       PostProjectsByProjectIdStudiesApiArg
@@ -668,6 +671,20 @@ export type DeleteProjectsByProjectIdApiResponse = unknown;
 export type DeleteProjectsByProjectIdApiArg = {
   /** project id you want to delete */
   projectId: number;
+};
+export type GetTimetableByIdApiResponse = /** status 200 The timetable content */ {
+  id?: number;
+  name?: string;
+  train_schedules?: {
+    id?: number;
+    train_name?: string;
+    departure_time?: number;
+    train_path?: number;
+  }[];
+};
+export type GetTimetableByIdApiArg = {
+  /** Timetable ID */
+  id: number;
 };
 export type PostProjectsByProjectIdStudiesApiResponse =
   /** status 201 The created operational study */ StudyResult;

--- a/front/src/reducers/osrdsimulation/simulation.js
+++ b/front/src/reducers/osrdsimulation/simulation.js
@@ -13,7 +13,7 @@ export const UPDATE_SIMULATION = 'osrdsimu/UPDATE_SIMULATION';
 export const UNDO_SIMULATION = 'osrdsimu/UNDO_SIMULATION';
 export const REDO_SIMULATION = 'osrdsimu/REDO_SIMULATION';
 
-const timetableURI = '/timetable/';
+const timetableURI = '/editoast/timetable/';
 
 export function updateSimulation(simulation) {
   return (dispatch) => {

--- a/python/api/openapi.yaml
+++ b/python/api/openapi.yaml
@@ -460,6 +460,7 @@ paths:
                 $ref: "#/components/schemas/LightRollingStock"
   /timetable/{id}/:
     get:
+      deprecated: true
       tags:
         - timetable
       summary: Retrieve a timetable and its train schedules
@@ -873,7 +874,6 @@ paths:
           description: No content
 
   /projects/{project_id}/image/:
-    
     get:
       deprecated: true
       tags:


### PR DESCRIPTION
This PR is 
- migrating `timetable/` endpoint to editoast with an integration test.
- adding a test for `timetable not found`


close #3446
close #3447 