### PR TITLE
editor: fixes #3904 and #3906

### DIFF
--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { flatMap, forEach, uniq } from 'lodash';
+import { flatMap, forEach, isNumber, uniq } from 'lodash';
 import { useSelector } from 'react-redux';
 import { TFunction } from 'i18next';
 import cx from 'classnames';
@@ -223,8 +223,8 @@ function getSumUpContent(
       forEach(speedSection.properties.speed_limit_by_tag, (limit, tag) => {
         subtexts.push(
           <>
-            <span className={cx(classes.muted, 'mr-2')}>{tag} -</span>{' '}
-            <span>{getSpeedSectionsNameString(limit)}</span>
+            <span className={cx(classes.muted, 'mr-2')}>{tag}</span>{' '}
+            <span>{isNumber(limit) ? getSpeedSectionsNameString(limit) : '-'}</span>
           </>
         );
       });

--- a/front/src/applications/editor/tools/speedSectionEdition/utils.ts
+++ b/front/src/applications/editor/tools/speedSectionEdition/utils.ts
@@ -139,8 +139,8 @@ export function getPointAt(track: TrackSectionEntity, at: number): Position {
   return along(track.geometry, (at * computedLength) / dataLength).geometry.coordinates;
 }
 
-export function msToKmh(v: number): string {
-  return (v * 3.6).toFixed(1);
+export function msToKmh(v: number): number {
+  return v * 3.6;
 }
 export function kmhToMs(v: number): number {
   return v / 3.6;

--- a/front/src/types/editor.ts
+++ b/front/src/types/editor.ts
@@ -43,7 +43,7 @@ export interface SpeedSectionEntity
     MultiLineString,
     {
       speed_limit?: number;
-      speed_limit_by_tag?: Record<string, number>;
+      speed_limit_by_tag?: Record<string, number | undefined>;
       track_ranges?: {
         applicable_directions: ApplicableDirection;
         begin: number;


### PR DESCRIPTION
Details:
- Writes a new component dedicated to handle speed editions in km/h, while the value is stored as m/s
- Handles weird behaviours by only updating the local component state when the related number m/s value changes
- Uses this new component for both speed_limit and speed_limit_by_tag edition