### PR TITLE
editor: fixes issue #3577

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -24,23 +24,24 @@ import {
   EditorState,
   ExtendedEditorContextType,
   FullTool,
-  OSRDConf,
   Tool,
 } from './tools/types';
 import TOOLS from './tools/list';
+import { getInfraID, getSwitchTypes } from '../../reducers/osrdconf/selectors';
 
 const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { openModal, closeModal } = useModal();
   const { urlInfra } = useParams();
-  const osrdConf = useSelector((state: { osrdconf: OSRDConf }) => state.osrdconf);
+  const infraID = useSelector(getInfraID);
+  const switchTypes = useSelector(getSwitchTypes);
   const editorState = useSelector((state: { editor: EditorState }) => state.editor);
   const { fullscreen } = useSelector((state: { main: MainState }) => state.main);
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const [toolAndState, setToolAndState] = useState<FullTool<any>>({
     tool: TOOLS[0],
-    state: TOOLS[0].getInitialState({ osrdConf }),
+    state: TOOLS[0].getInitialState({ infraID, switchTypes }),
   });
   const [renderingFingerprint, setRenderingFingerprint] = useState(Date.now());
   const forceRender = useCallback(() => {
@@ -49,13 +50,13 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
 
   const switchTool = useCallback(
     <S extends CommonToolState>(tool: Tool<S>, partialState?: Partial<S>) => {
-      const state = { ...tool.getInitialState({ osrdConf }), ...(partialState || {}) };
+      const state = { ...tool.getInitialState({ infraID, switchTypes }), ...(partialState || {}) };
       setToolAndState({
         tool,
         state,
       });
     },
-    [osrdConf, setToolAndState]
+    [infraID, setToolAndState]
   );
   const setToolState = useCallback(
     <S extends CommonToolState>(state: Partial<S>) => {
@@ -104,7 +105,7 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
       toolAndState,
       openModal,
       closeModal,
-      osrdConf,
+      infraID,
       t,
       forceRender,
       renderingFingerprint,
@@ -115,13 +116,14 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
       ...context,
       dispatch,
       editorState,
-      osrdConf,
+      infraID,
+      switchTypes,
       mapState: {
         viewport,
         mapStyle,
       },
     }),
-    [context, dispatch, editorState, mapStyle, osrdConf, viewport]
+    [context, dispatch, editorState, mapStyle, infraID, switchTypes, viewport]
   );
 
   const actionsGroups = useMemo(
@@ -142,8 +144,8 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
   useEffect(() => {
     // load the data model
     dispatch(loadDataModel());
-    if (isNil(urlInfra) && !isNil(osrdConf.infraID)) {
-      navigate(`/editor/${osrdConf.infraID}`);
+    if (isNil(urlInfra) && !isNil(infraID)) {
+      navigate(`/editor/${infraID}`);
     }
   }, []);
 
@@ -175,7 +177,7 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
         className={cx(
           'editor-root mastcontainer mastcontainer-map',
           fullscreen && ' fullscreen',
-          osrdConf.infraID && 'infra-selected'
+          infraID && 'infra-selected'
         )}
       >
         <div className="layout">
@@ -290,7 +292,7 @@ const EditorUnplugged: FC<{ t: TFunction }> = ({ t }) => {
                             'editor-btn',
                             'btn-rounded',
                             isActive && isActive(editorState) ? 'active' : '',
-                            isBlink && isBlink(editorState, osrdConf.infraID)
+                            isBlink && isBlink(editorState, infraID)
                               ? 'btn-map-infras-blinking'
                               : ''
                           )}

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -15,8 +15,9 @@ import {
   SwitchEntity,
   TrackSectionEntity,
 } from '../../../types';
-import { EditoastType, OSRDConf } from '../tools/types';
+import { EditoastType } from '../tools/types';
 import { getEntities, getEntity } from '../data/api';
+import { getInfraID } from '../../../reducers/osrdconf/selectors';
 
 function prettifyStringsArray(strings: string[], finalSeparator: string): string {
   switch (strings.length) {
@@ -41,7 +42,7 @@ const DEFAULT_CLASSES = {
 };
 
 async function getAdditionalEntities(
-  infra: string,
+  infra: number,
   entity: EditorEntity
 ): Promise<Record<string, EditorEntity>> {
   switch (entity.objType) {
@@ -236,7 +237,7 @@ const EntitySumUp: FC<
   )
 > = ({ entity, id, objType, classes, status }) => {
   const { t } = useTranslation();
-  const osrdConf = useSelector((state: { osrdconf: OSRDConf }) => state.osrdconf);
+  const infraID = useSelector(getInfraID);
   const [state, setState] = useState<
     | { type: 'idle' }
     | { type: 'loading' }
@@ -249,7 +250,7 @@ const EntitySumUp: FC<
       setState({ type: 'loading' });
 
       if (entity) {
-        getAdditionalEntities(osrdConf.infraID as string, entity).then((additionalEntities) => {
+        getAdditionalEntities(infraID as number, entity).then((additionalEntities) => {
           setState({
             type: 'ready',
             entity,
@@ -257,22 +258,20 @@ const EntitySumUp: FC<
           });
         });
       } else {
-        getEntity(osrdConf.infraID as string, id as string, objType as EditoastType).then(
+        getEntity(infraID as number, id as string, objType as EditoastType).then(
           (fetchedEntity) => {
-            getAdditionalEntities(osrdConf.infraID as string, fetchedEntity).then(
-              (additionalEntities) => {
-                setState({
-                  type: 'ready',
-                  entity: fetchedEntity,
-                  additionalEntities,
-                });
-              }
-            );
+            getAdditionalEntities(infraID as number, fetchedEntity).then((additionalEntities) => {
+              setState({
+                type: 'ready',
+                entity: fetchedEntity,
+                additionalEntities,
+              });
+            });
           }
         );
       }
     }
-  }, [entity, id, objType, osrdConf.infraID, state.type]);
+  }, [entity, id, objType, infraID, state.type]);
 
   if (state.type === 'loading' || state.type === 'idle') return <Spinner />;
 

--- a/front/src/applications/editor/components/InfraErrors/InfraErrorsModal.tsx
+++ b/front/src/applications/editor/components/InfraErrors/InfraErrorsModal.tsx
@@ -2,10 +2,10 @@ import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
-import { OsrdConfState } from 'applications/operationalStudies/consts';
 import { Modal } from 'common/BootstrapSNCF/ModalSNCF';
 import InfraErrorsList from './InfraErrorsList';
 import { InfraError } from './types';
+import { getInfraID } from '../../../../reducers/osrdconf/selectors';
 
 interface InfraErrorsModalProps {
   onErrorClick: (infraId: number, item: InfraError) => void | Promise<void>;
@@ -13,7 +13,7 @@ interface InfraErrorsModalProps {
 
 const InfraErrorsModal: FC<InfraErrorsModalProps> = ({ onErrorClick }) => {
   const { t } = useTranslation();
-  const infraID = useSelector((state: { osrdconf: OsrdConfState }) => state.osrdconf.infraID);
+  const infraID = useSelector(getInfraID);
 
   return (
     <Modal title={t('Editor.infra-errors.modal.title', { id: infraID })}>

--- a/front/src/applications/editor/tools/pointEdition/tool-factory.ts
+++ b/front/src/applications/editor/tools/pointEdition/tool-factory.ts
@@ -81,7 +81,7 @@ function getPointEditionTool<T extends EditorPoint>({
     ],
 
     // Interactions:
-    onClickMap(_e, { setState, state, osrdConf: { infraID } }) {
+    onClickMap(_e, { setState, state, infraID }) {
       const { isHoveringTarget, entity, nearestPoint } = state;
       if (entity.geometry && !isEqual(entity.geometry, NULL_GEOMETRY) && isHoveringTarget) {
         setState({
@@ -106,7 +106,7 @@ function getPointEditionTool<T extends EditorPoint>({
 
         // retrieve the track section to be sure that the computation of the distance will be good
         // we can't trust maplibre, because the stored gemetry is not necessary the real one
-        getEntity(infraID as string, newEntity.properties.track, 'TrackSection').then((track) => {
+        getEntity(infraID as number, newEntity.properties.track, 'TrackSection').then((track) => {
           newEntity.properties.position = nearestPointOnLine(
             (track as Feature<LineString>).geometry,
             newEntity.geometry as Point,
@@ -178,12 +178,12 @@ function getPointEditionTool<T extends EditorPoint>({
     },
 
     // Lifecycle:
-    onMount({ state: { entity }, osrdConf: { infraID } }) {
+    onMount({ state: { entity }, infraID }) {
       const trackId = entity.properties?.track;
 
       if (typeof trackId !== 'string') return;
 
-      getEntity(infraID as string, trackId, 'TrackSection').then((track) => {
+      getEntity(infraID as number, trackId, 'TrackSection').then((track) => {
         const dbPosition = entity.properties.position;
         const computedPosition = nearestPointOnLine(
           (track as Feature<LineString>).geometry,

--- a/front/src/applications/editor/tools/routeEdition/components.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components.tsx
@@ -9,6 +9,7 @@ import GeoJSONs from '../../../../common/Map/Layers/GeoJSONs';
 import { RouteEditionState } from './types';
 import { EditRoutePathEditionLayers, EditRoutePathLeftPanel } from './components/EditRoutePath';
 import { EditRouteMetadataLayers, EditRouteMetadataPanel } from './components/EditRouteMetadata';
+import { getMapStyle } from '../../../../reducers/map/selectors';
 
 export const RouteEditionLeftPanel: FC = () => {
   const { state } = useContext(EditorContext) as ExtendedEditorContextType<RouteEditionState>;
@@ -30,9 +31,7 @@ export const RouteEditionLayers: FC = () => {
     renderingFingerprint,
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<RouteEditionState>;
-  const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
-    mapStyle: string;
-  };
+  const mapStyle = useSelector(getMapStyle);
 
   return (
     <>

--- a/front/src/applications/editor/tools/routeEdition/components/Endpoints.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/Endpoints.tsx
@@ -4,8 +4,9 @@ import { BsArrowBarRight, BsBoxArrowInRight } from 'react-icons/bs';
 import { HiSwitchVertical } from 'react-icons/hi';
 import { FaFlagCheckered } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-
 import { useSelector } from 'react-redux';
+
+import { getInfraID } from 'reducers/osrdconf/selectors';
 import WayPointInput from './WayPointInput';
 import {
   BufferStopEntity,
@@ -15,7 +16,6 @@ import {
   WayPointEntity,
 } from '../../../../../types';
 import { RouteState } from '../types';
-import { OSRDConf } from '../../types';
 import EditorContext from '../../../context';
 import { getEntity } from '../../../data/api';
 import { BufferStopEditionTool, DetectorEditionTool } from '../../pointEdition/tools';
@@ -98,7 +98,7 @@ export const EditEndpoints: FC<{ state: RouteState; onChange: (newState: RouteSt
 const ExtremityDisplay: FC<WayPoint> = ({ type, id }) => {
   const { t } = useTranslation();
   const { switchTool } = useContext(EditorContext);
-  const osrdConf = useSelector(({ osrdconf }: { osrdconf: OSRDConf }) => osrdconf);
+  const infraID = useSelector(getInfraID);
 
   return (
     <div className="d-flex align-items-center">
@@ -108,7 +108,7 @@ const ExtremityDisplay: FC<WayPoint> = ({ type, id }) => {
           className="btn btn-primary btn-sm"
           title={t('common.open')}
           onClick={() => {
-            getEntity<WayPointEntity>(osrdConf.infraID as string, id, type).then((entity) => {
+            getEntity<WayPointEntity>(infraID as number, id, type).then((entity) => {
               if (type === 'Detector') {
                 switchTool(DetectorEditionTool, {
                   initialEntity: entity as DetectorEntity,

--- a/front/src/applications/editor/tools/routeEdition/components/WayPointInput.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/WayPointInput.tsx
@@ -6,11 +6,12 @@ import { Position } from 'geojson';
 
 import { EndPoint, WayPoint, WayPointEntity } from '../../../../../types';
 import EditorContext from '../../../context';
-import { ExtendedEditorContextType, OSRDConf } from '../../types';
+import { ExtendedEditorContextType } from '../../types';
 import { EditRoutePathState } from '../types';
 import { getEntity } from '../../../data/api';
 import EntitySumUp from '../../../components/EntitySumUp';
 import Tipped from '../../../components/Tipped';
+import { getInfraID } from '../../../../../reducers/osrdconf/selectors';
 
 const WayPointInput: FC<{
   endPoint: EndPoint;
@@ -21,7 +22,7 @@ const WayPointInput: FC<{
     EditorContext
   ) as ExtendedEditorContextType<EditRoutePathState>;
   const { t } = useTranslation();
-  const osrdConf = useSelector(({ osrdconf }: { osrdconf: OSRDConf }) => osrdconf);
+  const infraID = useSelector(getInfraID);
   const [entityState, setEntityState] = useState<
     { type: 'data'; entity: WayPointEntity } | { type: 'loading' } | { type: 'empty' }
   >({ type: 'empty' });
@@ -67,8 +68,8 @@ const WayPointInput: FC<{
     ) {
       if (wayPoint) {
         setEntityState({ type: 'loading' });
-        getEntity<WayPointEntity>(osrdConf.infraID as string, wayPoint.id, wayPoint.type).then(
-          (entity) => setEntityState({ type: 'data', entity })
+        getEntity<WayPointEntity>(infraID as number, wayPoint.id, wayPoint.type).then((entity) =>
+          setEntityState({ type: 'data', entity })
         );
       } else {
         setEntityState({ type: 'empty' });

--- a/front/src/applications/editor/tools/routeEdition/utils.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.ts
@@ -6,7 +6,6 @@ import lineSlice from '@turf/line-slice';
 import { RouteCandidate, RouteEditionState } from './types';
 import { DEFAULT_COMMON_TOOL_STATE } from '../types';
 import {
-  Direction,
   PartialButFor,
   RouteEntity,
   TrackRange,
@@ -65,7 +64,7 @@ export function computeRouteGeometry(
     removeDuplicatePoints(
       trackRanges.flatMap((range, i) => {
         const track = tracks[range.track];
-        const direction = range.direction;
+        const { direction } = range;
 
         if (!track) throw new Error(`Track ${range.track} not found`);
 

--- a/front/src/applications/editor/tools/selection/components.tsx
+++ b/front/src/applications/editor/tools/selection/components.tsx
@@ -16,6 +16,7 @@ import EntitySumUp from '../../components/EntitySumUp';
 
 import './styles.scss';
 import { zoneToFeature } from '../../../../utils/mapboxHelper';
+import { getMapStyle } from '../../../../reducers/map/selectors';
 
 export const SelectionMessages: FC = () => {
   const { t, state } = useContext(EditorContext) as EditorContextType<SelectionState>;
@@ -39,9 +40,7 @@ export const SelectionLayers: FC = () => {
     editorState: { editorLayers },
     renderingFingerprint,
   } = useContext(EditorContext) as ExtendedEditorContextType<SelectionState>;
-  const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
-    mapStyle: string;
-  };
+  const mapStyle = useSelector(getMapStyle);
 
   let selectionZone: Zone | undefined;
 

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -217,7 +217,7 @@ const SelectionTool: Tool<SelectionState> = {
       selection,
     });
   },
-  onClickMap(e, { setState, state, osrdConf }) {
+  onClickMap(e, { setState, state, infraID }) {
     const position = e.lngLat;
     const map = e.target;
 
@@ -240,7 +240,7 @@ const SelectionTool: Tool<SelectionState> = {
 
           setState({ isLoading: true });
           getMixedEntities(
-            osrdConf.infraID as string,
+            infraID as number,
             selection.flatMap((entity) =>
               entity.properties?.id
                 ? [
@@ -296,7 +296,7 @@ const SelectionTool: Tool<SelectionState> = {
 
           setState({ isLoading: true });
           getMixedEntities(
-            osrdConf.infraID as string,
+            infraID as number,
             selection.flatMap((entity) =>
               entity.properties?.id
                 ? [

--- a/front/src/applications/editor/tools/switchEdition/tool.ts
+++ b/front/src/applications/editor/tools/switchEdition/tool.ts
@@ -17,10 +17,10 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
     );
   },
 
-  getInitialState({ osrdConf }) {
-    if (!osrdConf.switchTypes?.length) throw new Error('There is no switch type yet.');
+  getInitialState({ switchTypes }) {
+    if (!switchTypes?.length) throw new Error('There is no switch type yet.');
 
-    const entity = getNewSwitch(osrdConf.switchTypes[0]);
+    const entity = getNewSwitch(switchTypes[0]);
 
     return {
       ...DEFAULT_COMMON_TOOL_STATE,
@@ -36,10 +36,10 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
         id: 'new-switch',
         icon: IoMdAddCircleOutline,
         labelTranslationKey: 'Editor.tools.switch-edition.actions.new-switch',
-        onClick({ setState, osrdConf }) {
-          if (!osrdConf.switchTypes?.length) throw new Error('There is no switch type yet.');
+        onClick({ setState, switchTypes }) {
+          if (!switchTypes?.length) throw new Error('There is no switch type yet.');
 
-          const entity = getNewSwitch(osrdConf.switchTypes[0]);
+          const entity = getNewSwitch(switchTypes[0]);
 
           setState({
             ...DEFAULT_COMMON_TOOL_STATE,

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -15,6 +15,7 @@ import { CreateEntityOperation, TrackSectionEntity } from '../../../../types';
 import { ExtendedEditorContextType } from '../types';
 import { injectGeometry } from './utils';
 import { NEW_ENTITY_ID } from '../../data/utils';
+import { getMapStyle } from '../../../../reducers/map/selectors';
 
 export const TRACK_LAYER_ID = 'trackEditionTool/new-track-path';
 export const POINTS_LAYER_ID = 'trackEditionTool/new-track-points';
@@ -28,9 +29,7 @@ export const TrackEditionLayers: FC = () => {
     renderingFingerprint,
     editorState: { editorLayers },
   } = useContext(EditorContext) as ExtendedEditorContextType<TrackEditionState>;
-  const { mapStyle } = useSelector((s: { map: { mapStyle: string } }) => s.map) as {
-    mapStyle: string;
-  };
+  const mapStyle = useSelector(getMapStyle);
 
   const isAddingPointOnExistingSection =
     typeof state.nearestPoint?.properties?.sectionIndex === 'number';

--- a/front/src/applications/editor/tools/types.ts
+++ b/front/src/applications/editor/tools/types.ts
@@ -59,8 +59,8 @@ export interface MapState {
   viewport: ViewState;
 }
 export interface OSRDConf {
-  infraID: string | number | undefined;
-  switchTypes: SwitchType[] | null;
+  infraID: number | undefined;
+  switchTypes: SwitchType[] | undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -90,7 +90,8 @@ export interface ExtendedEditorContextType<S> extends EditorContextType<S> {
   dispatch: Dispatch<any>;
   editorState: EditorState;
   mapState: MapState;
-  osrdConf: OSRDConf;
+  infraID: number | undefined;
+  switchTypes: SwitchType[] | undefined;
 }
 
 export type ReadOnlyEditorContextType<S> = Omit<
@@ -130,7 +131,10 @@ export interface Tool<S> {
   icon: IconType;
   labelTranslationKey: string;
   actions: ToolAction<S>[][];
-  getInitialState: (context: { osrdConf: OSRDConf }) => S;
+  getInitialState: (context: {
+    infraID: number | undefined;
+    switchTypes: SwitchType[] | undefined;
+  }) => S;
   requiredLayers?: Set<LayerType>;
   isDisabled?: (context: ReadOnlyEditorContextType<S>) => boolean;
 

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -4,7 +4,7 @@ import chroma from 'chroma-js';
 import { Feature, FeatureCollection } from 'geojson';
 import { isPlainObject, keyBy, mapValues } from 'lodash';
 import { Layer, Source } from 'react-map-gl';
-import { getConf } from 'reducers/osrdconf/selectors';
+import { getInfraID } from 'reducers/osrdconf/selectors';
 import { SymbolPaint } from 'mapbox-gl';
 
 import { AnyLayer, Theme } from '../../../types';
@@ -26,7 +26,7 @@ import {
   getLineTextErrorsLayerProps,
   getPointTextErrorsLayerProps,
 } from './Errors';
-import { LayerType, OSRDConf } from '../../../applications/editor/tools/types';
+import { LayerType } from '../../../applications/editor/tools/types';
 import { ALL_SIGNAL_LAYERS, SYMBOLS_TO_LAYERS } from '../Consts/SignalsNames';
 import { MAP_TRACK_SOURCE, MAP_URL } from '../const';
 
@@ -245,7 +245,7 @@ const GeoJSONs: FC<{
   layers?: Set<LayerType>;
   fingerprint?: string | number;
 }> = ({ colors, hidden, selection, layers, fingerprint, prefix = 'editor/' }) => {
-  const osrdConf = useSelector(getConf);
+  const infraID = useSelector(getInfraID);
   const selectedPrefix = `${prefix}selected/`;
   const hiddenColors = useMemo(
     () => transformTheme(colors, (color) => chroma(color).desaturate(50).brighten(1).hex()),
@@ -293,14 +293,14 @@ const GeoJSONs: FC<{
           ? [
               {
                 id: `${prefix}geo/${source.entityType}`,
-                url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${osrdConf.infraID}`,
+                url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${infraID}`,
                 layers: source
                   .getLayers({ ...hiddenLayerContext, sourceTable: source.entityType }, prefix)
                   .map((layer) => adaptFilter(layer, (hidden || []).concat(selection || []), [])),
               },
               {
                 id: `${selectedPrefix}geo/${source.entityType}`,
-                url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${osrdConf.infraID}`,
+                url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${infraID}`,
                 layers: source
                   .getLayers({ ...layerContext, sourceTable: source.entityType }, selectedPrefix)
                   .map((layer) => adaptFilter(layer, hidden || [], selection || [])),
@@ -308,16 +308,7 @@ const GeoJSONs: FC<{
             ]
           : []
       ),
-    [
-      hidden,
-      hiddenLayerContext,
-      layerContext,
-      layers,
-      osrdConf.infraID,
-      prefix,
-      selectedPrefix,
-      selection,
-    ]
+    [hidden, hiddenLayerContext, layerContext, layers, infraID, prefix, selectedPrefix, selection]
   );
 
   return (


### PR DESCRIPTION
The cause of this issue is a recent update of selectors, that made all inline selectors broken. And the editor was full of them...

This commit replaces all inline selectors to external stores (internal ones were not impacted, so I'll deal with them later) by the proper ones.