### PR TITLE
editoast: fix infra update

### DIFF
--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub const RAILJSON_VERSION: &str = "3.3.0";
+pub const INFRA_VERSION: &str = "0";
 
 #[derive(
     Clone,
@@ -45,18 +46,17 @@ pub struct Infra {
     pub id: Option<i64>,
     #[diesel(deserialize_as = String)]
     pub name: Option<String>,
-    #[derivative(Default(value = "RAILJSON_VERSION.into()"))]
-    pub railjson_version: String,
+    #[diesel(deserialize_as = String)]
+    pub railjson_version: Option<String>,
     #[serde(skip_serializing)]
     #[diesel(deserialize_as = Uuid)]
     pub owner: Option<Uuid>,
-    #[derivative(Default(value = "'0'.into()"))]
-    pub version: String,
+    #[diesel(deserialize_as = String)]
+    pub version: Option<String>,
     #[diesel(deserialize_as = Option<String>)]
-    #[derivative(Default(value = "Some(Some('0'.into()))"))]
     pub generated_version: Option<Option<String>>,
-    #[derivative(Default(value = "false"))]
-    pub locked: bool,
+    #[diesel(deserialize_as = bool)]
+    pub locked: Option<bool>,
     #[diesel(deserialize_as = NaiveDateTime)]
     pub created: Option<NaiveDateTime>,
     #[derivative(Default(value = "Utc::now().naive_utc()"))]
@@ -88,13 +88,15 @@ impl Infra {
     pub fn bump_version(&self, conn: &mut PgConnection) -> Result<Self> {
         let new_version = self
             .version
+            .as_ref()
+            .unwrap()
             .parse::<u32>()
             .expect("Cannot convert version into an Integer")
             + 1;
         let infra_id = self.id.unwrap();
         let new_version = new_version.to_string();
         let mut infra = self.clone();
-        infra.version = new_version;
+        infra.version = Some(new_version);
         let infra = infra.update_conn(conn, infra_id)?.unwrap();
         Ok(infra)
     }
@@ -140,9 +142,9 @@ impl Infra {
         )
         .bind::<Text, _>(new_name)
         .bind::<Text, _>(RAILJSON_VERSION)
-        .bind::<Text,_>(infra_to_clone.version)
+        .bind::<Text,_>(infra_to_clone.version.unwrap())
         .bind::<Nullable<Text>,_>(infra_to_clone.generated_version.unwrap())
-        .bind::<Bool,_>(infra_to_clone.locked)
+        .bind::<Bool,_>(infra_to_clone.locked.unwrap())
         .bind::<BigInt,_>(infra_id)
         .get_result::<Infra>(&mut conn)
         {
@@ -166,7 +168,7 @@ impl Infra {
         // Check if refresh is needed
         if !force
             && self.generated_version.is_some()
-            && &self.version == self.generated_version.as_ref().unwrap().as_ref().unwrap()
+            && &self.version == self.generated_version.as_ref().unwrap()
         {
             return Ok(false);
         }
@@ -175,7 +177,7 @@ impl Infra {
 
         // Update generated infra version
         let mut infra = self.clone();
-        infra.generated_version = Some(Some(self.version.clone()));
+        infra.generated_version = Some(self.version.clone());
         infra.update_conn(conn, self.id.unwrap())?;
 
         Ok(true)
@@ -216,7 +218,8 @@ impl Identifiable for Infra {
 pub mod tests {
     use super::Infra;
     use crate::client::PostgresConfig;
-    use crate::models::Create;
+    use crate::models::infra::INFRA_VERSION;
+    use crate::models::{Create, RAILJSON_VERSION};
     use actix_web::test as actix_test;
     use chrono::Utc;
     use diesel::result::Error;
@@ -228,6 +231,10 @@ pub mod tests {
             name: Some("test".into()),
             created: Some(Utc::now().naive_utc()),
             owner: Some(Uuid::nil()),
+            railjson_version: Some(RAILJSON_VERSION.into()),
+            version: Some(INFRA_VERSION.into()),
+            generated_version: Some(Some(INFRA_VERSION.into())),
+            locked: Some(false),
             ..Default::default()
         }
     }
@@ -246,6 +253,11 @@ pub mod tests {
     async fn create_infra() {
         test_infra_transaction(|_, infra| {
             assert_eq!("test", infra.name.unwrap());
+            assert_eq!(Uuid::nil(), infra.owner.unwrap());
+            assert_eq!(RAILJSON_VERSION, infra.railjson_version.unwrap());
+            assert_eq!(INFRA_VERSION, infra.version.unwrap());
+            assert_eq!(INFRA_VERSION, infra.generated_version.unwrap().unwrap());
+            assert!(!infra.locked.unwrap());
         })
         .await;
     }

--- a/editoast/src/schema/railjson.rs
+++ b/editoast/src/schema/railjson.rs
@@ -139,7 +139,7 @@ pub mod test {
 
         let s_railjson = find_railjson(&mut conn, &infra).unwrap();
 
-        assert_eq!(infra.railjson_version, railjson.version);
+        assert_eq!(infra.railjson_version.unwrap(), railjson.version);
         assert!(check_objects_eq(
             &s_railjson.buffer_stops,
             &railjson.buffer_stops
@@ -196,7 +196,7 @@ pub mod test {
 
     fn find_railjson(conn: &mut PgConnection, infra: &Infra) -> Result<RailJson> {
         let railjson = RailJson {
-            version: infra.clone().railjson_version,
+            version: infra.clone().railjson_version.unwrap(),
             operational_points: find_objects(conn, infra.id.unwrap()),
             routes: find_objects(conn, infra.id.unwrap()),
             switch_types: find_objects(conn, infra.id.unwrap()),

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -59,7 +59,7 @@ fn apply_edit(
     infra_cache: &mut InfraCache,
 ) -> Result<(Vec<OperationResult>, Zone)> {
     // Check if the infra is locked
-    if infra.locked {
+    if infra.locked.unwrap() {
         return Err(EditionError::InfraIsLocked(infra.id.unwrap()).into());
     }
 
@@ -91,7 +91,7 @@ fn apply_edit(
 
     // Bump infra generated version to the infra version
     let mut infra_bump = infra.clone();
-    infra_bump.generated_version = Some(Some(infra.version.clone()));
+    infra_bump.generated_version = Some(Some(infra.version.unwrap()));
     match infra_bump.update_conn(conn, infra.id.unwrap()) {
         Ok(infra) => infra.unwrap(),
         Err(_) => {

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -93,7 +93,7 @@ async fn get_railjson(infra: Path<i64>, db_pool: Data<DbPool>) -> Result<impl Re
             "operational_points": {operational_points},
             "catenaries": {catenaries}
         }}"#,
-        version = infra_meta.railjson_version,
+        version = infra_meta.railjson_version.unwrap(),
         track_sections = res[ObjectType::TrackSection],
         signals = res[ObjectType::Signal],
         speed_sections = res[ObjectType::SpeedSection],
@@ -109,7 +109,7 @@ async fn get_railjson(infra: Path<i64>, db_pool: Data<DbPool>) -> Result<impl Re
 
     Ok(HttpResponse::Ok()
         .content_type(ContentType::json())
-        .append_header(("x-infra-version", infra_meta.version))
+        .append_header(("x-infra-version", infra_meta.version.unwrap()))
         .body(railjson))
 }
 

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -338,7 +338,7 @@ async fn call_core_pf_and_save_result(
                 let track_map = payload.fetch_track_map(conn)?;
                 let mut waypoints = payload.parse_waypoints(&track_map)?;
                 let mut rolling_stocks = payload.parse_rolling_stocks(conn)?;
-                let response = PathfindingRequest::new(infra.id.unwrap(), infra.version.clone())
+                let response = PathfindingRequest::new(infra.id.unwrap(), infra.version.unwrap())
                     .with_waypoints(&mut waypoints)
                     .with_rolling_stocks(&mut rolling_stocks)
                     .fetch(core.as_ref())


### PR DESCRIPTION
Remove default values in infra model (except modified_date which must be always modified) and replace them with Option. Set default values at creation. Default values will not be set at update anymore.

Fixes #4108.