### PR TITLE
editoast: migration of /pathfinding endpoints

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1033,6 +1034,7 @@ dependencies = [
  "mvt",
  "pathfinding",
  "pointy",
+ "postgis_diesel",
  "r2d2",
  "rand 0.8.5",
  "redis",
@@ -1047,6 +1049,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -2166,6 +2169,17 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "postgis_diesel"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db7bc162f8e7a4da3dfeb760ae767045b75028f3db81c4f53ad8abec841419c"
+dependencies = [
+ "byteorder",
+ "diesel",
+ "serde",
 ]
 
 [[package]]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -53,7 +53,7 @@ mvt = "0.8.1"
 pointy = "0.4.0"
 futures = "0.3"
 postgis_diesel = { version = "2.1.0", features = ["serde"] }
-uuid = { version = "1.3.0" }
+uuid = { version = "1" }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -20,6 +20,7 @@ diesel = { version = "2.0", features = [
     "postgres",
     "serde_json",
     "chrono",
+    "uuid",
 ] }
 diesel_json = "0.2.0"
 image = "0.24"
@@ -51,6 +52,8 @@ editoast_derive = { path = "./editoast_derive" }
 mvt = "0.8.1"
 pointy = "0.4.0"
 futures = "0.3"
+postgis_diesel = { version = "2.1.0", features = ["serde"] }
+uuid = { version = "1.3.0" }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/editoast/diesel.toml
+++ b/editoast/diesel.toml
@@ -1,2 +1,0 @@
-[print_schema]
-import_types = ["diesel::sql_types::*", "postgis_diesel::sql_types::*"]

--- a/editoast/diesel.toml
+++ b/editoast/diesel.toml
@@ -1,0 +1,2 @@
+[print_schema]
+import_types = ["diesel::sql_types::*", "postgis_diesel::sql_types::*"]

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -13,7 +13,7 @@ use actix_web::web::{block, Data};
 use async_trait::async_trait;
 use diesel::PgConnection;
 
-pub use self::pathfinding::Pathfinding;
+pub use self::pathfinding::*;
 pub use documents::Document;
 pub use projects::{Project, ProjectWithStudies};
 pub use rolling_stock_models::rolling_stock::RollingStockModel;

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -1,4 +1,5 @@
 mod documents;
+mod pathfinding;
 mod projects;
 pub mod rolling_stock_models;
 mod scenario;
@@ -12,6 +13,7 @@ use actix_web::web::{block, Data};
 use async_trait::async_trait;
 use diesel::PgConnection;
 
+pub use self::pathfinding::Pathfinding;
 pub use documents::Document;
 pub use projects::{Project, ProjectWithStudies};
 pub use rolling_stock_models::rolling_stock::RollingStockModel;

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -1,0 +1,34 @@
+//! LOL
+
+use crate::tables::osrd_infra_pathmodel;
+use chrono::{NaiveDateTime, Utc};
+use derivative::Derivative;
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use editoast_derive::Model;
+use postgis_diesel::types::*;
+use serde::Serialize;
+
+#[derive(
+    Clone, Debug, Serialize, Insertable, Derivative, Queryable, QueryableByName, AsChangeset, Model,
+)]
+#[derivative(Default(new = "true"))]
+#[model(table = "osrd_infra_pathmodel")]
+#[model(create, delete, retrieve, update)]
+#[diesel(table_name = osrd_infra_pathmodel)]
+pub struct Pathfinding {
+    pub id: i64,
+    pub owner: uuid::Uuid,
+    #[derivative(Default(value = "Utc::now().naive_utc()"))]
+    pub created: NaiveDateTime,
+    pub payload: serde_json::Value,
+    pub slopes: serde_json::Value,
+    pub curves: serde_json::Value,
+    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
+    pub geographic: LineString<Point>,
+    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
+    pub schematic: LineString<Point>,
+    pub infra_id: i64,
+}

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -1,5 +1,6 @@
-//! LOL
+//! Provides the [Pathfinding] model
 
+use crate::schema::Direction;
 use crate::tables::osrd_infra_pathmodel;
 use chrono::{NaiveDateTime, Utc};
 use derivative::Derivative;
@@ -9,10 +10,15 @@ use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use editoast_derive::Model;
 use postgis_diesel::types::*;
+use serde::Deserialize;
 use serde::Serialize;
 
+/// Describes a pathfinding that resulted from a simulation and stored in the DB
+///
+/// It differs from infra/pathfinding that performs a topological pathfinding
+/// meant to be used with the infra editor.
 #[derive(
-    Clone, Debug, Serialize, Insertable, Derivative, Queryable, QueryableByName, AsChangeset, Model,
+    Debug, Clone, Serialize, Insertable, Derivative, Queryable, QueryableByName, AsChangeset, Model,
 )]
 #[derivative(Default(new = "true"))]
 #[model(table = "osrd_infra_pathmodel")]
