### PR TITLE
editoast: bump dependencies

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
 dependencies = [
  "serde",
  "serde_json",
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8455fa3621f6b41c514946de66ea0531f57ca017b2e6c7cc368035ea5b46df"
+checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -25,7 +25,7 @@ diesel = { version = "2.0", features = [
 ] }
 diesel_json = "0.2.0"
 image = "0.24"
-json-patch = "0.3.0"
+json-patch = "1.0"
 pathfinding = "4.2.1"
 rand = "0.8.5"
 actix-web = "4"
@@ -33,7 +33,7 @@ actix-http = "3.3.1"
 actix-cors = "0.6.4"
 env_logger = "0.10.0"
 r2d2 = "~0.8.2"
-redis = { version = "0.22", features = [
+redis = { version = "0.23", features = [
     "tokio-comp",
     "connection-manager",
     "tokio-native-tls-comp",


### PR DESCRIPTION
- **serde_yaml** from 0.9.19 to 0.9.21 (close #3841)
- **redis** from 0.22.3 to 0.23.0 (close #3830)
- **spin** from 0.9.7 to 0.9.8 (close #3785)
- **json-patch** from 0.3.0 to 1.0.0 (close #3776)
- **futures** from 0.3.27 to 0.3.28 (close #3755)