### PR TITLE
front: energy consumption is displayed even after drag&drop on GET

### DIFF
--- a/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers.ts
+++ b/front/src/applications/operationalStudies/components/SimulationResults/ChartHelpers/ChartHelpers.ts
@@ -106,6 +106,7 @@ export function makeStairCase(data: Array<{ time: number; position: number }>) {
 export const timeShiftTrain = (train: Train, offset: number) => ({
   ...train,
   base: {
+    mechanical_energy_consumed: train.base.mechanical_energy_consumed,
     head_positions: train.base.head_positions.map((section) =>
       section.map((step) => ({ ...step, time: offsetSeconds(step.time + offset) }))
     ),

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -87,6 +87,7 @@ export interface Regime {
   route_aspects: RouteAspect[];
   signal_aspects?: SignalAspect[];
   error?: string;
+  mechanical_energy_consumed?: number;
 }
 
 export interface ElectrificationConditions {


### PR DESCRIPTION
closes #3938