### PR TITLE
front: reset GEV graph each time the selected train changes

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/SpeedSpaceChart.jsx
@@ -38,7 +38,6 @@ export default function SpeedSpaceChart(props) {
     dispatchUpdateMustRedraw,
     dispatchUpdateTimePositionValues,
     initialHeightOfSpeedSpaceChart,
-    mustRedraw,
     positionValues,
     trainSimulation,
     simulationIsPlaying,
@@ -141,11 +140,15 @@ export default function SpeedSpaceChart(props) {
     );
   }, [chart]);
 
+  // reset the chart if the trainSimulation has changed
+  useEffect(() => {
+    setResetChart(true);
+  }, [trainSimulation]);
+
   // redraw the train if necessary
   useEffect(() => {
     createChartAndTrain();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mustRedraw, rotate, localSettings]);
+  }, [rotate, localSettings]);
 
   // draw or redraw the position line indictator when usefull
   useEffect(() => {
@@ -159,7 +162,7 @@ export default function SpeedSpaceChart(props) {
       rotate,
       timePosition
     );
-  }, [chart, mustRedraw, positionValues, timePosition]);
+  }, [chart, positionValues, timePosition]);
 
   useEffect(() => {
     if (chartXGEV) {
@@ -281,10 +284,6 @@ SpeedSpaceChart.propTypes = {
    */
   initialHeightOfSpeedSpaceChart: PropTypes.number.isRequired,
   /**
-   * Force d3 render trigger ! To be removed
-   */
-  mustRedraw: PropTypes.bool,
-  /**
    * Current Position to be showed (vertical line)
    */
   positionValues: PropTypes.object,
@@ -309,7 +308,6 @@ SpeedSpaceChart.defaultProps = {
   chartXGEV: undefined,
   dispatchUpdateMustRedraw: noop,
   dispatchUpdateTimePositionValues: noop,
-  mustRedraw: false,
   onSetBaseHeightOfSpeedSpaceChart: noop,
   onSetSettings: noop,
   positionValues: ORSD_GRAPH_SAMPLE_DATA.positionValues,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/d3Helpers.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/d3Helpers.jsx
@@ -5,41 +5,31 @@ import { defineLinear } from 'applications/operationalStudies/components/Simulat
 import * as d3 from 'd3';
 import { createProfileSegment } from 'applications/operationalStudies/consts';
 import drawElectricalProfile from '../ChartHelpers/drawElectricalProfile';
-import { SPEED_SPACE_CHART_KEY_VALUES } from '../simulationResultsConsts';
+import { POSITION, SPEED, SPEED_SPACE_CHART_KEY_VALUES } from '../simulationResultsConsts';
 
 function createChart(
   CHART_ID,
   chart,
   resetChart,
-  dataSimulation,
+  trainSimulation,
   rotate,
   heightOfSpeedSpaceChart,
   ref,
   setResetChart
 ) {
   d3.select(`#${CHART_ID}`).remove();
-  const defineX =
+  const scaleX =
     chart === undefined || resetChart
       ? defineLinear(
-          d3.max(Object.values(dataSimulation), (data) =>
-            d3.max(
-              data,
-              (d) =>
-                d[rotate ? SPEED_SPACE_CHART_KEY_VALUES[1] : SPEED_SPACE_CHART_KEY_VALUES[0]] + 100
-            )
-          )
+          d3.max(trainSimulation.speed, (speedObject) => speedObject[rotate ? SPEED : POSITION]) +
+            100
         )
       : chart.x;
-  const defineY =
+  const scaleY =
     chart === undefined || resetChart
       ? defineLinear(
-          d3.max(Object.values(dataSimulation), (data) =>
-            d3.max(
-              data,
-              (d) =>
-                d[rotate ? SPEED_SPACE_CHART_KEY_VALUES[0] : SPEED_SPACE_CHART_KEY_VALUES[1]] + 50
-            )
-          )
+          d3.max(trainSimulation.speed, (speedObject) => speedObject[rotate ? POSITION : SPEED]) +
+            50
         )
       : chart.y;
 
@@ -52,8 +42,8 @@ function createChart(
   return defineChart(
     width,
     heightOfSpeedSpaceChart,
-    defineX,
-    defineY,
+    scaleX,
+    scaleY,
     ref,
     rotate,
     SPEED_SPACE_CHART_KEY_VALUES,

--- a/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/withOSRDData.jsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SpeedSpaceChart/withOSRDData.jsx
@@ -18,7 +18,6 @@ import SpeedSpaceChart from './SpeedSpaceChart';
 const withOSRDData = (Component) =>
   function WrapperComponent(props) {
     const chartXGEV = useSelector((state) => state.osrdsimulation.chartXGEV);
-    const mustRedraw = useSelector((state) => state.osrdsimulation.mustRedraw);
     const positionValues = useSelector((state) => state.osrdsimulation.positionValues);
     const selectedTrain = useSelector((state) => state.osrdsimulation.selectedTrain);
     const speedSpaceSettings = useSelector((state) => state.osrdsimulation.speedSpaceSettings);
@@ -61,7 +60,6 @@ const withOSRDData = (Component) =>
         {...props}
         trainSimulation={trainSimulation}
         chartXGEV={chartXGEV}
-        mustRedraw={mustRedraw}
         dispatchUpdateMustRedraw={dispatchUpdateMustRedraw}
         dispatchUpdateTimePositionValues={dispatchUpdateTimePositionValues}
         positionValues={positionValues}


### PR DESCRIPTION
Closes #3154 

- add an useEffect to reset the GEV graph each time the selected train changes
- simplify the computation of the scale
- remove mustRedraw of the GEV (manage the re-drawing of the GEV more locally)