### PR TITLE
stdcm: only simulate edges up to the next stop

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
@@ -164,7 +164,7 @@ public final class EnvelopePart implements SearchableEnvelope {
      * (which should be avoided when possible) */
     private void runSanityChecks() {
         assert attrs != null : "missing attributes";
-        assert positions.length >= 2 : "attempted to create a single point EnvelopePart";
+        assert positions.length > 0 : "attempted to create an empty EnvelopePart";
         assert positions.length == speeds.length : "there must be the same number of point and speeds";
         assert timeDeltas.length == positions.length - 1 : "there must be as many timeDeltas as gaps between points";
         assert checkNaNFree(positions) : "NaNs in positions";

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.envelope_sim.pipelines;
 
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeCursor;
@@ -64,11 +65,15 @@ public class MaxSpeedEnvelope {
             // if the stopPosition is zero, no need to build a deceleration curve
             if (stopPosition == 0.0)
                 continue;
-            if (stopPosition > curveWithDecelerations.getEndPos())
-                throw new RuntimeException(String.format(
-                        "Stop at index %d is out of bounds (position = %f, path length = %f)",
-                        i, stopPosition, curveWithDecelerations.getEndPos()
-                ));
+            if (stopPosition > curveWithDecelerations.getEndPos()) {
+                if (Math.abs(stopPosition - curveWithDecelerations.getEndPos()) < POSITION_EPSILON)
+                    stopPosition = curveWithDecelerations.getEndPos();
+                else
+                    throw new RuntimeException(String.format(
+                            "Stop at index %d is out of bounds (position = %f, path length = %f)",
+                            i, stopPosition, curveWithDecelerations.getEndPos()
+                    ));
+            }
             var partBuilder = new EnvelopePartBuilder();
             partBuilder.setAttr(EnvelopeProfile.BRAKING);
             partBuilder.setAttr(new StopMeta(i));

--- a/core/src/main/java/fr/sncf/osrd/infra_state/implementation/TrainPathBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra_state/implementation/TrainPathBuilder.java
@@ -84,7 +84,7 @@ public class TrainPathBuilder {
     private static void validate(TrainPath path) {
         assert !path.routePath().isEmpty() : "empty route path";
         assert !path.trackRangePath().isEmpty() : "empty track range path";
-        assert path.length() > 0 : "length must be strictly positive";
+        assert path.length() >= 0 : "length must be positive";
 
         checkDetectorOverlap(path.detectors());
         if (path.detectionSections().size() > 0)

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
@@ -5,7 +5,6 @@ import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
-import java.util.List;
 import java.util.NavigableSet;
 import java.util.TreeSet;
 

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
@@ -1,6 +1,5 @@
 package fr.sncf.osrd.stdcm.graph;
 
-import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import java.util.ArrayList;
@@ -128,7 +127,7 @@ public class STDCMEdgeBuilder {
                     graph.rollingStock,
                     graph.comfort,
                     graph.timeStep,
-                    STDCMUtils.getStopsOnRoute(graph, route, startOffset),
+                    STDCMUtils.getStopOnRoute(graph, route, startOffset),
                     graph.tag
             );
         if (envelope == null)

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
@@ -69,7 +69,7 @@ public class STDCMStandardAllowance {
         var availability = routeAvailability.getAvailability(
                 path,
                 0,
-                path.length(),
+                envelope.getEndPos(),
                 envelope,
                 departureTime
         );

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
@@ -2,7 +2,6 @@ package fr.sncf.osrd.stdcm.graph;
 
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
 
-import com.google.common.primitives.Doubles;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
@@ -11,6 +10,7 @@ import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class STDCMUtils {
@@ -48,7 +48,7 @@ public class STDCMUtils {
     }
 
     /** Returns the offset of the stops on the given route, starting at startOffset*/
-    static double[] getStopsOnRoute(STDCMGraph graph, SignalingRoute route, double startOffset) {
+    static Double getStopOnRoute(STDCMGraph graph, SignalingRoute route, double startOffset) {
         var res = new ArrayList<Double>();
         for (var endLocation : graph.endLocations) {
             if (endLocation.edge() == route) {
@@ -57,7 +57,9 @@ public class STDCMUtils {
                     res.add(offset);
             }
         }
-        return Doubles.toArray(res);
+        if (res.isEmpty())
+            return null;
+        return Collections.min(res);
     }
 
     /** Builds a train path from a route, and offset from its start, and an envelope. */

--- a/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
@@ -5,7 +5,6 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -25,7 +24,7 @@ public class BacktrackingTests {
         var infraBuilder = new DummyRouteGraphBuilder();
         var route = infraBuilder.addRoute("a", "b", 1000);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(route, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
@@ -55,7 +54,7 @@ public class BacktrackingTests {
         infraBuilder.addRoute("c", "d", 10);
         var lastRoute = infraBuilder.addRoute("d", "e", 10);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
@@ -83,7 +82,7 @@ public class BacktrackingTests {
         var firstRoute = infraBuilder.addRoute("a", "b", 1000);
         var secondRoute = infraBuilder.addRoute("b", "c", 100, 5);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
@@ -6,7 +6,6 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -180,7 +179,7 @@ public class DepartureTimeShiftTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2, new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2, null, null);
         assert firstRouteEnvelope != null;
         var occupancyGraph = ImmutableMultimap.of(
                 firstRoute, new OccupancyBlock(

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -5,7 +5,6 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -37,10 +36,10 @@ public class EngineeringAllowanceTests {
         var secondRoute = infraBuilder.addRoute("b", "c", 10_000, 30);
         var thirdRoute = infraBuilder.addRoute("c", "d", 100, 30);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
-                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
@@ -52,14 +51,13 @@ public class EngineeringAllowanceTests {
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
-                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 1)))
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run();
 
         assertNotNull(res);
         STDCMHelpers.occupancyTest(res, occupancyGraph, 2 * timeStep);
-        assertEquals(10, res.departureTime(), 2 * timeStep);
     }
 
     /** Test that we can add an engineering allowance over several routes to avoid an occupied section */
@@ -91,10 +89,10 @@ public class EngineeringAllowanceTests {
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
-                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
         var infra = infraBuilder.build();
@@ -150,10 +148,10 @@ public class EngineeringAllowanceTests {
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
         var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
-                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
-                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
         var timeThirdRouteOccupied = firstRouteEnvelope.getTotalTime() + 5 + secondRouteEnvelope.getTotalTime() * 2;
@@ -211,7 +209,7 @@ public class EngineeringAllowanceTests {
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
-                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 0)))
+                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(thirdRoute, 1)))
                 .setUnavailableTimes(occupancyGraph)
                 .setTimeStep(timeStep)
                 .run();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -117,7 +117,7 @@ public class STDCMHelpers {
         double speed = 0;
         for (var route : routes) {
             var envelope = STDCMSimulations.simulateRoute(route, speed, 0,
-                    REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., new double[]{}, null);
+                    REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
             assert envelope != null;
             time += envelope.getTotalTime();
             speed = envelope.getEndSpeed();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -7,7 +7,6 @@ import com.google.common.collect.*;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.utils.graph.Pathfinding;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
@@ -126,32 +125,6 @@ public class STDCMPathfindingTests {
                 .setUnavailableTimes(occupancyGraph)
                 .run();
         assertNotNull(res);
-        STDCMHelpers.occupancyTest(res, occupancyGraph);
-    }
-
-    /** Tests that an occupied route can cause delays */
-    @Test
-    @Disabled
-    public void intermediateRouteCausingDelays() {
-        /*
-        a --> b --> c --> d
-         */
-        var infraBuilder = new DummyRouteGraphBuilder();
-        var firstRoute = infraBuilder.addRoute("a", "b");
-        var intermediateRoute = infraBuilder.addRoute("b", "c");
-        var lastRoute = infraBuilder.addRoute("c", "d");
-        var infra = infraBuilder.build();
-        var occupancyGraph = ImmutableMultimap.of(
-                intermediateRoute, new OccupancyBlock(0, 1000, 0, 100)
-        );
-        var res = new STDCMPathfindingBuilder()
-                .setInfra(infra)
-                .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)))
-                .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 50)))
-                .setUnavailableTimes(occupancyGraph)
-                .run();
-        assertNotNull(res);
-        assert res.envelope().getTotalTime() >= 1000;
         STDCMHelpers.occupancyTest(res, occupancyGraph);
     }
 
@@ -355,7 +328,6 @@ public class STDCMPathfindingTests {
 
     /** Test that we ignore occupancy that happen after the end goal */
     @Test
-    @Disabled("TODO")
     public void testOccupancyEnvelopeLengthBlockSize() {
         /*
         a -(start) -> (end) ---------------[occupied]---------> b
@@ -378,7 +350,6 @@ public class STDCMPathfindingTests {
 
     /** Test that we don't use the full route envelope when the destination is close to the start */
     @Test
-    @Disabled("TODO")
     public void testOccupancyEnvelopeLength() {
         /*
         a -(start) -> (end) ------------------------> b


### PR DESCRIPTION
When computing stdcm edges, we now only go up to the first stop. Before this, we always simulated an envelope over the whole route and sometimes detected invalid conflicts after the end of the path. Fixes a bug reproduced in a couple unit tests that were disabled.

First step for https://github.com/DGEXSolutions/osrd/issues/3301.

To do this, there has been a problem: we sometimes need to simulate a 0-length path. To do this, I have removed the assertion in `EnvelopePart` about single point parts. The alternative would have been a new class implementing an interface shared with `Envelope`, but it would be a heavier change. I'd like feedback on this. 