### PR TITLE
api: fix example rolling stock

### DIFF
--- a/python/api/static/example_rolling_stock.json
+++ b/python/api/static/example_rolling_stock.json
@@ -81,7 +81,7 @@
     "number": "1",
     "reference": "",
     "family": "",
-    "rolling_stock_type": "",
+    "type": "",
     "grouping": "",
     "series": "",
     "subseries": "",


### PR DESCRIPTION
The key changed from `type` to `rolling_stock_type` in e0a83a3735effee659d7ad096b80647161d93ee1