### PR TITLE
codecov: java: fix coverage for assertions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -30,3 +30,7 @@ flags:
     paths:
       - front/
     carryforward: true
+
+parsers:
+  jacoco:
+    partials_as_hits: true


### PR DESCRIPTION
Assertions lowering the coverage value because of "partial hits" is a problem, this change tries to fix it.

I couldn't just filter out the assert statements, so the only option I've found was to consider partials  hits as covered. 