### PR TITLE
core: fetch and cache the infrastructure version

### DIFF
--- a/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
@@ -29,6 +29,7 @@ public class ApiTest {
         lenient().when(remoteCall.execute()).thenAnswer(
                 invocation -> new Response.Builder().protocol(Protocol.HTTP_1_1).request(argument.getValue())
                         .code(200).message("OK")
+                        .addHeader("x-infra-version", "1")
                         .body(ResponseBody.create(parseMockRequest(argument.getValue(), regex),
                                 MediaType.get("application/json; charset=utf-8"))).build());
 


### PR DESCRIPTION
We previously mistakenly used the requested infrastructure version as the reference for the current infrastructure version.

That is not correct, and cannot come close when the client does not request a specific infrastructure version.

As the infrastructure is retrieved over multiple transactions, there can be no guarantee whatsoever that the infrastructure is valid.

To mitigate this issue, the infrastructure version is retrieved first, so that an up-to-date infrastructure can be downloaded later on.