### PR TITLE
core: fix "end of enveloppe" routes occupancies not being computed correctly

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -121,6 +121,7 @@ private fun routeOccupancies(
         val exit = events.last()
         if (exit.isEntry) {
             routeOccupancies[route] = ResultOccupancyTiming(entry.time.toDouble() / 1000, envelope.totalTime)
+            continue;
         }
         routeOccupancies[route] = ResultOccupancyTiming(entry.time.toDouble() / 1000, exit.time.toDouble() / 1000)
     }


### PR DESCRIPTION
Fixes #3975.