### PR TITLE
core: add track data to kt infra

### DIFF
--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/ArrayList.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/ArrayList.kt
@@ -143,7 +143,7 @@ private fun CollectionItemType.generateArrayList(context: GeneratorContext, curr
                 override fun remove(index: Int): $type {
                     assert(index < usedElements)
                     val oldValue = buffer[index]
-                    for (i in index until usedElements)
+                    for (i in index until usedElements - 1)
                         buffer[i] = buffer[i + 1]
                     usedElements--
                     return oldValue

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
@@ -1,6 +1,9 @@
 package fr.sncf.osrd.signaling
 
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.DistanceList
+import fr.sncf.osrd.utils.units.Speed
 
 
 enum class ProtectionStatus {

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/BlockBuilder.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/BlockBuilder.kt
@@ -5,6 +5,10 @@ import fr.sncf.osrd.sim_infra.impl.BlockInfraBuilder
 import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
 import fr.sncf.osrd.utils.indexing.IdxMap
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.MutableDistanceList
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.mutableDistanceArrayListOf
 import mu.KotlinLogging
 
 
@@ -66,7 +70,7 @@ internal fun internalBuildBlocks(
             // end with a buffer stop, blocks are expected to end with the route.
             // such blocks are not valid, and can be fixed by adding a delimiter signal
             // right before the end of the route.
-            val routeEndsAtBufferStop = rawSignalingInfra.isBufferStop(routeExitDet.detector)
+            val routeEndsAtBufferStop = rawSignalingInfra.isBufferStop(routeExitDet.value)
             for (curBlock in currentBlocks) {
                 if (curBlock.zonePaths.size == 0)
                     continue
@@ -185,7 +189,7 @@ private fun getInitPartialBlocks(
     entryDet: DirDetectorId,
 ): MutableList<PartialBlock> {
     val initialBlocks = mutableListOf<PartialBlock>()
-    val isBufferStop = rawSignalingInfra.isBufferStop(entryDet.detector)
+    val isBufferStop = rawSignalingInfra.isBufferStop(entryDet.value)
     if (entrySignals == null) {
         if (!isBufferStop)
             logger.debug { "no signal at non buffer stop" }

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.loadedSignalInfra
 import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.Distance
 import mu.KotlinLogging
 
 

--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -8,6 +8,8 @@ import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.mutableDistanceArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -29,8 +31,8 @@ class BlockBuilderTest {
         val builder = RawInfraBuilder()
         // region switches
         val switch = builder.movableElement(delay = 10L.milliseconds) {
-            config("xy")
-            config("vy")
+            config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+            config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
         }
         // endregion
 
@@ -41,20 +43,20 @@ class BlockBuilderTest {
         val zoneD = builder.zone(listOf())
 
         val detectorU = builder.detector("U")
-        builder.setNextZone(detectorU.normal, zoneA)
+        builder.setNextZone(detectorU.increasing, zoneA)
         val detectorV = builder.detector("V")
-        builder.setNextZone(detectorV.normal, zoneC)
-        builder.setNextZone(detectorV.reverse, zoneA)
+        builder.setNextZone(detectorV.increasing, zoneC)
+        builder.setNextZone(detectorV.decreasing, zoneA)
         val detectorW = builder.detector("W")
-        builder.setNextZone(detectorW.normal, zoneB)
+        builder.setNextZone(detectorW.increasing, zoneB)
         val detectorX = builder.detector("X")
-        builder.setNextZone(detectorX.normal, zoneC)
-        builder.setNextZone(detectorX.reverse, zoneB)
+        builder.setNextZone(detectorX.increasing, zoneC)
+        builder.setNextZone(detectorX.decreasing, zoneB)
         val detectorY = builder.detector("Y")
-        builder.setNextZone(detectorY.normal, zoneD)
-        builder.setNextZone(detectorY.reverse, zoneC)
+        builder.setNextZone(detectorY.increasing, zoneD)
+        builder.setNextZone(detectorY.decreasing, zoneC)
         val detectorZ = builder.detector("Z")
-        builder.setNextZone(detectorZ.reverse, zoneD)
+        builder.setNextZone(detectorZ.decreasing, zoneD)
         // endregion
 
         // region signals
@@ -67,17 +69,17 @@ class BlockBuilderTest {
         // endregion
 
         // region zone paths
-        val zonePathWX = builder.zonePath(detectorW.normal, detectorX.normal, 10.meters) {
+        val zonePathWX = builder.zonePath(detectorW.increasing, detectorX.increasing, 10.meters) {
             signal(signalX, 8.meters)
         }
-        val zonePathXY = builder.zonePath(detectorX.normal, detectorY.normal, 10.meters) {
+        val zonePathXY = builder.zonePath(detectorX.increasing, detectorY.increasing, 10.meters) {
             movableElement(switch, StaticIdx(0u), 5.meters)
         }
-        val zonePathYZ = builder.zonePath(detectorY.normal, detectorZ.normal, 10.meters)
-        val zonePathUV = builder.zonePath(detectorU.normal, detectorV.normal, 10.meters) {
+        val zonePathYZ = builder.zonePath(detectorY.increasing, detectorZ.increasing, 10.meters)
+        val zonePathUV = builder.zonePath(detectorU.increasing, detectorV.increasing, 10.meters) {
             signal(signalV, 8.meters)
         }
-        val zonePathVY = builder.zonePath(detectorV.normal, detectorY.normal, 10.meters) {
+        val zonePathVY = builder.zonePath(detectorV.increasing, detectorY.increasing, 10.meters) {
             movableElement(switch, StaticIdx(1u), 5.meters)
         }
         // endregion

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -1,9 +1,8 @@
 package fr.sncf.osrd.sim_infra.api
 
-import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.StaticIdxSpace
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.*
+
 import java.util.Comparator
 import java.util.PriorityQueue
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
@@ -1,20 +1,9 @@
-@file:PrimitiveWrapperCollections(
-    wrapper = Distance::class,
-    primitive = Long::class,
-    fromPrimitive = "Distance(%s)",
-    toPrimitive = "%s.millimeters",
-    collections = ["Array", "ArrayList"],
-)
-
 package fr.sncf.osrd.sim_infra.api
 
-import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
-import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.units.*
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.StaticIdxSpace
-import fr.sncf.osrd.utils.indexing.mutableDynIdxArrayListOf
-import kotlin.math.absoluteValue
 
 /** A fixed size signaling block */
 sealed interface Block
@@ -30,33 +19,6 @@ typealias PhysicalSignalId = StaticIdx<PhysicalSignal>
 sealed interface LogicalSignal
 typealias LogicalSignalId = StaticIdx<LogicalSignal>
 
-@JvmInline
-value class Distance(val millimeters: Long) : Comparable<Distance> {
-    val absoluteValue get() = Distance(millimeters.absoluteValue)
-    val meters get() = millimeters / 1000.0
-    operator fun plus(value: Distance): Distance {
-        return Distance(millimeters + value.millimeters)
-    }
-
-    operator fun minus(value: Distance): Distance {
-        return Distance(millimeters - value.millimeters)
-    }
-
-    companion object {
-        @JvmStatic
-        val ZERO = Distance(millimeters = 0L)
-    }
-
-    override fun compareTo(other: Distance): Int {
-        return millimeters.compareTo(other.millimeters)
-    }
-}
-
-val Double.meters: Distance get() = Distance((this * 1000).toLong())
-val Int.meters: Distance get() = Distance(this.toLong() * 1000)
-
-@JvmInline
-value class Speed(val value: ULong)
 
 
 interface RawSignalingInfra : RoutingInfra {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
@@ -1,0 +1,30 @@
+package fr.sncf.osrd.sim_infra.api
+
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.indexing.*
+
+
+/** Detectors detect when trains arrive and leave a given point location */
+sealed interface Detector
+typealias DetectorId = StaticIdx<Detector>
+
+/** A track chunk are internal subdivisions of track sections. These subdivisions are separated by detectors. */
+sealed interface TrackChunk
+typealias TrackChunkId = StaticIdx<TrackChunk>
+
+
+interface TrackInfra {
+    fun getTrackSectionId(trackSection: TrackSectionId): String
+    fun getTrackSectionDetectors(trackSection: TrackSectionId): StaticIdxList<Detector>
+    fun getTrackSectionChunks(trackSection: TrackSectionId): StaticIdxList<TrackChunk>
+}
+
+/** A directional detector encodes a direction over a detector */
+typealias DirDetectorId = DirStaticIdx<Detector>
+val DetectorId.increasing get() = DirDetectorId(this, Direction.INCREASING)
+val DetectorId.decreasing get() = DirDetectorId(this, Direction.DECREASING)
+
+
+/** A directional detector encodes a direction over a track chunk */
+typealias DirTrackChunkId = DirStaticIdx<TrackChunk>
+typealias OptDirTrackChunkId = OptDirStaticIdx<TrackChunk>

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackNetworkInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackNetworkInfra.kt
@@ -1,0 +1,67 @@
+package fr.sncf.osrd.sim_infra.api
+
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.Endpoint
+import fr.sncf.osrd.utils.indexing.*
+import kotlin.time.Duration
+
+
+/** A track section is a real-life section of track, which cannot be interrupted by switches. */
+sealed interface TrackSection
+typealias TrackSectionId = StaticIdx<TrackSection>
+
+/** Track nodes connect track sections together.
+ * Each node corresponds to either a railway switch, or an abstract boundary.
+ */
+sealed interface TrackNode
+typealias TrackNodeId = StaticIdx<TrackNode>
+
+/** Track nodes have ports, which can be connected to track section endpoints */
+sealed interface TrackNodePort
+typealias TrackNodePortId = StaticIdx<TrackNodePort>
+
+/**
+ * A possible track node config. Each switch has its own config id space.
+ * Abstract boundary nodes (sometimes called track section links) have a single config.
+ */
+sealed interface TrackNodeConfig
+typealias TrackNodeConfigId = StaticIdx<TrackNodeConfig>
+
+
+interface TrackNetworkInfra {
+    fun getNextTrackSection(current: DirTrackSectionId, config: TrackNodeConfigId): OptDirTrackSectionId
+
+    fun getNextTrackNode(trackSection: DirTrackSectionId): OptStaticIdx<TrackNode>
+    fun getNextTrackNodePort(trackSection: DirTrackSectionId): OptStaticIdx<TrackNodePort>
+    /** Returns the track section which is plugged into a given node port */
+    fun getPortTrackSection(trackNode: TrackNodeId, port: TrackNodePortId): EndpointTrackSectionId
+
+    /** Returns the collection of all possible configurations for the node.
+     * Switches always have more than one, and abstract nodes (track section links) always have one.
+     */
+    fun getTrackNodeConfigs(trackNode: TrackNodeId): StaticIdxSpace<TrackNodeConfig>
+    /** Returns the number of ports for this node. Abstract nodes have two ports, and switches have at least 3. */
+    fun getTrackNodePorts(trackNode: TrackNodeId): StaticIdxSpace<TrackNodePort>
+    /** Given a node, a configuration, and an entry port, returns either the exit port,
+     * or -1 if the entry cannot be used in this configuration.
+     */
+    fun getTrackNodeExitPort(trackNode: TrackNodeId, config: TrackNodeConfigId, entryPort: TrackNodePortId): OptStaticIdx<TrackNodePort>
+    /** Returns the time it takes for the node to change configuration */
+    fun getTrackNodeDelay(trackNode: TrackNodeId): Duration
+    fun getTrackNodeConfigName(trackNode: TrackNodeId, config: TrackNodeConfigId): String
+
+    val trackNodes: StaticIdxSpace<TrackNode>
+    val trackSections: StaticIdxSpace<TrackSection>
+}
+
+
+/** A directional detector encodes a direction over a track section */
+typealias DirTrackSectionId = DirStaticIdx<TrackSection>
+typealias OptDirTrackSectionId = OptDirStaticIdx<TrackSection>
+val TrackSectionId.increasing get() = DirTrackSectionId(this, Direction.INCREASING)
+val TrackSectionId.decreasing get() = DirTrackSectionId(this, Direction.DECREASING)
+
+typealias EndpointTrackSectionId = EndpointStaticIdx<TrackSection>
+typealias OptEndpointTrackSectionId = OptEndpointStaticIdx<TrackSection>
+val TrackSectionId.start get() = EndpointTrackSectionId(this, Endpoint.START)
+val TrackSectionId.end get() = EndpointTrackSectionId(this, Endpoint.END)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -1,0 +1,21 @@
+package fr.sncf.osrd.sim_infra.api
+
+import fr.sncf.osrd.railjson.schema.geom.LineString
+import fr.sncf.osrd.utils.indexing.StaticIdxCollection
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.DistanceRangeMap
+
+interface TrackProperties {
+    fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString
+    fun getTrackChunkLength(trackChunk: TrackChunkId): Distance
+    fun getTrackFromChunk(trackChunk: TrackChunkId): TrackSectionId
+
+    // non-overlapping attributes:
+    fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double>
+    // TODO: voltages
+    // TODO: loading gauge
+
+    // overlapping attributes:
+    // TODO: speed sections
+    // TODO: operational points
+}

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraBuilder.kt
@@ -1,9 +1,8 @@
 package fr.sncf.osrd.sim_infra.impl
 
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.StaticIdxMap
-import fr.sncf.osrd.utils.indexing.StaticPool
+import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.*
 
 
 interface BlockInfraBuilder {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.sim_infra.impl
 
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.*
 
 class BlockDescriptor(
     val startAtBufferStop: Boolean,

--- a/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/api/InterlockingSim.kt
+++ b/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/api/InterlockingSim.kt
@@ -16,13 +16,13 @@ enum class MovableElementInitPolicy {
 }
 
 interface MovableElementSim {
-    fun watchMovableElement(movable: MovableElementId): StateFlow<MovableElementConfigId?>
-    suspend fun move(movable: MovableElementId, config: MovableElementConfigId)
-    suspend fun lockMovableElement(movable: MovableElementId)
-    suspend fun unlockMovableElement(movable: MovableElementId)
+    fun watchMovableElement(movable: TrackNodeId): StateFlow<TrackNodeConfigId?>
+    suspend fun move(movable: TrackNodeId, config: TrackNodeConfigId)
+    suspend fun lockMovableElement(movable: TrackNodeId)
+    suspend fun unlockMovableElement(movable: TrackNodeId)
 }
 
-suspend inline fun <T> MovableElementSim.withLock(movable: MovableElementId, action: () -> T): T {
+suspend inline fun <T> MovableElementSim.withLock(movable: TrackNodeId, action: () -> T): T {
     contract {
         callsInPlace(action, InvocationKind.EXACTLY_ONCE)
     }
@@ -79,7 +79,7 @@ typealias ZoneReservationId = DynIdx<ZoneReservation>
 interface ZoneRequirements {
     val entry: DirDetectorId
     val exit: DirDetectorId
-    val movableElements: Map<MovableElementId, MovableElementConfigId>
+    val movableElements: Map<TrackNodeId, TrackNodeConfigId>
 }
 
 fun ZoneRequirements.compatibleWith(other: ZoneRequirements): Boolean {

--- a/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/impl/MovableElements.kt
+++ b/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/impl/MovableElements.kt
@@ -11,41 +11,41 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 
 
-fun movableElementSim(infra: MovableElementsInfra, initPolicy: MovableElementInitPolicy): MovableElementSim {
+fun movableElementSim(infra: TrackNetworkInfra, initPolicy: MovableElementInitPolicy): MovableElementSim {
     return MovableElementSimImpl(infra, initPolicy)
 }
 
 internal class MovableElementSimImpl(
-    private val infra: MovableElementsInfra,
+    private val infra: TrackNetworkInfra,
     private val initPolicy: MovableElementInitPolicy,
 ) : MovableElementSim {
-    private val states: List<MutableStateFlow<MovableElementConfigId?>> = infra.movableElements.map {
+    private val states: List<MutableStateFlow<TrackNodeConfigId?>> = infra.trackNodes.map {
         MutableStateFlow(null)
     }
 
-    private val locks = infra.movableElements.map { Mutex() }
+    private val locks = infra.trackNodes.map { Mutex() }
 
-    override fun watchMovableElement(movable: MovableElementId): StateFlow<MovableElementConfigId?> {
+    override fun watchMovableElement(movable: TrackNodeId): StateFlow<TrackNodeConfigId?> {
         return states[movable.index]
     }
 
-    override suspend fun lockMovableElement(movable: MovableElementId) {
+    override suspend fun lockMovableElement(movable: TrackNodeId) {
         locks[movable.index].lock()
     }
 
-    override suspend fun move(movable: MovableElementId, config: MovableElementConfigId) {
+    override suspend fun move(movable: TrackNodeId, config: TrackNodeConfigId) {
         assert(locks[movable.index].isLocked) { "cannot move a non-locked movable element" }
         states[movable.index].update { prevConfig ->
             if (prevConfig == null) {
                 if (initPolicy == MovableElementInitPolicy.PESSIMISTIC)
-                    delay(infra.getMovableElementDelay(movable))
+                    delay(infra.getTrackNodeDelay(movable))
             } else if (prevConfig != config)
-                delay(infra.getMovableElementDelay(movable))
+                delay(infra.getTrackNodeDelay(movable))
             config
         }
     }
 
-    override suspend fun unlockMovableElement(movable: MovableElementId) {
+    override suspend fun unlockMovableElement(movable: TrackNodeId) {
         locks[movable.index].unlock()
     }
 }

--- a/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/impl/Reservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/main/kotlin/fr/sncf/osrd/sim/interlocking/impl/Reservation.kt
@@ -51,7 +51,7 @@ fun ReservationInfra.getRequirements(zonePath: ZonePathId): ZoneRequirements {
     val exit = getZonePathExit(zonePath)
     val movableElements = getZonePathMovableElements(zonePath)
     val movableElementsConfigs = getZonePathMovableElementsConfigs(zonePath)
-    val movableElementRequirements = HashMap<MovableElementId, MovableElementConfigId>(movableElements.size)
+    val movableElementRequirements = HashMap<TrackNodeId, TrackNodeConfigId>(movableElements.size)
     for (i in 0 until movableElements.size)
         movableElementRequirements[movableElements[i]] = movableElementsConfigs[i]
     return ZoneRequirementsImpl(
@@ -76,13 +76,13 @@ fun zoneReservation(train: TrainId, requirements: ZoneRequirements, status: Zone
 internal data class ZoneRequirementsImpl(
     override val entry: DirDetectorId,
     override val exit: DirDetectorId,
-    override val movableElements: Map<MovableElementId, MovableElementConfigId>,
+    override val movableElements: Map<TrackNodeId, TrackNodeConfigId>,
 ) : ZoneRequirements
 
 fun zoneRequirements(
     entry: DirDetectorId,
     exit: DirDetectorId,
-    movableElements: Map<MovableElementId, MovableElementConfigId>
+    movableElements: Map<TrackNodeId, TrackNodeConfigId>
 ): ZoneRequirements {
     return ZoneRequirementsImpl(entry, exit, movableElements)
 }

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
@@ -20,16 +20,16 @@ class TestLocation {
         val infra = rawInfra {
             // create a test switch
             val switchA = movableElement(delay = 42L.milliseconds) {
-                config("a")
-                config("b")
+                config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
             }
 
             val zoneA = zone(listOf(switchA))
 
             val detectorA = detector("A")
-            setNextZone(detectorA.normal, zoneA)
+            setNextZone(detectorA.increasing, zoneA)
             val detectorB = detector("B")
-            setNextZone(detectorB.reverse, zoneA)
+            setNextZone(detectorB.decreasing, zoneA)
         }
 
         val sim = locationSim(infra)

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.sim
 import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.impl.MovableElementSimImpl
 import fr.sncf.osrd.sim.interlocking.api.withLock
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.impl.rawInfra
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -18,14 +19,14 @@ class TestMovableElements {
         // setup test data
         val infra = rawInfra {
             movableElement(delay = 42L.milliseconds) {
-                config("a")
-                config("b")
+                config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
             }
         }
 
         val sim = MovableElementSimImpl(infra, MovableElementInitPolicy.PESSIMISTIC)
-        val movableElement = infra.movableElements[0]
-        val configs = infra.getMovableElementConfigs(movableElement)
+        val movableElement = infra.trackNodes[0]
+        val configs = infra.getTrackNodeConfigs(movableElement)
 
         // workerA moves the switch from config 0 to config 1
         val workerA = async {

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.mutableArenaMap
+import fr.sncf.osrd.utils.units.meters
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
@@ -37,8 +38,8 @@ class TestReservation {
         // region build the test infrastructure
         val builder = RawInfraBuilder()
         val switch = builder.movableElement(delay = 42L.milliseconds) {
-            config("a")
-            config("b")
+            config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+            config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
         }
 
         val zoneA = builder.zone(listOf())
@@ -47,22 +48,22 @@ class TestReservation {
         val zoneD = builder.zone(listOf())
 
         val detectorU = builder.detector("U")
-        builder.setNextZone(detectorU.normal, zoneA)
+        builder.setNextZone(detectorU.increasing, zoneA)
         val detectorV = builder.detector("V")
-        builder.setNextZone(detectorV.normal, zoneC)
-        builder.setNextZone(detectorV.reverse, zoneA)
+        builder.setNextZone(detectorV.increasing, zoneC)
+        builder.setNextZone(detectorV.decreasing, zoneA)
         val detectorW = builder.detector("W")
-        builder.setNextZone(detectorW.normal, zoneB)
+        builder.setNextZone(detectorW.increasing, zoneB)
         val detectorX = builder.detector("X")
-        builder.setNextZone(detectorX.normal, zoneC)
-        builder.setNextZone(detectorX.reverse, zoneB)
+        builder.setNextZone(detectorX.increasing, zoneC)
+        builder.setNextZone(detectorX.decreasing, zoneB)
         val detectorY = builder.detector("Y")
-        builder.setNextZone(detectorY.normal, zoneD)
-        builder.setNextZone(detectorY.reverse, zoneC)
+        builder.setNextZone(detectorY.increasing, zoneD)
+        builder.setNextZone(detectorY.decreasing, zoneC)
         val detectorZ = builder.detector("Z")
-        builder.setNextZone(detectorZ.reverse, zoneD)
+        builder.setNextZone(detectorZ.decreasing, zoneD)
 
-        val testZonePath = builder.zonePath(detectorU.normal, detectorV.normal, 42.meters) {}
+        val testZonePath = builder.zonePath(detectorU.increasing, detectorV.increasing, 42.meters) {}
 
         val infra = builder.build()
         // endregion
@@ -121,7 +122,7 @@ class TestReservation {
         reference.add(ZoneEvent(0L, zoneState(arena.clone())))
 
         // pre-reservation at time 0
-        val requirements = zoneRequirements(detectorU.normal, detectorV.normal, mapOf())
+        val requirements = zoneRequirements(detectorU.increasing, detectorV.increasing, mapOf())
         val reservationId = arena.allocate(zoneReservation(trainA, requirements, PRE_RESERVED))
         reference.add(ZoneEvent(0L, zoneState(arena.clone())))
 

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -6,12 +6,13 @@ import fr.sncf.osrd.sim.interlocking.impl.LocationSimImpl
 import fr.sncf.osrd.sim.interlocking.impl.movableElementSim
 import fr.sncf.osrd.sim.interlocking.impl.reservationSim
 import fr.sncf.osrd.sim.interlocking.impl.routingSim
-import fr.sncf.osrd.sim_infra.api.meters
-import fr.sncf.osrd.sim_infra.api.normal
-import fr.sncf.osrd.sim_infra.api.reverse
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.api.increasing
+import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.meters
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
@@ -42,8 +43,8 @@ class TestRouting {
         val builder = RawInfraBuilder()
         // region switches
         val switch = builder.movableElement(delay = 10L.milliseconds) {
-            config("xy")
-            config("vy")
+            config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+            config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
         }
 
         // endregion
@@ -55,41 +56,41 @@ class TestRouting {
         val zoneD = builder.zone(listOf())
 
         val detectorU = builder.detector("U")
-        builder.setNextZone(detectorU.normal, zoneA)
+        builder.setNextZone(detectorU.increasing, zoneA)
         val detectorV = builder.detector("V")
-        builder.setNextZone(detectorV.normal, zoneC)
-        builder.setNextZone(detectorV.reverse, zoneA)
+        builder.setNextZone(detectorV.increasing, zoneC)
+        builder.setNextZone(detectorV.decreasing, zoneA)
         val detectorW = builder.detector("W")
-        builder.setNextZone(detectorW.normal, zoneB)
+        builder.setNextZone(detectorW.increasing, zoneB)
         val detectorX = builder.detector("X")
-        builder.setNextZone(detectorX.normal, zoneC)
-        builder.setNextZone(detectorX.reverse, zoneB)
+        builder.setNextZone(detectorX.increasing, zoneC)
+        builder.setNextZone(detectorX.decreasing, zoneB)
         val detectorY = builder.detector("Y")
-        builder.setNextZone(detectorY.normal, zoneD)
-        builder.setNextZone(detectorY.reverse, zoneC)
+        builder.setNextZone(detectorY.increasing, zoneD)
+        builder.setNextZone(detectorY.decreasing, zoneC)
         val detectorZ = builder.detector("Z")
-        builder.setNextZone(detectorZ.reverse, zoneD)
+        builder.setNextZone(detectorZ.decreasing, zoneD)
         // endregion
 
         // region routes
         // create a route from W to Z, releasing at Y and Z
         val routeWZ = builder.route("W-Z") {
-            zonePath(builder.zonePath(detectorW.normal, detectorX.normal, 10.meters)) // zone B
-            zonePath(builder.zonePath(detectorX.normal, detectorY.normal, 10.meters) {
+            zonePath(builder.zonePath(detectorW.increasing, detectorX.increasing, 10.meters)) // zone B
+            zonePath(builder.zonePath(detectorX.increasing, detectorY.increasing, 10.meters) {
                 movableElement(switch, StaticIdx(0u), 5.meters)
             }) // zone C
-            zonePath(builder.zonePath(detectorY.normal, detectorZ.normal, 10.meters)) // zone D
+            zonePath(builder.zonePath(detectorY.increasing, detectorZ.increasing, 10.meters)) // zone D
             // release at zone C and D
             releaseZone(1)
             releaseZone(2)
         }
 
         val routeUZ = builder.route("U-Z") {
-            zonePath(builder.zonePath(detectorU.normal, detectorV.normal, 10.meters)) // zone A
-            zonePath(builder.zonePath(detectorV.normal, detectorY.normal, 10.meters) {
+            zonePath(builder.zonePath(detectorU.increasing, detectorV.increasing, 10.meters)) // zone A
+            zonePath(builder.zonePath(detectorV.increasing, detectorY.increasing, 10.meters) {
                 movableElement(switch, StaticIdx(1u), 5.meters)
             }) // zone C
-            zonePath(builder.zonePath(detectorY.normal, detectorZ.normal, 10.meters)) // zone D
+            zonePath(builder.zonePath(detectorY.increasing, detectorZ.increasing, 10.meters)) // zone D
             // release at zone D
             releaseZone(2)
         }

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -4,12 +4,13 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.meters
-import fr.sncf.osrd.sim_infra.api.normal
-import fr.sncf.osrd.sim_infra.api.reverse
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.api.increasing
+import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
@@ -31,8 +32,8 @@ class TestBALtoBAL {
         val builder = RawInfraBuilder()
         // region switches
         val switch = builder.movableElement(delay = 10L.milliseconds) {
-            config("xy")
-            config("vy")
+            config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+            config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
         }
         // endregion
 
@@ -43,20 +44,20 @@ class TestBALtoBAL {
         val zoneD = builder.zone(listOf())
 
         val detectorU = builder.detector("U")
-        builder.setNextZone(detectorU.normal, zoneA)
+        builder.setNextZone(detectorU.increasing, zoneA)
         val detectorV = builder.detector("V")
-        builder.setNextZone(detectorV.normal, zoneC)
-        builder.setNextZone(detectorV.reverse, zoneA)
+        builder.setNextZone(detectorV.increasing, zoneC)
+        builder.setNextZone(detectorV.decreasing, zoneA)
         val detectorW = builder.detector("W")
-        builder.setNextZone(detectorW.normal, zoneB)
+        builder.setNextZone(detectorW.increasing, zoneB)
         val detectorX = builder.detector("X")
-        builder.setNextZone(detectorX.normal, zoneC)
-        builder.setNextZone(detectorX.reverse, zoneB)
+        builder.setNextZone(detectorX.increasing, zoneC)
+        builder.setNextZone(detectorX.decreasing, zoneB)
         val detectorY = builder.detector("Y")
-        builder.setNextZone(detectorY.normal, zoneD)
-        builder.setNextZone(detectorY.reverse, zoneC)
+        builder.setNextZone(detectorY.increasing, zoneD)
+        builder.setNextZone(detectorY.decreasing, zoneC)
         val detectorZ = builder.detector("Z")
-        builder.setNextZone(detectorZ.reverse, zoneD)
+        builder.setNextZone(detectorZ.decreasing, zoneD)
         // endregion
 
         // region signals
@@ -69,17 +70,17 @@ class TestBALtoBAL {
         // endregion
 
         // region zone paths
-        val zonePathWX = builder.zonePath(detectorW.normal, detectorX.normal, 10.meters) {
+        val zonePathWX = builder.zonePath(detectorW.increasing, detectorX.increasing, 10.meters) {
             signal(signalX, 8.meters)
         }
-        val zonePathXY = builder.zonePath(detectorX.normal, detectorY.normal, 10.meters) {
+        val zonePathXY = builder.zonePath(detectorX.increasing, detectorY.increasing, 10.meters) {
             movableElement(switch, StaticIdx(0u), 5.meters)
         }
-        val zonePathYZ = builder.zonePath(detectorY.normal, detectorZ.normal, 10.meters)
-        val zonePathUV = builder.zonePath(detectorU.normal, detectorV.normal, 10.meters) {
+        val zonePathYZ = builder.zonePath(detectorY.increasing, detectorZ.increasing, 10.meters)
+        val zonePathUV = builder.zonePath(detectorU.increasing, detectorV.increasing, 10.meters) {
             signal(signalV, 8.meters)
         }
-        val zonePathVY = builder.zonePath(detectorV.normal, detectorY.normal, 10.meters) {
+        val zonePathVY = builder.zonePath(detectorV.increasing, detectorY.increasing, 10.meters) {
             movableElement(switch, StaticIdx(1u), 5.meters)
         }
         // endregion
@@ -114,8 +115,8 @@ class TestBALtoBAL {
         val loadedSignalInfra = simulator.loadSignals(infra)
         val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
         val fullPath = mutableStaticIdxArrayListOf<Block>()
-        fullPath.add(blockInfra.getBlocksAtDetector(detectorU.normal).first())
-        fullPath.add(blockInfra.getBlocksAtDetector(detectorV.normal).first())
+        fullPath.add(blockInfra.getBlocksAtDetector(detectorU.increasing).first())
+        fullPath.add(blockInfra.getBlocksAtDetector(detectorV.increasing).first())
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.CLEAR)
         val res = simulator.evaluate(infra, loadedSignalInfra, blockInfra, fullPath, 0, fullPath.size, zoneStates, ZoneStatus.INCOMPATIBLE)
         assertEquals("A", res[loadedSignalInfra.getLogicalSignals(signalV).first()]!!.getEnum("aspect"))

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -10,6 +10,7 @@ import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.utils.indexing.IdxMap
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -34,15 +35,15 @@ class TestBAPRtoBAL {
         val zoneC = builder.zone(listOf())
 
         val detectorW = builder.detector("w")
-        builder.setNextZone(detectorW.normal, zoneA)
+        builder.setNextZone(detectorW.increasing, zoneA)
         val detectorX = builder.detector("X")
-        builder.setNextZone(detectorX.normal, zoneB)
-        builder.setNextZone(detectorX.reverse, zoneA)
+        builder.setNextZone(detectorX.increasing, zoneB)
+        builder.setNextZone(detectorX.decreasing, zoneA)
         val detectorY = builder.detector("Y")
-        builder.setNextZone(detectorY.normal, zoneC)
-        builder.setNextZone(detectorY.reverse, zoneB)
+        builder.setNextZone(detectorY.increasing, zoneC)
+        builder.setNextZone(detectorY.decreasing, zoneB)
         val detectorZ = builder.detector("Z")
-        builder.setNextZone(detectorZ.reverse, zoneC)
+        builder.setNextZone(detectorZ.decreasing, zoneC)
         // endregion
 
         // region signals
@@ -62,15 +63,15 @@ class TestBAPRtoBAL {
         // endregion
 
         // region zone paths
-        val zonePathWX = builder.zonePath(detectorW.normal, detectorX.normal, 10.meters) {
+        val zonePathWX = builder.zonePath(detectorW.increasing, detectorX.increasing, 10.meters) {
             signal(signalm, 6.meters)
             signal(signalM, 8.meters)
         }
-        val zonePathXY = builder.zonePath(detectorX.normal, detectorY.normal, 10.meters) {
+        val zonePathXY = builder.zonePath(detectorX.increasing, detectorY.increasing, 10.meters) {
             signal(signaln, 6.meters)
             signal(signalN, 8.meters)
         }
-        val zonePathYZ = builder.zonePath(detectorY.normal, detectorZ.normal, 10.meters)
+        val zonePathYZ = builder.zonePath(detectorY.increasing, detectorZ.increasing, 10.meters)
 
         // endregion
 
@@ -95,9 +96,9 @@ class TestBAPRtoBAL {
         val loadedSignalInfra = simulator.loadSignals(infra)
         val blockInfra = simulator.buildBlocks(infra, loadedSignalInfra)
         val fullPath = mutableStaticIdxArrayListOf<Block>()
-        fullPath.add(blockInfra.getBlocksAtDetector(detectorW.normal).first())
-        fullPath.add(blockInfra.getBlocksAtDetector(detectorX.normal).first())
-        fullPath.add(blockInfra.getBlocksAtDetector(detectorY.normal).first())
+        fullPath.add(blockInfra.getBlocksAtDetector(detectorW.increasing).first())
+        fullPath.add(blockInfra.getBlocksAtDetector(detectorX.increasing).first())
+        fullPath.add(blockInfra.getBlocksAtDetector(detectorY.increasing).first())
         val zoneStates = mutableListOf(ZoneStatus.CLEAR, ZoneStatus.CLEAR, ZoneStatus.INCOMPATIBLE)
         val res = simulator.evaluate(infra, loadedSignalInfra, blockInfra, fullPath, 0, fullPath.size, zoneStates, ZoneStatus.INCOMPATIBLE)
         val logicalSignals = listOf(signalm, signalM, signaln, signalN).map{loadedSignalInfra.getLogicalSignals(it).first()}

--- a/core/kt-osrd-utils/build.gradle
+++ b/core/kt-osrd-utils/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     ksp project(':kt-fast-collections-generator')
 
     api libs.kotlinx.coroutines.core
+    implementation libs.guava
     implementation libs.kotlin.stdlib
     testImplementation libs.kotlin.test
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Direction.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Direction.kt
@@ -1,12 +1,19 @@
 package fr.sncf.osrd.utils
 
+/** A direction along an axis */
 enum class Direction {
-    NORMAL,
-    REVERSE;
+    /** The direction along which the position measure increases */
+    INCREASING,
+    /** The direction along which the position measure decreases */
+    DECREASING;
 
     val opposite: Direction get() = when (this) {
-        NORMAL -> REVERSE
-        REVERSE -> NORMAL
+        INCREASING -> DECREASING
+        DECREASING -> INCREASING
+    }
+
+    val toEndpoint: Endpoint get() = when(this) {
+        INCREASING -> Endpoint.END
+        DECREASING -> Endpoint.START
     }
 }
-

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DirectionalMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DirectionalMap.kt
@@ -1,0 +1,14 @@
+package fr.sncf.osrd.utils
+
+/** Simple utility class to store a pair of values, each linked to a direction */
+class DirectionalMap<T> (
+    private val forwards: T,
+    private val backwards: T,
+) {
+    fun get(dir: Direction): T {
+        return when (dir) {
+            Direction.INCREASING -> forwards
+            Direction.DECREASING -> backwards
+        }
+    }
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Endpoint.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Endpoint.kt
@@ -1,0 +1,21 @@
+package fr.sncf.osrd.utils
+
+/** An endpoint on an oriented segment */
+enum class Endpoint {
+    /** The point at the start of the oriented segment */
+    START,
+    /** The point at the end of the oriented segment */
+    END;
+
+    val opposite: Endpoint get() = when (this) {
+        START -> END
+        END -> START
+    }
+
+    val directionAway: Direction get() = when (this) {
+        START -> Direction.INCREASING
+        END -> Direction.DECREASING
+    }
+
+    val directionFrom: Direction get() = directionAway.opposite
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/DirStaticIdx.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/DirStaticIdx.kt
@@ -1,0 +1,31 @@
+@file:PrimitiveWrapperCollections(
+    wrapper = DirStaticIdx::class,
+    primitive = UInt::class,
+    fromPrimitive = "DirStaticIdx(%s)",
+    toPrimitive = "%s.index",
+    collections = ["Array", "ArrayList", "ArraySortedSet"],
+)
+
+package fr.sncf.osrd.utils.indexing
+
+import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
+import fr.sncf.osrd.utils.Direction
+
+@JvmInline
+value class DirStaticIdx<T>(val data: UInt) : NumIdx {
+    public constructor(detector: StaticIdx<T>, direction: Direction) : this(
+        (detector.index shl 1) or when (direction) {
+            Direction.INCREASING -> 0u
+            Direction.DECREASING -> 1u
+        })
+
+    val value: StaticIdx<T> get() = StaticIdx(data shr 1)
+    val direction: Direction
+        get() = when ((data and 1u) != 0u) {
+            false -> Direction.INCREASING
+            true -> Direction.DECREASING
+        }
+
+    val opposite: DirStaticIdx<T> get() = DirStaticIdx(data xor 1u)
+    override val index get() = data
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
@@ -9,6 +9,8 @@
 package fr.sncf.osrd.utils.indexing
 
 import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.Endpoint
 
 /** The type-safe index. The index type can be an abstract token,
  * such as an empty sealed interface. */
@@ -16,10 +18,93 @@ import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
 value class StaticIdx<T>(override val index: UInt) : NumIdx
 
 @JvmInline
+value class OptStaticIdx<T>(private val data: UInt) {
+
+    constructor() : this(UInt.MAX_VALUE)
+
+    val isNone: Boolean get () = data == UInt.MAX_VALUE
+
+    fun asIndex(): StaticIdx<T> {
+        assert(!isNone)
+        return StaticIdx(data)
+    }
+
+    fun <U> map(onSome: (StaticIdx<T>) -> U, onNone: () -> U): U {
+        return if (isNone) {
+            onNone()
+        } else {
+            onSome(asIndex())
+        }
+    }
+}
+
+@JvmInline
+value class EndpointStaticIdx<T>(val data: UInt) : NumIdx {
+    public constructor(value: StaticIdx<T>, endpoint: Endpoint) : this(
+        (value.index shl 1) or when (endpoint) {
+            Endpoint.START -> 0u
+            Endpoint.END -> 1u
+        })
+
+    val value: StaticIdx<T> get() = StaticIdx(data shr 1)
+    val endpoint: Endpoint
+        get() = when ((data and 1u) != 0u) {
+            false -> Endpoint.START
+            true -> Endpoint.END
+        }
+
+    val opposite: DirStaticIdx<T> get() = DirStaticIdx(data xor 1u)
+    override val index get() = data
+}
+
+
+@JvmInline
+value class OptDirStaticIdx<T>(private val data: UInt) {
+    constructor() : this(UInt.MAX_VALUE)
+    constructor(value: StaticIdx<T>, dir: Direction) : this(DirStaticIdx(value, dir).data)
+    val isNone: Boolean get () = data == UInt.MAX_VALUE
+
+    private fun asIndex(): DirStaticIdx<T> {
+        assert(!isNone)
+        return DirStaticIdx(data)
+    }
+
+    fun <U> map(onSome: (DirStaticIdx<T>) -> U, onNone: () -> U): U {
+        return if (isNone) {
+            onNone()
+        } else {
+            onSome(asIndex())
+        }
+    }
+}
+
+
+@JvmInline
+value class OptEndpointStaticIdx<T>(private val data: UInt) {
+
+    constructor() : this(UInt.MAX_VALUE)
+
+    val isNone: Boolean get () = data == UInt.MAX_VALUE
+
+    private fun asIndex(): EndpointStaticIdx<T> {
+        assert(!isNone)
+        return EndpointStaticIdx(data)
+    }
+
+    fun <U> map(onSome: (EndpointStaticIdx<T>) -> U, onNone: () -> U): U {
+        return if (isNone) {
+            onNone()
+        } else {
+            onSome(asIndex())
+        }
+    }
+}
+
+@JvmInline
 value class StaticPool<IndexT, ValueT>(private val items: MutableList<ValueT>) : StaticIdxIterable<IndexT> {
     constructor() : this(mutableListOf())
 
-    val size: Int get() = items.size
+    val size: UInt get() = items.size.toUInt()
 
     operator fun get(i: StaticIdx<IndexT>): ValueT {
         return items[i.index]
@@ -36,7 +121,7 @@ value class StaticPool<IndexT, ValueT>(private val items: MutableList<ValueT>) :
     }
 
     fun space(): StaticIdxSpace<IndexT> {
-        return StaticIdxSpace(size.toUInt())
+        return StaticIdxSpace(size)
     }
 
     override fun iterator(): StaticIdxIterator<IndexT> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -1,0 +1,38 @@
+@file:PrimitiveWrapperCollections(
+    wrapper = Distance::class,
+    primitive = Long::class,
+    fromPrimitive = "Distance(%s)",
+    toPrimitive = "%s.millimeters",
+    collections = ["Array", "ArrayList"],
+)
+
+package fr.sncf.osrd.utils.units
+
+import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
+import kotlin.math.absoluteValue
+
+@JvmInline
+value class Distance(val millimeters: Long) : Comparable<Distance> {
+    val absoluteValue get() = Distance(millimeters.absoluteValue)
+    val meters get() = millimeters / 1000.0
+    operator fun plus(value: Distance): Distance {
+        return Distance(millimeters + value.millimeters)
+    }
+
+    operator fun minus(value: Distance): Distance {
+        return Distance(millimeters - value.millimeters)
+    }
+
+    companion object {
+        @JvmStatic
+        val ZERO = Distance(millimeters = 0L)
+        fun fromMeters(meters: Double) = Distance(millimeters = (meters * 1_000.0).toLong())
+    }
+
+    override fun compareTo(other: Distance): Int {
+        return millimeters.compareTo(other.millimeters)
+    }
+}
+
+val Double.meters: Distance get() = Distance((this * 1000).toLong())
+val Int.meters: Distance get() = Distance(this.toLong() * 1000)

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/DistanceRangeMap.kt
@@ -1,0 +1,101 @@
+package fr.sncf.osrd.utils.units
+
+import com.google.common.collect.RangeMap
+
+data class DistanceRangeMap<T>(
+    private val bounds: MutableDistanceArrayList,
+    private val values: MutableList<T?>,
+) : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
+
+    /** When iterating over the values of the map, this represents one range of constant value */
+    data class RangeMapEntry<T>(
+        val lower: Distance,
+        val upper: Distance,
+        val value: T,
+    )
+
+    constructor() : this(MutableDistanceArrayList(), ArrayList())
+
+    /** Sets the value between the lower and upper distances */
+    fun put(lower: Distance, upper: Distance, value: T) {
+        var startIndex = 0
+        while (startIndex < bounds.size && bounds[startIndex] < lower)
+            startIndex++
+        bounds.insert(startIndex, lower)
+
+        // Add a new entry with the previous value, to "split" the current range
+        if (startIndex > 0 && startIndex <= values.size)
+            values.add(startIndex, values[startIndex - 1])
+        else if (startIndex > values.size) {
+            // The ranges don't overlap: we add a null value
+            values.add(startIndex - 1, null)
+        }
+        values.add(startIndex, value)
+        val endIndex = startIndex + 1
+        while (endIndex < bounds.size && bounds[endIndex] < upper) {
+            bounds.remove(endIndex)
+            values.removeAt(endIndex)
+        }
+        bounds.insert(endIndex, upper)
+        mergeAdjacent()
+    }
+
+    /** Iterates over the entries in the map */
+    override fun iterator(): Iterator<RangeMapEntry<T>> {
+        return asList().iterator()
+    }
+
+    /** Returns a list of the entries in the map */
+    fun asList(): List<RangeMapEntry<T>> {
+        assert(bounds.size == values.size + 1 || (bounds.size == 0 && values.isEmpty()))
+        val res = ArrayList<RangeMapEntry<T>>()
+        for (i in 0 until values.size) {
+            if (values[i] != null)
+                res.add(RangeMapEntry(
+                    bounds[i],
+                    bounds[i + 1],
+                    values[i]!!
+                ))
+        }
+        return res
+    }
+
+    /** Merges adjacent values, removes 0-length ranges */
+    private fun mergeAdjacent() {
+        fun remove(i: Int) {
+            values.removeAt(i)
+            bounds.remove(i + 1)
+        }
+        // Merge identical ranges
+        var i = 0
+        while (i < values.size - 1) {
+            if (values[i] == values[i + 1])
+                remove(i)
+            else
+                i++
+        }
+        // Merge 0 length ranges
+        i = 0
+        while (i < bounds.size - 1) {
+            if (bounds[i] == bounds[i + 1])
+                remove(i)
+            else
+                i++
+        }
+        if (values.isEmpty() && bounds.size > 0)
+            bounds.remove(0)
+    }
+
+    companion object {
+        fun <T>from(map: RangeMap<Double, T>): DistanceRangeMap<T> {
+            val res = DistanceRangeMap<T>()
+            for (entry in map.asMapOfRanges())
+                res.put(
+                    Distance.fromMeters(entry.key.lowerEndpoint()),
+                    Distance.fromMeters(entry.key.upperEndpoint()),
+                    entry.value
+                )
+            return res
+        }
+    }
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -1,0 +1,10 @@
+package fr.sncf.osrd.utils.units
+
+private const val multiplier = 1000.0
+
+@JvmInline
+value class Speed(private val millimetersPerSeconds: ULong) {
+    val metersPerSeconds get() = millimetersPerSeconds.toDouble() / multiplier
+}
+
+val Double.metersPerSeconds: Distance get() = Distance((this * multiplier).toLong())

--- a/core/kt-osrd-utils/src/test/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/test/kotlin/fr/sncf/osrd/utils/TestDistanceRangeMap.kt
@@ -1,0 +1,94 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.DistanceRangeMap
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestDistanceRangeMap {
+    @Test
+    fun testEmpty() {
+        val rangeMap = DistanceRangeMap<Int>()
+        assertEquals(emptyList(), rangeMap.asList())
+    }
+
+    @Test
+    fun testSingleEntry() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(100), Distance(1000), 42)
+        assertEquals(listOf(DistanceRangeMap.RangeMapEntry(
+            Distance(100), Distance(1000), 42
+        )), rangeMap.asList())
+    }
+
+    @Test
+    fun testEmptyEntry() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(100), Distance(100), 42)
+        assertEquals(emptyList(), rangeMap.asList())
+    }
+
+    @Test
+    fun testOverlappingRanges() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(100), Distance(200), 42)
+        rangeMap.put(Distance(150), Distance(300), 43)
+        assertEquals(listOf(
+            DistanceRangeMap.RangeMapEntry(Distance(100), Distance(150), 42),
+                    DistanceRangeMap.RangeMapEntry(Distance(150), Distance(300), 43)
+        ), rangeMap.asList())
+    }
+
+    @Test
+    fun testNonOverlappingRanges() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(100), Distance(200), 42)
+        rangeMap.put(Distance(300), Distance(400), 43)
+        assertEquals(listOf(
+            DistanceRangeMap.RangeMapEntry(Distance(100), Distance(200), 42),
+            DistanceRangeMap.RangeMapEntry(Distance(300), Distance(400), 43)
+        ), rangeMap.asList())
+    }
+
+    @Test
+    fun testSplitRange() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(100), Distance(200), 42)
+        rangeMap.put(Distance(120), Distance(130), 43)
+        assertEquals(listOf(
+            DistanceRangeMap.RangeMapEntry(Distance(100), Distance(120), 42),
+            DistanceRangeMap.RangeMapEntry(Distance(120), Distance(130), 43),
+            DistanceRangeMap.RangeMapEntry(Distance(130), Distance(200), 42)
+        ), rangeMap.asList())
+    }
+
+    @Test
+    fun testOverwritingSeveralRanges() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(0), Distance(100), 1)
+        rangeMap.put(Distance(100), Distance(200), 2)
+        rangeMap.put(Distance(200), Distance(300), 3)
+        rangeMap.put(Distance(300), Distance(400), 4)
+        rangeMap.put(Distance(400), Distance(500), 5)
+        rangeMap.put(Distance(50), Distance(450), 42)
+        assertEquals(listOf(
+            DistanceRangeMap.RangeMapEntry(Distance(0), Distance(50), 1),
+            DistanceRangeMap.RangeMapEntry(Distance(50), Distance(450), 42),
+            DistanceRangeMap.RangeMapEntry(Distance(450), Distance(500), 5)
+        ), rangeMap.asList())
+    }
+
+    @Test
+    fun testMergeRanges() {
+        val rangeMap = DistanceRangeMap<Int>()
+        rangeMap.put(Distance(0), Distance(100), 42)
+        rangeMap.put(Distance(100), Distance(200), 2)
+        rangeMap.put(Distance(200), Distance(300), 3)
+        rangeMap.put(Distance(300), Distance(400), 4)
+        rangeMap.put(Distance(400), Distance(500), 42)
+        rangeMap.put(Distance(50), Distance(450), 42)
+        assertEquals(listOf(
+            DistanceRangeMap.RangeMapEntry(Distance(0), Distance(500), 42),
+        ), rangeMap.asList())
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/infra/api/Direction.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/api/Direction.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.infra.api;
 
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeEndpoint;
+import org.jetbrains.annotations.NotNull;
 
 /** Encodes a direction in a one dimension space */
 public enum Direction {
@@ -38,5 +39,13 @@ public enum Direction {
         if (this == FORWARD)
             return BACKWARD;
         return FORWARD;
+    }
+
+    /** Converts a legacy Direction into the new class related to the kt infra */
+    @NotNull
+    public fr.sncf.osrd.utils.Direction toKtDirection() {
+        if (this == FORWARD)
+            return fr.sncf.osrd.utils.Direction.INCREASING;
+        return fr.sncf.osrd.utils.Direction.DECREASING;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
@@ -14,6 +14,7 @@ import fr.sncf.osrd.infra.api.tracks.undirected.OperationalPoint;
 import fr.sncf.osrd.infra.api.tracks.undirected.SpeedLimits;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection;
+import fr.sncf.osrd.railjson.schema.geom.LineString;
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.Comparator;
 import java.util.List;
@@ -104,6 +105,16 @@ public class TrackRangeView {
     public RangeMap<Double, Double> getSlopes() {
         var originalSlopes = track.getEdge().getSlopes().get(track.getDirection());
         return convertMap(originalSlopes);
+    }
+
+    /** Returns the geographic data of the range */
+    public LineString getGeo() {
+        var trackLength = track.getEdge().getLength();
+        var forwardResult = track.getEdge().getGeo().slice(begin / trackLength, end / trackLength);
+        if (track.getDirection().equals(Direction.FORWARD))
+            return forwardResult;
+        else
+            return forwardResult.reverse();
     }
 
     /** Returns true if the location is included in the range */

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -14,6 +14,8 @@ import fr.sncf.osrd.standalone_sim.result.*
 import fr.sncf.osrd.train.StandaloneTrainSchedule
 import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.meters
 import kotlin.math.abs
 import kotlin.math.max
 

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.standalone_sim.result.SignalUpdate
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.Distance
 import java.awt.Color
 
 data class SignalAspectChangeEvent(val newAspect: String, val time: Long)

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -10,12 +10,22 @@ import fr.sncf.osrd.infra.api.reservation.ReservationRoute
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra
 import fr.sncf.osrd.infra.api.tracks.undirected.*
 import fr.sncf.osrd.infra.api.tracks.undirected.Detector
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackNode.Joint
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection
+import fr.sncf.osrd.infra.implementation.tracks.directed.DiTrackEdgeImpl
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.TrackNode
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
-import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
+import fr.sncf.osrd.utils.DirectionalMap
+import fr.sncf.osrd.utils.Endpoint
+import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.DistanceRangeMap
+import fr.sncf.osrd.utils.units.MutableDistanceArrayList
+import fr.sncf.osrd.utils.units.meters
+import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.seconds
 
 
@@ -23,8 +33,8 @@ class SimInfraAdapter(
     val simInfra: RawInfra,
     val zoneMap: BiMap<DetectionSection, ZoneId>,
     val detectorMap: BiMap<Detector, DetectorId>,
-    val switchMap: BiMap<Switch, MovableElementId>,
-    val switchGroupsMap: Map<Switch, Map<String, MovableElementConfigId>>,
+    val trackNodeMap: BiMap<Switch, TrackNodeId>,
+    val trackNodeGroupsMap: Map<Switch, Map<String, TrackNodeConfigId>>,
     val routeMap: BiMap<ReservationRoute, RouteId>,
     val signalMap: BiMap<String, PhysicalSignalId>,
     val rjsSignalMap: BiMap<String, RJSSignal>
@@ -47,32 +57,112 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     val builder = RawInfraBuilder()
     val zoneMap = HashBiMap.create<DetectionSection, ZoneId>()
     val detectorMap = HashBiMap.create<Detector, DetectorId>()
-    val switchMap = HashBiMap.create<Switch, MovableElementId>()
-    val switchGroupsMap = mutableMapOf<Switch, Map<String, MovableElementConfigId>>()
+    val trackNodeMap = HashBiMap.create<Switch, TrackNodeId>()
+    val trackSectionMap = HashBiMap.create<TrackEdge, TrackSectionId>()
+    val trackNodeGroupsMap = mutableMapOf<Switch, Map<String, TrackNodeConfigId>>()
     val signalsPerTrack: MutableMap<String, MutableList<TrackSignal>> = mutableMapOf()
     val signalMap = HashBiMap.create<String, PhysicalSignalId>()
     val rjsSignalMap = HashBiMap.create<String, RJSSignal>()
     val routeMap = HashBiMap.create<ReservationRoute, RouteId>()
+    val trackChunkMap = mutableMapOf<TrackSection, Map<Distance, TrackChunkId>>()
+
+    // parse tracks
+    for (edge in infra.trackGraph.edges()) {
+        val track = edge as? TrackSection
+        if (track != null) {
+            val trackLength = Distance.fromMeters(track.length)
+            var lastOffset = 0.meters
+            trackSectionMap[track] = builder.trackSection(track.id) {
+                val chunkMap = mutableMapOf<Distance, TrackChunkId>()
+                fun makeChunk(startOffset: Distance, endOffset: Distance) {
+                    if (startOffset == endOffset)
+                        return
+                    val rangeViewForward = TrackRangeView(startOffset.meters, endOffset.meters,
+                        DiTrackEdgeImpl(track, Direction.FORWARD))
+                    val rangeViewBackward = TrackRangeView(startOffset.meters, endOffset.meters,
+                        DiTrackEdgeImpl(track, Direction.BACKWARD))
+                    fun <T>makeDirectionalMap(f: (range: TrackRangeView) -> T) : DirectionalMap<T>{
+                        return DirectionalMap(f.invoke(rangeViewForward), f.invoke(rangeViewBackward))
+                    }
+                    val chunkId = builder.trackChunk(
+                        rangeViewForward.geo,
+                        makeDirectionalMap { range -> DistanceRangeMap.from(range.slopes) },
+                        endOffset - startOffset
+                    )
+                    chunk(chunkId)
+                    chunkMap[startOffset] = chunkId
+                }
+                for (d in track.detectors) {
+                    val detectorId = builder.detector(d.id)
+                    detectorMap[d] = detectorId
+                    val endOffset = Distance.fromMeters(d.offset)
+                    makeChunk(lastOffset, endOffset)
+                    lastOffset = endOffset
+                }
+                makeChunk(lastOffset, trackLength)
+                trackChunkMap[track] = chunkMap
+            }
+        }
+    }
 
     // parse switches
     for (switchEntry in infra.switches) {
         val oldSwitch = switchEntry.value!!
-        switchMap[oldSwitch] = builder.movableElement(oldSwitch.groupChangeDelay.seconds) {
-            val switchGroups = mutableMapOf<String, MovableElementConfigId>()
+        val nodeGraph = oldSwitch.graph!!
+        val infraGraph = infra.trackGraph!!
+        trackNodeMap[oldSwitch] = builder.movableElement(oldSwitch.groupChangeDelay.seconds) {
+            val nodeMap: MutableMap<SwitchPort, TrackNodePortId> = mutableMapOf()
+            for (node in nodeGraph.nodes()) {
+                var track: TrackEdge? = null
+                for (edge in infraGraph.incidentEdges(node)) {
+                    if (edge is TrackSection) {
+                        track = edge
+                        break
+                    }
+                }
+                track!!
+                val endpoint = if (infraGraph.incidentNodes(track).nodeU() == node)
+                    Endpoint.START
+                else
+                    Endpoint.END
+                nodeMap[node] = port(EndpointTrackSectionId(trackSectionMap[track]!!, endpoint))
+            }
+            val switchGroups = mutableMapOf<String, TrackNodeConfigId>()
             for (group in oldSwitch.groups.entries()) {
                 val groupName = group.key!!
-                switchGroups[groupName] = config(groupName)
+                val nodes = nodeGraph.incidentNodes(group.value!!)
+                val portPair = Pair(nodeMap[nodes.nodeU()]!!, nodeMap[nodes.nodeV()]!!)
+                switchGroups[groupName] = config(groupName, portPair)
             }
-            switchGroupsMap[oldSwitch] = switchGroups
+            trackNodeGroupsMap[oldSwitch] = switchGroups
+        }
+    }
+
+    // parse track links
+    for (node in infra.trackGraph.nodes()) {
+        if (node is Joint) {
+            val edges = infra.trackGraph.incidentEdges(node)
+            assert(edges.count() == 2)
+            builder.movableElement(ZERO) {
+                val ports = ArrayList<TrackNodePortId>()
+                for (edge in edges) {
+                    val endpoint = if (infra.trackGraph.incidentNodes(edge).nodeU() == node)
+                        Endpoint.START
+                    else
+                        Endpoint.END
+                    ports.add(port(EndpointTrackSectionId(trackSectionMap[edge]!!, endpoint)))
+                }
+                config("default", Pair(ports[0], ports[1]))
+            }
         }
     }
 
     fun getOrCreateDet(oldDiDetector: DiDetector): DirDetectorId {
         val oldDetector = oldDiDetector.detector
-        val detector = detectorMap.getOrPut(oldDetector!!) { builder.detector(oldDetector.id) }
+        val detector = detectorMap[oldDetector!!]!!
         return when (oldDiDetector.direction!!) {
-            Direction.FORWARD -> detector.normal
-            Direction.BACKWARD -> detector.reverse
+            Direction.FORWARD -> detector.increasing
+            Direction.BACKWARD -> detector.decreasing
         }
     }
 
@@ -80,8 +170,8 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
         val oldDetector = oldDiDetector.detector
         val detector = detectorMap[oldDetector!!]!!
         return when (oldDiDetector.direction!!) {
-            Direction.FORWARD -> detector.normal
-            Direction.BACKWARD -> detector.reverse
+            Direction.FORWARD -> detector.increasing
+            Direction.BACKWARD -> detector.decreasing
         }
     }
 
@@ -90,9 +180,9 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     for (detectionSection in infra.detectionSections) {
         val oldSwitches = detectionSection!!.switches!!
         val oldDiDetectors = detectionSection.detectors!!
-        val switches = mutableStaticIdxArraySetOf<MovableElement>()
+        val switches = mutableStaticIdxArraySetOf<TrackNode>()
         for (oldSwitch in oldSwitches)
-            switches.add(switchMap[oldSwitch]!!)
+            switches.add(trackNodeMap[oldSwitch]!!)
         val detectors = mutableListOf<DirDetectorId>()
         for (oldDiDetector in oldDiDetectors)
             detectors.add(getOrCreateDet(oldDiDetector!!))
@@ -155,7 +245,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
                     viewIterator,
                     oldStartDet, oldEndDet,
                     entry, exit,
-                    switchMap, switchGroupsMap,
+                    trackNodeMap, trackNodeGroupsMap, trackChunkMap,
                     signalsPerTrack,
                     builder
                 )
@@ -179,7 +269,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     // TODO: check the length of built routes is the same as on the base infra
     // assert(route.length.meters == routeLength)
 
-    return SimInfraAdapter(builder.build(), zoneMap, detectorMap, switchMap, switchGroupsMap, routeMap, signalMap, rjsSignalMap)
+    return SimInfraAdapter(builder.build(), zoneMap, detectorMap, trackNodeMap, trackNodeGroupsMap, routeMap, signalMap, rjsSignalMap)
 }
 
 private fun buildZonePath(
@@ -188,8 +278,9 @@ private fun buildZonePath(
     oldEndDet: DiDetector,
     entry: DirDetectorId,
     exit: DirDetectorId,
-    switchMap: HashBiMap<Switch, MovableElementId>,
-    switchGroupsMap: MutableMap<Switch, Map<String, MovableElementConfigId>>,
+    trackNodeMap: HashBiMap<Switch, TrackNodeId>,
+    trackNodeGroupsMap: MutableMap<Switch, Map<String, TrackNodeConfigId>>,
+    trackChunkMap: MutableMap<TrackSection, Map<Distance, TrackChunkId>>,
     signalsPerTrack: Map<String, MutableList<TrackSignal>>,
     builder: RawInfraBuilder
 ): ZonePathId {
@@ -201,8 +292,8 @@ private fun buildZonePath(
     // 3) compute the zone path's track section path in order to find signals
 
     var zonePathLength = 0.meters
-    val movableElements = MutableStaticIdxArrayList<MovableElement>()
-    val movableElementsConfigs = MutableStaticIdxArrayList<MovableElementConfig>()
+    val movableElements = MutableStaticIdxArrayList<TrackNode>()
+    val movableElementsConfigs = MutableStaticIdxArrayList<TrackNodeConfig>()
     val movableElementsDistances = MutableDistanceArrayList()
 
     val zoneTrackPath = mutableListOf<ZonePathTrackSpan>()
@@ -229,9 +320,9 @@ private fun buildZonePath(
                 assert(curView.end.meters == curView.begin.meters)
                 // We assume paths do not end on a SwitchBranch
                 assert(curView.track.edge != oldEndDet.detector.trackSection)
-                val movableElement = switchMap[edge.switch]!!
+                val movableElement = trackNodeMap[edge.switch]!!
                 val branchGroup = edge.switch!!.findBranchGroup(edge)!!
-                val movableElementConfig = switchGroupsMap[edge.switch]!![branchGroup]!!
+                val movableElementConfig = trackNodeGroupsMap[edge.switch]!![branchGroup]!!
                 movableElements.add(movableElement)
                 movableElementsConfigs.add(movableElementConfig)
                 movableElementsDistances.add(zonePathLength)
@@ -299,10 +390,17 @@ private fun buildZonePath(
         signalPositions.add(zonePathSignal.position)
     }
 
+    // Build chunk list
+    val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
+    for (range in zoneTrackPath) {
+        val chunk = trackChunkMap[range.track]!![range.begin]!!
+        chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))
+    }
+
     return builder.zonePath(
         entry, exit, zonePathLength,
         movableElements, movableElementsConfigs, movableElementsDistances,
-        signals, signalPositions,
+        signals, signalPositions, chunks
     )
 }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
@@ -1,7 +1,13 @@
 package fr.sncf.osrd.sim_infra_adapter
 
 import fr.sncf.osrd.Helpers
+import fr.sncf.osrd.utils.units.DistanceRangeMap
+import fr.sncf.osrd.utils.units.meters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class RawInfraAdapterTest {
     @Test
@@ -16,5 +22,64 @@ class RawInfraAdapterTest {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
         adaptRawInfra(oldInfra)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["small_infra/infra.json", "tiny_infra/infra.json"])
+    fun testTrackChunksOnRoutes(infraPath: String) {
+        val epsilon = 1e-2 // fairly high value, because we compare integer millimeters with float meters
+        val rjsInfra = Helpers.getExampleInfra(infraPath)
+        val oldInfra = Helpers.infraFromRJS(rjsInfra)
+        val infra = adaptRawInfra(oldInfra)
+        for (route in infra.routes.iterator()) {
+            val oldRoute = oldInfra.reservationRouteMap[infra.getRouteName(route)]!!
+            val chunks = infra.getChunksOnRoute(route)
+            var offset = 0.meters
+            for (chunk in chunks) {
+                val end = offset + infra.getTrackChunkLength(chunk.value)
+                val trackRangeViews = oldRoute.getTrackRanges(offset.meters, end.meters)!!
+                assertTrue { trackRangeViews.size == 1 } // This may fail because of float rounding,
+                                                         // but as long as it's true it makes testing much easier
+                val trackRangeView = trackRangeViews[0]
+                assertEquals(
+                    trackRangeView.track.edge.id,
+                    infra.getTrackSectionId(infra.getTrackFromChunk(chunk.value))
+                )
+                assertEquals(trackRangeView.length, infra.getTrackChunkLength(chunk.value).meters, epsilon)
+                assertEquals(trackRangeView.track.direction.toKtDirection(), chunk.direction)
+
+                offset = end
+            }
+            assertEquals(offset.meters, oldRoute.length, epsilon)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["small_infra/infra.json", "tiny_infra/infra.json"])
+    fun testChunkSlopes(infraPath: String) {
+        val rjsInfra = Helpers.getExampleInfra(infraPath)
+        val oldInfra = Helpers.infraFromRJS(rjsInfra)
+        val infra = adaptRawInfra(oldInfra)
+        for (route in infra.routes.iterator()) {
+            val oldRoute = oldInfra.reservationRouteMap[infra.getRouteName(route)]!!
+            val chunks = infra.getChunksOnRoute(route)
+            var offset = 0.meters
+            for (chunk in chunks) {
+                val end = offset + infra.getTrackChunkLength(chunk.value)
+                val trackRangeViews = oldRoute.getTrackRanges(offset.meters, end.meters)!!
+                assertTrue { trackRangeViews.size == 1 } // This may fail because of float rounding,
+                                                         // but as long as it's true it makes testing much easier
+                val trackRangeView = trackRangeViews[0]
+
+                val slopes = infra.getTrackChunkSlope(chunk)
+                val refSlopes = trackRangeView.slopes
+
+                assertEquals(
+                    DistanceRangeMap.from(refSlopes),
+                    slopes
+                )
+                offset = end
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds track and chunk data to the new kotlin infra. There's still some data missing (voltages, speed section, ...), but nothing too tricky, they can be added when needed.

I struggled a little with the building process, especially when it comes to cross-references. Please let me know if there's a better way to handle this. 