### PR TITLE
tests: setup video recording

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,3 +82,10 @@ jobs:
         run: |
           cd front
           yarn e2e-tests
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: front/test-results/
+          retention-days: 30

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -40,6 +40,7 @@ const config: PlaywrightTestConfig = {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     locale: 'fr',
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/front/tests/home-page.spec.tsx
+++ b/front/tests/home-page.spec.tsx
@@ -1,20 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { PlaywrightHomePage } from './home-page-model';
 
 // Describe the test suite for the home page of OSDR
 test.describe('Home page OSRD', () => {
-  // Declare the necessary variable for the test
   let playwrightHomePage: PlaywrightHomePage;
 
-  // This function will run before all the tests in this suite
-  test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
+  test.beforeEach(async ({ page }) => {
     // Create an instance of the PlaywrightHomePage class
     playwrightHomePage = new PlaywrightHomePage(page);
     // Go to the home page of OSDR
     await playwrightHomePage.goToHomePage();
   });
-  // This function will run after each test in this suite
+
   test.afterEach(async () => {
     // Navigate back to the home page of OSDR
     await playwrightHomePage.backToHomePage();
@@ -28,7 +25,6 @@ test.describe('Home page OSRD', () => {
   test('should be correctly redirected to the  "Operational Studies" page after clicking on the link', async () => {
     // Navigate to the "Operational Studies" page
     await playwrightHomePage.goToOperationalStudiesPage();
-
     // Check that the URL of the page matches the expected pattern
     await expect(playwrightHomePage.page).toHaveURL(/.*\/operational-studies/);
   });

--- a/front/tests/operational-studies.spec.ts
+++ b/front/tests/operational-studies.spec.ts
@@ -1,13 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { PlaywrightHomePage } from './home-page-model';
 
 test.describe('Testing if all mandatory elements simulation configuration are loaded in operationnal studies app', () => {
-  // Declare the necessary variable for the test
   let playwrightHomePage: PlaywrightHomePage;
 
-  test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-
+  test.beforeEach(async ({ page }) => {
     playwrightHomePage = new PlaywrightHomePage(page);
     await playwrightHomePage.goToHomePage();
 
@@ -27,7 +24,7 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
       .getByRole('button')
       .click();
 
-    await page.getByTestId('scenarios-add-train-schedule-button').click();
+    await playwrightHomePage.page.getByTestId('scenarios-add-train-schedule-button').click();
   });
 
   test('RollingStockSelector is displayed', async () => {
@@ -37,6 +34,7 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
   test('SpeedLimitSelector is displayed', async () => {
     expect(playwrightHomePage.page.getByTestId('speed-limit-by-tag-selector')).not.toEqual(null);
   });
+
   test('Itinerary module and subcomponents are displayed', async () => {
     // Here is how to create a locator for a specific element
     const itinerary = playwrightHomePage.page.getByTestId('itinerary');

--- a/front/tests/stdcm-page.spec.ts
+++ b/front/tests/stdcm-page.spec.ts
@@ -8,10 +8,7 @@ test.describe('STDCM page', () => {
   let playwrightHomePage: PlaywrightHomePage;
   let playwrightSTDCMPage: PlaywrightSTDCMPage;
 
-  // This function will run before all the tests in this suite
-  test.beforeAll(async ({ browser }) => {
-    const page = await browser.newPage();
-
+  test('should be correctly displays the rolling stock list and select one', async ({ page }) => {
     // Create an instance of the PlaywrightHomePage class
     playwrightHomePage = new PlaywrightHomePage(page);
 
@@ -31,9 +28,7 @@ test.describe('STDCM page', () => {
     await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration project');
     await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration study');
     await playwrightSTDCMPage.clickItemScenarioExploratorByName('_@Test integration scenario');
-  });
 
-  test('should be correctly displays the rolling stock list and select one', async () => {
     const rollingStockTranslation =
       playwrightSTDCMPage.getmanageTrainScheduleTranslations('rollingstock');
     const rollingStockTranslationRegEx = new RegExp(rollingStockTranslation as string);


### PR DESCRIPTION
`beforeAll` is not supported yet for video recording. We must use `beforeEach` in tests.
Example of video: 
[11:36 AM](https://osrd-data-sncf.slack.com/archives/D04LY5NNY4Q/p1685007386894789)
https://github.com/DGEXSolutions/osrd/actions/runs/5078271641
[video.webm](https://github.com/DGEXSolutions/osrd/assets/32448554/b65a5b47-6de8-4165-be8d-ffd9146daa40)
