### PR TITLE
front: refresh conflicts when train is moved on timetable + use train…

### DIFF
--- a/front/src/applications/operationalStudies/components/Scenario/ConflictsList.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ConflictsList.tsx
@@ -9,6 +9,7 @@ export type Conflict = {
   conflict_type: string;
   start_time: string;
   end_time: string;
+  train_names: string[];
 };
 
 type ConflictTableProps = {
@@ -24,8 +25,8 @@ function ConflictCard({ conflict }: { conflict: Conflict }) {
     <div className="conflict-card">
       <BsLightningFill color="red" />
       <div className="conflict-trains">
-        <div className="card-text">{conflict.train_ids[0]}</div>
-        <div className="card-text">{conflict.train_ids[1]}</div>
+        <div className="card-text">{conflict.train_names[0]}</div>
+        <div className="card-text">{conflict.train_names[1]}</div>
       </div>
       <div className="conflict-type">
         <p className="card-text">{t(`${conflict.conflict_type}`)}</p>

--- a/front/src/applications/operationalStudies/components/Scenario/Timetable.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/Timetable.tsx
@@ -29,6 +29,7 @@ import ConflictsList, { Conflict } from './ConflictsList';
 
 type Props = {
   setDisplayTrainScheduleManagement: (mode: string) => void;
+  refreshConflict: () => void;
   trainsWithDetails: boolean;
   conflicts: Conflict[];
 };
@@ -37,6 +38,7 @@ export default function Timetable({
   setDisplayTrainScheduleManagement,
   trainsWithDetails,
   conflicts,
+  refreshConflict,
 }: Props) {
   const selectedProjection = useSelector(
     (state: RootState) => state.osrdsimulation.selectedProjection
@@ -160,6 +162,7 @@ export default function Timetable({
       );
     } else {
       setTrainsList(departureArrivalTimes);
+      refreshConflict();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [departureArrivalTimes, debouncedTerm]);

--- a/front/src/applications/operationalStudies/views/Scenario.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario.tsx
@@ -127,6 +127,15 @@ export default function Scenario() {
         });
     }
   };
+  const refreshConflicts = () => {
+    if (timetableId) {
+      getTimetableConflicts({ id: timetableId })
+        .unwrap()
+        .then((data) => {
+          setConflicts(data as Conflict[]);
+        });
+    }
+  };
 
   useEffect(() => {
     if (!scenarioId || !studyId || !projectId) {
@@ -247,6 +256,7 @@ export default function Scenario() {
                   setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
                   trainsWithDetails={trainsWithDetails}
                   conflicts={conflicts}
+                  refreshConflict={refreshConflicts}
                 />
               </div>
             </div>


### PR DESCRIPTION
… name instead of id in conflict card

close #4401 