### PR TITLE
front: clean GEV

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity.jsx
@@ -377,10 +377,10 @@ const enableInteractivity = (
   drawGuideLines(chart);
 };
 
-// keyValues ['time', 'position']
+// keyValues ['time', 'position'] or ['position', 'speed']
 export const isolatedEnableInteractivity = (
   chart,
-  dataSimulation,
+  selectedTrainData,
   keyValues,
   listValues,
   rotate,
@@ -443,7 +443,7 @@ export const isolatedEnableInteractivity = (
 
         debounceUpdateTimePositionValues(timePositionLocal, 15);
         const immediatePositionsValuesForPointer = interpolateOnTime(
-          dataSimulation,
+          selectedTrainData,
           keyValues,
           LIST_VALUES_NAME_SPACE_TIME,
           timePositionLocal
@@ -454,9 +454,13 @@ export const isolatedEnableInteractivity = (
         const positionLocal = rotate
           ? chart.y.invert(pointer(event, event.currentTarget)[1])
           : chart.x.invert(pointer(event, event.currentTarget)[0]);
-        const timePositionLocal = interpolateOnPosition(dataSimulation, keyValues, positionLocal);
+        const timePositionLocal = interpolateOnPosition(
+          selectedTrainData,
+          keyValues,
+          positionLocal
+        );
         const immediatePositionsValuesForPointer = interpolateOnTime(
-          dataSimulation,
+          selectedTrainData,
           keyValues,
           LIST_VALUES_NAME_SPEED_SPACE,
           datetime2sec(timePositionLocal)

--- a/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity.jsx
@@ -481,7 +481,18 @@ export const isolatedEnableInteractivity = (
         });
 
         if (timePositionLocal) {
-          debounceUpdateTimePositionValues(timePositionLocal, null, 15);
+          debounceUpdateTimePositionValues(timePositionLocal, 15);
+        }
+
+        if (chart?.svg) {
+          const verticalMark = pointer(event, event.currentTarget)[0];
+          const horizontalMark = pointer(event, event.currentTarget)[1];
+          chart.svg.selectAll('#vertical-line').attr('x1', verticalMark).attr('x2', verticalMark);
+          chart.svg
+            .selectAll('#horizontal-line')
+            .attr('y1', horizontalMark)
+            .attr('y2', horizontalMark);
+          updatePointers(chart, keyValues, listValues, immediatePositionsValuesForPointer, rotate);
         }
       }
 

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpaceTimeChart/SpaceTimeChart.jsx
@@ -11,7 +11,7 @@ import {
   timeShiftTrain,
   interpolateOnTime,
 } from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers';
-import ORSD_GET_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
+import ORSD_GRAPH_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
 import { CgLoadbar } from 'react-icons/cg';
 import ChartModal from 'applications/operationalStudies/components/SimulationResults/ChartModal';
 import { GiResize } from 'react-icons/gi';
@@ -337,18 +337,18 @@ SpaceTimeChart.propTypes = {
 };
 
 SpaceTimeChart.defaultProps = {
-  allowancesSettings: ORSD_GET_SAMPLE_DATA.allowancesSettings,
+  allowancesSettings: ORSD_GRAPH_SAMPLE_DATA.allowancesSettings,
   dispatchUpdateChart: noop,
   dispatchUpdateDepartureArrivalTimes: noop,
   dispatchUpdateMustRedraw: noop,
   dispatchUpdateSelectedTrain: noop,
   dispatchUpdateTimePositionValues: noop,
-  inputSelectedTrain: ORSD_GET_SAMPLE_DATA.selectedTrain,
+  inputSelectedTrain: ORSD_GRAPH_SAMPLE_DATA.selectedTrain,
   initialHeightOfSpaceTimeChart: 400,
   onOffsetTimeByDragging: noop,
   onSetBaseHeightOfSpaceTimeChart: noop,
-  positionValues: ORSD_GET_SAMPLE_DATA.positionValues,
-  simulation: ORSD_GET_SAMPLE_DATA.simulation.present,
+  positionValues: ORSD_GRAPH_SAMPLE_DATA.positionValues,
+  simulation: ORSD_GRAPH_SAMPLE_DATA.simulation.present,
   simulationIsPlaying: false,
-  timePosition: ORSD_GET_SAMPLE_DATA.timePosition,
+  timePosition: ORSD_GRAPH_SAMPLE_DATA.timePosition,
 };

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
@@ -20,6 +20,7 @@ import {
   drawTrain,
 } from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/d3Helpers';
 import ElectricalProfilesLegend from './ElectricalProfilesLegend';
+import prepareData from './prepareData';
 
 const CHART_ID = 'SpeedSpaceChart';
 const CHART_MIN_HEIGHT = 250;
@@ -315,5 +316,8 @@ SpeedSpaceChart.defaultProps = {
   simulationIsPlaying: false,
   speedSpaceSettings: ORSD_GRAPH_SAMPLE_DATA.speedSpaceSettings,
   timePosition: ORSD_GRAPH_SAMPLE_DATA.timePosition,
-  trainSimulation: ORSD_GRAPH_SAMPLE_DATA.selectedTrainSimulation,
+  trainSimulation: prepareData(
+    ORSD_GRAPH_SAMPLE_DATA.simulation.present,
+    ORSD_GRAPH_SAMPLE_DATA.selectedTrain
+  ),
 };

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
@@ -1,16 +1,19 @@
 import { noop } from 'lodash';
 import * as d3 from 'd3';
-import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { CgLoadbar } from 'react-icons/cg';
 import { GiResize } from 'react-icons/gi';
 import PropTypes from 'prop-types';
 import { Rnd } from 'react-rnd';
-import ORSD_GEV_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
-import enableInteractivity, {
+import ORSD_GRAPH_SAMPLE_DATA from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData';
+import {
+  isolatedEnableInteractivity,
   traceVerticalLine,
 } from 'applications/operationalStudies/components/SimulationResults/ChartHelpers/enableInteractivity';
-import { LIST_VALUES_NAME_SPEED_SPACE } from 'applications/operationalStudies/components/SimulationResults/simulationResultsConsts';
-import prepareData from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/prepareData';
+import {
+  LIST_VALUES_NAME_SPEED_SPACE,
+  SPEED_SPACE_CHART_KEY_VALUES,
+} from 'applications/operationalStudies/components/SimulationResults/simulationResultsConsts';
 import SpeedSpaceSettings from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceSettings/SpeedSpaceSettings';
 import {
   createChart,
@@ -27,52 +30,42 @@ const CHART_MIN_HEIGHT = 250;
  * - Vertical line to the current position
  * - 2 marchs displayed: base and alternative
  *
- */ export default function SpeedSpaceChart(props) {
+ */
+export default function SpeedSpaceChart(props) {
   const {
-    simulation,
     chartXGEV,
-    dispatch,
+    dispatchUpdateMustRedraw,
+    dispatchUpdateTimePositionValues,
+    initialHeightOfSpeedSpaceChart,
     mustRedraw,
     positionValues,
-    selectedTrain,
+    trainSimulation,
+    simulationIsPlaying,
     speedSpaceSettings,
-    timePosition,
-    consolidatedSimulation,
-    initialHeightOfSpeedSpaceChart,
     onSetSettings,
     onSetBaseHeightOfSpeedSpaceChart,
-    dispatchUpdateMustRedraw,
+    timePosition,
   } = props;
 
-  const [showSettings, setShowSettings] = useState(false);
-  const [rotate, setRotate] = useState(false);
-  const [resetChart, setResetChart] = useState(false);
+  const [baseHeightOfSpeedSpaceChart, setBaseHeightOfSpeedSpaceChart] = useState(
+    initialHeightOfSpeedSpaceChart
+  );
   const [chart, setChart] = useState(undefined);
-  const [zoomLevel, setZoomLevel] = useState(1);
-  const [yPosition, setYPosition] = useState(0);
-  const [localSettings, setLocalSettings] = useState(speedSpaceSettings);
   const [isActive, setIsActive] = useState(false);
-
   const [heightOfSpeedSpaceChart, setHeightOfSpeedSpaceChart] = useState(
     initialHeightOfSpeedSpaceChart
   );
-
-  const [baseHeightOfSpeedSpaceChart, setBaseHeightOfSpeedSpaceChart] =
-    useState(heightOfSpeedSpaceChart);
+  const [localSettings, setLocalSettings] = useState(speedSpaceSettings);
+  const [resetChart, setResetChart] = useState(false);
+  const [rotate, setRotate] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   const ref = useRef();
-  const keyValues = ['position', 'speed'];
 
   const onLocalSetSettings = (settings) => {
     setLocalSettings(settings);
     onSetSettings(settings);
   };
-
-  // Prepare data
-  const dataSimulation = useMemo(
-    () => prepareData(simulation, selectedTrain, keyValues),
-    [simulation, selectedTrain, keyValues]
-  );
 
   // draw the train
   const createChartAndTrain = useCallback(() => {
@@ -80,58 +73,19 @@ const CHART_MIN_HEIGHT = 250;
       CHART_ID,
       chart,
       resetChart,
-      dataSimulation,
+      trainSimulation,
       rotate,
-      keyValues,
       heightOfSpeedSpaceChart,
       ref,
-      dispatch,
       setResetChart
     );
     setChart(localChart);
-    drawTrain(
-      LIST_VALUES_NAME_SPEED_SPACE,
-      simulation,
-      selectedTrain,
-      dataSimulation,
-      keyValues,
-      positionValues,
-      rotate,
-      localSettings,
-      mustRedraw,
-      setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      dispatch,
-      zoomLevel,
-      CHART_ID,
-      localChart,
-      resetChart,
-      heightOfSpeedSpaceChart,
-      ref,
-      setResetChart,
-      true
-    );
-  }, [
-    chart,
-    dataSimulation,
-    dispatch,
-    heightOfSpeedSpaceChart,
-    keyValues,
-    localSettings,
-    mustRedraw,
-    positionValues,
-    resetChart,
-    rotate,
-    selectedTrain,
-    simulation,
-    yPosition,
-    zoomLevel,
-  ]);
+    drawTrain(trainSimulation, rotate, localSettings, localChart);
+  }, [chart, trainSimulation, heightOfSpeedSpaceChart, localSettings, resetChart, rotate]);
 
   // rotation Handle (button on right bottom)
   const toggleRotation = () => {
+    // TODO: this should be moved in createChart
     d3.select(`#${CHART_ID}`).remove();
     setChart({
       ...chart,
@@ -141,48 +95,6 @@ const CHART_MIN_HEIGHT = 250;
       originalScaleY: chart.originalScaleX,
     });
     setRotate(!rotate);
-  };
-
-  // Reset Chart Handle (first button on right bottom)
-  const resetChartToggle = () => {
-    const localChart = createChart(
-      CHART_ID,
-      chart,
-      resetChart,
-      dataSimulation,
-      false,
-      keyValues,
-      heightOfSpeedSpaceChart,
-      ref,
-      dispatch,
-      setResetChart
-    );
-    setChart(localChart);
-    drawTrain(
-      LIST_VALUES_NAME_SPEED_SPACE,
-      simulation,
-      selectedTrain,
-      dataSimulation,
-      keyValues,
-      positionValues,
-      false,
-      localSettings,
-      mustRedraw,
-      setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      dispatch,
-      zoomLevel,
-      CHART_ID,
-      localChart,
-      resetChart,
-      heightOfSpeedSpaceChart,
-      ref,
-      setResetChart,
-      true
-    );
-    setRotate(false);
   };
 
   const debounceResize = (interval) => {
@@ -201,12 +113,10 @@ const CHART_MIN_HEIGHT = 250;
         CHART_ID,
         chart,
         resetChart,
-        dataSimulation,
+        trainSimulation,
         rotate,
-        keyValues,
         heightOfSpeedSpaceChart,
         ref,
-        dispatch,
         setResetChart
       )
     );
@@ -214,19 +124,19 @@ const CHART_MIN_HEIGHT = 250;
 
   // plug event handlers once the chart is ready or recreated
   useEffect(() => {
-    enableInteractivity(
+    isolatedEnableInteractivity(
       chart,
-      dataSimulation,
-      dispatch,
-      keyValues,
+      trainSimulation,
+      SPEED_SPACE_CHART_KEY_VALUES,
       LIST_VALUES_NAME_SPEED_SPACE,
-      positionValues,
       rotate,
       setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      zoomLevel
+      noop,
+      noop,
+      noop,
+      simulationIsPlaying,
+      dispatchUpdateMustRedraw,
+      dispatchUpdateTimePositionValues
     );
   }, [chart]);
 
@@ -234,14 +144,14 @@ const CHART_MIN_HEIGHT = 250;
   useEffect(() => {
     createChartAndTrain();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mustRedraw, rotate, consolidatedSimulation, localSettings]);
+  }, [mustRedraw, rotate, localSettings]);
 
   // draw or redraw the position line indictator when usefull
   useEffect(() => {
     traceVerticalLine(
       chart,
-      dataSimulation,
-      keyValues,
+      trainSimulation,
+      SPEED_SPACE_CHART_KEY_VALUES,
       LIST_VALUES_NAME_SPEED_SPACE,
       positionValues,
       'speed',
@@ -265,12 +175,20 @@ const CHART_MIN_HEIGHT = 250;
   }, []);
 
   // reset chart
-  useEffect(() => resetChartToggle(), [resetChart]);
+  useEffect(() => {
+    if (resetChart) {
+      if (rotate) {
+        // cancel rotation and redraw the train
+        toggleRotation();
+      } else {
+        createChartAndTrain();
+      }
+    }
+  }, [resetChart]);
 
   // draw the first chart
   useEffect(() => {
     createChartAndTrain();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -351,23 +269,16 @@ const CHART_MIN_HEIGHT = 250;
 }
 
 SpeedSpaceChart.propTypes = {
-  dispatchUpdateMustRedraw: PropTypes.func,
-  /**
-   * height of chart
-   */
-  heightOfSpeedSpaceChart: PropTypes.number,
-  /**
-   * current simulation (selected train) ! to be removed
-   */
-  simulation: PropTypes.object,
   /**
    * Current X linear scale for synced charts
    */
   chartXGEV: PropTypes.func,
+  dispatchUpdateMustRedraw: PropTypes.func,
+  dispatchUpdateTimePositionValues: PropTypes.func,
   /**
-   * Dispath to store func
+   * height of chart
    */
-  dispatch: PropTypes.func,
+  initialHeightOfSpeedSpaceChart: PropTypes.number.isRequired,
   /**
    * Force d3 render trigger ! To be removed
    */
@@ -377,40 +288,32 @@ SpeedSpaceChart.propTypes = {
    */
   positionValues: PropTypes.object,
   /**
-   * Current Selected Train index
+   * current simulation (selected train)
    */
-  selectedTrain: PropTypes.number,
+  trainSimulation: PropTypes.object,
+  simulationIsPlaying: PropTypes.bool,
   /**
    * Chart settings
    */
   speedSpaceSettings: PropTypes.object,
+  onSetSettings: PropTypes.func,
+  onSetBaseHeightOfSpeedSpaceChart: PropTypes.func,
   /**
    * Current Time Position to be showed (vertical line)
    */
   timePosition: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
-  /**
-   * Current Simulation with more data (for current train)
-   */
-  consolidatedSimulation: PropTypes.array,
-  /**
-   * Toggle the Settings div ! Not isolated
-   */
-  toggleSetting: PropTypes.func,
 };
 
 SpeedSpaceChart.defaultProps = {
-  heightOfSpeedSpaceChart: 250,
-  simulation: ORSD_GEV_SAMPLE_DATA.simulation.present,
   chartXGEV: undefined,
-  dispatch: noop,
-  mustRedraw: ORSD_GEV_SAMPLE_DATA.mustRedraw,
-  positionValues: ORSD_GEV_SAMPLE_DATA.positionValues,
-  selectedTrain: ORSD_GEV_SAMPLE_DATA.selectedTrain,
-  speedSpaceSettings: ORSD_GEV_SAMPLE_DATA.speedSpaceSettings,
-  timePosition: ORSD_GEV_SAMPLE_DATA.timePosition,
-  consolidatedSimulation: ORSD_GEV_SAMPLE_DATA.consolidatedSimulation,
-  toggleSetting: noop,
-  onSetSettings: noop,
   dispatchUpdateMustRedraw: noop,
+  dispatchUpdateTimePositionValues: noop,
+  mustRedraw: false,
   onSetBaseHeightOfSpeedSpaceChart: noop,
+  onSetSettings: noop,
+  positionValues: ORSD_GRAPH_SAMPLE_DATA.positionValues,
+  simulationIsPlaying: false,
+  speedSpaceSettings: ORSD_GRAPH_SAMPLE_DATA.speedSpaceSettings,
+  timePosition: ORSD_GRAPH_SAMPLE_DATA.timePosition,
+  trainSimulation: ORSD_GRAPH_SAMPLE_DATA.selectedTrainSimulation,
 };

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/d3Helpers.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/d3Helpers.jsx
@@ -5,6 +5,7 @@ import { defineLinear } from 'applications/operationalStudies/components/Simulat
 import * as d3 from 'd3';
 import { createProfileSegment } from 'applications/operationalStudies/consts';
 import drawElectricalProfile from '../ChartHelpers/drawElectricalProfile';
+import { SPEED_SPACE_CHART_KEY_VALUES } from '../simulationResultsConsts';
 
 function createChart(
   CHART_ID,
@@ -12,10 +13,8 @@ function createChart(
   resetChart,
   dataSimulation,
   rotate,
-  keyValues,
   heightOfSpeedSpaceChart,
   ref,
-  _dispatch,
   setResetChart
 ) {
   d3.select(`#${CHART_ID}`).remove();
@@ -23,7 +22,11 @@ function createChart(
     chart === undefined || resetChart
       ? defineLinear(
           d3.max(Object.values(dataSimulation), (data) =>
-            d3.max(data, (d) => d[rotate ? keyValues[1] : keyValues[0]] + 100)
+            d3.max(
+              data,
+              (d) =>
+                d[rotate ? SPEED_SPACE_CHART_KEY_VALUES[1] : SPEED_SPACE_CHART_KEY_VALUES[0]] + 100
+            )
           )
         )
       : chart.x;
@@ -31,7 +34,11 @@ function createChart(
     chart === undefined || resetChart
       ? defineLinear(
           d3.max(Object.values(dataSimulation), (data) =>
-            d3.max(data, (d) => d[rotate ? keyValues[0] : keyValues[1]] + 50)
+            d3.max(
+              data,
+              (d) =>
+                d[rotate ? SPEED_SPACE_CHART_KEY_VALUES[0] : SPEED_SPACE_CHART_KEY_VALUES[1]] + 50
+            )
           )
         )
       : chart.y;
@@ -49,7 +56,7 @@ function createChart(
     defineY,
     ref,
     rotate,
-    keyValues,
+    SPEED_SPACE_CHART_KEY_VALUES,
     CHART_ID
   );
 }
@@ -74,38 +81,10 @@ function drawAxisTitle(chart, rotate) {
     .text('M');
 }
 
-function drawTrain(
-  LIST_VALUES_NAME_SPEED_SPACE,
-  simulation,
-  selectedTrain,
-
-  dataSimulation,
-  keyValues,
-  positionValues,
-  rotate,
-  speedSpaceSettings,
-  mustRedraw,
-  setChart,
-  setYPosition,
-  setZoomLevel,
-  yPosition,
-  dispatch,
-  zoomLevel,
-  CHART_ID,
-  chart,
-  resetChart,
-  heightOfSpeedSpaceChart,
-  ref,
-  setResetChart,
-  force = false
-) {
-  if (chart && (mustRedraw || force)) {
+function drawTrain(dataSimulation, rotate, speedSpaceSettings, chart) {
+  if (chart) {
     const chartLocal = chart;
     chartLocal.drawZone.select('g').remove();
-    /*
-      chartLocal.drawZone.append('g').attr('id', 'speedSpaceChart').attr('class', 'chartTrain');
-      drawAxisTitle(chartLocal, rotate);
-      */
     chartLocal.drawZone.append('g').attr('id', 'speedSpaceChart').attr('class', 'chartTrain');
     drawAxisTitle(chartLocal, rotate);
 
@@ -115,7 +94,7 @@ function drawTrain(
       dataSimulation.areaBlock,
       'speedSpaceChart',
       'curveLinear',
-      keyValues,
+      SPEED_SPACE_CHART_KEY_VALUES,
       rotate
     );
 
@@ -125,7 +104,7 @@ function drawTrain(
       dataSimulation.speed,
       'speedSpaceChart',
       'curveLinear',
-      keyValues,
+      SPEED_SPACE_CHART_KEY_VALUES,
       'speed',
       rotate
     );
@@ -136,7 +115,7 @@ function drawTrain(
         dataSimulation.margins_speed,
         'speedSpaceChart',
         'curveLinear',
-        keyValues,
+        SPEED_SPACE_CHART_KEY_VALUES,
         'margins_speed',
         rotate
       );
@@ -148,7 +127,7 @@ function drawTrain(
         dataSimulation.eco_speed,
         'speedSpaceChart',
         'curveLinear',
-        keyValues,
+        SPEED_SPACE_CHART_KEY_VALUES,
         'eco_speed',
         rotate
       );
@@ -160,7 +139,7 @@ function drawTrain(
         dataSimulation.vmax,
         'speedSpaceChart',
         'curveLinear',
-        keyValues,
+        SPEED_SPACE_CHART_KEY_VALUES,
         'vmax',
         rotate
       );
@@ -229,28 +208,6 @@ function drawTrain(
         );
       });
     }
-    // Operational points
-    /*
-    drawOPs(simulation, selectedTrain, rotate, chartLocal);
-
-    enableInteractivity(
-      chartLocal,
-      dataSimulation,
-      dispatch,
-      keyValues,
-      LIST_VALUES_NAME_SPEED_SPACE,
-      positionValues,
-      rotate,
-      setChart,
-      setYPosition,
-      setZoomLevel,
-      yPosition,
-      zoomLevel
-    );
-
-    setChart(chartLocal);
-    dispatch(updateMustRedraw(false));
-    */
   }
 }
 

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/prepareData.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/prepareData.ts
@@ -2,6 +2,7 @@ import { mergeDatasAreaConstant } from 'applications/operationalStudies/componen
 import createSlopeCurve from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/createSlopeCurve';
 import createCurveCurve from 'applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/createCurveCurve';
 import { ModesAndProfiles, SimulationSnapshot } from 'reducers/osrdsimulation/types';
+import { SPEED_SPACE_CHART_KEY_VALUES } from 'applications/operationalStudies/components/SimulationResults/simulationResultsConsts';
 
 export interface GevPreparedata {
   speed: Record<string, number>[];
@@ -16,13 +17,8 @@ export interface GevPreparedata {
   modesAndProfiles: ModesAndProfiles[];
 }
 
-// called with keyValues
-// ['position', 'speed']
-function prepareData(
-  simulation: SimulationSnapshot,
-  selectedTrain: number,
-  keyValues: string[]
-): GevPreparedata {
+/// SpeedSpaceChart only
+function prepareData(simulation: SimulationSnapshot, selectedTrain: number): GevPreparedata {
   const dataSimulation: GevPreparedata = {
     speed: [],
     margins_speed: [],
@@ -39,9 +35,11 @@ function prepareData(
     ...step,
     speed: step.speed * 3.6,
   }));
+
   if (simulation.trains[selectedTrain].modes_and_profiles) {
     dataSimulation.modesAndProfiles = simulation.trains[selectedTrain].modes_and_profiles;
   }
+
   if (simulation.trains[selectedTrain].margins && !simulation.trains[selectedTrain].margins.error) {
     dataSimulation.margins_speed = simulation.trains[selectedTrain].margins.speeds.map(
       (step: any) => ({
@@ -50,13 +48,19 @@ function prepareData(
       })
     );
   }
+
   if (simulation.trains[selectedTrain].eco && !simulation.trains[selectedTrain].eco.error) {
     dataSimulation.eco_speed = simulation.trains[selectedTrain].eco.speeds.map((step) => ({
       ...step,
       speed: step.speed * 3.6,
     }));
   }
-  dataSimulation.areaBlock = mergeDatasAreaConstant(dataSimulation.speed, [0], keyValues);
+
+  dataSimulation.areaBlock = mergeDatasAreaConstant(
+    dataSimulation.speed,
+    [0],
+    SPEED_SPACE_CHART_KEY_VALUES
+  );
   dataSimulation.vmax = simulation.trains[selectedTrain].vmax.map((step) => ({
     speed: step.speed * 3.6,
     position: step.position,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/sampleData.jsx
@@ -1,4 +1,4 @@
-const ORSD_GEV_SAMPLE_DATA = {
+const ORSD_GRAPH_SAMPLE_DATA = {
   chart: {
     width: 902,
     height: 369,
@@ -16404,4 +16404,4 @@ const ORSD_GEV_SAMPLE_DATA = {
   },
 };
 
-export default ORSD_GEV_SAMPLE_DATA;
+export default ORSD_GRAPH_SAMPLE_DATA;

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/withOSRDData.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/withOSRDData.jsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { updateMustRedraw, updateSpeedSpaceSettings } from 'reducers/osrdsimulation/actions';
+import {
+  updateMustRedraw,
+  updateSpeedSpaceSettings,
+  updateTimePositionValues,
+} from 'reducers/osrdsimulation/actions';
+import { getIsPlaying } from 'reducers/osrdsimulation/selectors';
+import prepareData from './prepareData';
 import SpeedSpaceChart from './SpeedSpaceChart';
 
 /**
@@ -22,7 +28,17 @@ const withOSRDData = (Component) =>
       (state) => state.osrdsimulation.consolidatedSimulation
     );
 
+    const isPlaying = useSelector(getIsPlaying);
+
     const dispatch = useDispatch();
+
+    const dispatchUpdateMustRedraw = (newMustRedraw) => {
+      dispatch(updateMustRedraw(newMustRedraw));
+    };
+
+    const dispatchUpdateTimePositionValues = (newTimePositionValues) => {
+      dispatch(updateTimePositionValues(newTimePositionValues));
+    };
 
     const toggleSetting = (settingName) => {
       dispatch(
@@ -34,19 +50,26 @@ const withOSRDData = (Component) =>
       dispatch(updateMustRedraw(true));
     };
 
+    // Prepare data
+    const trainSimulation = useMemo(
+      () => prepareData(simulation, selectedTrain),
+      [simulation, selectedTrain]
+    );
+
     return (
       <Component
         {...props}
-        simulation={simulation}
+        trainSimulation={trainSimulation}
         chartXGEV={chartXGEV}
         mustRedraw={mustRedraw}
-        dispatch={dispatch}
+        dispatchUpdateMustRedraw={dispatchUpdateMustRedraw}
+        dispatchUpdateTimePositionValues={dispatchUpdateTimePositionValues}
         positionValues={positionValues}
-        selectedTrain={selectedTrain}
         speedSpaceSettings={speedSpaceSettings}
         timePosition={timePosition}
         consolidatedSimulation={consolidatedSimulation}
         toggleSetting={toggleSetting}
+        simulationIsPlaying={isPlaying}
       />
     );
   };

--- a/front/src/applications/operationalStudies/components/SimulationResults/simulationResultsConsts.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/simulationResultsConsts.ts
@@ -12,9 +12,12 @@ export const LIST_VALUES_NAME_SPEED_SPACE = ['speed', 'margins_speed', 'eco_spee
 export const LIST_VALUES_NAME_SPACE_CURVES_SLOPES = ['slopesCurve'];
 export const KEY_VALUES_FOR_CONSOLIDATED_SIMULATION = ['time', 'position'];
 
+// CHARTS
 export const TIME = 'time';
 export const POSITION = 'position';
+export const SPEED = 'speed';
 export const KEY_VALUES_FOR_SPACE_TIME_CHART = [TIME, POSITION];
+export const SPEED_SPACE_CHART_KEY_VALUES = [POSITION, SPEED];
 
 // Signal Base is the Signaling system chosen for results display
 


### PR DESCRIPTION
close #3573

This PR:
- removes unused params in functions or component
- reorders params for more clarity
- introduces constants
- transform the GEV which takes now only the simulation of the selected train (no need for the complete simulation + the selected train index)
- rename variables