### PR TITLE
editoast: docker-compose: stop providing ROCKET_PROFILE

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -114,8 +114,6 @@ services:
       args:
         OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
     restart: unless-stopped
-    environment:
-      ROCKET_PROFILE: debug
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
       start_period: 4s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,6 @@ services:
     ports: ["8090:80"]
     environment:
       EDITOAST_PORT: 80
-      ROCKET_PROFILE: debug
       PSQL_HOST: "postgres"
       REDIS_URL: "redis://redis"
       OSRD_BACKEND_URL: "http://osrd-core"


### PR DESCRIPTION
We use Actix Web now, not Rocket.