### PR TITLE
core: fix checkstyle CI

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -183,7 +183,7 @@ allprojects {
         // report all diagnosed bugs
         reportLevel = 'low'
         maxHeapSize = '1g'
-        excludeFilter = file('config/spotbugs/exclude.xml')
+        excludeFilter = rootProject.file('config/spotbugs/exclude.xml')
     }
 
     tasks.withType(com.github.spotbugs.snom.SpotBugsTask).tap {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,43 +150,50 @@ processTestResources.configure {
 
 // region CODE_QUALITY
 
-checkstyle {
-    toolVersion '9.2'
-    configFile rootProject.file('config/checkstyle/checkstyle.xml')
-    ignoreFailures false
-    maxWarnings 0
-    showViolations true
-}
+allprojects {
 
-tasks.withType(Checkstyle) {
-    reports {
-        xml.required = true
+    apply plugin: 'checkstyle'
+    apply plugin: 'com.github.spotbugs'
+    checkstyle {
+        toolVersion '9.2'
+        configFile rootProject.file('config/checkstyle/checkstyle.xml')
+        ignoreFailures false
+        maxWarnings 0
+        showViolations true
     }
-}
 
-// enable all linter warnings, and error out on warnings
-tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:all" << "-Werror"
-    options.encoding = "UTF-8"
-}
+    tasks.withType(Checkstyle).configureEach {
+        reports {
+            xml.required = true
+        }
+    }
 
-spotbugs {
-    ignoreFailures = false
-    showStackTraces = true
-    showProgress = true
-    // can also be 'more' or 'default'
-    effort = 'max'
-    // report all diagnosed bugs
-    reportLevel = 'low'
-    maxHeapSize = '1g'
-    excludeFilter = file('config/spotbugs/exclude.xml')
-}
+    // enable all linter warnings, and error out on warnings
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs << "-Xlint:all" << "-Werror"
+        options.encoding = "UTF-8"
+    }
 
-tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
-    if (project.hasProperty("spotbugs_report_xml")) {
-        reports { xml.required = true }
-    } else {
-        reports { html.required = true }
+    spotbugs {
+        ignoreFailures = false
+        showStackTraces = true
+        showProgress = true
+        // can also be 'more' or 'default'
+        effort = 'max'
+        // report all diagnosed bugs
+        reportLevel = 'low'
+        maxHeapSize = '1g'
+        excludeFilter = file('config/spotbugs/exclude.xml')
+    }
+
+    tasks.withType(com.github.spotbugs.snom.SpotBugsTask).tap {
+        configureEach {
+            if (project.hasProperty("spotbugs_report_xml")) {
+                reports { xml.required = true }
+            } else {
+                reports { html.required = true }
+            }
+        }
     }
 }
 

--- a/core/config/spotbugs/exclude-railjson.xml
+++ b/core/config/spotbugs/exclude-railjson.xml
@@ -1,0 +1,8 @@
+<FindBugsFilter>
+  <Match>
+    <Bug code="EI2,EI,THROWS,UrF,UuF" />
+  </Match>
+  <Match>
+    <Source name="~.*\.kt"/>
+  </Match>
+</FindBugsFilter>

--- a/core/envelope-sim/build.gradle
+++ b/core/envelope-sim/build.gradle
@@ -28,10 +28,6 @@ dependencies {
     // fast primitive collections
     implementation libs.hppc
 
-    // for linter annotations
-    compileOnly libs.jcip.annotations
-    compileOnly libs.spotbugs.annotations
-
     // Use JUnit Jupiter API for testing.
     testImplementation libs.junit.jupiter.api
     testImplementation libs.junit.jupiter.params
@@ -42,7 +38,12 @@ dependencies {
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly libs.junit.jupiter.engine
 
-    // linter annotations
+    // for linter annotations
+    testFixturesCompileOnly libs.jcip.annotations
+    testFixturesCompileOnly libs.spotbugs.annotations
+    compileOnly libs.jcip.annotations
+    compileOnly libs.spotbugs.annotations
+    testCompileOnly libs.jcip.annotations
     testCompileOnly libs.spotbugs.annotations
 }
 

--- a/core/envelope-sim/build.gradle
+++ b/core/envelope-sim/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'java-test-fixtures'
     id 'jacoco'
-    alias(libs.plugins.spotbugs)
 }
 
 repositories {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/DriverBehaviour.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/DriverBehaviour.java
@@ -1,11 +1,10 @@
 package fr.sncf.osrd;
 
+import java.util.List;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
-
-import java.util.List;
 
 public class DriverBehaviour {
     public final double acceleratingPostponementOffset;
@@ -15,15 +14,17 @@ public class DriverBehaviour {
         this.acceleratingPostponementOffset = 50;
         this.brakingAnticipationOffset = 100;
     }
+
     public DriverBehaviour(double acceleratingPostponementOffset, double brakingAnticipationOffset) {
         this.acceleratingPostponementOffset = acceleratingPostponementOffset;
         this.brakingAnticipationOffset = brakingAnticipationOffset;
     }
 
+    /** Applies the driver behavior to the MRSP, adding reaction time for MRSP changes */
     public Envelope applyToMRSP(Envelope mrsp) {
         var builder = new MRSPEnvelopeBuilder();
         var totalLength = mrsp.getTotalDistance();
-        for(EnvelopePart part: mrsp) {
+        for (EnvelopePart part: mrsp) {
             var begin = part.getBeginPos();
             var end = part.getEndPos();
             // compute driver behaviour offsets

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/SpeedConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/SpeedConstraint.java
@@ -2,8 +2,10 @@ package fr.sncf.osrd.envelope.part.constraints;
 
 import static fr.sncf.osrd.envelope.EnvelopePhysics.intersectStepWithSpeed;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.EnvelopePoint;
 
+@SuppressFBWarnings({"FE_FLOATING_POINT_EQUALITY"})
 public class SpeedConstraint implements EnvelopePartConstraint {
     public final double speedConstraint;
     private final EnvelopePartConstraintType type;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
@@ -171,9 +171,11 @@ public class EnvelopeSimPath implements PhysicsPath {
     /**
      * Get the catenary related data for a given power class and power restriction map.
      */
-    public ImmutableRangeMap<Double, ElectrificationConditions> getElecCondMap(String basePowerClass,
-                                                                               RangeMap<Double, String> powerRestrictionMap,
-                                                                               Map<String, String> powerRestrictionToPowerClass) {
+    public ImmutableRangeMap<Double, ElectrificationConditions> getElecCondMap(
+            String basePowerClass,
+            RangeMap<Double, String> powerRestrictionMap,
+            Map<String, String> powerRestrictionToPowerClass
+    ) {
         return getElecCondMap(basePowerClass, powerRestrictionMap, powerRestrictionToPowerClass, false);
     }
 

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -177,7 +177,11 @@ public class AllowanceTests {
         assertEquals(marginTime, targetTime, 2 * TIME_STEP);
     }
 
-    private void testTransitionPoints(Envelope base, EnvelopeSimContext context, AbstractAllowanceWithRanges allowance) {
+    private void testTransitionPoints(
+            Envelope base,
+            EnvelopeSimContext context,
+            AbstractAllowanceWithRanges allowance
+    ) {
 
         final double tolerance = 0.02; // percentage
         var beginPos = allowance.beginPos;
@@ -324,7 +328,7 @@ public class AllowanceTests {
         double end = 40_000;
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance( begin, end, 8.33, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(begin, end, 8.33, allowanceValue);
         var marecoThrown =
                 assertThrows(AllowanceConvergenceException.class,
                         () -> marecoAllowance.apply(maxEffortEnvelope, testContext));
@@ -350,7 +354,7 @@ public class AllowanceTests {
         double end = 21_000;
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance( begin, end, 8.33, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(begin, end, 8.33, allowanceValue);
         var marecoThrown =
                 assertThrows(AllowanceConvergenceException.class,
                         () -> marecoAllowance.apply(maxEffortEnvelope, testContext));
@@ -396,8 +400,8 @@ public class AllowanceTests {
         var engineeringAllowanceValue = new AllowanceValue.FixedTime(30);
 
         // test mareco distribution
-        var standardMarecoAllowance = makeStandardMarecoAllowance( 0, length, 8.33, standardAllowanceValue);
-        var engineeringMarecoAllowance = makeStandardMarecoAllowance( begin, end, 8.33, engineeringAllowanceValue);
+        var standardMarecoAllowance = makeStandardMarecoAllowance(0, length, 8.33, standardAllowanceValue);
+        var engineeringMarecoAllowance = makeStandardMarecoAllowance(begin, end, 8.33, engineeringAllowanceValue);
         testEngineeringOnStandardAllowance(maxEffortEnvelope, testContext, standardMarecoAllowance,
                 engineeringMarecoAllowance);
 

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
@@ -73,6 +73,7 @@ public class EnvelopeTestUtils {
         Assertions.assertEquals(expected.getMinSpeed(), actual.getMinSpeed(), delta);
     }
 
+    /** Asserts that the envelopes are equals, with a delta tolerance when comparing speeds */
     public static void assertEquals(Envelope expected, Envelope actual, double delta) {
         Assertions.assertEquals(expected.size(), actual.size());
         Assertions.assertEquals(expected.continuous, actual.continuous);
@@ -82,14 +83,17 @@ public class EnvelopeTestUtils {
             assertEquals(expected.get(i), actual.get(i), delta);
     }
 
+    /** Asserts that the envelopes are equals, with a 0.01 tolerance when comparing speeds */
     static void assertEquals(Envelope expected, Envelope actual) {
         assertEquals(expected, actual, 0.01);
     }
 
+    /** Creates a flat envelope part */
     public static EnvelopePart makeFlatPart(TestAttr attr, double beginPos, double endPos, double speed) {
         return makeFlatPart(List.of(attr), beginPos, endPos, speed);
     }
 
+    /** Creates a flat envelope part */
     public static EnvelopePart makeFlatPart(Iterable<EnvelopeAttr> attrs,
                                             double beginPos, double endPos, double speed) {
         return EnvelopePart.generateTimes(

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathBuilder.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathBuilder.java
@@ -6,8 +6,8 @@ import com.google.common.collect.TreeRangeMap;
 import java.util.Map;
 
 /** This is a simple fixture to build EnvelopeSimPath with some electrification conditions.
- * <p>
- * Electrification conditions (mode and electrical profile here) are used to select
+ *
+ * <p>Electrification conditions (mode and electrical profile here) are used to select
  * which effort curve to use in a rolling stock. Their values are unconstrained strings.
  * If they do not match any effort curve in a rolling stock, they are ignored.
  **/
@@ -24,7 +24,7 @@ public class EnvelopeSimPathBuilder {
 
     /** Builds an EnvelopeSimPath with some electrification modes and a set of electrical profiles */
     public static EnvelopeSimPath withElectricalProfiles1500() {
-        var path = withModes(10);
+        final var path = withModes(10);
 
         RangeMap<Double, String> profiles1 = TreeRangeMap.create();
         profiles1.put(Range.closed(3.0, 8.0), "A");
@@ -45,7 +45,7 @@ public class EnvelopeSimPathBuilder {
     /** Builds an EnvelopeSimPath with some electrification modes and
      * a set of electrical profiles different from `withElectricalProfiles25000` */
     public static EnvelopeSimPath withElectricalProfiles25000(double length) {
-        var path = withModes(length);
+        final var path = withModes(length);
 
         TreeRangeMap<Double, String> electricalProfiles5 = TreeRangeMap.create();
         electricalProfiles5.put(Range.closedOpen(10., 12.), "25000");

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleContextBuilder.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleContextBuilder.java
@@ -3,12 +3,14 @@ package fr.sncf.osrd.envelope_sim;
 public class SimpleContextBuilder {
     public static final double TIME_STEP = 4;
 
+    /** Creates a simple envelope sim context from a length, constant slope, and time step */
     public static EnvelopeSimContext makeSimpleContext(double length, double slope, double timeStep) {
         var testRollingStock = SimpleRollingStock.STANDARD_TRAIN;
         var testPath = new FlatPath(length, slope);
         return new EnvelopeSimContext(testRollingStock, testPath, timeStep, SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
     }
 
+    /** Creates a simple envelope sim context from a length and a constant slope */
     public static EnvelopeSimContext makeSimpleContext(double length, double slope) {
         return makeSimpleContext(length, slope, TIME_STEP);
     }

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/SimpleRollingStock.java
@@ -1,9 +1,11 @@
 package fr.sncf.osrd.envelope_sim;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import java.util.ArrayList;
 
+@SuppressFBWarnings({ "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" })
 public class SimpleRollingStock implements PhysicsRollingStock {
 
     public final double A; // in newtons
@@ -144,6 +146,7 @@ public class SimpleRollingStock implements PhysicsRollingStock {
         return maxEffort / Math.max(1, speed);
     }
 
+    /** Creates the effort speed curve, from a given max speed and curve shape */
     public static TractiveEffortPoint[] createEffortSpeedCurve(double maxSpeed, CurveShape curveShape) {
         var newEffortCurve = new ArrayList<TractiveEffortPoint>();
 
@@ -155,6 +158,7 @@ public class SimpleRollingStock implements PhysicsRollingStock {
         return newEffortCurve.toArray(new TractiveEffortPoint[0]);
     }
 
+    /** Creates a range of effort points, from a given max speed and curve shape */
     public static ImmutableRangeMap<Double, TractiveEffortPoint[]> createEffortCurveMap(double maxSpeed,
                                                                                         CurveShape curveShape) {
         var builder = ImmutableRangeMap.<Double, TractiveEffortPoint[]>builder();
@@ -186,15 +190,15 @@ public class SimpleRollingStock implements PhysicsRollingStock {
         );
     }
 
-    static final public ImmutableRangeMap<Double, TractiveEffortPoint[]> LINEAR_EFFORT_CURVE_MAP =
+    public static final ImmutableRangeMap<Double, TractiveEffortPoint[]> LINEAR_EFFORT_CURVE_MAP =
             createEffortCurveMap(MAX_SPEED, CurveShape.LINEAR);
 
-    static final public ImmutableRangeMap<Double, TractiveEffortPoint[]> HYPERBOLIC_EFFORT_CURVE_MAP =
+    public static final ImmutableRangeMap<Double, TractiveEffortPoint[]> HYPERBOLIC_EFFORT_CURVE_MAP =
             createEffortCurveMap(MAX_SPEED, CurveShape.HYPERBOLIC);
 
-    static final public SimpleRollingStock SHORT_TRAIN = SimpleRollingStock.build(1, .5, GammaType.CONST);
+    public static final SimpleRollingStock SHORT_TRAIN = SimpleRollingStock.build(1, .5, GammaType.CONST);
 
-    static final public SimpleRollingStock STANDARD_TRAIN = SimpleRollingStock.build(400, .5, GammaType.CONST);
+    public static final SimpleRollingStock STANDARD_TRAIN = SimpleRollingStock.build(400, .5, GammaType.CONST);
 
-    static final public SimpleRollingStock MAX_DEC_TRAIN = SimpleRollingStock.build(400, .95, GammaType.MAX);
+    public static final SimpleRollingStock MAX_DEC_TRAIN = SimpleRollingStock.build(400, .95, GammaType.MAX);
 }

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -57,33 +57,33 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
     }
 
     override fun buildBlocks(
-        rawInfra: RawSignalingInfra,
+        rawSignalingInfra: RawSignalingInfra,
         loadedSignalInfra: LoadedSignalInfra
     ): BlockInfra {
-        val blockInfra = internalBuildBlocks(sigModuleManager, rawInfra, loadedSignalInfra)
+        val blockInfra = internalBuildBlocks(sigModuleManager, rawSignalingInfra, loadedSignalInfra)
         for (block in blockInfra.blocks) {
             val sigSystem = blockInfra.getBlockSignalingSystem(block)
             val path = blockInfra.getBlockPath(block)
-            val length = Distance(path.map { rawInfra.getZonePathLength(it) }.sumOf { it.millimeters })
+            val length = Distance(path.map { rawSignalingInfra.getZonePathLength(it) }.sumOf { it.millimeters })
             val startAtBufferStop = blockInfra.blockStartAtBufferStop(block)
             val stopAtBufferStop = blockInfra.blockStopAtBufferStop(block)
             val signals = blockInfra.getBlockSignals(block)
-            val signalTypes = signals.map { rawInfra.getSignalingSystemId(it) }
+            val signalTypes = signals.map { rawSignalingInfra.getSignalingSystemId(it) }
             val signalSettings = signals.map { loadedSignalInfra.getSettings(it) }
             val signalsPositions = blockInfra.getSignalsPositions(block)
             val sigBlock = SigBlock(startAtBufferStop, stopAtBufferStop, signalTypes, signalSettings, signalsPositions, length)
             val reporter = object : BlockDiagReporter {
                 override fun reportBlock(errorType: String) {
                     logger.debug {
-                        val entrySignal = rawInfra.getLogicalSignalName(signals[0])
-                        val exitSignal = rawInfra.getLogicalSignalName(signals[signals.size - 1])
+                        val entrySignal = rawSignalingInfra.getLogicalSignalName(signals[0])
+                        val exitSignal = rawSignalingInfra.getLogicalSignalName(signals[signals.size - 1])
                         "error in block from $entrySignal to $exitSignal: $errorType"
                     }
                 }
 
                 override fun reportSignal(sigIndex: Int, errorType: String) {
                     logger.debug {
-                        val signal = rawInfra.getLogicalSignalName(signals[sigIndex])
+                        val signal = rawSignalingInfra.getLogicalSignalName(signals[sigIndex])
                         "error at signal $signal: $errorType"
                     }
                 }

--- a/core/osrd-railjson/build.gradle
+++ b/core/osrd-railjson/build.gradle
@@ -36,3 +36,8 @@ dependencies {
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly libs.junit.jupiter.engine
 }
+
+spotbugs {
+    // Ignores unread or unused errors, which are wrongly detected all over this subproject
+    excludeFilter = rootProject.file('config/spotbugs/exclude-railjson.xml')
+}

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/external_generated_inputs/RJSElectricalProfileSet.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/external_generated_inputs/RJSElectricalProfileSet.java
@@ -1,11 +1,10 @@
 package fr.sncf.osrd.railjson.schema.external_generated_inputs;
 
+import java.util.List;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSTrackRange;
-
-import java.util.List;
 
 public class RJSElectricalProfileSet {
     public static final JsonAdapter<RJSElectricalProfileSet> adapter =

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSRollingStock.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSRollingStock.java
@@ -33,7 +33,7 @@ public class RJSRollingStock implements Identified {
     @Json(name = "effort_curves")
     public RJSEffortCurves effortCurves;
 
-    @Json(name="power_restrictions")
+    @Json(name = "power_restrictions")
     public Map<String, String> powerRestrictions;
 
     /** The class of power usage of the train */

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
@@ -162,6 +162,7 @@ private fun signalUpdates(
     // TODO: maybe have those be specific to the signaling system
     // FIXME: this doesn't work if the train goes through the same signal twice
     // This is probably a weird edge case anyway
+    @Suppress("UNUSED_PARAMETER")
     fun blinking(aspect: String): Boolean {
         return false
     }


### PR DESCRIPTION
Checkstyle/spotbugs config did not apply to subprojects, it missed a lot of errors.

This isn't the "good practice" way to share settings between subprojects (see [this link](https://docs.gradle.org/current/samples/sample_convention_plugins.html)), but I couldn't make it work with the proper method.

I also removed the need for docstrings for constructors, as most of the time it's just `/** Constructor */`. But I didn't remove the ones that were already there.

Actually still a work in progress, because it's a pain to make everything work properly