### PR TITLE
editoast: enhance missing buffer stop warnings

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -383,7 +383,7 @@ paths:
               - missing_route
               - unused_port
               - duplicated_group
-              - no_buffer_stop
+              - missing_buffer_stop
               - path_is_not_continuous
               - overlapping_switches
               - overlapping_track_links
@@ -1909,7 +1909,7 @@ components:
                 - missing_route
                 - unused_port
                 - duplicated_group
-                - no_buffer_stop
+                - missing_buffer_stop
                 - path_is_not_continuous
                 - overlapping_switches
                 - overlapping_track_links

--- a/editoast/src/generated_data/error/buffer_stops.rs
+++ b/editoast/src/generated_data/error/buffer_stops.rs
@@ -3,7 +3,7 @@ use crate::infra_cache::Graph;
 use super::{GlobalErrorGenerator, NoContext};
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, ObjectRef, ObjectType};
+use crate::schema::{Endpoint, InfraError, ObjectRef, ObjectType};
 
 // TODO: Use a macro instead to force order and priority continuity
 // Example: `static_priority_array![[check_invalid_ref], [check_out_of_range]]`
@@ -66,16 +66,36 @@ fn check_missing(infra_cache: &InfraCache, graph: &Graph) -> Vec<InfraError> {
 
     for track in infra_cache.track_sections().values() {
         let track = track.unwrap_track_section();
-        if !graph.has_neighbour(&track.get_begin()) || !graph.has_neighbour(&track.get_end()) {
-            let track_refs = infra_cache.track_sections_refs.get(&track.obj_id);
-            if track_refs.is_none()
-                || !track_refs
-                    .unwrap()
-                    .iter()
-                    .any(|x| x.obj_type == ObjectType::BufferStop)
-            {
-                infra_errors.push(InfraError::new_no_buffer_stop(track, "buffer_stop"));
+        let is_linked_start = graph.has_neighbour(&track.get_begin());
+        let is_linked_end = graph.has_neighbour(&track.get_end());
+        if is_linked_start && is_linked_end {
+            continue;
+        }
+        let buffer_stops = infra_cache.get_track_refs_type(&track.obj_id, ObjectType::BufferStop);
+        if buffer_stops.len() >= 2 {
+            continue;
+        } else if buffer_stops.is_empty() {
+            // Missing buffer stops where the track is not linked
+            if !is_linked_end {
+                infra_errors.push(InfraError::new_missing_buffer_stop(track, Endpoint::End));
             }
+            if !is_linked_start {
+                infra_errors.push(InfraError::new_missing_buffer_stop(track, Endpoint::Begin));
+            }
+            continue;
+        } else if is_linked_end || is_linked_start {
+            // Only one buffer stop and the track is linked to another track
+            continue;
+        }
+        // Only one buffer stop and the track is not linked to another track
+        // We have to determine if the missing buffer stop should be at the begin or the end
+        let bs_id = &buffer_stops[0].obj_id;
+        let buffer_stop = infra_cache.buffer_stops().get(bs_id).unwrap();
+        let buffer_stop = buffer_stop.unwrap_buffer_stop();
+        if buffer_stop.position < track.length / 2. {
+            infra_errors.push(InfraError::new_missing_buffer_stop(track, Endpoint::End));
+        } else {
+            infra_errors.push(InfraError::new_missing_buffer_stop(track, Endpoint::Begin));
         }
     }
     infra_errors
@@ -87,9 +107,12 @@ pub mod tests {
     use super::check_out_of_range;
     use super::InfraError;
     use crate::generated_data::error::buffer_stops::check_missing;
+    use crate::infra_cache::tests::create_track_section_cache;
     use crate::infra_cache::tests::{create_buffer_stop_cache, create_small_infra_cache};
     use crate::infra_cache::Graph;
+    use crate::schema::Endpoint;
     use crate::schema::{ObjectRef, ObjectType};
+    use ntest::test_case;
 
     #[test]
     fn invalid_ref() {
@@ -118,17 +141,51 @@ pub mod tests {
     }
 
     #[test]
-    fn missing_buffer_stop() {
+    fn simple_missing_buffer_stop() {
         let mut infra_cache = create_small_infra_cache();
         let obj_ref = ObjectRef::new(ObjectType::BufferStop, "BF1");
         infra_cache.apply_delete(&obj_ref);
         let graph = Graph::load(&infra_cache);
         let errors = check_missing(&infra_cache, &graph);
         assert_eq!(1, errors.len());
-        let infra_error = InfraError::new_no_buffer_stop(
+        let infra_error = InfraError::new_missing_buffer_stop(
             infra_cache.track_sections().get("A").unwrap(),
-            "buffer_stop",
+            Endpoint::Begin,
         );
         assert_eq!(infra_error, errors[0]);
+    }
+
+    #[test_case(25.)]
+    #[test_case(175.)]
+    fn complex_missing_buffer_stop(pos: f64) {
+        let mut infra_cache = create_small_infra_cache();
+        let track = create_track_section_cache("test", 200.);
+        infra_cache.add(track.clone());
+        let bs = create_buffer_stop_cache("bs_test", &track.obj_id, pos);
+        infra_cache.add(bs);
+        let graph = Graph::load(&infra_cache);
+        let errors = check_missing(&infra_cache, &graph);
+        assert_eq!(1, errors.len());
+        let missing_endpoint = if pos < 100. {
+            Endpoint::End
+        } else {
+            Endpoint::Begin
+        };
+        let error = InfraError::new_missing_buffer_stop(&track, missing_endpoint);
+        assert_eq!(error, errors[0]);
+    }
+
+    #[test]
+    fn missing_two_buffer_stop() {
+        let mut infra_cache = create_small_infra_cache();
+        let track = create_track_section_cache("test", 200.);
+        infra_cache.add(track.clone());
+        let graph = Graph::load(&infra_cache);
+        let errors = check_missing(&infra_cache, &graph);
+        assert_eq!(2, errors.len());
+        let error = InfraError::new_missing_buffer_stop(&track, Endpoint::End);
+        assert_eq!(error, errors[0]);
+        let error = InfraError::new_missing_buffer_stop(&track, Endpoint::Begin);
+        assert_eq!(error, errors[1]);
     }
 }

--- a/editoast/src/schema/errors.rs
+++ b/editoast/src/schema/errors.rs
@@ -1,4 +1,4 @@
-use super::{OSRDIdentified, OSRDObject, ObjectType};
+use super::{Endpoint, OSRDIdentified, OSRDObject, ObjectType};
 use crate::schema::ObjectRef;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumVariantNames;
@@ -8,7 +8,7 @@ use strum_macros::EnumVariantNames;
 pub struct InfraError {
     obj_id: String,
     obj_type: ObjectType,
-    field: String,
+    field: Option<String>,
     is_warning: bool,
     #[serde(flatten)]
     sub_type: InfraErrorType,
@@ -32,7 +32,9 @@ pub enum InfraErrorType {
     InvalidRoute,
     InvalidSwitchPorts,
     MissingRoute,
-    NoBufferStop,
+    MissingBufferStop {
+        endpoint: Endpoint,
+    },
     ObjectOutOfPath {
         reference: ObjectRef,
     },
@@ -63,7 +65,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::InvalidReference { reference },
         }
@@ -78,7 +80,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::OutOfRange {
                 position,
@@ -91,7 +93,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: "".into(), // This error concern the whole object consistency
+            field: None, // This error concern the whole object consistency
             is_warning: false,
             sub_type: InfraErrorType::InvalidRoute,
         }
@@ -101,7 +103,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: true,
             sub_type: InfraErrorType::EmptyObject,
         }
@@ -115,7 +117,7 @@ impl InfraError {
         Self {
             obj_id: route.get_id().clone(),
             obj_type: route.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::ObjectOutOfPath { reference },
         }
@@ -140,7 +142,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::UnknownPortName { port_name },
         }
@@ -150,7 +152,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::InvalidSwitchPorts,
         }
@@ -164,7 +166,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: true,
             sub_type: InfraErrorType::UnusedPort {
                 port_name: port_name.as_ref().into(),
@@ -180,7 +182,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: true,
             sub_type: InfraErrorType::DuplicatedGroup {
                 original_group_path,
@@ -197,7 +199,7 @@ impl InfraError {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: Some(field.as_ref().into()),
             is_warning: false,
             sub_type: InfraErrorType::InvalidGroup {
                 group: group.as_ref().into(),
@@ -206,13 +208,13 @@ impl InfraError {
         }
     }
 
-    pub fn new_no_buffer_stop<T: AsRef<str>, O: OSRDObject>(obj: &O, field: T) -> Self {
+    pub fn new_missing_buffer_stop<O: OSRDObject>(obj: &O, endpoint: Endpoint) -> Self {
         Self {
             obj_id: obj.get_id().clone(),
             obj_type: obj.get_type(),
-            field: field.as_ref().into(),
+            field: None,
             is_warning: true,
-            sub_type: InfraErrorType::NoBufferStop,
+            sub_type: InfraErrorType::MissingBufferStop { endpoint },
         }
     }
 

--- a/front/src/applications/editor/components/InfraErrors/types.ts
+++ b/front/src/applications/editor/components/InfraErrors/types.ts
@@ -21,7 +21,7 @@ export const InfraErrorTypeList: Array<InfraErrorType> = [
   'missing_route',
   'unused_port',
   'duplicated_group',
-  'no_buffer_stop',
+  'missing_buffer_stop',
   'path_is_not_continuous',
   'overlapping_switches',
   'overlapping_track_links',

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -475,7 +475,7 @@ export type GetInfraByIdErrorsApiArg = {
     | 'missing_route'
     | 'unused_port'
     | 'duplicated_group'
-    | 'no_buffer_stop'
+    | 'missing_buffer_stop'
     | 'path_is_not_continuous'
     | 'overlapping_switches'
     | 'overlapping_track_links';
@@ -981,7 +981,7 @@ export type InfraError = {
       | 'missing_route'
       | 'unused_port'
       | 'duplicated_group'
-      | 'no_buffer_stop'
+      | 'missing_buffer_stop'
       | 'path_is_not_continuous'
       | 'overlapping_switches'
       | 'overlapping_track_links';


### PR DESCRIPTION
This PR improves the accuracy of the `missing_buffer_stop` warning. If a track has no neighbor then we expect to have two buffer stops one at the beginning and one at the end of the track section.