### PR TITLE
front: disable edition/deletion of locked rolling stocks

### DIFF
--- a/editoast/src/models/rolling_stock/light_rolling_stock.rs
+++ b/editoast/src/models/rolling_stock/light_rolling_stock.rs
@@ -94,6 +94,7 @@ impl From<LightRollingStockModel> for LightRollingStock {
             id: rolling_stock_model.id,
             name: rolling_stock_model.name,
             version: rolling_stock_model.version,
+            locked: rolling_stock_model.locked,
             effort_curves: rolling_stock_model.effort_curves,
             base_power_class: rolling_stock_model.base_power_class,
             length: rolling_stock_model.length,

--- a/editoast/src/schema/rolling_stock/light_rolling_stock.rs
+++ b/editoast/src/schema/rolling_stock/light_rolling_stock.rs
@@ -1,4 +1,4 @@
-use diesel::sql_types::{Array, BigInt, Double, Jsonb, Nullable, Text};
+use diesel::sql_types::{Array, BigInt, Bool, Double, Jsonb, Nullable, Text};
 use diesel_json::Json as DieselJson;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -16,6 +16,8 @@ pub struct LightRollingStock {
     pub name: String,
     #[diesel(sql_type = Text)]
     pub version: String,
+    #[diesel(sql_type = Bool)]
+    pub locked: bool,
     #[diesel(sql_type = Jsonb)]
     pub effort_curves: DieselJson<LightEffortCurves>,
     #[diesel(sql_type = Text)]

--- a/editoast/src/views/rolling_stocks.rs
+++ b/editoast/src/views/rolling_stocks.rs
@@ -413,7 +413,6 @@ pub mod tests {
         let response_body: RollingStock = assert_status_and_read!(post_response, StatusCode::OK);
         let rolling_stock_id = response_body.id;
         rolling_stock.id = Some(response_body.id);
-        println!("{:?}", rolling_stock);
         let expected_body = RollingStock::from(rolling_stock.clone());
         assert_eq!(response_body, expected_body);
 

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorButtons.tsx
@@ -4,30 +4,41 @@ import { FaPencilAlt } from 'react-icons/fa';
 
 type RollingStockEditorButtonsProps = {
   setIsEditing: (isEditing: boolean) => void;
+  isRollingStockLocked: boolean;
   isCondensed: boolean;
 };
 
-function RollingStockEditorButtons({ setIsEditing, isCondensed }: RollingStockEditorButtonsProps) {
+function RollingStockEditorButtons({
+  setIsEditing,
+  isRollingStockLocked,
+  isCondensed,
+}: RollingStockEditorButtonsProps) {
   return (
     <div
       className={`rollingstock-editor-buttons ${
         isCondensed ? 'condensed flex-column align-items-center rounded-right' : ''
       } d-flex p-1`}
     >
-      <div
-        role="button"
+      <button
+        type="button"
+        className="btn btn-primary px-1 py-0"
         tabIndex={0}
-        className="btn-primary rounded px-2 py-1"
+        disabled={isRollingStockLocked}
         onClick={() => setIsEditing(true)}
       >
         <FaPencilAlt />
-      </div>
-      <div role="button" tabIndex={0} className="btn-primary rounded px-2 py-1">
+      </button>
+      <button type="button" className="btn btn-primary px-1 py-0" tabIndex={0}>
         <BiDuplicate />
-      </div>
-      <div role="button" tabIndex={0} className="btn-primary rounded px-2 py-1">
+      </button>
+      <button
+        type="button"
+        className="btn btn-primary px-1 py-0"
+        tabIndex={0}
+        disabled={isRollingStockLocked}
+      >
         <BiTrash />
-      </div>
+      </button>
     </div>
   );
 }

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorCard.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorCard.tsx
@@ -1,19 +1,19 @@
 import React, { SetStateAction, useState, Dispatch } from 'react';
 import { LightRollingStock } from 'common/api/osrdEditoastApi';
 import RollingStockCardDetail from 'common/RollingStockSelector/RollingStockCardDetail';
-import { RollingStockInfos } from 'common/RollingStockSelector/RollingStockHelpers';
+import { RollingStockInfo } from 'common/RollingStockSelector/RollingStockHelpers';
 import RollingStockEditorForm from './RollingStockEditorForm';
 
 type RollingStockEditorCardProps = {
   isEditing: boolean;
   setIsEditing: Dispatch<SetStateAction<boolean>>;
-  data: LightRollingStock;
+  rollingStock: LightRollingStock;
 };
 
 export default function RollingStockEditorCard({
   isEditing,
   setIsEditing,
-  data,
+  rollingStock,
 }: RollingStockEditorCardProps) {
   const [curvesComfortList, setCurvesComfortList] = useState<string[]>([]);
 
@@ -21,14 +21,14 @@ export default function RollingStockEditorCard({
     <div className="rollingstock-editor-form w-100 pr-4">
       <div className="rollingstock-header-form" style={{ height: '3rem' }}>
         <div className="rollingstock-title-form">
-          <RollingStockInfos form="-form" data={data} />
+          <RollingStockInfo form="-form" rollingStock={rollingStock} />
         </div>
       </div>
       {isEditing ? (
-        <RollingStockEditorForm rollingStockData={data} setIsEditing={setIsEditing} />
+        <RollingStockEditorForm rollingStock={rollingStock} setIsEditing={setIsEditing} />
       ) : (
         <RollingStockCardDetail
-          id={data.id}
+          id={rollingStock.id}
           hideCurves
           form="rollingstock-editor-form-text"
           curvesComfortList={curvesComfortList}

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorForm.tsx
@@ -114,14 +114,11 @@ const RollingStockEditorSelect = ({
 };
 
 type RollingStockParametersProps = {
-  rollingStockData?: LightRollingStock;
+  rollingStock?: LightRollingStock;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const RollingStockEditorForm = ({
-  rollingStockData,
-  setIsEditing,
-}: RollingStockParametersProps) => {
+const RollingStockEditorForm = ({ rollingStock, setIsEditing }: RollingStockParametersProps) => {
   const { t } = useTranslation('rollingStockEditor');
   const { openModal } = useModal();
   const jsonSchema = openapiSchemaToJsonSchema(RollingStockBaseOpenapiSchema);
@@ -139,15 +136,15 @@ const RollingStockEditorForm = ({
   } = useForm<RollingStockParametersValues>({
     resolver: resolver as Resolver<RollingStockParametersValues, unknown>,
     defaultValues: {
-      startup_time: rollingStockData?.startup_time || 0,
-      startup_acceleration: rollingStockData?.startup_acceleration || 0,
-      comfort_acceleration: rollingStockData?.comfort_acceleration || 0,
-      gamma_value: rollingStockData?.gamma.value || 0,
-      inertia_coefficient: rollingStockData?.inertia_coefficient || 0,
-      loading_gauge: (rollingStockData?.loading_gauge as string) || '...',
-      rolling_resistance_A: rollingStockData?.rolling_resistance.A || 0,
-      rolling_resistance_B: rollingStockData?.rolling_resistance.B || 0,
-      rolling_resistance_C: rollingStockData?.rolling_resistance.C || 0,
+      startup_time: rollingStock?.startup_time || 0,
+      startup_acceleration: rollingStock?.startup_acceleration || 0,
+      comfort_acceleration: rollingStock?.comfort_acceleration || 0,
+      gamma_value: rollingStock?.gamma.value || 0,
+      inertia_coefficient: rollingStock?.inertia_coefficient || 0,
+      loading_gauge: (rollingStock?.loading_gauge as string) || '...',
+      rolling_resistance_A: rollingStock?.rolling_resistance.A || 0,
+      rolling_resistance_B: rollingStock?.rolling_resistance.B || 0,
+      rolling_resistance_C: rollingStock?.rolling_resistance.C || 0,
     },
   } as UseFormProps<RollingStockParametersValues>);
 

--- a/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
+++ b/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
@@ -27,8 +27,8 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
     <div className="d-flex pt-5 mt-5">
       <div className="d-flex ml-4 flex-column" style={{ width: '37%' }}>
         {rollingStocks.length > 0 ? (
-          rollingStocks.map((data) => (
-            <div className="d-flex rollingstock-editor-list" key={data.id}>
+          rollingStocks.map((rollingStock) => (
+            <div className="d-flex rollingstock-editor-list" key={rollingStock.id}>
               <div
                 role="button"
                 tabIndex={0}
@@ -38,17 +38,21 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
               >
                 <RollingStockCard
                   isOnEditMode
-                  data={data}
-                  key={data.id}
+                  rollingStock={rollingStock}
+                  key={rollingStock.id}
                   noCardSelected={openedRollingStockCardId === undefined}
-                  isOpen={data.id === openedRollingStockCardId}
+                  isOpen={rollingStock.id === openedRollingStockCardId}
                   setOpenedRollingStockCardId={setOpenedRollingStockCardId}
-                  ref2scroll={rollingStockID === data.id ? ref2scroll : undefined}
+                  ref2scroll={rollingStockID === rollingStock.id ? ref2scroll : undefined}
                 />
               </div>
-              {data.id === openedRollingStockCardId && (
+              {rollingStock.id === openedRollingStockCardId && (
                 <div className="align-self-start">
-                  <RollingStockEditorButtons isCondensed setIsEditing={setIsEditing} />
+                  <RollingStockEditorButtons
+                    isCondensed
+                    setIsEditing={setIsEditing}
+                    isRollingStockLocked={rollingStock.locked ?? false}
+                  />
                 </div>
               )}
             </div>
@@ -61,7 +65,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
         {selectedRollingStock ? (
           <RollingStockEditorCard
             isEditing={isEditing}
-            data={selectedRollingStock}
+            rollingStock={selectedRollingStock}
             setIsEditing={setIsEditing}
           />
         ) : (

--- a/front/src/common/RollingStockSelector/RollingStock.scss
+++ b/front/src/common/RollingStockSelector/RollingStock.scss
@@ -44,11 +44,11 @@
 
 .osrd-config-item-container {
   .rollingstock-minicard {
-    .rollingstock-infos {
+    .rollingstock-info {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      .rollingstock-infos-begin {
+      .rollingstock-info-begin {
         display: flex;
         align-items: center;
         flex-grow: 1;
@@ -57,11 +57,11 @@
         padding: 0.25rem 0.5rem;
         position: relative;
         min-height: 1.5rem;
-        .rollingstock-infos-series {
+        .rollingstock-info-series {
           position: relative;
           font-weight: bold;
         }
-        .rollingstock-infos-unit {
+        .rollingstock-info-unit {
           position: relative;
           &.UM2 {
             color: #6e1e78;
@@ -73,7 +73,7 @@
           margin-left: 0.25rem;
           font-size: 0.7rem;
         }
-        .rollingstock-infos-subseries {
+        .rollingstock-info-subseries {
           position: relative;
           margin-left: 0.25rem;
           text-transform: uppercase;
@@ -103,7 +103,7 @@
       justify-content: space-between;
       margin-top: 0.5rem;
       gap: 0.5rem;
-      .rollingstock-infos-comfort {
+      .rollingstock-info-comfort {
         display: flex;
         align-items: center;
         background-color: var(--coolgray1);
@@ -116,7 +116,7 @@
       .comfort-HEATING {
         display: flex;
       }
-      .rollingstock-infos-end {
+      .rollingstock-info-end {
         display: flex;
         align-items: center;
         height: 1.5rem;
@@ -176,20 +176,20 @@
     white-space: nowrap;
     height: 1.5rem;
     overflow: hidden;
-    .rollingstock-infos {
+    .rollingstock-info {
       display: flex;
       align-items: center;
       height: 1.5rem;
       justify-content: space-between;
-      .rollingstock-infos-begin {
+      .rollingstock-info-begin {
         height: 1.5rem;
         display: flex;
         align-items: center;
-        .rollingstock-infos-series {
+        .rollingstock-info-series {
           height: 1.5rem;
           font-weight: bold;
         }
-        .rollingstock-infos-unit {
+        .rollingstock-info-unit {
           &.UM2 {
             color: #6e1e78;
           }
@@ -200,13 +200,13 @@
           margin-left: 0.25rem;
           font-size: 0.7rem;
         }
-        .rollingstock-infos-subseries {
+        .rollingstock-info-subseries {
           margin-left: 0.25rem;
           text-transform: uppercase;
           font-size: 0.7rem;
         }
       }
-      .rollingstock-infos-middle {
+      .rollingstock-info-middle {
         white-space: normal;
         overflow-wrap: break-word;
         overflow: hidden;
@@ -216,7 +216,7 @@
         font-size: 0.6rem;
         line-height: 0.6rem;
       }
-      .rollingstock-infos-end {
+      .rollingstock-info-end {
         display: flex;
         align-items: center;
         color: #4d4d4d;

--- a/front/src/common/RollingStockSelector/RollingStockCard.jsx
+++ b/front/src/common/RollingStockSelector/RollingStockCard.jsx
@@ -8,12 +8,18 @@ import { AiOutlineColumnWidth } from 'react-icons/ai';
 import { LazyLoadComponent } from 'react-lazy-load-image-component';
 import RollingStockCardDetail from './RollingStockCardDetail';
 import RollingStock2Img from './RollingStock2Img';
-import { RollingStockInfos } from './RollingStockHelpers';
+import { RollingStockInfo } from './RollingStockHelpers';
 import RollingStockCardButtons from './RollingStockCardButtons';
 
 function RollingStockCard(props) {
-  const { data, ref2scroll, setOpenedRollingStockCardId, isOpen, noCardSelected, isOnEditMode } =
-    props;
+  const {
+    rollingStock,
+    ref2scroll,
+    setOpenedRollingStockCardId,
+    isOpen,
+    noCardSelected,
+    isOnEditMode,
+  } = props;
   const [tractionModes, setTractionModes] = useState({
     electric: false,
     thermal: false,
@@ -24,17 +30,17 @@ function RollingStockCard(props) {
   const ref2scrollWhenOpened = useRef();
   function displayCardDetail() {
     if (!isOpen) {
-      setOpenedRollingStockCardId(data.id);
+      setOpenedRollingStockCardId(rollingStock.id);
       setTimeout(() => ref2scrollWhenOpened.current?.scrollIntoView({ behavior: 'smooth' }), 500);
     }
   }
 
   useEffect(() => {
-    if (typeof data.effort_curves.modes === 'object') {
+    if (typeof rollingStock.effort_curves.modes === 'object') {
       const localVoltages = {};
       const localModes = {};
-      Object.keys(data.effort_curves.modes).forEach((modeName) => {
-        if (data.effort_curves.modes[modeName].is_electric) {
+      Object.keys(rollingStock.effort_curves.modes).forEach((modeName) => {
+        if (rollingStock.effort_curves.modes[modeName].is_electric) {
           localModes.electric = true;
           localVoltages[modeName] = true;
         } else {
@@ -56,7 +62,7 @@ function RollingStockCard(props) {
       onClick={displayCardDetail}
       tabIndex={0}
       ref={ref2scroll}
-      data-testid={`rollingstock-${data.name}`}
+      data-testid={`rollingstock-${rollingStock.name}`}
     >
       <div
         className="rollingstock-header"
@@ -66,16 +72,16 @@ function RollingStockCard(props) {
         ref={isOpen && !isOnEditMode ? ref2scrollWhenOpened : undefined}
       >
         <div className="rollingstock-title">
-          <RollingStockInfos data={data} />
+          <RollingStockInfo rollingStock={rollingStock} />
           <div className="sr-only">
             <small className="text-primary mr-1">ID</small>
-            <span className="font-weight-lighter small">{data.id}</span>
+            <span className="font-weight-lighter small">{rollingStock.id}</span>
           </div>
         </div>
       </div>
       {isOpen && !isOnEditMode ? (
         <RollingStockCardDetail
-          id={data.id}
+          id={rollingStock.id}
           curvesComfortList={curvesComfortList}
           setCurvesComfortList={setCurvesComfortList}
         />
@@ -87,7 +93,7 @@ function RollingStockCard(props) {
             }`}
           >
             <div className="rollingstock-body-img">
-              <RollingStock2Img rollingStock={data} />
+              <RollingStock2Img rollingStock={rollingStock} />
             </div>
           </div>
         </LazyLoadComponent>
@@ -109,7 +115,7 @@ function RollingStockCard(props) {
                     </span>
                     <small>
                       {tractionModes.voltages.map((voltage) => (
-                        <span className="mr-1" key={`${voltage}${data.id}`}>
+                        <span className="mr-1" key={`${voltage}${rollingStock.id}`}>
                           {voltage}V
                         </span>
                       ))}
@@ -121,26 +127,26 @@ function RollingStockCard(props) {
             <div className="col-2">
               <div className="rollingstock-size text-nowrap">
                 <AiOutlineColumnWidth />
-                {data.length}m
+                {rollingStock.length}m
               </div>
             </div>
             <div className="col-2">
               <div className="rollingstock-weight text-nowrap">
                 <FaWeightHanging />
-                {Math.round(data.mass / 1000)}t
+                {Math.round(rollingStock.mass / 1000)}t
               </div>
             </div>
             <div className="col-3">
               <div className="rollingstock-speed text-nowrap">
                 <IoIosSpeedometer />
-                {Math.round(data.max_speed * 3.6)}km/h
+                {Math.round(rollingStock.max_speed * 3.6)}km/h
               </div>
             </div>
           </div>
         </div>
         {isOpen && curvesComfortList && !isOnEditMode ? (
           <RollingStockCardButtons
-            id={data.id}
+            id={rollingStock.id}
             curvesComfortList={curvesComfortList}
             setOpenedRollingStockCardId={setOpenedRollingStockCardId}
           />
@@ -156,7 +162,7 @@ RollingStockCard.defaultProps = {
 };
 
 RollingStockCard.propTypes = {
-  data: PropTypes.object.isRequired,
+  rollingStock: PropTypes.object.isRequired,
   isOpen: PropTypes.bool.isRequired,
   setOpenedRollingStockCardId: PropTypes.func.isRequired,
   ref2scroll: PropTypes.object,

--- a/front/src/common/RollingStockSelector/RollingStockHelpers.jsx
+++ b/front/src/common/RollingStockSelector/RollingStockHelpers.jsx
@@ -5,18 +5,18 @@ import { ImFire } from 'react-icons/im';
 
 export function checkUnit({ unit, detail, form }) {
   if (unit && unit !== 'US') {
-    return <span className={`rollingstock-infos-unit${form ? '-form' : ''} ${unit}`}>{unit}</span>;
+    return <span className={`rollingstock-info-unit${form ? '-form' : ''} ${unit}`}>{unit}</span>;
   }
   if (detail?.search(/UM3/i) !== -1) {
     return (
-      <span className={`rollingstock-infos-unit${form ? '-form' : ''} UM3${form ? '-form' : ''}`}>
+      <span className={`rollingstock-info-unit${form ? '-form' : ''} UM3${form ? '-form' : ''}`}>
         UM3
       </span>
     );
   }
   if (detail?.search(/UM|MUX/i) !== -1) {
     return (
-      <span className={`rollingstock-infos-unit${form ? '-form' : ''} UM2${form ? '-form' : ''}`}>
+      <span className={`rollingstock-info-unit${form ? '-form' : ''} UM2${form ? '-form' : ''}`}>
         UM2
       </span>
     );
@@ -25,17 +25,17 @@ export function checkUnit({ unit, detail, form }) {
 }
 
 // TODO: refactor the form props here and in _rollingStockForm.scss
-export function RollingStockInfos({ form, data, showSeries, showMiddle, showEnd }) {
-  const { metadata } = data;
+export function RollingStockInfo({ form, rollingStock, showSeries, showMiddle, showEnd }) {
+  const { metadata } = rollingStock;
   return (
-    <div className={`rollingstock-infos${form}`}>
+    <div className={`rollingstock-info${form}`}>
       {showSeries ? (
-        <span className={`rollingstock-infos-begin${form}`}>
-          <span className={`rollingstock-infos-series${form}`}>
+        <span className={`rollingstock-info-begin${form}`}>
+          <span className={`rollingstock-info-series${form}`}>
             {metadata.series ? metadata.series : metadata?.reference}
           </span>
           {checkUnit(metadata, form)}
-          <span className={`rollingstock-infos-subseries${form}`}>
+          <span className={`rollingstock-info-subseries${form}`}>
             {metadata.series && metadata.series !== metadata.subseries
               ? metadata?.subseries
               : metadata?.detail}
@@ -43,11 +43,11 @@ export function RollingStockInfos({ form, data, showSeries, showMiddle, showEnd 
         </span>
       ) : null}
       {showMiddle && metadata.series ? (
-        <span className={`rollingstock-infos-middle${form}`}>
+        <span className={`rollingstock-info-middle${form}`}>
           {`${metadata?.family} / ${metadata?.type} / ${metadata?.grouping}`}
         </span>
       ) : null}
-      {showEnd ? <span className={`rollingstock-infos-end${form}`}>{data.name}</span> : null}
+      {showEnd ? <span className={`rollingstock-info-end${form}`}>{rollingStock.name}</span> : null}
     </div>
   );
 }
@@ -73,16 +73,16 @@ export function comfort2pictogram(comfort) {
   }
 }
 
-RollingStockInfos.defaultProps = {
+RollingStockInfo.defaultProps = {
   form: '',
   showSeries: true,
   showMiddle: true,
   showEnd: true,
 };
 
-RollingStockInfos.propTypes = {
+RollingStockInfo.propTypes = {
   form: PropTypes.string,
-  data: PropTypes.object.isRequired,
+  rollingStock: PropTypes.object.isRequired,
   showSeries: PropTypes.bool,
   showMiddle: PropTypes.bool,
   showEnd: PropTypes.bool,

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -179,7 +179,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
       filteredRollingStockList.length > 0 ? (
         filteredRollingStockList.map((item) => (
           <RollingStockCard
-            data={item}
+            rollingStock={item}
             key={item.id}
             noCardSelected={openRollingStockCardId === undefined}
             isOpen={item.id === openRollingStockCardId}

--- a/front/src/common/RollingStockSelector/RollingStockSelector.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockSelector.tsx
@@ -3,7 +3,7 @@ import RollingStockModal from 'common/RollingStockSelector/RollingStockModal';
 import icon from 'assets/pictures/components/train.svg';
 import {
   comfort2pictogram,
-  RollingStockInfos,
+  RollingStockInfo,
 } from 'common/RollingStockSelector/RollingStockHelpers';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { RollingStock } from 'common/api/osrdEditoastApi';
@@ -46,8 +46,8 @@ const RollingStockSelector = ({
           <div className="rollingstock-minicard">
             {condensed ? (
               <div className="d-flex align-items-center font-weight-bold">
-                <RollingStockInfos
-                  data={rollingStockSelected}
+                <RollingStockInfo
+                  rollingStock={rollingStockSelected}
                   showMiddle={false}
                   showSeries={false}
                 />
@@ -58,18 +58,22 @@ const RollingStockSelector = ({
               </div>
             ) : (
               <>
-                <RollingStockInfos data={rollingStockSelected} showMiddle={false} showEnd={false} />
+                <RollingStockInfo
+                  rollingStock={rollingStockSelected}
+                  showMiddle={false}
+                  showEnd={false}
+                />
                 <div className="rollingstock-container-img">
                   <div className="rollingstock-img">{image}</div>
                 </div>
                 <div className="rollingstock-minicard-end">
-                  <span className="rollingstock-infos-comfort text-uppercase small">
+                  <span className="rollingstock-info-comfort text-uppercase small">
                     <span className="text-uppercase font-weight-bold">{comfort}</span>
                     <span className="mx-2">{comfort2pictogram(rollingStockComfort)}</span>
                     {comfortType}
                   </span>
-                  <RollingStockInfos
-                    data={rollingStockSelected}
+                  <RollingStockInfo
+                    rollingStock={rollingStockSelected}
                     showMiddle={false}
                     showSeries={false}
                   />

--- a/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
+++ b/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
@@ -53,21 +53,21 @@
     white-space: nowrap;
     height: 3rem;
     overflow: hidden;
-    .rollingstock-infos-form {
+    .rollingstock-info-form {
       display: flex;
       align-items: center;
       height: 3rem;
       justify-content: space-between;
-      .rollingstock-infos-begin-form {
+      .rollingstock-info-begin-form {
         height: 3rem;
         display: flex;
         align-items: center;
         font-size: 1rem;
-        .rollingstock-infos-series-form {
+        .rollingstock-info-series-form {
           font-weight: bold;
           font-size: x-large;
         }
-        .rollingstock-infos-unit {
+        .rollingstock-info-unit {
           &.UM2 {
             color: #6e1e78;
             font-size: medium;
@@ -80,13 +80,13 @@
           margin-left: 0.5rem;
           font-size: 0.7rem;
         }
-        .rollingstock-infos-subseries-form {
+        .rollingstock-info-subseries-form {
           margin-left: 0.5rem;
           text-transform: uppercase;
           font-size: 0.9rem;
         }
       }
-      .rollingstock-infos-middle-form {
+      .rollingstock-info-middle-form {
         white-space: normal;
         overflow-wrap: break-word;
         overflow: hidden;
@@ -96,7 +96,7 @@
         font-size: 0.8rem;
         line-height: 0.8rem;
       }
-      .rollingstock-infos-end-form {
+      .rollingstock-info-end-form {
         display: flex;
         align-items: center;
         color: #4d4d4d;

--- a/front/tests/assets/operationStudies/test_variables.ts
+++ b/front/tests/assets/operationStudies/test_variables.ts
@@ -1,10 +1,10 @@
 export default {
   numberOfRollingstock: process.env.CI ? '3' : '446',
-  numberOfRollingstockWithElectrical: process.env.CI ? '3' : '262',
+  numberOfRollingstockWithElectrical: process.env.CI ? '3' : '265',
   searchRollingstock: process.env.CI ? '7200' : 'tgv',
   numberOfRollingstockWithSearch: process.env.CI ? '1' : '27',
   rollingstockTestID: process.env.CI
     ? 'rollingstock-_@Test BB 7200GVLOCOMOTIVES'
     : 'rollingstock-1TGV2N2',
-  rollingstockInfos: process.env.CI ? /BB 7200GV/ : /TGV2N2US/,
+  rollingStockInfo: process.env.CI ? /BB 7200GV/ : /TGV2N2US/,
 };

--- a/front/tests/operational-studies.spec.ts
+++ b/front/tests/operational-studies.spec.ts
@@ -99,10 +99,10 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
     await rollingstockCard.locator('button').click();
 
     expect(
-      await playwrightRollingstockModalPage.getRollingstockMiniCardInfos().first().textContent()
-    ).toMatch(VARIABLES.rollingstockInfos);
+      await playwrightRollingstockModalPage.getRollingStockMiniCardInfo().first().textContent()
+    ).toMatch(VARIABLES.rollingStockInfo);
     expect(
-      await playwrightRollingstockModalPage.getRollingstockInfosComfort().textContent()
+      await playwrightRollingstockModalPage.getRollingStockInfoComfort().textContent()
     ).toMatch(/ConfortSStandard/i);
   });
 });

--- a/front/tests/rollingstock-modal-model.ts
+++ b/front/tests/rollingstock-modal-model.ts
@@ -57,12 +57,12 @@ class PlaywrightRollingstockModalPage {
     return this.getRollingstockModal.getByTestId(rollingstockTestID);
   }
 
-  getRollingstockMiniCardInfos() {
-    return this.getRollingstockMiniCard.locator('.rollingstock-infos');
+  getRollingStockMiniCardInfo() {
+    return this.getRollingstockMiniCard.locator('.rollingstock-info');
   }
 
-  getRollingstockInfosComfort() {
-    return this.getRollingstockMiniCard.locator('.rollingstock-infos-comfort');
+  getRollingStockInfoComfort() {
+    return this.getRollingstockMiniCard.locator('.rollingstock-info-comfort');
   }
 }
 

--- a/front/tests/stdcm-page-model.ts
+++ b/front/tests/stdcm-page-model.ts
@@ -60,7 +60,7 @@ export class PlaywrightSTDCMPage {
     this.getRollingStockSearchFilter = page.locator('.rollingstock-search-filters');
     this.getRollingStockSearchList = page.locator('.rollingstock-search-list');
     this.getRollingStockListItem = page.locator('.rollingstock-container');
-    this.getRollingstockSpanNames = this.getRollingStockListItem.locator('.rollingstock-infos-end');
+    this.getRollingstockSpanNames = this.getRollingStockListItem.locator('.rollingstock-info-end');
     this.rollingstockTranslation = rollingstockTranslation;
   }
 

--- a/front/tests/stdcm-page.spec.ts
+++ b/front/tests/stdcm-page.spec.ts
@@ -51,7 +51,7 @@ test.describe('STDCM page', () => {
     await playwrightSTDCMPage.page.waitForSelector('.rollingstock-container');
 
     const infoCardText = await playwrightSTDCMPage.getRollingStockListItem
-      .locator('.rollingstock-infos')
+      .locator('.rollingstock-info')
       .allTextContents();
     expect(infoCardText).toContain(
       'BB 7200GVLOCOMOTIVES / Locomotives électriques / Locomotives électriques courant continu_@Test BB 7200GVLOCOMOTIVES'


### PR DESCRIPTION
Edition/deletion buttons should be disabled and greyed when rolling_stock is locked. 
editoast: add locked to light_rolling_stock schema to send it to front.

Fixes #4247.

Locked rolling_stock:
![image](https://github.com/DGEXSolutions/osrd/assets/104149586/cf9ec7a3-d6df-4f46-8f85-e8ad3360d18d)

Unlocked rolling_stock:
![image](https://github.com/DGEXSolutions/osrd/assets/104149586/e59c6fea-5de2-40e7-abb5-d9e5f92db6fb)
