### PR TITLE
api: front: train_schedule/results replace param train_ids by timetable_id

### DIFF
--- a/front/src/applications/operationalStudies/components/Scenario/getTimetable.jsx
+++ b/front/src/applications/operationalStudies/components/Scenario/getTimetable.jsx
@@ -41,8 +41,8 @@ export default async function getTimetable(timetableID) {
 
       const simulationLocal = await get(`${trainscheduleURI}results/`, {
         params: {
-          train_ids: trainSchedulesIDs.join(','),
-          path: selectedProjectionPath,
+          timetable_id: timetableID,
+          path_id: selectedProjectionPath,
         },
       });
       simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);

--- a/front/src/applications/stdcm/getStdcmTimetable.jsx
+++ b/front/src/applications/stdcm/getStdcmTimetable.jsx
@@ -41,8 +41,8 @@ export default async function getStdcmTimetable(
     try {
       const simulationLocal = await get(`${trainscheduleURI}results/`, {
         params: {
-          train_ids: trainSchedulesIDs.join(','),
-          path: tempProjectedPathId || tempSelectedProjection.path,
+          timetable_id: timetableID,
+          path_id: tempProjectedPathId || tempSelectedProjection.path,
         },
       });
       simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);

--- a/front/src/applications/stdcm/views/StdcmRequestModal.jsx
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.jsx
@@ -75,38 +75,33 @@ export default function StdcmRequestModal(props) {
             })
           );
 
-          // ask for timetable with the new path
-          get(`${timetableURI}${osrdconf.timetableID}/`).then((timetable) => {
-            // eslint-disable-next-line camelcase
-            const trainIds = timetable.train_schedules.map((train_schedule) => train_schedule.id);
-            get(`${trainscheduleURI}results/`, {
-              params: {
-                train_ids: trainIds.join(','),
-                path: result.path.id,
-              },
-            }).then((simulationLocal) => {
-              const newSimulation = {};
-              newSimulation.trains = [...simulationLocal];
-              newSimulation.trains = [...newSimulation.trains, fakedNewTrain];
-              const consolidatedSimulation = createTrain(
-                dispatch,
-                KEY_VALUES_FOR_CONSOLIDATED_SIMULATION,
-                newSimulation.trains,
-                t
-              );
-              dispatch(updateConsolidatedSimulation(consolidatedSimulation));
-              dispatch(updateSimulation(newSimulation));
-              dispatch(updateSelectedTrain(newSimulation.trains.length - 1));
+          get(`${trainscheduleURI}results/`, {
+            params: {
+              timetable_id: osrdconf.timetableID,
+              path: result.path.id,
+            },
+          }).then((simulationLocal) => {
+            const newSimulation = {};
+            newSimulation.trains = [...simulationLocal];
+            newSimulation.trains = [...newSimulation.trains, fakedNewTrain];
+            const consolidatedSimulation = createTrain(
+              dispatch,
+              KEY_VALUES_FOR_CONSOLIDATED_SIMULATION,
+              newSimulation.trains,
+              t
+            );
+            dispatch(updateConsolidatedSimulation(consolidatedSimulation));
+            dispatch(updateSimulation(newSimulation));
+            dispatch(updateSelectedTrain(newSimulation.trains.length - 1));
 
-              dispatch(
-                updateSelectedProjection({
-                  id: fakedNewTrain.id,
-                  path: result.path,
-                })
-              );
+            dispatch(
+              updateSelectedProjection({
+                id: fakedNewTrain.id,
+                path: result.path,
+              })
+            );
 
-              dispatch(updateMustRedraw(true));
-            });
+            dispatch(updateMustRedraw(true));
           });
         })
         .catch((e) => {

--- a/front/src/common/api/osrdMiddlewareApi.ts
+++ b/front/src/common/api/osrdMiddlewareApi.ts
@@ -138,7 +138,7 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/train_schedule/results/`,
-        params: { path: queryArg.path, train_ids: queryArg.trainIds },
+        params: { path_id: queryArg.pathId, timetable_id: queryArg.timetableId },
       }),
     }),
     getInfraByIdSpeedLimitTags: build.query<
@@ -489,9 +489,9 @@ export type GetTrainScheduleResultsApiResponse =
   /** status 200 The train schedules results */ TrainScheduleResult[];
 export type GetTrainScheduleResultsApiArg = {
   /** Path id used to project the train path */
-  path?: number;
-  /** List of train schedule ids */
-  trainIds: number[];
+  pathId?: number;
+  /** Timetable id of the simulation */
+  timetableId: number;
 };
 export type GetInfraByIdSpeedLimitTagsApiResponse = /** status 200 Tags list */ string[];
 export type GetInfraByIdSpeedLimitTagsApiArg = {

--- a/front/src/reducers/osrdsimulation/simulation.js
+++ b/front/src/reducers/osrdsimulation/simulation.js
@@ -60,13 +60,11 @@ export async function progressiveDuplicateTrain(
     actualTrainCount += trainStep;
   }
   await post(`${trainscheduleURI}standalone_simulation/`, params);
-  const timetable = await get(`${timetableURI}${timetableID}/`);
-  const trainSchedulesIDs = timetable.train_schedules.map((train) => train.id);
   try {
     const simulationLocal = await get(`${trainscheduleURI}results/`, {
       params: {
-        train_ids: trainSchedulesIDs.join(','),
-        path: selectedProjection.path,
+        timetable_id: timetableID,
+        path_id: selectedProjection.path,
       },
     });
     simulationLocal.sort((a, b) => a.base.stops[0].time > b.base.stops[0].time);

--- a/python/api/openapi.yaml
+++ b/python/api/openapi.yaml
@@ -612,19 +612,15 @@ paths:
       summary: Retrieve the simulation result of multiple train schedules
       parameters:
         - in: query
-          name: path
+          name: path_id
           schema:
             type: integer
           description: Path id used to project the train path
         - in: query
-          name: train_ids
+          name: timetable_id
           schema:
-            type: array
-            uniqueItems: true
-            minItems: 1
-            items:
-              type: integer
-          description: List of train schedule ids
+            type: integer
+          description: Timetable id of the simulation
           required: true
       responses:
         200:


### PR DESCRIPTION
closes #3234 and #2510

The endpoint train_schedule/results now takes timetable_id as a param (instead of train_ids).

To avoid bugs, the endpoints will be migrated to rtk and the files migrated to TS later.