### PR TITLE
{api, editoast}: projection: compare floats using an ε of 1 mm

### DIFF
--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -54,7 +54,10 @@ impl Projection {
                 continue;
             }
             assert_eq!(res.last().unwrap().direction, r.direction);
-            assert!(res.last().unwrap().begin == r.end || res.last().unwrap().end == r.begin);
+            assert!(
+                (res.last().unwrap().begin - r.end).abs() * 1000.0 < 1.0
+                    || (res.last().unwrap().end - r.begin).abs() * 1000.0 < 1.0
+            );
             res.last_mut().unwrap().begin = res.last().unwrap().begin.min(r.begin);
             res.last_mut().unwrap().end = res.last().unwrap().end.max(r.end);
         }

--- a/python/api/osrd_infra/views/projection.py
+++ b/python/api/osrd_infra/views/projection.py
@@ -39,7 +39,7 @@ class Projection:
                 res.append(r)
                 continue
             assert res[-1].direction == r.direction
-            assert res[-1].begin == r.end or res[-1].end == r.begin
+            assert abs(res[-1].begin - r.end) * 1000 < 1 or abs(res[-1].end - r.begin) * 1000 < 1
             res[-1] = DirectionalTrackRange(
                 track=r.track,
                 direction=r.direction,


### PR DESCRIPTION
Because of float manipulation, there might be a very slight offset that resulted in a failed assertion