### PR TITLE
[front] Linear metadata : adding a visual indicator on hover

### DIFF
--- a/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
@@ -153,12 +153,7 @@ export interface LinearMetadataDatavizProps<T> {
   /**
    * Event when mouse leave into data item
    */
-  onMouseLeave?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    item: LinearMetadataItem<T>,
-    index: number,
-    point: number // point on the linear metadata
-  ) => void;
+  onMouseLeave?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 
   /**
    * Event when mouse wheel on a data item
@@ -331,7 +326,10 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
     <div className={cx('linear-metadata-visualisation')}>
       <div
         ref={wrapper}
-        onMouseLeave={() => setHoverAtx(null)}
+        onMouseLeave={(e) => {
+          setHoverAtx(null);
+          if (onMouseLeave) onMouseLeave(e);
+        }}
         className={cx(
           'data',
           highlighted.length > 0 && 'has-highlight',
@@ -348,7 +346,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
         {/* Display the Y axis if there is one */}
         {field && min !== max && <Scale className="scale-y" begin={min} end={max} />}
 
-        {hoverAtx && (
+        {hoverAtx && !draginStartAt && (
           <div
             className="hover-x"
             style={{ position: 'relative', left: `${hoverAtx}px`, borderLeft: '1px dotted' }}
@@ -414,13 +412,6 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
                 const item = data[segment.index];
                 const point = getPositionFromMouseEvent(e, item);
                 onMouseEnter(e, item, segment.index, point);
-              }
-            }}
-            onMouseLeave={(e) => {
-              if (onMouseLeave && data[segment.index]) {
-                const item = data[segment.index];
-                const point = getPositionFromMouseEvent(e, item);
-                onMouseLeave(e, item, segment.index, point);
               }
             }}
             onMouseDown={(e) => {

--- a/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
@@ -213,7 +213,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
   const [max, setMax] = useState<number>(0);
   // Computed data for the viz and the viewbox
   const [data4viz, setData4viz] = useState<Array<LinearMetadataItem & { index: number }>>([]);
-
+  const [hoverAtx, setHoverAtx] = useState<number | null>(null);
   /**
    * When data change (or the field)
    * => we recompute the min/max
@@ -331,6 +331,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
     <div className={cx('linear-metadata-visualisation')}>
       <div
         ref={wrapper}
+        onMouseLeave={() => setHoverAtx(null)}
         className={cx(
           'data',
           highlighted.length > 0 && 'has-highlight',
@@ -346,6 +347,13 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
         )}
         {/* Display the Y axis if there is one */}
         {field && min !== max && <Scale className="scale-y" begin={min} end={max} />}
+
+        {hoverAtx && (
+          <div
+            className="hover-x"
+            style={{ position: 'relative', left: `${hoverAtx}px`, borderLeft: '1px dotted' }}
+          />
+        )}
 
         {/* Create one div per item for the X axis */}
         {data4viz.map((segment) => (
@@ -377,16 +385,24 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
               }
             }}
             onMouseOver={(e) => {
-              if (!draginStartAt && onMouseOver && data[segment.index]) {
-                const item = data[segment.index];
-                const point = getPositionFromMouseEvent(e, item);
-                onMouseOver(e, item, segment.index, point);
+              if (!draginStartAt) {
+                // handle mouse over
+                if (onMouseOver && data[segment.index]) {
+                  const item = data[segment.index];
+                  const point = getPositionFromMouseEvent(e, item);
+                  onMouseOver(e, item, segment.index, point);
+                }
               }
             }}
             onFocus={() => undefined}
             role="button"
             tabIndex={0}
             onMouseMove={(e) => {
+              // display vertical bar when hover element
+              setHoverAtx(
+                e.clientX - (wrapper.current ? wrapper.current.getBoundingClientRect().x : 0)
+              );
+
               if (!draginStartAt && onMouseMove && data[segment.index]) {
                 const item = data[segment.index];
                 const point = getPositionFromMouseEvent(e, item);

--- a/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/dataviz.tsx
@@ -349,7 +349,12 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
         {hoverAtx && !draginStartAt && (
           <div
             className="hover-x"
-            style={{ position: 'relative', left: `${hoverAtx}px`, borderLeft: '1px dotted' }}
+            style={{
+              position: 'absolute',
+              height: '100%',
+              left: `${hoverAtx}px`,
+              borderLeft: '1px dotted',
+            }}
           />
         )}
 


### PR DESCRIPTION
Fix #1567 Linear metadata : adding a visual indicator  where we hover

It's useful when you want to cut a segment in two parts for example.