### PR TITLE
editoast: add non-json response support to CoreClient

### DIFF
--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::views::rolling_stocks::RollingStockForm;
 use crate::{models::RoutePath, schema::Direction};
 
-use super::AsCoreRequest;
+use super::{AsCoreRequest, Json};
 
 pub type PathfindingWaypoints = Vec<Vec<Waypoint>>;
 
@@ -52,7 +52,7 @@ pub struct Warning {
     message: String,
 }
 
-impl AsCoreRequest<PathfindingResponse> for PathfindingRequest {
+impl AsCoreRequest<Json<PathfindingResponse>> for PathfindingRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/pathfinding/routes";
 }


### PR DESCRIPTION
The main diff is that the response of a `CoreRequest` should be a `CoreResponse` and not directly a `DeserializeOwned`. It allows:

* empty responses support: `impl AsCoreRequest<()> for RequestWithExpectedEmptyResponse` (serve JSON parser forbids no content)
* raw response support for when the response is not a JSON doc: `impl AsCoreRequest<Bytes> for MyNonJsonRequest` (it is provided as an example ; the same mechanism could be implemented for Strings)

Required by #4056 