### PR TITLE
core: fix cache_status_endpoint

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/InfraCacheStatusEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraCacheStatusEndpoint.java
@@ -51,7 +51,8 @@ public final class InfraCacheStatusEndpoint implements Take {
             if (infra != null) {
                 var request = adapterRequest.fromJson(body);
                 var infraCacheEntry = infraManager.getInfraCache(request.infra);
-                res.put(request.infra, SerializedInfraCache.from(infraCacheEntry));
+                if (infraCacheEntry != null)
+                    res.put(request.infra, SerializedInfraCache.from(infraCacheEntry));
             } else {
                 infraManager.forEach((infraId, infraCacheEntry) -> {
                     res.put(infraId, SerializedInfraCache.from(infraCacheEntry));


### PR DESCRIPTION
fix cache_status endpoint. It returned an error if the infra had not been downloaded instead of returning an empty dictionary