### PR TITLE
front: tests: Add a `yarn e2e-tests` and display playwright outputs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -90,5 +90,5 @@ jobs:
 
       - name: Run Playwright tests
         run: |
-          cd tests
-          poetry run pytest -m e2e
+          cd front
+          yarn e2e-tests

--- a/front/package.json
+++ b/front/package.json
@@ -174,7 +174,8 @@
     "generate-types": "exec scripts/generate-types.sh",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "generate-licenses": "license-checker-rseidelsohn --json --production --direct --excludePackagesStartingWith '@types' --excludePrivatePackages --customPath src/common/ReleaseInformations/json/licenseCustomFormat.json > src/common/ReleaseInformations/json/licenses.json"
+    "generate-licenses": "license-checker-rseidelsohn --json --production --direct --excludePackagesStartingWith '@types' --excludePrivatePackages --customPath src/common/ReleaseInformations/json/licenseCustomFormat.json > src/common/ReleaseInformations/json/licenses.json",
+    "e2e-tests": "cd ../tests && poetry install && poetry run pytest -m e2e -s"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Playwright outputs are available now :tada: https://github.com/DGEXSolutions/osrd/actions/runs/4575652320/jobs/8078747352?pr=3770#step:17:32

close https://github.com/DGEXSolutions/osrd/issues/3760