### PR TITLE
editoast: migrate endpoint to create a rolling_stock livery

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -84,6 +84,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-multipart"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee489e3c01eae4d1c35b03c4493f71cb40d93f66b14558feb1b1a807671cc4e"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec592f234db8a253cf80531246a4407c8a70530423eea80688a6c5a44a110e7"
+dependencies = [
+ "darling",
+ "parse-size",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1068,7 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-http",
+ "actix-multipart",
  "actix-web",
  "async-std",
  "async-trait",
@@ -2188,6 +2227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +2898,15 @@ checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
  "serde",
 ]
 

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -55,6 +55,7 @@ futures = "0.3"
 postgis_diesel = { version = "2.1.0", features = ["serde"] }
 geos = { version = "8.2.0", features = ["json"] }
 rangemap = "1.3"
+actix-multipart = "0.6.0"
 
 [dev-dependencies]
 async-std = { version = "1.5", features = ["attributes", "tokio1"] }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -811,6 +811,7 @@ paths:
                     schematic:
                       description: object's schematic in geojson format
                       $ref: "#/components/schemas/Geometry"
+  
   /infra/{id}/clone/:
     post:
       tags:
@@ -1069,6 +1070,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RollingStock"
+
+  /rolling_stock/{id}/livery:
+    post:
+      tags:
+        - rolling_stock
+        - rolling_stock_livery
+      summary: Create a rolling stock livery
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Rolling Stock ID
+          required: true
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        200:
+          description: The rolling stock livery
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStockLivery"
 
   /projects/:
     post:
@@ -2081,16 +2116,7 @@ components:
             liveries:
               type: array
               items:
-                type: object
-                properties:
-                  id:
-                    type: number
-                  name:
-                    type: string
-                  compound_image_id:
-                    type: number
-                    nullable: true
-                required: [id, name, compound_image_id]
+                $ref: "#/components/schemas/RollingStockLivery"
           required: [id, liveries]
 
     RollingStockCreatePayload:
@@ -2252,6 +2278,17 @@ components:
         - base_power_class
         - power_restrictions
         - metadata
+
+    RollingStockLivery:
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+        compound_image_id:
+                    type: number
+                    nullable: true
+      required: [id, name, compound_image_id]
 
     RouteTrackRangesComputed:
       type: object

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -19,7 +19,10 @@ pub use self::pathfinding::*;
 pub use documents::Document;
 pub use infra::{Infra, RAILJSON_VERSION};
 pub use projects::{Ordering, Project, ProjectWithStudies};
-pub use rolling_stock::{LightRollingStockModel, RollingStockLiveryModel, RollingStockModel};
+pub use rolling_stock::{
+    LightRollingStockModel, RollingStockLiveryModel, RollingStockModel,
+    RollingStockSeparatedImageModel,
+};
 pub use scenario::{Scenario, ScenarioWithCountTrains, ScenarioWithDetails};
 pub use study::{Study, StudyWithScenarios};
 pub use timetable::{Timetable, TimetableWithSchedules};

--- a/editoast/src/models/rolling_stock/mod.rs
+++ b/editoast/src/models/rolling_stock/mod.rs
@@ -3,6 +3,7 @@ pub mod rolling_stock_image;
 pub mod rolling_stock_livery;
 
 pub use light_rolling_stock::LightRollingStockModel;
+pub use rolling_stock_image::RollingStockSeparatedImageModel;
 pub use rolling_stock_livery::RollingStockLiveryModel;
 
 use crate::error::Result;

--- a/editoast/src/models/rolling_stock/rolling_stock_image.rs
+++ b/editoast/src/models/rolling_stock/rolling_stock_image.rs
@@ -4,15 +4,24 @@
 //! A rolling stock can have several liveries, and each livery can have one or several separated
 //! images and one compound image (created by aggregating the seperated images together).
 
-use crate::tables::osrd_infra_rollingstockimage;
+use crate::tables::osrd_infra_rollingstockseparatedimage;
+use derivative::Derivative;
+use editoast_derive::Model;
 use serde::Serialize;
 
