### PR TITLE
core: refactor electrification conditions

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -74,7 +74,7 @@ public final class TrainPhysicsIntegrator {
     private IntegrationStep step(double timeStep, double position, double speed) {
         double tractionForce = 0;
         double brakingForce = 0;
-        var tractiveEffortCurve = tractiveEffortCurveMap.get(position);
+        var tractiveEffortCurve = tractiveEffortCurveMap.get(Math.min(Math.max(0, position), path.getLength()));
         assert tractiveEffortCurve != null;
         double maxTractionForce = PhysicsRollingStock.getMaxEffort(speed, tractiveEffortCurve);
         double rollingResistance = rollingStock.getRollingResistance(speed);

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Electrification.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Electrification.java
@@ -1,0 +1,9 @@
+package fr.sncf.osrd.envelope_sim.electrification;
+
+public sealed interface Electrification permits Electrified, NonElectrified {
+    Electrification withElectricalProfile(String profile);
+
+    Electrification withPowerRestriction(String powerRestriction);
+
+    boolean equals(Object o);
+}

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Electrified.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Electrified.java
@@ -1,0 +1,49 @@
+package fr.sncf.osrd.envelope_sim.electrification;
+
+import java.util.Objects;
+
+/**
+ * Electrification conditions at a point in the path
+ */
+public non-sealed class Electrified implements Electrification {
+    /** Tractive mode the train should use */
+    public final String mode;
+    /** Electrical profile value (can be null) */
+    public final String profile;
+    /** Power restriction code (can be null) */
+    public final String powerRestriction;
+
+    public Electrified(String mode, String profile, String powerRestriction) {
+        this.mode = mode;
+        this.profile = profile;
+        this.powerRestriction = powerRestriction;
+    }
+
+    public Electrified(String mode) {
+        this(mode, null, null);
+    }
+
+    @Override
+    public Electrification withElectricalProfile(String profile) {
+        return new Electrified(mode, profile, powerRestriction);
+    }
+
+    @Override
+    public Electrification withPowerRestriction(String powerRestriction) {
+        return new Electrified(mode, profile, powerRestriction);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Electrified other))
+            return false;
+        return Objects.equals(mode, other.mode)
+                && Objects.equals(profile, other.profile)
+                && Objects.equals(powerRestriction, other.powerRestriction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mode, powerRestriction, profile);
+    }
+}

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/NonElectrified.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/NonElectrified.java
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.envelope_sim.electrification;
+
+public non-sealed class NonElectrified implements Electrification {
+    @Override
+    public Electrification withElectricalProfile(String profile) {
+        return this;
+    }
+
+    @Override
+    public Electrification withPowerRestriction(String powerRestriction) {
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof NonElectrified;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+}

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/RangeMapUtils.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/RangeMapUtils.java
@@ -1,0 +1,70 @@
+package fr.sncf.osrd.envelope_utils;
+
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+import java.util.function.BiFunction;
+
+public class RangeMapUtils {
+    /**
+     * Returns a range map where the adjacent ranges of same values have been merged
+     */
+    public static <T> RangeMap<Double, T> mergeRanges(RangeMap<Double, T> map) {
+        TreeRangeMap<Double, T> result = TreeRangeMap.create();
+        var entryIterator = map.asMapOfRanges().entrySet().iterator();
+        if (!entryIterator.hasNext())
+            return result;
+        var currentEntry = entryIterator.next();
+        var currentRange = currentEntry.getKey();
+        var currentValue = currentEntry.getValue();
+        while (entryIterator.hasNext()) {
+            var nextEntry = entryIterator.next();
+            var nextRange = nextEntry.getKey();
+            var nextValue = nextEntry.getValue();
+            if (currentValue.equals(nextValue) && currentRange.isConnected(nextRange)) {
+                currentRange = Range.closedOpen(currentRange.lowerEndpoint(), nextRange.upperEndpoint());
+            } else {
+                result.put(currentRange, currentValue);
+                currentRange = nextRange;
+                currentValue = nextValue;
+            }
+        }
+        result.put(currentRange, currentValue);
+        return result;
+    }
+
+    /**
+     * Return the first map updated with another, using a merge function to fuse the values of intersecting ranges
+     */
+    public static <T, U> TreeRangeMap<Double, T> updateRangeMap(RangeMap<Double, T> map, RangeMap<Double, U> update,
+                                             BiFunction<T, U, T> mergeFunction) {
+        TreeRangeMap<Double, T> result = TreeRangeMap.create();
+        result.putAll(map);
+        for (var updateEntry : update.asMapOfRanges().entrySet()) {
+            for (var intersectedEntry : map.subRangeMap(updateEntry.getKey()).asMapOfRanges().entrySet()) {
+                var intersectedRange = intersectedEntry.getKey();
+                var intersectedValue = intersectedEntry.getValue();
+                result.putCoalescing(intersectedRange, mergeFunction.apply(intersectedValue, updateEntry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns true if the ranges of the range map are contiguous (i.e. the upper endpoint of a range
+     * is the lower endpoint of the next range) and cover the whole length
+     */
+    public static <T> boolean fullyCovers(RangeMap<Double, T> map, double length) {
+        var entryIterator = map.asMapOfRanges().entrySet().iterator();
+        if (!entryIterator.hasNext())
+            return length == 0.0;
+        var currentRange = entryIterator.next().getKey();
+        while (entryIterator.hasNext()) {
+            var nextRange = entryIterator.next().getKey();
+            if (!currentRange.upperEndpoint().equals(nextRange.lowerEndpoint()))
+                return false;
+            currentRange = nextRange;
+        }
+        return currentRange.upperEndpoint().equals(length);
+    }
+}

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -1,15 +1,20 @@
 package fr.sncf.osrd.envelope_sim;
 
-import static fr.sncf.osrd.envelope.EnvelopeShape.*;
+import static fr.sncf.osrd.envelope.EnvelopeShape.CONSTANT;
+import static fr.sncf.osrd.envelope.EnvelopeShape.DECREASING;
+import static fr.sncf.osrd.envelope.EnvelopeShape.INCREASING;
+import static fr.sncf.osrd.envelope.EnvelopeShape.check;
+import static fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder.buildNonElectrified;
 import static fr.sncf.osrd.envelope_sim.MaxEffortEnvelopeBuilder.makeComplexMaxEffortEnvelope;
 import static fr.sncf.osrd.envelope_sim.MaxEffortEnvelopeBuilder.makeSimpleMaxEffortEnvelope;
 import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.TIME_STEP;
 import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.makeSimpleContext;
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.SPEED_EPSILON;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.carrotsearch.hppc.DoubleArrayList;
-import com.google.common.collect.ImmutableRangeMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeShape;
@@ -111,12 +116,7 @@ public class AllowanceTests {
     @Test
     public void complexTestBinarySearchContinuity() {
         var length = 50_000;
-        var trainPath = new EnvelopeSimPath(
-                length,
-                new double[]{0, 800, 35_000, length},
-                new double[]{0, 50, -10},
-                ImmutableRangeMap.of()
-        );
+        var trainPath = buildNonElectrified(length, new double[]{0, 800, 35_000, length}, new double[]{0, 50, -10});
         var testContext = new EnvelopeSimContext(SimpleRollingStock.STANDARD_TRAIN, trainPath,
                 2., SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
         var stops = new double[] {};
@@ -494,7 +494,7 @@ public class AllowanceTests {
 
         var testRollingStock = SimpleRollingStock.STANDARD_TRAIN;
         var length = 100_000;
-        var testPath = new EnvelopeSimPath(length, gradePositions, gradeValues, ImmutableRangeMap.of());
+        var testPath = buildNonElectrified(length, gradePositions, gradeValues);
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
         var stops = new double[] { 50_000, testContext.path.getLength() };
@@ -532,8 +532,7 @@ public class AllowanceTests {
         gradePositions.add(length);
 
         var testRollingStock = SimpleRollingStock.STANDARD_TRAIN;
-        var testPath = new EnvelopeSimPath(
-                length, gradePositions.toArray(), gradeValues.toArray(), ImmutableRangeMap.of());
+        var testPath = buildNonElectrified(length, gradePositions.toArray(), gradeValues.toArray());
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
         var stops = new double[]{ 50_000, length };
@@ -638,7 +637,7 @@ public class AllowanceTests {
         var length = 15000;
         var gradePositions = new double[] { 0, 7000, 8100, length };
         var gradeValues = new double[] { 0, 40, 0 };
-        var testPath = new EnvelopeSimPath(length, gradePositions, gradeValues, ImmutableRangeMap.of());
+        var testPath = buildNonElectrified(length, gradePositions, gradeValues);
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, TIME_STEP,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
         var stops = new double[] { length };

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeMaintainSpeedTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeMaintainSpeedTest.java
@@ -1,10 +1,10 @@
 package fr.sncf.osrd.envelope_sim;
 
 import static fr.sncf.osrd.envelope.EnvelopeShape.*;
+import static fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder.buildNonElectrified;
 import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.TIME_STEP;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.ImmutableRangeMap;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeShape;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -17,11 +17,11 @@ public class EnvelopeMaintainSpeedTest {
     @Test
     public void suddenSlope() {
         var stops = new double[] { };
-        var path = new EnvelopeSimPath(
+        var path = buildNonElectrified(
                 10000,
                 new double[] { 0, 5000, 6000, 7000, 8000, 8500, 9000, 10000 },
-                new double[] { 0, 40, -40, 0, 50, -50, 0 },
-                ImmutableRangeMap.of());
+                new double[] { 0, 40, -40, 0, 50, -50, 0 }
+        );
         var testRollingStock = SimpleRollingStock.STANDARD_TRAIN;
         var context = new EnvelopeSimContext(testRollingStock, path, TIME_STEP,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathTest.java
@@ -1,21 +1,26 @@
 package fr.sncf.osrd.envelope_sim;
 
+import static fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder.buildNonElectrified;
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.fullyCovers;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
+import fr.sncf.osrd.envelope_sim.electrification.Electrification;
+import fr.sncf.osrd.envelope_sim.electrification.Electrified;
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import java.util.HashMap;
 import java.util.Map;
 
 public class EnvelopeSimPathTest {
     @Test
     void testAverageGrade() {
-        var path = new EnvelopeSimPath(10, new double[]{0, 3, 6, 9, 10}, new double[]{0, 2, -2, 0},
-                ImmutableRangeMap.of());
+        var path = buildNonElectrified(10, new double[]{0, 3, 6, 9, 10}, new double[]{0, 2, -2, 0});
         assertEquals(10, path.getLength());
         assertEquals(0, path.getAverageGrade(0, 3));
         assertEquals(0, path.getAverageGrade(0, 10));
@@ -26,8 +31,7 @@ public class EnvelopeSimPathTest {
 
     @Test
     void findHighGradePosition() {
-        var path = new EnvelopeSimPath(10, new double[]{0, 3, 6, 9, 10}, new double[]{0, 2, -2, 0},
-                ImmutableRangeMap.of());
+        var path = buildNonElectrified(10, new double[]{0, 3, 6, 9, 10}, new double[]{0, 2, -2, 0});
         assertEquals(0, path.getAverageGrade(0, 3));
         assertEquals(0, path.getAverageGrade(0, 10));
         assertEquals(0, path.getAverageGrade(9, 10));
@@ -37,16 +41,20 @@ public class EnvelopeSimPathTest {
 
     @Test
     void getCatenaryModeAndProfileOnlyModes() {
-        TreeRangeMap<Double, String> modes = TreeRangeMap.create();
-        modes.put(Range.closed(3.0, 7.0), "1500");
-        modes.put(Range.closed(7.1, 10.0), "25000");
-        var path = new EnvelopeSimPath(10, new double[] { 0, 10 }, new double[] { 0 }, modes);
-        var modeAndProfileMap = path.getElecCondMap(null, null, null, true);
+        var modes = TreeRangeMap.<Double, Electrification>create();
+        modes.put(Range.closed(0.0, 10.0), new NonElectrified());
+        modes.put(Range.closed(3.0, 7.0), new Electrified("1500"));
+        modes.put(Range.closed(7.1, 10.0), new Electrified("25000"));
+        var path = new EnvelopeSimPath(10, new double[] { 0, 10 }, new double[] { 0 }, ImmutableRangeMap.copyOf(modes),
+                new HashMap<>());
+        var modeAndProfileMap = path.getElectrificationMap(null, null, null, true);
 
-        assertNull(modeAndProfileMap.get(0.));
-        assertEquals(modeAndProfileMap.get(4.), new EnvelopeSimPath.ElectrificationConditions("1500", null, null));
-        assertNull(modeAndProfileMap.get(7.05));
-        assertEquals(modeAndProfileMap.get(7.2), new EnvelopeSimPath.ElectrificationConditions("25000", null, null));
+        assertTrue(fullyCovers(modeAndProfileMap, 10));
+
+        assertEquals(modeAndProfileMap.get(0.), new NonElectrified());
+        assertEquals(modeAndProfileMap.get(4.), new Electrified("1500"));
+        assertEquals(modeAndProfileMap.get(7.05), new NonElectrified());
+        assertEquals(modeAndProfileMap.get(7.2), new Electrified("25000"));
     }
 
     @ParameterizedTest
@@ -54,64 +62,61 @@ public class EnvelopeSimPathTest {
     void getCatenaryModeAndProfile(boolean withEmptyPowerRestrictionMap) {
         var path = EnvelopeSimPathBuilder.withElectricalProfiles1500();
 
-        RangeMap<Double, EnvelopeSimPath.ElectrificationConditions> modeAndProfileMap;
+        RangeMap<Double, Electrification> modeAndProfileMap;
         if (withEmptyPowerRestrictionMap)
-            modeAndProfileMap = path.getElecCondMap("2", ImmutableRangeMap.of(), Map.of("Restrict1", "1"));
+            modeAndProfileMap = path.getElectrificationMap("2", ImmutableRangeMap.of(), Map.of("Restrict1", "1"));
         else
-            modeAndProfileMap = path.getElecCondMap("2", null, Map.of("Restrict1", "1"));
+            modeAndProfileMap = path.getElectrificationMap("2", null, Map.of("Restrict1", "1"));
 
-        assertEquals(7, modeAndProfileMap.asMapOfRanges().size());
+        assertTrue(fullyCovers(modeAndProfileMap, path.length));
 
-        assertEquals(modeAndProfileMap.get(2.0), new EnvelopeSimPath.ElectrificationConditions("1500", null, null));
-        assertEquals(modeAndProfileMap.get(3.5), new EnvelopeSimPath.ElectrificationConditions("1500", "A", null));
-        assertEquals(modeAndProfileMap.get(5.5), new EnvelopeSimPath.ElectrificationConditions("1500", "C", null));
-        assertEquals(modeAndProfileMap.get(6.5), new EnvelopeSimPath.ElectrificationConditions("1500", "B", null));
+        assertEquals(9, modeAndProfileMap.asMapOfRanges().size());
+
+        assertEquals(modeAndProfileMap.get(2.0), new Electrified("1500", null, null));
+        assertEquals(modeAndProfileMap.get(3.5), new Electrified("1500", "A", null));
+        assertEquals(modeAndProfileMap.get(5.5), new Electrified("1500", "C", null));
+        assertEquals(modeAndProfileMap.get(6.5), new Electrified("1500", "B", null));
     }
 
     @Test
     void getCatenaryModeAndProfileWithPowerRestrictions() {
         var path = EnvelopeSimPathBuilder.withElectricalProfiles1500();
 
-        RangeMap<Double, EnvelopeSimPath.ElectrificationConditions> modeAndProfileMap;
         var powerRestrictionMap = TreeRangeMap.<Double, String>create();
         powerRestrictionMap.put(Range.closed(2.5, 6.5), "Restrict2");
 
-        modeAndProfileMap = path.getElecCondMap("1", powerRestrictionMap, Map.of("Restrict2", "2"));
+        var modeAndProfileMap = path.getElectrificationMap("1", powerRestrictionMap, Map.of("Restrict2", "2"));
 
-        assertEquals(8, modeAndProfileMap.asMapOfRanges().size());
+        assertTrue(fullyCovers(modeAndProfileMap, path.length));
 
-        assertNull(modeAndProfileMap.get(0.5));
-        assertEquals(modeAndProfileMap.get(2.75),
-                new EnvelopeSimPath.ElectrificationConditions("1500", null, "Restrict2"));
-        assertEquals(modeAndProfileMap.get(3.25),
-                new EnvelopeSimPath.ElectrificationConditions("1500", "A", "Restrict2"));
-        assertEquals(modeAndProfileMap.get(4.5),
-                new EnvelopeSimPath.ElectrificationConditions("1500", "B", "Restrict2"));
-        assertEquals(modeAndProfileMap.get(5.5),
-                new EnvelopeSimPath.ElectrificationConditions("1500", "C", "Restrict2"));
-        assertEquals(modeAndProfileMap.get(6.25),
-                new EnvelopeSimPath.ElectrificationConditions("1500", "B", "Restrict2"));
-        assertEquals(modeAndProfileMap.get(6.75), new EnvelopeSimPath.ElectrificationConditions("1500", "A", null));
+        assertEquals(10, modeAndProfileMap.asMapOfRanges().size());
+
+        assertEquals(modeAndProfileMap.get(0.5), new NonElectrified());
+        assertEquals(modeAndProfileMap.get(2.75), new Electrified("1500", null, "Restrict2"));
+        assertEquals(modeAndProfileMap.get(3.25), new Electrified("1500", "A", "Restrict2"));
+        assertEquals(modeAndProfileMap.get(4.5), new Electrified("1500", "B", "Restrict2"));
+        assertEquals(modeAndProfileMap.get(5.5), new Electrified("1500", "C", "Restrict2"));
+        assertEquals(modeAndProfileMap.get(6.25), new Electrified("1500", "B", "Restrict2"));
+        assertEquals(modeAndProfileMap.get(6.75), new Electrified("1500", "A", null));
     }
 
     @Test
     void getCatenaryModeAndProfileWithPowerRestrictionsWithoutElectricalProfiles() {
         var path = EnvelopeSimPathBuilder.withElectricalProfiles1500();
 
-        RangeMap<Double, EnvelopeSimPath.ElectrificationConditions> modeAndProfileMap;
         var powerRestrictionMap = TreeRangeMap.<Double, String>create();
         powerRestrictionMap.put(Range.closed(2.5, 6.5), "Restrict2");
 
-        modeAndProfileMap = path.getElecCondMap("1", powerRestrictionMap, Map.of("Restrict2", "2"), true);
+        var modeAndProfileMap = path.getElectrificationMap("1", powerRestrictionMap, Map.of("Restrict2", "2"), true);
 
-        assertEquals(4, modeAndProfileMap.asMapOfRanges().size());
+        assertEquals(6, modeAndProfileMap.asMapOfRanges().size());
 
-        assertEquals(modeAndProfileMap.get(2.0), new EnvelopeSimPath.ElectrificationConditions("1500", null, null));
+        assertEquals(modeAndProfileMap.get(2.0), new Electrified("1500", null, null));
         assertEquals(modeAndProfileMap.get(4.5),
-                new EnvelopeSimPath.ElectrificationConditions("1500", null, "Restrict2"));
+                new Electrified("1500", null, "Restrict2"));
         assertSame(modeAndProfileMap.get(4.5), modeAndProfileMap.get(5.5));
         assertSame(modeAndProfileMap.get(5.5), modeAndProfileMap.get(6.25));
-        assertEquals(modeAndProfileMap.get(6.75), new EnvelopeSimPath.ElectrificationConditions("1500", null, null));
-        assertEquals(modeAndProfileMap.get(9.0), new EnvelopeSimPath.ElectrificationConditions("25000", null, null));
+        assertEquals(modeAndProfileMap.get(6.75), new Electrified("1500", null, null));
+        assertEquals(modeAndProfileMap.get(9.0), new Electrified("25000", null, null));
     }
 }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeTest.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.envelope_sim;
 
 import static fr.sncf.osrd.envelope.EnvelopeShape.*;
+import static fr.sncf.osrd.envelope_sim.EnvelopeSimPathBuilder.buildNonElectrified;
 import static fr.sncf.osrd.envelope_sim.MaxEffortEnvelopeBuilder.makeComplexMaxEffortEnvelope;
 import static fr.sncf.osrd.envelope_sim.MaxEffortEnvelopeBuilder.makeSimpleMaxEffortEnvelope;
 import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.TIME_STEP;
@@ -8,7 +9,6 @@ import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.makeSimpleContext;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.ImmutableRangeMap;
 import fr.sncf.osrd.envelope.EnvelopeTransitions;
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -139,12 +139,7 @@ public class MaxEffortEnvelopeTest {
     @Test
     public void testNotEnoughTractionToRestart() {
         var length = 10_000;
-        var path = new EnvelopeSimPath(
-                length,
-                new double[]{0, 5_000, 5_100, length},
-                new double[]{0, 1_000, 0},
-                ImmutableRangeMap.of()
-        );
+        var path = buildNonElectrified(length, new double[]{0, 5_000, 5_100, length}, new double[]{0, 1_000, 0});
         var testContext = new EnvelopeSimContext(SimpleRollingStock.STANDARD_TRAIN, path, 2.,
                 SimpleRollingStock.LINEAR_EFFORT_CURVE_MAP);
         var stops = new double[] {5_100, length};

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_utils/RangeMapUtilsTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_utils/RangeMapUtilsTest.java
@@ -1,0 +1,56 @@
+package fr.sncf.osrd.envelope_utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeMap;
+import org.junit.jupiter.api.Test;
+
+public class RangeMapUtilsTest {
+    @Test
+    public void testMergeRanges() {
+        var toMerge = TreeRangeMap.<Double, String>create();
+        toMerge.put(Range.closedOpen(-7.0, 1.0), "a");
+        toMerge.put(Range.closedOpen(1.0, 7.0), "a");
+        toMerge.put(Range.closedOpen(7.0, 8.0), "b");
+        toMerge.put(Range.closedOpen(8.0, 9.0), "a");
+        toMerge.put(Range.closedOpen(9.1, 10.0), "a");
+        toMerge.put(Range.closedOpen(10.0, 12.0), "a");
+
+        var expectedMerge = TreeRangeMap.<Double, String>create();
+        expectedMerge.put(Range.closedOpen(-7.0, 7.0), "a");
+        expectedMerge.put(Range.closedOpen(7.0, 8.0), "b");
+        expectedMerge.put(Range.closedOpen(8.0, 9.0), "a");
+        expectedMerge.put(Range.closedOpen(9.1, 12.0), "a");
+
+        var merged = RangeMapUtils.mergeRanges(toMerge);
+
+        assertEquals(expectedMerge, merged);
+    }
+
+    @Test
+    public void testMergeNoRanges() {
+        var toMerge = TreeRangeMap.<Double, String>create();
+        var expectedMerge = TreeRangeMap.<Double, String>create();
+        var merged = RangeMapUtils.mergeRanges(toMerge);
+        assertEquals(expectedMerge, merged);
+    }
+
+    @Test
+    public void testFullyCoversFail() {
+        var rangeMap = TreeRangeMap.<Double, String>create();
+        rangeMap.put(Range.closedOpen(0.0, 1.0), "a");
+        rangeMap.put(Range.closedOpen(1.0, 2.0), "b");
+        rangeMap.put(Range.closedOpen(2.1, 3.0), "c");
+
+        assertFalse(RangeMapUtils.fullyCovers(rangeMap, 3.0));
+    }
+
+    @Test
+    public void testFullyCoversEmpty() {
+        var rangeMap = TreeRangeMap.<Double, String>create();
+
+        assertFalse(RangeMapUtils.fullyCovers(rangeMap, 3.0));
+    }
+}

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathBuilder.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPathBuilder.java
@@ -1,31 +1,55 @@
 package fr.sncf.osrd.envelope_sim;
 
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.updateRangeMap;
+
+import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
-import java.util.Map;
+import fr.sncf.osrd.envelope_sim.electrification.Electrification;
+import fr.sncf.osrd.envelope_sim.electrification.Electrified;
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
+import java.util.HashMap;
 
-/** This is a simple fixture to build EnvelopeSimPath with some electrification conditions.
+/**
+ * This is a simple fixture to build EnvelopeSimPath with some electrification conditions.
  *
  * <p>Electrification conditions (mode and electrical profile here) are used to select
  * which effort curve to use in a rolling stock. Their values are unconstrained strings.
  * If they do not match any effort curve in a rolling stock, they are ignored.
  **/
 public class EnvelopeSimPathBuilder {
+    private static RangeMap<Double, Electrification> getModeMap(double length) {
+        var electrificationMap = TreeRangeMap.<Double, Electrification>create();
+        electrificationMap.put(Range.closed(0.0, length), new NonElectrified());
+        electrificationMap.put(Range.closed(1.0, 8.0), new Electrified("1500"));
+        electrificationMap.put(Range.closed(8.1, 20.), new Electrified("25000"));
+        electrificationMap.put(Range.closed(30., 50.), new Electrified("unhandled"));
+        return electrificationMap.subRangeMap(Range.closed(0.0, length));
+    }
+
+    private static EnvelopeSimPath buildElectrified(double length, RangeMap<Double, Electrification> electrificationMap,
+                                                    HashMap<String, ImmutableRangeMap<Double, Electrification>>
+                                                            electrificationMapByPowerClass) {
+        return new EnvelopeSimPath(length, new double[] { 0, length }, new double[] { 0 },
+                ImmutableRangeMap.copyOf(electrificationMap), electrificationMapByPowerClass);
+    }
+
+    /** Builds an EnvelopeSimPath with no electrification */
+    public static EnvelopeSimPath buildNonElectrified(double length, double[] gradePositions, double[] gradeValues) {
+        var defaultElectrificationMap = ImmutableRangeMap.<Double, Electrification>builder()
+                .put(Range.closed(0.0, length), new NonElectrified())
+                .build();
+        return new EnvelopeSimPath(length, gradePositions, gradeValues, defaultElectrificationMap, new HashMap<>());
+    }
 
     /** Builds an EnvelopeSimPath with some electrification modes */
     public static EnvelopeSimPath withModes(double length) {
-        TreeRangeMap<Double, String> catenaryModes = TreeRangeMap.create();
-        catenaryModes.put(Range.closed(1.0, 8.0), "1500");
-        catenaryModes.put(Range.closed(8.1, 20.), "25000");
-        catenaryModes.put(Range.closed(30., 50.), "unhandled");
-        return new EnvelopeSimPath(length, new double[]{0, length}, new double[]{0}, catenaryModes);
+        return buildElectrified(length, ImmutableRangeMap.copyOf(getModeMap(length)), new HashMap<>());
     }
 
     /** Builds an EnvelopeSimPath with some electrification modes and a set of electrical profiles */
     public static EnvelopeSimPath withElectricalProfiles1500() {
-        final var path = withModes(10);
-
         RangeMap<Double, String> profiles1 = TreeRangeMap.create();
         profiles1.put(Range.closed(3.0, 8.0), "A");
         profiles1.put(Range.closed(8.1, 10.5), "25000");
@@ -38,33 +62,46 @@ public class EnvelopeSimPathBuilder {
         profiles2.put(Range.closed(7.0, 8.0), "A");
         profiles2.put(Range.closed(8.1, 10.5), "25000");
 
-        path.setElectricalProfiles(Map.of("1", profiles1, "2", profiles2));
-        return path;
+        var defaultElectrificationMap = getModeMap(10.);
+        var byPowerClass = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        byPowerClass.put("1", ImmutableRangeMap.copyOf(
+                updateRangeMap(defaultElectrificationMap, profiles1, Electrification::withElectricalProfile)));
+        byPowerClass.put("2", ImmutableRangeMap.copyOf(
+                updateRangeMap(defaultElectrificationMap, profiles2, Electrification::withElectricalProfile)));
+
+        return buildElectrified(10., ImmutableRangeMap.copyOf(defaultElectrificationMap), byPowerClass);
     }
 
     /** Builds an EnvelopeSimPath with some electrification modes and
      * a set of electrical profiles different from `withElectricalProfiles25000` */
     public static EnvelopeSimPath withElectricalProfiles25000(double length) {
-        final var path = withModes(length);
+        var defaultElecMap = getModeMap(length);
 
-        TreeRangeMap<Double, String> electricalProfiles5 = TreeRangeMap.create();
-        electricalProfiles5.put(Range.closedOpen(10., 12.), "25000");
-        electricalProfiles5.put(Range.closedOpen(12., 14.), "22500");
-        electricalProfiles5.put(Range.closedOpen(14., 16.), "20000");
-        electricalProfiles5.put(Range.closedOpen(16., 18.), "22500");
-        electricalProfiles5.put(Range.closed(18., 20.), "25000");
+        HashMap<String, ImmutableRangeMap<Double, String>> electricalProfiles = new HashMap<>();
+        electricalProfiles.put("5", new ImmutableRangeMap.Builder<Double, String>()
+                .put(Range.closedOpen(10., 12.), "25000")
+                .put(Range.closedOpen(12., 14.), "22500")
+                .put(Range.closedOpen(14., 16.), "20000")
+                .put(Range.closedOpen(16., 18.), "22500")
+                .put(Range.closed(18., 20.), "25000")
+                .build());
 
-        TreeRangeMap<Double, String> electricalProfiles4 = TreeRangeMap.create();
-        electricalProfiles4.put(Range.closedOpen(10., 13.), "25000");
-        electricalProfiles4.put(Range.closedOpen(13., 17.), "22500");
-        electricalProfiles4.put(Range.closed(17., 20.), "25000");
+        electricalProfiles.put("4", new ImmutableRangeMap.Builder<Double, String>()
+                .put(Range.closedOpen(10., 13.), "25000")
+                .put(Range.closedOpen(13., 17.), "22500")
+                .put(Range.closedOpen(17., 20.), "25000")
+                .build());
 
-        TreeRangeMap<Double, String> electricalProfiles3 = TreeRangeMap.create();
-        electricalProfiles3.put(Range.closedOpen(10., 20.), "25000");
+        electricalProfiles.put("3", new ImmutableRangeMap.Builder<Double, String>()
+                .put(Range.closedOpen(10., 20.), "25000")
+                .build());
 
-        path.setElectricalProfiles(
-                Map.of("5", electricalProfiles5, "4", electricalProfiles4, "3", electricalProfiles3));
+        var byPowerClass = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        for (var entry : electricalProfiles.entrySet()) {
+            var elecMap = updateRangeMap(defaultElecMap, entry.getValue(), Electrification::withElectricalProfile);
+            byPowerClass.put(entry.getKey(), ImmutableRangeMap.copyOf(elecMap));
+        }
 
-        return path;
+        return buildElectrified(length, ImmutableRangeMap.copyOf(getModeMap(length)), byPowerClass);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
@@ -1,21 +1,36 @@
 package fr.sncf.osrd.envelope_sim_infra;
 
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.mergeRanges;
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.updateRangeMap;
+
 import com.carrotsearch.hppc.DoubleArrayList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPath;
+import fr.sncf.osrd.envelope_sim.electrification.Electrification;
+import fr.sncf.osrd.envelope_sim.electrification.Electrified;
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
+import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping;
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.infra_state.api.TrainPath;
+import java.util.HashMap;
 import java.util.List;
 
 public class EnvelopeTrainPath {
+    /** Create EnvelopePath from a list of TrackRangeView, with no electrical profile */
+    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath) {
+        return from(trackSectionPath, null);
+    }
 
     /** Create EnvelopePath from a list of TrackRangeView */
-    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath) {
+    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath,
+                                       ElectricalProfileMapping electricalProfileMapping) {
         var gradePositions = new DoubleArrayList();
         gradePositions.add(0);
         var gradeValues = new DoubleArrayList();
-        var catenaries = ImmutableRangeMap.<Double, String>builder();
+        var catenaries = TreeRangeMap.<Double, String>create();
         double length = 0;
 
         for (var range : trackSectionPath) {
@@ -27,13 +42,9 @@ public class EnvelopeTrainPath {
                     gradeValues.add(entry.getValue());
                 }
                 // Add catenaries
-                var catenariesRange =
-                        range.getCatenaryVoltages().subRangeMap(Range.closed(0., range.getLength())).asMapOfRanges();
-                for (var entry : catenariesRange.entrySet()) {
-                    double lower = entry.getKey().lowerEndpoint() + length;
-                    double upper = entry.getKey().upperEndpoint() + length;
-                    catenaries.put(Range.closedOpen(lower, upper), entry.getValue());
-                }
+                var catenariesInRange = range.getCatenaryVoltages().subRangeMap(Range.closed(0., range.getLength()));
+                transferRangeMap(catenariesInRange, catenaries, length);
+
                 // Update length
                 length += range.getLength();
             }
@@ -43,11 +54,56 @@ public class EnvelopeTrainPath {
             gradeValues.add(0);
         }
 
-        return new EnvelopeSimPath(length, gradePositions.toArray(), gradeValues.toArray(), catenaries.build());
+        var electrificationMap = buildElectrificationMap(mergeRanges(catenaries), length);
+
+        var electrificationMapByPowerClass = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        if (electricalProfileMapping != null) {
+            var profileMap = electricalProfileMapping.getProfilesOnPath(trackSectionPath);
+            electrificationMapByPowerClass = buildElectrificationMapByPowerClass(electrificationMap, profileMap);
+        }
+        return new EnvelopeSimPath(length, gradePositions.toArray(), gradeValues.toArray(), electrificationMap,
+                electrificationMapByPowerClass);
     }
 
     /** Create EnvelopePath from a train path */
+    public static EnvelopeSimPath from(TrainPath trainsPath, ElectricalProfileMapping electricalProfileMapping) {
+        return from(TrainPath.removeLocation(trainsPath.trackRangePath()), electricalProfileMapping);
+    }
+
+    /** Create EnvelopePath from a train path, with no electrical profile */
     public static EnvelopeSimPath from(TrainPath trainsPath) {
-        return from(TrainPath.removeLocation(trainsPath.trackRangePath()));
+        return from(trainsPath, null);
+    }
+
+    private static <T> void transferRangeMap(RangeMap<Double, T> source, RangeMap<Double, T> dest,
+                                             double offset) {
+        for (var entry : source.asMapOfRanges().entrySet()) {
+            var range = entry.getKey();
+            var value = entry.getValue();
+            dest.put(Range.closedOpen(range.lowerEndpoint() + offset, range.upperEndpoint() + offset), value);
+        }
+    }
+
+    private static ImmutableRangeMap<Double, Electrification> buildElectrificationMap(
+            RangeMap<Double, String> catenaryModes,
+            double length) {
+        TreeRangeMap<Double, Electrification> res = TreeRangeMap.create();
+        res.put(Range.closed(0.0, length), new NonElectrified());
+        res = updateRangeMap(res, catenaryModes,
+                (electrification, catenaryMode) -> new Electrified(catenaryMode));
+        return ImmutableRangeMap.copyOf(res);
+    }
+
+    private static HashMap<String, ImmutableRangeMap<Double, Electrification>> buildElectrificationMapByPowerClass(
+            ImmutableRangeMap<Double, Electrification> electrificationMap,
+            HashMap<String, RangeMap<Double, String>> profileMap) {
+        var res = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        for (var entry : profileMap.entrySet()) {
+            var withElectricalProfiles = ImmutableRangeMap.copyOf(
+                    updateRangeMap(electrificationMap, mergeRanges(entry.getValue()),
+                            Electrification::withElectricalProfile));
+            res.put(entry.getKey(), withElectricalProfiles);
+        }
+        return res;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMapping.java
+++ b/core/src/main/java/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMapping.java
@@ -4,9 +4,10 @@ import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
-import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * A mapping from track sections to electrical profile values
@@ -37,14 +38,14 @@ public class ElectricalProfileMapping {
     /**
      * Returns the electrical profile values encountered along the train path, for each power class given.
      */
-    public HashMap<String, RangeMap<Double, String>> getProfilesOnPath(TrainPath trainPath) {
+    public HashMap<String, RangeMap<Double, String>> getProfilesOnPath(List<TrackRangeView> trackSectionPath) {
         var res = new HashMap<String, RangeMap<Double, String>>();
         for (var entry : mapping.entrySet()) {
             var powerClass = entry.getKey();
             var byTrackMapping = entry.getValue();
             var rangeMap = new ImmutableRangeMap.Builder<Double, String>();
             double offset = 0;
-            for (var trackRange : TrainPath.removeLocation(trainPath.trackRangePath())) {
+            for (var trackRange : trackSectionPath) {
                 var trackID = trackRange.track.getEdge().getID();
                 if (byTrackMapping.containsKey(trackID)) {
                     var pathRangeMapping = trackRange.convertMap(byTrackMapping.get(trackID));

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/EnvelopeSimContextBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/EnvelopeSimContextBuilder.java
@@ -12,8 +12,8 @@ public class EnvelopeSimContextBuilder {
             double timeStep,
             RollingStock.Comfort comfort
     ) {
-        var elecCondMap = path.getElecCondMap(null, null, null, true); // Only electrification modes for now
-        var curvesAndConditions = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort, path.getLength());
+        var elecCondMap = path.getElectrificationMap(null, null, null, true); // Only electrification modes for now
+        var curvesAndConditions = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort);
         return new EnvelopeSimContext(rollingStock, path, timeStep, curvesAndConditions.curves());
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/external_generated_inputs/ElectricalProfileMappingTest.java
@@ -11,6 +11,7 @@ import static fr.sncf.osrd.Helpers.*;
 import static fr.sncf.osrd.api.StandaloneSimulationTest.smallInfraTrainPath;
 
 import fr.sncf.osrd.Helpers;
+import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
 import fr.sncf.osrd.railjson.schema.infra.RJSRoutePath;
@@ -64,7 +65,7 @@ public class ElectricalProfileMappingTest {
                 "BAL3")));
         var path = TrainPathBuilder.from(infra, rjsPath);
 
-        var profiles = profileMap.getProfilesOnPath(path);
+        var profiles = profileMap.getProfilesOnPath(TrainPath.removeLocation(path.trackRangePath()));
         assertEquals(profiles.keySet(), new HashSet<>(singletonList("1")));
         var profileRangeMap = profiles.get("1");
         assertEquals("22500", profileRangeMap.get(0.));
@@ -89,7 +90,7 @@ public class ElectricalProfileMappingTest {
         var rjsPath = smallInfraTrainPath();
         var path = TrainPathBuilder.from(infra, rjsPath);
 
-        var profiles = profileMap.getProfilesOnPath(path);
+        var profiles = profileMap.getProfilesOnPath(TrainPath.removeLocation(path.trackRangePath()));
         assertEquals(profiles.keySet(), new HashSet<>(asList("1", "2", "3", "4", "5")));
 
         var expectedResults = new ArrayList<HashSet<String>>();

--- a/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.java
+++ b/core/src/test/java/fr/sncf/osrd/train/TestRollingStock.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.train;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static fr.sncf.osrd.envelope_sim.EnvelopeSimPath.ElectrificationConditions;
+import static fr.sncf.osrd.train.RollingStock.InfraConditions;
 
 import com.google.common.collect.*;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPath;
@@ -45,9 +45,9 @@ public class TestRollingStock {
             RangeMap<Double, String> powerRestrictionMap) {
         var rollingStock = TestTrains.REALISTIC_FAST_TRAIN;
 
-        var elecCondMap = path.getElecCondMap(rollingStock.basePowerClass, powerRestrictionMap,
+        var elecCondMap = path.getElectrificationMap(rollingStock.basePowerClass, powerRestrictionMap,
                 rollingStock.powerRestrictions);
-        var tractiveEffortCurveMap = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort, path.getLength());
+        var tractiveEffortCurveMap = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort);
         testRangeCoverage(tractiveEffortCurveMap.conditions(), path.getLength());
         testRangeCoverage(tractiveEffortCurveMap.curves(), path.getLength());
         var nCurves = tractiveEffortCurveMap.curves().subRangeMap(Range.closed(0., path.getLength())).asMapOfRanges()
@@ -71,9 +71,9 @@ public class TestRollingStock {
         var rollingStock = TestTrains.REALISTIC_FAST_TRAIN;
 
         var comfort = RollingStock.Comfort.STANDARD;
-        var elecCondMap = path.getElecCondMap(rollingStock.basePowerClass, powerRestrictionMap,
+        var elecCondMap = path.getElectrificationMap(rollingStock.basePowerClass, powerRestrictionMap,
                 rollingStock.powerRestrictions);
-        var res = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort, path.getLength());
+        var res = rollingStock.mapTractiveEffortCurves(elecCondMap, comfort);
 
         testRangeCoverage(res.curves(), path.getLength());
         assertEquals(14, res.curves().subRangeMap(Range.closed(0., path.getLength())).asMapOfRanges().size(),
@@ -85,21 +85,21 @@ public class TestRollingStock {
                         .map(Range::lowerEndpoint).toArray());
 
         // Check that the conditions are correct
-        assertArrayEquals(new ElectrificationConditions[] {
-                new ElectrificationConditions("thermal", null, null), // 0
-                new ElectrificationConditions("1500", null, null),    // 1
-                new ElectrificationConditions("1500", null, null),    // 5 "Restrict1" invalid for 1500
-                new ElectrificationConditions("thermal", null, null), // 8
-                new ElectrificationConditions("25000", null, "Restrict2"),  // 8.1
-                new ElectrificationConditions("25000", "25000", "Restrict2"), // 10
-                new ElectrificationConditions("25000", "25000", null), // 11
-                new ElectrificationConditions("25000", "22500", null), // 12
-                new ElectrificationConditions("25000", "20000", null), // 14
-                new ElectrificationConditions("25000", "22500", "Restrict1"), // 15
-                new ElectrificationConditions("25000", "25000", "Restrict1"), // 17
-                new ElectrificationConditions("25000", "25000", null), // 18 "UnknownRestrict" invalid for 25000
-                new ElectrificationConditions("thermal", null, null), // 20 No mode given
-                new ElectrificationConditions("thermal", null, null)  // 30 Invalid mode
+        assertArrayEquals(new InfraConditions[] {
+                new InfraConditions("thermal", null, null), // 0
+                new InfraConditions("1500", null, null),    // 1
+                new InfraConditions("1500", null, null),    // 5 "Restrict1" invalid for 1500
+                new InfraConditions("thermal", null, null), // 8
+                new InfraConditions("25000", null, "Restrict2"),  // 8.1
+                new InfraConditions("25000", "25000", "Restrict2"), // 10
+                new InfraConditions("25000", "25000", null), // 11
+                new InfraConditions("25000", "22500", null), // 12
+                new InfraConditions("25000", "20000", null), // 14
+                new InfraConditions("25000", "22500", "Restrict1"), // 15
+                new InfraConditions("25000", "25000", "Restrict1"), // 17
+                new InfraConditions("25000", "25000", null), // 18 "UnknownRestrict" invalid for 25000
+                new InfraConditions("thermal", null, null), // 20 No mode given
+                new InfraConditions("thermal", null, null)  // 30 Invalid mode
         },
                 res.conditions().subRangeMap(Range.closed(0., path.getLength())).asMapOfRanges().values().stream()
                     .toArray());


### PR DESCRIPTION
This PR is a refacto needed for #4296 

It uncouples rolling stock effort curve conditions models and electrification state in the infrastructure.
It also replaces `ElectrificationConditions` by a sealed interface which, for now, is only implemented by `Electrified` and `NonElectrified` but in the aforementioned PR we will add `Neutral`
