### PR TITLE
editoast: use fixtures in tests where possible

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -65,13 +65,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
+          args: --release --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
 
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
 
       - name: Coverage
-        run: cargo tarpaulin -r ./editoast --out Xml -- --test-threads 1
+        run: cargo tarpaulin --release -r ./editoast --out Xml -- --test-threads 1
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -29,9 +29,18 @@ $ cargo run -- runserver
 
 ## Tests
 
+In order to run tests, you need to have a postgresql database running. 
+
+To avoid thread conflicts while accessing the database, use the `--test-threads=1` option.
+
+Finally, with target debug, the test threads overflow their stack. To avoid this, you can either increase the stack size with the `RUST_MIN_STACK` environment variable or use the release target.
+
 ```sh
-# limit threads to avoid test errors with database connections
-cargo test
+cargo test --release -- --test-threads=1
+
+# or
+
+RUST_MIN_STACK=8388608 cargo test -- --test-threads=1
 ```
 
 ## Useful tools

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -10,6 +10,7 @@ pub mod tests {
     };
     use crate::schema::RailJson;
     use crate::views::infra::InfraForm;
+    use crate::DbPool;
 
     use actix_web::web::Data;
     use chrono::Utc;
@@ -22,13 +23,31 @@ pub mod tests {
     #[derive(Debug)]
     pub struct TestFixture<T: Delete + Identifiable + Send> {
         pub model: T,
-        pub db_pool: Data<Pool<diesel::r2d2::ConnectionManager<diesel::PgConnection>>>,
+        pub db_pool: Data<DbPool>,
         pub infra: Option<Infra>,
     }
 
     impl<T: Delete + Identifiable + Send> TestFixture<T> {
         pub fn id(&self) -> i64 {
             self.model.get_id()
+        }
+
+        pub fn new(model: T, db_pool: Data<DbPool>) -> Self {
+            TestFixture {
+                model,
+                db_pool,
+                infra: None,
+            }
+        }
+    }
+
+    impl<T: Create + Delete + Identifiable + Send> TestFixture<T> {
+        pub async fn create(model: T, db_pool: Data<DbPool>) -> Self {
+            TestFixture {
+                model: model.create(db_pool.clone()).await.unwrap(),
+                db_pool,
+                infra: None,
+            }
         }
     }
 
@@ -42,48 +61,38 @@ pub mod tests {
     }
 
     #[fixture]
-    pub fn db_pool() -> Data<Pool<ConnectionManager<diesel::PgConnection>>> {
+    pub fn db_pool() -> Data<DbPool> {
         let manager = ConnectionManager::<PgConnection>::new(PostgresConfig::default().url());
         Data::new(Pool::builder().max_size(1).build(manager).unwrap())
     }
 
     #[fixture]
-    pub async fn fast_rolling_stock(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<RollingStockModel> {
-        TestFixture {
-            model: serde_json::from_str::<RollingStockModel>(include_str!(
+    pub async fn fast_rolling_stock(db_pool: Data<DbPool>) -> TestFixture<RollingStockModel> {
+        TestFixture::create(
+            serde_json::from_str::<RollingStockModel>(include_str!(
                 "./tests/example_rolling_stock_1.json"
             ))
-            .expect("Unable to parse")
-            .create(db_pool.clone())
-            .await
-            .unwrap(),
+            .expect("Unable to parse"),
             db_pool,
-            infra: None,
-        }
+        )
+        .await
     }
 
     #[fixture]
-    pub async fn other_rolling_stock(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<RollingStockModel> {
-        TestFixture {
-            model: serde_json::from_str::<RollingStockModel>(include_str!(
+    pub async fn other_rolling_stock(db_pool: Data<DbPool>) -> TestFixture<RollingStockModel> {
+        TestFixture::create(
+            serde_json::from_str::<RollingStockModel>(include_str!(
                 "./tests/example_rolling_stock_2_energy_sources.json"
             ))
-            .expect("Unable to parse")
-            .create(db_pool.clone())
-            .await
-            .unwrap(),
+            .expect("Unable to parse"),
             db_pool,
-            infra: None,
-        }
+        )
+        .await
     }
 
     #[fixture]
     pub async fn train_schedule(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        db_pool: Data<DbPool>,
         #[future] pathfinding: TestFixture<Pathfinding>,
         #[future] timetable: TestFixture<Timetable>,
         #[future] fast_rolling_stock: TestFixture<RollingStockModel>,
@@ -98,15 +107,11 @@ pub mod tests {
             rolling_stock.id(),
         )
         .await;
-        TestFixture {
-            model: train_schedule,
-            db_pool,
-            infra: None,
-        }
+        TestFixture::new(train_schedule, db_pool)
     }
 
     async fn make_train_schedule(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        db_pool: Data<DbPool>,
         path_id: i64,
         timetable_id: i64,
         rolling_stock_id: i64,
@@ -135,18 +140,18 @@ pub mod tests {
 
     #[fixture]
     pub async fn train_schedule_with_scenario(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        db_pool: Data<DbPool>,
         #[future] pathfinding: TestFixture<Pathfinding>,
         #[future] fast_rolling_stock: TestFixture<RollingStockModel>,
-        #[future] project_study_scenario_timetable: ProjectStudyScenarioFixtureSet,
+        #[future] scenario_fixture_set: ScenarioFixtureSet,
     ) -> TrainScheduleFixtureSet {
-        let ProjectStudyScenarioFixtureSet {
+        let ScenarioFixtureSet {
             project,
             study,
             scenario,
             timetable,
             infra,
-        } = project_study_scenario_timetable.await;
+        } = scenario_fixture_set.await;
 
         let pathfinding = pathfinding.await;
         let rolling_stock = fast_rolling_stock.await;
@@ -157,11 +162,7 @@ pub mod tests {
             rolling_stock.id(),
         )
         .await;
-        let train_schedule = TestFixture {
-            model: ts_model,
-            db_pool,
-            infra: None,
-        };
+        let train_schedule = TestFixture::new(ts_model, db_pool);
         TrainScheduleFixtureSet {
             train_schedule,
             project,
@@ -174,7 +175,7 @@ pub mod tests {
         }
     }
 
-    pub struct ProjectStudyScenarioFixtureSet {
+    pub struct ScenarioFixtureSet {
         pub project: TestFixture<Project>,
         pub study: TestFixture<Study>,
         pub scenario: TestFixture<Scenario>,
@@ -183,32 +184,13 @@ pub mod tests {
     }
 
     #[fixture]
-    pub async fn project_study_scenario_timetable(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+    pub async fn scenario_fixture_set(
+        db_pool: Data<DbPool>,
         #[future] empty_infra: TestFixture<Infra>,
         #[future] timetable: TestFixture<Timetable>,
-    ) -> ProjectStudyScenarioFixtureSet {
-        let project_model = Project {
-            name: Some(String::from("project_α")),
-            creation_date: Some(Utc::now().naive_utc()),
-            ..Project::default()
-        };
-        let project = TestFixture {
-            model: project_model.create(db_pool.clone()).await.unwrap(),
-            db_pool: db_pool.clone(),
-            infra: None,
-        };
-        let study_model = Study {
-            name: Some(String::from("study_β")),
-            project_id: Some(project.id()),
-            creation_date: Some(Utc::now().naive_utc()),
-            ..Study::default()
-        };
-        let study = TestFixture {
-            model: study_model.create(db_pool.clone()).await.unwrap(),
-            db_pool: db_pool.clone(),
-            infra: None,
-        };
+        #[future] study_fixture_set: StudyFixtureSet,
+    ) -> ScenarioFixtureSet {
+        let StudyFixtureSet { project, study } = study_fixture_set.await;
         let empty_infra = empty_infra.await;
         let timetable = timetable.await;
         let scenario_model = Scenario {
@@ -219,12 +201,8 @@ pub mod tests {
             creation_date: Some(Utc::now().naive_utc()),
             ..Scenario::default()
         };
-        let scenario = TestFixture {
-            model: scenario_model.create(db_pool.clone()).await.unwrap(),
-            db_pool: db_pool.clone(),
-            infra: None,
-        };
-        ProjectStudyScenarioFixtureSet {
+        let scenario = TestFixture::create(scenario_model, db_pool.clone()).await;
+        ScenarioFixtureSet {
             project,
             study,
             scenario,
@@ -233,25 +211,62 @@ pub mod tests {
         }
     }
 
+    pub struct StudyFixtureSet {
+        pub project: TestFixture<Project>,
+        pub study: TestFixture<Study>,
+    }
+
     #[fixture]
-    pub async fn timetable(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<Timetable> {
-        let timetable_model = Timetable {
-            id: None,
-            name: Some(String::from("with_electrical_profiles")),
+    pub async fn study_fixture_set(
+        db_pool: Data<DbPool>,
+        #[future] project: TestFixture<Project>,
+    ) -> StudyFixtureSet {
+        let project = project.await;
+        let study_model = Study {
+            name: Some("test_study".into()),
+            project_id: Some(project.id()),
+            description: Some("test".into()),
+            creation_date: Some(Utc::now().naive_utc()),
+            business_code: Some("AAA".into()),
+            service_code: Some("BBB".into()),
+            state: Some("some_type".into()),
+            study_type: Some("some_type".into()),
+            budget: Some(0),
+            tags: Some(vec![]),
+            ..Default::default()
         };
-        TestFixture {
-            model: timetable_model.create(db_pool.clone()).await.unwrap(),
-            db_pool,
-            infra: None,
+        StudyFixtureSet {
+            project,
+            study: TestFixture::create(study_model, db_pool).await,
         }
     }
 
     #[fixture]
-    pub async fn document_example(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<Document> {
+    pub async fn project(db_pool: Data<DbPool>) -> TestFixture<Project> {
+        let project_model = Project {
+            name: Some("test_project".into()),
+            objectives: Some("".into()),
+            description: Some("".into()),
+            funders: Some("".into()),
+            budget: Some(0),
+            tags: Some(vec![]),
+            creation_date: Some(Utc::now().naive_utc()),
+            ..Default::default()
+        };
+        TestFixture::create(project_model, db_pool).await
+    }
+
+    #[fixture]
+    pub async fn timetable(db_pool: Data<DbPool>) -> TestFixture<Timetable> {
+        let timetable_model = Timetable {
+            id: None,
+            name: Some(String::from("with_electrical_profiles")),
+        };
+        TestFixture::create(timetable_model, db_pool).await
+    }
+
+    #[fixture]
+    pub async fn document_example(db_pool: Data<DbPool>) -> TestFixture<Document> {
         let img = image::open("src/tests/example_rolling_stock_image_1.gif").unwrap();
         let mut img_bytes: Vec<u8> = Vec::new();
         assert!(img
@@ -260,19 +275,12 @@ pub mod tests {
                 image::ImageOutputFormat::Png
             )
             .is_ok());
-        TestFixture {
-            model: Document::new(String::from("image/png"), img_bytes)
-                .create(db_pool.clone())
-                .await
-                .unwrap(),
-            db_pool,
-            infra: None,
-        }
+        TestFixture::create(Document::new(String::from("image/png"), img_bytes), db_pool).await
     }
 
     #[fixture]
     pub async fn rolling_stock_livery(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        db_pool: Data<DbPool>,
         #[future] fast_rolling_stock: TestFixture<RollingStockModel>,
         #[future] document_example: TestFixture<Document>,
     ) -> TestFixture<RollingStockLiveryModel> {
@@ -284,50 +292,32 @@ pub mod tests {
             rolling_stock_id: Some(rolling_stock.id()),
             compound_image_id: Some(Some(image.id())),
         };
-        TestFixture {
-            model: rolling_stock_livery.create(db_pool.clone()).await.unwrap(),
-            db_pool,
-            infra: None,
-        }
+        TestFixture::create(rolling_stock_livery, db_pool).await
     }
 
     #[fixture]
     pub async fn electrical_profile_set(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
+        db_pool: Data<DbPool>,
     ) -> TestFixture<ElectricalProfileSet> {
-        TestFixture {
-            model: serde_json::from_str::<ElectricalProfileSet>(include_str!(
+        TestFixture::create(
+            serde_json::from_str::<ElectricalProfileSet>(include_str!(
                 "./tests/electrical_profile_set.json"
             ))
-            .expect("Unable to parse")
-            .create(db_pool.clone())
-            .await
-            .unwrap(),
+            .expect("Unable to parse"),
             db_pool,
-            infra: None,
-        }
+        )
+        .await
     }
 
     #[fixture]
-    pub async fn empty_infra(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<Infra> {
+    pub async fn empty_infra(db_pool: Data<DbPool>) -> TestFixture<Infra> {
         let infra_form = InfraForm {
             name: String::from("test_infra"),
         };
-        TestFixture {
-            model: Infra::from(infra_form)
-                .create(db_pool.clone())
-                .await
-                .unwrap(),
-            db_pool,
-            infra: None,
-        }
+        TestFixture::create(Infra::from(infra_form), db_pool).await
     }
 
-    async fn make_small_infra(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> Infra {
+    async fn make_small_infra(db_pool: Data<DbPool>) -> Infra {
         let railjson: RailJson =
             serde_json::from_str(include_str!("tests/small_infra/small_infra.json")).unwrap();
         let infra = Infra::from(InfraForm {
@@ -347,20 +337,12 @@ pub mod tests {
     /// is made, the `editoast/tests/small_infra/small_infra.json` file should be updated
     /// to the latest infra description.
     #[fixture]
-    pub async fn small_infra(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<Infra> {
-        TestFixture {
-            model: make_small_infra(db_pool.clone()).await,
-            db_pool,
-            infra: None,
-        }
+    pub async fn small_infra(db_pool: Data<DbPool>) -> TestFixture<Infra> {
+        TestFixture::new(make_small_infra(db_pool.clone()).await, db_pool)
     }
 
     #[fixture]
-    pub async fn pathfinding(
-        db_pool: Data<Pool<ConnectionManager<diesel::PgConnection>>>,
-    ) -> TestFixture<Pathfinding> {
+    pub async fn pathfinding(db_pool: Data<DbPool>) -> TestFixture<Pathfinding> {
         let small_infra = make_small_infra(db_pool.clone()).await;
         let pf_cs = PathfindingChangeset {
             infra_id: small_infra.id,

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -129,7 +129,7 @@ impl From<TrainScheduleChangeset> for TrainSchedule {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, Clone, Queryable)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Queryable)]
 pub struct TrainScheduleDetails {
     pub id: i64,
     pub train_name: String,

--- a/editoast/src/tests/train_schedule.json
+++ b/editoast/src/tests/train_schedule.json
@@ -1,5 +1,4 @@
 {
-  "id": 74,
   "train_name": "train δ",
   "labels": [],
   "departure_time": 36000,


### PR DESCRIPTION
This PR uses fixtures everywhere I found objects being instantiated in db, except in post endpoints where we really want to create objects.

However, this makes the test overflow their stack.
This can be solved by passing the `--release` flag to the command or to set the variable `RUST_MIN_STACK` to something greater than `3.000.000`.
In the CI, I used the flag (because I couldn't make it work with the variable) but it slows down the `editoast tests` CI to 30 min... (against 15 to 20 normally)