### PR TITLE
front: Rolling stock modal fixes

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2215,9 +2215,15 @@ components:
 
     LightRollingStock:
       allOf:
-        - $ref: "#/components/schemas/RollingStock"
+        - $ref: "#/components/schemas/RollingStockBase"
         - type: object
           properties:
+            id:
+              type: number
+            liveries:
+              type: array
+              items:
+                $ref: "#/components/schemas/RollingStockLivery"
             effort_curves:
               type: object
               properties:
@@ -2232,7 +2238,7 @@ components:
                         type: boolean
                     required: [is_electric]
               required: [default_mode, modes]
-          required: [effort_curves]
+          required: [id, liveries, effort_curves]
 
     PowerPack:
       description: energy source for a rolling stock representing a power pack (hydrogen, fuel...)
@@ -2268,6 +2274,33 @@ components:
           required: [id, liveries]
 
     RollingStockUpsertPayload:
+      allOf:
+        - $ref: "#/components/schemas/RollingStockBase"
+        - type: object
+          properties:
+            effort_curves:
+              type: object
+              properties:
+                default_mode:
+                  type: string
+                modes:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      curves:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ConditionalEffortCurve"
+                      default_curve:
+                        $ref: "#/components/schemas/EffortCurve"
+                      is_electric:
+                        type: boolean
+                    required: [curves, default_curve, is_electric]
+              required: [default_mode, modes]
+          required: [effort_curves]
+    
+    RollingStockBase:
       properties:
         version:
           type: string
@@ -2334,26 +2367,6 @@ components:
             - "FR3.3"
             - "FR3.3/GB/G2"
             - "GLOTT"
-        effort_curves:
-          type: object
-          properties:
-            default_mode:
-              type: string
-            modes:
-              type: object
-              additionalProperties:
-                type: object
-                properties:
-                  curves:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/ConditionalEffortCurve"
-                  default_curve:
-                    $ref: "#/components/schemas/EffortCurve"
-                  is_electric:
-                    type: boolean
-                required: [curves, default_curve, is_electric]
-          required: [default_mode, modes]
         base_power_class:
           type: string
           example: "5"
@@ -2426,7 +2439,6 @@ components:
         - mass
         - rolling_resistance
         - loading_gauge
-        - effort_curves
         - base_power_class
         - power_restrictions
         - metadata