@@ -23,12 +29,70 @@ pub struct Pathfinding {
     pub owner: uuid::Uuid,
     #[derivative(Default(value = "Utc::now().naive_utc()"))]
     pub created: NaiveDateTime,
-    pub payload: serde_json::Value,
-    pub slopes: serde_json::Value,
-    pub curves: serde_json::Value,
+    #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
+    pub payload: diesel_json::Json<PathfindingCorePayload>,
+    #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
+    pub slopes: diesel_json::Json<SlopeGraph>,
+    #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
+    pub curves: diesel_json::Json<CurveGraph>,
     #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
     pub geographic: LineString<Point>,
     #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
     pub schematic: LineString<Point>,
     pub infra_id: i64,
+}
+
+pub type SlopeGraph = Vec<Slope>;
+pub type CurveGraph = Vec<Curve>;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Slope {
+    gradient: f64,
+    position: f64,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Curve {
+    radius: f64,
+    position: f64,
+}
+
+#[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
+pub struct PathfindingCorePayload {
+    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
+    pub geographic: LineString<Point>,
+    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
+    pub schematic: LineString<Point>,
+    pub route_paths: Vec<RoutePath>,
+    pub path_waypoints: Vec<PathWaypoint>,
+    pub warnings: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct RoutePath {
+    pub route: String,
+    pub signaling_type: String,
+    pub track_sections: Vec<RouteTrackSection>,
+}
+
+#[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
+#[derivative(Default)]
+pub struct RouteTrackSection {
+    pub track: String,
+    #[derivative(Default(value = "Direction::StartToStop"))]
+    pub direction: Direction,
+    pub begin: f64,
+    pub end: f64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct PathWaypoint {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub track: String,
+    #[serde(default)]
+    pub duration: f64,
+    pub position: f64,
+    pub suggestion: bool,
 }

--- a/editoast/src/schema/track_section.rs
+++ b/editoast/src/schema/track_section.rs
@@ -12,6 +12,7 @@ use crate::map::BoundingBox;
 
 use derivative::Derivative;
 use editoast_derive::InfraModel;
+use postgis_diesel::types as postgis;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, InfraModel)]
@@ -128,6 +129,14 @@ impl LineString {
             max.1 = max.1.max(p[1]);
         }
         BoundingBox(min, max)
+    }
+}
+
+impl From<postgis::LineString<postgis::Point>> for LineString {
+    fn from(value: postgis::LineString<postgis::Point>) -> Self {
+        Self::LineString {
+            coordinates: value.points.into_iter().map(|p| [p.x, p.y]).collect(),
+        }
     }
 }
 

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -330,3 +330,22 @@ table! {
 joinable!(  osrd_infra_trainschedule -> osrd_infra_timetable (timetable_id));
 
 allow_tables_to_appear_in_same_query!(osrd_infra_trainschedule, osrd_infra_timetable);
+
+table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
+
+    osrd_infra_pathmodel(id) {
+        id -> BigInt,
+        owner -> Uuid,
+        created -> Timestamp,
+        payload -> Jsonb,
+        slopes -> Jsonb,
+        curves -> Jsonb,
+        geographic -> Geometry,
+        schematic -> Geometry,
+        infra_id -> BigInt,
+    }
+}
+
+joinable!(osrd_infra_trainschedule -> osrd_infra_pathmodel (path_id));

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -5,6 +5,7 @@ mod layers;
 pub mod light_rolling_stocks;
 pub mod pagination;
 pub mod params;
+pub mod pathfinding;
 pub mod projects;
 pub mod rolling_stocks;
 pub mod scenario;
@@ -34,9 +35,7 @@ pub fn routes() -> impl HttpServiceFactory {
         timetable::routes(),
         rolling_stocks::routes(),
         light_rolling_stocks::routes(),
-        timetable::routes(),
-        rolling_stocks::routes(),
-        light_rolling_stocks::routes()
+        pathfinding::routes()
     ]
 }
 

--- a/editoast/src/views/pathfinding.rs
+++ b/editoast/src/views/pathfinding.rs
@@ -1,0 +1,78 @@
+use actix_web::get;
+use actix_web::web::{Data, Json, Path};
+use actix_web::{dev::HttpServiceFactory, web};
+use editoast_derive::EditoastError;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::error::Result;
+use crate::models::Pathfinding;
+use crate::models::Retrieve;
+use crate::schema::LineString;
+use crate::DbPool;
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "pathfinding")]
+enum PathfindingError {
+    /// Couldn't found the scenario with the given scenario ID
+    #[error("Pathfinding {id} does not exist")]
+    #[editoast_error(status = 404)]
+    NotFound { id: i64 },
+}
+
+/// Returns `/pathfinding` routes
+pub fn routes() -> impl HttpServiceFactory {
+    web::scope("/pathfinding").service(get_pf)
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Response {
+    pub id: i64,
+    pub owner: String,
+    pub created: String,
+    pub slopes: serde_json::Value,
+    pub curves: serde_json::Value,
+    pub geographic: LineString,
+    pub schematic: LineString,
+    pub steps: serde_json::Value,
+}
+
+impl From<Pathfinding> for Response {
+    fn from(value: Pathfinding) -> Self {
+        let Pathfinding {
+            id,
+            owner,
+            created,
+            slopes,
+            curves,
+            geographic,
+            schematic,
+            payload,
+            ..
+        } = value;
+        Self {
+            id,
+            owner: owner.to_string(),
+            created: created.format("%Y-%m-%d %H:%M:%S.%f").to_string(),
+            slopes,
+            curves,
+            geographic: geographic.into(),
+            schematic: schematic.into(),
+            steps: payload
+                .as_object()
+                .expect("invalid pathfinding payload")
+                .get("path_waypoints")
+                .expect("missing 'path_waypoints' from pathfinding payload")
+                .clone(),
+        }
+    }
+}
+
+#[get("{id}")]
+async fn get_pf(path: Path<i64>, db_pool: Data<DbPool>) -> Result<Json<Response>> {
+    let id = path.into_inner();
+    match Pathfinding::retrieve(db_pool, id).await? {
+        Some(pf) => Ok(Json(pf.into())),
+        None => Err(PathfindingError::NotFound { id }.into()),
+    }
+}


### PR DESCRIPTION
Adds GET and DELETE /pathfinding/id, two crates: postgis_diesel (geometry columns) and uuid.
Creates the Pathfinding model using the Model macro.

fixes #3739
fixes #3741 