### PR TITLE
editoast: allow create_livery for locked rolling_stock

### DIFF
--- a/editoast/src/views/rolling_stocks/mod.rs
+++ b/editoast/src/views/rolling_stocks/mod.rs
@@ -323,9 +323,6 @@ async fn create_livery(
     MultipartForm(form): MultipartForm<RollingStockLiveryCreateForm>,
 ) -> Result<Json<RollingStockLivery>> {
     let rolling_stock_id = rolling_stock_id.into_inner();
-    assert_rolling_stock_unlocked(
-        retrieve_existing_rolling_stock(&db_pool, rolling_stock_id).await?,
-    )?;
 
     let formatted_images = format_images(form.images)?;
 


### PR DESCRIPTION
If rolling_stock is locked and has no livery (for ex, if it is imported from osrd_dags), you can't create a livery for it. Create_livery should be allowed for locked rolling_stock.