### PR TITLE
core: mareco: rework accelerating slope detection

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/AcceleratingSlopeCoast.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/AcceleratingSlopeCoast.java
@@ -1,38 +1,92 @@
 package fr.sncf.osrd.envelope_sim.allowances.mareco_impl;
 
+import static java.lang.Double.NaN;
+
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeCursor;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.Action;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
+import fr.sncf.osrd.envelope_utils.DistanceAverage;
 import java.util.ArrayList;
 
 /** Encodes metadata about an accelerating slope on a plateau */
 public class AcceleratingSlopeCoast implements CoastingOpportunity {
-    private double endPos;
+    /** Position where the coasting envelope should merge back into the base envelope */
+    private double endPos = NaN;
 
     /** Average acceleration of the train during the slope */
-    private double slopeAverageAcceleration;
+    private double slopeAverageAcceleration = NaN;
 
     /** An estimate of the average acceleration of the train
      * from the start of coasting to the beginning of the accelerating slope */
-    private double previousAccelerationEstimate;
+    private double previousAccelerationEstimate = NaN;
+
+    /** Position where the train starts accelerating again until it reaches the max speed */
+    private final double accelerationStartPosition;
 
     /** The start and end speed limit of the accelerating slope */
-    private double speedLimit;
+    private final double speedLimit;
+
+    /** Used to compute the mean acceleration over the accelerating slope */
+    private final DistanceAverage meanAccelerationBuilder = new DistanceAverage();
 
     private AcceleratingSlopeCoast(
-            double endPos,
-            double slopeAverageAcceleration,
-            double previousAccelerationEstimate,
+            double accelerationStartPosition,
             double speedLimit
     ) {
-        this.endPos = endPos;
-        this.slopeAverageAcceleration = slopeAverageAcceleration;
-        this.previousAccelerationEstimate = previousAccelerationEstimate;
+        this.accelerationStartPosition = accelerationStartPosition;
         this.speedLimit = speedLimit;
+    }
+
+    /** Finish building the slope instance, once we know the end position */
+    private AcceleratingSlopeCoast build(double endPos, EnvelopeSimContext context) {
+        this.slopeAverageAcceleration = meanAccelerationBuilder.getAverage();
+        this.previousAccelerationEstimate = estimatePreviousAcceleration(context);
+        this.endPos = endPos;
+        assert !Double.isNaN(slopeAverageAcceleration);
+        assert !Double.isNaN(endPos);
+        assert !Double.isNaN(previousAccelerationEstimate);
+        assert !Double.isNaN(speedLimit);
+        return this;
+    }
+
+    /** Estimates the average acceleration during the part where the train decelerates */
+    private double estimatePreviousAcceleration(EnvelopeSimContext context) {
+        // We look for the natural acceleration an offset before the start of the slope.
+        // The exact offset is arbitrary, we only need an approximation
+        // (as long as there is no discontinuity in the binary search).
+        // It still needs to be fairly large as the train covers a wide area.
+        // We use the train length to make sure the head of the train isn't on the slope.
+        var accelerationStart = findExactStartAcceleratingSlope(context);
+        var offset = context.rollingStock.getLength();
+        var estimatePosition = Math.max(0, accelerationStart - offset);
+        return Math.min(0, getNaturalAcceleration(context, estimatePosition, speedLimit));
+    }
+
+    /** Returns the exact position where the natural acceleration sign goes from negative to positive */
+    private double findExactStartAcceleratingSlope(EnvelopeSimContext context) {
+        // We do this by starting from the first position with a positive acceleration,
+        // and we go back until it's negative. We may go back for more than one step if the part
+        // started in a slope.
+
+        double positionStep = 10; // Because we interpolate, there's no need for a small step
+        var position = accelerationStartPosition;
+        while (position > 0 && getNaturalAcceleration(context, position, speedLimit) > 0)
+            position -= positionStep;
+        if (position <= 0)
+            return 0; // The path is on a negative slope from its start
+        var accelerationPrevStep =  getNaturalAcceleration(context, position, speedLimit);
+        var accelerationNextStep = getNaturalAcceleration(context, position + positionStep, speedLimit);
+        assert accelerationPrevStep <= 0;
+        assert accelerationNextStep >= 0;
+        return interpolateAccelerationSignChange(
+                accelerationNextStep, accelerationPrevStep,
+                position + positionStep, position
+        );
     }
 
     @Override
@@ -47,6 +101,7 @@ public class AcceleratingSlopeCoast implements CoastingOpportunity {
         // the lowest possible speed that will catch up with target speed at the end
         double wle = rollingStock.getRollingResistance(v1) * v1 * vf / (v1 - vf);
         double accelRatio = previousAccelerationEstimate / slopeAverageAcceleration;
+        assert accelRatio <= 0;
         return 1 / (1 / speedLimit + rollingStock.getRollingResistance(speedLimit) / (wle * (1 - accelRatio)));
     }
 
@@ -75,11 +130,6 @@ public class AcceleratingSlopeCoast implements CoastingOpportunity {
             double vf
     ) {
         var res = new ArrayList<AcceleratingSlopeCoast>();
-        double previousPosition = 0.0;
-        double previousAcceleration = 0.0;
-        double meanAcceleration = 0.0;
-        double accelerationLength = 0.0;
-        var currentAcceleratingSlope = new AcceleratingSlopeCoast(0, 0, 0, 0);
         var cursor = EnvelopeCursor.forward(envelope);
         // scan until maintain speed envelope parts
         while (cursor.findPart(MaxEffortEnvelope::maxEffortPlateau)) {
@@ -91,61 +141,63 @@ public class AcceleratingSlopeCoast implements CoastingOpportunity {
                 continue;
             }
 
+            double previousPosition = NaN;
+            double previousAcceleration = NaN;
+            AcceleratingSlopeCoast currentAcceleratingSlope = null;
+
             // constant variables for this plateau
-            double rollingResistance = context.rollingStock.getRollingResistance(speed);
             var envelopePart = cursor.getPart();
             var positionStep = context.timeStep * speed;
 
-            // initializing variables
-            double position = cursor.getPosition();
-            double weightForce = TrainPhysicsIntegrator.getWeightForce(context.rollingStock, context.path, position);
-            var naturalAcceleration = TrainPhysicsIntegrator.computeAcceleration(context.rollingStock,
-                    rollingResistance, weightForce, speed, 0, 0, 1);
-
-            while (cursor.getPosition() <= envelopePart.getEndPos()) {
+            while (!cursor.hasReachedEnd() && cursor.getPosition() <= envelopePart.getEndPos()) {
+                double position = cursor.getPosition();
+                double naturalAcceleration = getNaturalAcceleration(context, position, speed);
                 if (naturalAcceleration > 0) {
-                    // beginning of accelerating slope
-                    // add acceleration * distance step to the weighted mean acceleration
-                    var distanceStep = cursor.getStepLength();
-                    meanAcceleration += naturalAcceleration * distanceStep;
-                    accelerationLength += distanceStep;
-                    if (previousAcceleration < 0)
-                        currentAcceleratingSlope.previousAccelerationEstimate = previousAcceleration;
-                } else if (naturalAcceleration <= 0 && accelerationLength > 0) {
+                    // Accelerating slope
+                    if (currentAcceleratingSlope == null)
+                        currentAcceleratingSlope = new AcceleratingSlopeCoast(position, speed);
+                    currentAcceleratingSlope.meanAccelerationBuilder.addSegment(positionStep, naturalAcceleration);
+                } else if (currentAcceleratingSlope != null) {
                     // end the accelerating slope
-                    currentAcceleratingSlope.endPos = previousPosition;
-                    currentAcceleratingSlope.speedLimit = speed;
-                    meanAcceleration /= accelerationLength;
-                    currentAcceleratingSlope.slopeAverageAcceleration = meanAcceleration;
-                    res.add(currentAcceleratingSlope);
-                    // reset meanAcceleration, accelerationLength, and accelerating slope
-                    meanAcceleration = 0;
-                    accelerationLength = 0;
-                    currentAcceleratingSlope = new AcceleratingSlopeCoast(0, 0, 0, 0);
+                    var endPos = interpolateAccelerationSignChange(
+                            naturalAcceleration, previousAcceleration,
+                            position, previousPosition
+                    );
+                    res.add(currentAcceleratingSlope.build(endPos, context));
+                    currentAcceleratingSlope = null; // reset the accelerating slope
                 }
                 previousAcceleration = naturalAcceleration;
                 previousPosition = position;
                 cursor.findPosition(position + positionStep);
-                if (cursor.hasReachedEnd())
-                    break;
-                position = cursor.getPosition();
-                weightForce = TrainPhysicsIntegrator.getWeightForce(context.rollingStock, context.path, position);
-                naturalAcceleration = TrainPhysicsIntegrator.computeAcceleration(context.rollingStock,
-                        rollingResistance, weightForce, speed, 0, 0, 1);
             }
             // if the end of the plateau is an accelerating slope
-            if (accelerationLength > 0) {
-                currentAcceleratingSlope.endPos = previousPosition;
-                currentAcceleratingSlope.speedLimit = speed;
-                meanAcceleration /= accelerationLength;
-                currentAcceleratingSlope.slopeAverageAcceleration = meanAcceleration;
-                res.add(currentAcceleratingSlope);
-                // reset meanAcceleration, accelerationLength, and accelerating slope
-                meanAcceleration = 0;
-                accelerationLength = 0;
-                currentAcceleratingSlope = new AcceleratingSlopeCoast(0, 0, 0, 0);
-            }
+            if (currentAcceleratingSlope != null)
+                res.add(currentAcceleratingSlope.build(previousPosition, context));
         }
+        return res;
+    }
+
+    /** Returns acceleration at the given position if the train coasts */
+    private static double getNaturalAcceleration(EnvelopeSimContext context, double position, double speed) {
+        return TrainPhysicsIntegrator.step(context, position, speed, Action.COAST, 1).acceleration;
+    }
+
+    /** Interpolate the exact position where the natural acceleration is 0 */
+    private static double interpolateAccelerationSignChange(
+            double currentAcceleration,
+            double previousAcceleration,
+            double currentPosition,
+            double previousPosition
+    ) {
+        assert !Double.isNaN(previousAcceleration);
+        if (Math.abs(currentPosition - previousPosition) < TrainPhysicsIntegrator.POSITION_EPSILON)
+            return currentPosition;
+        if (Math.abs(currentAcceleration - previousAcceleration) < TrainPhysicsIntegrator.SPEED_EPSILON)
+            return currentPosition;
+        double factor = (previousAcceleration - currentAcceleration) / (previousPosition - currentPosition);
+        double y0 = previousAcceleration - factor * previousPosition;
+        var res = -y0 / factor;
+        assert previousPosition <= res && res <= currentPosition;
         return res;
     }
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
@@ -80,7 +80,7 @@ public final class CoastingGenerator {
             return backwardPartBuilder.build();
 
         var resultCoast = coastFromBeginning(envelope, context, constrainedBuilder.getLastPos());
-        assert resultCoast == null || resultCoast.getEndPos() <= endPos;
+        assert resultCoast == null || resultCoast.getEndPos() <= endPos + context.timeStep * speed;
         return resultCoast;
     }
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/DistanceAverage.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/DistanceAverage.java
@@ -1,0 +1,19 @@
+package fr.sncf.osrd.envelope_utils;
+
+/** This class can be used to compute average values over distances,
+ * adding segments iteratively. */
+public class DistanceAverage {
+    private double totalWeightedValue = 0;
+    private double totalLength = 0;
+
+    /** Add a segment of size `length`, with an average value of `value` */
+    public void addSegment(double length, double value) {
+        totalWeightedValue += value * length;
+        totalLength += length;
+    }
+
+    /** Returns the average value over all the given segments */
+    public double getAverage() {
+        return totalWeightedValue / totalLength;
+    }
+}


### PR DESCRIPTION
Rework the methods used to detect accelerating slopes. It is *mostly* a cleanup that moves code around into smaller parts, but there are a few actual changes aiming to fix https://github.com/DGEXSolutions/osrd/issues/3140:

1. Fix a bug where "previous[...]" variables would carry over from one plateau to the next, causing binary search discontinuities
2. Finer interpolation to detect the end of the accelerating slope
3. Rework of the "previous acceleration" estimation: instead of picking the previous value (which caused *several* problems), we find the exact start of the accelerating slope, then get the acceleration a certain distance before that.

Fixes https://github.com/DGEXSolutions/osrd/issues/3140

https://github.com/DGEXSolutions/osrd/issues/2584 now appears in a unit test, and it seems closely related. I'll try to fix this on the same branch (-> draft)