### PR TITLE
editoast: TrackSectionModel & crate geos 

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -22,8 +22,8 @@ jobs:
           # run the CI on the actual latest commit of the PR, not the attempted merge
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Install lib posgresql
-        run: sudo apt-get install -y libpq-dev
+      - name: Install lib posgresql & geos
+        run: sudo apt-get install -y libpq-dev libgeos-dev
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -579,6 +579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "c_vec"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7a427adc0135366d99db65b36dae9237130997e560ed61118041fb72be6e8"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1035,7 @@ dependencies = [
  "enum-map",
  "env_logger",
  "futures",
+ "geos",
  "image",
  "json-patch",
  "mvt",
@@ -1357,6 +1364,41 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geojson"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d90d17275f3d3d1c6e64d2703e2667f875e2bb80437e4675537f87fec0f07c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "geos"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2faf51d32b09edaf404d9a6eb6b4e7a777d6f6002c9f84bc8f7d5d124c57d80"
+dependencies = [
+ "c_vec",
+ "geojson",
+ "geos-sys",
+ "libc",
+ "num",
+]
+
+[[package]]
+name = "geos-sys"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ece257289a8aa90a1016447b870e4df1d389f6ff21b411cc7f046944370db3e"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1900,6 +1942,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,12 +1986,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -54,6 +54,7 @@ pointy = "0.4.0"
 futures = "0.3"
 postgis_diesel = { version = "2.1.0", features = ["serde"] }
 uuid = { version = "1" }
+geos = { version = "8.1.0", features = ["json"] }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -7,6 +7,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 
+# geos crate requirement
+RUN apt update -yqq &&  apt install -yqq --no-install-recommends libgeos-dev
+
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
@@ -19,7 +22,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM debian:bullseye-slim as runner
 
 RUN apt update -yqq && \
-    apt install -yqq --no-install-recommends libpq-dev curl ca-certificates && \
+    apt install -yqq --no-install-recommends libpq-dev curl ca-certificates libgeos-dev && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/*
 

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -13,6 +13,7 @@ It will apply modification and update generated data such as object geometry.
 - [rustup](https://rustup.rs/)
 - [libpq](https://www.postgresql.org/docs/current/libpq.html)
 - [openssl](https://www.openssl.org)
+- [libgeos](https://libgeos.org/usage/install/)
 
 ## Steps
 

--- a/editoast/src/models/infra_objects/mod.rs
+++ b/editoast/src/models/infra_objects/mod.rs
@@ -1,0 +1,1 @@
+pub mod track_section;

--- a/editoast/src/models/infra_objects/track_section.rs
+++ b/editoast/src/models/infra_objects/track_section.rs
@@ -1,0 +1,20 @@
+//! Provides the [TrackSectionModel] model
+
+use crate::{schema::TrackSection, tables::osrd_infra_tracksectionmodel};
+use derivative::Derivative;
+use diesel::{prelude::*, result::Error as DieselError, ExpressionMethods, QueryDsl};
+use editoast_derive::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Derivative, Serialize, Deserialize, Queryable, QueryableByName, Model)]
+#[derivative(Default(new = "true"))]
+#[model(table = "osrd_infra_tracksectionmodel")]
+#[model(retrieve, delete)]
+#[diesel(table_name = osrd_infra_tracksectionmodel)]
+pub struct TrackSectionModel {
+    pub id: i64,
+    pub obj_id: String,
+    #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
+    pub data: diesel_json::Json<TrackSection>,
+    pub infra_id: i64,
+}

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -1,4 +1,5 @@
 mod documents;
+pub mod infra_objects;
 mod pathfinding;
 mod projects;
 pub mod rolling_stock;

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -30,7 +30,7 @@ pub struct Pathfinding {
     #[derivative(Default(value = "Utc::now().naive_utc()"))]
     pub created: NaiveDateTime,
     #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
-    pub payload: diesel_json::Json<PathfindingCorePayload>,
+    pub payload: diesel_json::Json<PathfindingPayload>,
     #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
     pub slopes: diesel_json::Json<SlopeGraph>,
     #[derivative(Default(value = "diesel_json::Json::new(Default::default())"))]
@@ -59,14 +59,9 @@ pub struct Curve {
 
 #[derive(Debug, Clone, Derivative, Deserialize, Serialize)]
 #[derivative(Default)]
-pub struct PathfindingCorePayload {
-    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
-    pub geographic: LineString<Point>,
-    #[derivative(Default(value = "LineString { points: vec![], srid: None }"))]
-    pub schematic: LineString<Point>,
+pub struct PathfindingPayload {
     pub route_paths: Vec<RoutePath>,
     pub path_waypoints: Vec<PathWaypoint>,
-    pub warnings: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -35,7 +35,7 @@ use strum_macros::Display;
 use strum_macros::EnumIter;
 pub use switch::{Switch, SwitchCache};
 pub use switch_type::{SwitchPortConnection, SwitchType};
-pub use track_section::{Curve, LineString, Slope, TrackSection, TrackSectionCache};
+pub use track_section::{Curve, Slope, TrackSection, TrackSectionCache};
 pub use track_section_link::TrackSectionLink;
 
 use self::utils::{Identifier, NonBlankString};

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -88,7 +88,7 @@ table! {
         id -> BigInt,
         obj_id -> Text,
         infra_id -> BigInt,
-        data -> Json,
+        data -> Jsonb,
     }
 }
 
@@ -98,7 +98,7 @@ table! {
     osrd_infra_tracksectionmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -107,7 +107,7 @@ table! {
     osrd_infra_signalmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -116,7 +116,7 @@ table! {
     osrd_infra_speedsectionmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -125,7 +125,7 @@ table! {
     osrd_infra_tracksectionlinkmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -134,7 +134,7 @@ table! {
     osrd_infra_switchmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -143,7 +143,7 @@ table! {
     osrd_infra_switchtypemodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -152,7 +152,7 @@ table! {
     osrd_infra_detectormodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -170,7 +170,7 @@ table! {
     osrd_infra_routemodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -179,7 +179,7 @@ table! {
     osrd_infra_operationalpointmodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }
@@ -188,7 +188,7 @@ table! {
     osrd_infra_catenarymodel(id) {
         id -> BigInt,
         obj_id -> Text,
-        data -> Json,
+        data -> Jsonb,
         infra_id -> BigInt,
     }
 }


### PR DESCRIPTION
As part of the work to migrate /pathfinding endpoints to editoast.

* Adds a naive TrackSectionModel to retrieve track sections from the DB using the `Model` API. There is probably a smarter/more generic way to do this but that is subject for another PR.
* Replaces the basic LineString implementation with the crate `geos::geojson` which is a reexport of the crate `geojson`.
* Introduces the crate `geos` that can perform some operations on geometries defined using geojson objects (among other things) that will prove useful when migrating the endpoint POST and PUT /pathfinding. It uses the same underlying GEOS C lib than Django's Postgis extension.