### PR TITLE
front: tests: make e2e tests work when running on a dirty env

### DIFF
--- a/front/src/applications/operationalStudies/components/Home/ProjectCard.tsx
+++ b/front/src/applications/operationalStudies/components/Home/ProjectCard.tsx
@@ -56,7 +56,7 @@ export default function ProjectCard({ setFilterChips, project }: Props) {
   }, []);
 
   return (
-    <div className="projects-list-project-card">
+    <div className="projects-list-project-card" data-testid={project.name}>
       <div className="projects-list-project-card-img">
         <LazyLoadImage src={imageUrl} alt="project logo" />
         <button className="btn btn-primary btn-sm" onClick={handleClick} type="button">

--- a/front/src/applications/operationalStudies/components/Project/StudyCard.tsx
+++ b/front/src/applications/operationalStudies/components/Project/StudyCard.tsx
@@ -45,7 +45,7 @@ export default function StudyCard({ setFilterChips, study }: Props) {
 
   return (
     <div className="studies-list-card">
-      <div className="studies-list-card-name">
+      <div className="studies-list-card-name" data-testid={study.name}>
         <span className="mr-2">
           <img src={studyLogo} alt="study logo" height="24" />
         </span>

--- a/front/src/applications/operationalStudies/components/Study/ScenarioCard.tsx
+++ b/front/src/applications/operationalStudies/components/Study/ScenarioCard.tsx
@@ -39,7 +39,7 @@ export default function StudyCard({ setFilterChips, scenario }: Props) {
 
   return (
     <div className="scenarios-list-card">
-      <div className="scenarios-list-card-name">
+      <div className="scenarios-list-card-name" data-testid={scenario.name}>
         <span className="mr-2">
           <RiFolderChartLine />
         </span>

--- a/front/tests/operational-studies.spec.ts
+++ b/front/tests/operational-studies.spec.ts
@@ -14,18 +14,16 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
     // Real click on project, study, scenario
     await playwrightHomePage.goToOperationalStudiesPage();
     await playwrightHomePage.page
-      .locator('.projects-list-project-card-img')
-      .first()
+      .getByTestId('_@Test integration project')
+      .locator('div')
       .getByRole('button')
       .click();
     await playwrightHomePage.page
-      .locator('.studies-list-card-name')
-      .first()
+      .getByTestId('_@Test integration study')
       .getByRole('button')
       .click();
     await playwrightHomePage.page
-      .locator('.scenarios-list-card-name')
-      .first()
+      .getByTestId('_@Test integration scenario')
       .getByRole('button')
       .click();
 

--- a/front/tests/stdcm-page.spec.ts
+++ b/front/tests/stdcm-page.spec.ts
@@ -28,17 +28,22 @@ test.describe('STDCM page', () => {
     // Opens the scenario explorator and selects project, study and scenario
     await playwrightSTDCMPage.openScenarioExplorator();
     await playwrightSTDCMPage.getScenarioExploratorModalOpen();
-    await playwrightSTDCMPage.clickItemScenarioExploratorByName('Project test');
-    await playwrightSTDCMPage.clickItemScenarioExploratorByName('Study test');
-    await playwrightSTDCMPage.clickItemScenarioExploratorByName('Scenario test');
+    await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration project');
+    await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration study');
+    await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration scenario');
   });
 
   test('should be correctly displays the rolling stock list and select one', async () => {
     const rollingStockTranslation =
       playwrightSTDCMPage.getmanageTrainScheduleTranslations('rollingstock');
     const rollingStockTranslationRegEx = new RegExp(rollingStockTranslation as string);
+    // Check that the three tests rolling stocks are present
+    playwrightSTDCMPage.getRollingstockByTestId(`rollingstock-_@Test Locomotives électriques`);
+    playwrightSTDCMPage.getRollingstockByTestId(
+      `rollingstock-_@Test Locomotives électriques courant continu7200GH`
+    );
     const rollingstockItem = playwrightSTDCMPage.getRollingstockByTestId(
-      `rollingstock-BB 7200GVLOCOMOTIVES`
+      `rollingstock-_@Test BB 7200GVLOCOMOTIVES`
     );
     // Check that no rollingstock is selected
     await expect(
@@ -52,21 +57,17 @@ test.describe('STDCM page', () => {
 
     await playwrightSTDCMPage.page.waitForSelector('.rollingstock-container');
 
-    const numberOfRollingstock = await playwrightSTDCMPage.getRollingStockListItem.count();
-
-    expect(numberOfRollingstock).toEqual(3);
-
     const infoCardText = await playwrightSTDCMPage.getRollingStockListItem
       .locator('.rollingstock-infos')
       .allTextContents();
     expect(infoCardText).toContain(
-      'BB 7200GVLOCOMOTIVES / Locomotives électriques / Locomotives électriques courant continuBB 7200GVLOCOMOTIVES'
+      'BB 7200GVLOCOMOTIVES / Locomotives électriques / Locomotives électriques courant continu_@Test BB 7200GVLOCOMOTIVES'
     );
     expect(infoCardText).toContain(
-      'BB 15000BB15000 USLOCOMOTIVES / Locomotives électriques / Locomotives électriques monophaséLocomotives électriques'
+      'BB 15000BB15000 USLOCOMOTIVES / Locomotives électriques / Locomotives électriques monophasé_@Test Locomotives électriques'
     );
     expect(infoCardText).toContain(
-      'BB 22200V160LOCOMOTIVES / Locomotives électriques / Locomotives électriques bi courantLocomotives électriques courant continu7200GH'
+      'BB 22200V160LOCOMOTIVES / Locomotives électriques / Locomotives électriques bi courant_@Test Locomotives électriques courant continu7200GH'
     );
 
     const footerCardText = await playwrightSTDCMPage.getRollingStockListItem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def foo_project_id() -> int:
     response = requests.post(
         EDITOAST_URL + "projects/",
         json={
-            "name": "Project test",
+            "name": "_@Test integration project",
             "description": "",
             "objectives": "",
             "funders": "",
@@ -72,7 +72,7 @@ def foo_project_id() -> int:
 @pytest.fixture
 def foo_study_id(foo_project_id: int) -> int:
     payload = {
-        "name": "Study test",
+        "name": "_@Test integration study",
         "service_code": "AAA",
         "business_code": "BBB",
         "tags": [],

--- a/tests/tests/test_e2e.py
+++ b/tests/tests/test_e2e.py
@@ -7,7 +7,7 @@ import pytest
 @pytest.mark.e2e
 @pytest.mark.names_and_metadata(
     {
-        "BB 7200GVLOCOMOTIVES": {
+        "_@Test BB 7200GVLOCOMOTIVES": {
             "type": "Locomotives électriques",
             "unit": "US",
             "detail": "BB 7200",
@@ -18,7 +18,7 @@ import pytest
             "reference": "7200",
             "subseries": "GV",
         },
-        "Locomotives électriques": {
+        "_@Test Locomotives électriques": {
             "type": "Locomotives électriques",
             "unit": "US",
             "detail": "BB15000 US",
@@ -29,7 +29,7 @@ import pytest
             "reference": "15000",
             "subseries": "BB 15000",
         },
-        "Locomotives électriques courant continu7200GH": {
+        "_@Test Locomotives électriques courant continu7200GH": {
             "type": "Locomotives électriques",
             "unit": "US",
             "detail": "BB 22200",

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -32,4 +32,4 @@ def test_get_scenario(small_scenario: Scenario):
     )
     assert response.status_code == 200
     body = _ScenarioResponse(**response.json())
-    assert body.name == "Scenario test"
+    assert body.name == "_@Test integration scenario"

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -15,7 +15,7 @@ def create_op_study(base_url, project_id: int) -> int:
 
 def create_scenario(base_url, infra_id, project_id, op_study_id) -> Tuple[int, int]:
 
-    scenario_payload = {"name": "Scenario test", "infra_id": infra_id}
+    scenario_payload = {"name": "_@Test integration scenario", "infra_id": infra_id}
     r = requests.post(
         base_url + f"projects/{project_id}/studies/{op_study_id}/scenarios/",
         json=scenario_payload,


### PR DESCRIPTION
Thanks to this PR e2e tests can be run without having to start from an empty database.

Top be merged after https://github.com/DGEXSolutions/osrd/pull/3699 for conflict reason

close #3778 