-#[derive(Debug, Identifiable, Queryable, Serialize)]
+#[derive(Debug, Derivative, Identifiable, Insertable, Model, Queryable, Serialize)]
+#[derivative(Default)]
+#[model(table = "osrd_infra_rollingstockseparatedimage")]
+#[model(create)]
 #[diesel(belongs_to(RollingStockLiveryModel, foreign_key = livery_id))]
-#[diesel(table_name = osrd_infra_rollingstockimage)]
+#[diesel(table_name = osrd_infra_rollingstockseparatedimage)]
 pub struct RollingStockSeparatedImageModel {
-    id: i64,
-    image_id: i64, // FK to document
-    livery_id: i64,
-    order: i64,
+    #[diesel(deserialize_as = i64)]
+    pub id: Option<i64>,
+    #[diesel(deserialize_as = i64)]
+    pub image_id: Option<i64>, // FK to document
+    #[diesel(deserialize_as = i64)]
+    pub livery_id: Option<i64>,
+    #[diesel(deserialize_as = i32)]
+    pub order: Option<i32>,
 }

--- a/editoast/src/models/rolling_stock/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock/rolling_stock_livery.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crate::models::{Delete, Document, Identifiable};
 use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLivery;
 use crate::tables::osrd_infra_rollingstocklivery;
+use derivative::Derivative;
 use diesel::expression_methods::ExpressionMethods;
 use diesel::result::Error as DieselError;
 use diesel::sql_types::{BigInt, Text};
@@ -21,7 +22,8 @@ use editoast_derive::Model;
 ///
 /// /!\ Its compound image is not deleted by cascade if the livery is removed.
 ///
-#[derive(Debug, Identifiable, Insertable, Model, Queryable, Serialize)]
+#[derive(Debug, Derivative, Identifiable, Insertable, Model, Queryable, Serialize)]
+#[derivative(Default)]
 #[model(table = "osrd_infra_rollingstocklivery")]
 #[model(create, retrieve)]
 #[diesel(belongs_to(RollingStockModel, foreign_key = rolling_stock_id))]

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -295,11 +295,11 @@ table! {
 }
 
 table! {
-    osrd_infra_rollingstockimage(id) {
+    osrd_infra_rollingstockseparatedimage(id) {
         id -> BigInt,
-        image -> Binary,
-        livery_id -> Nullable<BigInt>,
-        order -> Nullable<BigInt>,
+        image_id -> BigInt,
+        livery_id -> BigInt,
+        order -> Integer,
     }
 }
 

--- a/editoast/src/views/rolling_stocks.rs
+++ b/editoast/src/views/rolling_stocks.rs
@@ -1,18 +1,26 @@
 use crate::error::Result;
-use crate::models::{Create, Retrieve, RollingStockModel};
+use crate::models::rolling_stock::RollingStockSeparatedImageModel;
+use crate::models::{Create, Document, Retrieve, RollingStockLiveryModel, RollingStockModel};
+use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLivery;
 use crate::schema::rolling_stock::{
     EffortCurves, Gamma, RollingResistance, RollingStock, RollingStockMetadata,
     RollingStockWithLiveries,
 };
 use crate::DbPool;
+use actix_multipart::form::text::Text;
 use actix_web::dev::HttpServiceFactory;
-use actix_web::web::{self, Data, Json, Path};
+use actix_web::web::{self, scope, Data, Json, Path};
 use actix_web::{get, post};
 use diesel_json::Json as DieselJson;
 use editoast_derive::EditoastError;
+use image::io::Reader as ImageReader;
+use image::{DynamicImage, GenericImage, ImageBuffer, ImageOutputFormat};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::io::{BufReader, Cursor, Read};
 use thiserror::Error;
+
+use actix_multipart::form::{tempfile::TempFile, MultipartForm};
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "rollingstocks")]
@@ -20,10 +28,18 @@ pub enum RollingStockError {
     #[error("Rolling stock '{rolling_stock_id}', could not be found")]
     #[editoast_error(status = 404)]
     NotFound { rolling_stock_id: i64 },
+    #[error("Impossible to read the separated image")]
+    #[editoast_error(status = 500)]
+    CannotReadImage,
+    #[error("Impossible to copy the separated image on the compound image")]
+    #[editoast_error(status = 500)]
+    CannotCreateCompoundImage,
 }
 
 pub fn routes() -> impl HttpServiceFactory {
-    web::scope("/rolling_stock").service((get, create))
+    web::scope("/rolling_stock")
+        .service((get, create))
+        .service(scope("/{rolling_stock_id}").service(create_livery))
 }
 
 #[get("/{rolling_stock_id}")]
