### PR TITLE
editoast: add get_catenaries_on_path endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1595,6 +1595,28 @@ paths:
               schema:
                 $ref: "#/components/schemas/ScenarioResult"
 
+  /pathfinding/{path_id}/catenaries/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve the modes of catenaries along a path
+      parameters:
+        - in: path
+          name: path_id
+          schema:
+            type: integer
+          description: The path's id
+          required: true
+      responses:
+        200:
+          description: A list of ranges associated to catenary modes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CatenaryRange"
+
 components:
   schemas:
     BoundingBox:
@@ -2265,6 +2287,21 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TrackRange"
+
+    CatenaryRange:
+      type: object
+      properties:
+        begin:
+          type: number
+          format: float
+          example: 0.0
+        end:
+          type: number
+          format: float
+          example: 100.0
+        mode:
+          type: string
+          example: "25000"
 
     SearchQuery:
       type: array

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1609,13 +1609,30 @@ paths:
           required: true
       responses:
         200:
-          description: A list of ranges associated to catenary modes
+          description: A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/CatenaryRange"
+                type: object 
+                properties:
+                  catenary_ranges:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatenaryRange"
+                  warnings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum: ["CatenaryOverlap"]
+                        catenary_id:
+                          type: string
+                        overlapping_ranges:
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/TrackRange"
 
 components:
   schemas:

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -1,7 +1,7 @@
 use actix_web::{error::JsonPayloadError, http::StatusCode, HttpResponse, ResponseError};
 use diesel::result::Error as DieselError;
 use redis::RedisError;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::result::Result as StdResult;
