### PR TITLE
front: use enhanced endpoint to sort light rolling stock

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1038,6 +1038,8 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/LightRollingStock"
+                required:
+                  - results
 
   /light_rolling_stock/{id}/:
     get:

--- a/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
@@ -3,7 +3,8 @@ import ImportTrainScheduleConfig from 'applications/operationalStudies/component
 import ImportTrainScheduleTrainsList from 'applications/operationalStudies/components/ImportTrainSchedule/ImportTrainScheduleTrainsList';
 import Loader from 'common/Loader';
 import { TrainSchedule, TrainScheduleImportConfig } from 'applications/operationalStudies/types';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
+
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { setFailure } from 'reducers/main';
@@ -14,17 +15,10 @@ export default function ImportTrainSchedule() {
   const [config, setConfig] = useState<TrainScheduleImportConfig | undefined>(undefined);
   const [trainsList, setTrainsList] = useState<TrainSchedule[] | undefined>(undefined);
 
-  const { rollingStocks, isError } = osrdEditoastApi.useGetLightRollingStockQuery(
-    {
+  const { data: { results: rollingStocks } = { results: [] }, isError } =
+    enhancedEditoastApi.useGetLightRollingStockQuery({
       pageSize: 1000,
-    },
-    {
-      selectFromResult: (response) => ({
-        ...response,
-        rollingStocks: response.data?.results || [],
-      }),
-    }
-  );
+    });
 
   const updateTrainslist = (trainsSchedules?: TrainSchedule[]) => {
     setTrainsList(trainsSchedules);

--- a/front/src/applications/rollingStockEditor/Home.tsx
+++ b/front/src/applications/rollingStockEditor/Home.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { sortBy } from 'lodash';
+import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
 
 import logo from 'assets/pictures/home/rollingstockeditor.svg';
 import NavBarSNCF from 'common/BootstrapSNCF/NavBarSNCF';
@@ -10,17 +9,10 @@ import RollingStockEditor from './views/RollingStockEditor';
 const HomeRollingStockEditor: FC = () => {
   const { t } = useTranslation(['home/home', 'referenceMap']);
 
-  const { rollingStocks } = osrdEditoastApi.useGetLightRollingStockQuery(
-    {
-      pageSize: 100,
-    },
-    {
-      selectFromResult: (response) => ({
-        ...response,
-        rollingStocks: sortBy(response.data?.results, ['metadata.reference', 'name']) || [],
-      }),
-    }
-  );
+  const { data: { results: rollingStocks } = { results: [] } } =
+    enhancedEditoastApi.useGetLightRollingStockQuery({
+      pageSize: 1000,
+    });
 
   return (
     <>

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -4,9 +4,10 @@ import { setFailure } from 'reducers/main';
 import { useTranslation } from 'react-i18next';
 import { BsLightningFill } from 'react-icons/bs';
 import { MdLocalGasStation } from 'react-icons/md';
-import { isEmpty, sortBy } from 'lodash';
+import { isEmpty } from 'lodash';
 
-import { LightRollingStock, osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { LightRollingStock } from 'common/api/osrdEditoastApi';
+import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
 import { RootState } from 'reducers';
 import { getRollingStockID } from 'reducers/osrdconf/selectors';
 import Loader from 'common/Loader';
@@ -96,17 +97,14 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
     import('./RollingStockDarkMode.scss');
   }
 
-  const { rollingStocks, isSuccess, isError, error } = osrdEditoastApi.useGetLightRollingStockQuery(
-    {
-      pageSize: 1000,
-    },
-    {
-      selectFromResult: (response) => ({
-        ...response,
-        rollingStocks: sortBy(response.data?.results, ['metadata.reference', 'name']) || [],
-      }),
-    }
-  );
+  const {
+    data: { results: rollingStocks } = { results: [] },
+    isSuccess,
+    isError,
+    error,
+  } = enhancedEditoastApi.useGetLightRollingStockQuery({
+    pageSize: 1000,
+  });
   const [filteredRollingStockList, setFilteredRollingStockList] = useState<LightRollingStock[]>(
     () => filterRollingStocks(rollingStocks, filters)
   );

--- a/front/src/common/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/common/RollingStockSelector/RollingStockModal.tsx
@@ -166,7 +166,7 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
   }, [isError]);
 
   useEffect(() => {
-    if (rollingStocks !== undefined) {
+    if (rollingStocks && rollingStocks.length !== 0) {
       updateSearch();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/front/src/common/api/enhancedEditoastApi.ts
+++ b/front/src/common/api/enhancedEditoastApi.ts
@@ -1,0 +1,18 @@
+import { sortBy } from 'lodash';
+
+import { osrdEditoastApi, GetLightRollingStockApiResponse } from "./osrdEditoastApi";
+
+const enhancedEditoastApi = osrdEditoastApi.enhanceEndpoints({
+  endpoints: {
+    getLightRollingStock: {
+      transformResponse: (response: GetLightRollingStockApiResponse) => {
+        return {          
+          ...response,
+            results: sortBy(response?.results, ['metadata.reference', 'name']),
+        }
+      }
+    }
+  }
+})
+
+export { enhancedEditoastApi } ;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -771,7 +771,7 @@ export type GetLightRollingStockApiResponse = /** status 200 The rolling stock l
   count?: number;
   next?: any;
   previous?: any;
-  results?: LightRollingStock[];
+  results: LightRollingStock[];
 };
 export type GetLightRollingStockApiArg = {
   /** Page number */


### PR DESCRIPTION
Brings back the change that was previously reverted in https://github.com/osrd-project/osrd/pull/4411


also fixes #4410, thanks to @Erashin & @Uriel-Sautron !