@@ -93,6 +109,136 @@ async fn create(
     let rolling_stock: RollingStock = rolling_stock.create(db_pool).await?.into();
 
     Ok(Json(rolling_stock))
+}
+
+#[derive(Debug, MultipartForm)]
+struct RollingStockLiveryCreateForm {
+    pub name: Text<String>,
+    pub images: Vec<TempFile>,
+}
+
+#[post("/livery")]
+async fn create_livery(
+    db_pool: Data<DbPool>,
+    rolling_stock_id: Path<i64>,
+    MultipartForm(form): MultipartForm<RollingStockLiveryCreateForm>,
+) -> Result<Json<RollingStockLivery>> {
+    let rolling_stock_id = rolling_stock_id.into_inner();
+    let rolling_stock = RollingStockModel::retrieve(db_pool.clone(), rolling_stock_id).await?;
+    if rolling_stock.is_none() {
+        return Err(RollingStockError::NotFound { rolling_stock_id }.into());
+    }
+
+    let formatted_images = format_images(form.images)?;
+
+    // create compound image
+    let compound_image = create_compound_image(db_pool.clone(), formatted_images.clone()).await?;
+
+    // create livery
+    let rolling_stock_livery = RollingStockLiveryModel {
+        name: Some(form.name.into_inner()),
+        rolling_stock_id: Some(rolling_stock_id),
+        compound_image_id: Some(compound_image.id),
+        ..Default::default()
+    };
+    let rolling_stock_livery: RollingStockLivery =
+        rolling_stock_livery.create(db_pool.clone()).await?.into();
+
+    // create separated images
+    let FormattedImages { images, .. } = formatted_images;
+    for (index, image) in images.into_iter().enumerate() {
+        let mut w = Cursor::new(Vec::new());
+        image.write_to(&mut w, ImageOutputFormat::Png).unwrap();
+
+        let image = Document::new(String::from("image/png"), w.into_inner())
+            .create(db_pool.clone())
+            .await?;
+        let _ = RollingStockSeparatedImageModel {
+            image_id: Some(image.id.unwrap()),
+            livery_id: Some(rolling_stock_livery.id),
+            order: Some(index.try_into().unwrap()),
+            ..Default::default()
+        }
+        .create(db_pool.clone())
+        .await?;
+    }
+
+    Ok(Json(rolling_stock_livery))
+}
+
+#[derive(Clone, Debug)]
+struct FormattedImages {
+    compound_image_height: u32,
+    compound_image_width: u32,
+    images: Vec<DynamicImage>,
+}
+
+fn format_images(mut tmp_images: Vec<TempFile>) -> Result<FormattedImages> {
+    let mut separated_images = vec![];
+    let mut max_height: u32 = 0;
+    let mut total_width: u32 = 0;
+
+    tmp_images.sort_by_key(|f| f.file_name.clone().unwrap());
+
+    for f in tmp_images {
+        let file = f.file.into_file();
+        let mut reader = BufReader::new(file);
+        let mut buffer = vec![];
+        reader.read_to_end(&mut buffer).unwrap();
+
+        let image = ImageReader::new(Cursor::new(buffer))
+            .with_guessed_format()
+            .unwrap();
+
+        let image = match image.decode() {
+            Ok(image) => image,
+            Err(_) => return Err(RollingStockError::CannotReadImage.into()),
+        };
+        max_height = max_height.max(image.height());
+        total_width += image.width();
+
+        separated_images.push(image);
+    }
+
+    Ok(FormattedImages {
+        compound_image_height: max_height,
+        compound_image_width: total_width,
+        images: separated_images,
+    })
+}
+
+async fn create_compound_image(
+    db_pool: Data<DbPool>,
+    formatted_images: FormattedImages,
+) -> Result<Document> {
+    let FormattedImages {
+        compound_image_height,
+        compound_image_width,
+        images,
+    } = formatted_images;
+    let mut compound_image = ImageBuffer::new(compound_image_width, compound_image_height);
+    let mut ind_width = 0;
+
+    // create the compound_image
+    for image in images {
+        match compound_image.copy_from(&image, ind_width, compound_image_height - image.height()) {
+            Ok(_) => (),
+            Err(_) => return Err(RollingStockError::CannotCreateCompoundImage.into()),
+        };
+        ind_width += image.width();
+    }
+
+    // convert compound_image to PNG
+    let mut w = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(compound_image)
+        .write_to(&mut w, ImageOutputFormat::Png)
+        .unwrap();
+
+    // save the compound_image in the db
+    let compound_image = Document::new(String::from("image/png"), w.into_inner())
+        .create(db_pool.clone())
+        .await?;
+    Ok(compound_image)
 }
 
 #[cfg(test)]

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -217,6 +217,16 @@ const injectedRtkApi = api.injectEndpoints({
     getRollingStockById: build.query<GetRollingStockByIdApiResponse, GetRollingStockByIdApiArg>({
       query: (queryArg) => ({ url: `/rolling_stock/${queryArg.id}/` }),
     }),
+    postRollingStockByIdLivery: build.mutation<
+      PostRollingStockByIdLiveryApiResponse,
+      PostRollingStockByIdLiveryApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/rolling_stock/${queryArg.id}/livery`,
+        method: 'POST',
+        body: queryArg.body,
+      }),
+    }),
     postProjects: build.mutation<PostProjectsApiResponse, PostProjectsApiArg>({
       query: (queryArg) => ({
         url: `/projects/`,
@@ -672,6 +682,16 @@ export type GetRollingStockByIdApiResponse =
 export type GetRollingStockByIdApiArg = {
   /** Rolling Stock ID */
   id: number;
+};
+export type PostRollingStockByIdLiveryApiResponse =
+  /** status 200 The rolling stock livery */ RollingStockLivery;
+export type PostRollingStockByIdLiveryApiArg = {
+  /** Rolling Stock ID */
+  id: number;
+  body: {
+    name?: string;
+    images?: Blob[];
+  };
 };
 export type PostProjectsApiResponse = /** status 201 The created project */ ProjectResult;
 export type PostProjectsApiArg = {
@@ -1150,13 +1170,14 @@ export type RollingStockCreatePayload = {
     unit: string;
   };
 };
+export type RollingStockLivery = {
+  id: number;
+  name: string;
+  compound_image_id: number | null;
+};
 export type RollingStock = RollingStockCreatePayload & {
   id: number;
-  liveries: {
-    id: number;
-    name: string;
-    compound_image_id: number | null;
-  }[];
+  liveries: RollingStockLivery[];
 };
 export type LightRollingStock = RollingStock & {
   effort_curves: {

--- a/python/api/openapi.yaml
+++ b/python/api/openapi.yaml
@@ -275,6 +275,7 @@ paths:
           description: No content
   /rolling_stock/:
     get:
+      deprecated: true
       tags:
         - rolling_stock
       summary: Paginated list of rolling stock
@@ -372,6 +373,7 @@ paths:
                 format: binary
   /rolling_stock_livery/:
     post:
+      deprecated: true
       tags:
         - rolling_stock
         - livery


### PR DESCRIPTION
closes #3498 

:warning: this new endpoint is not tested because TestRequest does not support multipart for the moment. Here is a ticket #3931 to add tests on this specific endpoint (in the future).

To test this endpoint, you can use postman with this configuration (select form-data for the body, use the images in editoast/src/tests if you want). You can add several images for a single request.
![image](https://user-images.githubusercontent.com/45000526/232759029-14b631e3-739e-40ae-92b2-3f71270c5a3c.png)
