### PR TITLE
editor: fixes issues #3318 and #3394

### DIFF
--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { flatMap, map, uniq } from 'lodash';
+import { flatMap, uniq } from 'lodash';
 import { useSelector } from 'react-redux';
 import { TFunction } from 'i18next';
 import cx from 'classnames';
@@ -59,7 +59,9 @@ async function getAdditionalEntities(
       return {};
     }
     case 'Switch': {
-      const trackIDs = map((entity as SwitchEntity).properties.ports, (port) => port.track);
+      const trackIDs = flatMap((entity as SwitchEntity).properties.ports, (port) =>
+        port.track ? [port.track] : []
+      );
       return getEntities<TrackSectionEntity>(infra, trackIDs, 'TrackSection');
     }
     case 'Route': {

--- a/front/src/applications/editor/data/api.ts
+++ b/front/src/applications/editor/data/api.ts
@@ -110,7 +110,7 @@ type EditoastEntity<T extends EditorEntity = EditorEntity> = {
   schematic: T['geometry'];
 };
 
-function editoastToEditorEntity<T extends EditorEntity = EditorEntity>(
+export function editoastToEditorEntity<T extends EditorEntity = EditorEntity>(
   entity: EditoastEntity,
   type: T['objType']
 ): T {

--- a/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
@@ -53,13 +53,7 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
       .colors(candidates.length)
       .map((str) => chroma(str).css());
 
-    const features = await getRouteGeometries(
-      infraId,
-      entryPoint,
-      entryPointDirection,
-      exitPoint,
-      candidates
-    );
+    const features = await getRouteGeometries(infraId, entryPoint, exitPoint, candidates);
 
     setState({
       optionsState: {

--- a/front/src/applications/editor/tools/routeEdition/utils.test.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.test.ts
@@ -1,0 +1,158 @@
+import { LineString, Point, Position } from 'geojson';
+import length from '@turf/length';
+import { lineString } from '@turf/helpers';
+
+import { editoastToEditorEntity } from '../../data/api';
+import { computeRouteGeometry, removeDuplicatePoints } from './utils';
+import { DetectorEntity, TrackSectionEntity } from '../../../../types';
+
+const p1: Position = [-1.1, 49.5];
+const p2: Position = [-1.2, 49.5];
+const p3: Position = [-1.3, 49.5];
+const p4: Position = [-1.4, 49.5];
+const p5: Position = [-1.5, 49.5];
+const path1 = [p1, p2, p3];
+const path2 = [p3, p4, p5];
+const l1 = length(lineString(path1));
+const l2 = length(lineString(path2));
+
+const ts1: TrackSectionEntity = editoastToEditorEntity(
+  {
+    railjson: {
+      curves: [{ begin: 0.0, end: l1, radius: 0.0 }],
+      extensions: { sncf: { line_code: 1, line_name: '1', track_name: '1', track_number: 1 } },
+      geo: {
+        coordinates: [p1, p2, p3],
+        type: 'LineString',
+      },
+      id: 'ts1',
+      length: l1,
+      loading_gauge_limits: [],
+      sch: {
+        coordinates: [p1, p2, p3],
+        type: 'LineString',
+      },
+      slopes: [{ begin: 0.0, end: l1, gradient: 0.0 }],
+    },
+    geographic: {
+      coordinates: [p1, p2, p3],
+      type: 'LineString',
+    },
+    schematic: {
+      coordinates: [p1, p2, p3],
+      type: 'LineString',
+    },
+  },
+  'TrackSection'
+);
+const ts2: TrackSectionEntity = editoastToEditorEntity(
+  {
+    railjson: {
+      curves: [{ begin: 0.0, end: l2, radius: 0.0 }],
+      extensions: { sncf: { line_code: 2, line_name: '2', track_name: '2', track_number: 2 } },
+      geo: {
+        coordinates: [p3, p4, p5],
+        type: 'LineString',
+      },
+      id: 'ts2',
+      length: l2,
+      loading_gauge_limits: [],
+      sch: {
+        coordinates: [p3, p4, p5],
+        type: 'LineString',
+      },
+      slopes: [{ begin: 0.0, end: l2, gradient: 0.0 }],
+    },
+    geographic: {
+      coordinates: [p3, p4, p5],
+      type: 'LineString',
+    },
+    schematic: {
+      coordinates: [p3, p4, p5],
+      type: 'LineString',
+    },
+  },
+  'TrackSection'
+);
+const d1: DetectorEntity<Point> = editoastToEditorEntity(
+  {
+    railjson: {
+      applicable_directions: 'BOTH',
+      id: 'd1',
+      position: 0.0,
+      track: 'ts1',
+    },
+    geographic: { coordinates: p1, type: 'Point' },
+    schematic: { coordinates: p1, type: 'Point' },
+  },
+  'Detector'
+);
+const d2: DetectorEntity<Point> = editoastToEditorEntity(
+  {
+    railjson: {
+      applicable_directions: 'BOTH',
+      id: 'd2',
+      position: l1,
+      track: 'ts1',
+    },
+    geographic: { coordinates: p3, type: 'Point' },
+    schematic: { coordinates: p3, type: 'Point' },
+  },
+  'Detector'
+);
+const d3: DetectorEntity<Point> = editoastToEditorEntity(
+  {
+    railjson: {
+      applicable_directions: 'BOTH',
+      id: 'd3',
+      position: l2,
+      track: 'ts2',
+    },
+    geographic: { coordinates: p5, type: 'Point' },
+    schematic: { coordinates: p5, type: 'Point' },
+  },
+  'Detector'
+);
+
+describe('getRouteGeometry(...) utils', () => {
+  it('should work with a single track section', () => {
+    expect(
+      computeRouteGeometry({ ts1, ts2 }, d1, d2, [{ track: 'ts1', direction: 'START_TO_STOP' }])
+        .geometry
+    ).toEqual<LineString>(ts1.geometry);
+  });
+  it('should work with a single track section (backwards)', () => {
+    expect(
+      computeRouteGeometry({ ts1, ts2 }, d2, d1, [{ track: 'ts1', direction: 'STOP_TO_START' }])
+        .geometry
+    ).toEqual<LineString>({
+      ...ts1.geometry,
+      coordinates: ts1.geometry.coordinates.slice(0).reverse(),
+    });
+  });
+
+  it('should work with two track sections', () => {
+    expect(
+      computeRouteGeometry({ ts1, ts2 }, d1, d3, [
+        { track: 'ts1', direction: 'START_TO_STOP' },
+        { track: 'ts2', direction: 'START_TO_STOP' },
+      ]).geometry
+    ).toEqual<LineString>({
+      ...ts1.geometry,
+      coordinates: removeDuplicatePoints(ts1.geometry.coordinates.concat(ts2.geometry.coordinates)),
+    });
+  });
+  it('should work with two track sections (backwards)', () => {
+    expect(
+      computeRouteGeometry({ ts1, ts2 }, d3, d1, [
+        { track: 'ts2', direction: 'STOP_TO_START' },
+        { track: 'ts1', direction: 'STOP_TO_START' },
+      ]).geometry
+    ).toEqual<LineString>({
+      ...ts1.geometry,
+      coordinates: removeDuplicatePoints(ts1.geometry.coordinates.concat(ts2.geometry.coordinates))
+        .slice(0)
+        .reverse(),
+    });
+  });
+});

--- a/front/src/applications/editor/tools/switchEdition/tool.ts
+++ b/front/src/applications/editor/tools/switchEdition/tool.ts
@@ -1,13 +1,10 @@
 import { TbSwitch2 } from 'react-icons/tb';
-import { TiDeleteOutline } from 'react-icons/ti';
-
 import { IoMdAddCircleOutline } from 'react-icons/io';
+
 import { DEFAULT_COMMON_TOOL_STATE, Tool } from '../types';
 import { SwitchEditionState } from './types';
 import { getNewSwitch } from './utils';
 import { SwitchEditionLayers, SwitchEditionLeftPanel, SwitchMessages } from './components';
-import { NEW_ENTITY_ID } from '../../data/utils';
-import { TrackSectionEntity } from '../../../../types';
 
 const SwitchEditionTool: Tool<SwitchEditionState> = {
   id: 'switch-edition',
@@ -35,21 +32,6 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
 
   actions: [
     [
-      {
-        id: 'delete-switch',
-        icon: TiDeleteOutline,
-        labelTranslationKey: 'Editor.tools.switch-edition.actions.delete-switch',
-        onClick() {
-          // TODO:
-          // Delete currently edited switch
-        },
-        isDisabled({ state }) {
-          return (
-            !state.initialEntity.properties?.id ||
-            state.initialEntity.properties.id === NEW_ENTITY_ID
-          );
-        },
-      },
       {
         id: 'new-switch',
         icon: IoMdAddCircleOutline,
@@ -82,9 +64,9 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
       });
     }
   },
-  onClickEntity(feature, e, { state }) {
-    if (state.portEditionState.type === 'selection') {
-      state.portEditionState.onSelect(feature as TrackSectionEntity, [e.point.x, e.point.y]);
+  onClickEntity(_feature, _e, { state }) {
+    if (state.portEditionState.type === 'selection' && state.portEditionState.hoveredPoint) {
+      state.portEditionState.onSelect(state.portEditionState.hoveredPoint);
     }
   },
 

--- a/front/src/applications/editor/tools/switchEdition/types.ts
+++ b/front/src/applications/editor/tools/switchEdition/types.ts
@@ -1,5 +1,14 @@
+import { Position } from 'geojson';
+
 import { CommonToolState } from '../types';
-import { SwitchEntity, TrackEndpoint, TrackSectionEntity } from '../../../../types';
+import { EndPoint, SwitchEntity } from '../../../../types';
+
+export type PortEndPointCandidate = {
+  endPoint: EndPoint;
+  position: Position;
+  trackSectionId: string;
+  trackSectionName: string;
+};
 
 export type SwitchEditionState = CommonToolState & {
   initialEntity: Partial<SwitchEntity>;
@@ -10,7 +19,7 @@ export type SwitchEditionState = CommonToolState & {
     | {
         type: 'selection';
         portId: string;
-        onSelect: (track: TrackSectionEntity, position: [number, number]) => void;
-        hoveredPoint: TrackEndpoint | null;
+        onSelect: (candidate: PortEndPointCandidate) => void;
+        hoveredPoint: PortEndPointCandidate | null;
       };
 };

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -193,6 +193,8 @@ export type Theme = {
   [key: string]: { [key: string]: string };
 };
 
+export declare type PartialButFor<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
+
 //
 // API
 //


### PR DESCRIPTION
About #3318:
  - Uses each track range direction instead of trying to find which way to go by comparing current range extremities to last point crossed
  - Adds some unit tests for the routes geometry computation helpers

About #3394:
  - Since hovered entities are not accurate enough, the hovered track section is fully loaded before trying to determinate which extremity is the closest to the mouse
  - The hovered endpoint is now saved in the SwitchEditionState, and the exact same value is used when the user clicks, so that we are sure the selected endpoint is the same as the one displayed over the map