### PR TITLE
Docker: add backend URL for editoast service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       ROCKET_PROFILE: debug
       PSQL_HOST: "postgres"
       REDIS_URL: "redis://redis"
+      OSRD_BACKEND_URL: "http://osrd-core"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       start_period: 4s


### PR DESCRIPTION
Using docker compose, editoast was not able to call back core as it was lacking the `OSRD_BACKEND_URL` environment var.