### PR TITLE
core: migrate pathfinding postprocessing to new infra

### DIFF
--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/ArrayList.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/ArrayList.kt
@@ -31,6 +31,7 @@ private fun CollectionItemType.generateArrayList(context: GeneratorContext, curr
             import ${type.qualifiedName}
 
             /** GENERATED CODE */
+            @Suppress("INAPPLICABLE_JVM_NAME")
             class Mutable${simpleName}ArrayList${paramsDecl} private constructor(
                 private var usedElements: Int,
                 private var buffer: ${bufferType},
@@ -80,6 +81,7 @@ private fun CollectionItemType.generateArrayList(context: GeneratorContext, curr
                 }
 
                 /** GENERATED CODE */
+                @JvmName("add")
                 override fun add(element: $type): Boolean {
                     ensureBufferSpace(1)
                     buffer[usedElements++] = element

--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/Interfaces.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/Interfaces.kt
@@ -27,13 +27,16 @@ private fun CollectionItemType.generateInterfaces(context: GeneratorContext, cur
             }
 
             /** GENERATED CODE */
+            @Suppress("INAPPLICABLE_JVM_NAME")
             interface ${simpleName}List${paramsDecl} : ${simpleName}Collection${paramsUse} {
+                @JvmName("get")
                 operator fun get(index: Int): $type
                 fun clone(): Mutable${simpleName}List${paramsUse}
                 fun reversed() : Mutable${simpleName}ArrayList${paramsUse}
             }
 
             /** GENERATED CODE */
+            @Suppress("INAPPLICABLE_JVM_NAME")
             interface Mutable${simpleName}List${paramsDecl} : ${simpleName}List${paramsUse} {
                 fun ensureCapacity(expectedElements: Int)
                 fun add(element: ${type}): Boolean
@@ -41,6 +44,7 @@ private fun CollectionItemType.generateInterfaces(context: GeneratorContext, cur
                 fun add(elemA: ${type}, elemB: ${type}, elemC: ${type})
                 fun addAll(elements: Collection<${type}>): Boolean
                 fun addAll(iterable: Iterable<${type}>): Boolean
+                @JvmName("insert")
                 fun insert(index: Int, elem: ${type})
                 fun set(index: Int, element: ${type}): $type
                 fun remove(index: Int): $type

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
@@ -32,6 +32,7 @@ fun LocationInfra.isBufferStop(detector: StaticIdx<Detector>): Boolean {
 }
 
 
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface ReservationInfra : LocationInfra {
     val zonePaths: StaticIdxSpace<ZonePath>
     fun findZonePath(entry: DirDetectorId, exit: DirDetectorId,
@@ -39,6 +40,7 @@ interface ReservationInfra : LocationInfra {
                      trackNodeConfigs: StaticIdxList<TrackNodeConfig>): ZonePathId?
     fun getZonePathEntry(zonePath: ZonePathId): DirDetectorId
     fun getZonePathExit(zonePath: ZonePathId): DirDetectorId
+    @JvmName("getZonePathLength")
     fun getZonePathLength(zonePath: ZonePathId): Distance
     /** The movable elements in the order encountered when traversing the zone from entry to exit */
     fun getZonePathMovableElements(zonePath: ZonePathId): StaticIdxList<TrackNode>
@@ -47,6 +49,7 @@ interface ReservationInfra : LocationInfra {
     /** The distances from the beginning of the zone path to its switches, in encounter order */
     fun getZonePathMovableElementsDistances(zonePath: ZonePathId): DistanceList
     /** Returns the list of track chunks on the zone path */
+    @JvmName("getZonePathChunks")
     fun getZonePathChunks(zonePath: ZonePathId): DirStaticIdxList<TrackChunk>
 }
 
@@ -60,15 +63,21 @@ sealed interface Route
 typealias RouteId = StaticIdx<Route>
 
 
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface RoutingInfra : ReservationInfra {
+    @get:JvmName("getRoutes")
     val routes: StaticIdxSpace<Route>
+    @JvmName("getRoutePath")
     fun getRoutePath(route: RouteId): StaticIdxList<ZonePath>
+    @JvmName("getRouteName")
     fun getRouteName(route: RouteId): String?
 
     /** Returns a list of indices of zones in the train path at which the reservations shall be released. */
     fun getRouteReleaseZones(route: RouteId): IntArray
+    @JvmName("getChunksOnRoute")
     fun getChunksOnRoute(route: RouteId): DirStaticIdxList<TrackChunk>
-    fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxCollection<Route>
+    @JvmName("getRoutesOnTrackChunk")
+    fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxList<Route>
 }
 
 fun ReservationInfra.findZonePath(entry: DirDetectorId, exit: DirDetectorId): ZonePathId? {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -25,7 +25,9 @@ typealias SigStateSchema = SigSchema<SignalStateMarker>
 
 
 /** The signaling system manager is a repository for drivers and signaling systems */
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface InfraSigSystemManager {
+    @get:JvmName("getSignalingSystems")
     val signalingSystems: StaticIdxSpace<SignalingSystem>
     fun findSignalingSystem(sigSystem: String): SignalingSystemId
     fun getStateSchema(sigSystem: SignalingSystemId): SigStateSchema
@@ -52,8 +54,11 @@ interface LoadedSignalInfra {
     fun isBlockDelimiter(signal: LogicalSignalId): Boolean
 }
 
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface BlockInfra {
+    @get:JvmName("getBlocks")
     val blocks: StaticIdxSpace<Block>
+    @JvmName("getBlockPath")
     fun getBlockPath(block: BlockId): StaticIdxList<ZonePath>
     fun getBlockSignals(block: BlockId): StaticIdxList<LogicalSignal>
     fun blockStartAtBufferStop(block: BlockId): Boolean
@@ -107,7 +112,7 @@ fun filterBlocks(
     return res
 }
 
-
+@JvmName("findRouteBlocks")
 fun findRouteBlocks(
     signalingInfra: RawSignalingInfra,
     blockInfra: BlockInfra,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/Path.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/Path.kt
@@ -10,10 +10,20 @@ import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.meters
 
 data class IdxWithOffset<T>(
+    @get:JvmName("getValue")
     val value: StaticIdx<T>,
+    @get:JvmName("getOffset")
     val offset: Distance,
 )
 
+data class TrackLocation(
+    @get:JvmName("getTrackId")
+    val trackId: TrackSectionId,
+    @get:JvmName("getOffset")
+    val offset: Distance
+)
+
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface Path {
     fun getSlopes(): DistanceRangeMap<Double>
     fun getOperationalPointParts(): List<IdxWithOffset<OperationalPointPart>>
@@ -22,9 +32,15 @@ interface Path {
     fun getGeo(): LineString
     fun getLoadingGauge(): DistanceRangeMap<LoadingGaugeConstraint>
     fun getCatenary(): DistanceRangeMap<String>
+    @JvmName("getLength")
+    fun getLength(): Distance
+
+    @JvmName("getTrackLocationAtOffset")
+    fun getTrackLocationAtOffset(pathOffset: Distance): TrackLocation
 }
 
 /** Build a Path from chunks and offsets, filtering the chunks outside the offsets */
+@JvmName("buildPathFrom")
 fun buildPathFrom(
     infra: TrackProperties,
     chunks: DirStaticIdxList<TrackChunk>,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackInfra.kt
@@ -13,8 +13,10 @@ sealed interface TrackChunk
 typealias TrackChunkId = StaticIdx<TrackChunk>
 
 
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface TrackInfra {
-    fun getTrackSectionId(trackSection: TrackSectionId): String
+    @JvmName("getTrackSectionName")
+    fun getTrackSectionName(trackSection: TrackSectionId): String
     fun getTrackSectionFromName(name: String): TrackSectionId?
     fun getTrackSectionChunks(trackSection: TrackSectionId): StaticIdxList<TrackChunk>
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -17,11 +17,15 @@ import fr.sncf.osrd.utils.units.Speed
 sealed interface OperationalPointPart
 typealias OperationalPointPartId = StaticIdx<OperationalPointPart>
 
+@Suppress("INAPPLICABLE_JVM_NAME")
 interface TrackProperties {
 
     // Chunk attributes
+    @JvmName("getTrackChunkLength")
     fun getTrackChunkLength(trackChunk: TrackChunkId): Distance
+    @JvmName("getTrackChunkOffset")
     fun getTrackChunkOffset(trackChunk: TrackChunkId): Distance
+    @JvmName("getTrackFromChunk")
     fun getTrackFromChunk(trackChunk: TrackChunkId): TrackSectionId
 
     // Linear track attributes
@@ -38,5 +42,6 @@ interface TrackProperties {
     fun getTrackChunkOperationalPointParts(trackChunk: TrackChunkId): StaticIdxList<OperationalPointPart>
     fun getOperationalPointPartChunk(operationalPoint: OperationalPointPartId): TrackChunkId
     fun getOperationalPointPartChunkOffset(operationalPoint: OperationalPointPartId): Distance
+    @JvmName("getOperationalPointPartName")
     fun getOperationalPointPartName(operationalPoint: OperationalPointPartId): String
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
@@ -1,0 +1,85 @@
+package fr.sncf.osrd.sim_infra.impl
+
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.units.Distance
+
+/** These classes shouldn't be generally used, it's only here to make it easier to track objects
+ * when using a debugger. They can be used to create watches containing the object properties. */
+
+data class DirectedViewer<T>(
+    val direction: Direction,
+    val value: T,
+)
+
+data class ChunkViewer(
+    val trackName: String,
+    val offset: Distance,
+    val length: Distance,
+    val id: TrackChunkId,
+)
+
+data class ZonePathViewer(
+    val chunks: List<DirectedViewer<ChunkViewer>>,
+    val id: ZonePathId,
+)
+
+data class BlockViewer(
+    val zones: List<ZonePathViewer>,
+    val id: BlockId,
+)
+
+data class RouteViewer(
+    val name: String,
+    val blocks: List<BlockViewer>,
+    val id: RouteId,
+)
+
+@JvmName("makeChunk")
+fun makeChunk(infra: RawInfra, id: StaticIdx<TrackChunk>): ChunkViewer {
+    return ChunkViewer(
+        infra.getTrackSectionName(infra.getTrackFromChunk(id)),
+        infra.getTrackChunkOffset(id),
+        infra.getTrackChunkLength(id),
+        id,
+    )
+}
+
+@JvmName("makeZonePath")
+fun makeZonePath(infra: RawInfra, id: StaticIdx<ZonePath>): ZonePathViewer {
+    return ZonePathViewer(
+        infra.getZonePathChunks(id)
+            .map { dirChunk -> DirectedViewer(dirChunk.direction, makeChunk(infra, dirChunk.value)) },
+        id,
+    )
+}
+
+@JvmName("makeBlock")
+fun makeBlock(rawInfra: RawInfra, blockInfra: BlockInfra, id: StaticIdx<Block>): BlockViewer {
+    return BlockViewer(
+        blockInfra.getBlockPath(id)
+            .map { path -> makeZonePath(rawInfra, path) },
+        id,
+    )
+}
+
+@JvmName("makeRoute")
+fun makeRoute(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    signalingSystems: StaticIdxList<SignalingSystem>,
+    id: StaticIdx<Route>,
+): RouteViewer {
+    val ids = MutableStaticIdxArrayList<Route>()
+    ids.add(id)
+    return RouteViewer(
+        rawInfra.getRouteName(id)!!,
+        getRouteBlocks(rawInfra, blockInfra, ids, signalingSystems)
+            .flatten()
+            .map { block -> makeBlock(rawInfra, blockInfra, block) },
+        id,
+    )
+}

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -30,7 +30,7 @@ class TrackChunkDescriptor(
     val curves: DirectionalMap<DistanceRangeMap<Double>>,
     val gradients: DirectionalMap<DistanceRangeMap<Double>>,
     val length: Distance,
-    val routes: DirectionalMap<StaticIdxCollection<Route>>,
+    val routes: DirectionalMap<StaticIdxList<Route>>,
     var track: StaticIdx<TrackSection>,
     val offset: Distance,
     var operationalPointParts: StaticIdxList<OperationalPointPart>,
@@ -137,7 +137,7 @@ class RawInfraImpl(
     override val trackSections: StaticIdxSpace<TrackSection>
         get() = trackSectionPool.space()
 
-    override fun getTrackSectionId(trackSection: TrackSectionId): String {
+    override fun getTrackSectionName(trackSection: TrackSectionId): String {
         return trackSectionPool[trackSection].name
     }
 
@@ -215,7 +215,7 @@ class RawInfraImpl(
         return res
     }
 
-    override fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxCollection<Route> {
+    override fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxList<Route> {
         return trackChunkPool[trackChunk.value].routes.get(trackChunk.direction)
     }
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -6,8 +6,11 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /** When iterating over the values of the map, this represents one range of constant value */
     data class RangeMapEntry<T>(
+        @get:JvmName("getLower")
         val lower: Distance,
+        @get:JvmName("getUpper")
         val upper: Distance,
+        @get:JvmName("getValue")
         val value: T,
     )
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/DirStaticIdx.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/DirStaticIdx.kt
@@ -17,7 +17,8 @@ value class DirStaticIdx<T>(val data: UInt) : NumIdx {
         (detector.index shl 1) or when (direction) {
             Direction.INCREASING -> 0u
             Direction.DECREASING -> 1u
-        })
+        }
+    )
 
     val value: StaticIdx<T> get() = StaticIdx(data shr 1)
     val direction: Direction
@@ -32,4 +33,14 @@ value class DirStaticIdx<T>(val data: UInt) : NumIdx {
     override fun toString(): String {
         return String.format("(id=%s, dir=%s)", value.index, direction)
     }
+}
+
+@JvmName("toDirection")
+fun <T> toDirection(dirStaticIdx: DirStaticIdx<T>): Direction {
+    return dirStaticIdx.direction
+}
+
+@JvmName("toValue")
+fun <T> toValue(dirStaticIdx: DirStaticIdx<T>): StaticIdx<T> {
+    return dirStaticIdx.value
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -26,7 +26,12 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
     companion object {
         @JvmStatic
         val ZERO = Distance(millimeters = 0L)
+        @JvmStatic
+        @JvmName("fromMeters")
         fun fromMeters(meters: Double) = Distance(millimeters = (meters * 1_000.0).toLong())
+        @JvmStatic
+        @JvmName("toMeters")
+        fun toMeters(distance: Distance) = distance.meters
     }
 
     override fun compareTo(other: Distance): Int {

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/GeomUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/GeomUtils.java
@@ -54,7 +54,7 @@ public class GeomUtils {
         res.schematic = toRJSLineString(concatenate(schList));
     }
 
-    private static RJSLineString toRJSLineString(LineString lineString) {
+    static RJSLineString toRJSLineString(LineString lineString) {
         var coordinates = new ArrayList<List<Double>>();
         for (var p : lineString.getPoints())
             coordinates.add(List.of(p.x(), p.y()));

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/LegacyPathfindingResultConverter.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/LegacyPathfindingResultConverter.java
@@ -1,0 +1,267 @@
+package fr.sncf.osrd.api.pathfinding;
+
+
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+import fr.sncf.osrd.api.pathfinding.response.*;
+import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.infra.implementation.tracks.undirected.TrackSectionImpl;
+import fr.sncf.osrd.railjson.schema.infra.RJSRoutePath;
+import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange;
+import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+public class LegacyPathfindingResultConverter {
+    /**
+     * The pathfinding algorithm produces a path in the signaling route graph.
+     * This makes total sense, but also isn't enough: the caller wants to know
+     * which waypoints were encountered, as well as the track section path and
+     * its geometry.
+     */
+    public static PathfindingResult convert(
+            Pathfinding.Result<SignalingRoute> path,
+            SignalingInfra infra,
+            DiagnosticRecorderImpl warningRecorder
+    ) {
+        // Compute the path length
+        double pathLength = 0.;
+        for (var range : path.ranges())
+            pathLength += range.end() - range.start();
+
+        var res = new PathfindingResult(pathLength);
+
+        // Builds a mapping between routes and all user defined waypoints on the route
+        var userDefinedWaypointsPerRoute = HashMultimap.<SignalingRoute, Double>create();
+        for (var waypoint : path.waypoints())
+            userDefinedWaypointsPerRoute.put(waypoint.edge(), waypoint.offset());
+
+        // for each signaling route slice, find the waypoints on this slice, and merge these with user defined waypoints
+        double pathOffset = 0.;
+        for (var signalingRouteEdgeRange : path.ranges()) {
+            // Ignore cases where the range length is 0
+            if (signalingRouteEdgeRange.start() < signalingRouteEdgeRange.end())
+                res.routePaths.add(makeRouteResult(signalingRouteEdgeRange));
+            var waypoints = getWaypointsOnRoute(
+                    signalingRouteEdgeRange,
+                    userDefinedWaypointsPerRoute.get(signalingRouteEdgeRange.edge()),
+                    pathOffset
+            );
+            for (var waypoint : waypoints)
+                addStep(res, waypoint);
+            pathOffset += signalingRouteEdgeRange.end() - signalingRouteEdgeRange.start();
+        }
+
+        // iterate on all the track section ranges of all routes, and build a schematic and geographic result geometry
+        GeomUtils.addGeometry(res, infra);
+        res.warnings = warningRecorder.warnings;
+
+        var pathTrackRangeViews =
+                path.ranges()
+                        .stream()
+                        .flatMap(signalingRouteEdgeRange -> signalingRouteEdgeRange.edge()
+                                .getInfraRoute()
+                                .getTrackRanges(signalingRouteEdgeRange.start(), signalingRouteEdgeRange.end())
+                                .stream())
+                        .filter(trackRangeView -> trackRangeView.track.getEdge() instanceof TrackSectionImpl)
+                        .toList();
+        res.curves = computeCurves(pathTrackRangeViews);
+        res.slopes = computeSlopes(pathTrackRangeViews);
+        return res;
+    }
+
+    /** Adds all waypoints on the route range, both suggestions (OP) and user defined waypoints */
+    public static List<PathWaypointResult> getWaypointsOnRoute(
+            Pathfinding.EdgeRange<SignalingRoute> routeRange,
+            Set<Double> userDefinedWaypointOffsets,
+            double pathOffset
+    ) {
+        var res = new ArrayList<PathWaypointResult>();
+
+        // We need a mutable copy to remove elements as we find them
+        var waypointsOffsetsList = new ArrayList<>(userDefinedWaypointOffsets);
+
+        double routeOffset = 0;
+        for (var routeTrackRange : routeRange.edge().getInfraRoute().getTrackRanges()) {
+            if (!(routeTrackRange.track.getEdge() instanceof TrackSection trackSection))
+                continue;
+
+            if (routeOffset > routeRange.end())
+                break;
+
+            if (routeOffset + routeTrackRange.getLength() >= routeRange.start()) {
+                // Truncate the range to match the part of the route we use
+                var pathTrackRange = truncateTrackRange(routeTrackRange, routeOffset, routeRange);
+                if (pathTrackRange != null) {
+                    // List all waypoints on the track range in a tree map, with offsets from the range start as key
+                    var waypoints = new ArrayList<PathWaypointResult>();
+
+                    // Offset of the track on the path
+                    var trackPathOffset = pathOffset + routeOffset - routeRange.start();
+
+                    // Add operational points as optional waypoints
+                    for (var op : pathTrackRange.getOperationalPoints()) {
+                        var waypointTrackOffset = routeTrackRange.offsetOf(op.element().offset());
+                        var waypointPathOffset = trackPathOffset + waypointTrackOffset;
+                        waypoints.add(PathWaypointResult.suggestion(op.element(), trackSection, waypointPathOffset));
+                    }
+
+                    // Add user defined waypoints
+                    var pathTrackRangeRouteOffset =
+                            routeOffset + Math.abs(pathTrackRange.getStart() - routeTrackRange.getStart());
+                    for (int i = 0; i < waypointsOffsetsList.size(); i++) {
+                        var waypointRouteOffset = waypointsOffsetsList.get(i);
+                        var trackRangeOffset = waypointRouteOffset - pathTrackRangeRouteOffset;
+
+                        // We can have tiny differences here because we accumulate offsets in a different way
+                        if (Math.abs(trackRangeOffset - pathTrackRange.getLength()) < POSITION_EPSILON)
+                            trackRangeOffset = pathTrackRange.getLength();
+                        if (Math.abs(trackRangeOffset) < POSITION_EPSILON)
+                            trackRangeOffset = 0;
+
+                        if (trackRangeOffset >= 0 && trackRangeOffset <= pathTrackRange.getLength()) {
+                            var location = pathTrackRange.offsetLocation(trackRangeOffset);
+                            var waypointPathOffset = pathOffset + waypointRouteOffset - routeRange.start();
+                            waypoints.add(PathWaypointResult.userDefined(location, waypointPathOffset));
+                            waypointsOffsetsList.remove(i--); // Avoids duplicates on track transitions
+                        }
+                    }
+
+                    // Adds all waypoints in order
+                    waypoints.sort(Comparator.comparingDouble(x -> x.pathOffset));
+                    res.addAll(waypoints);
+                }
+            }
+
+            routeOffset += routeTrackRange.getLength();
+        }
+        assert waypointsOffsetsList.isEmpty();
+        return res;
+    }
+
+    /** Truncates a track range view so that it's limited to the route range */
+    private static TrackRangeView truncateTrackRange(
+            TrackRangeView range,
+            double offset,
+            Pathfinding.EdgeRange<SignalingRoute> routeRange
+    ) {
+        var truncatedRange = range;
+        if (offset < routeRange.start()) {
+            var truncateLength = routeRange.start() - offset;
+            if (truncateLength > truncatedRange.getLength() + POSITION_EPSILON)
+                return null;
+            truncatedRange = truncatedRange.truncateBeginByLength(truncateLength);
+        }
+        if (offset + range.getLength() > routeRange.end()) {
+            var truncateLength = offset + range.getLength() - routeRange.end();
+            if (truncateLength > truncatedRange.getLength() + POSITION_EPSILON)
+                return null;
+            truncatedRange = truncatedRange.truncateEndByLength(truncateLength);
+        }
+        return truncatedRange;
+    }
+
+    /** Adds a single route to the result, including waypoints present on the route */
+    private static RJSRoutePath makeRouteResult(
+            Pathfinding.EdgeRange<SignalingRoute> element
+    ) {
+        var routeResult = new RJSRoutePath(
+                element.edge().getInfraRoute().getID(),
+                element.edge().getSignalingType()
+        );
+        double offset = 0;
+        for (var range : element.edge().getInfraRoute().getTrackRanges()) {
+            if (!(range.track.getEdge() instanceof TrackSection trackSection))
+                continue;
+
+            // Truncate the ranges to match the part of the route we use
+            var truncatedRange = truncateTrackRange(range, offset, element);
+            offset += range.getLength();
+            if (truncatedRange == null)
+                continue;
+
+            // Add the track ranges to the result
+            routeResult.trackSections.add(new RJSDirectionalTrackRange(
+                    trackSection.getID(),
+                    truncatedRange.getStart(),
+                    truncatedRange.getStop()
+            ));
+        }
+        return routeResult;
+    }
+
+    /** Adds a single waypoint to the result */
+    static void addStep(PathfindingResult res, PathWaypointResult newStep) {
+        var waypoints = res.pathWaypoints;
+        if (waypoints.isEmpty()) {
+            waypoints.add(newStep);
+            return;
+        }
+        var lastStep = waypoints.get(waypoints.size() - 1);
+        if (lastStep.isDuplicate(newStep)) {
+            lastStep.merge(newStep);
+            return;
+        }
+        waypoints.add(newStep);
+    }
+
+    /**
+     * Coalesce several range maps into one by shifting the N+1th range so it begins
+     * at the end of the Nth one.
+     *
+     * <pre>
+     * {[[1, 5], [5, 10]], [[0, 13]], [[1, 100]]} => [[1, 5], [5, 10], [10, 23], [24, 124]]
+     * </pre>
+     */
+    static RangeMap<Double, Double> shiftingOffsetMergeRanges(List<RangeMap<Double, Double>> rangeMaps) {
+        var offset = 0.;
+        var result = TreeRangeMap.<Double, Double>create();
+        for (var tsMap : rangeMaps) {
+            for (var entry : tsMap.asMapOfRanges().entrySet()) {
+                var range = entry.getKey();
+                var shiftedRange = Range.closed(
+                        offset + range.lowerEndpoint(),
+                        offset + range.upperEndpoint()
+                );
+                result.putCoalescing(shiftedRange, entry.getValue());
+            }
+            var span = tsMap.span();
+            offset += span.upperEndpoint() - span.lowerEndpoint();
+        }
+        return result;
+    }
+
+    /**
+     * Generates and returns a list of points, generated by `factory` for both the lower and upper endpoint of
+     * each range of `ranges`, in ascending order.
+     */
+    static <T> List<T> generateChartPoints(RangeMap<Double, Double> ranges, BiFunction<Double, Double, T> factory) {
+        return ranges.asMapOfRanges().entrySet().stream().flatMap(entry -> Stream.of(
+                factory.apply(entry.getKey().lowerEndpoint(), entry.getValue()),
+                factory.apply(entry.getKey().upperEndpoint(), entry.getValue())
+        )).toList();
+    }
+
+    /** Computes the graph of the curves of every TrackRangeView on path. */
+    static List<CurveChartPointResult> computeCurves(List<TrackRangeView> pathTrackRangeViews) {
+        var curves = pathTrackRangeViews.stream().map(TrackRangeView::getCurves).toList();
+        var shiftedRangeMap = shiftingOffsetMergeRanges(curves);
+        return generateChartPoints(shiftedRangeMap, CurveChartPointResult::new);
+    }
+
+    /** Computes the graph of the slopes of every TrackRangeView on path. */
+    static List<SlopeChartPointResult> computeSlopes(List<TrackRangeView> pathTrackRangeViews) {
+        var slopes = pathTrackRangeViews.stream().map(TrackRangeView::getSlopes).toList();
+        var shiftedRangeMap = shiftingOffsetMergeRanges(slopes);
+        return generateChartPoints(shiftedRangeMap, SlopeChartPointResult::new);
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.java
@@ -1,267 +1,431 @@
 package fr.sncf.osrd.api.pathfinding;
 
-
-import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+import static fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection.START_TO_STOP;
+import static fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection.STOP_TO_START;
+import static fr.sncf.osrd.sim_infra.api.PathKt.buildPathFrom;
+import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toDirection;
+import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toValue;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Range;
-import com.google.common.collect.RangeMap;
-import com.google.common.collect.TreeRangeMap;
-import fr.sncf.osrd.api.pathfinding.response.*;
-import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
-import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
-import fr.sncf.osrd.infra.implementation.tracks.undirected.TrackSectionImpl;
+import com.google.common.collect.Iterables;
+import fr.sncf.osrd.api.pathfinding.response.CurveChartPointResult;
+import fr.sncf.osrd.api.pathfinding.response.PathWaypointResult;
+import fr.sncf.osrd.api.pathfinding.response.PathfindingResult;
+import fr.sncf.osrd.api.pathfinding.response.SlopeChartPointResult;
+import fr.sncf.osrd.railjson.schema.geom.RJSLineString;
 import fr.sncf.osrd.railjson.schema.infra.RJSRoutePath;
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange;
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
+import fr.sncf.osrd.sim_infra.api.*;
+import fr.sncf.osrd.utils.Direction;
+import fr.sncf.osrd.utils.DistanceRangeMap;
 import fr.sncf.osrd.utils.graph.Pathfinding;
+import fr.sncf.osrd.utils.indexing.DirStaticIdxList;
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList;
+import fr.sncf.osrd.utils.indexing.StaticIdxList;
+import fr.sncf.osrd.utils.units.Distance;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 public class PathfindingResultConverter {
+
     /**
-     * The pathfinding algorithm produces a path in the signaling route graph.
+     * The pathfinding algorithm produces a path in the block graph.
      * This makes total sense, but also isn't enough: the caller wants to know
      * which waypoints were encountered, as well as the track section path and
      * its geometry.
      */
     public static PathfindingResult convert(
-            Pathfinding.Result<SignalingRoute> path,
-            SignalingInfra infra,
+            RawSignalingInfra infra,
+            BlockInfra blockInfra,
+            Pathfinding.Result<Integer> rawPath,
             DiagnosticRecorderImpl warningRecorder
     ) {
-        // Compute the path length
-        double pathLength = 0.;
-        for (var range : path.ranges())
-            pathLength += range.end() - range.start();
-
-        var res = new PathfindingResult(pathLength);
-
-        // Builds a mapping between routes and all user defined waypoints on the route
-        var userDefinedWaypointsPerRoute = HashMultimap.<SignalingRoute, Double>create();
-        for (var waypoint : path.waypoints())
-            userDefinedWaypointsPerRoute.put(waypoint.edge(), waypoint.offset());
-
-        // for each signaling route slice, find the waypoints on this slice, and merge these with user defined waypoints
-        double pathOffset = 0.;
-        for (var signalingRouteEdgeRange : path.ranges()) {
-            // Ignore cases where the range length is 0
-            if (signalingRouteEdgeRange.start() < signalingRouteEdgeRange.end())
-                res.routePaths.add(makeRouteResult(signalingRouteEdgeRange));
-            var waypoints = getWaypointsOnRoute(
-                    signalingRouteEdgeRange,
-                    userDefinedWaypointsPerRoute.get(signalingRouteEdgeRange.edge()),
-                    pathOffset
-            );
-            for (var waypoint : waypoints)
-                addStep(res, waypoint);
-            pathOffset += signalingRouteEdgeRange.end() - signalingRouteEdgeRange.start();
-        }
-
-        // iterate on all the track section ranges of all routes, and build a schematic and geographic result geometry
-        GeomUtils.addGeometry(res, infra);
-        res.warnings = warningRecorder.warnings;
-
-        var pathTrackRangeViews =
-                path.ranges()
-                        .stream()
-                        .flatMap(signalingRouteEdgeRange -> signalingRouteEdgeRange.edge()
-                                .getInfraRoute()
-                                .getTrackRanges(signalingRouteEdgeRange.start(), signalingRouteEdgeRange.end())
-                                .stream())
-                        .filter(trackRangeView -> trackRangeView.track.getEdge() instanceof TrackSectionImpl)
-                        .toList();
-        res.curves = computeCurves(pathTrackRangeViews);
-        res.slopes = computeSlopes(pathTrackRangeViews);
-        return res;
+        var path = makePath(infra, blockInfra, rawPath.ranges());
+        var result = new PathfindingResult(Distance.toMeters(path.getLength()));
+        result.routePaths = makeRoutePath(blockInfra, infra, rawPath.ranges());
+        result.pathWaypoints = makePathWaypoint(path, rawPath, infra, blockInfra);
+        result.geographic = makeGeographic(path);
+        result.schematic = makeSchematic(path);
+        result.slopes = makeSlopes(path);
+        result.curves = makeCurves(path);
+        result.warnings = warningRecorder.getWarnings();
+        return result;
     }
 
-    /** Adds all waypoints on the route range, both suggestions (OP) and user defined waypoints */
-    public static List<PathWaypointResult> getWaypointsOnRoute(
-            Pathfinding.EdgeRange<SignalingRoute> routeRange,
-            Set<Double> userDefinedWaypointOffsets,
-            double pathOffset
+    /** Creates a `Path` instance from a list of block range */
+    static Path makePath(
+            RawSignalingInfra infra,
+            BlockInfra blockInfra,
+            List<Pathfinding.EdgeRange<Integer>> blockRanges
     ) {
+        assert (blockRanges.size() > 0);
+        long totalBlockPathLength = 0;
+        var chunks = new MutableDirStaticIdxArrayList<TrackChunk>();
+        for (var range : blockRanges) {
+            var zonePaths = blockInfra.getBlockPath(range.edge());
+            for (var zonePath : toIntList(zonePaths)) {
+                chunks.addAll(infra.getZonePathChunks(zonePath));
+                var zoneLength = infra.getZonePathLength(zonePath);
+                totalBlockPathLength += zoneLength;
+            }
+        }
+        long startOffset = Math.round(blockRanges.get(0).start());
+        var lastRange = blockRanges.get(blockRanges.size() - 1);
+        var lastBlockLength = getBlockLength(infra, blockInfra, lastRange.edge());
+        var endOffset = totalBlockPathLength - lastBlockLength + Math.round(lastRange.end());
+        return buildPathFrom(infra, chunks, startOffset, endOffset);
+    }
+
+    /** Get the length of a single block. Returns a Long, which should be interpreted as a `Distance` */
+    static long getBlockLength(RawSignalingInfra infra, BlockInfra blockInfra, int block) {
+        long totalBlockLength = 0;
+        var zonePaths = blockInfra.getBlockPath(block);
+        for (var zonePath : toIntList(zonePaths)) {
+            var zoneLength = infra.getZonePathLength(zonePath);
+            totalBlockLength += zoneLength;
+        }
+        return totalBlockLength;
+    }
+
+    /** Make the list of waypoints on the path, in order. Both user-defined waypoints and operational points. */
+    static List<PathWaypointResult> makePathWaypoint(
+            Path path,
+            Pathfinding.Result<Integer> rawPath,
+            RawSignalingInfra infra,
+            BlockInfra blockInfra) {
+        var waypoints = new ArrayList<PathWaypointResult>();
+        waypoints.addAll(makeUserDefinedWaypoints(path, infra, blockInfra, rawPath));
+        waypoints.addAll(makeOperationalPoints(infra, path));
+        return sortAndMergeDuplicates(waypoints);
+    }
+
+    /** Returns all the user defined waypoints on the path */
+    private static Collection<PathWaypointResult> makeUserDefinedWaypoints(
+            Path path,
+            RawSignalingInfra infra,
+            BlockInfra blockInfra,
+            Pathfinding.Result<Integer> rawPath
+    ) {
+        // Builds a mapping between blocks and all user defined waypoints on the block
+        var userDefinedWaypointsPerBlock = HashMultimap.<Integer, Long>create();
+        for (var waypoint : rawPath.waypoints())
+            userDefinedWaypointsPerBlock.put(waypoint.edge(), Math.round(waypoint.offset()));
+
         var res = new ArrayList<PathWaypointResult>();
 
-        // We need a mutable copy to remove elements as we find them
-        var waypointsOffsetsList = new ArrayList<>(userDefinedWaypointOffsets);
-
-        double routeOffset = 0;
-        for (var routeTrackRange : routeRange.edge().getInfraRoute().getTrackRanges()) {
-            if (!(routeTrackRange.track.getEdge() instanceof TrackSection trackSection))
-                continue;
-
-            if (routeOffset > routeRange.end())
-                break;
-
-            if (routeOffset + routeTrackRange.getLength() >= routeRange.start()) {
-                // Truncate the range to match the part of the route we use
-                var pathTrackRange = truncateTrackRange(routeTrackRange, routeOffset, routeRange);
-                if (pathTrackRange != null) {
-                    // List all waypoints on the track range in a tree map, with offsets from the range start as key
-                    var waypoints = new ArrayList<PathWaypointResult>();
-
-                    // Offset of the track on the path
-                    var trackPathOffset = pathOffset + routeOffset - routeRange.start();
-
-                    // Add operational points as optional waypoints
-                    for (var op : pathTrackRange.getOperationalPoints()) {
-                        var waypointTrackOffset = routeTrackRange.offsetOf(op.element().offset());
-                        var waypointPathOffset = trackPathOffset + waypointTrackOffset;
-                        waypoints.add(PathWaypointResult.suggestion(op.element(), trackSection, waypointPathOffset));
-                    }
-
-                    // Add user defined waypoints
-                    var pathTrackRangeRouteOffset =
-                            routeOffset + Math.abs(pathTrackRange.getStart() - routeTrackRange.getStart());
-                    for (int i = 0; i < waypointsOffsetsList.size(); i++) {
-                        var waypointRouteOffset = waypointsOffsetsList.get(i);
-                        var trackRangeOffset = waypointRouteOffset - pathTrackRangeRouteOffset;
-
-                        // We can have tiny differences here because we accumulate offsets in a different way
-                        if (Math.abs(trackRangeOffset - pathTrackRange.getLength()) < POSITION_EPSILON)
-                            trackRangeOffset = pathTrackRange.getLength();
-                        if (Math.abs(trackRangeOffset) < POSITION_EPSILON)
-                            trackRangeOffset = 0;
-
-                        if (trackRangeOffset >= 0 && trackRangeOffset <= pathTrackRange.getLength()) {
-                            var location = pathTrackRange.offsetLocation(trackRangeOffset);
-                            var waypointPathOffset = pathOffset + waypointRouteOffset - routeRange.start();
-                            waypoints.add(PathWaypointResult.userDefined(location, waypointPathOffset));
-                            waypointsOffsetsList.remove(i--); // Avoids duplicates on track transitions
-                        }
-                    }
-
-                    // Adds all waypoints in order
-                    waypoints.sort(Comparator.comparingDouble(x -> x.pathOffset));
-                    res.addAll(waypoints);
-                }
+        long lengthPrevBlocks = 0;
+        long startFirstRange = Math.round(rawPath.ranges().get(0).start());
+        for (var blockRange : rawPath.ranges()) {
+            for (var waypoint : userDefinedWaypointsPerBlock.get(blockRange.edge())) {
+                var pathOffset = lengthPrevBlocks + waypoint - startFirstRange;
+                res.add(makePendingWaypoint(infra, path, false, pathOffset, null));
             }
-
-            routeOffset += routeTrackRange.getLength();
+            lengthPrevBlocks += getBlockLength(infra, blockInfra, blockRange.edge());
         }
-        assert waypointsOffsetsList.isEmpty();
         return res;
     }
 
-    /** Truncates a track range view so that it's limited to the route range */
-    private static TrackRangeView truncateTrackRange(
-            TrackRangeView range,
-            double offset,
-            Pathfinding.EdgeRange<SignalingRoute> routeRange
+
+    /** Returns all the operational points on the path as waypoints */
+    private static Collection<PathWaypointResult> makeOperationalPoints(
+            RawSignalingInfra infra,
+            Path path
     ) {
-        var truncatedRange = range;
-        if (offset < routeRange.start()) {
-            var truncateLength = routeRange.start() - offset;
-            if (truncateLength > truncatedRange.getLength() + POSITION_EPSILON)
-                return null;
-            truncatedRange = truncatedRange.truncateBeginByLength(truncateLength);
+        var res = new ArrayList<PathWaypointResult>();
+        for (var opWithOffset : path.getOperationalPointParts()) {
+            var opId = opWithOffset.getValue();
+            var opName = infra.getOperationalPointPartName(opId);
+            res.add(makePendingWaypoint(infra, path, true, opWithOffset.getOffset(), opName));
         }
-        if (offset + range.getLength() > routeRange.end()) {
-            var truncateLength = offset + range.getLength() - routeRange.end();
-            if (truncateLength > truncatedRange.getLength() + POSITION_EPSILON)
-                return null;
-            truncatedRange = truncatedRange.truncateEndByLength(truncateLength);
-        }
-        return truncatedRange;
+        return res;
     }
 
-    /** Adds a single route to the result, including waypoints present on the route */
-    private static RJSRoutePath makeRouteResult(
-            Pathfinding.EdgeRange<SignalingRoute> element
+    /** Creates a pending waypoint from a path and its offset */
+    private static PathWaypointResult makePendingWaypoint(
+            RawSignalingInfra infra,
+            Path path,
+            boolean suggestion,
+            long pathOffset,
+            String opName
     ) {
-        var routeResult = new RJSRoutePath(
-                element.edge().getInfraRoute().getID(),
-                element.edge().getSignalingType()
-        );
-        double offset = 0;
-        for (var range : element.edge().getInfraRoute().getTrackRanges()) {
-            if (!(range.track.getEdge() instanceof TrackSection trackSection))
-                continue;
-
-            // Truncate the ranges to match the part of the route we use
-            var truncatedRange = truncateTrackRange(range, offset, element);
-            offset += range.getLength();
-            if (truncatedRange == null)
-                continue;
-
-            // Add the track ranges to the result
-            routeResult.trackSections.add(new RJSDirectionalTrackRange(
-                    trackSection.getID(),
-                    truncatedRange.getStart(),
-                    truncatedRange.getStop()
-            ));
-        }
-        return routeResult;
+        var rawLocation = path.getTrackLocationAtOffset(pathOffset);
+        var trackName = infra.getTrackSectionName(rawLocation.getTrackId());
+        var location = new PathWaypointResult.PathWaypointLocation(trackName,
+                Distance.toMeters(rawLocation.getOffset()));
+        return new PathWaypointResult(location, Distance.toMeters(pathOffset), suggestion, opName);
     }
 
-    /** Adds a single waypoint to the result */
-    static void addStep(PathfindingResult res, PathWaypointResult newStep) {
-        var waypoints = res.pathWaypoints;
-        if (waypoints.isEmpty()) {
-            waypoints.add(newStep);
-            return;
-        }
-        var lastStep = waypoints.get(waypoints.size() - 1);
-        if (lastStep.isDuplicate(newStep)) {
-            lastStep.merge(newStep);
-            return;
-        }
-        waypoints.add(newStep);
-    }
-
-    /**
-     * Coalesce several range maps into one by shifting the N+1th range so it begins
-     * at the end of the Nth one.
-     *
-     * <pre>
-     * {[[1, 5], [5, 10]], [[0, 13]], [[1, 100]]} => [[1, 5], [5, 10], [10, 23], [24, 124]]
-     * </pre>
-     */
-    static RangeMap<Double, Double> shiftingOffsetMergeRanges(List<RangeMap<Double, Double>> rangeMaps) {
-        var offset = 0.;
-        var result = TreeRangeMap.<Double, Double>create();
-        for (var tsMap : rangeMaps) {
-            for (var entry : tsMap.asMapOfRanges().entrySet()) {
-                var range = entry.getKey();
-                var shiftedRange = Range.closed(
-                        offset + range.lowerEndpoint(),
-                        offset + range.upperEndpoint()
-                );
-                result.putCoalescing(shiftedRange, entry.getValue());
+    /** Sorts the waypoints on the path. When waypoints overlap, the user-defined one is kept. */
+    private static List<PathWaypointResult> sortAndMergeDuplicates(ArrayList<PathWaypointResult> waypoints) {
+        waypoints.sort(Comparator.comparingDouble(wp -> wp.pathOffset));
+        var res = new ArrayList<PathWaypointResult>();
+        PathWaypointResult last = null;
+        for (var waypoint : waypoints) {
+            if (last != null && last.isDuplicate(waypoint))
+                last.merge(waypoint);
+            else {
+                last = waypoint;
+                res.add(last);
             }
-            var span = tsMap.span();
-            offset += span.upperEndpoint() - span.lowerEndpoint();
         }
-        return result;
+        return res;
+    }
+
+    /** Returns the geographic linestring of the path */
+    private static RJSLineString makeGeographic(Path path) {
+        return GeomUtils.toRJSLineString(path.getGeo());
+    }
+
+    /** Returns the schematic linestring of the path */
+    private static RJSLineString makeSchematic(Path path) {
+        return makeGeographic(path);    // TODO: add schematic data to the infra
+    }
+
+    /** Returns the slopes on the path */
+    private static List<SlopeChartPointResult> makeSlopes(Path path) {
+        return generateChartPoints(path.getSlopes(), SlopeChartPointResult::new);
+    }
+
+    /** Returns the curves on the path */
+    private static List<CurveChartPointResult> makeCurves(Path path) {
+        return generateChartPoints(path.getCurves(), CurveChartPointResult::new);
     }
 
     /**
      * Generates and returns a list of points, generated by `factory` for both the lower and upper endpoint of
      * each range of `ranges`, in ascending order.
      */
-    static <T> List<T> generateChartPoints(RangeMap<Double, Double> ranges, BiFunction<Double, Double, T> factory) {
-        return ranges.asMapOfRanges().entrySet().stream().flatMap(entry -> Stream.of(
-                factory.apply(entry.getKey().lowerEndpoint(), entry.getValue()),
-                factory.apply(entry.getKey().upperEndpoint(), entry.getValue())
+    private static <T> List<T> generateChartPoints(
+            DistanceRangeMap<Double> ranges,
+            BiFunction<Double, Double, T> factory
+    ) {
+        return ranges.asList().stream().flatMap(entry -> Stream.of(
+                factory.apply(Distance.toMeters(entry.getLower()), entry.getValue()),
+                factory.apply(Distance.toMeters(entry.getUpper()), entry.getValue())
         )).toList();
     }
 
-    /** Computes the graph of the curves of every TrackRangeView on path. */
-    static List<CurveChartPointResult> computeCurves(List<TrackRangeView> pathTrackRangeViews) {
-        var curves = pathTrackRangeViews.stream().map(TrackRangeView::getCurves).toList();
-        var shiftedRangeMap = shiftingOffsetMergeRanges(curves);
-        return generateChartPoints(shiftedRangeMap, CurveChartPointResult::new);
+    /** Returns the route path, from the raw block pathfinding result */
+    static List<RJSRoutePath> makeRoutePath(
+            BlockInfra blockInfra,
+            RawSignalingInfra infra,
+            List<Pathfinding.EdgeRange<Integer>> ranges
+    ) {
+        var blocks = ranges.stream()
+                .map(Pathfinding.EdgeRange::edge)
+                .toList();
+        var chunkPath = new ArrayList<Integer>();
+        var routes = blocksToRoutes(chunkPath, blockInfra, infra, blocks);
+        var startOffset = findStartOffset(infra, chunkPath.get(0), routes.get(0), ranges.get(0));
+        var endOffset = findEndOffset(infra, Iterables.getLast(chunkPath),
+                Iterables.getLast(routes), Iterables.getLast(ranges));
+        return convertRoutesToRJS(infra, routes, startOffset, endOffset);
     }
 
-    /** Computes the graph of the slopes of every TrackRangeView on path. */
-    static List<SlopeChartPointResult> computeSlopes(List<TrackRangeView> pathTrackRangeViews) {
-        var slopes = pathTrackRangeViews.stream().map(TrackRangeView::getSlopes).toList();
-        var shiftedRangeMap = shiftingOffsetMergeRanges(slopes);
-        return generateChartPoints(shiftedRangeMap, SlopeChartPointResult::new);
+    /** Converts a list of route with start/end offsets into a list of RJSRoutePath */
+    private static List<RJSRoutePath> convertRoutesToRJS(
+            RawSignalingInfra infra,
+            List<Integer> routes,
+            double startOffset,
+            double endOffset
+    ) {
+        if (routes.size() == 0)
+            return List.of();
+        if (routes.size() == 1)
+            return List.of(convertRouteToRJS(infra, routes.get(0), startOffset, endOffset));
+        var res = new ArrayList<RJSRoutePath>();
+        res.add(convertRouteToRJS(infra, routes.get(0), startOffset, null));
+        for (int i = 1; i < routes.size() - 1; i++)
+            res.add(convertRouteToRJS(infra, routes.get(i), null, null));
+        res.add(convertRouteToRJS(infra, routes.get(routes.size() - 1), null, endOffset));
+        return res;
+    }
+
+    /** Converts a single route to RJSRoutePath */
+    private static RJSRoutePath convertRouteToRJS(
+            RawSignalingInfra infra,
+            int route,
+            Double startOffset,
+            Double endOffset
+    ) {
+        if (startOffset == null)
+            startOffset = 0.;
+        if (endOffset == null)
+            endOffset = getRouteLength(infra, route);
+        return new RJSRoutePath(
+                infra.getRouteName(route),
+                makeRJSTrackRanges(infra, route, startOffset, endOffset),
+                "TODO: signaling type"
+        );
+    }
+
+    /** Make the list of RJSDirectionalTrackRange on a route */
+    private static List<RJSDirectionalTrackRange> makeRJSTrackRanges(
+            RawSignalingInfra infra,
+            int route,
+            double routeStartOffset,
+            double routeEndOffset
+    ) {
+        var res = new ArrayList<RJSDirectionalTrackRange>();
+        var chunkStartPathOffset = 0.;
+        for (var dirChunkId: toIntList(infra.getChunksOnRoute(route))) {
+            var chunkLength = Distance.toMeters(infra.getTrackChunkLength(toValue(dirChunkId)));
+            var trackId = infra.getTrackFromChunk(toValue(dirChunkId));
+            var chunkTrackOffset = Distance.toMeters(infra.getTrackChunkOffset(toValue(dirChunkId)));
+
+            var startOfRouteRange = routeStartOffset + chunkTrackOffset - chunkStartPathOffset;
+            var endOfRouteRange = routeEndOffset + chunkTrackOffset - chunkStartPathOffset;
+            var rangeStartOnTrack = Math.max(chunkTrackOffset, startOfRouteRange);
+            var rangeEndOnTrack = Math.min(chunkTrackOffset + chunkLength, endOfRouteRange);
+
+            if (rangeStartOnTrack < rangeEndOnTrack) {
+                var trackName = infra.getTrackSectionName(trackId);
+                var direction = toDirection(dirChunkId) == Direction.INCREASING ? START_TO_STOP : STOP_TO_START;
+                res.add(new RJSDirectionalTrackRange(trackName, rangeStartOnTrack, rangeEndOnTrack, direction));
+            }
+            chunkStartPathOffset += chunkLength;
+        }
+
+        // Merge the adjacent ranges
+        for (int i = 1; i < res.size(); i++) {
+            if (res.get(i).trackSectionID.equals(res.get(i - 1).trackSectionID)) {
+                assert res.get(i - 1).direction == res.get(i).direction;
+                if (res.get(i - 1).direction == START_TO_STOP) {
+                    assert Math.abs(res.get(i - 1).end - res.get(i).begin) < 1e-5;
+                    res.get(i - 1).end = res.get(i).end;
+                } else {
+                    assert Math.abs(res.get(i - 1).begin - res.get(i).end) < 1e-5;
+                    res.get(i - 1).begin = res.get(i).begin;
+                }
+                res.remove(i--);
+            }
+        }
+        return res;
+    }
+
+    /** Returns the length of a route (in meters) */
+    private static double getRouteLength(RawSignalingInfra infra, int route) {
+        return toIntList(infra.getRoutePath(route)).stream()
+                .mapToDouble(zonePathId -> Distance.toMeters(infra.getZonePathLength(zonePathId)))
+                .sum();
+    }
+
+    /** Returns the offset (in meters) of the range start on the given route */
+    private static double findStartOffset(
+            RawSignalingInfra infra,
+            int firstChunk,
+            int routeStaticIdx,
+            Pathfinding.EdgeRange<Integer> range
+    ) {
+        double offset = 0.;
+        for (var dirChunkId : toIntList(infra.getChunksOnRoute(routeStaticIdx))) {
+            if (dirChunkId == firstChunk)
+                break;
+            offset += Distance.toMeters(infra.getTrackChunkLength(toValue(dirChunkId)));
+        }
+        offset += range.start();
+        return offset;
+    }
+
+    /** Returns the offset (in meters) of the range end on the given route */
+    private static double findEndOffset(
+            RawSignalingInfra infra,
+            int lastChunk,
+            int routeStaticIdx,
+            Pathfinding.EdgeRange<Integer> range
+    ) {
+        double offset = 0.;
+        for (var dirChunkId : toIntList(infra.getChunksOnRoute(routeStaticIdx))) {
+            if (dirChunkId == lastChunk)
+                break;
+            offset += Distance.toMeters(infra.getTrackChunkLength(toValue(dirChunkId)));
+        }
+        offset += range.end();
+        return offset;
+    }
+
+    /** Converts a list of blocks into a list of routes, ignoring ranges */
+    private static List<Integer> blocksToRoutes(
+            ArrayList<Integer> chunkPath,
+            BlockInfra blockInfra,
+            RawSignalingInfra infra,
+            List<Integer> blocks
+    ) {
+        for (var blockId : blocks)
+            for (var zonePathId : toIntList(blockInfra.getBlockPath(blockId)))
+                chunkPath.addAll(toIntList(infra.getZonePathChunks(zonePathId)));
+        var chunkStartIndex = 0;
+        var res = new ArrayList<Integer>();
+        while (true) {
+            var route = findRoute(infra, chunkPath, chunkStartIndex, chunkStartIndex != 0);
+            res.add(route);
+            chunkStartIndex += infra.getChunksOnRoute(route).getSize();
+            if (chunkStartIndex >= chunkPath.size())
+                return res;
+        }
+    }
+
+    /** Finds a valid route that follows the given path */
+    private static int findRoute(
+            RawSignalingInfra infra,
+            List<Integer> chunks,
+            int startIndex,
+            boolean routeMustIncludeStart
+    ) {
+        for (var routeId : toIntList(infra.getRoutesOnTrackChunk(chunks.get(startIndex))))
+            if (routeMatchPath(infra, chunks, startIndex, routeMustIncludeStart, routeId))
+                return routeId;
+        throw new RuntimeException("Couldn't find a route matching the given chunk list");
+    }
+
+    /** Returns false if the route differs from the path */
+    private static boolean routeMatchPath(
+            RawSignalingInfra infra,
+            List<Integer> chunks,
+            int chunkIndex,
+            boolean routeMustIncludeStart,
+            int routeId
+    ) {
+        var firstChunk = chunks.get(chunkIndex);
+        var routeChunks = infra.getChunksOnRoute(routeId);
+        var routeChunkIndex = 0;
+        if (routeMustIncludeStart) {
+            if (routeChunks.get(0) != firstChunk)
+                return false;
+        } else {
+            while (routeChunks.get(routeChunkIndex) != firstChunk)
+                routeChunkIndex++;
+        }
+        while (true) {
+            if (routeChunkIndex == routeChunks.getSize())
+                return true; // end of route
+            if (chunkIndex == chunks.size())
+                return true; // end of path
+            if (routeChunks.get(routeChunkIndex) != chunks.get(chunkIndex))
+                return false; // route and path differ
+            routeChunkIndex++;
+            chunkIndex++;
+        }
+    }
+
+    /** Iterating over an iterable of value class doesn't automatically convert it to the underlying type,
+     * this prevents typing errors caused by java inability to handle them */
+    static <T> List<Integer> toIntList(StaticIdxList<T> list) {
+        var res = new ArrayList<Integer>();
+        for (int i = 0; i < list.getSize(); i++)
+            res.add(list.get(i));
+        return res;
+    }
+
+    /** Iterating over an iterable of value class doesn't automatically convert it to the underlying type,
+     * this prevents typing errors caused by java inability to handle them
+     * TODO: find a better way to handle this */
+    static <T> List<Integer> toIntList(DirStaticIdxList<T> list) {
+        var res = new ArrayList<Integer>();
+        for (int i = 0; i < list.getSize(); i++)
+            res.add(list.get(i));
+        return res;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
@@ -75,7 +75,7 @@ public class PathfindingRoutesEndpoint implements Take {
 
             var path = runPathfinding(infra, reqWaypoints, rollingStocks);
 
-            var res = PathfindingResultConverter.convert(path, infra, recorder);
+            var res = LegacyPathfindingResultConverter.convert(path, infra, recorder);
 
             validate(infra, res, reqWaypoints);
 

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathWaypointResult.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathWaypointResult.java
@@ -31,7 +31,7 @@ public class PathWaypointResult {
     /**
      * Constructor
      */
-    private PathWaypointResult(
+    public PathWaypointResult(
             PathWaypointLocation location,
             double pathOffset,
             boolean suggestion,

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathfindingResult.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathfindingResult.java
@@ -17,9 +17,9 @@ public class PathfindingResult {
             .adapter(PathfindingResult.class)
             .failOnUnknown();
     @Json(name = "route_paths")
-    public final List<RJSRoutePath> routePaths = new ArrayList<>();
+    public List<RJSRoutePath> routePaths = new ArrayList<>();
     @Json(name = "path_waypoints")
-    public final List<PathWaypointResult> pathWaypoints = new ArrayList<>();
+    public List<PathWaypointResult> pathWaypoints = new ArrayList<>();
 
     public final double length;
 

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -1,28 +1,22 @@
 package fr.sncf.osrd.api.stdcm;
 
 import fr.sncf.osrd.api.ExceptionHandler;
-import fr.sncf.osrd.api.FullInfra;
 import fr.sncf.osrd.api.InfraManager;
-import fr.sncf.osrd.api.pathfinding.PathfindingResultConverter;
+import fr.sncf.osrd.api.pathfinding.LegacyPathfindingResultConverter;
 import fr.sncf.osrd.api.pathfinding.PathfindingRoutesEndpoint;
 import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint;
-import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.stdcm.STDCMStep;
 import fr.sncf.osrd.stdcm.graph.STDCMPathfinding;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
 import fr.sncf.osrd.envelope_sim_infra.MRSP;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
-import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.railjson.parser.RJSRollingStockParser;
 import fr.sncf.osrd.railjson.parser.RJSStandaloneTrainScheduleParser;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
 import fr.sncf.osrd.standalone_sim.ScheduleMetadataExtractor;
-import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.standalone_sim.result.ResultEnvelopePoint;
 import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
 import fr.sncf.osrd.stdcm.preprocessing.implementation.RouteAvailabilityLegacyAdapter;
@@ -30,8 +24,6 @@ import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
 import fr.sncf.osrd.train.TrainStop;
-import fr.sncf.osrd.utils.graph.GraphAdapter;
-import fr.sncf.osrd.utils.graph.Pathfinding;
 import fr.sncf.osrd.utils.graph.Pathfinding.EdgeLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +133,7 @@ public class STDCMEndpoint implements Take {
                     fullInfra
             ));
             simResult.ecoSimulations.add(null);
-            var pathfindingRes = PathfindingResultConverter.convert(res.routes(), infra, recorder);
+            var pathfindingRes = LegacyPathfindingResultConverter.convert(res.routes(), infra, recorder);
             var response = new STDCMResponse(simResult, pathfindingRes, res.departureTime());
             return new RsJson(new RsWithBody(STDCMResponse.adapter.toJson(response)));
         } catch (Throwable ex) {

--- a/core/src/main/java/fr/sncf/osrd/cli/StandaloneSimulationCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/StandaloneSimulationCommand.java
@@ -8,7 +8,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import fr.sncf.osrd.api.FullInfra;
-import fr.sncf.osrd.api.pathfinding.PathfindingResultConverter;
+import fr.sncf.osrd.api.pathfinding.LegacyPathfindingResultConverter;
 import fr.sncf.osrd.api.pathfinding.PathfindingRoutesEndpoint;
 import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint;
 import fr.sncf.osrd.railjson.parser.RJSRollingStockParser;
@@ -93,7 +93,7 @@ public class StandaloneSimulationCommand implements CliCommand {
             logger.info("Running simulation for schedule group: {}", trainScheduleGroup.id);
             var rawPathfindingResult = PathfindingRoutesEndpoint.runPathfinding(
                     infra.java(), trainScheduleGroup.waypoints, rollingStocks.values());
-            var pathfindingResult = PathfindingResultConverter.convert(
+            var pathfindingResult = LegacyPathfindingResultConverter.convert(
                     rawPathfindingResult, infra.java(), diagnosticRecorder);
             var res = StandaloneSim.runFromRJS(
                     infra, null, new RJSTrainPath(pathfindingResult.routePaths), rollingStocks,

--- a/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
@@ -1,0 +1,234 @@
+package fr.sncf.osrd.api.pathfinding;
+
+import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.*;
+import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toDirection;
+import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toValue;
+import static org.junit.jupiter.api.Assertions.*;
+
+import fr.sncf.osrd.Helpers;
+import fr.sncf.osrd.api.FullInfra;
+import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
+import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
+import fr.sncf.osrd.sim_infra.api.*;
+import fr.sncf.osrd.sim_infra.impl.PathImpl;
+import fr.sncf.osrd.utils.Direction;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList;
+import fr.sncf.osrd.utils.indexing.StaticIdxList;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class PathfindingResultConverterTest {
+
+    /** Convert block ranges into a path, with the chunks going forward */
+    @Test
+    public void testMakePathForward() {
+        var infra = getSmallInfra();
+        var blocks = getBlocksOnRoutes(infra, List.of(
+                "rt.DA2->DA6_1",
+                "rt.DA6_1->DA6_2"
+        ));
+        var ranges = new ArrayList<Pathfinding.EdgeRange<Integer>>();
+        for (var block : blocks) {
+            ranges.add(new Pathfinding.EdgeRange<>(block, 0,
+                    getBlockLength(infra.rawInfra(), infra.blockInfra(), block)));
+        }
+        var path = makePath(infra.rawInfra(), infra.blockInfra(), ranges);
+        var pathImpl = (PathImpl) path;
+        var expectedLength = 1980000 + 1600000; // length of route 1 + 2
+        assertEquals(0, pathImpl.getBeginOffset());
+        assertEquals(expectedLength, pathImpl.getEndOffset());
+        checkBlocks(
+                infra,
+                pathImpl,
+                Set.of(
+                        "TA0",
+                        "TA6"
+                ),
+                Direction.INCREASING,
+                expectedLength
+        );
+    }
+
+    /** Convert block ranges into a path, with the chunks going backward and partial ranges */
+    @Test
+    public void testMakePathBackward() {
+        var infra = getSmallInfra();
+        var blocks = getBlocksOnRoutes(infra, List.of(
+                "rt.DD0_11->DD0_8",
+                "rt.DD0_8->DD0_5"
+        ));
+        assert blocks.size() == 2;
+        var ranges = List.of(
+                new Pathfinding.EdgeRange<>(blocks.get(0), 10_000,
+                        getBlockLength(infra.rawInfra(), infra.blockInfra(), blocks.get(0))),
+                new Pathfinding.EdgeRange<>(blocks.get(1), 0,
+                        getBlockLength(infra.rawInfra(), infra.blockInfra(), blocks.get(1)) - 10_000)
+        );
+        var path = makePath(infra.rawInfra(), infra.blockInfra(), ranges);
+        var pathImpl = (PathImpl) path;
+        var expectedBlockLength = 4612500 + 4612500; // length of route 1 + 2
+        assertEquals(10_000, pathImpl.getBeginOffset());
+        assertEquals(expectedBlockLength - 10_000, pathImpl.getEndOffset());
+        checkBlocks(
+                infra,
+                pathImpl,
+                Set.of(
+                        "TD0"
+                ),
+                Direction.DECREASING,
+                expectedBlockLength
+        );
+    }
+
+    /** Tests the waypoint result on a path that has one user-defined waypoint and one operational point */
+    @Test
+    public void testPathWaypoint() {
+        var infra = getSmallInfra();
+        var blocks = getBlocksOnRoutes(infra, List.of(
+                "rt.DD1_8->DD1_11"
+        ));
+        assert blocks.size() == 1;
+        var ranges = List.of(new Pathfinding.EdgeRange<>(blocks.get(0), 5_000,
+                getBlockLength(infra.rawInfra(), infra.blockInfra(), blocks.get(0))));
+        var path = makePath(infra.rawInfra(), infra.blockInfra(), ranges);
+        var rawResult = new Pathfinding.Result<>(ranges, List.of(
+                new Pathfinding.EdgeLocation<>(ranges.get(0).edge(), 10_000)
+        ));
+        var waypoints = makePathWaypoint(
+                path, rawResult, infra.rawInfra(), infra.blockInfra()
+        );
+
+        assertEquals(2, waypoints.size());
+
+        assertEquals("TD1", waypoints.get(0).location.trackSection);
+        assertEquals(12_510, waypoints.get(0).location.offset, 1e-5);
+        assertFalse(waypoints.get(0).suggestion);
+        assertNull(waypoints.get(0).id);
+
+        assertEquals("TD1", waypoints.get(1).location.trackSection);
+        assertEquals(14_000, waypoints.get(1).location.offset, 1e-5);
+        assertTrue(waypoints.get(1).suggestion);
+        assertEquals("Mid_East_station", waypoints.get(1).id);
+    }
+
+    @Test
+    public void testRoutePath() {
+        var infra = getSmallInfra();
+        var blocks = getBlocksOnRoutes(infra, List.of(
+                "rt.DA2->DA6_1",
+                "rt.DA6_1->DA6_2"
+        ));
+        var ranges = new ArrayList<Pathfinding.EdgeRange<Integer>>();
+        for (var block : blocks) {
+            ranges.add(new Pathfinding.EdgeRange<>(block, 0,
+                    getBlockLength(infra.rawInfra(), infra.blockInfra(), block)));
+        }
+        var routePath = makeRoutePath(infra.blockInfra(), infra.rawInfra(), ranges);
+        assertEquals(2, routePath.size());
+        System.out.println(routePath);
+        assertEquals("rt.DA2->DA6_1", routePath.get(0).route);
+        assertEquals(2, routePath.get(0).trackSections.size());
+        assertEquals(1820, routePath.get(0).trackSections.get(0).begin);
+        assertEquals(2000, routePath.get(0).trackSections.get(0).end);
+        assertEquals("TA0", routePath.get(0).trackSections.get(0).trackSectionID);
+        assertEquals(EdgeDirection.START_TO_STOP, routePath.get(0).trackSections.get(0).direction);
+
+        assertEquals(0, routePath.get(0).trackSections.get(1).begin);
+        assertEquals(1800, routePath.get(0).trackSections.get(1).end);
+        assertEquals("TA6", routePath.get(0).trackSections.get(1).trackSectionID);
+        assertEquals(EdgeDirection.START_TO_STOP, routePath.get(0).trackSections.get(1).direction);
+
+        assertEquals("rt.DA6_1->DA6_2", routePath.get(1).route);
+        assertEquals(1, routePath.get(1).trackSections.size());
+        assertEquals(1800, routePath.get(1).trackSections.get(0).begin);
+        assertEquals(3400, routePath.get(1).trackSections.get(0).end);
+        assertEquals("TA6", routePath.get(1).trackSections.get(0).trackSectionID);
+        assertEquals(EdgeDirection.START_TO_STOP, routePath.get(1).trackSections.get(0).direction);
+    }
+
+    /** Tests the whole conversion process. This is more of a smoke test, the values have been checked in other tests */
+    @Test
+    public void testConvert() {
+        var infra = getSmallInfra();
+        var blocks = getBlocksOnRoutes(infra, List.of(
+                "rt.DD0_11->DD0_8",
+                "rt.DD0_8->DD0_5"
+        ));
+        assert blocks.size() == 2;
+        var ranges = List.of(
+                new Pathfinding.EdgeRange<>(blocks.get(0), 10_000,
+                        getBlockLength(infra.rawInfra(), infra.blockInfra(), blocks.get(0))),
+                new Pathfinding.EdgeRange<>(blocks.get(1), 0,
+                        getBlockLength(infra.rawInfra(), infra.blockInfra(), blocks.get(1)) - 10_000)
+        );
+        var rawResult = new Pathfinding.Result<>(ranges, List.of());
+        var res = PathfindingResultConverter.convert(infra.rawInfra(), infra.blockInfra(),
+                rawResult, new DiagnosticRecorderImpl(false));
+        assertNotNull(res);
+    }
+
+    private static void checkBlocks(
+            FullInfra infra,
+            PathImpl path,
+            Set<String> allowedTracks,
+            Direction direction,
+            long length
+    ) {
+        var totalLength = 0;
+        for (Integer dirChunk : toIntList(path.getChunks())) {
+            var trackName = infra.rawInfra().getTrackSectionName(infra.rawInfra().getTrackFromChunk(toValue(dirChunk)));
+            assertTrue(allowedTracks.contains(trackName));
+            assertEquals(direction, toDirection(dirChunk));
+            totalLength += infra.rawInfra().getTrackChunkLength(toValue(dirChunk));
+        }
+        assertEquals(length, totalLength);
+    }
+
+    /** returns the blocks on the given routes */
+    private static List<Integer> getBlocksOnRoutes(FullInfra infra, List<String> names) {
+        var res = new ArrayList<Integer>();
+        var routes = new MutableStaticIdxArrayList<Route>();
+        for (var name: names)
+            routes.add(getRouteFromName(infra.rawInfra(), name));
+        var routeBlocks = LoadedSignalingInfraKt.getRouteBlocks(
+                infra.rawInfra(),
+                infra.blockInfra(),
+                routes,
+                getSignalingSystem(infra)
+        );
+        for (var blockList : routeBlocks)
+            res.addAll(toIntList(blockList));
+        return res;
+    }
+
+    /** Finds the id of the route with the given name */
+    private static int getRouteFromName(RawSignalingInfra infra, String name) {
+        for (int i = 0; i < infra.getRoutes(); i++) {
+            if (name.equals(infra.getRouteName(i)))
+                return i;
+        }
+        throw new RuntimeException("Can't find the given route");
+    }
+
+    /** Returns the idx list of signaling systems */
+    private static StaticIdxList<SignalingSystem> getSignalingSystem(FullInfra infra) {
+        var res = new MutableStaticIdxArrayList<SignalingSystem>();
+        for (int i = 0; i < infra.signalingSimulator().getSigModuleManager().getSignalingSystems(); i++)
+            res.add(i);
+        return res;
+    }
+
+    /** Loads small infra as a RawSignalingInfra */
+    private static FullInfra getSmallInfra() {
+        try {
+            return Helpers.fullInfraFromRJS(Helpers.getExampleInfra("small_infra/infra.json"));
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingTest.java
@@ -470,7 +470,7 @@ public class PathfindingTest extends ApiTest {
                     loc.offset() / 2,
                     loc.offset() + (loc.edge().getInfraRoute().getLength() - loc.offset()) / 2
             );
-            var waypoints = PathfindingResultConverter.getWaypointsOnRoute(routeRange, Set.of(loc.offset()), 0.);
+            var waypoints = LegacyPathfindingResultConverter.getWaypointsOnRoute(routeRange, Set.of(loc.offset()), 0.);
             var userDefinedWaypoints = waypoints.stream()
                     .filter(wp -> !wp.suggestion)
                     .toList();

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
@@ -47,7 +47,7 @@ class RawInfraAdapterTest {
                 val trackRangeView = trackRangeViews[0]
                 assertEquals(
                     trackRangeView.track.edge.id,
-                    infra.getTrackSectionId(infra.getTrackFromChunk(chunk.value))
+                    infra.getTrackSectionName(infra.getTrackFromChunk(chunk.value))
                 )
                 assertEquals(trackRangeView.length, infra.getTrackChunkLength(chunk.value).meters, epsilon)
                 assertEquals(trackRangeView.track.direction.toKtDirection(), chunk.direction)


### PR DESCRIPTION
Implements #4255 

The new class isn't connected to anything. The previous class has been renamed to `LegacyPathfindingResultConverter` and is still used.

This PR includes a file that is only used for debugging purpose, it's used to create watches with infra elements. I believe it can be useful enough to be pushed, but it can be removed if it's seen as just clutter. 