### PR TITLE
stdcm waypoints and intermediate stops

### DIFF
--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -712,16 +712,22 @@ components:
         end_time:
           type: number
           format: double
-        start_points:
+        steps:
           type: array
+          minimum: 2
           items:
-            $ref: "#/components/schemas/Waypoint"
-          minimum: 1
-        end_points:
-          type: array
-          items:
-            $ref: "#/components/schemas/Waypoint"
-          minimum: 1
+            type: object
+            properties:
+              waypoints:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Waypoint"
+                minimum: 1
+              stop:
+                type: boolean
+              stop_duration:
+                type: number
+                format: double
         speed_limit_tags:
           type: string
           description: Train composition used for speed limit

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
@@ -112,7 +112,16 @@ public class PathfindingRoutesEndpoint implements Take {
         var electrificationConstraints = new ElectrificationConstraints(rollingStocks);
         final List<EdgeToRanges<SignalingRoute>> constraintsList =
                 List.of(loadingGaugeConstraints, electrificationConstraints);
+        var remainingDistanceEstimators = makeHeuristics(waypoints);
 
+        // Compute the paths from the entry waypoint to the exit waypoint
+        return computePaths(infra, waypoints, constraintsList, remainingDistanceEstimators);
+    }
+
+    /** Initialize the heuristics */
+    public static ArrayList<AStarHeuristic<SignalingRoute>> makeHeuristics(
+            List<Collection<Pathfinding.EdgeLocation<SignalingRoute>>> waypoints
+    ) {
         // Compute the minimum distance between steps
         double[] stepMinDistance = new double[waypoints.size() - 1];
         for (int i = 0; i < waypoints.size() - 2; i++) {
@@ -129,9 +138,7 @@ public class PathfindingRoutesEndpoint implements Take {
         for (int i = 0; i < waypoints.size() - 1; i++) {
             remainingDistanceEstimators.add(new RemainingDistanceEstimator(waypoints.get(i + 1), stepMinDistance[i]));
         }
-
-        // Compute the paths from the entry waypoint to the exit waypoint
-        return computePaths(infra, waypoints, constraintsList, remainingDistanceEstimators);
+        return remainingDistanceEstimators;
     }
 
 

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api.stdcm;
 
+import com.google.common.collect.Iterables;
 import fr.sncf.osrd.api.ExceptionHandler;
 import fr.sncf.osrd.api.FullInfra;
 import fr.sncf.osrd.api.InfraManager;
@@ -89,8 +90,9 @@ public class STDCMEndpoint implements Take {
             final var infra = fullInfra.java();
             final var rollingStock = RJSRollingStockParser.parse(request.rollingStock);
             final var comfort = RJSRollingStockParser.parseComfort(request.comfort);
-            final var startLocations = findRoutes(infra, request.startPoints);
-            final var endLocations = findRoutes(infra, request.endPoints);
+            // TODO: handle more than 2 waypoints
+            final var startLocations = findRoutes(infra, request.steps.get(0).waypoints);
+            final var endLocations = findRoutes(infra, Iterables.getLast(request.steps).waypoints);
             final String tag = request.speedLimitComposition;
             var occupancies = request.routeOccupancies;
             AllowanceValue standardAllowance = null;

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -89,7 +89,6 @@ public class STDCMEndpoint implements Take {
             final var infra = fullInfra.java();
             final var rollingStock = RJSRollingStockParser.parse(request.rollingStock);
             final var comfort = RJSRollingStockParser.parseComfort(request.comfort);
-            // TODO: handle more than 2 waypoints
             final var steps = parseSteps(infra, request.steps);
             final String tag = request.speedLimitComposition;
             var occupancies = request.routeOccupancies;
@@ -148,7 +147,7 @@ public class STDCMEndpoint implements Take {
             simResult.baseSimulations.add(ScheduleMetadataExtractor.run(
                     res.envelope(),
                     res.trainPath(),
-                    makeTrainSchedule(res.envelope().getEndPos(), rollingStock, comfort),
+                    makeTrainSchedule(res.envelope().getEndPos(), rollingStock, comfort, res.stopResults()),
                     fullInfra
             ));
             simResult.ecoSimulations.add(null);
@@ -226,11 +225,12 @@ public class STDCMEndpoint implements Take {
 
         var path = TrainPathBuilder.from(routes, startLocation, lastLocation);
         DriverBehaviour driverBehaviour = new DriverBehaviour(0, 0);
+        var stops = List.of(new TrainStop(path.length(), 0.1));  // TODO: fix this
         var standaloneResult = StandaloneSim.run(
                 fullInfra,
                 path,
                 EnvelopeTrainPath.from(path),
-                List.of(makeTrainSchedule(path.length(), rollingStock, comfort)),
+                List.of(makeTrainSchedule(path.length(), rollingStock, comfort, stops)),
                 timeStep,
                 driverBehaviour
         );
@@ -245,9 +245,9 @@ public class STDCMEndpoint implements Take {
     private static StandaloneTrainSchedule makeTrainSchedule(
             double endPos,
             RollingStock rollingStock,
-            RollingStock.Comfort comfort
+            RollingStock.Comfort comfort,
+            List<TrainStop> trainStops
     ) {
-        List<TrainStop> trainStops = new ArrayList<>();
         trainStops.add(new TrainStop(endPos, 0.1));
         return new StandaloneTrainSchedule(rollingStock, 0., trainStops, List.of(), null, comfort, null, null);
     }

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -225,12 +225,11 @@ public class STDCMEndpoint implements Take {
 
         var path = TrainPathBuilder.from(routes, startLocation, lastLocation);
         DriverBehaviour driverBehaviour = new DriverBehaviour(0, 0);
-        var stops = List.of(new TrainStop(path.length(), 0.1));  // TODO: fix this
         var standaloneResult = StandaloneSim.run(
                 fullInfra,
                 path,
                 EnvelopeTrainPath.from(path),
-                List.of(makeTrainSchedule(path.length(), rollingStock, comfort, stops)),
+                List.of(makeTrainSchedule(path.length(), rollingStock, comfort, new ArrayList<>())),
                 timeStep,
                 driverBehaviour
         );

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
@@ -175,6 +175,7 @@ public final class STDCMRequest {
         public Collection<PathfindingWaypoint> waypoints;
 
 
+        /** Create a new step */
         public STDCMStep(double stopDuration, boolean stop, Collection<PathfindingWaypoint> waypoints) {
             this.stopDuration = stopDuration;
             this.stop = stop;

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMRequest.java
@@ -12,6 +12,7 @@ import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock;
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowance;
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceValue;
 import java.util.Collection;
+import java.util.List;
 
 @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
 public final class STDCMRequest {
@@ -50,17 +51,10 @@ public final class STDCMRequest {
     @Json(name = "route_occupancies")
     public Collection<RouteOccupancy> routeOccupancies;
 
-    /**
-     * List of possible start points for the train
+    /** A list of steps on the path. A step is a set of location with a stop duration.
+     *  The path only has to go through a single point per location.
      */
-    @Json(name = "start_points")
-    public Collection<PathfindingWaypoint> startPoints;
-
-    /**
-     * List of possible end points for the train
-     */
-    @Json(name = "end_points")
-    public Collection<PathfindingWaypoint> endPoints;
+    public List<STDCMStep> steps;
 
     /**
      * Train start time
@@ -133,7 +127,6 @@ public final class STDCMRequest {
                 null,
                 null,
                 null,
-                null,
                 Double.NaN,
                 Double.NaN,
                 null,
@@ -150,8 +143,7 @@ public final class STDCMRequest {
             String expectedVersion,
             RJSRollingStock rollingStock,
             Collection<RouteOccupancy> routeOccupancies,
-            Collection<PathfindingWaypoint> startPoints,
-            Collection<PathfindingWaypoint> endPoints,
+            List<STDCMStep> steps,
             double startTime,
             double endTime,
             String speedLimitComposition,
@@ -162,13 +154,32 @@ public final class STDCMRequest {
         this.expectedVersion = expectedVersion;
         this.rollingStock = rollingStock;
         this.routeOccupancies = routeOccupancies;
-        this.startPoints = startPoints;
-        this.endPoints = endPoints;
+        this.steps = steps;
         this.startTime = startTime;
         this.endTime = endTime;
         this.speedLimitComposition = speedLimitComposition;
         this.gridMarginBeforeSTDCM = marginBefore;
         this.gridMarginAfterSTDCM = marginAfter;
+    }
+
+    public static class STDCMStep {
+        /** Duration of the stop, if the train stops */
+        @Json(name = "stop_duration")
+        public double stopDuration;
+
+        /** If set to false, the train passes through the point without stopping */
+        public boolean stop;
+
+        /** List of possible points to validate the step: the train only has to pass through or stop at
+         * one of the points. */
+        public Collection<PathfindingWaypoint> waypoints;
+
+
+        public STDCMStep(double stopDuration, boolean stop, Collection<PathfindingWaypoint> waypoints) {
+            this.stopDuration = stopDuration;
+            this.stop = stop;
+            this.waypoints = waypoints;
+        }
     }
 
     public static class RouteOccupancy {

--- a/core/src/main/java/fr/sncf/osrd/stdcm/STDCMResult.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/STDCMResult.java
@@ -4,7 +4,9 @@ import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.PhysicsPath;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.train.TrainStop;
 import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.List;
 
 /** This is the result of the STDCM computation.
  * It is made of a physical path part and envelope, as well as different representations
@@ -14,5 +16,6 @@ public record STDCMResult(
         Envelope envelope,
         TrainPath trainPath,
         PhysicsPath physicsPath,
-        double departureTime
+        double departureTime,
+        List<TrainStop> stopResults
 ) {}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/STDCMStep.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/STDCMStep.java
@@ -1,0 +1,12 @@
+package fr.sncf.osrd.stdcm;
+
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.Collection;
+
+public record STDCMStep(
+        Collection<Pathfinding.EdgeLocation<SignalingRoute>> locations,
+        double duration,
+        boolean stop
+)
+{}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/AllowanceManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/AllowanceManager.java
@@ -77,6 +77,7 @@ public class AllowanceManager {
                     .setPrevNode(node)
                     .setEnvelope(extractEnvelopeSection(totalEnvelope, previousEnd, end))
                     .setForceMaxDelay(true)
+                    .setWaypointIndex(edge.waypointIndex())
                     .findEdgeSameNextOccupancy(edge.timeNextOccupancy());
             if (prevEdge == null)
                 return null;
@@ -107,6 +108,10 @@ public class AllowanceManager {
     private List<STDCMEdge> findAffectedEdges(STDCMEdge edge, double delayNeeded) {
         var res = new ArrayDeque<STDCMEdge>();
         while (true) {
+            if (edge.endAtStop()) {
+                // Engineering allowances can't span over stops
+                return new ArrayList<>(res);
+            }
             var endTime = edge.timeStart() + edge.getTotalTime();
             var maxDelayAddedOnEdge = edge.timeNextOccupancy() - endTime;
             if (delayNeeded > maxDelayAddedOnEdge) {

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/BacktrackingManager.java
@@ -71,6 +71,7 @@ public class BacktrackingManager {
                 .setPrevAddedDelay(old.totalDepartureTimeShift() - old.addedDelay())
                 .setPrevNode(prevNode)
                 .setEnvelope(newEnvelope)
+                .setWaypointIndex(old.waypointIndex())
                 .findEdgeSameNextOccupancy(old.timeNextOccupancy());
     }
 

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/DelayManager.java
@@ -113,7 +113,11 @@ public class DelayManager {
             double startTime
     ) {
         var speedRatio = graph.getStandardAllowanceSpeedRatio(envelope);
-        var scaledEnvelope = LinearAllowance.scaleEnvelope(envelope, speedRatio);
+        Envelope scaledEnvelope;
+        if (envelope.getEndPos() == 0)
+            scaledEnvelope = envelope;
+        else
+            scaledEnvelope = LinearAllowance.scaleEnvelope(envelope, speedRatio);
         return routeAvailability.getAvailability(
                 path,
                 startOffset,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdge.java
@@ -81,7 +81,7 @@ public record STDCMEdge(
                 newWaypointIndex++; // Skip waypoints where we don't stop (not handled here)
             return new STDCMNode(
                     getTotalTime() + timeStart() + stopDuration,
-                    0,
+                    envelope.getEndSpeed(),
                     null,
                     totalDepartureTimeShift(),
                     maximumAddedDelayAfter(),

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdge.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdge.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.Objects;
 
 public record STDCMEdge(
@@ -28,7 +29,11 @@ public record STDCMEdge(
         int minuteTimeStart,
         // Speed factor used to account for standard allowance.
         // e.g. if we have a 5% standard allowance, this value is 1/1.05
-        double standardAllowanceSpeedFactor
+        double standardAllowanceSpeedFactor,
+        // Index of the last waypoint passed by this train
+        int waypointIndex,
+        // True if the edge end is a stop
+        boolean endAtStop
 ) {
     @Override
     public boolean equals(Object other) {
@@ -55,18 +60,46 @@ public record STDCMEdge(
 
     /** Returns the node at the end of this edge */
     STDCMNode getEdgeEnd(STDCMGraph graph) {
-        return new STDCMNode(
-                getTotalTime() + timeStart(),
-                envelope().getEndSpeed(),
-                graph.infra.getSignalingRouteGraph().incidentNodes(route()).nodeV(),
-                totalDepartureTimeShift(),
-                maximumAddedDelayAfter(),
-                this
-        );
+        if (!endAtStop) {
+            // We move on to the next route
+            return new STDCMNode(
+                    getTotalTime() + timeStart(),
+                    envelope().getEndSpeed(),
+                    graph.infra.getSignalingRouteGraph().incidentNodes(route()).nodeV(),
+                    totalDepartureTimeShift(),
+                    maximumAddedDelayAfter(),
+                    this,
+                    waypointIndex,
+                    null,
+                    -1
+            );
+        } else {
+            // New edge on the same route, after a stop
+            double stopDuration = graph.steps.get(waypointIndex + 1).duration();
+            var newWaypointIndex = waypointIndex + 1;
+            while (newWaypointIndex + 1 < graph.steps.size() && !graph.steps.get(newWaypointIndex + 1).stop())
+                newWaypointIndex++; // Skip waypoints where we don't stop (not handled here)
+            return new STDCMNode(
+                    getTotalTime() + timeStart() + stopDuration,
+                    0,
+                    null,
+                    totalDepartureTimeShift(),
+                    maximumAddedDelayAfter(),
+                    this,
+                    newWaypointIndex,
+                    new Pathfinding.EdgeLocation<>(route, envelopeStartOffset + getLength()),
+                    stopDuration
+            );
+        }
     }
 
     /** Returns how long it takes to go from the start to the end of the route, accounting standard allowance. */
     public double getTotalTime() {
         return envelope.getTotalTime() / standardAllowanceSpeedFactor;
+    }
+
+    /** Returns the length of the edge */
+    public double getLength() {
+        return envelope.getEndPos();
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
@@ -169,7 +169,7 @@ public class STDCMEdgeBuilder {
             return Set.of();
         return Set.of(Math.min(
                 prevMaximumAddedDelay,
-                graph.delayManager.findMaximumAddedDelay(
+                lastOpeningDelay + graph.delayManager.findMaximumAddedDelay(
                         route,
                         startTime + lastOpeningDelay,
                         startOffset,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
@@ -4,14 +4,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
-import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.STDCMStep;
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Graph;
-import fr.sncf.osrd.utils.graph.Pathfinding;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 
 /** This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding implementation.
  * Most of the logic has been delegated to helper classes in this module:
@@ -26,7 +25,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
     public final RollingStock rollingStock;
     public final RollingStock.Comfort comfort;
     public final double timeStep;
-    final Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations;
+    final List<STDCMStep> steps;
     final DelayManager delayManager;
     final AllowanceManager allowanceManager;
     final BacktrackingManager backtrackingManager;
@@ -42,7 +41,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
             RouteAvailabilityInterface routeAvailability,
             double maxRunTime,
             double minScheduleTimeStart,
-            Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
+            List<STDCMStep> steps,
             String tag,
             AllowanceValue standardAllowance
     ) {
@@ -50,7 +49,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         this.rollingStock = rollingStock;
         this.comfort = comfort;
         this.timeStep = timeStep;
-        this.endLocations = endLocations;
+        this.steps = steps;
         this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, routeAvailability, this);
         this.allowanceManager = new AllowanceManager(this);
         this.backtrackingManager = new BacktrackingManager(this);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
@@ -80,14 +80,19 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
 
     @Override
     public Collection<STDCMEdge> getAdjacentEdges(STDCMNode node) {
-        var res = new ArrayList<STDCMEdge>();
-        var neighbors = infra.getSignalingRouteGraph().outEdges(node.detector());
-        for (var neighbor : neighbors) {
-            res.addAll(
-                    STDCMEdgeBuilder.fromNode(this, node, neighbor)
-                            .makeAllEdges()
-            );
+        if (node.detector() == null)
+            return STDCMEdgeBuilder.fromNode(this, node, node.locationOnRoute().edge())
+                    .makeAllEdges();
+        else {
+            var res = new ArrayList<STDCMEdge>();
+            var neighbors = infra.getSignalingRouteGraph().outEdges(node.detector());
+            for (var neighbor : neighbors) {
+                res.addAll(
+                        STDCMEdgeBuilder.fromNode(this, node, neighbor)
+                                .makeAllEdges()
+                );
+            }
+            return res;
         }
-        return res;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMNode.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMNode.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.stdcm.graph;
 
 import fr.sncf.osrd.infra.api.reservation.DiDetector;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.utils.graph.Pathfinding;
 
 public record STDCMNode(
         // Time at the transition of the edge
@@ -14,6 +16,12 @@ public record STDCMNode(
         // Maximum delay we can add by delaying the start time without causing conflicts
         double maximumAddedDelay,
         // Edge that lead to this node
-        STDCMEdge previousEdge
+        STDCMEdge previousEdge,
+        // Index of the last waypoint passed by the train
+        int waypointIndex,
+        // Position on a route, if this node isn't on the transition between routes (stop)
+        Pathfinding.EdgeLocation<SignalingRoute> locationOnRoute,
+        // When the node is a stop, how long the train remains here
+        double stopDuration
 ) {
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
@@ -67,7 +67,7 @@ public class STDCMPathfinding {
                 .setEdgeToLength(STDCMEdge::getLength)
                 .addBlockedRangeOnEdges(edge -> loadingGaugeConstraints.apply(edge.route()))
                 .addBlockedRangeOnEdges(edge -> electrificationConstraints.apply(edge.route()))
-                .setTotalDistanceUntilEdgeLocation(range -> totalDistanceUntilEdgeLocation(range, maxDepartureDelay))
+                .setTotalCostUntilEdgeLocation(range -> totalCostUntilEdgeLocation(range, maxDepartureDelay))
                 .runPathfinding(
                         convertLocations(graph, steps.get(0).locations(), startTime, maxDepartureDelay),
                         makeObjectiveFunction(steps)
@@ -107,8 +107,8 @@ public class STDCMPathfinding {
         return globalResult;
     }
 
-    /** Compute the total distance of a path (in s) to an edge location
-     * This estimation of the total distance is used to compare paths in the pathfinding algorithm.
+    /** Compute the total cost of a path (in s) to an edge location
+     * This estimation of the total cost is used to compare paths in the pathfinding algorithm.
      * We select the shortest path (in duration), and for 2 paths with the same duration, we select the earliest one.
      * The path weight which takes into account the total duration of the path and the time shift at the departure
      * (with different weights): path_duration * searchTimeRange + departure_time_shift.
@@ -121,7 +121,7 @@ public class STDCMPathfinding {
      * - the second one leaves at 9:00 and lasts for 20:01 min.
      * As we are looking for the fastest train, the first train should have the lightest weight, which is the case with
      * the formula above.*/
-    private static double totalDistanceUntilEdgeLocation(
+    private static double totalCostUntilEdgeLocation(
             Pathfinding.EdgeLocation<STDCMEdge> range,
             double searchTimeRange
     ) {

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
@@ -14,7 +14,6 @@ import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.TrainStop;
 import fr.sncf.osrd.utils.graph.Pathfinding;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.stdcm.graph;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+
 import com.google.common.collect.Iterables;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.stdcm.STDCMResult;
@@ -97,7 +99,11 @@ public class STDCMPostProcessing {
                 length += nextRange.end() - nextRange.start();
                 i++;
             }
-            res.add(new Pathfinding.EdgeRange<>(range.edge().route(), start, start + length));
+            var end = start + length;
+            var routeLength = range.edge().route().getInfraRoute().getLength();
+            if (Math.abs(end - routeLength) < POSITION_EPSILON)
+                end = routeLength;
+            res.add(new Pathfinding.EdgeRange<>(range.edge().route(), start, end));
             i++;
         }
         return res;

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
@@ -71,6 +71,8 @@ public class STDCMSimulations {
     ) {
         if (stopPosition != null && stopPosition == 0)
             return makeSinglePointEnvelope(0);
+        if (start >= route.getInfraRoute().getLength())
+            return makeSinglePointEnvelope(initialSpeed);
         var context = makeSimContext(List.of(route), start, rollingStock, comfort, timeStep);
         double[] stops = new double[]{};
         double length = context.path.getLength();
@@ -106,13 +108,11 @@ public class STDCMSimulations {
     /** Returns the time at which the offset on the given route is reached */
     public static double interpolateTime(
             Envelope envelope,
-            SignalingRoute route,
+            double envelopeStartOffset,
             double routeOffset,
             double startTime,
             double speedRatio
     ) {
-        var routeLength = route.getInfraRoute().getLength();
-        var envelopeStartOffset = routeLength - envelope.getEndPos();
         var envelopeOffset = Math.max(0, routeOffset - envelopeStartOffset);
         assert envelopeOffset <= envelope.getEndPos();
         return startTime + (envelope.interpolateTotalTime(envelopeOffset) / speedRatio);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph;
 
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder;
@@ -69,7 +70,7 @@ public class STDCMSimulations {
             Double stopPosition,
             String tag
     ) {
-        if (stopPosition != null && stopPosition == 0)
+        if (stopPosition != null && Math.abs(stopPosition) < POSITION_EPSILON)
             return makeSinglePointEnvelope(0);
         if (start >= route.getInfraRoute().getLength())
             return makeSinglePointEnvelope(initialSpeed);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper;
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.TrainStop;
@@ -47,7 +48,7 @@ public class STDCMStandardAllowance {
                     rangeTransitions
             );
             var conflictOffset = findConflictOffsets(
-                    newEnvelope, routeAvailability, ranges, departureTime);
+                    newEnvelope, routeAvailability, ranges, departureTime, stops);
             if (Double.isNaN(conflictOffset))
                 return newEnvelope;
             assert !rangeTransitions.contains(conflictOffset) : "conflict offset is already on a range transition";
@@ -72,14 +73,16 @@ public class STDCMStandardAllowance {
             Envelope envelope,
             RouteAvailabilityInterface routeAvailability,
             List<Pathfinding.EdgeRange<STDCMEdge>> ranges,
-            double departureTime
+            double departureTime,
+            List<TrainStop> stops
     ) {
         var path = STDCMUtils.makePathFromRanges(ranges);
+        var envelopeWithStops = new EnvelopeStopWrapper(envelope, stops);
         var availability = routeAvailability.getAvailability(
                 path,
                 0,
                 envelope.getEndPos(),
-                envelope,
+                envelopeWithStops,
                 departureTime
         );
         assert !(availability.getClass() == RouteAvailabilityInterface.NotEnoughLookahead.class);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMUtils.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.stdcm.graph;
 
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
 
+import com.google.common.collect.Iterables;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
@@ -50,7 +51,8 @@ public class STDCMUtils {
     /** Returns the offset of the stops on the given route, starting at startOffset*/
     static Double getStopOnRoute(STDCMGraph graph, SignalingRoute route, double startOffset) {
         var res = new ArrayList<Double>();
-        for (var endLocation : graph.endLocations) {
+        // FIXME: use more than the last step
+        for (var endLocation : Iterables.getLast(graph.steps).locations()) {
             if (endLocation.edge() == route) {
                 var offset = endLocation.offset() - startOffset;
                 if (offset >= 0)

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm.preprocessing.implementation;
 
 import com.google.common.collect.Multimap;
-import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.stdcm.OccupancyBlock;
@@ -26,7 +26,7 @@ public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterfac
             TrainPath path,
             double startOffset,
             double endOffset,
-            Envelope envelope,
+            EnvelopeTimeInterpolate envelope,
             double startTime
     ) {
         assert Math.abs((endOffset - startOffset) - envelope.getEndPos()) < 1e-5;
@@ -42,7 +42,7 @@ public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterfac
             TrainPath path,
             double startOffset,
             double endOffset,
-            Envelope envelope,
+            EnvelopeTimeInterpolate envelope,
             double startTime
     ) {
         double minimumDelay = 0;
@@ -92,7 +92,7 @@ public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterfac
             TrainPath path,
             double startOffset,
             double endOffset,
-            Envelope envelope,
+            EnvelopeTimeInterpolate envelope,
             double startTime
     ) {
         double maximumDelay = Double.POSITIVE_INFINITY;
@@ -136,7 +136,7 @@ public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterfac
             OccupancyBlock block,
             TrainPath.LocatedElement<SignalingRoute> route,
             double startOffset,
-            Envelope envelope,
+            EnvelopeTimeInterpolate envelope,
             double startTime
     ) {
         var startRouteOffsetOnEnvelope = route.pathOffset() - startOffset;

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/RouteAvailabilityInterface.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces;
 
 import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 
 /** Abstract interface used to request the availability of path sections */
@@ -32,7 +33,7 @@ public interface RouteAvailabilityInterface {
             TrainPath path,
             double startOffset,
             double endOffset,
-            Envelope envelope,
+            EnvelopeTimeInterpolate envelope,
             double startTime
     );
 

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/Pathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/Pathfinding.java
@@ -73,7 +73,7 @@ public class Pathfinding<NodeT, EdgeT> {
      * Function to call to know the cost of the path from the departure point to the edge location .
      * Used in STDCM. Either totalDistanceUntilEdgeLocation or edgeRangeCost must be defined.
     */
-    private TotalDistanceUntilEdgeLocation<EdgeT> totalDistanceUntilEdgeLocation = null;
+    private TotalCostUntilEdgeLocation<EdgeT> totalCostUntilEdgeLocation = null;
 
     /** Constructor */
     public Pathfinding(Graph<NodeT, EdgeT> graph) {
@@ -99,8 +99,8 @@ public class Pathfinding<NodeT, EdgeT> {
     }
 
     /** Sets the functor used to estimate the cost for a range */
-    public Pathfinding<NodeT, EdgeT> setTotalDistanceUntilEdgeLocation(TotalDistanceUntilEdgeLocation<EdgeT> f) {
-        this.totalDistanceUntilEdgeLocation = f;
+    public Pathfinding<NodeT, EdgeT> setTotalCostUntilEdgeLocation(TotalCostUntilEdgeLocation<EdgeT> f) {
+        this.totalCostUntilEdgeLocation = f;
         return this;
     }
 
@@ -227,7 +227,7 @@ public class Pathfinding<NodeT, EdgeT> {
     private void checkParameters() {
         assert edgeToLength != null;
         assert estimateRemainingDistance != null;
-        if (totalDistanceUntilEdgeLocation == null && edgeRangeCost == null)
+        if (totalCostUntilEdgeLocation == null && edgeRangeCost == null)
             edgeRangeCost = (range) -> range.end - range.start;
     }
 
@@ -302,8 +302,8 @@ public class Pathfinding<NodeT, EdgeT> {
         if (range == null)
             return;
         double totalDistance = 0;
-        if (totalDistanceUntilEdgeLocation != null)
-            totalDistance = totalDistanceUntilEdgeLocation.apply(new EdgeLocation<>(range.edge, range.end));
+        if (totalCostUntilEdgeLocation != null)
+            totalDistance = totalCostUntilEdgeLocation.apply(new EdgeLocation<>(range.edge, range.end));
         else {
             totalDistance = prevDistance + edgeRangeCost.apply(range);
         }

--- a/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TotalCostUntilEdgeLocation.java
+++ b/core/src/main/java/fr/sncf/osrd/utils/graph/functional_interfaces/TotalCostUntilEdgeLocation.java
@@ -3,6 +3,6 @@ package fr.sncf.osrd.utils.graph.functional_interfaces;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 
 @FunctionalInterface
-public interface TotalDistanceUntilEdgeLocation<EdgeT>  {
+public interface TotalCostUntilEdgeLocation<EdgeT>  {
     double apply(Pathfinding.EdgeLocation<EdgeT> edgeLocation);
 }

--- a/core/src/test/java/fr/sncf/osrd/api/STDCMEndpointTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/STDCMEndpointTest.java
@@ -24,16 +24,18 @@ public class STDCMEndpointTest extends ApiTest {
                 "1",
                 parseRollingStockDir(getResourcePath("rolling_stocks/")).get(0),
                 Set.of(),
-                Set.of(new PathfindingWaypoint(
-                        "ne.micro.foo_b",
-                        100,
-                        EdgeDirection.START_TO_STOP
-                )),
-                Set.of(new PathfindingWaypoint(
-                        "ne.micro.bar_a",
-                        100,
-                        EdgeDirection.START_TO_STOP
-                )),
+                List.of(
+                        new STDCMRequest.STDCMStep(0, true, Set.of(new PathfindingWaypoint(
+                                "ne.micro.foo_b",
+                                100,
+                                EdgeDirection.START_TO_STOP
+                        ))),
+                        new STDCMRequest.STDCMStep(0, true, Set.of(new PathfindingWaypoint(
+                                "ne.micro.bar_a",
+                                100,
+                                EdgeDirection.START_TO_STOP
+                        )))
+                ),
                 0,
                 0,
                 "foo",

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -14,6 +14,7 @@ import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
+import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
 import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
@@ -138,15 +139,16 @@ public class STDCMHelpers {
             ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph,
             double tolerance
     ) {
+        var envelopeWrapper = new EnvelopeStopWrapper(res.envelope(), res.stopResults());
         var routes = res.trainPath().routePath();
         for (var index = 0; index < routes.size(); index++) {
             var startRoutePosition = routes.get(index).pathOffset();
             var routeOccupancies = occupancyGraph.get(routes.get(index).element());
             for (var occupancy : routeOccupancies) {
-                var enterTime = res.departureTime() + res.envelope().interpolateTotalTimeClamp(
+                var enterTime = res.departureTime() + envelopeWrapper.interpolateTotalTimeClamp(
                         startRoutePosition + occupancy.distanceStart()
                 );
-                var exitTime = res.departureTime() + res.envelope().interpolateTotalTimeClamp(
+                var exitTime = res.departureTime() + envelopeWrapper.interpolateTotalTimeClamp(
                         startRoutePosition + occupancy.distanceEnd()
                 );
                 assertTrue(

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -27,7 +27,7 @@ public class StandardAllowanceTests {
     ){}
 
     /** Runs the pathfinding with the given parameters, with and without allowance */
-    private static STDCMAllowanceResults runWithAndWithoutAllowance(STDCMPathfindingBuilder builder) {
+    static STDCMAllowanceResults runWithAndWithoutAllowance(STDCMPathfindingBuilder builder) {
         builder.setTimeStep(timeStep);
         var resultWithAllowance = builder.run();
         builder.setStandardAllowance(null);
@@ -43,7 +43,7 @@ public class StandardAllowanceTests {
     }
 
     /** Compares the run time with and without allowance, checks that the allowance is properly applied */
-    private static void checkAllowanceResult(STDCMAllowanceResults results, AllowanceValue value, double tolerance) {
+    static void checkAllowanceResult(STDCMAllowanceResults results, AllowanceValue value, double tolerance) {
         if (Double.isNaN(tolerance))
             tolerance = 2 * timeStep;
         var baseEnvelope = results.withoutAllowance.envelope();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
@@ -1,0 +1,370 @@
+package fr.sncf.osrd.stdcm;
+
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.SPEED_EPSILON;
+import static fr.sncf.osrd.stdcm.STDCMHelpers.occupancyTest;
+import static fr.sncf.osrd.stdcm.StandardAllowanceTests.checkAllowanceResult;
+import static fr.sncf.osrd.stdcm.StandardAllowanceTests.runWithAndWithoutAllowance;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.common.collect.ImmutableMultimap;
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
+import fr.sncf.osrd.train.TrainStop;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.util.List;
+import java.util.Set;
+
+public class StopTests {
+    /** Look for a path in an empty timetable, with a stop in the middle of a route */
+    @Test
+    public void emptyTimetableWithStop() {
+        /*
+        a --> b --> c
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 50)), 10_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 100)), 0, true))
+                .run();
+        assertNotNull(res);
+        double expectedOffset = 150;
+
+        // Check that we stop
+        assertEquals(0, res.envelope().interpolateSpeed(expectedOffset), SPEED_EPSILON);
+
+        // Check that the stop is properly returned
+        assertEquals(
+                List.of(
+                        new TrainStop(expectedOffset, 10_000)
+                ),
+                res.stopResults()
+        );
+    }
+
+    /** Look for a path in an empty timetable, with a stop at the start of a route */
+    @Test
+    public void emptyTimetableWithStopRouteStart() {
+        /*
+        a --> b --> c
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 0)), 10_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 100)), 0, true))
+                .run();
+        assertNotNull(res);
+        checkStop(res, List.of(
+                new TrainStop(100, 10_000)
+        ));
+    }
+
+    /** Look for a path in an empty timetable, with a stop at the end of a route */
+    @Test
+    public void emptyTimetableWithStopRouteEnd() {
+        /*
+        a --> b --> c
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 100)), 10_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 100)), 0, true))
+                .run();
+        assertNotNull(res);
+        checkStop(res, List.of(
+                new TrainStop(100, 10_000)
+        ));
+    }
+
+    /** Checks that we can make a detour to pass by an intermediate step */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void detourForStep(boolean stop) {
+        /*
+        a --> b --> c --> d --> e
+               \         ^
+                \       /
+                 \     /
+                  \   /
+                   v /
+                    x
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routesDirectPath = List.of(
+                infraBuilder.addRoute("a", "b"),
+                infraBuilder.addRoute("b", "c"),
+                infraBuilder.addRoute("c", "d"),
+                infraBuilder.addRoute("d", "e")
+        );
+        var detour = List.of(
+                infraBuilder.addRoute("b", "x", 100_000),
+                infraBuilder.addRoute("x", "d", 100_000)
+        );
+        var infra = infraBuilder.build();
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartTime(100)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routesDirectPath.get(0), 0)), 0, false))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(detour.get(1), 1_000)), 0, stop))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routesDirectPath.get(3), 0)), 0, true))
+                .run();
+        assertNotNull(res);
+        var routes = res.routes().ranges().stream()
+                .map(route -> route.edge().getInfraRoute().getID()).toList();
+        assertEquals(
+                List.of(
+                        "a->b",
+                        "b->x",
+                        "x->d",
+                        "d->e"
+                ), routes
+        );
+        assertNotEquals(stop, res.stopResults().isEmpty());
+        assertEquals(stop, res.envelope().interpolateSpeed(101_100) == 0);
+    }
+
+    /** Test that the stop time is properly accounted for, by making the train stop for too long to find a solution */
+    @Test
+    public void testImpossibleSolutionBecauseOfStop() {
+        /*
+        a --> b --> c
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var firstRoute = infraBuilder.addRoute("a", "b");
+        var secondRoute = infraBuilder.addRoute("b", "c");
+        var infra = infraBuilder.build();
+        var unavailableTimes = ImmutableMultimap.of(
+                secondRoute, new OccupancyBlock(100_000, POSITIVE_INFINITY, 0, 100)
+        );
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 10)), 100_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(secondRoute, 100)), 0, true))
+                .setUnavailableTimes(unavailableTimes)
+                .run();
+        assertNull(res);
+    }
+
+    /** Checks that we add the right amount of delay with a stop */
+    @Test
+    public void delayWithStop() {
+        /*
+        a --> b --> c -> d
+         */
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b"),
+                infraBuilder.addRoute("b", "c"),
+                infraBuilder.addRoute("c", "d", 1)
+        );
+        var infra = infraBuilder.build();
+        var occupancy = ImmutableMultimap.of(
+                routes.get(2), new OccupancyBlock(0, 12_000, 0, 1),
+                routes.get(2), new OccupancyBlock(12_010, POSITIVE_INFINITY, 0, 1)
+        );
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 50)), 10_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(2), 1)), 0, true))
+                .setUnavailableTimes(occupancy)
+                .run();
+        assertNotNull(res);
+        checkStop(res, List.of(
+                new TrainStop(50, 10_000)
+        ));
+        occupancyTest(res, occupancy);
+    }
+
+    /** Checks that we can handle engineering allowance with a stop */
+    @Test
+    public void engineeringAllowanceWithStops() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        e |################### end ###
+          |################### /   ###
+        d |                   /
+          |               __/
+        c |    __________/   <-- stop
+          |   /
+        b |  /
+          | /##################
+        a |/_##################_> time
+
+         */
+
+        // Note: this test will need to be updated once we can add delay by making stops longer
+
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1, 20),
+                infraBuilder.addRoute("b", "c", 1_000, 20),
+                infraBuilder.addRoute("c", "d", 100, 20),
+                infraBuilder.addRoute("d", "e", 1, 20)
+        );
+        var occupancy = ImmutableMultimap.of(
+                routes.get(0), new OccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
+                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+        );
+        double timeStep = 2;
+        var infra = infraBuilder.build();
+        var res = new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancy)
+                .setTimeStep(timeStep)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(1), 50)), 1_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(3), 1)), 0, true))
+                .run();
+        assertNotNull(res);
+        checkStop(res, List.of(
+                new TrainStop(51, 1_000)
+        ));
+        occupancyTest(res, occupancy, 2 * timeStep);
+    }
+
+    /** Checks that we can handle a standard allowance with a stop */
+    @Test
+    public void standardAllowanceWithStops() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        e |################ end ###
+          |################ /   ###
+        d |                /
+          |               /
+        c |    __________/   <-- stop
+          |   /
+        b |  /
+          | /
+        a |/____________________> time
+
+         */
+
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1, 20),
+                infraBuilder.addRoute("b", "c", 1_000, 20),
+                infraBuilder.addRoute("c", "d", 100, 20),
+                infraBuilder.addRoute("d", "e", 1, 20)
+        );
+        var occupancy = ImmutableMultimap.of(
+                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+        );
+        double timeStep = 2;
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(20);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancy)
+                .setTimeStep(timeStep)
+                .setStandardAllowance(allowance)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(1), 50)), 1_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(3), 1)), 0, true))
+        );
+        assertNotNull(res);
+        var expectedStops = List.of(
+                new TrainStop(51, 1_000)
+        );
+        checkStop(res.withAllowance(), expectedStops);
+        checkStop(res.withoutAllowance(), expectedStops);
+        occupancyTest(res.withAllowance(), occupancy, 2 * timeStep);
+        occupancyTest(res.withoutAllowance(), occupancy, 2 * timeStep);
+        checkAllowanceResult(res, allowance, 4 * timeStep);
+    }
+
+    /** Checks that we can handle both a standard and engineering allowance with a stop */
+    @Test
+    public void standardAndEngineeringAllowanceWithStops() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        e |################### end ###
+          |################### /   ###
+        d |                   /
+          |               __/
+        c |    __________/   <-- stop
+          |   /
+        b |  /
+          | /##################
+        a |/_##################_> time
+
+         */
+
+        // Note: this test will need to be updated once we can add delay by making stops longer
+
+        var infraBuilder = new DummyRouteGraphBuilder();
+        var routes = List.of(
+                infraBuilder.addRoute("a", "b", 1, 20),
+                infraBuilder.addRoute("b", "c", 1_000, 20),
+                infraBuilder.addRoute("c", "d", 100, 20),
+                infraBuilder.addRoute("d", "e", 1, 20)
+        );
+        var occupancy = ImmutableMultimap.of(
+                routes.get(0), new OccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
+                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+        );
+        double timeStep = 2;
+        var infra = infraBuilder.build();
+        var allowance = new AllowanceValue.Percentage(20);
+        var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setUnavailableTimes(occupancy)
+                .setTimeStep(timeStep)
+                .setStandardAllowance(allowance)
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(0), 0)), 0, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(1), 50)), 1_000, true))
+                .addStep(new STDCMStep(Set.of(new Pathfinding.EdgeLocation<>(routes.get(3), 1)), 0, true))
+        );
+        assertNotNull(res);
+        var expectedStops = List.of(
+                new TrainStop(51, 1_000)
+        );
+        checkStop(res.withAllowance(), expectedStops);
+        checkStop(res.withoutAllowance(), expectedStops);
+        occupancyTest(res.withAllowance(), occupancy, 2 * timeStep);
+        occupancyTest(res.withoutAllowance(), occupancy, 2 * timeStep);
+    }
+
+    /** Check that the train actually stops at the expected times and positions */
+    private static void checkStop(STDCMResult res, List<TrainStop> expectedStops) {
+        // Check that the stops are properly returned
+        assertEquals(
+                expectedStops,
+                res.stopResults()
+        );
+
+        // Check that we stop
+        for (var stop : expectedStops)
+            assertEquals(0, res.envelope().interpolateSpeed(stop.position), SPEED_EPSILON);
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
@@ -331,7 +331,7 @@ public class StopTests {
         var occupancy = ImmutableMultimap.of(
                 routes.get(0), new OccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
                 routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
-                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+                routes.get(3), new OccupancyBlock(1_300, POSITIVE_INFINITY, 0, 1)
         );
         double timeStep = 2;
         var infra = infraBuilder.build();

--- a/front/src/applications/stdcm/formatStcmConf.ts
+++ b/front/src/applications/stdcm/formatStcmConf.ts
@@ -109,6 +109,7 @@ export default function formatStdcmConf(
 
     const osrdConfStdcm = {
       ...getOpenApiSteps(osrdconf),
+      rolling_stock: osrdconf.rollingStockID,
       comfort: osrdconf.rollingStockComfort,
       timetable: osrdconf.timetableID,
       start_time: originDate, // Build a date

--- a/front/src/applications/stdcm/formatStcmConf.ts
+++ b/front/src/applications/stdcm/formatStcmConf.ts
@@ -108,13 +108,11 @@ export default function formatStdcmConf(
     standardAllowance.value_type = standardAllowanceType;
 
     const osrdConfStdcm = {
-      infra: osrdconf.infraID,
-      rolling_stock: osrdconf.rollingStockID,
+      ...getOpenApiSteps(osrdconf),
       comfort: osrdconf.rollingStockComfort,
       timetable: osrdconf.timetableID,
       start_time: originDate, // Build a date
       end_time: destinationDate, // Build a date
-      steps: getOpenApiSteps(osrdconf),
       maximum_departure_delay: maximumDepartureDelay,
       maximum_relative_run_time: 2,
       speed_limit_tags: osrdconf.speedLimitByTag,

--- a/front/src/applications/stdcm/formatStcmConf.ts
+++ b/front/src/applications/stdcm/formatStcmConf.ts
@@ -11,6 +11,7 @@ import { makeEnumBooleans } from 'utils/constants';
 
 import { ActionFailure } from 'reducers/main';
 import { ThunkAction } from 'types';
+import { getOpenApiSteps } from 'common/Pathfinding/Pathfinding'
 
 export default function formatStdcmConf(
   dispatch: Dispatch,
@@ -113,18 +114,7 @@ export default function formatStdcmConf(
       timetable: osrdconf.timetableID,
       start_time: originDate, // Build a date
       end_time: destinationDate, // Build a date
-      start_points: [
-        {
-          track_section: osrdconf?.origin?.id,
-          geo_coordinate: osrdconf?.origin?.coordinates,
-        },
-      ],
-      end_points: [
-        {
-          track_section: osrdconf?.destination?.id,
-          geo_coordinate: osrdconf?.destination?.coordinates,
-        },
-      ],
+      steps: getOpenApiSteps(osrdconf),
       maximum_departure_delay: maximumDepartureDelay,
       maximum_relative_run_time: 2,
       speed_limit_tags: osrdconf.speedLimitByTag,

--- a/front/src/common/api/osrdMiddlewareApi.ts
+++ b/front/src/common/api/osrdMiddlewareApi.ts
@@ -988,8 +988,10 @@ export type StdcmRequest = {
   timetable?: number;
   start_time?: number;
   end_time?: number;
-  start_points?: Waypoint[];
-  end_points?: Waypoint[];
+  steps?: {
+    duration?: number;
+    waypoints?: Waypoint;
+  }[];
   maximum_departure_delay?: number;
   maximum_relative_run_time?: number;
   speed_limit_tags?: string;

--- a/python/api/openapi.yaml
+++ b/python/api/openapi.yaml
@@ -1560,16 +1560,17 @@ components:
         end_time:
           type: number
           format: double
-        start_points:
+        steps:
           type: array
-          minimum: 1
+          minItems: 2
           items:
-            $ref: "#/components/schemas/Waypoint"
-        end_points:
-          type: array
-          minimum: 1
-          items:
-            $ref: "#/components/schemas/Waypoint"
+            type: object
+            properties:
+              duration:
+                type: number
+                format: float
+              waypoints:
+                $ref: "#/components/schemas/Waypoint"
         maximum_departure_delay:
           type: number
           format: double

--- a/python/api/osrd_infra/serializers.py
+++ b/python/api/osrd_infra/serializers.py
@@ -215,22 +215,25 @@ class StandaloneSimulationSerializer(Serializer):
 
 
 class STDCMInputSerializer(Serializer):
-    class WaypointInputSerializer(Serializer):
-        track_section = serializers.CharField(max_length=255)
-        geo_coordinate = serializers.JSONField(required=False)
-        offset = serializers.FloatField(required=False)
+    class StepInputSerializer(Serializer):
+        class WaypointInputSerializer(Serializer):
+            track_section = serializers.CharField(max_length=255)
+            geo_coordinate = serializers.JSONField(required=False)
+            offset = serializers.FloatField(required=False)
+
+        duration = serializers.FloatField(required=False)
+        waypoints = serializers.ListField(
+            min_length=1,
+            child=WaypointInputSerializer(),
+        )
 
     infra = serializers.PrimaryKeyRelatedField(queryset=Infra.objects.all())
     timetable = serializers.PrimaryKeyRelatedField(queryset=Timetable.objects.all())
     start_time = serializers.FloatField(required=False, allow_null=True)
     end_time = serializers.FloatField(required=False, allow_null=True)
-    start_points = serializers.ListField(
-        min_length=1,
-        child=WaypointInputSerializer(),
-    )
-    end_points = serializers.ListField(
-        min_length=1,
-        child=WaypointInputSerializer(),
+    steps = serializers.ListField(
+        min_length=2,
+        child=StepInputSerializer(),
     )
     rolling_stock = serializers.PrimaryKeyRelatedField(queryset=RollingStock.objects.all())
     comfort = serializers.ChoiceField(choices=[(x.value, x.name) for x in ComfortType], default=ComfortType.STANDARD)

--- a/python/api/osrd_infra/views/stdcm.py
+++ b/python/api/osrd_infra/views/stdcm.py
@@ -95,7 +95,7 @@ def parse_stdcm_steps(request, infra):
         res.append(
             {
                 "waypoints": step_waypoints,
-                "step_duration": duration,
+                "stop_duration": duration,
                 "stop": duration > 0,
             }
         )
@@ -106,7 +106,15 @@ def compute_stdcm(request, user):
     core_output = request_stdcm(make_stdcm_core_payload(request))
     path = PathModel()
     infra = request["infra"]
-    postprocess_path(path, core_output["path"], infra, user, [0, 0])
+    step_durations = [0]
+    for stop in core_output["simulation"]["base_simulations"][0]["stops"]:
+        step_durations.append(stop["duration"])
+
+    # Dummy values, we don't need actual stop values to be linked to the path,
+    # and it's difficult to sort out the waypoints where the train doesn't stop
+    step_durations = [0] * len(core_output["path"]["path_waypoints"])
+
+    postprocess_path(path, core_output["path"], infra, user, step_durations)
     path.save()
 
     schedule = TrainSchedule()

--- a/python/api/osrd_infra/views/stdcm.py
+++ b/python/api/osrd_infra/views/stdcm.py
@@ -7,7 +7,7 @@ from config import settings
 from osrd_infra.models import PathModel, TrainSchedule
 from osrd_infra.serializers import PathSerializer, STDCMInputSerializer
 from osrd_infra.utils import make_exception_from_error
-from osrd_infra.views import fetch_track_sections, parse_waypoint, postprocess_path
+from osrd_infra.views import parse_steps_input, postprocess_path
 from osrd_infra.views.train_schedule import (
     create_simulation_report,
     process_simulation_response,
@@ -24,14 +24,6 @@ class InvalidSTDCMInput(APIException):
     status_code = 400
     default_detail = "The STDCM request had invalid inputs"
     default_code = "stdcm_invalid_input"
-
-
-def get_track_ids(request):
-    waypoints = request["start_points"] + request["end_points"]
-    res = list()
-    for waypoint in waypoints:
-        res.append(waypoint["track_section"])
-    return res
 
 
 def request_stdcm(payload):
@@ -63,21 +55,14 @@ def make_route_occupancies(timetable):
 
 
 def make_stdcm_core_payload(request):
-    start_points = []
-    end_points = []
     infra = request["infra"]
-    track_map = fetch_track_sections(infra, get_track_ids(request))
-    for waypoint in request["start_points"]:
-        start_points += parse_waypoint(waypoint, track_map)
-    for waypoint in request["end_points"]:
-        end_points += parse_waypoint(waypoint, track_map)
+    steps = parse_stdcm_steps(request, infra)
     res = {
         "infra": infra.pk,
         "expected_version": infra.version,
         "rolling_stock": request["rolling_stock"].to_schema().dict(),
         "comfort": request["comfort"],
-        "start_points": start_points,
-        "end_points": end_points,
+        "steps": steps,
         "route_occupancies": make_route_occupancies(request["timetable"]),
     }
     if "start_time" in request:
@@ -98,6 +83,22 @@ def make_stdcm_core_payload(request):
         if parameter in request:
             res[parameter] = request[parameter]
 
+    return res
+
+
+def parse_stdcm_steps(request, infra):
+    waypoints, step_durations = parse_steps_input(request["steps"], infra)
+    assert len(waypoints) == len(step_durations)
+    assert len(waypoints) >= 2, "Need at least two steps to run an stdcm pathfinding"
+    res = []
+    for step_waypoints, duration in zip(waypoints, step_durations):
+        res.append(
+            {
+                "waypoints": step_waypoints,
+                "step_duration": duration,
+                "stop": duration > 0,
+            }
+        )
     return res
 
 

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -209,17 +209,25 @@ def make_stdcm_payload(scenario: Scenario, path: List[Tuple[str, float]], rollin
         "maximum_relative_run_time": random.random() * 4,
         "margin_before": random.randint(0, 600),
         "margin_after": random.randint(0, 600),
-        "start_points": [
+        "steps": [
             {
-                "track_section": start_edge,
-                "offset": start_offset,
-            }
-        ],
-        "end_points": [
+                "waypoints": [
+                    {
+                        "track_section": start_edge,
+                        "offset": start_offset,
+                    }
+                ],
+                "duration": 0.1,
+            },
             {
-                "track_section": last_edge,
-                "offset": last_offset,
-            }
+                "waypoints": [
+                    {
+                        "track_section": last_edge,
+                        "offset": last_offset,
+                    }
+                ],
+                "duration": 0.1,
+            },
         ],
     }
     allowance_value = make_random_allowance_value(0)

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -198,8 +198,6 @@ def make_stdcm_payload(scenario: Scenario, path: List[Tuple[str, float]], rollin
     """
     Creates a payload for an STDCM request
     """
-    start_edge, start_offset = path[0]
-    last_edge, last_offset = path[1]
     res = {
         "infra": scenario.infra,
         "rolling_stock": rolling_stock,
@@ -209,26 +207,7 @@ def make_stdcm_payload(scenario: Scenario, path: List[Tuple[str, float]], rollin
         "maximum_relative_run_time": random.random() * 4,
         "margin_before": random.randint(0, 600),
         "margin_after": random.randint(0, 600),
-        "steps": [
-            {
-                "waypoints": [
-                    {
-                        "track_section": start_edge,
-                        "offset": start_offset,
-                    }
-                ],
-                "duration": 0.1,
-            },
-            {
-                "waypoints": [
-                    {
-                        "track_section": last_edge,
-                        "offset": last_offset,
-                    }
-                ],
-                "duration": 0.1,
-            },
-        ],
+        "steps": [convert_stop(stop) for stop in path],
     }
     allowance_value = make_random_allowance_value(0)
     if allowance_value["value_type"] != "time" and random.randint(0, 2) == 0:

--- a/tests/tests/regression_tests_data/stdcm_envelope_discontinuity.json
+++ b/tests/tests/regression_tests_data/stdcm_envelope_discontinuity.json
@@ -1,0 +1,46 @@
+{
+    "error_type": "STDCM",
+    "code": 500,
+    "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"stack_trace\":[\"STDCMUtils.java:38\",\"STDCMPostProcessing.java:40\",\"STDCMPathfinding.java:76\",\"STDCMEndpoint.java:124\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}",
+    "infra_name": "small_infra",
+    "path_payload": {},
+    "stdcm_payload": {
+        "infra": 4,
+        "rolling_stock": 99,
+        "timetable": 194,
+        "start_time": 72585,
+        "maximum_departure_delay": 11781,
+        "maximum_relative_run_time": 2.583918620503443,
+        "margin_before": 326,
+        "margin_after": 554,
+        "steps": [
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TE0",
+                        "offset": 21.536276842572867
+                    }
+                ]
+            },
+            {
+                "duration": 91.38670424368811,
+                "waypoints": [
+                    {
+                        "track_section": "TE0",
+                        "offset": 165.59434139086298
+                    }
+                ]
+            },
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TF1",
+                        "offset": 0.8508378694731533
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/tests/regression_tests_data/stdcm_track_discontinuity.json
+++ b/tests/tests/regression_tests_data/stdcm_track_discontinuity.json
@@ -1,0 +1,55 @@
+{
+    "error_type": "STDCM",
+    "code": 500,
+    "error": "[very_long_html]",
+    "infra_name": "small_infra",
+    "path_payload": {},
+    "stdcm_payload": {
+        "infra": 4,
+        "rolling_stock": 57,
+        "timetable": 247,
+        "start_time": 32932,
+        "maximum_departure_delay": 14236,
+        "maximum_relative_run_time": 2.4285493636940516,
+        "margin_before": 116,
+        "margin_after": 369,
+        "steps": [
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TA4",
+                        "offset": 3.873162621826137
+                    }
+                ]
+            },
+            {
+                "duration": 132.1022484526423,
+                "waypoints": [
+                    {
+                        "track_section": "TA4",
+                        "offset": 38.604771378263074
+                    }
+                ]
+            },
+            {
+                "duration": 929.5615124770158,
+                "waypoints": [
+                    {
+                        "track_section": "TA7",
+                        "offset": 2234.4917124706953
+                    }
+                ]
+            },
+            {
+                "duration": 606.1796930381452,
+                "waypoints": [
+                    {
+                        "track_section": "TG4",
+                        "offset": 365.01345811311415
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/tests/regression_tests_data/stdcm_zero_time_delta.json
+++ b/tests/tests/regression_tests_data/stdcm_zero_time_delta.json
@@ -1,0 +1,55 @@
+{
+    "error_type": "STDCM",
+    "code": 500,
+    "error": "{\"type\":\"core:assert_error\",\"assert_message\":\"zero timeDeltas\",\"cause\":\"INTERNAL\",\"message\":\"zero timeDeltas\",\"stack_trace\":[\"EnvelopePart.java:175\",\"EnvelopePart.java:79\",\"EnvelopePart.java:91\",\"EnvelopePart.java:104\",\"MRSP.java:37\",\"STDCMSimulations.java:84\",\"STDCMEdgeBuilder.java:137\",\"STDCMGraph.java:85\",\"STDCMGraph.java:21\",\"Pathfinding.java:196\",\"STDCMPathfinding.java:70\",\"STDCMEndpoint.java:124\",\"FkRegex.java:153\",\"FkRegex.java:217\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:84\",\"TkFallback.java:66\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:123\",\"BkBasic.java:99\",\"BkSafe.java:46\",\"BkWrap.java:51\",\"BkParallel.java:81\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}",
+    "infra_name": "small_infra",
+    "path_payload": {},
+    "stdcm_payload": {
+        "infra": 4,
+        "rolling_stock": 96,
+        "timetable": 206,
+        "start_time": 68278,
+        "maximum_departure_delay": 10102,
+        "maximum_relative_run_time": 3.142380551666401,
+        "margin_before": 593,
+        "margin_after": 564,
+        "steps": [
+            {
+                "duration": 813.0286733791074,
+                "waypoints": [
+                    {
+                        "track_section": "TG1",
+                        "offset": 2923.550391860934
+                    }
+                ]
+            },
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TG1",
+                        "offset": 3558.0285980746066
+                    }
+                ]
+            },
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TG3",
+                        "offset": 37.53601950217849
+                    }
+                ]
+            },
+            {
+                "duration": 831.953212514249,
+                "waypoints": [
+                    {
+                        "track_section": "TG5",
+                        "offset": 253.17877814332323
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -45,8 +45,10 @@ def test_empty_timetable(small_infra: Infra, foo_project_id: int, fast_rolling_s
         "timetable": timetable,
         "start_time": 0,
         "name": "foo",
-        "start_points": [_START],
-        "end_points": [_STOP],
+        "steps": [
+            {"duration": 0.1, "waypoints": [_START]},
+            {"duration": 0.1, "waypoints": [_STOP]},
+        ],
     }
     r = requests.post(API_URL + "stdcm/", json=payload)
     assert r.status_code == 200
@@ -61,8 +63,10 @@ def test_between_trains(small_scenario: Scenario, fast_rolling_stock: int, west_
         "timetable": small_scenario.timetable,
         "start_time": 5000,
         "name": "foo",
-        "start_points": [_START],
-        "end_points": [_STOP],
+        "steps": [
+            {"duration": 0.1, "waypoints": [_START]},
+            {"duration": 0.1, "waypoints": [_STOP]},
+        ],
     }
     r = requests.post(API_URL + "stdcm/", json=payload)
     if r.status_code // 100 != 2:


### PR DESCRIPTION
This PR is a collection of small changes that make it possible to handle intermediate steps in STDCM. 

* Adapt STDCM API to handle more than the start/end points. The API is now very close to the pathfinding API in that regard, but I didn't factorize too much because I expect more data to be added soon. 
* Edges stop at the first stop encountered (mostly handled in https://github.com/DGEXSolutions/osrd/pull/3667)
* Edges that stopped before the end of the route can lead to other edges, starting at the same point
* Edges/nodes keep track of how many steps have been passed

Most of the diff is in the form of new tests.

This hasn't been tested on actual infras and with front-end integration **yet**. I do intend to test everything before it's merged. 