### PR TITLE
Optimize core memory usage

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/ReservationInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/ReservationInfraBuilder.java
@@ -76,6 +76,9 @@ public class ReservationInfraBuilder {
         for (var route : routes) {
             double offset = 0.;
             for (var range : route.getTrackRanges()) {
+                // skip switch branch
+                if (range.track.getEdge() instanceof SwitchBranch)
+                    continue;
                 double rangeOffset; // Offset from the start of the track to the start of the range
                 if (range.track.getDirection().equals(FORWARD))
                     rangeOffset = range.begin;

--- a/core/src/test/java/fr/sncf/osrd/infra/reservation/ReservationInfraTests.java
+++ b/core/src/test/java/fr/sncf/osrd/infra/reservation/ReservationInfraTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.reservation.ReservationInfra;
+import fr.sncf.osrd.infra.api.tracks.undirected.SwitchBranch;
 import fr.sncf.osrd.infra.errors.DiscontinuousRoute;
 import fr.sncf.osrd.infra.implementation.reservation.ReservationInfraBuilder;
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
@@ -32,6 +33,10 @@ public class ReservationInfraTests {
         for (var route : reservationInfra.getInfraRouteGraph().edges()) {
             double offset = 0;
             for (var range : route.getTrackRanges()) {
+                if (range.track.getEdge() instanceof SwitchBranch) {
+                    assertEquals(0., range.getLength());
+                    continue;
+                }
                 double trackOffset;
                 if (offset > 0)
                     trackOffset = -offset;


### PR DESCRIPTION
This PR removes switch branches (fake edge inside a switch) from the `routeOnEdges` multimap.
This can reduce the storage of an infra by 200MB.