--- a/front/src/common/RollingStockSelector/RollingStockCard.jsx
+++ b/front/src/common/RollingStockSelector/RollingStockCard.jsx
@@ -12,15 +12,14 @@ import { RollingStockInfos } from './RollingStockHelpers';
 import RollingStockCardButtons from './RollingStockCardButtons';
 
 function RollingStockCard(props) {
+  const { data, ref2scroll, setOpenedRollingStockCardId, isOpen, noCardSelected } = props;
   const [tractionModes, setTractionModes] = useState({
     electric: false,
     thermal: false,
     voltages: [],
   });
   const [curvesComfortList, setCurvesComfortList] = useState();
-  const { data, ref2scroll, setOpenedRollingStockCardId, isOpen, noCardSelected } = props;
   const ref2scrollWhenOpened = useRef();
-
   function displayCardDetail() {
     if (!isOpen) {
       setOpenedRollingStockCardId(data.id);

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -58,7 +58,7 @@ export function rollingStockPassesEnergeticModeFilters(
 }
 
 interface RollingStockModal {
-  ref2scroll: MutableRefObject<HTMLDivElement>;
+  ref2scroll: MutableRefObject<HTMLDivElement | null>;
 }
 
 function RollingStockModal({ ref2scroll }: RollingStockModal) {

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -99,8 +99,8 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
 
   const updateSearch = () => {
     setOpenedRollingStockCardId(undefined);
-    const newFilteredRollingStock = rollingStocks
-      ?.filter(({ name, metadata, effort_curves: effortCurves }) => {
+    const newFilteredRollingStock = rollingStocks?.filter(
+      ({ name, metadata, effort_curves: effortCurves }) => {
         const passSearchedStringFilter = rollingStockPassesSearchedStringFilter(
           name,
           metadata,
@@ -112,12 +112,8 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
           effortCurves.modes
         );
         return passSearchedStringFilter && passEnergeticModesFilter;
-      })
-      .sort((a, b) => {
-        const { reference: refA } = a.metadata;
-        const { reference: refB } = b.metadata;
-        return refA.localeCompare(refB);
-      });
+      }
+    );
     if (newFilteredRollingStock) {
       setTimeout(() => {
         setFilteredRollingStockList(newFilteredRollingStock);

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -72,7 +72,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
     elec: false,
     thermal: false,
   });
-  const [isFiltering, setIsFiltering] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [openedRollingStockCardId, setOpenedRollingStockCardId] = useState();
   const { closeModal } = useContext(ModalContext);
 
@@ -94,7 +94,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
 
   const searchMateriel = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilters({ ...filters, text: e.target.value.toLowerCase() });
-    setIsFiltering(true);
+    setIsLoading(true);
   };
 
   const updateSearch = () => {
@@ -121,14 +121,14 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
     if (newFilteredRollingStock) {
       setTimeout(() => {
         setFilteredRollingStockList(newFilteredRollingStock);
-        setIsFiltering(false);
+        setIsLoading(false);
       }, 0);
     }
   };
 
   const toggleFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilters({ ...filters, [e.target.name]: !filters[e.target.name as 'elec' | 'thermal'] });
-    setIsFiltering(true);
+    setIsLoading(true);
   };
 
   if (rollingStockID !== undefined) {
@@ -159,7 +159,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
   );
 
   useEffect(() => {
-    if (isError && 'status' in error) {
+    if (isError && error && 'status' in error) {
       dispatch(
         setFailure({
           name: t('rollingstock:errorMessages.unableToRetrieveRollingStock'),
@@ -178,6 +178,16 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, isSuccess]);
+
+  function displayList() {
+    if (isEmpty(filteredRollingStockList)) {
+      if (isLoading) {
+        return <Loader msg={t('rollingstock:waitingLoader')} />;
+      }
+      return <div className="rollingstock-empty">{t('rollingstock:noResultFound')}</div>;
+    }
+    return listOfRollingStocks;
+  }
 
   return (
     <ModalBodySNCF>
@@ -243,13 +253,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
             </div>
           </div>
         </div>
-        <div className="rollingstock-search-list">
-          {!isEmpty(filteredRollingStockList) && !isFiltering ? (
-            listOfRollingStocks
-          ) : (
-            <Loader msg={t('rollingstock:waitingLoader')} />
-          )}
-        </div>
+        <div className="rollingstock-search-list">{displayList()}</div>
       </div>
     </ModalBodySNCF>
   );

--- a/front/src/common/RollingStockSelector/RollingStockSelector.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockSelector.tsx
@@ -29,7 +29,7 @@ const RollingStockSelector = ({
 }: RollingStockProps) => {
   const { openModal } = useModal();
 
-  const ref2scroll: React.RefObject<HTMLInputElement> = useRef<HTMLInputElement>(null);
+  const ref2scroll = useRef<HTMLDivElement>(null);
 
   return (
     <div className="osrd-config-item mb-2">

--- a/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
+++ b/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
@@ -1,0 +1,68 @@
+import { rollingStockPassesEnergeticModeFilters } from '../RollingStockModal';
+
+describe('rollingStockPassEnergeticModeFilters', () => {
+  describe('both false', () => {
+    it('should return true (all rolling stocks are accepted)', () => {
+      const filterElec = false;
+      const filterThermal = false;
+      const modes = {};
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(true);
+    });
+  });
+  describe('electrical true', () => {
+    it('should return true if one of the modes is electrical', () => {
+      const filterElec = true;
+      const filterThermal = false;
+      const modes = { '25000': { is_electric: true } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(true);
+    });
+    it('should return false if no mode is electrical', () => {
+      const filterElec = true;
+      const filterThermal = false;
+      const modes = { '25000': { is_electric: false } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(false);
+    });
+  });
+  describe('thermal true', () => {
+    it('should return true if one of the modes is thermal', () => {
+      const filterElec = false;
+      const filterThermal = true;
+      const modes = { '25000': { is_electric: false } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(true);
+    });
+    it('should return false if no mode is thermal', () => {
+      const filterElec = false;
+      const filterThermal = true;
+      const modes = { '25000': { is_electric: true } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(false);
+    });
+  });
+  describe('both true', () => {
+    it('should return true there exist both an electric and a thermal', () => {
+      const filterElec = true;
+      const filterThermal = true;
+      const modes = { '25000': { is_electric: true }, '99999': { is_electric: false } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(true);
+    });
+    it('should return false if there is no thermal', () => {
+      const filterElec = true;
+      const filterThermal = true;
+      const modes = { '25000': { is_electric: true }, '99999': { is_electric: true } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(false);
+    });
+    it('should return false if there is no electric', () => {
+      const filterElec = true;
+      const filterThermal = true;
+      const modes = { '25000': { is_electric: false }, '99999': { is_electric: false } };
+      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
+++ b/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
@@ -1,4 +1,7 @@
+import type { LightRollingStock } from 'common/api/osrdEditoastApi';
 import { rollingStockPassesEnergeticModeFilters } from '../RollingStockModal';
+
+type Modes = LightRollingStock['effort_curves']['modes'];
 
 describe('rollingStockPassEnergeticModeFilters', () => {
   describe('both false', () => {
@@ -14,14 +17,14 @@ describe('rollingStockPassEnergeticModeFilters', () => {
     it('should return true if one of the modes is electrical', () => {
       const filterElec = true;
       const filterThermal = false;
-      const modes = { '25000': { is_electric: true } };
+      const modes: Modes = { '25000': { is_electric: true } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(true);
     });
     it('should return false if no mode is electrical', () => {
       const filterElec = true;
       const filterThermal = false;
-      const modes = { '25000': { is_electric: false } };
+      const modes: Modes = { '25000': { is_electric: false } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(false);
     });
@@ -30,14 +33,14 @@ describe('rollingStockPassEnergeticModeFilters', () => {
     it('should return true if one of the modes is thermal', () => {
       const filterElec = false;
       const filterThermal = true;
-      const modes = { '25000': { is_electric: false } };
+      const modes: Modes = { '25000': { is_electric: false } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(true);
     });
     it('should return false if no mode is thermal', () => {
       const filterElec = false;
       const filterThermal = true;
-      const modes = { '25000': { is_electric: true } };
+      const modes: Modes = { '25000': { is_electric: true } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(false);
     });
@@ -46,21 +49,21 @@ describe('rollingStockPassEnergeticModeFilters', () => {
     it('should return true there exist both an electric and a thermal', () => {
       const filterElec = true;
       const filterThermal = true;
-      const modes = { '25000': { is_electric: true }, '99999': { is_electric: false } };
+      const modes: Modes = { '25000': { is_electric: true }, '99999': { is_electric: false } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(true);
     });
     it('should return false if there is no thermal', () => {
       const filterElec = true;
       const filterThermal = true;
-      const modes = { '25000': { is_electric: true }, '99999': { is_electric: true } };
+      const modes: Modes = { '25000': { is_electric: true }, '99999': { is_electric: true } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(false);
     });
     it('should return false if there is no electric', () => {
       const filterElec = true;
       const filterThermal = true;
-      const modes = { '25000': { is_electric: false }, '99999': { is_electric: false } };
+      const modes: Modes = { '25000': { is_electric: false }, '99999': { is_electric: false } };
       const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
       expect(result).toBe(false);
     });

--- a/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
+++ b/front/src/common/RollingStockSelector/__tests__/RollingStockModal.spec.ts
@@ -9,7 +9,11 @@ describe('rollingStockPassEnergeticModeFilters', () => {
       const filterElec = false;
       const filterThermal = false;
       const modes = {};
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(true);
     });
   });
@@ -18,14 +22,22 @@ describe('rollingStockPassEnergeticModeFilters', () => {
       const filterElec = true;
       const filterThermal = false;
       const modes: Modes = { '25000': { is_electric: true } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(true);
     });
     it('should return false if no mode is electrical', () => {
       const filterElec = true;
       const filterThermal = false;
       const modes: Modes = { '25000': { is_electric: false } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(false);
     });
   });
@@ -34,14 +46,22 @@ describe('rollingStockPassEnergeticModeFilters', () => {
       const filterElec = false;
       const filterThermal = true;
       const modes: Modes = { '25000': { is_electric: false } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(true);
     });
     it('should return false if no mode is thermal', () => {
       const filterElec = false;
       const filterThermal = true;
       const modes: Modes = { '25000': { is_electric: true } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(false);
     });
   });
@@ -50,21 +70,33 @@ describe('rollingStockPassEnergeticModeFilters', () => {
       const filterElec = true;
       const filterThermal = true;
       const modes: Modes = { '25000': { is_electric: true }, '99999': { is_electric: false } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(true);
     });
     it('should return false if there is no thermal', () => {
       const filterElec = true;
       const filterThermal = true;
       const modes: Modes = { '25000': { is_electric: true }, '99999': { is_electric: true } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(false);
     });
     it('should return false if there is no electric', () => {
       const filterElec = true;
       const filterThermal = true;
       const modes: Modes = { '25000': { is_electric: false }, '99999': { is_electric: false } };
-      const result = rollingStockPassesEnergeticModeFilters(filterElec, filterThermal, modes);
+      const result = rollingStockPassesEnergeticModeFilters(modes, {
+        text: '',
+        elec: filterElec,
+        thermal: filterThermal,
+      });
       expect(result).toBe(false);
     });
   });

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1142,19 +1142,6 @@ export type ElectricalProfile = {
   power_class?: string;
   track_ranges?: TrackRange[];
 };
-export type Comfort = 'AC' | 'HEATING' | 'STANDARD';
-export type EffortCurve = {
-  speeds?: number[];
-  max_efforts?: number[];
-};
-export type ConditionalEffortCurve = {
-  cond?: {
-    comfort?: Comfort | null;
-    electrical_profile_level?: string | null;
-    power_restriction_code?: string | null;
-  } | null;
-  curve?: EffortCurve;
-};
 export type SpeedDependantPower = {
   speeds: number[];
   powers: number[];
@@ -1199,7 +1186,7 @@ export type EnergySource =
   | ({
       energy_source_type: 'Battery';
     } & Battery);
-export type RollingStockUpsertPayload = {
+export type RollingStockBase = {
   version: string;
   name: string;
   length: number;
@@ -1221,16 +1208,6 @@ export type RollingStockUpsertPayload = {
     type: 'davis';
   };
   loading_gauge: 'G1' | 'G2' | 'GA' | 'GB' | 'GB1' | 'GC' | 'FR3.3' | 'FR3.3/GB/G2' | 'GLOTT';
-  effort_curves: {
-    default_mode: string;
-    modes: {
-      [key: string]: {
-        curves: ConditionalEffortCurve[];
-        default_curve: EffortCurve;
-        is_electric: boolean;
-      };
-    };
-  };
   base_power_class: string;
   power_restrictions: {
     [key: string]: string;
@@ -1253,11 +1230,9 @@ export type RollingStockLivery = {
   name: string;
   compound_image_id: number | null;
 };
-export type RollingStock = RollingStockUpsertPayload & {
+export type LightRollingStock = RollingStockBase & {
   id: number;
   liveries: RollingStockLivery[];
-};
-export type LightRollingStock = RollingStock & {
   effort_curves: {
     default_mode: string;
     modes: {
@@ -1266,6 +1241,35 @@ export type LightRollingStock = RollingStock & {
       };
     };
   };
+};
+export type Comfort = 'AC' | 'HEATING' | 'STANDARD';
+export type EffortCurve = {
+  speeds?: number[];
+  max_efforts?: number[];
+};
+export type ConditionalEffortCurve = {
+  cond?: {
+    comfort?: Comfort | null;
+    electrical_profile_level?: string | null;
+    power_restriction_code?: string | null;
+  } | null;
+  curve?: EffortCurve;
+};
+export type RollingStockUpsertPayload = RollingStockBase & {
+  effort_curves: {
+    default_mode: string;
+    modes: {
+      [key: string]: {
+        curves: ConditionalEffortCurve[];
+        default_curve: EffortCurve;
+        is_electric: boolean;
+      };
+    };
+  };
+};
+export type RollingStock = RollingStockUpsertPayload & {
+  id: number;
+  liveries: RollingStockLivery[];
 };
 export type ProjectResult = {
   id?: number;


### PR DESCRIPTION
- moved RollingStockModal to .tsx
- refactored rollingstock search/sort functions and wrote unit tests
- rolling stock modal now correctly states that no element was found.
- Editoast: didn’t change the schemas, just added a base schema to be extended, so that LightRollingStock `modes` property is generated correctly by our front tool.

closes #3272