@@ -23,11 +23,11 @@ pub trait EditoastError: Error + Send + Sync {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct InternalError {
     #[serde(skip)]
     status: StatusCode,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_deserializing)]
     error_type: &'static str,
     context: HashMap<String, Value>,
     message: String,

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -4,8 +4,9 @@ pub mod tests {
 
     use crate::client::PostgresConfig;
     use crate::models::{
-        Create, Delete, Document, Identifiable, RollingStockLiveryModel, RollingStockModel,
+        Create, Delete, Document, Identifiable, Infra, RollingStockLiveryModel, RollingStockModel,
     };
+    use crate::views::infra::InfraForm;
 
     use actix_web::web::Data;
     use diesel::r2d2::{ConnectionManager, Pool};
@@ -15,7 +16,7 @@ pub mod tests {
 
     pub struct TestFixture<T: Delete + Identifiable + Send> {
         pub model: T,
-        db_pool: Data<Pool<diesel::r2d2::ConnectionManager<diesel::PgConnection>>>,
+        pub db_pool: Data<Pool<diesel::r2d2::ConnectionManager<diesel::PgConnection>>>,
     }
 
     impl<T: Delete + Identifiable + Send> TestFixture<T> {
@@ -89,6 +90,22 @@ pub mod tests {
         };
         TestFixture {
             model: rolling_stock_livery.create(db_pool.clone()).await.unwrap(),
+            db_pool,
+        }
+    }
+
+    #[fixture]
+    pub async fn empty_infra(
+        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+    ) -> TestFixture<Infra> {
+        let infra_form = InfraForm {
+            name: String::from("test_infra"),
+        };
+        TestFixture {
+            model: Infra::from(infra_form)
+                .create(db_pool.clone())
+                .await
+                .unwrap(),
             db_pool,
         }
     }

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -887,6 +887,7 @@ pub mod tests {
     /// No speed section
     /// No signal
     /// No operational point
+    /// No catenary
     ///
     pub fn create_small_infra_cache() -> InfraCache {
         let mut infra_cache = InfraCache::default();

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -1,7 +1,7 @@
 use super::{Create, List, NoParams, Update};
 use crate::error::Result;
 use crate::infra_cache::InfraCache;
-use crate::models::Retrieve;
+use crate::models::{Identifiable, Retrieve};
 use crate::schema::{
     BufferStop, Catenary, Detector, OperationalPoint, RailJson, RailjsonError, Route, Signal,
     SpeedSection, Switch, SwitchType, TrackSection, TrackSectionLink,
@@ -203,6 +203,12 @@ impl List<NoParams> for Infra {
             .distinct()
             .paginate(page, page_size)
             .load_and_count(conn)
+    }
+}
+
+impl Identifiable for Infra {
+    fn get_id(&self) -> i64 {
+        self.id.unwrap()
     }
 }
 

--- a/editoast/src/models/infra_objects/catenary.rs
+++ b/editoast/src/models/infra_objects/catenary.rs
@@ -1,0 +1,36 @@
+#![cfg(test)]
+
+use crate::models::Identifiable;
+use crate::{schema::Catenary as CatenarySchema, tables::osrd_infra_catenarymodel};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use editoast_derive::Model;
+
+#[derive(Debug, Insertable, Queryable, QueryableByName, Model)]
+#[model(table = "osrd_infra_catenarymodel")]
+#[model(create, delete)]
+#[diesel(table_name = osrd_infra_catenarymodel)]
+pub struct Catenary {
+    #[diesel(deserialize_as = i64)]
+    pub id: Option<i64>,
+    pub obj_id: String,
+    pub data: diesel_json::Json<CatenarySchema>,
+    pub infra_id: i64,
+}
+
+impl Catenary {
+    pub fn new(data: CatenarySchema, infra_id: i64, obj_id: String) -> Self {
+        Self {
+            id: None,
+            obj_id,
+            data: diesel_json::Json(data),
+            infra_id,
+        }
+    }
+}
+
+impl Identifiable for Catenary {
+    fn get_id(&self) -> i64 {
+        self.id.unwrap()
+    }
+}

--- a/editoast/src/models/infra_objects/mod.rs
+++ b/editoast/src/models/infra_objects/mod.rs
@@ -1,1 +1,2 @@
+pub mod catenary;
 pub mod track_section;

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -1,7 +1,7 @@
 mod documents;
 pub mod infra;
 pub mod infra_objects;
-mod pathfinding;
+pub mod pathfinding;
 mod projects;
 pub mod rolling_stock;
 mod scenario;

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -1,6 +1,10 @@
 //! Provides the [Pathfinding] model
 
+use std::collections::HashSet;
+
+use crate::models::Identifiable;
 use crate::schema::Direction;
+use crate::schema::DirectionalTrackRange;
 use crate::tables::osrd_infra_pathmodel;
 use chrono::{NaiveDateTime, Utc};
 use derivative::Derivative;
@@ -25,7 +29,8 @@ use serde::Serialize;
 #[model(create, delete, retrieve, update)]
 #[diesel(table_name = osrd_infra_pathmodel)]
 pub struct Pathfinding {
-    pub id: i64,
+    #[diesel(deserialize_as = i64)]
+    pub id: Option<i64>,
     pub owner: uuid::Uuid,
     #[derivative(Default(value = "Utc::now().naive_utc()"))]
     pub created: NaiveDateTime,
@@ -68,17 +73,8 @@ pub struct PathfindingPayload {
 pub struct RoutePath {
     pub route: String,
     pub signaling_type: String,
-    pub track_sections: Vec<RouteTrackSection>,
-}
-
-#[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
-#[derivative(Default)]
-pub struct RouteTrackSection {
-    pub track: String,
-    #[derivative(Default(value = "Direction::StartToStop"))]
-    pub direction: Direction,
-    pub begin: f64,
-    pub end: f64,
+    #[serde(rename = "track_sections")]
+    pub track_ranges: Vec<DirectionalTrackRange>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -90,4 +86,206 @@ pub struct PathWaypoint {
     pub duration: f64,
     pub position: f64,
     pub suggestion: bool,
+}
+
+impl Pathfinding {
+    /// Returns the track sections ids used in this pathfinding
+    pub fn track_section_ids(&self) -> HashSet<String> {
+        self.payload
+            .route_paths
+            .iter()
+            .flat_map(|route_path| &route_path.track_ranges)
+            .map(|track_range| track_range.track.to_string())
+            .collect::<HashSet<_>>()
+    }
+
+    /// Returns the track ranges covered by this pathfinding's route paths.
+    /// Contiguous track ranges on the same track are merged.
+    pub fn merged_track_ranges(&self) -> Vec<DirectionalTrackRange> {
+        let mut res = Vec::new();
+        let mut track_ranges = self
+            .payload
+            .route_paths
+            .iter()
+            .flat_map(|route_path| &route_path.track_ranges)
+            .filter(|track_range| track_range.begin != track_range.end);
+        let mut current_range = track_ranges.next().unwrap().clone();
+        for track_range in track_ranges {
+            assert!(track_range.begin < track_range.end);
+            if track_range.track == current_range.track {
+                assert!(track_range.direction == current_range.direction);
+                match current_range.direction {
+                    Direction::StartToStop => {
+                        assert!(current_range.end == track_range.begin);
+                        current_range.end = track_range.end;
+                    }
+                    Direction::StopToStart => {
+                        assert!(current_range.begin == track_range.end);
+                        current_range.begin = track_range.begin;
+                    }
+                }
+            } else {
+                res.push(current_range.clone());
+                current_range = track_range.clone();
+            }
+        }
+        res.push(current_range);
+        res
+    }
+}
+
+impl Identifiable for Pathfinding {
+    fn get_id(&self) -> i64 {
+        self.id.unwrap()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub fn simple_pathfinding(infra_id: i64) -> Pathfinding {
+        //    T1       T2        T3       T4      T5
+        // |------> < ------| |------> |------> |------>
+        Pathfinding {
+            infra_id,
+            payload: diesel_json::Json(PathfindingPayload {
+                route_paths: vec![
+                    RoutePath {
+                        route: "route_1".into(),
+                        track_ranges: vec![
+                            DirectionalTrackRange {
+                                track: "track_1".into(),
+                                begin: 0.0,
+                                end: 10.0,
+                                direction: Direction::StartToStop,
+                            },
+                            DirectionalTrackRange {
+                                track: "track_2".into(),
+                                begin: 7.0,
+                                end: 10.0,
+                                direction: Direction::StopToStart,
+                            },
+                            DirectionalTrackRange {
+                                // This case happens I swear
+                                track: "track_2".into(),
+                                begin: 7.0,
+                                end: 7.0,
+                                direction: Direction::StartToStop,
+                            },
+                        ],
+                        signaling_type: "BAL3".into(),
+                    },
+                    RoutePath {
+                        route: "route_2".into(),
+                        track_ranges: vec![DirectionalTrackRange {
+                            track: "track_2".into(),
+                            begin: 3.0,
+                            end: 7.0,
+                            direction: Direction::StopToStart,
+                        }],
+                        signaling_type: "BAL3".into(),
+                    },
+                    RoutePath {
+                        route: "route_3".into(),
+                        track_ranges: vec![
+                            DirectionalTrackRange {
+                                track: "track_2".into(),
+                                begin: 0.0,
+                                end: 3.0,
+                                direction: Direction::StopToStart,
+                            },
+                            DirectionalTrackRange {
+                                track: "track_3".into(),
+                                begin: 0.0,
+                                end: 10.0,
+                                direction: Direction::StartToStop,
+                            },
+                            DirectionalTrackRange {
+                                track: "track_4".into(),
+                                begin: 0.0,
+                                end: 2.0,
+                                direction: Direction::StartToStop,
+                            },
+                        ],
+                        signaling_type: "BAL3".into(),
+                    },
+                    RoutePath {
+                        route: "route_4".into(),
+                        track_ranges: vec![
+                            DirectionalTrackRange {
+                                track: "track_4".into(),
+                                begin: 2.0,
+                                end: 10.0,
+                                direction: Direction::StartToStop,
+                            },
+                            DirectionalTrackRange {
+                                track: "track_5".into(),
+                                begin: 0.0,
+                                end: 8.0,
+                                direction: Direction::StartToStop,
+                            },
+                        ],
+                        signaling_type: "BAL3".into(),
+                    },
+                ],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_path_track_section_ids() {
+        let pathfinding = simple_pathfinding(0);
+        let track_section_ids = pathfinding.track_section_ids();
+        assert_eq!(
+            track_section_ids,
+            vec!["track_1", "track_2", "track_3", "track_4", "track_5"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_path_merged_track_ranges() {
+        let pathfinding = simple_pathfinding(0);
+        let merged_track_ranges = pathfinding.merged_track_ranges();
+        assert_eq!(
+            merged_track_ranges,
+            vec![
+                DirectionalTrackRange {
+                    track: "track_1".into(),
+                    begin: 0.0,
+                    end: 10.0,
+                    direction: Direction::StartToStop,
+                },
+                DirectionalTrackRange {
+                    track: "track_2".into(),
+                    begin: 0.0,
+                    end: 10.0,
+                    direction: Direction::StopToStart,
+                },
+                DirectionalTrackRange {
+                    track: "track_3".into(),
+                    begin: 0.0,
+                    end: 10.0,
+                    direction: Direction::StartToStop,
+                },
+                DirectionalTrackRange {
+                    track: "track_4".into(),
+                    begin: 0.0,
+                    end: 10.0,
+                    direction: Direction::StartToStop,
+                },
+                DirectionalTrackRange {
+                    track: "track_5".into(),
+                    begin: 0.0,
+                    end: 8.0,
+                    direction: Direction::StartToStop,
+                },
+            ]
+        );
+    }
 }

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -218,6 +218,15 @@ pub struct DirectionalTrackRange {
     pub direction: Direction,
 }
 
+impl DirectionalTrackRange {
+    pub fn entry_bound(&self) -> f64 {
+        match self.direction {
+            Direction::StartToStop => self.begin,
+            Direction::StopToStart => self.end,
+        }
+    }
+}
+
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[derivative(Default)]

--- a/editoast/src/views/pathfinding/catenaries.rs
+++ b/editoast/src/views/pathfinding/catenaries.rs
@@ -1,0 +1,486 @@
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::models::{pathfinding::Pathfinding, Infra, Retrieve};
+use crate::schema::{Direction, ObjectType};
+use crate::views::pathfinding::PathfindingError;
+use crate::DbPool;
+use actix_web::{
+    dev::HttpServiceFactory,
+    get, services,
+    web::{block, Data, Json, Path},
+};
+use chashmap::CHashMap;
+use rangemap::RangeMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::ops::Range;
+
+pub fn routes() -> impl HttpServiceFactory {
+    services![catenaries_on_path,]
+}
+
+/// A struct used for the result of the catenaries_on_path endpoint
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct CatenaryRange {
+    begin: f64,
+    end: f64,
+    mode: String,
+}
+
+impl CatenaryRange {
+    fn list_from_range_map(range_map: &RangeMap<Float, String>) -> Vec<CatenaryRange> {
+        range_map
+            .iter()
+            .map(|(range, mode)| CatenaryRange {
+                begin: range.start.0,
+                end: range.end.0,
+                mode: mode.to_string(),
+            })
+            .collect()
+    }
+}
+
+/// A struct to make f64 Ord, to use in RangeMap
+#[derive(Debug, PartialEq, Copy, Clone, Serialize)]
+struct Float(f64);
+
+impl Float {
+    fn new(f: f64) -> Self {
+        assert!(f.is_finite());
+        Self(f)
+    }
+}
+
+impl From<f64> for Float {
+    fn from(f: f64) -> Self {
+        Self::new(f)
+    }
+}
+
+impl Ord for Float {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.partial_cmp(&other.0).unwrap()
+    }
+}
+
+impl PartialOrd for Float {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Eq for Float {}
+
+/// Build a rangemap for each track section, giving the voltage for each range
+fn map_catenary_modes(
+    infra_cache: &InfraCache,
+    track_ids: HashSet<String>,
+) -> HashMap<String, RangeMap<Float, String>> {
+    let unique_catenary_ids = track_ids
+        .iter()
+        .flat_map(|track_id| {
+            infra_cache
+                .get_track_refs_type(track_id, ObjectType::Catenary)
+                .into_iter()
+        })
+        .map(|catenary_ref| &catenary_ref.obj_id)
+        .collect::<HashSet<_>>();
+
+    let mut res = HashMap::new();
+    for catenary_id in unique_catenary_ids {
+        let catenary = infra_cache
+            .catenaries()
+            .get(catenary_id)
+            .expect("catenary not found")
+            .unwrap_catenary();
+        for track_range in &catenary.track_ranges {
+            if track_ids.contains(track_range.track.as_str()) {
+                let res_entry = res
+                    .entry(track_range.track.to_string())
+                    .or_insert_with(RangeMap::new);
+                let range = track_range.begin.into()..track_range.end.into();
+                if res_entry.overlaps(&range) {
+                    // TODO: Send a 200 with an error payload here when encountering this case
+                }
+                res_entry.insert(range, catenary.voltage.0.clone());
+            }
+        }
+    }
+    res
+}
+
+fn clip_range_map(
+    range_map: &RangeMap<Float, String>,
+    clip_range: Range<Float>,
+) -> RangeMap<Float, String> {
+    let mut res = RangeMap::new();
+    for (range, value) in range_map.overlapping(&clip_range) {
+        let range = range.start.max(clip_range.start)..range.end.min(clip_range.end);
+        res.insert(range, value.clone());
+    }
+    res
+}
+
+/// Extend the pathfinding range map with the other one, as though entering from `range_entry` in the
+/// given direction.
+fn extend_path_range_map(
+    path_range_map: &mut RangeMap<Float, String>,
+    other_range_map: &RangeMap<Float, String>,
+    range_entry: f64,
+    offset: f64,
+    direction: Direction,
+) {
+    for (range, value) in other_range_map.iter() {
+        let (start, end) = match direction {
+            Direction::StartToStop => (range.start.0, range.end.0),
+            Direction::StopToStart => (range.end.0, range.start.0),
+        };
+
+        let range = ((start - range_entry).abs() + offset).into()
+            ..((end - range_entry).abs() + offset).into();
+        assert!(!path_range_map.overlaps(&range), "range overlap");
+        path_range_map.insert(range, value.clone());
+    }
+}
+
+fn make_path_range_map(
+    catenary_mode_map: &HashMap<String, RangeMap<Float, String>>,
+    pathfinding: &Pathfinding,
+) -> RangeMap<Float, String> {
+    let mut res = RangeMap::new();
+    let mut offset = 0.;
+
+    for track_range in pathfinding.merged_track_ranges() {
+        let mode_range_map_option = catenary_mode_map.get(&track_range.track as &str);
+        if let Some(mode_range_map) = mode_range_map_option {
+            let mode_range_map = clip_range_map(
+                mode_range_map,
+                track_range.begin.into()..track_range.end.into(),
+            );
+            let range_entry = match track_range.direction {
+                Direction::StartToStop => track_range.begin,
+                Direction::StopToStart => track_range.end,
+            };
+            extend_path_range_map(
+                &mut res,
+                &mode_range_map,
+                range_entry,
+                offset,
+                track_range.direction,
+            );
+        }
+        offset += track_range.end - track_range.begin;
+    }
+
+    res
+}
+
+#[get("/{path_id}/catenaries")]
+async fn catenaries_on_path(
+    pathfinding_id: Path<i64>,
+    db_pool: Data<DbPool>,
+    infra_caches: Data<CHashMap<i64, InfraCache>>,
+) -> Result<Json<Vec<CatenaryRange>>> {
+    let pathfinding_id = *pathfinding_id;
+    let pathfinding = match Pathfinding::retrieve(db_pool.clone(), pathfinding_id).await? {
+        Some(pf) => pf,
+        None => return Err(PathfindingError::NotFound { pathfinding_id }.into()),
+    };
+
+    let infra_id = pathfinding.infra_id;
+    let infra = match Infra::retrieve(db_pool.clone(), infra_id).await? {
+        Some(infra) => infra,
+        None => {
+            return Err(PathfindingError::InvalidInfraId {
+                pathfinding_id,
+                infra_id,
+            }
+            .into())
+        }
+    };
+
+    let track_section_ids = pathfinding.track_section_ids();
+
+    let catenary_mode_map = block::<_, Result<_>>(move || {
+        let mut conn = db_pool.get()?;
+        let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra)?;
+        Ok(map_catenary_modes(&infra_cache, track_section_ids))
+    })
+    .await
+    .unwrap()?;
+
+    let res = make_path_range_map(&catenary_mode_map, &pathfinding);
+    Ok(Json(CatenaryRange::list_from_range_map(&res)))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::{
+        fixtures::tests::{db_pool, empty_infra, TestFixture},
+        models::{
+            infra_objects::catenary::Catenary, pathfinding::tests::simple_pathfinding, Create,
+        },
+        schema::{ApplicableDirectionsTrackRange, Catenary as CatenarySchema},
+        views::tests::create_test_service,
+    };
+    use actix_http::StatusCode;
+    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use diesel::r2d2::ConnectionManager;
+    use r2d2::Pool;
+    use rstest::*;
+
+    use super::*;
+
+    macro_rules! range_map {
+        ($( $begin: expr , $end: expr => $value: expr ),*) => {{
+             let mut map: RangeMap<Float, String> = ::rangemap::RangeMap::new();
+             $( map.insert(($begin.into()..$end.into()), $value.into()); )*
+             map
+        }}
+    }
+
+    #[fixture]
+    fn simple_mode_map() -> HashMap<String, RangeMap<Float, String>> {
+        // The mode map associated to the following catenaries
+        let mut mode_map = vec![
+            ("track_1", "25kV"),
+            ("track_2", "25kV"),
+            ("track_5", "1.5kV"),
+        ]
+        .iter()
+        .map(|(track, voltage)| (track.to_string(), range_map!(0.0, 10.0 => *voltage)))
+        .collect::<HashMap<_, _>>();
+        mode_map.insert(
+            "track_3".to_string(),
+            range_map!(0.0, 5.0 => "25kV", 5.0, 10.0 => "1.5kV"),
+        );
+        mode_map
+    }
+
+    #[fixture]
+    async fn infra_with_catenaries(
+        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        #[future] empty_infra: TestFixture<Infra>,
+    ) -> TestFixture<Infra> {
+        let empty_infra = empty_infra.await;
+
+        // See the diagram in `models::pathfinding::tests::simple_path` to see how the track sections are connected.
+        let catenary_schemas = vec![
+            CatenarySchema {
+                track_ranges: vec![
+                    ApplicableDirectionsTrackRange {
+                        track: "track_1".into(),
+                        begin: 0.0,
+                        end: 10.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                    ApplicableDirectionsTrackRange {
+                        track: "track_2".into(),
+                        begin: 5.0,
+                        end: 10.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                ],
+                voltage: "25kV".into(),
+                ..Default::default()
+            },
+            CatenarySchema {
+                track_ranges: vec![
+                    ApplicableDirectionsTrackRange {
+                        track: "track_2".into(),
+                        begin: 0.0,
+                        end: 5.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                    ApplicableDirectionsTrackRange {
+                        track: "track_3".into(),
+                        begin: 0.0,
+                        end: 5.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                ],
+                voltage: "25kV".into(),
+                ..Default::default()
+            },
+            CatenarySchema {
+                track_ranges: vec![
+                    ApplicableDirectionsTrackRange {
+                        track: "track_3".into(),
+                        begin: 5.0,
+                        end: 10.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                    ApplicableDirectionsTrackRange {
+                        track: "track_5".into(),
+                        begin: 0.0,
+                        end: 10.0,
+                        applicable_directions: crate::schema::ApplicableDirections::Both,
+                    },
+                ],
+                voltage: "1.5kV".into(),
+                ..Default::default()
+            },
+        ];
+        for (i, catenary_schema) in catenary_schemas.into_iter().enumerate() {
+            Catenary::new(catenary_schema, empty_infra.id(), i.to_string())
+                .create(db_pool.clone())
+                .await
+                .expect("Could not create catenary");
+        }
+        empty_infra
+    }
+
+    #[test]
+    fn test_clip_range_map() {
+        let range_map = range_map!(0.0, 10.0 => "a", 10.0, 20.0 => "b", 20.0, 30.0 => "c");
+
+        let clipped = clip_range_map(&range_map, 5.0.into()..20.0.into());
+        assert_eq!(clipped, range_map!(5.0, 10.0 => "a", 10.0, 20.0 => "b"));
+    }
+
+    #[rstest]
+    async fn test_map_catenary_modes(
+        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        #[future] infra_with_catenaries: TestFixture<Infra>,
+        simple_mode_map: HashMap<String, RangeMap<Float, String>>,
+    ) {
+        let mut conn = db_pool.get().unwrap();
+        let infra_with_catenaries = infra_with_catenaries.await;
+        let infra_cache = InfraCache::load(&mut conn, &infra_with_catenaries.model)
+            .expect("Could not load infra_cache");
+        let track_sections: HashSet<_> =
+            vec!["track_1", "track_2", "track_3", "track_4", "track_5"]
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect();
+
+        let mode_map = map_catenary_modes(&infra_cache, track_sections);
+        assert_eq!(mode_map, simple_mode_map);
+    }
+
+    #[test]
+    fn test_extend_path_range_map_reversed() {
+        let mut path_range_map = range_map!(0.0, 10.0 => "A");
+
+        let mode_range_map = range_map!(10.0, 20.0 => "B", 20.0, 30.0 => "C");
+
+        extend_path_range_map(
+            &mut path_range_map,
+            &mode_range_map,
+            40.0,
+            20.0,
+            Direction::StopToStart,
+        );
+
+        let expected_range_map = range_map!(
+            0.0, 10.0 => "A",
+            30.0, 40.0 => "C",
+            40.0, 50.0 => "B"
+        );
+        assert_eq!(path_range_map, expected_range_map);
+    }
+
+    #[test]
+    fn test_extend_path_range_map_close() {
+        let mut path_range_map = range_map!(0.0, 10.0 => "A");
+
+        let mode_range_map = range_map!(10.0, 20.0 => "A", 20.0, 30.0 => "B");
+
+        extend_path_range_map(
+            &mut path_range_map,
+            &mode_range_map,
+            10.0,
+            10.0,
+            Direction::StartToStop,
+        );
+
+        let expected_range_map = range_map!(0.0, 20.0 => "A", 20.0, 30.0 => "B");
+        assert_eq!(path_range_map, expected_range_map);
+    }
+
+    #[test]
+    fn test_extend_path_range_map_from_the_beginning() {
+        let mut path_range_map = range_map!(0.0, 10.0 => "A");
+
+        let mode_range_map = range_map!(10.0, 20.0 => "A", 20.0, 30.0 => "B");
+
+        extend_path_range_map(
+            &mut path_range_map,
+            &mode_range_map,
+            0.0,
+            10.0,
+            Direction::StartToStop,
+        );
+
+        let expected_range_map = range_map!(
+            0.0, 10.0 => "A",
+            20.0, 30.0 => "A",
+            30.0, 40.0 => "B"
+        );
+        assert_eq!(path_range_map, expected_range_map);
+    }
+
+    #[rstest]
+    fn test_make_path_range_map(simple_mode_map: HashMap<String, RangeMap<Float, String>>) {
+        let pathfinding = simple_pathfinding(0);
+
+        let path_range_map = make_path_range_map(&simple_mode_map, &pathfinding);
+        assert_eq!(
+            path_range_map,
+            range_map!(
+                0.0, 25.0 => "25kV",
+                25.0, 30.0 => "1.5kV",
+                40.0, 48.0 => "1.5kV"
+            )
+        );
+    }
+
+    #[rstest]
+    async fn test_view_catenaries_on_path(
+        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        #[future] infra_with_catenaries: TestFixture<Infra>,
+    ) {
+        let infra_with_catenaries = infra_with_catenaries.await;
+        let pathfinding = simple_pathfinding(infra_with_catenaries.id());
+        let pathfinding = TestFixture {
+            model: pathfinding.create(db_pool.clone()).await.unwrap(),
+            db_pool,
+        };
+
+        let app = create_test_service().await;
+        let req = TestRequest::get()
+            .uri(&format!("/pathfinding/{}/catenaries/", pathfinding.id()))
+            .to_request();
+
+        let response = call_service(&app, req).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response: Vec<CatenaryRange> = read_body_json(response).await;
+        assert_eq!(response.len(), 3);
+        assert_eq!(
+            response[0],
+            CatenaryRange {
+                begin: 0.0,
+                end: 25.0,
+                mode: "25kV".into(),
+            }
+        );
+        assert_eq!(
+            response[1],
+            CatenaryRange {
+                begin: 25.0,
+                end: 30.0,
+                mode: "1.5kV".into(),
+            }
+        );
+        assert_eq!(
+            response[2],
+            CatenaryRange {
+                begin: 40.0,
+                end: 48.0,
+                mode: "1.5kV".into(),
+            }
+        );
+    }
+}

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -17,18 +17,22 @@ use thiserror::Error;
 use crate::{
     error::Result,
     models::{CurveGraph, Delete, PathWaypoint, Pathfinding, Retrieve, SlopeGraph},
+    schema::ApplicableDirectionsTrackRange,
     DbPool,
 };
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, EditoastError, Serialize)]
 #[editoast_error(base_id = "pathfinding")]
 enum PathfindingError {
     #[error("Pathfinding {pathfinding_id} does not exist")]
     #[editoast_error(status = 404)]
     NotFound { pathfinding_id: i64 },
-    #[error("Pathfinding {pathfinding_id} has reference to invalid infra id {infra_id}")]
+    #[error("Catenary {catenary_id} overlaps with other catenaries on the same track")]
     #[editoast_error(status = 500)]
-    InvalidInfraId { pathfinding_id: i64, infra_id: i64 },
+    CatenaryOverlap {
+        catenary_id: String,
+        overlapping_ranges: Vec<ApplicableDirectionsTrackRange>,
+    },
 }
 
 /// Returns `/pathfinding` routes

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -1,3 +1,5 @@
+mod catenaries;
+
 use actix_web::{
     delete,
     dev::HttpServiceFactory,
@@ -24,11 +26,14 @@ enum PathfindingError {
     #[error("Pathfinding {pathfinding_id} does not exist")]
     #[editoast_error(status = 404)]
     NotFound { pathfinding_id: i64 },
+    #[error("Pathfinding {pathfinding_id} has reference to invalid infra id {infra_id}")]
+    #[editoast_error(status = 500)]
+    InvalidInfraId { pathfinding_id: i64, infra_id: i64 },
 }
 
 /// Returns `/pathfinding` routes
 pub fn routes() -> impl HttpServiceFactory {
-    web::scope("/pathfinding").service((get_pf, del_pf))
+    web::scope("/pathfinding").service((get_pf, del_pf, catenaries::routes()))
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -63,7 +68,7 @@ impl From<Pathfinding> for Response {
             ..
         } = value;
         Self {
-            id,
+            id: id.expect("Pathfinding ID should be set"),
             owner,
             created,
             slopes: slopes.0,

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -851,7 +851,14 @@ export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg =
   scenarioPatchRequest: ScenarioPatchRequest;
 };
 export type GetPathfindingByPathIdCatenariesApiResponse =
-  /** status 200 A list of ranges associated to catenary modes */ CatenaryRange[];
+  /** status 200 A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list. */ {
+    catenary_ranges?: CatenaryRange[];
+    warnings?: {
+      type?: 'CatenaryOverlap';
+      catenary_id?: string;
+      overlapping_ranges?: TrackRange[];
+    }[];
+  };
 export type GetPathfindingByPathIdCatenariesApiArg = {
   /** The path's id */
   pathId: number;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -361,6 +361,12 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.scenarioPatchRequest,
       }),
     }),
+    getPathfindingByPathIdCatenaries: build.query<
+      GetPathfindingByPathIdCatenariesApiResponse,
+      GetPathfindingByPathIdCatenariesApiArg
+    >({
+      query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathId}/catenaries/` }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -844,6 +850,12 @@ export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg =
   /** The fields you want to update */
   scenarioPatchRequest: ScenarioPatchRequest;
 };
+export type GetPathfindingByPathIdCatenariesApiResponse =
+  /** status 200 A list of ranges associated to catenary modes */ CatenaryRange[];
+export type GetPathfindingByPathIdCatenariesApiArg = {
+  /** The path's id */
+  pathId: number;
+};
 export type SearchTrackResult = {
   infra_id: number;
   line_code: number;
@@ -1298,4 +1310,9 @@ export type ScenarioPatchRequest = {
   name?: string;
   description?: string;
   tags?: string[];
+};
+export type CatenaryRange = {
+  begin?: number;
+  end?: number;
+  mode?: string;
 };


### PR DESCRIPTION
closes: #3605 

In this PR, I add:
* Methods on the `Pathfinding ` model.
* A `Catenary` model specifically designed for fixtures.
* A `catenaries_on_pathfinding` view.
* An `empty_infra` fixture in `fixture.rs` and a `infra_with_catenaries` fixture.