### PR TITLE
editoast: move tempfile to dev-dependency

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -47,7 +47,6 @@ strum = "~0.24.1"
 strum_macros = "~0.24.3"
 thiserror = "1.0"
 enum-map = "2.5"
-tempfile = "3.5.0"
 editoast_derive = { path = "./editoast_derive" }
 mvt = "0.8.1"
 pointy = "0.4.0"
@@ -56,5 +55,6 @@ postgis_diesel = { version = "2.1.0", features = ["serde"] }
 uuid = { version = "1" }
 
 [dev-dependencies]
-rstest = "0.17.0"
 async-std = { version = "1.5", features = ["attributes", "tokio1"] }
+rstest = "0.17.0"
+tempfile = "3.5.0"


### PR DESCRIPTION
`tempfile` crate is only used for testing