### PR TITLE
core: fix the offset of signals inside blocks

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -287,10 +287,14 @@ private fun buildZonePath(
         zonePathPosition += (rangeEnd - rangeBegin)
     }
 
+    val zoneLength = zonePathPosition
+
     zonePathSignals.sortBy { it.position }
     val signals = MutableStaticIdxArrayList<PhysicalSignal>()
     val signalPositions = MutableDistanceArrayList()
     for (zonePathSignal in zonePathSignals) {
+        assert(zonePathSignal.position >= Distance.ZERO)
+        assert(zonePathSignal.position <= zoneLength)
         signals.add(zonePathSignal.signal)
         signalPositions.add(zonePathSignal.position)
     }


### PR DESCRIPTION
When building blocks, the length of some zone paths was appended to blocks they did not belong to. The issue was fixed by updating the length of blocks at the same time as building its list of zone paths.