### PR TITLE
front: removeUseless map symbol

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
@@ -531,9 +531,6 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
             />
           ))}
       </ReactMapGL>
-      <div className="handle-tab-resize">
-        <CgLoadbar />
-      </div>
     </>
   );
 };


### PR DESCRIPTION
Just remove a useless handle symbol under simulation map