### PR TITLE
editoast: add OpenAPI generation command

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -67,6 +67,9 @@ jobs:
           command: test
           args: --release --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
 
+      - name: Check openapi.yaml sync
+        run: diff <(cargo run --manifest-path editoast/Cargo.toml -- openapi) editoast/openapi.yaml
+
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
 

--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -68,7 +68,7 @@ jobs:
           args: --release --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
 
       - name: Check openapi.yaml sync
-        run: diff <(cargo run --manifest-path editoast/Cargo.toml -- openapi) editoast/openapi.yaml
+        run: diff <(cargo run --release --manifest-path editoast/Cargo.toml -- openapi) editoast/openapi.yaml
 
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "74bb1b4028935821b2d6b439bba2e970bdcf740832732437ead910c632e30d7d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "5ae467cbb0111869b765e13882a1dbbd6cb52f58203d8b80c44f667d4dd19843"
 dependencies = [
  "anstream",
  "anstyle",
@@ -702,14 +702,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -962,7 +962,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1025,7 +1025,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1045,8 +1045,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1102,6 +1108,7 @@ dependencies = [
  "pathfinding",
  "pointy",
  "postgis_diesel",
+ "pretty_assertions",
  "r2d2",
  "rand 0.8.5",
  "rangemap",
@@ -1118,6 +1125,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror",
+ "utoipa",
  "uuid",
 ]
 
@@ -1128,7 +1136,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1163,7 +1171,7 @@ checksum = "8560b409800a72d2d7860f8e5f4e0b0bd22bea6a352ea2a9ce30ccdef7f16d2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1420,7 +1428,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1471,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1019f6d372c5b53143f08deee4168d05c22920fe5e0f51f0dfb0e8ffb67ec11e"
+checksum = "9705398c5c7b26132e74513f4ee7c1d7dafd786004991b375c172be2be0eecaa"
 dependencies = [
  "approx",
  "num-traits",
@@ -1776,6 +1784,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1845,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -2196,7 +2205,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2338,9 +2347,9 @@ checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathfinding"
@@ -2379,7 +2388,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2440,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "postgis_diesel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9805d68d829535231159223a33b95292f7a9607e2617fd95223a361bc95a0c6"
+checksum = "f8253e9ecb290114a2cd4b7412ac03ebf92814daa89a96390b19f2933288d52d"
 dependencies = [
  "byteorder",
  "diesel",
@@ -2465,10 +2474,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.64"
+name = "pretty_assertions"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2535,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -2778,7 +2821,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.25",
+ "syn 2.0.26",
  "unicode-ident",
 ]
 
@@ -2832,15 +2875,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schannel"
@@ -2862,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2897,9 +2940,9 @@ checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "sentry"
@@ -3037,14 +3080,14 @@ checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -3074,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3206,7 +3249,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -3222,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3271,7 +3314,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -3456,9 +3499,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3471,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "ureq"
@@ -3507,10 +3550,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "uuid"
-version = "1.4.0"
+name = "utoipa"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+checksum = "68ae74ef183fae36d650f063ae7bde1cacbe1cd7e72b617cbe1e985551878b98"
+dependencies = [
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea8ac818da7e746a63285594cce8a96f5e00ee31994e655bd827569cb8b137b"
+dependencies = [
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "serde",
@@ -3588,7 +3657,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
  "wasm-bindgen-shared",
 ]
 
@@ -3622,7 +3691,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.26",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3763,6 +3832,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zstd"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -61,8 +61,10 @@ reqwest = { version = "0.11", features = ["json"] }
 osm4routing = "0.5.8"
 osmpbfreader = "0.16.0"
 itertools = "0.11"
+utoipa = { version = "3.3.0", features = ["actix_extras"] }
 
 [dev-dependencies]
 async-std = { version = "1.5", features = ["attributes", "tokio1"] }
 rstest = "0.18"
 tempfile = "3.6.0"
+pretty_assertions = "1.4.0"

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -56,3 +56,13 @@ To install them simply run:
 $ rustup component add rustfmt clippy
 $ cargo install cargo-tarpaulin
 ```
+
+## OpenApi generation
+
+We have to keep the OpenApi of the service statically in the repository.
+To make sure it is always valid a CI check has been set up. To update the
+OpenApi when a change has been made to an endpoint, run the following command:
+
+```sh
+cargo run openapi > openapi.yaml
+```

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1,2289 +1,1054 @@
-openapi: 3.0.2
-info:
-  title: OSRD Editoast
-  description: OSRD Edition service description
-  version: 0.1.0
-
-tags:
-  - name: infra
-    description: Infra
-  - name: routes
-    description: Operations related to infra routes
-  - name: timetable
-    description: Timetable
-  - name: pathfinding
-    description: Pathfinding operations
-  - name: layers
-    description: Map layers
-  - name: electrical_profiles
-    description: Electrical profiles
-  - name: train_schedule
-    description: Train Schedule
-
-paths:
-  /health/:
-    get:
-      responses:
-        200:
-          description: Check if Editoast is running correctly
-
-  /version/:
-    get:
-      responses:
-        200:
-          description: Return the service version
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  git_describe:
-                    type: string
-                    nullable: true
-                required:
-                  - git_describe
-
-  /search/:
-    post:
-      summary: Generic search endpoint
-      parameters:
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-          description: number of results
-      requestBody:
-        description: Search query
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                object:
-                  type: string
-                  example: "operationalpoint"
-                query:
-                  $ref: "#/components/schemas/SearchQuery"
-                page:
-                  type: integer
-                  default: 1
-                page_size:
-                  type: integer
-                  default: 25
-      responses:
-        200:
-          description: Search results, the structure of the returned objects depend on their type
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: "#/components/schemas/SearchTrackResult"
-                    - $ref: "#/components/schemas/SearchOperationalPointResult"
-                    - $ref: "#/components/schemas/SearchSignalResult"
-                    - $ref: "#/components/schemas/SearchStudyResult"
-                    - $ref: "#/components/schemas/SearchProjectResult"
-                    - $ref: "#/components/schemas/SearchScenarioResult"
-
-  /layers/layer/{layer_slug}/mvt/{view_slug}/:
-    get:
-      tags:
-        - layers
-      summary: Mvt View Metadata
-      parameters:
-        - required: true
-          schema:
-            title: Layer Slug
-            type: string
-          name: layer_slug
-          in: path
-        - required: true
-          schema:
-            title: View Slug
-            type: string
-          name: view_slug
-          in: path
-        - required: true
-          schema:
-            title: Infra id
-            type: integer
-          name: infra
-          in: query
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ViewMetadata"
-
-  /layers/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}/:
-    get:
-      tags:
-        - layers
-      summary: Mvt tile from the cache or the database, cache data in redis if needed
-      parameters:
-        - required: true
-          schema:
-            title: Layer Slug
-            type: string
-          name: layer_slug
-          in: path
-        - required: true
-          schema:
-            title: View Slug
-            type: string
-          name: view_slug
-          in: path
-        - required: true
-          schema:
-            title: Z
-            type: integer
-          name: z
-          in: path
-        - required: true
-          schema:
-            title: X
-            type: integer
-          name: x
-          in: path
-        - required: true
-          schema:
-            title: Y
-            type: integer
-          name: y
-          in: path
-        - required: true
-          schema:
-            title: Infra
-            type: integer
-          name: infra
-          in: query
-      responses:
-        200:
-          description: Successful Response
-          content:
-            application/x-octet-stream:
-              schema:
-                type: string
-
-  /infra/:
-    get:
-      tags:
-        - infra
-      summary: List all available infra
-      responses:
-        200:
-          description: The infra list
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Infra"
-                required: [count, next, previous]
-    post:
-      tags:
-        - infra
-      summary: Create an infra
-      requestBody:
-        description: Name of the infra to create
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-      responses:
-        201:
-          description: The created infra
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Infra"
-
-  /infra/{id}/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve a specific infra
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        200:
-          description: Information about the retrieved infra
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Infra"
-    delete:
-      tags:
-        - infra
-      summary: Delete an infra and all entities linked to it
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        204:
-          description: No content
-
-    post:
-      tags:
-        - infra
-      summary: Update/Create/Delete an object of the infra
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      requestBody:
-        description: Operations to do on the infra
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/Operation"
-      responses:
-        200:
-          description: An array containing infos about the operations processed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/OperationResult"
-
-    put:
-      tags:
-        - infra
-      summary: Update an infrastructure name
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      requestBody:
-        description: the name we want to give to the infra
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-      responses:
-        200:
-          description: The updated infra
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Infra"
-
-  /infra/{id}/load/:
-    post:
-      tags:
-        - infra
-      summary: Load an infra if not loaded
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        200:
-          description: No content
-
-  /infra/{id}/railjson/:
-    get:
-      tags:
-        - infra
-      summary: Serialize an infra to railjson
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-      responses:
-        200:
-          description: The infra in railjson format
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RailjsonFile"
-
-  /infra/railjson/:
-    post:
-      tags:
-        - infra
-      summary: Import an infra from railjson
-      parameters:
-        - in: query
-          name: name
-          schema:
-            type: string
-          description: Infra name
-          required: true
-        - in: query
-          name: generate_data
-          schema:
-            type: boolean
-            description: whether the layer should be generated or no
-            default: false
-      requestBody:
-        description: Railjson infra
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RailjsonFile"
-        required: true
-      responses:
-        201:
-          description: The imported infra id
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-
-  /infra/{id}/errors/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve a paginated list of errors
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-        - in: query
-          name: page
-          schema:
-            type: integer
-            default: 1
-          description: The page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            default: 25
-            minimum: 10
-          description: The number of item per page
-        - in: query
-          name: error_type
-          schema:
-            $ref: "#/components/schemas/InfraErrorType"
-          description: The type of error to filter on
-        - in: query
-          name: object_id
-          schema:
-            type: string
-          description: errors and warnings that only part of a given object
-        - in: query
-          name: level
-          schema:
-            type: string
-            enum: [errors, warnings, all]
-            default: all
-          description: Whether the response should include errors or warnings
-      responses:
-        200:
-          description: A paginated list of errors
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                    description: Total number of elements
-                    example: 1
-                  next:
-                    type: integer
-                    nullable: true
-                    example: null
-                    description: The index of the following page (null if no more pages available)
-                  previous:
-                    type: integer
-                    nullable: true
-                    example: null
-                    description: The index of the previous page (null if requesting the first page)
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/InfraError"
-
-  /infra/{id}/switch_types/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve a list of switch types
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        200:
-          description: A list of switch types
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  description: A switch type following Railjson spec
-                  example:
-                    id: Point
-                    ports: [LEFT, RIGHT, BASE]
-                    groups:
-                      LEFT: { src: BASE, dst: LEFT }
-                      RIGHT: { src: BASE, dst: RIGHT }
-
-  /infra/refresh/:
-    post:
-      tags:
-        - infra
-      summary: Refresh the layers
-      parameters:
-        - in: query
-          name: infras
-          schema:
-            type: array
-            items:
-              type: integer
-            default: []
-          description: A list of infra ID
-        - in: query
-          name: force
-          schema:
-            type: boolean
-            default: false
-          description: Force the refresh of the layers
-      responses:
-        200:
-          description: A list thats contains the ID of the infras that were refreshed*
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: integer
-
-  /infra/{id}/lines/{line_code}/bbox/:
-    get:
-      tags:
-        - infra
-      summary: Returns the BBoxes (geo and schematic) of a line
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-        - in: path
-          name: line_code
-          schema:
-            type: integer
-          description: a line code
-          required: true
-      responses:
-        200:
-          description: The BBox of the line
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Zone"
-
-  /infra/{id}/lock/:
-    post:
-      tags:
-        - infra
-      summary: Lock an infra from edition
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        204:
-          description: No content
-
-  /infra/{id}/unlock/:
-    post:
-      tags:
-        - infra
-      summary: Unlock an infra from edition
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        204:
-          description: No content
-
-  /infra/{id}/speed_limit_tags/:
-    get:
-      tags:
-        - infra
-      summary: List all speed limit tags
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra id
-          required: true
-      responses:
-        200:
-          description: Tags list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                example: ["freight", "heavy_load"]
-
-  /infra/{id}/voltages/:
-    get:
-      tags:
-        - infra
-      summary: List all voltages
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-        - in: query
-          name: include_rolling_stock_modes
-          schema:
-            type: boolean
-          description: include rolling stocks modes or not
-          required: false
-      responses:
-        200:
-          description: Voltages list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                example: ["750", "1500", "2500.5"]
-
-  /infra/{id}/attached/{track_id}/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve all objects attached to a given track
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-        - in: path
-          name: track_id
-          schema:
-            type: string
-          description: Track ID
-          required: true
-      responses:
-        200:
-          description: All objects attached to the given track (arranged by types)
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: array
-                  items:
-                    type: string
-                    description: Object IDs
-                example:
-                  Switch: ["switch.0", "switch.1"]
-                  Detector: ["detector.0"]
-                  BufferStop: []
-
-  /infra/{id}/routes/{waypoint_type}/{waypoint_id}/:
-    get:
-      tags:
-        - infra
-        - routes
-      summary: Retrieve all routes that starting and ending by the given waypoint (detector or buffer stop)
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-        - in: path
-          name: waypoint_type
-          schema:
-            type: string
-            enum: [Detector, BufferStop]
-          description: Type of the waypoint
-          required: true
-        - in: path
-          name: waypoint_id
-          schema:
-            type: string
-          description: The waypoint id
-          required: true
-      responses:
-        200:
-          description: All routes that starting and ending by the given waypoint
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  starting:
-                    type: array
-                    items:
-                      type: string
-                    example: ["route1", "route2"]
-                  ending:
-                    type: array
-                    items:
-                      type: string
-                    example: ["route3", "route4"]
-
-  /infra/{id}/routes/track_ranges/:
-    get:
-      tags:
-        - infra
-        - routes
-      summary: Compute the track ranges through which routes passes.
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-        - in: query
-          name: routes
-          schema:
-            type: string
-            description: A list of routes seperated by comma
-            example: "route1,route2,route3"
-          required: true
-      responses:
-        200:
-          description: Foreach route, the track ranges through which it passes or an error
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: "#/components/schemas/RouteTrackRangesNotFoundError"
-                    - $ref: "#/components/schemas/RouteTrackRangesCantComputePathError"
-                    - $ref: "#/components/schemas/RouteTrackRangesComputed"
-
-  /infra/{id}/pathfinding/:
-    post:
-      tags:
-        - infra
-        - pathfinding
-      summary: Compute paths given starting and ending track location. Return shortest paths.
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra ID
-          required: true
-        - in: query
-          name: number
-          schema:
-            type: number
-            format: integer
-            minimum: 1
-            maximum: 5
-            default: 5
-          description: Maximum number of paths to return
-      requestBody:
-        description: Starting and ending track location
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                starting:
-                  allOf:
-                    - $ref: "#/components/schemas/TrackLocation"
-                    - type: object
-                      properties:
-                        direction:
-                          $ref: "#/components/schemas/Direction"
-                ending:
-                  $ref: "#/components/schemas/TrackLocation"
-      responses:
-        200:
-          description: Paths, containing track ranges, detectors and switches with their directions. If no path is found, an empty list is returned.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    track_ranges:
-                      type: array
-                      minItems: 1
-                      items:
-                        $ref: "#/components/schemas/DirectionalTrackRange"
-                    detectors:
-                      type: array
-                      items:
-                        type: string
-                        example: "detector1"
-                    switches_directions:
-                      type: object
-                      example: { "switch1": "left", "switch2": "right" }
-                      additionalProperties:
-                        type: string
-
-  /infra/{id}/objects/{object_type}/:
-    post:
-      tags:
-        - infra
-      summary: "Retrieve a list of specific objects in railjson format"
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra id
-          required: true
-        - in: path
-          name: object_type
-          schema:
-            $ref: "#/components/schemas/ObjectType"
-          description: The type of the object
-          required: true
-      requestBody:
-        description: List of object id's
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                type: string
-      responses:
-        200:
-          description: No content
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - railjson
-                    - geographic
-                    - schematic
-                  properties:
-                    railjson:
-                      description: Object properties in railjson format
-                      $ref: "#/components/schemas/Railjson"
-                    geographic:
-                      description: object's geographic in geojson format
-                      $ref: "#/components/schemas/Geometry"
-                    schematic:
-                      description: object's schematic in geojson format
-                      $ref: "#/components/schemas/Geometry"
-
-  /infra/{id}/clone/:
-    post:
-      tags:
-        - infra
-      summary: Duplicate an infra
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Infra id
-          required: true
-        - in: query
-          name: name
-          schema:
-            type: string
-          description: New infra name
-          required: true
-      responses:
-        201:
-          description: The duplicated infra id
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id: { type: integer }
-
-  /electrical_profile_set/:
-    get:
-      tags:
-        - electrical_profiles
-      summary: Retrieve the list of ids and names of electrical profile sets available
-      responses:
-        200:
-          description: The list of ids and names of electrical profile sets available
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  required:
-                    - id
-                    - name
-                  properties:
-                    id:
-                      type: integer
-                    name:
-                      type: string
-                      example: "France 2023"
-
-    post:
-      tags:
-        - electrical_profiles
-      summary: import a new electrical profile set
-      parameters:
-        - in: query
-          name: name
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: The list of ids and names of electrical profile sets available
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ElectricalProfile"
-
-  /electrical_profile_set/{id}/:
-    get:
-      tags:
-        - electrical_profiles
-      summary: Retrieve the set of electrical profiles with the given id
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Electrical profile set ID
-          required: true
-      responses:
-        200:
-          description: The list of electrical profiles in the set
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ElectricalProfile"
-
-  /electrical_profile_set/{id}/level_order/:
-    get:
-      tags:
-        - electrical_profiles
-      summary: Retrieve the order of strength of the electrical profiles in the set with the given id
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Electrical profile set ID
-          required: true
-      responses:
-        200:
-          description: A dictionary mapping catenary modes to a list of electrical profiles ordered by decreasing strength
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: array
-                  items:
-                    type: string
-                example:
-                  "1500": ["A", "B", "C"]
-                  "25000": ["25000", "22500", "20000"]
-
-  /documents/{key}/:
-    get:
-      tags:
-        - documents
-      summary: Retrieve a document binary content
-      parameters:
-        - in: path
-          name: key
-          schema:
-            type: integer
-          description: A key identifying the document
-          required: true
-      responses:
-        200:
-          description: A document of any type (can be an image, a pdf...)
-    delete:
-      tags:
-        - documents
-      summary: Delete a document
-      parameters:
-        - in: path
-          name: key
-          schema:
-            type: integer
-          description: A key identifying the document
-          required: true
-      responses:
-        204:
-          description: No content
-
-  /documents/:
-    post:
-      tags:
-        - documents
-      summary: Add a document
-      responses:
-        201:
-          description: The key of the added document
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  document_key:
-                    type: integer
-                    example: 42
-
-  /light_rolling_stock/:
-    get:
-      tags:
-        - rolling_stock
-      summary: Paginated list of rolling stock with a lighter response
-      parameters:
-        - in: query
-          name: page
-          schema:
-            type: integer
-            minimum: 1
-            default: 1
-          description: Page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            maximum: 10000
-            minimum: 1
-            default: 100
-          description: Number of elements by page
-      responses:
-        200:
-          description: The rolling stock list
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/LightRollingStock"
-                required:
-                  - results
-
-  /light_rolling_stock/{id}/:
-    get:
-      tags:
-        - rolling_stock
-      summary: Retrieve a rolling stock's light representation
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Rolling Stock ID
-          required: true
-      responses:
-        200:
-          description: The rolling stock with their simplified effort curves
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LightRollingStock"
-
-  /pathfinding/:
-    post:
-      summary: Create a Path
-      requestBody:
-        description: Path information
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PathQuery"
-      responses:
-        201:
-          description: The created Path
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Path"
-
-  /pathfinding/{id}/:
-    get:
-      tags:
-        - pathfinding
-      summary: Retrieve a Path
-      parameters:
-        - in: path
-          name: id
-          schema: { type: integer }
-          description: Path ID
-          required: true
-      responses:
-        200:
-          description: The retrieved path
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Path"
-    put:
-      tags:
-        - pathfinding
-      summary: Update a path
-      parameters:
-        - in: path
-          name: id
-          schema: { type: integer }
-          description: Path ID
-          required: true
-      requestBody:
-        description: Updated Path
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PathQuery"
-      responses:
-        200:
-          description: The updated path
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Path"
-    delete:
-      tags:
-        - pathfinding
-      summary: Delete a path
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Path ID
-          required: true
-      responses:
-        204:
-          description: No content
-
-  /rolling_stock/:
-    post:
-      tags:
-        - rolling_stock
-      summary: Create a rolling stock
-      parameters:
-        - in: query
-          name: locked
-          description: whether or not the rolling_stock can be edited/deleted.
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RollingStockUpsertPayload"
-      responses:
-        200:
-          description: The created rolling stock
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RollingStock"
-
-  /rolling_stock/{id}/:
-    get:
-      tags:
-        - rolling_stock
-      summary: Retrieve a rolling stock
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Rolling Stock ID
-          required: true
-      responses:
-        200:
-          description: The rolling stock information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RollingStock"
-    patch:
-      tags:
-        - rolling_stock
-      summary: Patch a rolling stock
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Rolling Stock ID
-          required: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RollingStockUpsertPayload"
-      responses:
-        200:
-          description: The updated rolling stock
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RollingStock"
-    delete:
-      tags:
-        - rolling_stock
-      summary: Delete a rolling_stock and all entities linked to it
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: rolling_stock id
-          required: true
-        - in: query
-          name: force
-          description: force the deletion even if it’s used
-          schema:
-            type: boolean
-            default: false
-      responses:
-        204:
-          description: No content
-        409:
-          description: Rolling stock is used in a train schedule.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RollingStockUsage"
-
-  /rolling_stock/{id}/locked/:
-    patch:
-      tags:
-        - rolling_stock
-      summary: Update rolling_stock locked field
-      parameters:
-        - in: path
-          name: id
-          description: Rolling_stock id
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        description: New locked value
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                locked:
-                  type: boolean
-      responses:
-        204:
-          description: No content
-        404:
-          description: Not found
-
-  /rolling_stock/{id}/livery/:
-    post:
-      tags:
-        - rolling_stock
-        - rolling_stock_livery
-      summary: Create a rolling stock livery
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Rolling Stock ID
-          required: true
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                images:
-                  type: array
-                  items:
-                    type: string
-                    format: binary
-      responses:
-        200:
-          description: The rolling stock livery
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RollingStockLivery"
-
-  /projects/:
-    post:
-      tags:
-        - projects
-      summary: Create a new project
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ProjectCreateRequest"
-      responses:
-        201:
-          description: The created project
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectResult"
-    get:
-      tags:
-        - projects
-      summary: Paginated list of projects
-      parameters:
-        - in: query
-          name: ordering
-          schema:
-            type: string
-            enum:
-              [
-                "NameAsc",
-                "NameDesc",
-                "CreationDateAsc",
-                "CreationDateDesc",
-                "LastModifiedAsc",
-                "LastModifiedDesc",
-              ]
-        - in: query
-          name: name
-          schema:
-            type: string
-          description: Filter projects by name
-        - in: query
-          name: description
-          schema:
-            type: string
-          description: Filter projects by description
-        - in: query
-          name: tags
-          schema:
-            type: string
-          description: Filter projects by tags
-        - in: query
-          name: page
-          schema:
-            type: integer
-            minimum: 0
-          description: Page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            maximum: 10000
-            minimum: 1
-            default: 100
-          description: Number of elements by page
-      responses:
-        200:
-          description: the project list
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/ProjectResult"
-
-  /projects/{project_id}/:
-    get:
-      tags:
-        - projects
-      summary: Retrieve a project
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id you want to retrieve
-          required: true
-      responses:
-        200:
-          description: The project info
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectResult"
-    patch:
-      tags:
-        - projects
-      summary: Update a project
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id you want to update
-          required: true
-      requestBody:
-        description: The fields you want to update
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ProjectPatchRequest"
-      responses:
-        200:
-          description: The project updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ProjectResult"
-    delete:
-      tags:
-        - projects
-      summary: delete a project
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id you want to delete
-          required: true
-      responses:
-        204:
-          description: No content
-
-  /timetable/{id}/:
-    get:
-      tags:
-        - timetable
-      summary: Retrieve a timetable and its train schedules
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Timetable ID
-          required: true
-      responses:
-        200:
-          description: The timetable content
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TimetableWithSchedulesDetails"
-
-  /timetable/{id}/conflicts/:
-    get:
-      tags:
-        - timetable
-      summary: Retrieve all conflicts for a specific timetable
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Timetable ID
-          required: true
-      responses:
-        200:
-          description: The timetable conflicts content
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    train_ids:
-                      type: array
-                      items:
-                        type: number
-                    train_names:
-                      type: array
-                      items:
-                        type: string
-                    start_time:
-                      type: string
-                    end_time:
-                      type: string
-                    conflict_type:
-                      type: string
-                  required:
-                    [
-                      train_ids,
-                      train_names,
-                      start_time,
-                      end_time,
-                      conflict_type,
-                    ]
-
-  /projects/{project_id}/studies/:
-    post:
-      tags:
-        - studies
-      summary: Create a new operational study
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          required: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/StudyUpsertRequest"
-      responses:
-        201:
-          description: The created operational study
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/StudyResult"
-    get:
-      tags:
-        - studies
-      summary: Paginated list of operational studies
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          required: true
-        - in: query
-          name: ordering
-          schema:
-            type: string
-            enum:
-              [
-                "NameAsc",
-                "NameDesc",
-                "CreationDateAsc",
-                "CreationDateDesc",
-                "LastModifiedAsc",
-                "LastModifiedDesc",
-              ]
-        - in: query
-          name: name
-          schema:
-            type: string
-          description: Filter operational studies by name
-        - in: query
-          name: description
-          schema:
-            type: string
-          description: Filter operational studies by description
-        - in: query
-          name: tags
-          schema:
-            type: string
-          description: Filter operational studies by tags
-        - in: query
-          name: page
-          schema:
-            type: integer
-            minimum: 0
-          description: Page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            maximum: 10000
-            minimum: 1
-            default: 100
-          description: Number of elements by page
-      responses:
-        200:
-          description: the studies list
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/StudyResult"
-
-  /projects/{project_id}/studies/{study_id}/:
-    get:
-      tags:
-        - studies
-      summary: Retrieve an operational study
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the operational study
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-          description: study id you want to retrieve
-      responses:
-        200:
-          description: The operational study info
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/StudyResult"
-    patch:
-      tags:
-        - studies
-      summary: update an operational study
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the study
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-          description: study id you want to retrieve
-      requestBody:
-        description: The fields you want to update
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/StudyUpsertRequest"
-      responses:
-        200:
-          description: The operational study updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/StudyResult"
-    delete:
-      tags:
-        - studies
-      summary: delete an operational study
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the operational study
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-          description: study id you want to delete
-      responses:
-        204:
-          description: No content
-
-  /projects/{project_id}/studies/{study_id}/scenarios/:
-    post:
-      tags:
-        - scenarios
-      summary: Create a new scenario
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ScenarioRequest"
-      responses:
-        201:
-          description: The created scenario
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ScenarioResult"
-    get:
-      tags:
-        - scenarios
-      summary: Paginated list of scenarios
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-        - in: query
-          name: ordering
-          schema:
-            type: string
-            enum:
-              [
-                "NameAsc",
-                "NameDesc",
-                "CreationDateAsc",
-                "CreationDateDesc",
-                "LastModifiedAsc",
-                "LastModifiedDesc",
-              ]
-        - in: query
-          name: page
-          schema:
-            type: integer
-            minimum: 0
-          description: Page number
-        - in: query
-          name: page_size
-          schema:
-            type: integer
-            maximum: 10000
-            minimum: 1
-            default: 100
-          description: Number of elements by page
-      responses:
-        200:
-          description: list of scenarios
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  count:
-                    type: number
-                  next: {}
-                  previous: {}
-                  results:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/ScenarioListResult"
-
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/:
-    get:
-      tags:
-        - scenarios
-      summary: Retrieve a scenario
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the scenario
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-        - in: path
-          required: true
-          name: scenario_id
-          schema:
-            type: integer
-          description: scenario id you want to retrieve
-      responses:
-        200:
-          description: The operational study info
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ScenarioResult"
-    delete:
-      tags:
-        - scenarios
-      summary: delete a scenario
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the scenario
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-          description: study id refered to the scenario
-        - in: path
-          required: true
-          name: scenario_id
-          schema:
-            type: integer
-          description: scenario id you want to delete
-      responses:
-        204:
-          description: No content
-    patch:
-      tags:
-        - scenarios
-      summary: update a scenario
-      parameters:
-        - in: path
-          name: project_id
-          schema:
-            type: integer
-          description: project id refered to the scenario
-          required: true
-        - in: path
-          required: true
-          name: study_id
-          schema:
-            type: integer
-          description: study refered to the scenario
-        - in: path
-          required: true
-          name: scenario_id
-          schema:
-            type: integer
-          description: scenario you want to update
-      requestBody:
-        description: The fields you want to update
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ScenarioPatchRequest"
-      responses:
-        200:
-          description: The scenario updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ScenarioResult"
-
-  /pathfinding/{path_id}/catenaries/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve the modes of catenaries along a path
-      parameters:
-        - in: path
-          name: path_id
-          schema:
-            type: integer
-          description: The path's id
-          required: true
-      responses:
-        200:
-          description: A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  catenary_ranges:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/CatenaryRange"
-                  warnings:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        type:
-                          type: string
-                          enum: ["CatenaryOverlap"]
-                        catenary_id:
-                          type: string
-                        overlapping_ranges:
-                          type: array
-                          items:
-                            $ref: "#/components/schemas/TrackRange"
-
-  /train_schedule/{id}/:
-    get:
-      tags:
-        - train_schedule
-      summary: Retrieve a train schedule
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Train schedule ID
-          required: true
-      responses:
-        200:
-          description: The train schedule info
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TrainSchedule"
-    delete:
-      tags:
-        - train_schedule
-      summary: Delete a train schedule and its result
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Train schedule ID
-          required: true
-      responses:
-        204:
-          description: No content
-    patch:
-      tags:
-        - train_schedule
-      summary: Update a train_schedule and run a simulation accordingly
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Train schedule ID
-          required: true
-      requestBody:
-        description: Train schedule fields
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/TrainSchedule"
-        required: true
-      responses:
-        200:
-          description: The train schedule was updated successfully
-
-  /train_schedule/{id}/result/:
-    get:
-      tags:
-        - train_schedule
-      summary: Retrieve a simulation result
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Train schedule ID
-          required: true
-        - in: query
-          name: path_id
-          schema:
-            type: integer
-          description: Path id used to project the train path
-          required: true
-      responses:
-        200:
-          description: The train schedule result
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SimulationReport"
-
-  /train_schedule/results/:
-    get:
-      tags:
-        - train_schedule
-      summary: Retrieve the simulation result of multiple train schedules
-      parameters:
-        - in: query
-          name: path_id
-          schema:
-            type: integer
-          description: Path id used to project the train path
-          required: true
-        - in: query
-          name: train_ids
-          schema:
-            type: string
-            pattern: ^\d+(,\d+)*$
-          description: List of train schedule ids to return the results of
-          required: true
-      responses:
-        200:
-          description: The train schedules results
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/SimulationReport"
-
-  /train_schedule/standalone_simulation/:
-    post:
-      tags:
-        - train_schedule
-      summary: Create a batch of train schedule and run simulations accordingly
-      requestBody:
-        description: The list of train schedules to simulate
-        content:
-          application/json:
-            schema:
-              type: array
-              minItems: 1
-              items:
-                $ref: "#/components/schemas/TrainSchedule"
-        required: true
-      responses:
-        201:
-          description: The ids of the train_schedules created
-          content:
-            application/json:
-              schema:
-                type: array
-                minItems: 1
-                items:
-                  type: number
-                  format: integer
-
 components:
   schemas:
+    Allowance:
+      discriminator:
+        propertyName: allowance_type
+      oneOf:
+      - $ref: '#/components/schemas/EngineeringAllowance'
+      - $ref: '#/components/schemas/StandardAllowance'
+    AllowancePercentValue:
+      properties:
+        percentage:
+          example: 15.0
+          type: number
+        value_type:
+          enum:
+          - percentage
+          type: string
+      required:
+      - value_type
+      - percentage
+    AllowanceTimePerDistanceValue:
+      properties:
+        minutes:
+          description: Minutes per 100k
+          example: 5.0
+          type: number
+        value_type:
+          enum:
+          - time_per_distance
+          type: string
+      required:
+      - value_type
+      - minutes
+    AllowanceTimeValue:
+      properties:
+        seconds:
+          example: 180.0
+          type: number
+        value_type:
+          enum:
+          - time
+          type: string
+      required:
+      - value_type
+      - seconds
+    AllowanceValue:
+      discriminator:
+        propertyName: value_type
+      oneOf:
+      - $ref: '#/components/schemas/AllowanceTimePerDistanceValue'
+      - $ref: '#/components/schemas/AllowanceTimeValue'
+      - $ref: '#/components/schemas/AllowancePercentValue'
     Battery:
       description: energy source for a rolling stock representing a battery
-      type: object
-      required:
-        [
-          energy_source_type,
-          max_input_power,
-          max_output_power,
-          energy_storage,
-          efficiency,
-        ]
       properties:
-        energy_source_type:
-          type: string
-          enum: ["Battery"]
-        max_input_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
-        max_output_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
-        energy_storage:
-          $ref: "#/components/schemas/EnergyStorage"
         efficiency:
-          type: number
           format: float
-          minimum: 0
           maximum: 1
-
+          minimum: 0
+          type: number
+        energy_source_type:
+          enum:
+          - Battery
+          type: string
+        energy_storage:
+          $ref: '#/components/schemas/EnergyStorage'
+        max_input_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+        max_output_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+      required:
+      - energy_source_type
+      - max_input_power
+      - max_output_power
+      - energy_storage
+      - efficiency
+      type: object
     BoundingBox:
       description: A bounding box
-      type: array
-      minItems: 2
-      maxItems: 2
       items:
-        type: array
-        minItems: 2
-        maxItems: 2
         items:
           type: integer
-
+        maxItems: 2
+        minItems: 2
+        type: array
+      maxItems: 2
+      minItems: 2
+      type: array
     Catenary:
       description: energy source for a rolling stock representing a catenary
-      type: object
-      required:
-        [energy_source_type, max_input_power, max_output_power, efficiency]
       properties:
-        energy_source_type:
-          type: string
-          enum: ["Catenary"]
-        max_input_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
-        max_output_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
         efficiency:
-          type: number
           format: float
-          minimum: 0
           maximum: 1
-
-    Comfort:
-      description: Train comfort that will be used for the simulation
-      type: string
-      enum: ["AC", "HEATING", "STANDARD"]
-      default: "STANDARD"
-
-    ConditionalEffortCurve:
+          minimum: 0
+          type: number
+        energy_source_type:
+          enum:
+          - Catenary
+          type: string
+        max_input_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+        max_output_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+      required:
+      - energy_source_type
+      - max_input_power
+      - max_output_power
+      - efficiency
       type: object
+    CatenaryRange:
+      properties:
+        begin:
+          example: 0.0
+          format: float
+          type: number
+        end:
+          example: 100.0
+          format: float
+          type: number
+        mode:
+          example: '25000'
+          type: string
+      type: object
+    Comfort:
+      default: STANDARD
+      description: Train comfort that will be used for the simulation
+      enum:
+      - AC
+      - HEATING
+      - STANDARD
+      type: string
+    ConditionalEffortCurve:
       properties:
         cond:
-          type: object
           nullable: true
           properties:
             comfort:
-              $ref: "#/components/schemas/Comfort"
+              $ref: '#/components/schemas/Comfort'
               nullable: true
             electrical_profile_level:
-              type: string
               nullable: true
+              type: string
             power_restriction_code:
-              type: string
               nullable: true
+              type: string
+          type: object
         curve:
-          $ref: "#/components/schemas/EffortCurve"
-
-    EffortCurve:
+          $ref: '#/components/schemas/EffortCurve'
       type: object
+    DeleteOperation:
       properties:
-        speeds:
-          type: array
-          example: [0.0, 2.958, 46.719]
-          minItems: 2
-          items:
-            type: number
-            format: float
+        obj_id:
+          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
+          type: string
+        obj_type:
+          $ref: '#/components/schemas/ObjectType'
+        operation_type:
+          enum:
+          - DELETE
+          type: string
+      required:
+      - operation_type
+      - obj_type
+      - obj_id
+    Direction:
+      enum:
+      - START_TO_STOP
+      - STOP_TO_START
+      type: string
+    DirectionalTrackRange:
+      description: Track range associated with a direction
+      properties:
+        begin:
+          format: float
+          type: number
+        direction:
+          $ref: '#/components/schemas/Direction'
+        end:
+          example: 100.0
+          format: float
+          type: number
+        track:
+          example: 01234567-89ab-cdef-0123-456789abcdef
+          type: string
+      required:
+      - track
+      - begin
+      - end
+      - direction
+      type: object
+    EffortCurve:
+      properties:
         max_efforts:
-          type: array
-          example: [23500.0, 23200.0, 21200.0]
-          minItems: 2
+          example:
+          - 23500.0
+          - 23200.0
+          - 21200.0
           items:
-            type: number
             format: float
-
+            type: number
+          minItems: 2
+          type: array
+        speeds:
+          example:
+          - 0.0
+          - 2.958
+          - 46.719
+          items:
+            format: float
+            type: number
+          minItems: 2
+          type: array
+      type: object
+    ElectricalProfile:
+      properties:
+        power_class:
+          example: '1'
+          type: string
+        track_ranges:
+          items:
+            $ref: '#/components/schemas/TrackRange'
+          type: array
+        value:
+          example: A
+          type: string
+      type: object
+    ElectrificationRange:
+      properties:
+        electrificationUsage:
+          discriminator:
+            propertyName: object_type
+          oneOf:
+          - $ref: '#/components/schemas/Electrified'
+          - $ref: '#/components/schemas/Neutral'
+          - $ref: '#/components/schemas/NonElectrified'
+        start:
+          format: double
+          type: number
+        stop:
+          format: double
+          type: number
+      required:
+      - start
+      - stop
+      - is_electrified
+      - electrificationUsage
+    Electrified:
+      properties:
+        mode:
+          type: string
+        mode_handled:
+          type: boolean
+        object_type:
+          enum:
+          - Electrified
+          type: string
+        profile:
+          nullable: true
+          type: string
+        profile_handled:
+          type: boolean
+      required:
+      - mode
+      - mode_handled
+      - object_type
+      - profile_handled
     EnergySource:
       description: enery source of a rolling stock
-      oneOf:
-        - $ref: "#/components/schemas/Catenary"
-        - $ref: "#/components/schemas/PowerPack"
-        - $ref: "#/components/schemas/Battery"
       discriminator:
         propertyName: energy_source_type
-
+      oneOf:
+      - $ref: '#/components/schemas/Catenary'
+      - $ref: '#/components/schemas/PowerPack'
+      - $ref: '#/components/schemas/Battery'
     EnergyStorage:
       description: energy storage of an energy source (of a rolling stock, can be a electrical battery or a hydrogen/fuel powerPack)
-      type: object
-      required: [capacity, soc, soc_min, soc_max, refill_law]
       properties:
         capacity:
-          type: number
           format: float
-        soc:
           type: number
-          format: float
-          minimum: 0
-          maximum: 1
-        soc_min:
-          type: number
-          format: float
-          minimum: 0
-          maximum: 1
-        soc_max:
-          type: number
-          format: float
-          minimum: 0
-          maximum: 1
         refill_law:
           description: physical law defining how the storage can be refilled
           nullable: true
-          type: object
           properties:
-            tau:
-              type: number
-              format: float
-              minimum: 0
             soc_ref:
+              format: float
+              maximum: 1
+              minimum: 0
               type: number
+            tau:
               format: float
               minimum: 0
-              maximum: 1
-          required: [tau, soc_ref]
-
-    GeoJsonObject:
+              type: number
+          required:
+          - tau
+          - soc_ref
+          type: object
+        soc:
+          format: float
+          maximum: 1
+          minimum: 0
+          type: number
+        soc_max:
+          format: float
+          maximum: 1
+          minimum: 0
+          type: number
+        soc_min:
+          format: float
+          maximum: 1
+          minimum: 0
+          type: number
+      required:
+      - capacity
+      - soc
+      - soc_min
+      - soc_max
+      - refill_law
       type: object
+    EngineeringAllowance:
+      allOf:
+      - properties:
+          allowance_type:
+            enum:
+            - engineering
+            type: string
+          capacity_speed_limit:
+            format: double
+            type: number
+          distribution:
+            enum:
+            - MARECO
+            - LINEAR
+            type: string
+        required:
+        - allowance_type
+        - distribution
+        type: object
+      - $ref: '#/components/schemas/RangeAllowance'
+    GeoJsonObject:
       description: GeoJson format
       properties:
         coordinates:
-          type: array
           items:
+            items:
+              format: float
+              type: number
             type: array
-            items: { type: number, format: float }
-        type: { type: string }
-      required: [coordinates, type]
-
-    GeoJsonPosition:
+          type: array
+        type:
+          type: string
+      required:
+      - coordinates
+      - type
       type: object
+    GeoJsonPosition:
       properties:
         coordinates:
-          type: array
-          items: { type: number, format: float }
-          minItems: 2
+          items:
+            format: float
+            type: number
           maxItems: 2
-        type: { type: string }
-      required: [coordinates, type]
-
+          minItems: 2
+          type: array
+        type:
+          type: string
+      required:
+      - coordinates
+      - type
+      type: object
+    Geometry:
+      description: Definition of a GeoJSON geometry
+      oneOf:
+      - $ref: '#/components/schemas/Point'
+      - $ref: '#/components/schemas/LineString'
+      - $ref: '#/components/schemas/Polygon'
+      - $ref: '#/components/schemas/MultiPoint'
+      - $ref: '#/components/schemas/MultiLineString'
+      - $ref: '#/components/schemas/MultiPolygon'
+      type: object
     Infra:
       properties:
+        created:
+          format: date
+          type: string
+        generated_version:
+          example: '1'
+          nullable: true
+          type: string
         id:
           type: integer
-        name:
-          type: string
-        version:
-          type: string
-          example: "1"
-        railjson_version:
-          type: string
-          example: "3.3.1"
-        generated_version:
-          type: string
-          nullable: true
-          example: "1"
-        created:
-          type: string
-          format: date
-        modified:
-          type: string
-          format: date
         locked:
           type: boolean
-        state:
+        modified:
+          format: date
           type: string
+        name:
+          type: string
+        railjson_version:
+          example: 3.3.1
+          type: string
+        state:
           enum:
-            - NOT_LOADED
-            - INITIALIZING
-            - DOWNLOADING
-            - PARSING_JSON
-            - PARSING_INFRA
-            - ADAPTING_KOTLIN
-            - LOADING_SIGNALS
-            - BUILDING_BLOCKS
-            - CACHED
-            - TRANSIENT_ERROR
-            - ERROR
+          - NOT_LOADED
+          - INITIALIZING
+          - DOWNLOADING
+          - PARSING_JSON
+          - PARSING_INFRA
+          - ADAPTING_KOTLIN
+          - LOADING_SIGNALS
+          - BUILDING_BLOCKS
+          - CACHED
+          - TRANSIENT_ERROR
+          - ERROR
+          type: string
+        version:
+          example: '1'
+          type: string
       required:
-        [
-          id,
-          name,
-          version,
-          railjson_version,
-          generated_version,
-          created,
-          modified,
-          locked,
-          state,
-        ]
-
-    Zone:
-      type: object
+      - id
+      - name
+      - version
+      - railjson_version
+      - generated_version
+      - created
+      - modified
+      - locked
+      - state
+    InfraError:
+      description: An infra error or warning
       properties:
-        geo:
-          $ref: "#/components/schemas/BoundingBox"
-        sch:
-          $ref: "#/components/schemas/BoundingBox"
-
-    ObjectType:
+        geographic:
+          $ref: '#/components/schemas/Geometry'
+          description: Geojson of the geographic geometry of the error
+          nullable: true
+        information:
+          description: Information about the error (check schema documentation for more details)
+          properties:
+            error_type:
+              $ref: '#/components/schemas/InfraErrorType'
+            field:
+              type: string
+            is_warning:
+              type: boolean
+            obj_id:
+              type: string
+            obj_type:
+              enum:
+              - TrackSection
+              - Signal
+              - BufferStop
+              - Detector
+              - Switch
+              - Route
+              type: string
+          required:
+          - obj_id
+          - obj_type
+          - error_type
+          - is_warning
+          type: object
+        schematic:
+          description: Geojson of the schematic geometry of the error
+          nullable: true
+          type: object
+      required:
+      - information
+      type: object
+    InfraErrorType:
+      description: Type of the infra error
+      enum:
+      - duplicated_group
+      - empty_object
+      - invalid_group
+      - invalid_reference
+      - invalid_route
+      - invalid_switch_ports
+      - missing_route
+      - missing_buffer_stop
+      - object_out_of_path
+      - odd_buffer_stop_location
+      - out_of_range
+      - overlapping_speed_sections
+      - overlapping_switches
+      - overlapping_track_links
+      - overlapping_catenaries
+      - unknown_port_name
+      - unused_port
       type: string
+    LightRollingStock:
+      allOf:
+      - $ref: '#/components/schemas/RollingStockBase'
+      - properties:
+          effort_curves:
+            properties:
+              default_mode:
+                type: string
+              modes:
+                additionalProperties:
+                  properties:
+                    is_electric:
+                      type: boolean
+                  required:
+                  - is_electric
+                  type: object
+                type: object
+            required:
+            - default_mode
+            - modes
+            type: object
+          id:
+            type: number
+          liveries:
+            items:
+              $ref: '#/components/schemas/RollingStockLivery'
+            type: array
+        required:
+        - id
+        - liveries
+        - effort_curves
+        type: object
+    LineString:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          items:
+            $ref: '#/components/schemas/Point3D'
+          type: array
+        type:
+          enum:
+          - LineString
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    MultiLineString:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          items:
+            items:
+              $ref: '#/components/schemas/Point3D'
+            type: array
+          type: array
+        type:
+          enum:
+          - MultiLineString
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    MultiPoint:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          items:
+            $ref: '#/components/schemas/Point3D'
+          type: array
+        type:
+          enum:
+          - MultiPoint
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    MultiPolygon:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          items:
+            items:
+              items:
+                $ref: '#/components/schemas/Point3D'
+              type: array
+            type: array
+          type: array
+        type:
+          enum:
+          - MultiPolygon
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    Neutral:
+      properties:
+        is_lower_pantograph:
+          type: boolean
+        object_type:
+          enum:
+          - Neutral
+          type: string
+      required:
+      - is_lower_pantograph
+      - object_type
+    NonElectrified:
+      properties:
+        object_type:
+          enum:
+          - NonElectrified
+          type: string
+      required:
+      - object_type
+    ObjectType:
       description: Type of the object
       enum:
-        - TrackSection
-        - Signal
-        - SpeedSection
-        - Detector
-        - TrackSectionLink
-        - Switch
-        - SwitchType
-        - BufferStop
-        - Route
-        - OperationalPoint
-        - Catenary
-
+      - TrackSection
+      - Signal
+      - SpeedSection
+      - Detector
+      - TrackSectionLink
+      - Switch
+      - SwitchType
+      - BufferStop
+      - Route
+      - OperationalPoint
+      - Catenary
+      type: string
+    Operation:
+      oneOf:
+      - $ref: '#/components/schemas/RailjsonObject'
+      - $ref: '#/components/schemas/DeleteOperation'
+      - $ref: '#/components/schemas/UpdateOperation'
+    OperationObject:
+      properties:
+        obj_type:
+          $ref: '#/components/schemas/ObjectType'
+        operation_type:
+          enum:
+          - CREATE
+          - UPDATE
+          type: string
+        railjson:
+          $ref: '#/components/schemas/Railjson'
+      required:
+      - operation_type
+      - obj_type
+      - railjson
+    OperationResult:
+      oneOf:
+      - $ref: '#/components/schemas/DeleteOperation'
+      - $ref: '#/components/schemas/OperationObject'
+    Patch:
+      description: A JSONPatch document as defined by RFC 6902
+      properties:
+        from:
+          description: A string containing a JSON Pointer value.
+          type: string
+        op:
+          description: The operation to be performed
+          enum:
+          - add
+          - remove
+          - replace
+          - move
+          - copy
+          - test
+          type: string
+        path:
+          description: A JSON-Pointer
+          type: string
+        value:
+          description: The value to be used within the operations.
+          type: object
+      required:
+      - op
+      - path
+    Patches:
+      description: A list of Patch
+      items:
+        $ref: '#/components/schemas/Patch'
+      type: array
+    Path:
+      properties:
+        created:
+          format: date-time
+          type: string
+        curves:
+          description: Curves on the path
+          items:
+            properties:
+              position:
+                format: float
+                type: number
+              radius:
+                format: float
+                type: number
+            required:
+            - radius
+            - position
+            type: object
+          type: array
+        geographic:
+          $ref: '#/components/schemas/GeoJsonObject'
+        id:
+          type: integer
+        length:
+          description: Length of the path
+          format: float
+          type: number
+        owner:
+          format: uuid
+          type: string
+        schematic:
+          $ref: '#/components/schemas/GeoJsonObject'
+        slopes:
+          description: Slopes on the path
+          items:
+            properties:
+              gradient:
+                format: float
+                type: number
+              position:
+                format: float
+                type: number
+            required:
+            - gradient
+            - position
+            type: object
+          type: array
+        steps:
+          items:
+            $ref: '#/components/schemas/PathStep'
+          type: array
+      required:
+      - id
+      - owner
+      - created
+      - length
+      - geographic
+      - schematic
+      - slopes
+      - curves
+      - steps
+    PathQuery:
+      properties:
+        infra:
+          type: number
+        rolling_stocks:
+          description: List of rolling stocks that must be able to use this path
+          items:
+            type: integer
+          type: array
+        steps:
+          items:
+            properties:
+              duration:
+                format: float
+                type: number
+              waypoints:
+                items:
+                  $ref: '#/components/schemas/PathWaypoint'
+                type: array
+            required:
+            - duration
+            - waypoints
+            type: object
+          minItems: 2
+          type: array
+      required:
+      - infra
+      - steps
+      - rolling_stocks
+      type: object
+    PathStep:
+      properties:
+        duration:
+          format: float
+          type: number
+        geo:
+          $ref: '#/components/schemas/GeoJsonPosition'
+        id:
+          type: string
+        location:
+          $ref: '#/components/schemas/TrackSectionLocation'
+        name:
+          type: string
+        path_offset:
+          description: Offset of the step in the path
+          format: float
+          type: number
+        sch:
+          $ref: '#/components/schemas/GeoJsonPosition'
+        suggestion:
+          type: boolean
+      required:
+      - suggestion
+      - duration
+      - path_offset
+      - location
+      - sch
+      - geo
+      type: object
+    PathWaypoint:
+      properties:
+        geo_coordinate:
+          items:
+            format: float
+            type: number
+          maxItems: 2
+          minItems: 2
+          type: array
+        offset:
+          type: number
+        track_section:
+          description: track section ID of the waypoint
+          type: string
+      required:
+      - track_section
+      - geo_cordinate
+      type: object
+    Point:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          $ref: '#/components/schemas/Point3D'
+        type:
+          enum:
+          - Point
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    Point3D:
+      description: Point in 3D space
+      items:
+        type: number
+      maxItems: 3
+      minItems: 2
+      type: array
+    Polygon:
+      description: GeoJSon geometry
+      properties:
+        coordinates:
+          items:
+            items:
+              $ref: '#/components/schemas/Point3D'
+            type: array
+          type: array
+        type:
+          enum:
+          - Polygon
+          type: string
+      required:
+      - type
+      - coordinates
+      type: object
+    PowerPack:
+      description: energy source for a rolling stock representing a power pack (hydrogen, fuel...)
+      properties:
+        efficiency:
+          format: float
+          maximum: 1
+          minimum: 0
+          type: number
+        energy_source_type:
+          enum:
+          - PowerPack
+          type: string
+        energy_storage:
+          $ref: '#/components/schemas/EnergyStorage'
+        max_input_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+        max_output_power:
+          $ref: '#/components/schemas/SpeedDependantPower'
+      required:
+      - energy_source_type
+      - max_input_power
+      - max_output_power
+      - energy_storage
+      - efficiency
+      type: object
+    PowerRestrictionRange:
+      description: A range along the train path where a power restriction is applied.
+      example:
+        begin_position: 0.0
+        end_position: 1000.0
+        power_restriction_code: C1US
+      properties:
+        begin_position:
+          description: Offset from the start of the path, in meters.
+          format: float
+          type: number
+        end_position:
+          description: Offset from the start of the path, in meters.
+          format: float
+          type: number
+        power_restriction_code:
+          description: The power restriction code to apply.
+          type: string
+      required:
+      - begin_position
+      - end_position
+      - power_restriction_code
+      type: object
+    PowerRestrictionRangeItem:
+      properties:
+        code:
+          type: string
+        handled:
+          type: boolean
+        start:
+          format: double
+          type: number
+        stop:
+          format: double
+          type: number
+      required:
+      - start
+      - stop
+      - code
+      - handled
+    ProjectCreateRequest:
+      properties:
+        budget:
+          type: integer
+        description:
+          default: ''
+          maxLength: 1024
+          type: string
+        funders:
+          default: ''
+          maxLength: 1024
+          type: string
+        image:
+          description: The id of the image in the document table
+          type: integer
+        name:
+          maxLength: 128
+          type: string
+        objectives:
+          default: ''
+          maxLength: 4096
+          type: string
+        tags:
+          items:
+            maxLength: 255
+            type: string
+          type: array
+      required:
+      - name
+    ProjectPatchRequest:
+      properties:
+        budget:
+          type: integer
+        description:
+          maxLength: 1024
+          type: string
+        funders:
+          maxLength: 1024
+          type: string
+        image:
+          description: The id of the image in the document table
+          type: integer
+        name:
+          maxLength: 128
+          type: string
+        objectives:
+          maxLength: 4096
+          type: string
+        tags:
+          items:
+            maxLength: 255
+            type: string
+          type: array
+    ProjectResult:
+      properties:
+        budget:
+          type: integer
+        creation_date:
+          format: date-time
+          type: string
+        description:
+          type: string
+        funders:
+          type: string
+        id:
+          type: integer
+        image:
+          description: the image id
+          nullable: true
+          type: integer
+        last_modification:
+          format: date-time
+          type: string
+        name:
+          type: string
+        objectives:
+          type: string
+        studies_count:
+          type: integer
+        tags:
+          items:
+            type: string
+          type: array
+    Railjson:
+      additionalProperties: true
+      description: This field follows railjson format
+      example:
+        curves: []
+        geo:
+          coordinates:
+          - - 1.0
+            - 41.0
+          - - 2.0
+            - 42.0
+          type: LineString
+        id: bd840b06-84ba-4566-98c1-ccf0196c5f16
+        length: 1000
+        line_code: 1
+        line_name: my line
+        navigability: BOTH
+        sch:
+          coordinates:
+          - - 1.0
+            - 41.0
+          - - 2.0
+            - 42.0
+          type: LineString
+        slopes:
+        - begin: 250
+          end: 500
+          gradient: -1
+        track_name: track name
+        track_number: 1
+      properties:
+        id:
+          type: string
+      required:
+      - id
+      type: object
     RailjsonFile:
       properties:
-        version:
-          type: string
+        buffer_stops:
+          type: array
+        catenaries:
+          type: array
+        detectors:
+          type: array
         operational_points:
           type: array
         routes:
+          type: array
+        signals:
+          type: array
+        speed_sections:
           type: array
         switch_types:
           type: array
@@ -2293,621 +1058,124 @@ components:
           type: array
         track_sections:
           type: array
-        signals:
-          type: array
-        buffer_stops:
-          type: array
-        speed_sections:
-          type: array
-        catenaries:
-          type: array
-        detectors:
-          type: array
-
-    Operation:
-      oneOf:
-        - $ref: "#/components/schemas/RailjsonObject"
-        - $ref: "#/components/schemas/DeleteOperation"
-        - $ref: "#/components/schemas/UpdateOperation"
-
-    OperationResult:
-      oneOf:
-        - $ref: "#/components/schemas/DeleteOperation"
-        - $ref: "#/components/schemas/OperationObject"
-
+        version:
+          type: string
     RailjsonObject:
-      required:
-        - operation_type
-        - obj_type
-        - railjson
       properties:
-        operation_type:
-          type: string
-          enum:
-            - CREATE
         obj_type:
-          $ref: "#/components/schemas/ObjectType"
+          $ref: '#/components/schemas/ObjectType'
+        operation_type:
+          enum:
+          - CREATE
+          type: string
         railjson:
-          $ref: "#/components/schemas/Railjson"
-
-    DeleteOperation:
+          $ref: '#/components/schemas/Railjson'
       required:
-        - operation_type
-        - obj_type
-        - obj_id
+      - operation_type
+      - obj_type
+      - railjson
+    RangeAllowance:
       properties:
-        operation_type:
-          type: string
-          enum:
-            - DELETE
-        obj_type:
-          $ref: "#/components/schemas/ObjectType"
-        obj_id:
-          type: string
-          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
-
-    UpdateOperation:
-      required:
-        - operation_type
-        - obj_type
-        - railjson_patch
-      properties:
-        operation_type:
-          type: string
-          enum:
-            - UPDATE
-        obj_type:
-          $ref: "#/components/schemas/ObjectType"
-        obj_id:
-          type: string
-          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
-        railjson_patch:
-          $ref: "#/components/schemas/Patches"
-
-    OperationObject:
-      required:
-        - operation_type
-        - obj_type
-        - railjson
-      properties:
-        operation_type:
-          type: string
-          enum:
-            - CREATE
-            - UPDATE
-        obj_type:
-          $ref: "#/components/schemas/ObjectType"
-        railjson:
-          $ref: "#/components/schemas/Railjson"
-
-    Patch:
-      description: A JSONPatch document as defined by RFC 6902
-      required:
-        - "op"
-        - "path"
-      properties:
-        op:
-          type: string
-          description: The operation to be performed
-          enum:
-            - "add"
-            - "remove"
-            - "replace"
-            - "move"
-            - "copy"
-            - "test"
-        path:
-          type: string
-          description: A JSON-Pointer
+        begin_position:
+          type: number
+        end_position:
+          example: 1000.0
+          type: number
         value:
-          type: object
-          description: The value to be used within the operations.
-        from:
-          type: string
-          description: A string containing a JSON Pointer value.
-
-    Patches:
-      type: array
-      description: A list of Patch
-      items:
-        $ref: "#/components/schemas/Patch"
-
-    Railjson:
-      type: object
-      description: This field follows railjson format
-      additionalProperties: true
+          $ref: '#/components/schemas/AllowanceValue'
       required:
-        - id
-      properties:
-        id:
-          type: string
-      example:
-        id: bd840b06-84ba-4566-98c1-ccf0196c5f16
-        geo:
-          type: LineString
-          coordinates:
-            - - 1.0
-              - 41.0
-            - - 2.0
-              - 42.0
-        sch:
-          type: LineString
-          coordinates:
-            - - 1.0
-              - 41.0
-            - - 2.0
-              - 42.0
-        curves: []
-        length: 1000
-        slopes:
-          - end: 500
-            begin: 250
-            gradient: -1
-        line_code: 1
-        line_name: my line
-        track_name: track name
-        navigability: BOTH
-        track_number: 1
-
-    ViewMetadata:
-      properties:
-        type:
-          type: string
-          example: vector
-        name:
-          type: string
-          example: track_sections
-        promotedId:
-          type: object
-          example: { track_sections: "id" }
-        scheme:
-          type: string
-          example: "xyz"
-        tiles:
-          type: array
-          items:
-            type: string
-            example: http://localhost:7070/tile/track_sections/geo/{z}/{x}/{y}/?infra=1
-        attribution:
-          type: string
-        minzoom:
-          type: integer
-        maxzoom:
-          type: integer
-          example: 18
-
-    InfraErrorType:
-      type: string
-      description: Type of the infra error
-      enum:
-        - duplicated_group
-        - empty_object
-        - invalid_group
-        - invalid_reference
-        - invalid_route
-        - invalid_switch_ports
-        - missing_route
-        - missing_buffer_stop
-        - object_out_of_path
-        - odd_buffer_stop_location
-        - out_of_range
-        - overlapping_speed_sections
-        - overlapping_switches
-        - overlapping_track_links
-        - overlapping_catenaries
-        - unknown_port_name
-        - unused_port
-
-    InfraError:
-      type: object
-      description: An infra error or warning
-      required: [information]
-      properties:
-        geographic:
-          nullable: true
-          description: Geojson of the geographic geometry of the error
-          $ref: "#/components/schemas/Geometry"
-        schematic:
-          nullable: true
-          type: object
-          description: Geojson of the schematic geometry of the error
-        information:
-          type: object
-          description: Information about the error (check schema documentation for more details)
-          required: [obj_id, obj_type, error_type, is_warning]
-          properties:
-            obj_id:
-              type: string
-            obj_type:
-              type: string
-              enum:
-                - TrackSection
-                - Signal
-                - BufferStop
-                - Detector
-                - Switch
-                - Route
-            error_type:
-              $ref: "#/components/schemas/InfraErrorType"
-            field:
-              type: string
-            is_warning:
-              type: boolean
-
-    TrackSectionLocation:
-      type: object
-      description: A track location (track section and offset)
-      properties:
-        track_section:
-          type: string
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-        offset:
-          type: number
-          format: float
-          description: The offset on the track section
-          example: 42.
-      required: [track_section, offset]
-
-    TrackLocation:
-      type: object
-      description: A track location (track section and offset)
-      properties:
-        track:
-          type: string
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-        offset:
-          type: number
-          format: float
-          description: The offset on the track section
-          example: 42.
-      required: [track, offset]
-
-    Direction:
-      type: string
-      enum: [START_TO_STOP, STOP_TO_START]
-
-    TrackRange:
-      type: object
-      description: Track range
-      properties:
-        track:
-          type: string
-          example: 01234567-89ab-cdef-0123-456789abcdef
-        begin:
-          type: number
-          format: float
-        end:
-          type: number
-          format: float
-          example: 100
-
-    DirectionalTrackRange:
-      type: object
-      description: Track range associated with a direction
-      required:
-        - track
-        - begin
-        - end
-        - direction
-      properties:
-        track:
-          type: string
-          example: 01234567-89ab-cdef-0123-456789abcdef
-        begin:
-          type: number
-          format: float
-        end:
-          type: number
-          format: float
-          example: 100.
-        direction:
-          $ref: "#/components/schemas/Direction"
-
-    LightRollingStock:
-      allOf:
-        - $ref: "#/components/schemas/RollingStockBase"
-        - type: object
-          properties:
-            id:
-              type: number
-            liveries:
-              type: array
-              items:
-                $ref: "#/components/schemas/RollingStockLivery"
-            effort_curves:
-              type: object
-              properties:
-                default_mode:
-                  type: string
-                modes:
-                  type: object
-                  additionalProperties:
-                    type: object
-                    properties:
-                      is_electric:
-                        type: boolean
-                    required: [is_electric]
-              required: [default_mode, modes]
-          required: [id, liveries, effort_curves]
-
-    Path:
-      properties:
-        id: { type: integer }
-        owner:
-          type: string
-          format: uuid
-        created:
-          type: string
-          format: date-time
-        length:
-          type: number
-          format: float
-          description: Length of the path
-        geographic:
-          $ref: "#/components/schemas/GeoJsonObject"
-        schematic:
-          $ref: "#/components/schemas/GeoJsonObject"
-        slopes:
-          description: Slopes on the path
-          type: array
-          items:
-            type: object
-            properties:
-              gradient: { type: number, format: float }
-              position: { type: number, format: float }
-            required: [gradient, position]
-        curves:
-          description: Curves on the path
-          type: array
-          items:
-            type: object
-            properties:
-              radius: { type: number, format: float }
-              position: { type: number, format: float }
-            required: [radius, position]
-        steps:
-          type: array
-          items:
-            $ref: "#/components/schemas/PathStep"
-      required:
-        [
-          id,
-          owner,
-          created,
-          length,
-          geographic,
-          schematic,
-          slopes,
-          curves,
-          steps,
-        ]
-
-    PathQuery:
-      type: object
-      properties:
-        infra:
-          type: number
-        steps:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              duration: { type: number, format: float }
-              waypoints:
-                type: array
-                items:
-                  $ref: "#/components/schemas/PathWaypoint"
-            required: [duration, waypoints]
-        rolling_stocks:
-          description: List of rolling stocks that must be able to use this path
-          type: array
-          items: { type: integer }
-      required: [infra, steps, rolling_stocks]
-
-    PathStep:
-      type: object
-      properties:
-        id: { type: string }
-        name: { type: string }
-        suggestion: { type: boolean }
-        duration: { type: number, format: float }
-        path_offset:
-          type: number
-          format: float
-          description: Offset of the step in the path
-        location:
-          $ref: "#/components/schemas/TrackSectionLocation"
-        sch:
-          $ref: "#/components/schemas/GeoJsonPosition"
-        geo:
-          $ref: "#/components/schemas/GeoJsonPosition"
-      required: [suggestion, duration, path_offset, location, sch, geo]
-
-    PathWaypoint:
-      type: object
-      properties:
-        track_section:
-          description: track section ID of the waypoint
-          type: string
-        geo_coordinate:
-          type: array
-          items: { type: number, format: float }
-          minItems: 2
-          maxItems: 2
-        offset:
-          type: number
-      required: [track_section, geo_cordinate]
-
-    PowerPack:
-      description: energy source for a rolling stock representing a power pack (hydrogen, fuel...)
-      type: object
-      required:
-        [
-          energy_source_type,
-          max_input_power,
-          max_output_power,
-          energy_storage,
-          efficiency,
-        ]
-      properties:
-        energy_source_type:
-          type: string
-          enum: ["PowerPack"]
-        max_input_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
-        max_output_power:
-          $ref: "#/components/schemas/SpeedDependantPower"
-        energy_storage:
-          $ref: "#/components/schemas/EnergyStorage"
-        efficiency:
-          type: number
-          format: float
-          minimum: 0
-          maximum: 1
-
+      - begin_position
+      - end_position
+      - value
     RollingStock:
       allOf:
-        - $ref: "#/components/schemas/RollingStockUpsertPayload"
-        - type: object
-          properties:
-            id:
-              type: number
-            liveries:
-              type: array
-              items:
-                $ref: "#/components/schemas/RollingStockLivery"
-          required: [id, liveries]
-
-    RollingStockUpsertPayload:
-      allOf:
-        - $ref: "#/components/schemas/RollingStockBase"
-        - type: object
-          properties:
-            effort_curves:
-              type: object
-              properties:
-                default_mode:
-                  type: string
-                modes:
-                  type: object
-                  additionalProperties:
-                    type: object
-                    properties:
-                      curves:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/ConditionalEffortCurve"
-                      default_curve:
-                        $ref: "#/components/schemas/EffortCurve"
-                      is_electric:
-                        type: boolean
-                    required: [curves, default_curve, is_electric]
-              required: [default_mode, modes]
-          required: [effort_curves]
-
+      - $ref: '#/components/schemas/RollingStockUpsertPayload'
+      - properties:
+          id:
+            type: number
+          liveries:
+            items:
+              $ref: '#/components/schemas/RollingStockLivery'
+            type: array
+        required:
+        - id
+        - liveries
+        type: object
     RollingStockBase:
       properties:
-        railjson_version:
-          type: string
-          example: "3.0"
-        name:
-          type: string
-        locked:
-          type: boolean
-          default: false
-          description: Whether the rolling stock can be edited/deleted or not.
-        length:
-          type: number
-          format: float
-        max_speed:
-          type: number
-          format: float
-        startup_time:
-          type: number
-          format: float
-        startup_acceleration:
-          type: number
-          format: float
-        comfort_acceleration:
-          type: number
-          format: float
-        gamma:
-          type: object
-          properties:
-            type:
-              type: string
-              enum: ["CONST", "MAX"]
-            value:
-              type: number
-              format: float
-          required: [type, value]
-        inertia_coefficient:
-          type: number
-          format: float
-        features:
-          type: array
-          items:
-            type: string
-        mass:
-          type: number
-          format: float
-        rolling_resistance:
-          type: object
-          properties:
-            A:
-              type: number
-            B:
-              type: number
-            C:
-              type: number
-            type:
-              type: string
-              enum: ["davis"]
-          required: [A, B, C, type]
-        loading_gauge:
-          type: string
-          enum:
-            - "G1"
-            - "G2"
-            - "GA"
-            - "GB"
-            - "GB1"
-            - "GC"
-            - "FR3.3"
-            - "FR3.3/GB/G2"
-            - "GLOTT"
         base_power_class:
+          example: '5'
           type: string
-          example: "5"
-        power_restrictions:
-          type: object
-          description: Mapping of power restriction code to power class
-          additionalProperties:
-            type: string
-          example:
-            "C1US": "4"
-            "C2US": "3"
-        energy_sources:
-          type: array
-          items:
-            $ref: "#/components/schemas/EnergySource"
-        electrical_power_startup_time:
-          type: number
-          nullable: true
+        comfort_acceleration:
           format: float
+          type: number
+        electrical_power_startup_time:
           description: The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
           example: 5.0
-        raise_pantograph_time:
-          type: number
-          nullable: true
           format: float
-          description: The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
-          example: 15.0
-        metadata:
+          nullable: true
+          type: number
+        energy_sources:
+          items:
+            $ref: '#/components/schemas/EnergySource'
+          type: array
+        features:
+          items:
+            type: string
+          type: array
+        gamma:
+          properties:
+            type:
+              enum:
+              - CONST
+              - MAX
+              type: string
+            value:
+              format: float
+              type: number
+          required:
+          - type
+          - value
           type: object
+        inertia_coefficient:
+          format: float
+          type: number
+        length:
+          format: float
+          type: number
+        loading_gauge:
+          enum:
+          - G1
+          - G2
+          - GA
+          - GB
+          - GB1
+          - GC
+          - FR3.3
+          - FR3.3/GB/G2
+          - GLOTT
+          type: string
+        locked:
+          default: false
+          description: Whether the rolling stock can be edited/deleted or not.
+          type: boolean
+        mass:
+          format: float
+          type: number
+        max_speed:
+          format: float
+          type: number
+        metadata:
+          example:
+            detail: BB 7200
+            family: LOCOMOTIVES
+            grouping: Locomotives électriques courant continu
+            number: '1'
+            reference: '7200'
+            series: BB 7200
+            subseries: GV
+            type: Locomotives électriques
+            unit: US
           properties:
             detail:
               type: string
@@ -2927,1339 +1195,3144 @@ components:
               type: string
             unit:
               type: string
-          example:
-            detail: "BB 7200"
-            family: "LOCOMOTIVES"
-            grouping: "Locomotives électriques courant continu"
-            number: "1"
-            reference: "7200"
-            series: "BB 7200"
-            subseries: "GV"
-            type: "Locomotives électriques"
-            unit: "US"
           required:
-            [
-              detail,
-              family,
-              grouping,
-              number,
-              reference,
-              series,
-              subseries,
-              type,
-              unit,
-            ]
+          - detail
+          - family
+          - grouping
+          - number
+          - reference
+          - series
+          - subseries
+          - type
+          - unit
+          type: object
+        name:
+          type: string
+        power_restrictions:
+          additionalProperties:
+            type: string
+          description: Mapping of power restriction code to power class
+          example:
+            C1US: '4'
+            C2US: '3'
+          type: object
+        railjson_version:
+          example: '3.0'
+          type: string
+        raise_pantograph_time:
+          description: The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
+          example: 15.0
+          format: float
+          nullable: true
+          type: number
+        rolling_resistance:
+          properties:
+            A:
+              type: number
+            B:
+              type: number
+            C:
+              type: number
+            type:
+              enum:
+              - davis
+              type: string
+          required:
+          - A
+          - B
+          - C
+          - type
+          type: object
+        startup_acceleration:
+          format: float
+          type: number
+        startup_time:
+          format: float
+          type: number
       required:
-        - railjson_version
-        - name
-        - length
-        - max_speed
-        - startup_time
-        - startup_acceleration
-        - comfort_acceleration
-        - gamma
-        - inertia_coefficient
-        - features
-        - mass
-        - rolling_resistance
-        - loading_gauge
-        - base_power_class
-        - power_restrictions
-        - metadata
-        - energy_sources
-        - electrical_power_startup_time
-        - raise_pantograph_time
-
+      - railjson_version
+      - name
+      - length
+      - max_speed
+      - startup_time
+      - startup_acceleration
+      - comfort_acceleration
+      - gamma
+      - inertia_coefficient
+      - features
+      - mass
+      - rolling_resistance
+      - loading_gauge
+      - base_power_class
+      - power_restrictions
+      - metadata
+      - energy_sources
+      - electrical_power_startup_time
+      - raise_pantograph_time
     RollingStockLivery:
       properties:
-        id:
-          type: number
-        name:
-          type: string
         compound_image_id:
-          type: number
           nullable: true
-      required: [id, name, compound_image_id]
-
-    RouteTrackRangesComputed:
-      type: object
-      description: Route track ranges successfully computed
-      required:
-        - type
-        - track_ranges
-      properties:
-        type:
+          type: number
+        id:
+          type: number
+        name:
           type: string
-          enum:
-            - Computed
-        track_ranges:
-          type: array
-          items:
-            $ref: "#/components/schemas/DirectionalTrackRange"
-
-    RouteTrackRangesNotFoundError:
-      type: object
-      description: Error when the route id couldn't be found
       required:
-        - type
+      - id
+      - name
+      - compound_image_id
+    RollingStockUpsertPayload:
+      allOf:
+      - $ref: '#/components/schemas/RollingStockBase'
+      - properties:
+          effort_curves:
+            properties:
+              default_mode:
+                type: string
+              modes:
+                additionalProperties:
+                  properties:
+                    curves:
+                      items:
+                        $ref: '#/components/schemas/ConditionalEffortCurve'
+                      type: array
+                    default_curve:
+                      $ref: '#/components/schemas/EffortCurve'
+                    is_electric:
+                      type: boolean
+                  required:
+                  - curves
+                  - default_curve
+                  - is_electric
+                  type: object
+                type: object
+            required:
+            - default_mode
+            - modes
+            type: object
+        required:
+        - effort_curves
+        type: object
+    RollingStockUsage:
       properties:
-        type:
-          type: string
-          enum:
-            - NotFound
-
+        rolling_stock_id:
+          type: integer
+        usage:
+          properties:
+            project_id:
+              type: integer
+            project_name:
+              type: string
+            scenario_id:
+              type: integer
+            scenario_name:
+              type: string
+            study_id:
+              type: integer
+            study_name:
+              type: string
+            train_name:
+              type: string
+            train_schedule_id:
+              type: integer
+          required:
+          - train_schedule_id
+          - train_name
+          - project_id
+          - project_name
+          - study_id
+          - study_name
+          - scenario_id
+          - scenario_name
+          type: object
+      required:
+      - rolling_stock_id
+      - usage
+      type: object
     RouteTrackRangesCantComputePathError:
-      type: object
       description: Error when the route path couldn't be computed
-      required:
-        - type
       properties:
         type:
-          type: string
           enum:
-            - CantComputePath
-
-    SpeedDependantPower:
-      description: power-speed curve (in an energy source)
-      type: object
-      required: [speeds, powers]
-      properties:
-        speeds:
-          type: array
-          items:
-            type: number
-            format: float
-        powers:
-          type: array
-          items:
-            type: number
-            format: float
-
-    ElectricalProfile:
-      type: object
-      properties:
-        value:
+          - CantComputePath
           type: string
-          example: "A"
-        power_class:
-          type: string
-          example: "1"
+      required:
+      - type
+      type: object
+    RouteTrackRangesComputed:
+      description: Route track ranges successfully computed
+      properties:
         track_ranges:
-          type: array
           items:
-            $ref: "#/components/schemas/TrackRange"
-
-    CatenaryRange:
-      type: object
-      properties:
-        begin:
-          type: number
-          format: float
-          example: 0.0
-        end:
-          type: number
-          format: float
-          example: 100.0
-        mode:
-          type: string
-          example: "25000"
-
-    SearchQuery:
-      type: array
-      minItems: 1
-      nullable: true
-      items:
-        oneOf:
-          - type: boolean
-          - type: number
-          - type: integer
-          - type: string
-          - $ref: "#/components/schemas/SearchQuery"
-      example:
-        [
-          "and",
-          [
-            "or",
-            ["search", ["name"], "mich st"],
-            ["search", ["trigram"], null],
-          ],
-          ["=", ["infra_id"], 2],
-        ]
-
-    SearchOperationalPointResult:
-      required:
-        - obj_id
-        - name
-        - geographic
-        - ch
-        - schematic
-        - trigram
-        - track_sections
-      properties:
-        obj_id:
-          type: string
-        infra_id:
-          type: string
-        name:
-          type: string
-        uic:
-          type: integer
-        trigram:
-          type: string
-        ch:
-          type: string
-        geographic:
-          $ref: "#/components/schemas/MultiPoint"
-        schematic:
-          $ref: "#/components/schemas/MultiPoint"
-        track_sections:
+            $ref: '#/components/schemas/DirectionalTrackRange'
           type: array
-          items:
-            $ref: "#/components/schemas/TrackLocation"
-
-    SearchTrackResult:
-      required:
-        - infra_id
-        - line_code
-        - line_name
-      properties:
-        infra_id:
-          type: integer
-        line_code:
-          type: integer
-        line_name:
-          type: string
-
-    SearchSignalResult:
-      required:
-        - label
-        - geographic
-        - schematic
-        - line_code
-        - line_name
-      properties:
-        label:
-          type: string
-        infra_id:
-          type: integer
-        aspects:
-          type: array
-          items:
-            type: string
-        systems:
-          type: array
-          items:
-            type: string
         type:
+          enum:
+          - Computed
           type: string
-        line_code:
-          type: integer
-        line_name:
-          type: string
-        geographic:
-          $ref: "#/components/schemas/Point"
-        schematic:
-          $ref: "#/components/schemas/Point"
-
-    SearchProjectResult:
       required:
-        - id
-        - name
-        - description
-        - last_modification
+      - type
+      - track_ranges
+      type: object
+    RouteTrackRangesNotFoundError:
+      description: Error when the route id couldn't be found
       properties:
-        id:
-          type: integer
-        image:
-          type: integer
-        name:
+        type:
+          enum:
+          - NotFound
           type: string
-        studies_count:
-          type: integer
+      required:
+      - type
+      type: object
+    ScenarioListResult:
+      properties:
+        creation_date:
+          format: date-time
+          type: string
         description:
           type: string
-        last_modification:
+        electrical_profile_set_id:
+          nullable: true
+          type: integer
+        electrical_profile_set_name:
+          nullable: true
           type: string
-          format: date-time
-        tags:
-          type: array
-
-    SearchStudyResult:
-      required:
-        - id
-        - name
-        - project_id
-        - last_modification
-      properties:
         id:
           type: integer
-        project_id:
+        infra_id:
           type: integer
+        infra_name:
+          type: string
+        last_modification:
+          format: date-time
+          type: string
         name:
           type: string
-        scenarios_count:
-          type: integer
-        description:
-          type: string
-        last_modification:
-          type: string
-          format: date-time
-        tags:
-          type: array
-          items:
-            type: string
-
-    SearchScenarioResult:
-      required:
-        - id
-        - name
-        - study_id
-        - last_modification
-        - infra_id
-        - timetable_id
-      properties:
-        id:
-          type: integer
         study_id:
           type: integer
-        electrical_profile_set_id:
+        tags:
+          items:
+            type: string
+          type: array
+        timetable_id:
           type: integer
-        name:
-          type: string
         trains_count:
           type: integer
+    ScenarioPatchRequest:
+      properties:
+        description:
+          maxLength: 1024
+          type: string
+        name:
+          maxLength: 128
+          type: string
+        tags:
+          items:
+            maxLength: 255
+            type: string
+          type: array
+    ScenarioRequest:
+      properties:
+        description:
+          maxLength: 1024
+          type: string
+        electrical_profile_set_id:
+          description: Electrical profile set id (if any)
+          type: number
+        infra_id:
+          type: integer
+        name:
+          maxLength: 128
+          type: string
+        tags:
+          items:
+            maxLength: 255
+            type: string
+          type: array
+      required:
+      - name
+      - infra_id
+    ScenarioResult:
+      properties:
+        creation_date:
+          format: date-time
+          type: string
         description:
           type: string
-        last_modification:
+        electrical_profile_set_id:
+          nullable: true
+          type: integer
+        electrical_profile_set_name:
+          nullable: true
           type: string
-          format: date-time
+        id:
+          type: integer
         infra_id:
           type: integer
         infra_name:
           type: string
-        tags:
-          type: array
-          items:
-            type: string
-
-    ProjectCreateRequest:
-      properties:
-        name:
-          type: string
-          maxLength: 128
-        objectives:
-          type: string
-          maxLength: 4096
-          default: ""
-        description:
-          type: string
-          maxLength: 1024
-          default: ""
-        funders:
-          type: string
-          maxLength: 1024
-          default: ""
-        budget:
-          type: integer
-        image:
-          type: integer
-          description: The id of the image in the document table
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-      required:
-        - name
-
-    ProjectPatchRequest:
-      properties:
-        name:
-          type: string
-          maxLength: 128
-        objectives:
-          type: string
-          maxLength: 4096
-        description:
-          type: string
-          maxLength: 1024
-        funders:
-          type: string
-          maxLength: 1024
-        budget:
-          type: integer
-        image:
-          type: integer
-          description: The id of the image in the document table
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-
-    ProjectResult:
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        objectives:
-          type: string
-        description:
-          type: string
-        funders:
-          type: string
-        budget:
-          type: integer
-        image:
-          type: integer
-          nullable: true
-          description: the image id
-        creation_date:
-          type: string
-          format: date-time
         last_modification:
-          type: string
           format: date-time
-        studies_count:
-          type: integer
-        tags:
-          type: array
-          items:
-            type: string
-
-    StudyUpsertRequest:
-      properties:
-        name:
           type: string
-          maxLength: 128
-        service_code:
-          type: string
-          maxLength: 128
-        business_code:
-          type: string
-          maxLength: 128
-        description:
-          type: string
-          maxLength: 1024
-        budget:
-          type: integer
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-        start_date:
-          type: string
-          nullable: true
-          format: date-time
-        expected_end_date:
-          type: string
-          nullable: true
-          format: date-time
-        actual_end_date:
-          type: string
-          nullable: true
-          format: date-time
-        state:
-          type: string
-          enum: ["started", "inProgress", "finish"]
-        study_type:
-          type: string
-          enum:
-            [
-              "timeTables",
-              "flowRate",
-              "parkSizing",
-              "garageRequirement",
-              "operationOrSizing",
-              "operability",
-              "strategicPlanning",
-              "chartStability",
-              "disturbanceTests",
-            ]
-      required: [name, tags]
-
-    StudyResult:
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        project_id:
-          type: integer
-        description:
-          type: string
-        budget:
-          type: integer
-        tags:
-          type: array
-          items:
-            type: string
-        service_code:
-          type: string
-        business_code:
-          type: string
-        creation_date:
-          type: string
-          format: date-time
-        last_modification:
-          type: string
-          format: date-time
-        scenarios_count:
-          type: integer
-        start_date:
-          type: string
-          nullable: true
-          format: date-time
-        expected_end_date:
-          type: string
-          nullable: true
-          format: date-time
-        actual_end_date:
-          type: string
-          nullable: true
-          format: date-time
-        state:
-          type: string
-          enum: ["started", "inProgress", "finish"]
-        study_type:
-          type: string
-          enum:
-            [
-              "timeTables",
-              "flowRate",
-              "parkSizing",
-              "garageRequirement",
-              "operationOrSizing",
-              "operability",
-              "strategicPlanning",
-              "chartStability",
-              "disturbanceTests",
-            ]
-      required:
-        - id
-        - name
-        - project_id
-        - description
-        - budget
-        - tags
-        - service_code
-        - business_code
-        - creation_date
-        - last_modification
-        - scenarios_count
-        - start_date
-        - expected_end_date
-        - actual_end_date
-
-    ScenarioRequest:
-      properties:
-        name:
-          type: string
-          maxLength: 128
-        description:
-          type: string
-          maxLength: 1024
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-        infra_id:
-          type: integer
-        electrical_profile_set_id:
-          type: number
-          description: Electrical profile set id (if any)
-      required:
-        - "name"
-        - "infra_id"
-
-    ScenarioPatchRequest:
-      properties:
-        name:
-          type: string
-          maxLength: 128
-        description:
-          type: string
-          maxLength: 1024
-        tags:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-
-    ScenarioResult:
-      properties:
-        id:
-          type: integer
         name:
           type: string
         study_id:
           type: integer
-        description:
-          type: string
         tags:
-          type: array
           items:
             type: string
-        infra_id:
-          type: integer
-        infra_name:
-          type: string
-        electrical_profile_set_id:
-          type: integer
-          nullable: true
-        electrical_profile_set_name:
-          type: string
-          nullable: true
-        creation_date:
-          type: string
-          format: date-time
-        last_modification:
-          type: string
-          format: date-time
+          type: array
         timetable_id:
           type: integer
         trains_count:
           type: integer
         trains_schedules:
-          type: array
           items:
-            type: object
             properties:
+              departure_time:
+                type: string
               id:
                 type: integer
               train_name:
                 type: string
-              departure_time:
-                type: string
               train_path:
                 type: integer
-
-    ScenarioListResult:
+            type: object
+          type: array
+    SearchOperationalPointResult:
       properties:
-        id:
-          type: integer
+        ch:
+          type: string
+        geographic:
+          $ref: '#/components/schemas/MultiPoint'
+        infra_id:
+          type: string
         name:
           type: string
-        study_id:
+        obj_id:
+          type: string
+        schematic:
+          $ref: '#/components/schemas/MultiPoint'
+        track_sections:
+          items:
+            properties:
+              position:
+                type: integer
+              track:
+                type: string
+            required:
+            - track
+            - position
+            type: object
+          type: array
+        trigram:
+          type: string
+        uic:
           type: integer
+      required:
+      - obj_id
+      - name
+      - geographic
+      - ch
+      - schematic
+      - trigram
+      - track_sections
+    SearchProjectResult:
+      properties:
         description:
           type: string
+        id:
+          type: integer
+        image:
+          type: integer
+        last_modification:
+          format: date-time
+          type: string
+        name:
+          type: string
+        studies_count:
+          type: integer
         tags:
           type: array
-          items:
-            type: string
+      required:
+      - id
+      - name
+      - description
+      - last_modification
+    SearchQuery:
+      example:
+      - and
+      - - or
+        - - search
+          - - name
+          - mich st
+        - - search
+          - - trigram
+          - null
+      - - =
+        - - infra_id
+        - 2
+      items:
+        oneOf:
+        - type: boolean
+        - type: number
+        - type: integer
+        - type: string
+        - $ref: '#/components/schemas/SearchQuery'
+      minItems: 1
+      nullable: true
+      type: array
+    SearchScenarioResult:
+      properties:
+        description:
+          type: string
+        electrical_profile_set_id:
+          type: integer
+        id:
+          type: integer
         infra_id:
           type: integer
         infra_name:
           type: string
-        electrical_profile_set_id:
-          type: integer
-          nullable: true
-        electrical_profile_set_name:
-          type: string
-          nullable: true
-        creation_date:
-          type: string
-          format: date-time
         last_modification:
-          type: string
           format: date-time
-        timetable_id:
+          type: string
+        name:
+          type: string
+        study_id:
           type: integer
-        trains_count:
-          type: integer
-
-    Geometry:
-      type: object
-      description: Definition of a GeoJSON geometry
-      oneOf:
-        - $ref: "#/components/schemas/Point"
-        - $ref: "#/components/schemas/LineString"
-        - $ref: "#/components/schemas/Polygon"
-        - $ref: "#/components/schemas/MultiPoint"
-        - $ref: "#/components/schemas/MultiLineString"
-        - $ref: "#/components/schemas/MultiPolygon"
-
-    Point3D:
-      type: array
-      description: Point in 3D space
-      minItems: 2
-      maxItems: 3
-      items:
-        type: number
-
-    Point:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - Point
-        coordinates:
-          $ref: "#/components/schemas/Point3D"
-
-    LineString:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - LineString
-        coordinates:
-          type: array
-          items:
-            $ref: "#/components/schemas/Point3D"
-
-    Polygon:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - Polygon
-        coordinates:
-          type: array
-          items:
-            type: array
-            items:
-              $ref: "#/components/schemas/Point3D"
-
-    MultiPoint:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - MultiPoint
-        coordinates:
-          type: array
-          items:
-            $ref: "#/components/schemas/Point3D"
-
-    MultiLineString:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - MultiLineString
-        coordinates:
-          type: array
-          items:
-            type: array
-            items:
-              $ref: "#/components/schemas/Point3D"
-
-    MultiPolygon:
-      type: object
-      description: GeoJSon geometry
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - MultiPolygon
-        coordinates:
-          type: array
-          items:
-            type: array
-            items:
-              type: array
-              items:
-                $ref: "#/components/schemas/Point3D"
-
-    TrainSchedule:
-      type: object
-      properties:
-        train_name:
-          type: string
-        timetable:
-          type: integer
-        rolling_stock:
-          type: integer
-        departure_time:
-          type: number
-          format: float
-        path:
-          type: integer
-        initial_speed:
-          type: number
-          format: float
-        labels:
-          type: array
+        tags:
           items:
             type: string
-        scheduled_points:
           type: array
+        trains_count:
+          type: integer
+      required:
+      - id
+      - name
+      - study_id
+      - last_modification
+      - infra_id
+      - timetable_id
+    SearchSignalResult:
+      properties:
+        aspects:
           items:
-            type: object
-            required: [path_offset, time]
-            properties:
-              path_offset:
-                type: number
-                format: float
-                description: Offset in meters from the start of the path at which the train must be.
-              time:
-                type: number
-                format: float
-                description: Time in seconds (elapsed since the train's departure) at which the train must be.
-        allowances:
+            type: string
           type: array
-          items:
-            $ref: "#/components/schemas/Allowance"
-        speed_limit_tags:
-          description: Train category for speed limits
+        geographic:
+          $ref: '#/components/schemas/Point'
+        infra_id:
+          type: integer
+        label:
           type: string
-        comfort:
-          $ref: "#/components/schemas/Comfort"
-        options:
-          allOf:
-            - $ref: "#/components/schemas/TrainScheduleOptions"
-          nullable: true
-        power_restriction_ranges:
-          description: A list of ranges along the train path where power restrictions apply.
-          type: array
+        line_code:
+          type: integer
+        line_name:
+          type: string
+        schematic:
+          $ref: '#/components/schemas/Point'
+        systems:
           items:
-            $ref: "#/components/schemas/PowerRestrictionRange"
-          nullable: true
-    TimetableWithSchedulesDetails:
+            type: string
+          type: array
+        type:
+          type: string
+      required:
+      - label
+      - geographic
+      - schematic
+      - line_code
+      - line_name
+    SearchStudyResult:
+      properties:
+        description:
+          type: string
+        id:
+          type: integer
+        last_modification:
+          format: date-time
+          type: string
+        name:
+          type: string
+        project_id:
+          type: integer
+        scenarios_count:
+          type: integer
+        tags:
+          items:
+            type: string
+          type: array
+      required:
+      - id
+      - name
+      - project_id
+      - last_modification
+    SearchTrackResult:
+      properties:
+        infra_id:
+          type: integer
+        line_code:
+          type: integer
+        line_name:
+          type: string
+      required:
+      - infra_id
+      - line_code
+      - line_name
+    SimulationReport:
+      properties:
+        base:
+          $ref: '#/components/schemas/SimulationReportByTrain'
+        curves:
+          items:
+            properties:
+              position:
+                type: number
+              radius:
+                type: number
+            required:
+            - position
+            - radius
+            type: object
+          minItems: 2
+          type: array
+        eco:
+          $ref: '#/components/schemas/SimulationReportByTrain'
+        electrification_ranges:
+          description: A list of ranges which should be contiguous and which describe the electrification on the path and if it is handled by the train
+          items:
+            $ref: '#/components/schemas/ElectrificationRange'
+          minItems: 1
+          type: array
+        id:
+          type: integer
+        labels:
+          items:
+            type: string
+          type: array
+        name:
+          type: string
+        path:
+          description: id of the path used for projection
+          type: integer
+        power_restriction_ranges:
+          description: The list of ranges where power restrictions are applied
+          items:
+            $ref: '#/components/schemas/PowerRestrictionRangeItem'
+          type: array
+        slopes:
+          items:
+            properties:
+              gradient:
+                type: number
+              position:
+                type: number
+            required:
+            - position
+            - gradient
+            type: object
+          minItems: 2
+          type: array
+        speed_limit_tags:
+          type: string
+        vmax:
+          items:
+            properties:
+              position:
+                type: number
+              speed:
+                type: number
+            required:
+            - position
+            - speed
+            type: object
+          minItems: 2
+          type: array
+      required:
+      - id
+      - name
+      - labels
+      - path
+      - vmax
+      - slopes
+      - curves
+      - base
+      - electrification_ranges
+      - power_restriction_ranges
+    SimulationReportByTrain:
+      properties:
+        head_positions:
+          items:
+            items:
+              $ref: '#/components/schemas/SpaceTimePosition'
+            minItems: 1
+            type: array
+          minItems: 1
+          type: array
+        mechanical_energy_consumed:
+          format: float
+          type: number
+        route_aspects:
+          items:
+            properties:
+              aspect_label:
+                description: label of the new signal aspect
+                type: string
+              blinking:
+                description: true if the signal is blinking
+                type: boolean
+              color:
+                description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+                format: float
+                type: number
+              position_end:
+                description: the route ends at this position on the train path
+                format: float
+                type: number
+              position_start:
+                description: the route starts at this position on the train path
+                format: float
+                type: number
+              route_id:
+                description: id of the affected route on the train path
+                type: string
+              signal_id:
+                description: id of the updated signal
+                type: string
+              time_end:
+                description: the aspect stops being displayed at this time
+                format: float
+                type: number
+              time_start:
+                description: the aspect starts being displayed at this time
+                format: float
+                type: number
+            required:
+            - signal_id
+            - route_id
+            - time_start
+            - time_end
+            - position_start
+            - position_end
+            - color
+            - blinking
+            - aspect_label
+            type: object
+          type: array
+        signals:
+          items:
+            properties:
+              aspects:
+                items:
+                  type: string
+                type: array
+              geo_position:
+                items:
+                  format: float
+                  type: number
+                maxItems: 2
+                minItems: 2
+                type: array
+              schema_position:
+                items:
+                  format: float
+                  type: number
+                maxItems: 2
+                minItems: 2
+                type: array
+              signal_id:
+                type: integer
+            required:
+            - signal_id
+            - aspects
+            - geo_position
+            - schema_position
+            type: object
+          type: array
+        speeds:
+          items:
+            allOf:
+            - $ref: '#/components/schemas/SpaceTimePosition'
+            - properties:
+                speed:
+                  format: float
+                  type: number
+              required:
+              - speed
+              type: object
+          minItems: 1
+          type: array
+        stops:
+          items:
+            properties:
+              duration:
+                format: float
+                type: number
+              id:
+                description: Can be null if it's not an operational point
+                type: number
+              line_code:
+                type: number
+              line_name:
+                type: string
+              name:
+                description: Can be 'Unknown' if it's not an operational point
+                type: string
+              position:
+                format: float
+                type: number
+              time:
+                format: float
+                type: number
+              track_name:
+                type: string
+              track_number:
+                type: number
+            required:
+            - id
+            - name
+            - time
+            - position
+            - duration
+            - line_code
+            - track_number
+            - line_name
+            - track_name
+            type: object
+          type: array
+        tail_positions:
+          items:
+            items:
+              $ref: '#/components/schemas/SpaceTimePosition'
+            minItems: 1
+            type: array
+          minItems: 1
+          type: array
+      required:
+      - speeds
+      - head_positions
+      - tail_positions
+      - stops
+      - route_aspects
+      - signals
+      - mechanical_energy_consumed
+    SpaceTimePosition:
+      properties:
+        position:
+          format: float
+          type: number
+        time:
+          format: float
+          type: number
+      required:
+      - time
+      - position
+      - speed
       type: object
+    SpeedDependantPower:
+      description: power-speed curve (in an energy source)
+      properties:
+        powers:
+          items:
+            format: float
+            type: number
+          type: array
+        speeds:
+          items:
+            format: float
+            type: number
+          type: array
+      required:
+      - speeds
+      - powers
+      type: object
+    StandardAllowance:
+      properties:
+        allowance_type:
+          enum:
+          - standard
+          type: string
+        capacity_speed_limit:
+          format: double
+          type: number
+        default_value:
+          $ref: '#/components/schemas/AllowanceValue'
+        distribution:
+          enum:
+          - MARECO
+          - LINEAR
+          type: string
+        ranges:
+          items:
+            $ref: '#/components/schemas/RangeAllowance'
+          type: array
+      required:
+      - allowance_type
+      - default_value
+      - ranges
+      - distribution
+    StudyResult:
+      properties:
+        actual_end_date:
+          format: date-time
+          nullable: true
+          type: string
+        budget:
+          type: integer
+        business_code:
+          type: string
+        creation_date:
+          format: date-time
+          type: string
+        description:
+          type: string
+        expected_end_date:
+          format: date-time
+          nullable: true
+          type: string
+        id:
+          type: integer
+        last_modification:
+          format: date-time
+          type: string
+        name:
+          type: string
+        project_id:
+          type: integer
+        scenarios_count:
+          type: integer
+        service_code:
+          type: string
+        start_date:
+          format: date-time
+          nullable: true
+          type: string
+        state:
+          enum:
+          - started
+          - inProgress
+          - finish
+          type: string
+        study_type:
+          enum:
+          - timeTables
+          - flowRate
+          - parkSizing
+          - garageRequirement
+          - operationOrSizing
+          - operability
+          - strategicPlanning
+          - chartStability
+          - disturbanceTests
+          type: string
+        tags:
+          items:
+            type: string
+          type: array
+      required:
+      - id
+      - name
+      - project_id
+      - description
+      - budget
+      - tags
+      - service_code
+      - business_code
+      - creation_date
+      - last_modification
+      - scenarios_count
+      - start_date
+      - expected_end_date
+      - actual_end_date
+    StudyUpsertRequest:
+      properties:
+        actual_end_date:
+          format: date-time
+          nullable: true
+          type: string
+        budget:
+          type: integer
+        business_code:
+          maxLength: 128
+          type: string
+        description:
+          maxLength: 1024
+          type: string
+        expected_end_date:
+          format: date-time
+          nullable: true
+          type: string
+        name:
+          maxLength: 128
+          type: string
+        service_code:
+          maxLength: 128
+          type: string
+        start_date:
+          format: date-time
+          nullable: true
+          type: string
+        state:
+          enum:
+          - started
+          - inProgress
+          - finish
+          type: string
+        study_type:
+          enum:
+          - timeTables
+          - flowRate
+          - parkSizing
+          - garageRequirement
+          - operationOrSizing
+          - operability
+          - strategicPlanning
+          - chartStability
+          - disturbanceTests
+          type: string
+        tags:
+          items:
+            maxLength: 255
+            type: string
+          type: array
+      required:
+      - name
+      - tags
+    TimetableWithSchedulesDetails:
       properties:
         id:
           type: integer
         name:
           type: string
         train_schedule_summaries:
-          type: array
           items:
-            $ref: "#/components/schemas/TrainScheduleSummary"
-      required:
-        - id
-        - name
-        - train_schedule_summaries
-    TrainScheduleSummary:
-      type: object
-      properties:
-        id:
-          type: integer
-        train_name:
-          type: string
-        timetable_id:
-          type: integer
-        rolling_stock_id:
-          type: integer
-        departure_time:
-          type: number
-          format: float
-        path_id:
-          type: integer
-        initial_speed:
-          type: number
-          format: float
-        labels:
+            $ref: '#/components/schemas/TrainScheduleSummary'
           type: array
+      required:
+      - id
+      - name
+      - train_schedule_summaries
+      type: object
+    TrackLocation:
+      description: A track location (track section and offset)
+      properties:
+        offset:
+          description: The offset on the track section
+          example: 42.0
+          format: float
+          type: number
+        track:
+          description: The track section ID
+          example: 61205924-6667-11e3-81ff-01f464e0362d
+          type: string
+      type: object
+    TrackRange:
+      description: Track range
+      properties:
+        begin:
+          format: float
+          type: number
+        end:
+          example: 100
+          format: float
+          type: number
+        track:
+          example: 01234567-89ab-cdef-0123-456789abcdef
+          type: string
+      type: object
+    TrackSectionLocation:
+      description: A track location (track section and offset)
+      properties:
+        offset:
+          description: The offset on the track section
+          example: 42.0
+          format: float
+          type: number
+        track_section:
+          description: The track section ID
+          example: 61205924-6667-11e3-81ff-01f464e0362d
+          type: string
+      required:
+      - track_section
+      - offset
+      type: object
+    TrainSchedule:
+      properties:
+        allowances:
+          items:
+            $ref: '#/components/schemas/Allowance'
+          type: array
+        comfort:
+          $ref: '#/components/schemas/Comfort'
+        departure_time:
+          format: float
+          type: number
+        initial_speed:
+          format: float
+          type: number
+        labels:
           items:
             type: string
-        allowances:
           type: array
+        options:
+          allOf:
+          - $ref: '#/components/schemas/TrainScheduleOptions'
+          nullable: true
+        path:
+          type: integer
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
           items:
-            $ref: "#/components/schemas/Allowance"
+            $ref: '#/components/schemas/PowerRestrictionRange'
+          nullable: true
+          type: array
+        rolling_stock:
+          type: integer
+        scheduled_points:
+          items:
+            properties:
+              path_offset:
+                description: Offset in meters from the start of the path at which the train must be.
+                format: float
+                type: number
+              time:
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+                format: float
+                type: number
+            required:
+            - path_offset
+            - time
+            type: object
+          type: array
         speed_limit_tags:
           description: Train category for speed limits
           type: string
-        comfort:
-          $ref: "#/components/schemas/Comfort"
-        options:
-          allOf:
-            - $ref: "#/components/schemas/TrainScheduleOptions"
+        timetable:
+          type: integer
+        train_name:
+          type: string
+      type: object
+    TrainScheduleOptions:
+      description: Options for the standalone simulation
+      properties:
+        ignore_electrical_profiles:
           nullable: true
-        power_restriction_ranges:
-          description: A list of ranges along the train path where power restrictions apply.
-          type: array
+          type: boolean
+      type: object
+    TrainScheduleSummary:
+      properties:
+        allowances:
           items:
-            $ref: "#/components/schemas/PowerRestrictionRange"
-          nullable: true
+            $ref: '#/components/schemas/Allowance'
+          type: array
         arrival_time:
           type: number
+        comfort:
+          $ref: '#/components/schemas/Comfort'
+        departure_time:
+          format: float
+          type: number
+        id:
+          type: integer
+        initial_speed:
+          format: float
+          type: number
+        labels:
+          items:
+            type: string
+          type: array
         mechanical_energy_consumed:
-          type: object
           properties:
             base:
               type: number
             eco:
               type: number
-        stops_count:
+          type: object
+        options:
+          allOf:
+          - $ref: '#/components/schemas/TrainScheduleOptions'
+          nullable: true
+        path_id:
           type: integer
         path_length:
           type: integer
-      required:
-        [
-          id,
-          train_name,
-          departure_time,
-          path,
-          labels,
-          arrival_time,
-          mechanical_energy_consumed,
-        ]
-
-    TrainScheduleOptions:
-      description: Options for the standalone simulation
-      type: object
-      properties:
-        ignore_electrical_profiles:
-          type: boolean
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          items:
+            $ref: '#/components/schemas/PowerRestrictionRange'
           nullable: true
-
-    RollingStockUsage:
-      type: object
-      properties:
+          type: array
         rolling_stock_id:
           type: integer
-        usage:
-          type: object
-          properties:
-            train_schedule_id:
-              type: integer
-            train_name:
-              type: string
-            project_id:
-              type: integer
-            project_name:
-              type: string
-            study_id:
-              type: integer
-            study_name:
-              type: string
-            scenario_id:
-              type: integer
-            scenario_name:
-              type: string
-          required:
-            - train_schedule_id
-            - train_name
-            - project_id
-            - project_name
-            - study_id
-            - study_name
-            - scenario_id
-            - scenario_name
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+        stops_count:
+          type: integer
+        timetable_id:
+          type: integer
+        train_name:
+          type: string
       required:
-        - rolling_stock_id
-        - usage
-
-    PowerRestrictionRange:
-      description: A range along the train path where a power restriction is applied.
+      - id
+      - train_name
+      - departure_time
+      - path
+      - labels
+      - arrival_time
+      - mechanical_energy_consumed
       type: object
+    UpdateOperation:
       properties:
-        begin_position:
-          description: Offset from the start of the path, in meters.
-          type: number
-          format: float
-        end_position:
-          description: Offset from the start of the path, in meters.
-          type: number
-          format: float
-        power_restriction_code:
-          description: The power restriction code to apply.
+        obj_id:
+          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
           type: string
-      example:
-        begin_position: 0.0
-        end_position: 1000.0
-        power_restriction_code: "C1US"
-      required: [begin_position, end_position, power_restriction_code]
-
-    Allowance:
-      oneOf:
-        - $ref: "#/components/schemas/EngineeringAllowance"
-        - $ref: "#/components/schemas/StandardAllowance"
-      discriminator:
-        propertyName: allowance_type
-
-    StandardAllowance:
-      properties:
-        allowance_type:
+        obj_type:
+          $ref: '#/components/schemas/ObjectType'
+        operation_type:
+          enum:
+          - UPDATE
           type: string
-          enum: ["standard"]
-        default_value:
-          $ref: "#/components/schemas/AllowanceValue"
-        ranges:
-          type: array
-          items:
-            $ref: "#/components/schemas/RangeAllowance"
-        distribution:
-          type: string
-          enum: ["MARECO", "LINEAR"]
-        capacity_speed_limit:
-          type: number
-          format: double
-      required: [allowance_type, default_value, ranges, distribution]
-
-    EngineeringAllowance:
-      allOf:
-        - type: object
-          properties:
-            allowance_type:
-              type: string
-              enum: ["engineering"]
-            distribution:
-              type: string
-              enum: ["MARECO", "LINEAR"]
-            capacity_speed_limit:
-              type: number
-              format: double
-          required: [allowance_type, distribution]
-        - $ref: "#/components/schemas/RangeAllowance"
-
-    RangeAllowance:
-      properties:
-        begin_position:
-          type: number
-        end_position:
-          type: number
-          example: 1000.0
-        value:
-          $ref: "#/components/schemas/AllowanceValue"
-      required: [begin_position, end_position, value]
-
-    AllowanceValue:
-      oneOf:
-        - $ref: "#/components/schemas/AllowanceTimePerDistanceValue"
-        - $ref: "#/components/schemas/AllowanceTimeValue"
-        - $ref: "#/components/schemas/AllowancePercentValue"
-      discriminator:
-        propertyName: value_type
-
-    AllowanceTimePerDistanceValue:
-      properties:
-        value_type:
-          type: string
-          enum: ["time_per_distance"]
-        minutes:
-          type: number
-          example: 5.0
-          description: Minutes per 100k
-      required: [value_type, minutes]
-
-    AllowanceTimeValue:
-      properties:
-        value_type:
-          type: string
-          enum: ["time"]
-        seconds:
-          type: number
-          example: 180.0
-      required: [value_type, seconds]
-
-    AllowancePercentValue:
-      properties:
-        value_type:
-          type: string
-          enum: ["percentage"]
-        percentage:
-          type: number
-          example: 15.0
-      required: [value_type, percentage]
-
-    SimulationReportByTrain:
-      properties:
-        speeds:
-          type: array
-          minItems: 1
-          items:
-            allOf:
-              - $ref: "#/components/schemas/SpaceTimePosition"
-              - type: object
-                properties:
-                  speed:
-                    type: number
-                    format: float
-                required: [speed]
-        head_positions:
-          type: array
-          minItems: 1
-          items:
-            type: array
-            minItems: 1
-            items:
-              $ref: "#/components/schemas/SpaceTimePosition"
-        tail_positions:
-          type: array
-          minItems: 1
-          items:
-            type: array
-            minItems: 1
-            items:
-              $ref: "#/components/schemas/SpaceTimePosition"
-        stops:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: number
-                description: Can be null if it's not an operational point
-              name:
-                type: string
-                description: Can be 'Unknown' if it's not an operational point
-              time: { type: number, format: float }
-              position: { type: number, format: float }
-              duration: { type: number, format: float }
-              line_code: { type: number }
-              track_number: { type: number }
-              line_name: { type: string }
-              track_name: { type: string }
-            required:
-              [
-                id,
-                name,
-                time,
-                position,
-                duration,
-                line_code,
-                track_number,
-                line_name,
-                track_name,
-              ]
-        route_aspects:
-          type: array
-          items:
-            type: object
-            properties:
-              signal_id:
-                type: string
-                description: id of the updated signal
-              route_id:
-                type: string
-                description: id of the affected route on the train path
-              time_start:
-                type: number
-                format: float
-                description: the aspect starts being displayed at this time
-              time_end:
-                type: number
-                format: float
-                description: the aspect stops being displayed at this time
-              position_start:
-                type: number
-                format: float
-                description: the route starts at this position on the train path
-              position_end:
-                type: number
-                format: float
-                description: the route ends at this position on the train path
-              color:
-                type: number
-                format: float
-                description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
-              blinking:
-                type: boolean
-                description: true if the signal is blinking
-              aspect_label:
-                type: string
-                description: label of the new signal aspect
-            required:
-              - signal_id
-              - route_id
-              - time_start
-              - time_end
-              - position_start
-              - position_end
-              - color
-              - blinking
-              - aspect_label
-        signals:
-          type: array
-          items:
-            type: object
-            properties:
-              signal_id: { type: integer }
-              aspects:
-                type: array
-                items:
-                  type: string
-              geo_position:
-                type: array
-                items: { type: number, format: float }
-                minItems: 2
-                maxItems: 2
-              schema_position:
-                type: array
-                items: { type: number, format: float }
-                minItems: 2
-                maxItems: 2
-            required: [signal_id, aspects, geo_position, schema_position]
-        mechanical_energy_consumed:
-          type: number
-          format: float
+        railjson_patch:
+          $ref: '#/components/schemas/Patches'
       required:
-        - speeds
-        - head_positions
-        - tail_positions
-        - stops
-        - route_aspects
-        - signals
-        - mechanical_energy_consumed
-
-    SpaceTimePosition:
-      type: object
+      - operation_type
+      - obj_type
+      - railjson_patch
+    ViewMetadata:
       properties:
-        time: { type: number, format: float }
-        position: { type: number, format: float }
-      required: [time, position, speed]
-
-    SimulationReport:
-      properties:
-        id:
+        attribution:
+          type: string
+        maxzoom:
+          example: 18
+          type: integer
+        minzoom:
           type: integer
         name:
+          example: track_sections
           type: string
-        labels:
-          type: array
+        promotedId:
+          example:
+            track_sections: id
+          type: object
+        scheme:
+          example: xyz
+          type: string
+        tiles:
           items:
+            example: http://localhost:7070/tile/track_sections/geo/{z}/{x}/{y}/?infra=1
             type: string
-        path:
+          type: array
+        type:
+          example: vector
+          type: string
+    Zone:
+      properties:
+        geo:
+          $ref: '#/components/schemas/BoundingBox'
+        sch:
+          $ref: '#/components/schemas/BoundingBox'
+      type: object
+info:
+  description: OSRD Edition service description
+  title: OSRD Editoast
+  version: 0.1.0
+openapi: 3.0.2
+paths:
+  /documents/:
+    post:
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                properties:
+                  document_key:
+                    example: 42
+                    type: integer
+                type: object
+          description: The key of the added document
+      summary: Add a document
+      tags:
+      - documents
+  /documents/{key}/:
+    delete:
+      parameters:
+      - description: A key identifying the document
+        in: path
+        name: key
+        required: true
+        schema:
           type: integer
-          description: id of the path used for projection
-        vmax:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              speed: { type: number }
-            required: [position, speed]
-        slopes:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              gradient: { type: number }
-            required: [position, gradient]
-        curves:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              radius: { type: number }
-            required: [position, radius]
-        base:
-          $ref: "#/components/schemas/SimulationReportByTrain"
-        eco:
-          $ref: "#/components/schemas/SimulationReportByTrain"
-        speed_limit_tags:
+      responses:
+        '204':
+          description: No content
+      summary: Delete a document
+      tags:
+      - documents
+    get:
+      parameters:
+      - description: A key identifying the document
+        in: path
+        name: key
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: A document of any type (can be an image, a pdf...)
+      summary: Retrieve a document binary content
+      tags:
+      - documents
+  /electrical_profile_set/:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      example: France 2023
+                      type: string
+                  required:
+                  - id
+                  - name
+                  type: object
+                type: array
+          description: The list of ids and names of electrical profile sets available
+      summary: Retrieve the list of ids and names of electrical profile sets available
+      tags:
+      - electrical_profiles
+    post:
+      parameters:
+      - in: query
+        name: name
+        required: true
+        schema:
           type: string
-        electrification_ranges:
-          description: A list of ranges which should be contiguous and which describe the electrification on the path and if it is handled by the train
-          type: array
-          items:
-            $ref: "#/components/schemas/ElectrificationRange"
-          minItems: 1
-        power_restriction_ranges:
-          description: The list of ranges where power restrictions are applied
-          type: array
-          items:
-            $ref: "#/components/schemas/PowerRestrictionRangeItem"
-
-      required:
-        - id
-        - name
-        - labels
-        - path
-        - vmax
-        - slopes
-        - curves
-        - base
-        - electrification_ranges
-        - power_restriction_ranges
-
-    PowerRestrictionRangeItem:
-      properties:
-        start:
-          type: number
-          format: double
-        stop:
-          type: number
-          format: double
-        code:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ElectricalProfile'
+          description: The list of ids and names of electrical profile sets available
+      summary: import a new electrical profile set
+      tags:
+      - electrical_profiles
+  /electrical_profile_set/{id}/:
+    get:
+      parameters:
+      - description: Electrical profile set ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ElectricalProfile'
+                type: array
+          description: The list of electrical profiles in the set
+      summary: Retrieve the set of electrical profiles with the given id
+      tags:
+      - electrical_profiles
+  /electrical_profile_set/{id}/level_order/:
+    get:
+      parameters:
+      - description: Electrical profile set ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                example:
+                  '1500':
+                  - A
+                  - B
+                  - C
+                  '25000':
+                  - '25000'
+                  - '22500'
+                  - '20000'
+                type: object
+          description: A dictionary mapping catenary modes to a list of electrical profiles ordered by decreasing strength
+      summary: Retrieve the order of strength of the electrical profiles in the set with the given id
+      tags:
+      - electrical_profiles
+  /health/:
+    get:
+      responses:
+        '200':
+          description: Check if Editoast is running correctly
+  /infra/:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    items:
+                      $ref: '#/components/schemas/Infra'
+                    type: array
+                required:
+                - count
+                - next
+                - previous
+                type: object
+          description: The infra list
+      summary: List all available infra
+      tags:
+      - infra
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+              type: object
+        description: Name of the infra to create
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Infra'
+          description: The created infra
+      summary: Create an infra
+      tags:
+      - infra
+  /infra/railjson/:
+    post:
+      parameters:
+      - description: Infra name
+        in: query
+        name: name
+        required: true
+        schema:
           type: string
-        handled:
+      - in: query
+        name: generate_data
+        schema:
+          default: false
+          description: whether the layer should be generated or no
           type: boolean
-      required: [start, stop, code, handled]
-
-    ElectrificationRange:
-      properties:
-        start:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RailjsonFile'
+        description: Railjson infra
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                type: object
+          description: The imported infra id
+      summary: Import an infra from railjson
+      tags:
+      - infra
+  /infra/refresh/:
+    post:
+      parameters:
+      - description: A list of infra ID
+        in: query
+        name: infras
+        schema:
+          default: []
+          items:
+            type: integer
+          type: array
+      - description: Force the refresh of the layers
+        in: query
+        name: force
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: integer
+                type: array
+          description: A list thats contains the ID of the infras that were refreshed*
+      summary: Refresh the layers
+      tags:
+      - infra
+  /infra/{id}/:
+    delete:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Delete an infra and all entities linked to it
+      tags:
+      - infra
+    get:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Infra'
+          description: Information about the retrieved infra
+      summary: Retrieve a specific infra
+      tags:
+      - infra
+    post:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/Operation'
+              type: array
+        description: Operations to do on the infra
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OperationResult'
+                type: array
+          description: An array containing infos about the operations processed
+      summary: Update/Create/Delete an object of the infra
+      tags:
+      - infra
+    put:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+              type: object
+        description: the name we want to give to the infra
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Infra'
+          description: The updated infra
+      summary: Update an infrastructure name
+      tags:
+      - infra
+  /infra/{id}/attached/{track_id}/:
+    get:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Track ID
+        in: path
+        name: track_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    description: Object IDs
+                    type: string
+                  type: array
+                example:
+                  BufferStop: []
+                  Detector:
+                  - detector.0
+                  Switch:
+                  - switch.0
+                  - switch.1
+                type: object
+          description: All objects attached to the given track (arranged by types)
+      summary: Retrieve all objects attached to a given track
+      tags:
+      - infra
+  /infra/{id}/clone/:
+    post:
+      parameters:
+      - description: Infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: New infra name
+        in: query
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: integer
+                type: object
+          description: The duplicated infra id
+      summary: Duplicate an infra
+      tags:
+      - infra
+  /infra/{id}/errors/:
+    get:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The page number
+        in: query
+        name: page
+        schema:
+          default: 1
+          type: integer
+      - description: The number of item per page
+        in: query
+        name: page_size
+        schema:
+          default: 25
+          minimum: 10
+          type: integer
+      - description: The type of error to filter on
+        in: query
+        name: error_type
+        schema:
+          $ref: '#/components/schemas/InfraErrorType'
+      - description: errors and warnings that only part of a given object
+        in: query
+        name: object_id
+        schema:
+          type: string
+      - description: Whether the response should include errors or warnings
+        in: query
+        name: level
+        schema:
+          default: all
+          enum:
+          - errors
+          - warnings
+          - all
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    description: Total number of elements
+                    example: 1
+                    type: integer
+                  next:
+                    description: The index of the following page (null if no more pages available)
+                    example: null
+                    nullable: true
+                    type: integer
+                  previous:
+                    description: The index of the previous page (null if requesting the first page)
+                    example: null
+                    nullable: true
+                    type: integer
+                  results:
+                    items:
+                      $ref: '#/components/schemas/InfraError'
+                    type: array
+                type: object
+          description: A paginated list of errors
+      summary: Retrieve a paginated list of errors
+      tags:
+      - infra
+  /infra/{id}/lines/{line_code}/bbox/:
+    get:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: a line code
+        in: path
+        name: line_code
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Zone'
+          description: The BBox of the line
+      summary: Returns the BBoxes (geo and schematic) of a line
+      tags:
+      - infra
+  /infra/{id}/load/:
+    post:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: No content
+      summary: Load an infra if not loaded
+      tags:
+      - infra
+  /infra/{id}/lock/:
+    post:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Lock an infra from edition
+      tags:
+      - infra
+  /infra/{id}/objects/{object_type}/:
+    post:
+      parameters:
+      - description: Infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: The type of the object
+        in: path
+        name: object_type
+        required: true
+        schema:
+          $ref: '#/components/schemas/ObjectType'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                type: string
+              type: array
+        description: List of object id's
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    geographic:
+                      $ref: '#/components/schemas/Geometry'
+                      description: object's geographic in geojson format
+                    railjson:
+                      $ref: '#/components/schemas/Railjson'
+                      description: Object properties in railjson format
+                    schematic:
+                      $ref: '#/components/schemas/Geometry'
+                      description: object's schematic in geojson format
+                  required:
+                  - railjson
+                  - geographic
+                  - schematic
+                  type: object
+                type: array
+          description: No content
+      summary: Retrieve a list of specific objects in railjson format
+      tags:
+      - infra
+  /infra/{id}/pathfinding/:
+    post:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Maximum number of paths to return
+        in: query
+        name: number
+        schema:
+          default: 5
+          format: integer
+          maximum: 5
+          minimum: 1
           type: number
-          format: double
-        stop:
-          type: number
-          format: double
-        electrificationUsage:
-          oneOf:
-            - $ref: "#/components/schemas/Electrified"
-            - $ref: "#/components/schemas/Neutral"
-            - $ref: "#/components/schemas/NonElectrified"
-          discriminator:
-            propertyName: object_type
-      required: [start, stop, is_electrified, electrificationUsage]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                ending:
+                  $ref: '#/components/schemas/TrackLocation'
+                starting:
+                  allOf:
+                  - $ref: '#/components/schemas/TrackLocation'
+                  - properties:
+                      direction:
+                        $ref: '#/components/schemas/Direction'
+                    type: object
+              type: object
+        description: Starting and ending track location
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    detectors:
+                      items:
+                        example: detector1
+                        type: string
+                      type: array
+                    switches_directions:
+                      additionalProperties:
+                        type: string
+                      example:
+                        switch1: left
+                        switch2: right
+                      type: object
+                    track_ranges:
+                      items:
+                        $ref: '#/components/schemas/DirectionalTrackRange'
+                      minItems: 1
+                      type: array
+                  type: object
+                type: array
+          description: Paths, containing track ranges, detectors and switches with their directions. If no path is found, an empty list is returned.
+      summary: Compute paths given starting and ending track location. Return shortest paths.
+      tags:
+      - infra
+      - pathfinding
+  /infra/{id}/railjson/:
+    get:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RailjsonFile'
+          description: The infra in railjson format
+      summary: Serialize an infra to railjson
+      tags:
+      - infra
+  /infra/{id}/routes/track_ranges/:
+    get:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - in: query
+        name: routes
+        required: true
+        schema:
+          description: A list of routes seperated by comma
+          example: route1,route2,route3
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  oneOf:
+                  - $ref: '#/components/schemas/RouteTrackRangesNotFoundError'
+                  - $ref: '#/components/schemas/RouteTrackRangesCantComputePathError'
+                  - $ref: '#/components/schemas/RouteTrackRangesComputed'
+                type: array
+          description: Foreach route, the track ranges through which it passes or an error
+      summary: Compute the track ranges through which routes passes.
+      tags:
+      - infra
+      - routes
+  /infra/{id}/routes/{waypoint_type}/{waypoint_id}/:
+    get:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Type of the waypoint
+        in: path
+        name: waypoint_type
+        required: true
+        schema:
+          enum:
+          - Detector
+          - BufferStop
+          type: string
+      - description: The waypoint id
+        in: path
+        name: waypoint_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  ending:
+                    example:
+                    - route3
+                    - route4
+                    items:
+                      type: string
+                    type: array
+                  starting:
+                    example:
+                    - route1
+                    - route2
+                    items:
+                      type: string
+                    type: array
+                type: object
+          description: All routes that starting and ending by the given waypoint
+      summary: Retrieve all routes that starting and ending by the given waypoint (detector or buffer stop)
+      tags:
+      - infra
+      - routes
+  /infra/{id}/speed_limit_tags/:
+    get:
+      parameters:
+      - description: Infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                example:
+                - freight
+                - heavy_load
+                items:
+                  type: string
+                type: array
+          description: Tags list
+      summary: List all speed limit tags
+      tags:
+      - infra
+  /infra/{id}/switch_types/:
+    get:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  description: A switch type following Railjson spec
+                  example:
+                    groups:
+                      LEFT:
+                        dst: LEFT
+                        src: BASE
+                      RIGHT:
+                        dst: RIGHT
+                        src: BASE
+                    id: Point
+                    ports:
+                    - LEFT
+                    - RIGHT
+                    - BASE
+                  type: object
+                type: array
+          description: A list of switch types
+      summary: Retrieve a list of switch types
+      tags:
+      - infra
+  /infra/{id}/unlock/:
+    post:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Unlock an infra from edition
+      tags:
+      - infra
+  /infra/{id}/voltages/:
+    get:
+      parameters:
+      - description: Infra ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: include rolling stocks modes or not
+        in: query
+        name: include_rolling_stock_modes
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                example:
+                - '750'
+                - '1500'
+                - '2500.5'
+                items:
+                  type: string
+                type: array
+          description: Voltages list
+      summary: List all voltages
+      tags:
+      - infra
+  /layers/layer/{layer_slug}/mvt/{view_slug}/:
+    get:
+      parameters:
+      - in: path
+        name: layer_slug
+        required: true
+        schema:
+          title: Layer Slug
+          type: string
+      - in: path
+        name: view_slug
+        required: true
+        schema:
+          title: View Slug
+          type: string
+      - in: query
+        name: infra
+        required: true
+        schema:
+          title: Infra id
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ViewMetadata'
+          description: Successful Response
+      summary: Mvt View Metadata
+      tags:
+      - layers
+  /layers/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}/:
+    get:
+      parameters:
+      - in: path
+        name: layer_slug
+        required: true
+        schema:
+          title: Layer Slug
+          type: string
+      - in: path
+        name: view_slug
+        required: true
+        schema:
+          title: View Slug
+          type: string
+      - in: path
+        name: z
+        required: true
+        schema:
+          title: Z
+          type: integer
+      - in: path
+        name: x
+        required: true
+        schema:
+          title: X
+          type: integer
+      - in: path
+        name: y
+        required: true
+        schema:
+          title: Y
+          type: integer
+      - in: query
+        name: infra
+        required: true
+        schema:
+          title: Infra
+          type: integer
+      responses:
+        '200':
+          content:
+            application/x-octet-stream:
+              schema:
+                type: string
+          description: Successful Response
+      summary: Mvt tile from the cache or the database, cache data in redis if needed
+      tags:
+      - layers
+  /light_rolling_stock/:
+    get:
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          default: 1
+          minimum: 1
+          type: integer
+      - description: Number of elements by page
+        in: query
+        name: page_size
+        schema:
+          default: 100
+          maximum: 10000
+          minimum: 1
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    items:
+                      $ref: '#/components/schemas/LightRollingStock'
+                    type: array
+                required:
+                - results
+                type: object
+          description: The rolling stock list
+      summary: Paginated list of rolling stock with a lighter response
+      tags:
+      - rolling_stock
+  /light_rolling_stock/{id}/:
+    get:
+      parameters:
+      - description: Rolling Stock ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LightRollingStock'
+          description: The rolling stock with their simplified effort curves
+      summary: Retrieve a rolling stock's light representation
+      tags:
+      - rolling_stock
+  /pathfinding/:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PathQuery'
+        description: Path information
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Path'
+          description: The created Path
+      summary: Create a Path
+  /pathfinding/{id}/:
+    delete:
+      parameters:
+      - description: Path ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Delete a path
+      tags:
+      - pathfinding
+    get:
+      parameters:
+      - description: Path ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Path'
+          description: The retrieved path
+      summary: Retrieve a Path
+      tags:
+      - pathfinding
+    put:
+      parameters:
+      - description: Path ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PathQuery'
+        description: Updated Path
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Path'
+                type: array
+          description: The updated path
+      summary: Update a path
+      tags:
+      - pathfinding
+  /pathfinding/{path_id}/catenaries/:
+    get:
+      parameters:
+      - description: The path's id
+        in: path
+        name: path_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  catenary_ranges:
+                    items:
+                      $ref: '#/components/schemas/CatenaryRange'
+                    type: array
+                  warnings:
+                    items:
+                      properties:
+                        catenary_id:
+                          type: string
+                        overlapping_ranges:
+                          items:
+                            $ref: '#/components/schemas/TrackRange'
+                          type: array
+                        type:
+                          enum:
+                          - CatenaryOverlap
+                          type: string
+                      type: object
+                    type: array
+                type: object
+          description: A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list.
+      summary: Retrieve the modes of catenaries along a path
+      tags:
+      - infra
+  /projects/:
+    get:
+      parameters:
+      - in: query
+        name: ordering
+        schema:
+          enum:
+          - NameAsc
+          - NameDesc
+          - CreationDateAsc
+          - CreationDateDesc
+          - LastModifiedAsc
+          - LastModifiedDesc
+          type: string
+      - description: Filter projects by name
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: Filter projects by description
+        in: query
+        name: description
+        schema:
+          type: string
+      - description: Filter projects by tags
+        in: query
+        name: tags
+        schema:
+          type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          minimum: 0
+          type: integer
+      - description: Number of elements by page
+        in: query
+        name: page_size
+        schema:
+          default: 100
+          maximum: 10000
+          minimum: 1
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    items:
+                      $ref: '#/components/schemas/ProjectResult'
+                    type: array
+                type: object
+          description: the project list
+      summary: Paginated list of projects
+      tags:
+      - projects
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectCreateRequest'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResult'
+          description: The created project
+      summary: Create a new project
+      tags:
+      - projects
+  /projects/{project_id}/:
+    delete:
+      parameters:
+      - description: project id you want to delete
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: delete a project
+      tags:
+      - projects
+    get:
+      parameters:
+      - description: project id you want to retrieve
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResult'
+          description: The project info
+      summary: Retrieve a project
+      tags:
+      - projects
+    patch:
+      parameters:
+      - description: project id you want to update
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectPatchRequest'
+        description: The fields you want to update
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResult'
+          description: The project updated
+      summary: Update a project
+      tags:
+      - projects
+  /projects/{project_id}/studies/:
+    get:
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - in: query
+        name: ordering
+        schema:
+          enum:
+          - NameAsc
+          - NameDesc
+          - CreationDateAsc
+          - CreationDateDesc
+          - LastModifiedAsc
+          - LastModifiedDesc
+          type: string
+      - description: Filter operational studies by name
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: Filter operational studies by description
+        in: query
+        name: description
+        schema:
+          type: string
+      - description: Filter operational studies by tags
+        in: query
+        name: tags
+        schema:
+          type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          minimum: 0
+          type: integer
+      - description: Number of elements by page
+        in: query
+        name: page_size
+        schema:
+          default: 100
+          maximum: 10000
+          minimum: 1
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    items:
+                      $ref: '#/components/schemas/StudyResult'
+                    type: array
+                type: object
+          description: the studies list
+      summary: Paginated list of operational studies
+      tags:
+      - studies
+    post:
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyUpsertRequest'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyResult'
+          description: The created operational study
+      summary: Create a new operational study
+      tags:
+      - studies
+  /projects/{project_id}/studies/{study_id}/:
+    delete:
+      parameters:
+      - description: project id refered to the operational study
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - description: study id you want to delete
+        in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: delete an operational study
+      tags:
+      - studies
+    get:
+      parameters:
+      - description: project id refered to the operational study
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - description: study id you want to retrieve
+        in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyResult'
+          description: The operational study info
+      summary: Retrieve an operational study
+      tags:
+      - studies
+    patch:
+      parameters:
+      - description: project id refered to the study
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - description: study id you want to retrieve
+        in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyUpsertRequest'
+        description: The fields you want to update
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StudyResult'
+          description: The operational study updated
+      summary: update an operational study
+      tags:
+      - studies
+  /projects/{project_id}/studies/{study_id}/scenarios/:
+    get:
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      - in: query
+        name: ordering
+        schema:
+          enum:
+          - NameAsc
+          - NameDesc
+          - CreationDateAsc
+          - CreationDateDesc
+          - LastModifiedAsc
+          - LastModifiedDesc
+          type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          minimum: 0
+          type: integer
+      - description: Number of elements by page
+        in: query
+        name: page_size
+        schema:
+          default: 100
+          maximum: 10000
+          minimum: 1
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    items:
+                      $ref: '#/components/schemas/ScenarioListResult'
+                    type: array
+                type: object
+          description: list of scenarios
+      summary: Paginated list of scenarios
+      tags:
+      - scenarios
+    post:
+      parameters:
+      - in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioRequest'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioResult'
+          description: The created scenario
+      summary: Create a new scenario
+      tags:
+      - scenarios
+  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/:
+    delete:
+      parameters:
+      - description: project id refered to the scenario
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - description: study id refered to the scenario
+        in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      - description: scenario id you want to delete
+        in: path
+        name: scenario_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: delete a scenario
+      tags:
+      - scenarios
+    get:
+      parameters:
+      - description: project id refered to the scenario
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      - description: scenario id you want to retrieve
+        in: path
+        name: scenario_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioResult'
+          description: The operational study info
+      summary: Retrieve a scenario
+      tags:
+      - scenarios
+    patch:
+      parameters:
+      - description: project id refered to the scenario
+        in: path
+        name: project_id
+        required: true
+        schema:
+          type: integer
+      - description: study refered to the scenario
+        in: path
+        name: study_id
+        required: true
+        schema:
+          type: integer
+      - description: scenario you want to update
+        in: path
+        name: scenario_id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScenarioPatchRequest'
+        description: The fields you want to update
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioResult'
+          description: The scenario updated
+      summary: update a scenario
+      tags:
+      - scenarios
+  /rolling_stock/:
+    post:
+      parameters:
+      - description: whether or not the rolling_stock can be edited/deleted.
+        in: query
+        name: locked
+        schema:
+          default: false
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollingStockUpsertPayload'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollingStock'
+          description: The created rolling stock
+      summary: Create a rolling stock
+      tags:
+      - rolling_stock
+  /rolling_stock/{id}/:
+    delete:
+      parameters:
+      - description: rolling_stock id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: force the deletion even if it’s used
+        in: query
+        name: force
+        schema:
+          default: false
+          type: boolean
+      responses:
+        '204':
+          description: No content
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollingStockUsage'
+          description: Rolling stock is used in a train schedule.
+      summary: Delete a rolling_stock and all entities linked to it
+      tags:
+      - rolling_stock
+    get:
+      parameters:
+      - description: Rolling Stock ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollingStock'
+          description: The rolling stock information
+      summary: Retrieve a rolling stock
+      tags:
+      - rolling_stock
+    patch:
+      parameters:
+      - description: Rolling Stock ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RollingStockUpsertPayload'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollingStock'
+          description: The updated rolling stock
+      summary: Patch a rolling stock
+      tags:
+      - rolling_stock
+  /rolling_stock/{id}/livery/:
+    post:
+      parameters:
+      - description: Rolling Stock ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                images:
+                  items:
+                    format: binary
+                    type: string
+                  type: array
+                name:
+                  type: string
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RollingStockLivery'
+          description: The rolling stock livery
+      summary: Create a rolling stock livery
+      tags:
+      - rolling_stock
+      - rolling_stock_livery
+  /rolling_stock/{id}/locked/:
+    patch:
+      parameters:
+      - description: Rolling_stock id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                locked:
+                  type: boolean
+              type: object
+        description: New locked value
+        required: true
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: Not found
+      summary: Update rolling_stock locked field
+      tags:
+      - rolling_stock
+  /search/:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                object:
+                  example: operationalpoint
+                  type: string
+                page:
+                  default: 1
+                  type: integer
+                page_size:
+                  default: 25
+                  type: integer
+                query:
+                  $ref: '#/components/schemas/SearchQuery'
+              type: object
+        description: Search query
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  oneOf:
+                  - $ref: '#/components/schemas/SearchTrackResult'
+                  - $ref: '#/components/schemas/SearchOperationalPointResult'
+                  - $ref: '#/components/schemas/SearchSignalResult'
+                  - $ref: '#/components/schemas/SearchStudyResult'
+                  - $ref: '#/components/schemas/SearchProjectResult'
+                  - $ref: '#/components/schemas/SearchScenarioResult'
+                type: array
+          description: Search results, the structure of the returned objects depend on their type
+      summary: Generic search endpoint
+  /timetable/{id}/:
+    get:
+      parameters:
+      - description: Timetable ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TimetableWithSchedulesDetails'
+          description: The timetable content
+      summary: Retrieve a timetable and its train schedules
+      tags:
+      - timetable
+  /timetable/{id}/conflicts/:
+    get:
+      parameters:
+      - description: Timetable ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    conflict_type:
+                      type: string
+                    end_time:
+                      type: string
+                    start_time:
+                      type: string
+                    train_ids:
+                      items:
+                        type: number
+                      type: array
+                    train_names:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - train_ids
+                  - train_names
+                  - start_time
+                  - end_time
+                  - conflict_type
+                  type: object
+                type: array
+          description: The timetable conflicts content
+      summary: Retrieve all conflicts for a specific timetable
+      tags:
+      - timetable
+  /train_schedule/results/:
+    get:
+      parameters:
+      - description: Path id used to project the train path
+        in: query
+        name: path_id
+        required: true
+        schema:
+          type: integer
+      - description: List of train schedule ids to return the results of
+        in: query
+        name: train_ids
+        required: true
+        schema:
+          pattern: ^\d+(,\d+)*$
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/SimulationReport'
+                type: array
+          description: The train schedules results
+      summary: Retrieve the simulation result of multiple train schedules
+      tags:
+      - train_schedule
+  /train_schedule/standalone_simulation/:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/TrainSchedule'
+              minItems: 1
+              type: array
+        description: The list of train schedules to simulate
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                items:
+                  format: integer
+                  type: number
+                minItems: 1
+                type: array
+          description: The ids of the train_schedules created
+      summary: Create a batch of train schedule and run simulations accordingly
+      tags:
+      - train_schedule
+  /train_schedule/{id}/:
+    delete:
+      parameters:
+      - description: Train schedule ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Delete a train schedule and its result
+      tags:
+      - train_schedule
+    get:
+      parameters:
+      - description: Train schedule ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainSchedule'
+          description: The train schedule info
+      summary: Retrieve a train schedule
+      tags:
+      - train_schedule
+    patch:
+      parameters:
+      - description: Train schedule ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/TrainSchedule'
+              type: array
+        description: Train schedule fields
+        required: true
+      responses:
+        '200':
+          description: The train schedule was updated successfully
+      summary: Update a train_schedule and run a simulation accordingly
+      tags:
+      - train_schedule
+  /train_schedule/{id}/result/:
+    get:
+      parameters:
+      - description: Train schedule ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      - description: Path id used to project the train path
+        in: query
+        name: path_id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationReport'
+          description: The train schedule result
+      summary: Retrieve a simulation result
+      tags:
+      - train_schedule
+  /version/:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  git_describe:
+                    nullable: true
+                    type: string
+                required:
+                - git_describe
+                type: object
+          description: Return the service version
+tags:
+- description: Infra
+  name: infra
+- description: Operations related to infra routes
+  name: routes
+- description: Timetable
+  name: timetable
+- description: Pathfinding operations
+  name: pathfinding
+- description: Map layers
+  name: layers
+- description: Electrical profiles
+  name: electrical_profiles
+- description: Train Schedule
+  name: train_schedule
 
-    Electrified:
-      properties:
-        mode:
-          type: string
-        mode_handled:
-          type: boolean
-        object_type:
-          type: string
-          enum: ["Electrified"]
-        profile:
-          type: string
-          nullable: true
-        profile_handled:
-          type: boolean
-      required: [mode, mode_handled, object_type, profile_handled]
-    Neutral:
-      properties:
-        is_lower_pantograph:
-          type: boolean
-        object_type:
-          type: string
-          enum: ["Neutral"]
-      required: [is_lower_pantograph, object_type]
-    NonElectrified:
-      properties:
-        object_type:
-          type: string
-          enum: ["NonElectrified"]
-      required: [object_type]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4074,6 +4074,12 @@ paths:
       - rolling_stock
   /search/:
     post:
+      parameters:
+      - description: number of results
+        in: query
+        name: page_size
+        schema:
+          type: integer
       requestBody:
         content:
           application/json:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -46,6 +46,12 @@ paths:
   /search/:
     post:
       summary: Generic search endpoint
+      parameters:
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+          description: number of results
       requestBody:
         description: Search query
         required: true

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -1,0 +1,4266 @@
+openapi: 3.0.2
+info:
+  title: OSRD Editoast
+  description: OSRD Edition service description
+  version: 0.1.0
+
+tags:
+  - name: infra
+    description: Infra
+  - name: routes
+    description: Operations related to infra routes
+  - name: timetable
+    description: Timetable
+  - name: pathfinding
+    description: Pathfinding operations
+  - name: layers
+    description: Map layers
+  - name: electrical_profiles
+    description: Electrical profiles
+  - name: train_schedule
+    description: Train Schedule
+
+paths:
+  /health/:
+    get:
+      responses:
+        200:
+          description: Check if Editoast is running correctly
+
+  /version/:
+    get:
+      responses:
+        200:
+          description: Return the service version
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  git_describe:
+                    type: string
+                    nullable: true
+                required:
+                  - git_describe
+
+  /search/:
+    post:
+      summary: Generic search endpoint
+      requestBody:
+        description: Search query
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                object:
+                  type: string
+                  example: "operationalpoint"
+                query:
+                  $ref: "#/components/schemas/SearchQuery"
+                page:
+                  type: integer
+                  default: 1
+                page_size:
+                  type: integer
+                  default: 25
+      responses:
+        200:
+          description: Search results, the structure of the returned objects depend on their type
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/SearchTrackResult"
+                    - $ref: "#/components/schemas/SearchOperationalPointResult"
+                    - $ref: "#/components/schemas/SearchSignalResult"
+                    - $ref: "#/components/schemas/SearchStudyResult"
+                    - $ref: "#/components/schemas/SearchProjectResult"
+                    - $ref: "#/components/schemas/SearchScenarioResult"
+
+  /layers/layer/{layer_slug}/mvt/{view_slug}/:
+    get:
+      tags:
+        - layers
+      summary: Mvt View Metadata
+      parameters:
+        - required: true
+          schema:
+            title: Layer Slug
+            type: string
+          name: layer_slug
+          in: path
+        - required: true
+          schema:
+            title: View Slug
+            type: string
+          name: view_slug
+          in: path
+        - required: true
+          schema:
+            title: Infra id
+            type: integer
+          name: infra
+          in: query
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ViewMetadata"
+
+  /layers/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}/:
+    get:
+      tags:
+        - layers
+      summary: Mvt tile from the cache or the database, cache data in redis if needed
+      parameters:
+        - required: true
+          schema:
+            title: Layer Slug
+            type: string
+          name: layer_slug
+          in: path
+        - required: true
+          schema:
+            title: View Slug
+            type: string
+          name: view_slug
+          in: path
+        - required: true
+          schema:
+            title: Z
+            type: integer
+          name: z
+          in: path
+        - required: true
+          schema:
+            title: X
+            type: integer
+          name: x
+          in: path
+        - required: true
+          schema:
+            title: Y
+            type: integer
+          name: y
+          in: path
+        - required: true
+          schema:
+            title: Infra
+            type: integer
+          name: infra
+          in: query
+      responses:
+        200:
+          description: Successful Response
+          content:
+            application/x-octet-stream:
+              schema:
+                type: string
+
+  /infra/:
+    get:
+      tags:
+        - infra
+      summary: List all available infra
+      responses:
+        200:
+          description: The infra list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Infra"
+                required: [count, next, previous]
+    post:
+      tags:
+        - infra
+      summary: Create an infra
+      requestBody:
+        description: Name of the infra to create
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        201:
+          description: The created infra
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Infra"
+
+  /infra/{id}/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve a specific infra
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        200:
+          description: Information about the retrieved infra
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Infra"
+    delete:
+      tags:
+        - infra
+      summary: Delete an infra and all entities linked to it
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        204:
+          description: No content
+
+    post:
+      tags:
+        - infra
+      summary: Update/Create/Delete an object of the infra
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      requestBody:
+        description: Operations to do on the infra
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/Operation"
+      responses:
+        200:
+          description: An array containing infos about the operations processed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/OperationResult"
+
+    put:
+      tags:
+        - infra
+      summary: Update an infrastructure name
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      requestBody:
+        description: the name we want to give to the infra
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        200:
+          description: The updated infra
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Infra"
+
+  /infra/{id}/load/:
+    post:
+      tags:
+        - infra
+      summary: Load an infra if not loaded
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        200:
+          description: No content
+
+  /infra/{id}/railjson/:
+    get:
+      tags:
+        - infra
+      summary: Serialize an infra to railjson
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+      responses:
+        200:
+          description: The infra in railjson format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RailjsonFile"
+
+  /infra/railjson/:
+    post:
+      tags:
+        - infra
+      summary: Import an infra from railjson
+      parameters:
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: Infra name
+          required: true
+        - in: query
+          name: generate_data
+          schema:
+            type: boolean
+            description: whether the layer should be generated or no
+            default: false
+      requestBody:
+        description: Railjson infra
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RailjsonFile"
+        required: true
+      responses:
+        201:
+          description: The imported infra id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+
+  /infra/{id}/errors/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve a paginated list of errors
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+          description: The page number
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            default: 25
+            minimum: 10
+          description: The number of item per page
+        - in: query
+          name: error_type
+          schema:
+            $ref: "#/components/schemas/InfraErrorType"
+          description: The type of error to filter on
+        - in: query
+          name: object_id
+          schema:
+            type: string
+          description: errors and warnings that only part of a given object
+        - in: query
+          name: level
+          schema:
+            type: string
+            enum: [errors, warnings, all]
+            default: all
+          description: Whether the response should include errors or warnings
+      responses:
+        200:
+          description: A paginated list of errors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    description: Total number of elements
+                    example: 1
+                  next:
+                    type: integer
+                    nullable: true
+                    example: null
+                    description: The index of the following page (null if no more pages available)
+                  previous:
+                    type: integer
+                    nullable: true
+                    example: null
+                    description: The index of the previous page (null if requesting the first page)
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/InfraError"
+
+  /infra/{id}/switch_types/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve a list of switch types
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        200:
+          description: A list of switch types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: A switch type following Railjson spec
+                  example:
+                    id: Point
+                    ports: [LEFT, RIGHT, BASE]
+                    groups:
+                      LEFT: { src: BASE, dst: LEFT }
+                      RIGHT: { src: BASE, dst: RIGHT }
+
+  /infra/refresh/:
+    post:
+      tags:
+        - infra
+      summary: Refresh the layers
+      parameters:
+        - in: query
+          name: infras
+          schema:
+            type: array
+            items:
+              type: integer
+            default: []
+          description: A list of infra ID
+        - in: query
+          name: force
+          schema:
+            type: boolean
+            default: false
+          description: Force the refresh of the layers
+      responses:
+        200:
+          description: A list thats contains the ID of the infras that were refreshed*
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+
+  /infra/{id}/lines/{line_code}/bbox/:
+    get:
+      tags:
+        - infra
+      summary: Returns the BBoxes (geo and schematic) of a line
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+        - in: path
+          name: line_code
+          schema:
+            type: integer
+          description: a line code
+          required: true
+      responses:
+        200:
+          description: The BBox of the line
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Zone"
+
+  /infra/{id}/lock/:
+    post:
+      tags:
+        - infra
+      summary: Lock an infra from edition
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        204:
+          description: No content
+
+  /infra/{id}/unlock/:
+    post:
+      tags:
+        - infra
+      summary: Unlock an infra from edition
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        204:
+          description: No content
+
+  /infra/{id}/speed_limit_tags/:
+    get:
+      tags:
+        - infra
+      summary: List all speed limit tags
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra id
+          required: true
+      responses:
+        200:
+          description: Tags list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: ["freight", "heavy_load"]
+
+  /infra/{id}/voltages/:
+    get:
+      tags:
+        - infra
+      summary: List all voltages
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+        - in: query
+          name: include_rolling_stock_modes
+          schema:
+            type: boolean
+          description: include rolling stocks modes or not
+          required: false
+      responses:
+        200:
+          description: Voltages list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: ["750", "1500", "2500.5"]
+
+  /infra/{id}/attached/{track_id}/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve all objects attached to a given track
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+        - in: path
+          name: track_id
+          schema:
+            type: string
+          description: Track ID
+          required: true
+      responses:
+        200:
+          description: All objects attached to the given track (arranged by types)
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+                    description: Object IDs
+                example:
+                  Switch: ["switch.0", "switch.1"]
+                  Detector: ["detector.0"]
+                  BufferStop: []
+
+  /infra/{id}/routes/{waypoint_type}/{waypoint_id}/:
+    get:
+      tags:
+        - infra
+        - routes
+      summary: Retrieve all routes that starting and ending by the given waypoint (detector or buffer stop)
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+        - in: path
+          name: waypoint_type
+          schema:
+            type: string
+            enum: [Detector, BufferStop]
+          description: Type of the waypoint
+          required: true
+        - in: path
+          name: waypoint_id
+          schema:
+            type: string
+          description: The waypoint id
+          required: true
+      responses:
+        200:
+          description: All routes that starting and ending by the given waypoint
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  starting:
+                    type: array
+                    items:
+                      type: string
+                    example: ["route1", "route2"]
+                  ending:
+                    type: array
+                    items:
+                      type: string
+                    example: ["route3", "route4"]
+
+  /infra/{id}/routes/track_ranges/:
+    get:
+      tags:
+        - infra
+        - routes
+      summary: Compute the track ranges through which routes passes.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+        - in: query
+          name: routes
+          schema:
+            type: string
+            description: A list of routes seperated by comma
+            example: "route1,route2,route3"
+          required: true
+      responses:
+        200:
+          description: Foreach route, the track ranges through which it passes or an error
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: "#/components/schemas/RouteTrackRangesNotFoundError"
+                    - $ref: "#/components/schemas/RouteTrackRangesCantComputePathError"
+                    - $ref: "#/components/schemas/RouteTrackRangesComputed"
+
+  /infra/{id}/pathfinding/:
+    post:
+      tags:
+        - infra
+        - pathfinding
+      summary: Compute paths given starting and ending track location. Return shortest paths.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra ID
+          required: true
+        - in: query
+          name: number
+          schema:
+            type: number
+            format: integer
+            minimum: 1
+            maximum: 5
+            default: 5
+          description: Maximum number of paths to return
+      requestBody:
+        description: Starting and ending track location
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                starting:
+                  allOf:
+                    - $ref: "#/components/schemas/TrackLocation"
+                    - type: object
+                      properties:
+                        direction:
+                          $ref: "#/components/schemas/Direction"
+                ending:
+                  $ref: "#/components/schemas/TrackLocation"
+      responses:
+        200:
+          description: Paths, containing track ranges, detectors and switches with their directions. If no path is found, an empty list is returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    track_ranges:
+                      type: array
+                      minItems: 1
+                      items:
+                        $ref: "#/components/schemas/DirectionalTrackRange"
+                    detectors:
+                      type: array
+                      items:
+                        type: string
+                        example: "detector1"
+                    switches_directions:
+                      type: object
+                      example: { "switch1": "left", "switch2": "right" }
+                      additionalProperties:
+                        type: string
+
+  /infra/{id}/objects/{object_type}/:
+    post:
+      tags:
+        - infra
+      summary: "Retrieve a list of specific objects in railjson format"
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra id
+          required: true
+        - in: path
+          name: object_type
+          schema:
+            $ref: "#/components/schemas/ObjectType"
+          description: The type of the object
+          required: true
+      requestBody:
+        description: List of object id's
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        200:
+          description: No content
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - railjson
+                    - geographic
+                    - schematic
+                  properties:
+                    railjson:
+                      description: Object properties in railjson format
+                      $ref: "#/components/schemas/Railjson"
+                    geographic:
+                      description: object's geographic in geojson format
+                      $ref: "#/components/schemas/Geometry"
+                    schematic:
+                      description: object's schematic in geojson format
+                      $ref: "#/components/schemas/Geometry"
+
+  /infra/{id}/clone/:
+    post:
+      tags:
+        - infra
+      summary: Duplicate an infra
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Infra id
+          required: true
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: New infra name
+          required: true
+      responses:
+        201:
+          description: The duplicated infra id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: integer }
+
+  /electrical_profile_set/:
+    get:
+      tags:
+        - electrical_profiles
+      summary: Retrieve the list of ids and names of electrical profile sets available
+      responses:
+        200:
+          description: The list of ids and names of electrical profile sets available
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                      example: "France 2023"
+
+    post:
+      tags:
+        - electrical_profiles
+      summary: import a new electrical profile set
+      parameters:
+        - in: query
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: The list of ids and names of electrical profile sets available
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ElectricalProfile"
+
+  /electrical_profile_set/{id}/:
+    get:
+      tags:
+        - electrical_profiles
+      summary: Retrieve the set of electrical profiles with the given id
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Electrical profile set ID
+          required: true
+      responses:
+        200:
+          description: The list of electrical profiles in the set
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ElectricalProfile"
+
+  /electrical_profile_set/{id}/level_order/:
+    get:
+      tags:
+        - electrical_profiles
+      summary: Retrieve the order of strength of the electrical profiles in the set with the given id
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Electrical profile set ID
+          required: true
+      responses:
+        200:
+          description: A dictionary mapping catenary modes to a list of electrical profiles ordered by decreasing strength
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+                example:
+                  "1500": ["A", "B", "C"]
+                  "25000": ["25000", "22500", "20000"]
+
+  /documents/{key}/:
+    get:
+      tags:
+        - documents
+      summary: Retrieve a document binary content
+      parameters:
+        - in: path
+          name: key
+          schema:
+            type: integer
+          description: A key identifying the document
+          required: true
+      responses:
+        200:
+          description: A document of any type (can be an image, a pdf...)
+    delete:
+      tags:
+        - documents
+      summary: Delete a document
+      parameters:
+        - in: path
+          name: key
+          schema:
+            type: integer
+          description: A key identifying the document
+          required: true
+      responses:
+        204:
+          description: No content
+
+  /documents/:
+    post:
+      tags:
+        - documents
+      summary: Add a document
+      responses:
+        201:
+          description: The key of the added document
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  document_key:
+                    type: integer
+                    example: 42
+
+  /light_rolling_stock/:
+    get:
+      tags:
+        - rolling_stock
+      summary: Paginated list of rolling stock with a lighter response
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            maximum: 10000
+            minimum: 1
+            default: 100
+          description: Number of elements by page
+      responses:
+        200:
+          description: The rolling stock list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LightRollingStock"
+                required:
+                  - results
+
+  /light_rolling_stock/{id}/:
+    get:
+      tags:
+        - rolling_stock
+      summary: Retrieve a rolling stock's light representation
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Rolling Stock ID
+          required: true
+      responses:
+        200:
+          description: The rolling stock with their simplified effort curves
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LightRollingStock"
+
+  /pathfinding/:
+    post:
+      summary: Create a Path
+      requestBody:
+        description: Path information
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PathQuery"
+      responses:
+        201:
+          description: The created Path
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Path"
+
+  /pathfinding/{id}/:
+    get:
+      tags:
+        - pathfinding
+      summary: Retrieve a Path
+      parameters:
+        - in: path
+          name: id
+          schema: { type: integer }
+          description: Path ID
+          required: true
+      responses:
+        200:
+          description: The retrieved path
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Path"
+    put:
+      tags:
+        - pathfinding
+      summary: Update a path
+      parameters:
+        - in: path
+          name: id
+          schema: { type: integer }
+          description: Path ID
+          required: true
+      requestBody:
+        description: Updated Path
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PathQuery"
+      responses:
+        200:
+          description: The updated path
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Path"
+    delete:
+      tags:
+        - pathfinding
+      summary: Delete a path
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Path ID
+          required: true
+      responses:
+        204:
+          description: No content
+
+  /rolling_stock/:
+    post:
+      tags:
+        - rolling_stock
+      summary: Create a rolling stock
+      parameters:
+        - in: query
+          name: locked
+          description: whether or not the rolling_stock can be edited/deleted.
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RollingStockUpsertPayload"
+      responses:
+        200:
+          description: The created rolling stock
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStock"
+
+  /rolling_stock/{id}/:
+    get:
+      tags:
+        - rolling_stock
+      summary: Retrieve a rolling stock
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Rolling Stock ID
+          required: true
+      responses:
+        200:
+          description: The rolling stock information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStock"
+    patch:
+      tags:
+        - rolling_stock
+      summary: Patch a rolling stock
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Rolling Stock ID
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RollingStockUpsertPayload"
+      responses:
+        200:
+          description: The updated rolling stock
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStock"
+    delete:
+      tags:
+        - rolling_stock
+      summary: Delete a rolling_stock and all entities linked to it
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: rolling_stock id
+          required: true
+        - in: query
+          name: force
+          description: force the deletion even if it’s used
+          schema:
+            type: boolean
+            default: false
+      responses:
+        204:
+          description: No content
+        409:
+          description: Rolling stock is used in a train schedule.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStockUsage"
+
+  /rolling_stock/{id}/locked/:
+    patch:
+      tags:
+        - rolling_stock
+      summary: Update rolling_stock locked field
+      parameters:
+        - in: path
+          name: id
+          description: Rolling_stock id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        description: New locked value
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                locked:
+                  type: boolean
+      responses:
+        204:
+          description: No content
+        404:
+          description: Not found
+
+  /rolling_stock/{id}/livery/:
+    post:
+      tags:
+        - rolling_stock
+        - rolling_stock_livery
+      summary: Create a rolling stock livery
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Rolling Stock ID
+          required: true
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                images:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        200:
+          description: The rolling stock livery
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollingStockLivery"
+
+  /projects/:
+    post:
+      tags:
+        - projects
+      summary: Create a new project
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectCreateRequest"
+      responses:
+        201:
+          description: The created project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResult"
+    get:
+      tags:
+        - projects
+      summary: Paginated list of projects
+      parameters:
+        - in: query
+          name: ordering
+          schema:
+            type: string
+            enum:
+              [
+                "NameAsc",
+                "NameDesc",
+                "CreationDateAsc",
+                "CreationDateDesc",
+                "LastModifiedAsc",
+                "LastModifiedDesc",
+              ]
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: Filter projects by name
+        - in: query
+          name: description
+          schema:
+            type: string
+          description: Filter projects by description
+        - in: query
+          name: tags
+          schema:
+            type: string
+          description: Filter projects by tags
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 0
+          description: Page number
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            maximum: 10000
+            minimum: 1
+            default: 100
+          description: Number of elements by page
+      responses:
+        200:
+          description: the project list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProjectResult"
+
+  /projects/{project_id}/:
+    get:
+      tags:
+        - projects
+      summary: Retrieve a project
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id you want to retrieve
+          required: true
+      responses:
+        200:
+          description: The project info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResult"
+    patch:
+      tags:
+        - projects
+      summary: Update a project
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id you want to update
+          required: true
+      requestBody:
+        description: The fields you want to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectPatchRequest"
+      responses:
+        200:
+          description: The project updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResult"
+    delete:
+      tags:
+        - projects
+      summary: delete a project
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id you want to delete
+          required: true
+      responses:
+        204:
+          description: No content
+
+  /timetable/{id}/:
+    get:
+      tags:
+        - timetable
+      summary: Retrieve a timetable and its train schedules
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Timetable ID
+          required: true
+      responses:
+        200:
+          description: The timetable content
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TimetableWithSchedulesDetails"
+
+  /timetable/{id}/conflicts/:
+    get:
+      tags:
+        - timetable
+      summary: Retrieve all conflicts for a specific timetable
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Timetable ID
+          required: true
+      responses:
+        200:
+          description: The timetable conflicts content
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    train_ids:
+                      type: array
+                      items:
+                        type: number
+                    train_names:
+                      type: array
+                      items:
+                        type: string
+                    start_time:
+                      type: string
+                    end_time:
+                      type: string
+                    conflict_type:
+                      type: string
+                  required:
+                    [
+                      train_ids,
+                      train_names,
+                      start_time,
+                      end_time,
+                      conflict_type,
+                    ]
+
+  /projects/{project_id}/studies/:
+    post:
+      tags:
+        - studies
+      summary: Create a new operational study
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StudyUpsertRequest"
+      responses:
+        201:
+          description: The created operational study
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StudyResult"
+    get:
+      tags:
+        - studies
+      summary: Paginated list of operational studies
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: ordering
+          schema:
+            type: string
+            enum:
+              [
+                "NameAsc",
+                "NameDesc",
+                "CreationDateAsc",
+                "CreationDateDesc",
+                "LastModifiedAsc",
+                "LastModifiedDesc",
+              ]
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: Filter operational studies by name
+        - in: query
+          name: description
+          schema:
+            type: string
+          description: Filter operational studies by description
+        - in: query
+          name: tags
+          schema:
+            type: string
+          description: Filter operational studies by tags
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 0
+          description: Page number
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            maximum: 10000
+            minimum: 1
+            default: 100
+          description: Number of elements by page
+      responses:
+        200:
+          description: the studies list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/StudyResult"
+
+  /projects/{project_id}/studies/{study_id}/:
+    get:
+      tags:
+        - studies
+      summary: Retrieve an operational study
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the operational study
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+          description: study id you want to retrieve
+      responses:
+        200:
+          description: The operational study info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StudyResult"
+    patch:
+      tags:
+        - studies
+      summary: update an operational study
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the study
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+          description: study id you want to retrieve
+      requestBody:
+        description: The fields you want to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StudyUpsertRequest"
+      responses:
+        200:
+          description: The operational study updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StudyResult"
+    delete:
+      tags:
+        - studies
+      summary: delete an operational study
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the operational study
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+          description: study id you want to delete
+      responses:
+        204:
+          description: No content
+
+  /projects/{project_id}/studies/{study_id}/scenarios/:
+    post:
+      tags:
+        - scenarios
+      summary: Create a new scenario
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScenarioRequest"
+      responses:
+        201:
+          description: The created scenario
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScenarioResult"
+    get:
+      tags:
+        - scenarios
+      summary: Paginated list of scenarios
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+        - in: query
+          name: ordering
+          schema:
+            type: string
+            enum:
+              [
+                "NameAsc",
+                "NameDesc",
+                "CreationDateAsc",
+                "CreationDateDesc",
+                "LastModifiedAsc",
+                "LastModifiedDesc",
+              ]
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 0
+          description: Page number
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            maximum: 10000
+            minimum: 1
+            default: 100
+          description: Number of elements by page
+      responses:
+        200:
+          description: list of scenarios
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                  next: {}
+                  previous: {}
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ScenarioListResult"
+
+  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/:
+    get:
+      tags:
+        - scenarios
+      summary: Retrieve a scenario
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the scenario
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+        - in: path
+          required: true
+          name: scenario_id
+          schema:
+            type: integer
+          description: scenario id you want to retrieve
+      responses:
+        200:
+          description: The operational study info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScenarioResult"
+    delete:
+      tags:
+        - scenarios
+      summary: delete a scenario
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the scenario
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+          description: study id refered to the scenario
+        - in: path
+          required: true
+          name: scenario_id
+          schema:
+            type: integer
+          description: scenario id you want to delete
+      responses:
+        204:
+          description: No content
+    patch:
+      tags:
+        - scenarios
+      summary: update a scenario
+      parameters:
+        - in: path
+          name: project_id
+          schema:
+            type: integer
+          description: project id refered to the scenario
+          required: true
+        - in: path
+          required: true
+          name: study_id
+          schema:
+            type: integer
+          description: study refered to the scenario
+        - in: path
+          required: true
+          name: scenario_id
+          schema:
+            type: integer
+          description: scenario you want to update
+      requestBody:
+        description: The fields you want to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ScenarioPatchRequest"
+      responses:
+        200:
+          description: The scenario updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ScenarioResult"
+
+  /pathfinding/{path_id}/catenaries/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve the modes of catenaries along a path
+      parameters:
+        - in: path
+          name: path_id
+          schema:
+            type: integer
+          description: The path's id
+          required: true
+      responses:
+        200:
+          description: A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  catenary_ranges:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CatenaryRange"
+                  warnings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          enum: ["CatenaryOverlap"]
+                        catenary_id:
+                          type: string
+                        overlapping_ranges:
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/TrackRange"
+
+  /train_schedule/{id}/:
+    get:
+      tags:
+        - train_schedule
+      summary: Retrieve a train schedule
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Train schedule ID
+          required: true
+      responses:
+        200:
+          description: The train schedule info
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrainSchedule"
+    delete:
+      tags:
+        - train_schedule
+      summary: Delete a train schedule and its result
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Train schedule ID
+          required: true
+      responses:
+        204:
+          description: No content
+    patch:
+      tags:
+        - train_schedule
+      summary: Update a train_schedule and run a simulation accordingly
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Train schedule ID
+          required: true
+      requestBody:
+        description: Train schedule fields
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/TrainSchedule"
+        required: true
+      responses:
+        200:
+          description: The train schedule was updated successfully
+
+  /train_schedule/{id}/result/:
+    get:
+      tags:
+        - train_schedule
+      summary: Retrieve a simulation result
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Train schedule ID
+          required: true
+        - in: query
+          name: path_id
+          schema:
+            type: integer
+          description: Path id used to project the train path
+          required: true
+      responses:
+        200:
+          description: The train schedule result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulationReport"
+
+  /train_schedule/results/:
+    get:
+      tags:
+        - train_schedule
+      summary: Retrieve the simulation result of multiple train schedules
+      parameters:
+        - in: query
+          name: path_id
+          schema:
+            type: integer
+          description: Path id used to project the train path
+          required: true
+        - in: query
+          name: train_ids
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: List of train schedule ids to return the results of
+          required: true
+      responses:
+        200:
+          description: The train schedules results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SimulationReport"
+
+  /train_schedule/standalone_simulation/:
+    post:
+      tags:
+        - train_schedule
+      summary: Create a batch of train schedule and run simulations accordingly
+      requestBody:
+        description: The list of train schedules to simulate
+        content:
+          application/json:
+            schema:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/TrainSchedule"
+        required: true
+      responses:
+        201:
+          description: The ids of the train_schedules created
+          content:
+            application/json:
+              schema:
+                type: array
+                minItems: 1
+                items:
+                  type: number
+                  format: integer
+
+components:
+  schemas:
+    Battery:
+      description: energy source for a rolling stock representing a battery
+      type: object
+      required:
+        [
+          energy_source_type,
+          max_input_power,
+          max_output_power,
+          energy_storage,
+          efficiency,
+        ]
+      properties:
+        energy_source_type:
+          type: string
+          enum: ["Battery"]
+        max_input_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        max_output_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        energy_storage:
+          $ref: "#/components/schemas/EnergyStorage"
+        efficiency:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+
+    BoundingBox:
+      description: A bounding box
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        type: array
+        minItems: 2
+        maxItems: 2
+        items:
+          type: integer
+
+    Catenary:
+      description: energy source for a rolling stock representing a catenary
+      type: object
+      required:
+        [energy_source_type, max_input_power, max_output_power, efficiency]
+      properties:
+        energy_source_type:
+          type: string
+          enum: ["Catenary"]
+        max_input_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        max_output_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        efficiency:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+
+    Comfort:
+      description: Train comfort that will be used for the simulation
+      type: string
+      enum: ["AC", "HEATING", "STANDARD"]
+      default: "STANDARD"
+
+    ConditionalEffortCurve:
+      type: object
+      properties:
+        cond:
+          type: object
+          nullable: true
+          properties:
+            comfort:
+              $ref: "#/components/schemas/Comfort"
+              nullable: true
+            electrical_profile_level:
+              type: string
+              nullable: true
+            power_restriction_code:
+              type: string
+              nullable: true
+        curve:
+          $ref: "#/components/schemas/EffortCurve"
+
+    EffortCurve:
+      type: object
+      properties:
+        speeds:
+          type: array
+          example: [0.0, 2.958, 46.719]
+          minItems: 2
+          items:
+            type: number
+            format: float
+        max_efforts:
+          type: array
+          example: [23500.0, 23200.0, 21200.0]
+          minItems: 2
+          items:
+            type: number
+            format: float
+
+    EnergySource:
+      description: enery source of a rolling stock
+      oneOf:
+        - $ref: "#/components/schemas/Catenary"
+        - $ref: "#/components/schemas/PowerPack"
+        - $ref: "#/components/schemas/Battery"
+      discriminator:
+        propertyName: energy_source_type
+
+    EnergyStorage:
+      description: energy storage of an energy source (of a rolling stock, can be a electrical battery or a hydrogen/fuel powerPack)
+      type: object
+      required: [capacity, soc, soc_min, soc_max, refill_law]
+      properties:
+        capacity:
+          type: number
+          format: float
+        soc:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        soc_min:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        soc_max:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        refill_law:
+          description: physical law defining how the storage can be refilled
+          nullable: true
+          type: object
+          properties:
+            tau:
+              type: number
+              format: float
+              minimum: 0
+            soc_ref:
+              type: number
+              format: float
+              minimum: 0
+              maximum: 1
+          required: [tau, soc_ref]
+
+    GeoJsonObject:
+      type: object
+      description: GeoJson format
+      properties:
+        coordinates:
+          type: array
+          items:
+            type: array
+            items: { type: number, format: float }
+        type: { type: string }
+      required: [coordinates, type]
+
+    GeoJsonPosition:
+      type: object
+      properties:
+        coordinates:
+          type: array
+          items: { type: number, format: float }
+          minItems: 2
+          maxItems: 2
+        type: { type: string }
+      required: [coordinates, type]
+
+    Infra:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        version:
+          type: string
+          example: "1"
+        railjson_version:
+          type: string
+          example: "3.3.1"
+        generated_version:
+          type: string
+          nullable: true
+          example: "1"
+        created:
+          type: string
+          format: date
+        modified:
+          type: string
+          format: date
+        locked:
+          type: boolean
+        state:
+          type: string
+          enum:
+            - NOT_LOADED
+            - INITIALIZING
+            - DOWNLOADING
+            - PARSING_JSON
+            - PARSING_INFRA
+            - ADAPTING_KOTLIN
+            - LOADING_SIGNALS
+            - BUILDING_BLOCKS
+            - CACHED
+            - TRANSIENT_ERROR
+            - ERROR
+      required:
+        [
+          id,
+          name,
+          version,
+          railjson_version,
+          generated_version,
+          created,
+          modified,
+          locked,
+          state,
+        ]
+
+    Zone:
+      type: object
+      properties:
+        geo:
+          $ref: "#/components/schemas/BoundingBox"
+        sch:
+          $ref: "#/components/schemas/BoundingBox"
+
+    ObjectType:
+      type: string
+      description: Type of the object
+      enum:
+        - TrackSection
+        - Signal
+        - SpeedSection
+        - Detector
+        - TrackSectionLink
+        - Switch
+        - SwitchType
+        - BufferStop
+        - Route
+        - OperationalPoint
+        - Catenary
+
+    RailjsonFile:
+      properties:
+        version:
+          type: string
+        operational_points:
+          type: array
+        routes:
+          type: array
+        switch_types:
+          type: array
+        switches:
+          type: array
+        track_section_links:
+          type: array
+        track_sections:
+          type: array
+        signals:
+          type: array
+        buffer_stops:
+          type: array
+        speed_sections:
+          type: array
+        catenaries:
+          type: array
+        detectors:
+          type: array
+
+    Operation:
+      oneOf:
+        - $ref: "#/components/schemas/RailjsonObject"
+        - $ref: "#/components/schemas/DeleteOperation"
+        - $ref: "#/components/schemas/UpdateOperation"
+
+    OperationResult:
+      oneOf:
+        - $ref: "#/components/schemas/DeleteOperation"
+        - $ref: "#/components/schemas/OperationObject"
+
+    RailjsonObject:
+      required:
+        - operation_type
+        - obj_type
+        - railjson
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - CREATE
+        obj_type:
+          $ref: "#/components/schemas/ObjectType"
+        railjson:
+          $ref: "#/components/schemas/Railjson"
+
+    DeleteOperation:
+      required:
+        - operation_type
+        - obj_type
+        - obj_id
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - DELETE
+        obj_type:
+          $ref: "#/components/schemas/ObjectType"
+        obj_id:
+          type: string
+          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
+
+    UpdateOperation:
+      required:
+        - operation_type
+        - obj_type
+        - railjson_patch
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - UPDATE
+        obj_type:
+          $ref: "#/components/schemas/ObjectType"
+        obj_id:
+          type: string
+          example: bd840b06-84ba-4566-98c1-ccf0196c5f16
+        railjson_patch:
+          $ref: "#/components/schemas/Patches"
+
+    OperationObject:
+      required:
+        - operation_type
+        - obj_type
+        - railjson
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - CREATE
+            - UPDATE
+        obj_type:
+          $ref: "#/components/schemas/ObjectType"
+        railjson:
+          $ref: "#/components/schemas/Railjson"
+
+    Patch:
+      description: A JSONPatch document as defined by RFC 6902
+      required:
+        - "op"
+        - "path"
+      properties:
+        op:
+          type: string
+          description: The operation to be performed
+          enum:
+            - "add"
+            - "remove"
+            - "replace"
+            - "move"
+            - "copy"
+            - "test"
+        path:
+          type: string
+          description: A JSON-Pointer
+        value:
+          type: object
+          description: The value to be used within the operations.
+        from:
+          type: string
+          description: A string containing a JSON Pointer value.
+
+    Patches:
+      type: array
+      description: A list of Patch
+      items:
+        $ref: "#/components/schemas/Patch"
+
+    Railjson:
+      type: object
+      description: This field follows railjson format
+      additionalProperties: true
+      required:
+        - id
+      properties:
+        id:
+          type: string
+      example:
+        id: bd840b06-84ba-4566-98c1-ccf0196c5f16
+        geo:
+          type: LineString
+          coordinates:
+            - - 1.0
+              - 41.0
+            - - 2.0
+              - 42.0
+        sch:
+          type: LineString
+          coordinates:
+            - - 1.0
+              - 41.0
+            - - 2.0
+              - 42.0
+        curves: []
+        length: 1000
+        slopes:
+          - end: 500
+            begin: 250
+            gradient: -1
+        line_code: 1
+        line_name: my line
+        track_name: track name
+        navigability: BOTH
+        track_number: 1
+
+    ViewMetadata:
+      properties:
+        type:
+          type: string
+          example: vector
+        name:
+          type: string
+          example: track_sections
+        promotedId:
+          type: object
+          example: { track_sections: "id" }
+        scheme:
+          type: string
+          example: "xyz"
+        tiles:
+          type: array
+          items:
+            type: string
+            example: http://localhost:7070/tile/track_sections/geo/{z}/{x}/{y}/?infra=1
+        attribution:
+          type: string
+        minzoom:
+          type: integer
+        maxzoom:
+          type: integer
+          example: 18
+
+    InfraErrorType:
+      type: string
+      description: Type of the infra error
+      enum:
+        - duplicated_group
+        - empty_object
+        - invalid_group
+        - invalid_reference
+        - invalid_route
+        - invalid_switch_ports
+        - missing_route
+        - missing_buffer_stop
+        - object_out_of_path
+        - odd_buffer_stop_location
+        - out_of_range
+        - overlapping_speed_sections
+        - overlapping_switches
+        - overlapping_track_links
+        - overlapping_catenaries
+        - unknown_port_name
+        - unused_port
+
+    InfraError:
+      type: object
+      description: An infra error or warning
+      required: [information]
+      properties:
+        geographic:
+          nullable: true
+          description: Geojson of the geographic geometry of the error
+          $ref: "#/components/schemas/Geometry"
+        schematic:
+          nullable: true
+          type: object
+          description: Geojson of the schematic geometry of the error
+        information:
+          type: object
+          description: Information about the error (check schema documentation for more details)
+          required: [obj_id, obj_type, error_type, is_warning]
+          properties:
+            obj_id:
+              type: string
+            obj_type:
+              type: string
+              enum:
+                - TrackSection
+                - Signal
+                - BufferStop
+                - Detector
+                - Switch
+                - Route
+            error_type:
+              $ref: "#/components/schemas/InfraErrorType"
+            field:
+              type: string
+            is_warning:
+              type: boolean
+
+    TrackSectionLocation:
+      type: object
+      description: A track location (track section and offset)
+      properties:
+        track_section:
+          type: string
+          description: The track section ID
+          example: 61205924-6667-11e3-81ff-01f464e0362d
+        offset:
+          type: number
+          format: float
+          description: The offset on the track section
+          example: 42.
+      required: [track_section, offset]
+
+    TrackLocation:
+      type: object
+      description: A track location (track section and offset)
+      properties:
+        track:
+          type: string
+          description: The track section ID
+          example: 61205924-6667-11e3-81ff-01f464e0362d
+        offset:
+          type: number
+          format: float
+          description: The offset on the track section
+          example: 42.
+
+    Direction:
+      type: string
+      enum: [START_TO_STOP, STOP_TO_START]
+
+    TrackRange:
+      type: object
+      description: Track range
+      properties:
+        track:
+          type: string
+          example: 01234567-89ab-cdef-0123-456789abcdef
+        begin:
+          type: number
+          format: float
+        end:
+          type: number
+          format: float
+          example: 100
+
+    DirectionalTrackRange:
+      type: object
+      description: Track range associated with a direction
+      required:
+        - track
+        - begin
+        - end
+        - direction
+      properties:
+        track:
+          type: string
+          example: 01234567-89ab-cdef-0123-456789abcdef
+        begin:
+          type: number
+          format: float
+        end:
+          type: number
+          format: float
+          example: 100.
+        direction:
+          $ref: "#/components/schemas/Direction"
+
+    LightRollingStock:
+      allOf:
+        - $ref: "#/components/schemas/RollingStockBase"
+        - type: object
+          properties:
+            id:
+              type: number
+            liveries:
+              type: array
+              items:
+                $ref: "#/components/schemas/RollingStockLivery"
+            effort_curves:
+              type: object
+              properties:
+                default_mode:
+                  type: string
+                modes:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      is_electric:
+                        type: boolean
+                    required: [is_electric]
+              required: [default_mode, modes]
+          required: [id, liveries, effort_curves]
+
+    Path:
+      properties:
+        id: { type: integer }
+        owner:
+          type: string
+          format: uuid
+        created:
+          type: string
+          format: date-time
+        length:
+          type: number
+          format: float
+          description: Length of the path
+        geographic:
+          $ref: "#/components/schemas/GeoJsonObject"
+        schematic:
+          $ref: "#/components/schemas/GeoJsonObject"
+        slopes:
+          description: Slopes on the path
+          type: array
+          items:
+            type: object
+            properties:
+              gradient: { type: number, format: float }
+              position: { type: number, format: float }
+            required: [gradient, position]
+        curves:
+          description: Curves on the path
+          type: array
+          items:
+            type: object
+            properties:
+              radius: { type: number, format: float }
+              position: { type: number, format: float }
+            required: [radius, position]
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/PathStep"
+      required:
+        [
+          id,
+          owner,
+          created,
+          length,
+          geographic,
+          schematic,
+          slopes,
+          curves,
+          steps,
+        ]
+
+    PathQuery:
+      type: object
+      properties:
+        infra:
+          type: number
+        steps:
+          type: array
+          minItems: 2
+          items:
+            type: object
+            properties:
+              duration: { type: number, format: float }
+              waypoints:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PathWaypoint"
+            required: [duration, waypoints]
+        rolling_stocks:
+          description: List of rolling stocks that must be able to use this path
+          type: array
+          items: { type: integer }
+      required: [infra, steps, rolling_stocks]
+
+    PathStep:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        suggestion: { type: boolean }
+        duration: { type: number, format: float }
+        path_offset:
+          type: number
+          format: float
+          description: Offset of the step in the path
+        location:
+          $ref: "#/components/schemas/TrackSectionLocation"
+        sch:
+          $ref: "#/components/schemas/GeoJsonPosition"
+        geo:
+          $ref: "#/components/schemas/GeoJsonPosition"
+      required: [suggestion, duration, path_offset, location, sch, geo]
+
+    PathWaypoint:
+      type: object
+      properties:
+        track_section:
+          description: track section ID of the waypoint
+          type: string
+        geo_coordinate:
+          type: array
+          items: { type: number, format: float }
+          minItems: 2
+          maxItems: 2
+        offset:
+          type: number
+      required: [track_section, geo_cordinate]
+
+    PowerPack:
+      description: energy source for a rolling stock representing a power pack (hydrogen, fuel...)
+      type: object
+      required:
+        [
+          energy_source_type,
+          max_input_power,
+          max_output_power,
+          energy_storage,
+          efficiency,
+        ]
+      properties:
+        energy_source_type:
+          type: string
+          enum: ["PowerPack"]
+        max_input_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        max_output_power:
+          $ref: "#/components/schemas/SpeedDependantPower"
+        energy_storage:
+          $ref: "#/components/schemas/EnergyStorage"
+        efficiency:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+
+    RollingStock:
+      allOf:
+        - $ref: "#/components/schemas/RollingStockUpsertPayload"
+        - type: object
+          properties:
+            id:
+              type: number
+            liveries:
+              type: array
+              items:
+                $ref: "#/components/schemas/RollingStockLivery"
+          required: [id, liveries]
+
+    RollingStockUpsertPayload:
+      allOf:
+        - $ref: "#/components/schemas/RollingStockBase"
+        - type: object
+          properties:
+            effort_curves:
+              type: object
+              properties:
+                default_mode:
+                  type: string
+                modes:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      curves:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ConditionalEffortCurve"
+                      default_curve:
+                        $ref: "#/components/schemas/EffortCurve"
+                      is_electric:
+                        type: boolean
+                    required: [curves, default_curve, is_electric]
+              required: [default_mode, modes]
+          required: [effort_curves]
+
+    RollingStockBase:
+      properties:
+        railjson_version:
+          type: string
+          example: "3.0"
+        name:
+          type: string
+        locked:
+          type: boolean
+          default: false
+          description: Whether the rolling stock can be edited/deleted or not.
+        length:
+          type: number
+          format: float
+        max_speed:
+          type: number
+          format: float
+        startup_time:
+          type: number
+          format: float
+        startup_acceleration:
+          type: number
+          format: float
+        comfort_acceleration:
+          type: number
+          format: float
+        gamma:
+          type: object
+          properties:
+            type:
+              type: string
+              enum: ["CONST", "MAX"]
+            value:
+              type: number
+              format: float
+          required: [type, value]
+        inertia_coefficient:
+          type: number
+          format: float
+        features:
+          type: array
+          items:
+            type: string
+        mass:
+          type: number
+          format: float
+        rolling_resistance:
+          type: object
+          properties:
+            A:
+              type: number
+            B:
+              type: number
+            C:
+              type: number
+            type:
+              type: string
+              enum: ["davis"]
+          required: [A, B, C, type]
+        loading_gauge:
+          type: string
+          enum:
+            - "G1"
+            - "G2"
+            - "GA"
+            - "GB"
+            - "GB1"
+            - "GC"
+            - "FR3.3"
+            - "FR3.3/GB/G2"
+            - "GLOTT"
+        base_power_class:
+          type: string
+          example: "5"
+        power_restrictions:
+          type: object
+          description: Mapping of power restriction code to power class
+          additionalProperties:
+            type: string
+          example:
+            "C1US": "4"
+            "C2US": "3"
+        energy_sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/EnergySource"
+        electrical_power_startup_time:
+          type: number
+          nullable: true
+          format: float
+          description: The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
+          example: 5.0
+        raise_pantograph_time:
+          type: number
+          nullable: true
+          format: float
+          description: The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
+          example: 15.0
+        metadata:
+          type: object
+          properties:
+            detail:
+              type: string
+            family:
+              type: string
+            grouping:
+              type: string
+            number:
+              type: string
+            reference:
+              type: string
+            series:
+              type: string
+            subseries:
+              type: string
+            type:
+              type: string
+            unit:
+              type: string
+          example:
+            detail: "BB 7200"
+            family: "LOCOMOTIVES"
+            grouping: "Locomotives électriques courant continu"
+            number: "1"
+            reference: "7200"
+            series: "BB 7200"
+            subseries: "GV"
+            type: "Locomotives électriques"
+            unit: "US"
+          required:
+            [
+              detail,
+              family,
+              grouping,
+              number,
+              reference,
+              series,
+              subseries,
+              type,
+              unit,
+            ]
+      required:
+        - railjson_version
+        - name
+        - length
+        - max_speed
+        - startup_time
+        - startup_acceleration
+        - comfort_acceleration
+        - gamma
+        - inertia_coefficient
+        - features
+        - mass
+        - rolling_resistance
+        - loading_gauge
+        - base_power_class
+        - power_restrictions
+        - metadata
+        - energy_sources
+        - electrical_power_startup_time
+        - raise_pantograph_time
+
+    RollingStockLivery:
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+        compound_image_id:
+          type: number
+          nullable: true
+      required: [id, name, compound_image_id]
+
+    RouteTrackRangesComputed:
+      type: object
+      description: Route track ranges successfully computed
+      required:
+        - type
+        - track_ranges
+      properties:
+        type:
+          type: string
+          enum:
+            - Computed
+        track_ranges:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectionalTrackRange"
+
+    RouteTrackRangesNotFoundError:
+      type: object
+      description: Error when the route id couldn't be found
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - NotFound
+
+    RouteTrackRangesCantComputePathError:
+      type: object
+      description: Error when the route path couldn't be computed
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - CantComputePath
+
+    SpeedDependantPower:
+      description: power-speed curve (in an energy source)
+      type: object
+      required: [speeds, powers]
+      properties:
+        speeds:
+          type: array
+          items:
+            type: number
+            format: float
+        powers:
+          type: array
+          items:
+            type: number
+            format: float
+
+    ElectricalProfile:
+      type: object
+      properties:
+        value:
+          type: string
+          example: "A"
+        power_class:
+          type: string
+          example: "1"
+        track_ranges:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrackRange"
+
+    CatenaryRange:
+      type: object
+      properties:
+        begin:
+          type: number
+          format: float
+          example: 0.0
+        end:
+          type: number
+          format: float
+          example: 100.0
+        mode:
+          type: string
+          example: "25000"
+
+    SearchQuery:
+      type: array
+      minItems: 1
+      nullable: true
+      items:
+        oneOf:
+          - type: boolean
+          - type: number
+          - type: integer
+          - type: string
+          - $ref: "#/components/schemas/SearchQuery"
+      example:
+        [
+          "and",
+          [
+            "or",
+            ["search", ["name"], "mich st"],
+            ["search", ["trigram"], null],
+          ],
+          ["=", ["infra_id"], 2],
+        ]
+
+    SearchOperationalPointResult:
+      required:
+        - obj_id
+        - name
+        - geographic
+        - ch
+        - schematic
+        - trigram
+        - track_sections
+      properties:
+        obj_id:
+          type: string
+        infra_id:
+          type: string
+        name:
+          type: string
+        uic:
+          type: integer
+        trigram:
+          type: string
+        ch:
+          type: string
+        track_sections:
+          type: array
+          items:
+            type: object
+            required:
+              - track
+              - position
+            properties:
+              track:
+                type: string
+              position:
+                type: integer
+        geographic:
+          $ref: "#/components/schemas/MultiPoint"
+        schematic:
+          $ref: "#/components/schemas/MultiPoint"
+
+    SearchTrackResult:
+      required:
+        - infra_id
+        - line_code
+        - line_name
+      properties:
+        infra_id:
+          type: integer
+        line_code:
+          type: integer
+        line_name:
+          type: string
+
+    SearchSignalResult:
+      required:
+        - label
+        - geographic
+        - schematic
+        - line_code
+        - line_name
+      properties:
+        label:
+          type: string
+        infra_id:
+          type: integer
+        aspects:
+          type: array
+          items:
+            type: string
+        systems:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+        line_code:
+          type: integer
+        line_name:
+          type: string
+        geographic:
+          $ref: "#/components/schemas/Point"
+        schematic:
+          $ref: "#/components/schemas/Point"
+
+    SearchProjectResult:
+      required:
+        - id
+        - name
+        - description
+        - last_modification
+      properties:
+        id:
+          type: integer
+        image:
+          type: integer
+        name:
+          type: string
+        studies_count:
+          type: integer
+        description:
+          type: string
+        last_modification:
+          type: string
+          format: date-time
+        tags:
+          type: array
+
+    SearchStudyResult:
+      required:
+        - id
+        - name
+        - project_id
+        - last_modification
+      properties:
+        id:
+          type: integer
+        project_id:
+          type: integer
+        name:
+          type: string
+        scenarios_count:
+          type: integer
+        description:
+          type: string
+        last_modification:
+          type: string
+          format: date-time
+        tags:
+          type: array
+          items:
+            type: string
+
+    SearchScenarioResult:
+      required:
+        - id
+        - name
+        - study_id
+        - last_modification
+        - infra_id
+        - timetable_id
+      properties:
+        id:
+          type: integer
+        study_id:
+          type: integer
+        electrical_profile_set_id:
+          type: integer
+        name:
+          type: string
+        trains_count:
+          type: integer
+        description:
+          type: string
+        last_modification:
+          type: string
+          format: date-time
+        infra_id:
+          type: integer
+        infra_name:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+
+    ProjectCreateRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 128
+        objectives:
+          type: string
+          maxLength: 4096
+          default: ""
+        description:
+          type: string
+          maxLength: 1024
+          default: ""
+        funders:
+          type: string
+          maxLength: 1024
+          default: ""
+        budget:
+          type: integer
+        image:
+          type: integer
+          description: The id of the image in the document table
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+      required:
+        - name
+
+    ProjectPatchRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 128
+        objectives:
+          type: string
+          maxLength: 4096
+        description:
+          type: string
+          maxLength: 1024
+        funders:
+          type: string
+          maxLength: 1024
+        budget:
+          type: integer
+        image:
+          type: integer
+          description: The id of the image in the document table
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+
+    ProjectResult:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        objectives:
+          type: string
+        description:
+          type: string
+        funders:
+          type: string
+        budget:
+          type: integer
+        image:
+          type: integer
+          nullable: true
+          description: the image id
+        creation_date:
+          type: string
+          format: date-time
+        last_modification:
+          type: string
+          format: date-time
+        studies_count:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+
+    StudyUpsertRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 128
+        service_code:
+          type: string
+          maxLength: 128
+        business_code:
+          type: string
+          maxLength: 128
+        description:
+          type: string
+          maxLength: 1024
+        budget:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        start_date:
+          type: string
+          nullable: true
+          format: date-time
+        expected_end_date:
+          type: string
+          nullable: true
+          format: date-time
+        actual_end_date:
+          type: string
+          nullable: true
+          format: date-time
+        state:
+          type: string
+          enum: ["started", "inProgress", "finish"]
+        study_type:
+          type: string
+          enum:
+            [
+              "timeTables",
+              "flowRate",
+              "parkSizing",
+              "garageRequirement",
+              "operationOrSizing",
+              "operability",
+              "strategicPlanning",
+              "chartStability",
+              "disturbanceTests",
+            ]
+      required: [name, tags]
+
+    StudyResult:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        project_id:
+          type: integer
+        description:
+          type: string
+        budget:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        service_code:
+          type: string
+        business_code:
+          type: string
+        creation_date:
+          type: string
+          format: date-time
+        last_modification:
+          type: string
+          format: date-time
+        scenarios_count:
+          type: integer
+        start_date:
+          type: string
+          nullable: true
+          format: date-time
+        expected_end_date:
+          type: string
+          nullable: true
+          format: date-time
+        actual_end_date:
+          type: string
+          nullable: true
+          format: date-time
+        state:
+          type: string
+          enum: ["started", "inProgress", "finish"]
+        study_type:
+          type: string
+          enum:
+            [
+              "timeTables",
+              "flowRate",
+              "parkSizing",
+              "garageRequirement",
+              "operationOrSizing",
+              "operability",
+              "strategicPlanning",
+              "chartStability",
+              "disturbanceTests",
+            ]
+      required:
+        - id
+        - name
+        - project_id
+        - description
+        - budget
+        - tags
+        - service_code
+        - business_code
+        - creation_date
+        - last_modification
+        - scenarios_count
+        - start_date
+        - expected_end_date
+        - actual_end_date
+
+    ScenarioRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 128
+        description:
+          type: string
+          maxLength: 1024
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        infra_id:
+          type: integer
+        electrical_profile_set_id:
+          type: number
+          description: Electrical profile set id (if any)
+      required:
+        - "name"
+        - "infra_id"
+
+    ScenarioPatchRequest:
+      properties:
+        name:
+          type: string
+          maxLength: 128
+        description:
+          type: string
+          maxLength: 1024
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+
+    ScenarioResult:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        study_id:
+          type: integer
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        infra_id:
+          type: integer
+        infra_name:
+          type: string
+        electrical_profile_set_id:
+          type: integer
+          nullable: true
+        electrical_profile_set_name:
+          type: string
+          nullable: true
+        creation_date:
+          type: string
+          format: date-time
+        last_modification:
+          type: string
+          format: date-time
+        timetable_id:
+          type: integer
+        trains_count:
+          type: integer
+        trains_schedules:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              train_name:
+                type: string
+              departure_time:
+                type: string
+              train_path:
+                type: integer
+
+    ScenarioListResult:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        study_id:
+          type: integer
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        infra_id:
+          type: integer
+        infra_name:
+          type: string
+        electrical_profile_set_id:
+          type: integer
+          nullable: true
+        electrical_profile_set_name:
+          type: string
+          nullable: true
+        creation_date:
+          type: string
+          format: date-time
+        last_modification:
+          type: string
+          format: date-time
+        timetable_id:
+          type: integer
+        trains_count:
+          type: integer
+
+    Geometry:
+      type: object
+      description: Definition of a GeoJSON geometry
+      oneOf:
+        - $ref: "#/components/schemas/Point"
+        - $ref: "#/components/schemas/LineString"
+        - $ref: "#/components/schemas/Polygon"
+        - $ref: "#/components/schemas/MultiPoint"
+        - $ref: "#/components/schemas/MultiLineString"
+        - $ref: "#/components/schemas/MultiPolygon"
+
+    Point3D:
+      type: array
+      description: Point in 3D space
+      minItems: 2
+      maxItems: 3
+      items:
+        type: number
+
+    Point:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          $ref: "#/components/schemas/Point3D"
+
+    LineString:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          type: array
+          items:
+            $ref: "#/components/schemas/Point3D"
+
+    Polygon:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Point3D"
+
+    MultiPoint:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            $ref: "#/components/schemas/Point3D"
+
+    MultiLineString:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Point3D"
+
+    MultiPolygon:
+      type: object
+      description: GeoJSon geometry
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/Point3D"
+
+    TrainSchedule:
+      type: object
+      properties:
+        train_name:
+          type: string
+        timetable:
+          type: integer
+        rolling_stock:
+          type: integer
+        departure_time:
+          type: number
+          format: float
+        path:
+          type: integer
+        initial_speed:
+          type: number
+          format: float
+        labels:
+          type: array
+          items:
+            type: string
+        scheduled_points:
+          type: array
+          items:
+            type: object
+            required: [path_offset, time]
+            properties:
+              path_offset:
+                type: number
+                format: float
+                description: Offset in meters from the start of the path at which the train must be.
+              time:
+                type: number
+                format: float
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+        allowances:
+          type: array
+          items:
+            $ref: "#/components/schemas/Allowance"
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+        comfort:
+          $ref: "#/components/schemas/Comfort"
+        options:
+          allOf:
+            - $ref: "#/components/schemas/TrainScheduleOptions"
+          nullable: true
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          type: array
+          items:
+            $ref: "#/components/schemas/PowerRestrictionRange"
+          nullable: true
+    TimetableWithSchedulesDetails:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        train_schedule_summaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrainScheduleSummary"
+      required:
+        - id
+        - name
+        - train_schedule_summaries
+    TrainScheduleSummary:
+      type: object
+      properties:
+        id:
+          type: integer
+        train_name:
+          type: string
+        timetable_id:
+          type: integer
+        rolling_stock_id:
+          type: integer
+        departure_time:
+          type: number
+          format: float
+        path_id:
+          type: integer
+        initial_speed:
+          type: number
+          format: float
+        labels:
+          type: array
+          items:
+            type: string
+        allowances:
+          type: array
+          items:
+            $ref: "#/components/schemas/Allowance"
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+        comfort:
+          $ref: "#/components/schemas/Comfort"
+        options:
+          allOf:
+            - $ref: "#/components/schemas/TrainScheduleOptions"
+          nullable: true
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          type: array
+          items:
+            $ref: "#/components/schemas/PowerRestrictionRange"
+          nullable: true
+        arrival_time:
+          type: number
+        mechanical_energy_consumed:
+          type: object
+          properties:
+            base:
+              type: number
+            eco:
+              type: number
+        stops_count:
+          type: integer
+        path_length:
+          type: integer
+      required:
+        [
+          id,
+          train_name,
+          departure_time,
+          path,
+          labels,
+          arrival_time,
+          mechanical_energy_consumed,
+        ]
+
+    TrainScheduleOptions:
+      description: Options for the standalone simulation
+      type: object
+      properties:
+        ignore_electrical_profiles:
+          type: boolean
+          nullable: true
+
+    RollingStockUsage:
+      type: object
+      properties:
+        rolling_stock_id:
+          type: integer
+        usage:
+          type: object
+          properties:
+            train_schedule_id:
+              type: integer
+            train_name:
+              type: string
+            project_id:
+              type: integer
+            project_name:
+              type: string
+            study_id:
+              type: integer
+            study_name:
+              type: string
+            scenario_id:
+              type: integer
+            scenario_name:
+              type: string
+          required:
+            - train_schedule_id
+            - train_name
+            - project_id
+            - project_name
+            - study_id
+            - study_name
+            - scenario_id
+            - scenario_name
+      required:
+        - rolling_stock_id
+        - usage
+
+    PowerRestrictionRange:
+      description: A range along the train path where a power restriction is applied.
+      type: object
+      properties:
+        begin_position:
+          description: Offset from the start of the path, in meters.
+          type: number
+          format: float
+        end_position:
+          description: Offset from the start of the path, in meters.
+          type: number
+          format: float
+        power_restriction_code:
+          description: The power restriction code to apply.
+          type: string
+      example:
+        begin_position: 0.0
+        end_position: 1000.0
+        power_restriction_code: "C1US"
+      required: [begin_position, end_position, power_restriction_code]
+
+    Allowance:
+      oneOf:
+        - $ref: "#/components/schemas/EngineeringAllowance"
+        - $ref: "#/components/schemas/StandardAllowance"
+      discriminator:
+        propertyName: allowance_type
+
+    StandardAllowance:
+      properties:
+        allowance_type:
+          type: string
+          enum: ["standard"]
+        default_value:
+          $ref: "#/components/schemas/AllowanceValue"
+        ranges:
+          type: array
+          items:
+            $ref: "#/components/schemas/RangeAllowance"
+        distribution:
+          type: string
+          enum: ["MARECO", "LINEAR"]
+        capacity_speed_limit:
+          type: number
+          format: double
+      required: [allowance_type, default_value, ranges, distribution]
+
+    EngineeringAllowance:
+      allOf:
+        - type: object
+          properties:
+            allowance_type:
+              type: string
+              enum: ["engineering"]
+            distribution:
+              type: string
+              enum: ["MARECO", "LINEAR"]
+            capacity_speed_limit:
+              type: number
+              format: double
+          required: [allowance_type, distribution]
+        - $ref: "#/components/schemas/RangeAllowance"
+
+    RangeAllowance:
+      properties:
+        begin_position:
+          type: number
+        end_position:
+          type: number
+          example: 1000.0
+        value:
+          $ref: "#/components/schemas/AllowanceValue"
+      required: [begin_position, end_position, value]
+
+    AllowanceValue:
+      oneOf:
+        - $ref: "#/components/schemas/AllowanceTimePerDistanceValue"
+        - $ref: "#/components/schemas/AllowanceTimeValue"
+        - $ref: "#/components/schemas/AllowancePercentValue"
+      discriminator:
+        propertyName: value_type
+
+    AllowanceTimePerDistanceValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["time_per_distance"]
+        minutes:
+          type: number
+          example: 5.0
+          description: Minutes per 100k
+      required: [value_type, minutes]
+
+    AllowanceTimeValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["time"]
+        seconds:
+          type: number
+          example: 180.0
+      required: [value_type, seconds]
+
+    AllowancePercentValue:
+      properties:
+        value_type:
+          type: string
+          enum: ["percentage"]
+        percentage:
+          type: number
+          example: 15.0
+      required: [value_type, percentage]
+
+    SimulationReportByTrain:
+      properties:
+        speeds:
+          type: array
+          minItems: 1
+          items:
+            allOf:
+              - $ref: "#/components/schemas/SpaceTimePosition"
+              - type: object
+                properties:
+                  speed:
+                    type: number
+                    format: float
+                required: [speed]
+        head_positions:
+          type: array
+          minItems: 1
+          items:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/components/schemas/SpaceTimePosition"
+        tail_positions:
+          type: array
+          minItems: 1
+          items:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/components/schemas/SpaceTimePosition"
+        stops:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: number
+                description: Can be null if it's not an operational point
+              name:
+                type: string
+                description: Can be 'Unknown' if it's not an operational point
+              time: { type: number, format: float }
+              position: { type: number, format: float }
+              duration: { type: number, format: float }
+              line_code: { type: number }
+              track_number: { type: number }
+              line_name: { type: string }
+              track_name: { type: string }
+            required:
+              [
+                id,
+                name,
+                time,
+                position,
+                duration,
+                line_code,
+                track_number,
+                line_name,
+                track_name,
+              ]
+        route_aspects:
+          type: array
+          items:
+            type: object
+            properties:
+              signal_id:
+                type: string
+                description: id of the updated signal
+              route_id:
+                type: string
+                description: id of the affected route on the train path
+              time_start:
+                type: number
+                format: float
+                description: the aspect starts being displayed at this time
+              time_end:
+                type: number
+                format: float
+                description: the aspect stops being displayed at this time
+              position_start:
+                type: number
+                format: float
+                description: the route starts at this position on the train path
+              position_end:
+                type: number
+                format: float
+                description: the route ends at this position on the train path
+              color:
+                type: number
+                format: float
+                description: color of the aspect (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+              blinking:
+                type: boolean
+                description: true if the signal is blinking
+              aspect_label:
+                type: string
+                description: label of the new signal aspect
+            required:
+              - signal_id
+              - route_id
+              - time_start
+              - time_end
+              - position_start
+              - position_end
+              - color
+              - blinking
+              - aspect_label
+        signals:
+          type: array
+          items:
+            type: object
+            properties:
+              signal_id: { type: integer }
+              aspects:
+                type: array
+                items:
+                  type: string
+              geo_position:
+                type: array
+                items: { type: number, format: float }
+                minItems: 2
+                maxItems: 2
+              schema_position:
+                type: array
+                items: { type: number, format: float }
+                minItems: 2
+                maxItems: 2
+            required: [signal_id, aspects, geo_position, schema_position]
+        mechanical_energy_consumed:
+          type: number
+          format: float
+      required:
+        - speeds
+        - head_positions
+        - tail_positions
+        - stops
+        - route_aspects
+        - signals
+        - mechanical_energy_consumed
+
+    SpaceTimePosition:
+      type: object
+      properties:
+        time: { type: number, format: float }
+        position: { type: number, format: float }
+      required: [time, position, speed]
+
+    SimulationReport:
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        path:
+          type: integer
+          description: id of the path used for projection
+        vmax:
+          type: array
+          minItems: 2
+          items:
+            type: object
+            properties:
+              position: { type: number }
+              speed: { type: number }
+            required: [position, speed]
+        slopes:
+          type: array
+          minItems: 2
+          items:
+            type: object
+            properties:
+              position: { type: number }
+              gradient: { type: number }
+            required: [position, gradient]
+        curves:
+          type: array
+          minItems: 2
+          items:
+            type: object
+            properties:
+              position: { type: number }
+              radius: { type: number }
+            required: [position, radius]
+        base:
+          $ref: "#/components/schemas/SimulationReportByTrain"
+        eco:
+          $ref: "#/components/schemas/SimulationReportByTrain"
+        speed_limit_tags:
+          type: string
+        electrification_ranges:
+          description: A list of ranges which should be contiguous and which describe the electrification on the path and if it is handled by the train
+          type: array
+          items:
+            $ref: "#/components/schemas/ElectrificationRange"
+          minItems: 1
+        power_restriction_ranges:
+          description: The list of ranges where power restrictions are applied
+          type: array
+          items:
+            $ref: "#/components/schemas/PowerRestrictionRangeItem"
+
+      required:
+        - id
+        - name
+        - labels
+        - path
+        - vmax
+        - slopes
+        - curves
+        - base
+        - electrification_ranges
+        - power_restriction_ranges
+
+    PowerRestrictionRangeItem:
+      properties:
+        start:
+          type: number
+          format: double
+        stop:
+          type: number
+          format: double
+        code:
+          type: string
+        handled:
+          type: boolean
+      required: [start, stop, code, handled]
+
+    ElectrificationRange:
+      properties:
+        start:
+          type: number
+          format: double
+        stop:
+          type: number
+          format: double
+        electrificationUsage:
+          oneOf:
+            - $ref: "#/components/schemas/Electrified"
+            - $ref: "#/components/schemas/Neutral"
+            - $ref: "#/components/schemas/NonElectrified"
+          discriminator:
+            propertyName: object_type
+      required: [start, stop, is_electrified, electrificationUsage]
+
+    Electrified:
+      properties:
+        mode:
+          type: string
+        mode_handled:
+          type: boolean
+        object_type:
+          type: string
+          enum: ["Electrified"]
+        profile:
+          type: string
+          nullable: true
+        profile_handled:
+          type: boolean
+      required: [mode, mode_handled, object_type, profile_handled]
+    Neutral:
+      properties:
+        is_lower_pantograph:
+          type: boolean
+        object_type:
+          type: string
+          enum: ["Neutral"]
+      required: [is_lower_pantograph, object_type]
+    NonElectrified:
+      properties:
+        object_type:
+          type: string
+          enum: ["NonElectrified"]
+      required: [object_type]

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -26,6 +26,8 @@ pub enum Commands {
     ImportRailjson(ImportRailjsonArgs),
     ImportProfileSet(ImportProfileSetArgs),
     OsmToRailjson(OsmToRailjsonArgs),
+    #[command(about, long_about = "Prints the OpenApi of the service")]
+    Openapi,
 }
 
 #[derive(Args, Debug, Derivative, Clone)]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -20,6 +20,7 @@ use crate::models::Infra;
 use crate::schema::electrical_profiles::ElectricalProfileSetData;
 use crate::schema::RailJson;
 use crate::views::infra::InfraForm;
+use crate::views::OpenApiRoot;
 use actix_cors::Cors;
 use actix_web::middleware::{Condition, Logger, NormalizePath};
 use actix_web::web::{block, scope, Data, JsonConfig, PayloadConfig};
@@ -77,6 +78,10 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
         Commands::ImportProfileSet(args) => add_electrical_profile_set(args, pg_config).await,
         Commands::OsmToRailjson(args) => {
             converters::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
+        }
+        Commands::Openapi => {
+            generate_openapi();
+            Ok(())
         }
     }
 }
@@ -380,6 +385,12 @@ async fn clear(
         );
     }
     Ok(())
+}
+
+/// Prints the OpenApi to stdout
+fn generate_openapi() {
+    let openapi = OpenApiRoot::build_openapi();
+    println!("{}", serde_yaml::to_string(&openapi).unwrap());
 }
 
 #[cfg(test)]

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -1,0 +1,671 @@
+//! Provides [OpenApiMerger] that can be used to merge our old manually written
+//! OpenAPI with the new generated one incrementally in order to avoid protential
+//! breaking changes.
+//!
+//! This module is meant to be deleted at the end of the OpenAPI replacement
+//! process.
+
+use std::path::Path;
+
+use serde_json::Value as Json;
+
+pub(super) struct OpenApiMerger {
+    old: Json,
+    new: Json,
+}
+
+/// Returns the parent object of the JSON at path and the key to access the child, if they exist
+fn find_parent_of<'a>(
+    path: &'a Path,
+    json: &'a mut Json,
+) -> Option<(&'a mut Json, Option<String>)> {
+    find_json_at(path.parent().expect("path should have a parent"), json).map(|(parent, _)| {
+        let key =
+            find_path_in_object(Path::new(path.file_name().unwrap()), parent).map(|(key, _)| key);
+        (parent, key)
+    })
+}
+
+/// Searches the json object for the given path, returning its original key and
+/// the extra path components, if they exist
+fn find_path_in_object<'a>(path: &'a Path, json: &Json) -> Option<(String, &'a Path)> {
+    for key in json.as_object().unwrap().keys() {
+        let mut key_path = Path::new(key);
+        key_path = key_path.strip_prefix("/").unwrap_or(key_path);
+        if path.starts_with(key_path) {
+            let relative_path = path.strip_prefix(key_path).unwrap();
+            return Some((key.clone(), relative_path));
+        }
+    }
+    None
+}
+
+/// Returns the JSON value at path and its key in its parent, if they exist
+fn find_json_at<'a>(mut path: &'a Path, json: &'a mut Json) -> Option<(&'a mut Json, String)> {
+    path = path.strip_prefix("/").unwrap_or(path);
+    if path == Path::new("") {
+        return Some((json, String::new()));
+    }
+    let object = json.as_object_mut().expect("json in path is not an object");
+    for (key, json) in object.iter_mut() {
+        let mut key_path = Path::new(key);
+        key_path = key_path.strip_prefix("/").unwrap_or(key_path);
+        if path.starts_with(key_path) {
+            let relative_path = path.strip_prefix(key_path).unwrap();
+            match find_json_at(relative_path, json) {
+                Some((json, last_key)) if last_key.is_empty() => return Some((json, key.clone())),
+                None => continue,
+                ret => return ret,
+            }
+        }
+    }
+    None
+}
+
+/// Tries to find the JSON value at path. If the full path doesn't exist in the document,
+/// the function returns the deepest existing object alongwith the remaining non-existent path
+fn try_find_json_at<'a>(mut path: &'a Path, json: &'a mut Json) -> (&'a mut Json, &'a Path) {
+    path = path.strip_prefix("/").unwrap_or(path);
+    if path == Path::new("") {
+        return (json, path);
+    }
+    if !json.is_object() {
+        return (json, path);
+    };
+    let ro_json = json.to_owned();
+    if let Some((key, relative_path)) = find_path_in_object(path, &ro_json) {
+        try_find_json_at(
+            relative_path,
+            json.as_object_mut().unwrap().get_mut(&key).unwrap(),
+        )
+    } else {
+        (json, path)
+    }
+}
+
+impl OpenApiMerger {
+    pub fn new(old_content: String, new_content: String) -> Self {
+        Self {
+            old: serde_yaml::from_str(&old_content)
+                .expect("the old OpenAPI should be a valid YAML or JSON doc"),
+            new: serde_yaml::from_str(&new_content)
+                .expect("the new OpenAPI should be a valid YAML or JSON doc"),
+        }
+    }
+
+    /// Deletes a subtree from the old json openapi
+    #[must_use]
+    #[allow(unused)]
+    pub fn reject_old(mut self, path: &str) -> Self {
+        let path = Path::new(path);
+        let key = path
+            .file_name()
+            .expect("the path to reject should exist in the old OpenApi")
+            .to_str()
+            .unwrap()
+            .to_owned();
+        if let (json, Some(key)) =
+            find_parent_of(path, &mut self.old).expect("reject_old: could not find object at path")
+        {
+            json.as_object_mut().unwrap().remove(&key);
+        }
+        self
+    }
+
+    /// Takes the subtree at `new_src_path` in the new openapi alongwith its
+    /// key and inserts it into the object of the old openapi at `old_parent_path`
+    ///
+    /// ```
+    /// let old = json!({"paths": {"/A": null, "/B": {"C/": null}}});
+    /// let new = json!({"paths": {"/A": 12, "/B": null, "/B/C": null}});
+    /// assert_eq!(
+    ///     OpenApiMerger::new(old.to_string(), new.to_string())
+    ///         .take_new("paths/A", "paths")
+    ///         .take_new("paths/B/C", "paths")
+    ///         .finish();
+    ///     json!({"paths": {"/A": 12, "/B": {"C/": null}, "B/C/": null}})
+    /// );
+    /// ```
+    #[must_use]
+    #[allow(unused)]
+    pub fn take_new(mut self, new_src_path: &str, old_parent_path: &str) -> Self {
+        let src = Path::new(new_src_path);
+        let (new_object, new_key) =
+            find_json_at(src, &mut self.new).expect("take_new: src object must exist");
+        let dst = Path::new(old_parent_path);
+        let dst_object = find_json_at(dst, &mut self.old)
+            .expect("take_new: old_parent_path must exist")
+            .0;
+        let dst_map = dst_object
+            .as_object_mut()
+            .expect("take_new: old_parent_path must be an object");
+        if let Some((_, old_key)) =
+            find_json_at(Path::new(&new_key), &mut Json::Object(dst_map.to_owned()))
+        {
+            dst_map.remove(&old_key);
+        }
+        dst_map.insert(new_key, new_object.clone());
+        self
+    }
+
+    /// Takes the subtree at `new_src_path` in the new openapi and puts it at
+    /// the key `old_parent_path` in the old openapi
+    ///
+    /// ```
+    /// let old = json!({"paths": {"/A": null, "/B": {"C/": null}}});
+    /// let new = json!({"paths": {"/A": 12, "/B": null, "/B/C": 42}});
+    /// assert_eq!(
+    ///     OpenApiMerger::new(old.to_string(), new.to_string())
+    ///         .put_at("paths/A", "paths/A")
+    ///         .put_at("paths/B/C", "paths/B/C")
+    ///         .finish();
+    ///     json!({"paths": {"/A": 12, "/B": {"C/": 42}}})
+    /// );
+    /// ```
+    ///
+    /// See [OpenApiMerger::replace]
+    #[must_use]
+    #[allow(unused)]
+    pub fn put_at(mut self, new_src_path: &str, old_dst_path: &str) -> Self {
+        let src = Path::new(new_src_path);
+        let (new_object, _) =
+            find_json_at(src, &mut self.new).expect("put_at: src object must exist");
+        let dst = Path::new(old_dst_path);
+        let (parent_object, old_key) =
+            find_parent_of(dst, &mut self.old).expect("put_at: old_dst_path parent must exist");
+        parent_object
+            .as_object_mut()
+            .expect("put_at: old_dst_path parent must be an object")
+            .insert(
+                old_key.unwrap_or_else(|| {
+                    dst.file_name()
+                        .expect("put_at: dst path should end with a key name")
+                        .to_str()
+                        .unwrap()
+                        .to_owned()
+                }),
+                new_object.clone(),
+            );
+        self
+    }
+
+    /// Just like [Self::put_at] for when the src and the dst are identical
+    #[must_use]
+    #[allow(unused)]
+    pub fn replace(self, path: &str) -> Self {
+        self.put_at(path, path)
+    }
+
+    #[must_use]
+    #[allow(unused)]
+    /// Ensures that the full path exists by creating the hierarchy if not
+    ///
+    /// Does not overwrite existing values.
+    pub fn create_path(mut self, path: &str) -> Self {
+        let dst = Path::new(path);
+        match try_find_json_at(dst, &mut self.old) {
+            (_, path) if path == Path::new("") => {
+                return self;
+            }
+            (json, path) => {
+                let mut json = json;
+                for key in path {
+                    let key = key.to_str().unwrap();
+                    let object = json.as_object_mut().unwrap();
+                    object.insert(key.to_owned(), Json::Object(Default::default()));
+                    json = object.get_mut(&key.to_owned()).unwrap();
+                }
+            }
+        }
+        self
+    }
+
+    /// Returns the merged OpenAPI
+    pub fn finish(self) -> Json {
+        self.old
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+    use rstest::{fixture, rstest};
+    use serde_json::{json, Value};
+
+    use super::OpenApiMerger;
+
+    #[fixture]
+    fn old() -> Value {
+        json!({
+            "A": "old_A",
+            "B": "old_B",
+            "C": "old_C"
+        })
+    }
+
+    #[fixture]
+    fn new() -> Value {
+        json!({
+            "A": "new_A",
+            "B": "new_B",
+            "C": "new_C",
+            "D": "new_D"
+        })
+    }
+
+    #[rstest]
+    fn test_simple_update(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .replace("B")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "old_A",
+                "B": "new_B",
+                "C": "old_C"
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_simple_reject(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .reject_old("B")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "old_A",
+                "C": "old_C"
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_simple_new(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .replace("D")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "old_A",
+                "B": "old_B",
+                "C": "old_C",
+                "D": "new_D"
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_simple_take_new(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .take_new("B", "") // replacement
+            .take_new("D", "") // insertion
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "old_A",
+                "B": "new_B",
+                "C": "old_C",
+                "D": "new_D",
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_simple_put_at_existing_location(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .put_at("B", "A")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "new_B",
+                "B": "old_B",
+                "C": "old_C",
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_simple_put_at_new_location(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .put_at("D", "E")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "old_A",
+                "B": "old_B",
+                "C": "old_C",
+                "E": "new_D"
+            })
+        )
+    }
+
+    #[rstest::rstest]
+    async fn test_create_path() {
+        assert_eq!(
+            OpenApiMerger::new(
+                json!({
+                    "X": {
+                        "Y": 42
+                    }
+                })
+                .to_string(),
+                "".to_owned()
+            )
+            .create_path("A")
+            .create_path("nested/b/c/d")
+            .create_path("X/Y") // no replacement
+            .create_path("X/Z")
+            .finish(),
+            json!({
+                "A": {},
+                "nested": {
+                    "b": {
+                        "c": {
+                            "d": {}
+                        }
+                    }
+                },
+                "X": {
+                    "Y": 42,
+                    "Z": {}
+                }
+            })
+        );
+    }
+
+    #[rstest]
+    fn test_simple_all(old: Value, new: Value) {
+        let merged = OpenApiMerger::new(old.to_string(), new.to_string())
+            .replace("B")
+            .reject_old("C")
+            .put_at("D", "E")
+            .put_at("A", "F")
+            .take_new("A", "")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "new_A",
+                "B": "new_B",
+                "E": "new_D",
+                "F": "new_A"
+            })
+        )
+    }
+
+    #[fixture]
+    fn old_nested() -> Value {
+        json!({
+            "A": {
+                "A1": "old_A1",
+                "A2": "old_A2",
+                "A3": "old_A3"
+            },
+            "B": {
+                "B1": "old_B1",
+                "B2": "old_B2",
+                "B3": "old_B3"
+            },
+            "C": {
+                "C1": "old_C1",
+                "C2": "old_C2",
+                "C3": "old_C3"
+            }
+        })
+    }
+
+    #[fixture]
+    fn new_nested() -> Value {
+        json!({
+            "A": {
+                "A1": "new_A1",
+                "A2": "new_A2",
+                "A3": "new_A3",
+                "A4": "new_A4"
+            },
+            "B": {
+                "B1": "new_B1",
+                "B2": "new_B2",
+                "B3": "new_B3",
+                "B4": "new_B4"
+            },
+            "C": {
+                "C1": "new_C1",
+                "C2": "new_C2",
+                "C3": "new_C3",
+                "C4": "new_C4"
+            },
+            "D": {
+                "D1": "new_D1",
+                "D2": "new_D2",
+                "D3": "new_D3"
+            },
+            "E": {
+                "E1": "new_E1",
+                "E2": "new_E2",
+                "E3": "new_E3"
+            }
+        })
+    }
+
+    #[rstest]
+    fn test_nested_reject(old_nested: Value, new_nested: Value) {
+        let merged = OpenApiMerger::new(old_nested.to_string(), new_nested.to_string())
+            .reject_old("B/B2")
+            .reject_old("C")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": {
+                    "A1": "old_A1",
+                    "A2": "old_A2",
+                    "A3": "old_A3"
+                },
+                "B": {
+                    "B1": "old_B1",
+                    "B3": "old_B3"
+                }
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_nested_new(old_nested: Value, new_nested: Value) {
+        let merged = OpenApiMerger::new(old_nested.to_string(), new_nested.to_string())
+            .replace("D") // existing dst
+            .create_path("E")
+            .replace("E/E1") // new dst
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": {
+                    "A1": "old_A1",
+                    "A2": "old_A2",
+                    "A3": "old_A3"
+                },
+                "B": {
+                    "B1": "old_B1",
+                    "B2": "old_B2",
+                    "B3": "old_B3"
+                },
+                "C": {
+                    "C1": "old_C1",
+                    "C2": "old_C2",
+                    "C3": "old_C3"
+                },
+                "D": {
+                    "D1": "new_D1",
+                    "D2": "new_D2",
+                    "D3": "new_D3"
+                },
+                "E": {
+                    "E1": "new_E1"
+                }
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_nested_put_at(old_nested: Value, new_nested: Value) {
+        let merged = OpenApiMerger::new(old_nested.to_string(), new_nested.to_string())
+            .put_at("B/B2", "A")
+            .put_at("D", "C/C4")
+            .create_path("C/C4/E1")
+            .put_at("E/E1", "C/C4/E1/nested")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": "new_B2",
+                "B": {
+                    "B1": "old_B1",
+                    "B2": "old_B2",
+                    "B3": "old_B3"
+                },
+                "C": {
+                    "C1": "old_C1",
+                    "C2": "old_C2",
+                    "C3": "old_C3",
+                    "C4": {
+                        "D1": "new_D1",
+                        "D2": "new_D2",
+                        "D3": "new_D3",
+                        "E1": {
+                            "nested": "new_E1"
+                        }
+                    }
+                }
+            })
+        )
+    }
+
+    #[rstest]
+    fn test_nested_take_new(old_nested: Value, new_nested: Value) {
+        let merged = OpenApiMerger::new(old_nested.to_string(), new_nested.to_string())
+            .take_new("B/B2", "A")
+            .take_new("D", "C")
+            .create_path("B/B4/nested")
+            .take_new("E/E1", "B/B4/nested")
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "A": {
+                    "A1": "old_A1",
+                    "A2": "old_A2",
+                    "A3": "old_A3",
+                    "B2": "new_B2"
+                },
+                "B": {
+                    "B1": "old_B1",
+                    "B2": "old_B2",
+                    "B3": "old_B3",
+                    "B4": {
+                        "nested": {
+                            "E1": "new_E1"
+                        }
+                    }
+                },
+                "C": {
+                    "C1": "old_C1",
+                    "C2": "old_C2",
+                    "C3": "old_C3",
+                    "D": {
+                        "D1": "new_D1",
+                        "D2": "new_D2",
+                        "D3": "new_D3"
+                    }
+                }
+            })
+        )
+    }
+
+    #[rstest]
+    async fn test_insaaaaane() {
+        let hard_old = json!({
+            "paths": {
+                "/documents/": {
+                    "post": "post"
+                },
+                "/documents/{key}/": {
+                    "delete": "delete",
+                    "get": "get"
+                },
+                "/electrical_profile_set/": {
+                    "/": {
+                        "get": "get",
+                        "post": "post"
+                    },
+                    "/{id}/": {
+                        "get": "get"
+                    }
+                }
+            }
+        });
+        let hard_new = json!({
+            "paths": {
+                "/documents": {
+                    "post": "post",
+                    "patch": "patch"
+                },
+                "/documents/{key}/new": {
+                    "get": "get",
+                },
+                "/documents/{key}/bye": {
+                    "delete": "delete",
+                },
+                "/electrical_profile_set": {
+                    "get": "get",
+                    "post": "post",
+                    "put": "put"
+                },
+                "/electrical_profile_set/{id}": {
+                    "get": "get",
+                    "delete": "delete",
+                    "head": "head"
+                }
+            }
+        });
+        let merged = OpenApiMerger::new(hard_old.to_string(), hard_new.to_string())
+            .replace("paths/documents/")
+            .take_new("paths/documents/{key}/new", "paths")
+            .take_new("paths/documents/{key}/bye", "paths")
+            .take_new("paths/electrical_profile_set/", "paths") // takes the new one that replaces the old one with the trailing slash
+            .finish();
+        assert_eq!(
+            merged,
+            json!({
+                "paths": {
+                    "/documents/": {
+                        "post": "post",
+                        "patch": "patch"
+                    },
+                    "/documents/{key}/": {
+                        "delete": "delete",
+                        "get": "get"
+                    },
+                    "/electrical_profile_set": {
+                        "get": "get",
+                        "post": "post",
+                        "put": "put"
+                    },
+                    "/documents/{key}/new": {
+                        "get": "get",
+                    },
+                    "/documents/{key}/bye": {
+                        "delete": "delete",
+                    }
+                }
+            })
+        );
+    }
+}

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -527,7 +527,12 @@ const injectedRtkApi = api
         invalidatesTags: ['rolling_stock'],
       }),
       postSearch: build.mutation<PostSearchApiResponse, PostSearchApiArg>({
-        query: (queryArg) => ({ url: `/search/`, method: 'POST', body: queryArg.body }),
+        query: (queryArg) => ({
+          url: `/search/`,
+          method: 'POST',
+          body: queryArg.body,
+          params: { page_size: queryArg.pageSize },
+        }),
       }),
       getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
         query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
@@ -1133,6 +1138,8 @@ export type PostSearchApiResponse =
     | SearchScenarioResult
   )[];
 export type PostSearchApiArg = {
+  /** number of results */
+  pageSize?: number;
   /** Search query */
   body: {
     object?: string;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1,18 +1,18 @@
 import { baseEditoastApi as api } from './emptyApi';
 
 export const addTagTypes = [
-  'layers',
-  'infra',
-  'routes',
-  'pathfinding',
-  'electrical_profiles',
   'documents',
+  'electrical_profiles',
+  'infra',
+  'pathfinding',
+  'routes',
+  'layers',
   'rolling_stock',
-  'rolling_stock_livery',
   'projects',
-  'timetable',
   'studies',
   'scenarios',
+  'rolling_stock_livery',
+  'timetable',
   'train_schedule',
 ] as const;
 const injectedRtkApi = api
@@ -21,211 +21,20 @@ const injectedRtkApi = api
   })
   .injectEndpoints({
     endpoints: (build) => ({
-      getHealth: build.query<GetHealthApiResponse, GetHealthApiArg>({
-        query: () => ({ url: `/health/` }),
+      postDocuments: build.mutation<PostDocumentsApiResponse, PostDocumentsApiArg>({
+        query: () => ({ url: `/documents/`, method: 'POST' }),
+        invalidatesTags: ['documents'],
       }),
-      getVersion: build.query<GetVersionApiResponse, GetVersionApiArg>({
-        query: () => ({ url: `/version/` }),
-      }),
-      postSearch: build.mutation<PostSearchApiResponse, PostSearchApiArg>({
-        query: (queryArg) => ({
-          url: `/search/`,
-          method: 'POST',
-          body: queryArg.body,
-          params: { page_size: queryArg.pageSize },
-        }),
-      }),
-      getLayersLayerByLayerSlugMvtAndViewSlug: build.query<
-        GetLayersLayerByLayerSlugMvtAndViewSlugApiResponse,
-        GetLayersLayerByLayerSlugMvtAndViewSlugApiArg
+      deleteDocumentsByKey: build.mutation<
+        DeleteDocumentsByKeyApiResponse,
+        DeleteDocumentsByKeyApiArg
       >({
-        query: (queryArg) => ({
-          url: `/layers/layer/${queryArg.layerSlug}/mvt/${queryArg.viewSlug}/`,
-          params: { infra: queryArg.infra },
-        }),
-        providesTags: ['layers'],
+        query: (queryArg) => ({ url: `/documents/${queryArg.key}/`, method: 'DELETE' }),
+        invalidatesTags: ['documents'],
       }),
-      getLayersTileByLayerSlugAndViewSlugZXY: build.query<
-        GetLayersTileByLayerSlugAndViewSlugZXYApiResponse,
-        GetLayersTileByLayerSlugAndViewSlugZXYApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/layers/tile/${queryArg.layerSlug}/${queryArg.viewSlug}/${queryArg.z}/${queryArg.x}/${queryArg.y}/`,
-          params: { infra: queryArg.infra },
-        }),
-        providesTags: ['layers'],
-      }),
-      getInfra: build.query<GetInfraApiResponse, GetInfraApiArg>({
-        query: () => ({ url: `/infra/` }),
-        providesTags: ['infra'],
-      }),
-      postInfra: build.mutation<PostInfraApiResponse, PostInfraApiArg>({
-        query: (queryArg) => ({ url: `/infra/`, method: 'POST', body: queryArg.body }),
-        invalidatesTags: ['infra'],
-      }),
-      getInfraById: build.query<GetInfraByIdApiResponse, GetInfraByIdApiArg>({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/` }),
-        providesTags: ['infra'],
-      }),
-      deleteInfraById: build.mutation<DeleteInfraByIdApiResponse, DeleteInfraByIdApiArg>({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/`, method: 'DELETE' }),
-        invalidatesTags: ['infra'],
-      }),
-      postInfraById: build.mutation<PostInfraByIdApiResponse, PostInfraByIdApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['infra'],
-      }),
-      putInfraById: build.mutation<PutInfraByIdApiResponse, PutInfraByIdApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/`,
-          method: 'PUT',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['infra'],
-      }),
-      postInfraByIdLoad: build.mutation<PostInfraByIdLoadApiResponse, PostInfraByIdLoadApiArg>({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/load/`, method: 'POST' }),
-        invalidatesTags: ['infra'],
-      }),
-      getInfraByIdRailjson: build.query<
-        GetInfraByIdRailjsonApiResponse,
-        GetInfraByIdRailjsonApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/railjson/` }),
-        providesTags: ['infra'],
-      }),
-      postInfraRailjson: build.mutation<PostInfraRailjsonApiResponse, PostInfraRailjsonApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/railjson/`,
-          method: 'POST',
-          body: queryArg.railjsonFile,
-          params: { name: queryArg.name, generate_data: queryArg.generateData },
-        }),
-        invalidatesTags: ['infra'],
-      }),
-      getInfraByIdErrors: build.query<GetInfraByIdErrorsApiResponse, GetInfraByIdErrorsApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/errors/`,
-          params: {
-            page: queryArg.page,
-            page_size: queryArg.pageSize,
-            error_type: queryArg.errorType,
-            object_id: queryArg.objectId,
-            level: queryArg.level,
-          },
-        }),
-        providesTags: ['infra'],
-      }),
-      getInfraByIdSwitchTypes: build.query<
-        GetInfraByIdSwitchTypesApiResponse,
-        GetInfraByIdSwitchTypesApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/switch_types/` }),
-        providesTags: ['infra'],
-      }),
-      postInfraRefresh: build.mutation<PostInfraRefreshApiResponse, PostInfraRefreshApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/refresh/`,
-          method: 'POST',
-          params: { infras: queryArg.infras, force: queryArg.force },
-        }),
-        invalidatesTags: ['infra'],
-      }),
-      getInfraByIdLinesAndLineCodeBbox: build.query<
-        GetInfraByIdLinesAndLineCodeBboxApiResponse,
-        GetInfraByIdLinesAndLineCodeBboxApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/lines/${queryArg.lineCode}/bbox/` }),
-        providesTags: ['infra'],
-      }),
-      postInfraByIdLock: build.mutation<PostInfraByIdLockApiResponse, PostInfraByIdLockApiArg>({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/lock/`, method: 'POST' }),
-        invalidatesTags: ['infra'],
-      }),
-      postInfraByIdUnlock: build.mutation<
-        PostInfraByIdUnlockApiResponse,
-        PostInfraByIdUnlockApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/unlock/`, method: 'POST' }),
-        invalidatesTags: ['infra'],
-      }),
-      getInfraByIdSpeedLimitTags: build.query<
-        GetInfraByIdSpeedLimitTagsApiResponse,
-        GetInfraByIdSpeedLimitTagsApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/speed_limit_tags/` }),
-        providesTags: ['infra'],
-      }),
-      getInfraByIdVoltages: build.query<
-        GetInfraByIdVoltagesApiResponse,
-        GetInfraByIdVoltagesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/voltages/`,
-          params: { include_rolling_stock_modes: queryArg.includeRollingStockModes },
-        }),
-        providesTags: ['infra'],
-      }),
-      getInfraByIdAttachedAndTrackId: build.query<
-        GetInfraByIdAttachedAndTrackIdApiResponse,
-        GetInfraByIdAttachedAndTrackIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/attached/${queryArg.trackId}/` }),
-        providesTags: ['infra'],
-      }),
-      getInfraByIdRoutesAndWaypointTypeWaypointId: build.query<
-        GetInfraByIdRoutesAndWaypointTypeWaypointIdApiResponse,
-        GetInfraByIdRoutesAndWaypointTypeWaypointIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/routes/${queryArg.waypointType}/${queryArg.waypointId}/`,
-        }),
-        providesTags: ['infra', 'routes'],
-      }),
-      getInfraByIdRoutesTrackRanges: build.query<
-        GetInfraByIdRoutesTrackRangesApiResponse,
-        GetInfraByIdRoutesTrackRangesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/routes/track_ranges/`,
-          params: { routes: queryArg.routes },
-        }),
-        providesTags: ['infra', 'routes'],
-      }),
-      postInfraByIdPathfinding: build.mutation<
-        PostInfraByIdPathfindingApiResponse,
-        PostInfraByIdPathfindingApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/pathfinding/`,
-          method: 'POST',
-          body: queryArg.body,
-          params: { number: queryArg.number },
-        }),
-        invalidatesTags: ['infra', 'pathfinding'],
-      }),
-      postInfraByIdObjectsAndObjectType: build.mutation<
-        PostInfraByIdObjectsAndObjectTypeApiResponse,
-        PostInfraByIdObjectsAndObjectTypeApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/objects/${queryArg.objectType}/`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['infra'],
-      }),
-      postInfraByIdClone: build.mutation<PostInfraByIdCloneApiResponse, PostInfraByIdCloneApiArg>({
-        query: (queryArg) => ({
-          url: `/infra/${queryArg.id}/clone/`,
-          method: 'POST',
-          params: { name: queryArg.name },
-        }),
-        invalidatesTags: ['infra'],
+      getDocumentsByKey: build.query<GetDocumentsByKeyApiResponse, GetDocumentsByKeyApiArg>({
+        query: (queryArg) => ({ url: `/documents/${queryArg.key}/` }),
+        providesTags: ['documents'],
       }),
       getElectricalProfileSet: build.query<
         GetElectricalProfileSetApiResponse,
@@ -259,20 +68,200 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/electrical_profile_set/${queryArg.id}/level_order/` }),
         providesTags: ['electrical_profiles'],
       }),
-      getDocumentsByKey: build.query<GetDocumentsByKeyApiResponse, GetDocumentsByKeyApiArg>({
-        query: (queryArg) => ({ url: `/documents/${queryArg.key}/` }),
-        providesTags: ['documents'],
+      getHealth: build.query<GetHealthApiResponse, GetHealthApiArg>({
+        query: () => ({ url: `/health/` }),
       }),
-      deleteDocumentsByKey: build.mutation<
-        DeleteDocumentsByKeyApiResponse,
-        DeleteDocumentsByKeyApiArg
+      getInfra: build.query<GetInfraApiResponse, GetInfraApiArg>({
+        query: () => ({ url: `/infra/` }),
+        providesTags: ['infra'],
+      }),
+      postInfra: build.mutation<PostInfraApiResponse, PostInfraApiArg>({
+        query: (queryArg) => ({ url: `/infra/`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraRailjson: build.mutation<PostInfraRailjsonApiResponse, PostInfraRailjsonApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/railjson/`,
+          method: 'POST',
+          body: queryArg.railjsonFile,
+          params: { name: queryArg.name, generate_data: queryArg.generateData },
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraRefresh: build.mutation<PostInfraRefreshApiResponse, PostInfraRefreshApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/refresh/`,
+          method: 'POST',
+          params: { infras: queryArg.infras, force: queryArg.force },
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      deleteInfraById: build.mutation<DeleteInfraByIdApiResponse, DeleteInfraByIdApiArg>({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/`, method: 'DELETE' }),
+        invalidatesTags: ['infra'],
+      }),
+      getInfraById: build.query<GetInfraByIdApiResponse, GetInfraByIdApiArg>({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/` }),
+        providesTags: ['infra'],
+      }),
+      postInfraById: build.mutation<PostInfraByIdApiResponse, PostInfraByIdApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      putInfraById: build.mutation<PutInfraByIdApiResponse, PutInfraByIdApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/`,
+          method: 'PUT',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      getInfraByIdAttachedAndTrackId: build.query<
+        GetInfraByIdAttachedAndTrackIdApiResponse,
+        GetInfraByIdAttachedAndTrackIdApiArg
       >({
-        query: (queryArg) => ({ url: `/documents/${queryArg.key}/`, method: 'DELETE' }),
-        invalidatesTags: ['documents'],
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/attached/${queryArg.trackId}/` }),
+        providesTags: ['infra'],
       }),
-      postDocuments: build.mutation<PostDocumentsApiResponse, PostDocumentsApiArg>({
-        query: () => ({ url: `/documents/`, method: 'POST' }),
-        invalidatesTags: ['documents'],
+      postInfraByIdClone: build.mutation<PostInfraByIdCloneApiResponse, PostInfraByIdCloneApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/clone/`,
+          method: 'POST',
+          params: { name: queryArg.name },
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      getInfraByIdErrors: build.query<GetInfraByIdErrorsApiResponse, GetInfraByIdErrorsApiArg>({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/errors/`,
+          params: {
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+            error_type: queryArg.errorType,
+            object_id: queryArg.objectId,
+            level: queryArg.level,
+          },
+        }),
+        providesTags: ['infra'],
+      }),
+      getInfraByIdLinesAndLineCodeBbox: build.query<
+        GetInfraByIdLinesAndLineCodeBboxApiResponse,
+        GetInfraByIdLinesAndLineCodeBboxApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/lines/${queryArg.lineCode}/bbox/` }),
+        providesTags: ['infra'],
+      }),
+      postInfraByIdLoad: build.mutation<PostInfraByIdLoadApiResponse, PostInfraByIdLoadApiArg>({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/load/`, method: 'POST' }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraByIdLock: build.mutation<PostInfraByIdLockApiResponse, PostInfraByIdLockApiArg>({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/lock/`, method: 'POST' }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraByIdObjectsAndObjectType: build.mutation<
+        PostInfraByIdObjectsAndObjectTypeApiResponse,
+        PostInfraByIdObjectsAndObjectTypeApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/objects/${queryArg.objectType}/`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['infra'],
+      }),
+      postInfraByIdPathfinding: build.mutation<
+        PostInfraByIdPathfindingApiResponse,
+        PostInfraByIdPathfindingApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/pathfinding/`,
+          method: 'POST',
+          body: queryArg.body,
+          params: { number: queryArg.number },
+        }),
+        invalidatesTags: ['infra', 'pathfinding'],
+      }),
+      getInfraByIdRailjson: build.query<
+        GetInfraByIdRailjsonApiResponse,
+        GetInfraByIdRailjsonApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/railjson/` }),
+        providesTags: ['infra'],
+      }),
+      getInfraByIdRoutesTrackRanges: build.query<
+        GetInfraByIdRoutesTrackRangesApiResponse,
+        GetInfraByIdRoutesTrackRangesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/routes/track_ranges/`,
+          params: { routes: queryArg.routes },
+        }),
+        providesTags: ['infra', 'routes'],
+      }),
+      getInfraByIdRoutesAndWaypointTypeWaypointId: build.query<
+        GetInfraByIdRoutesAndWaypointTypeWaypointIdApiResponse,
+        GetInfraByIdRoutesAndWaypointTypeWaypointIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/routes/${queryArg.waypointType}/${queryArg.waypointId}/`,
+        }),
+        providesTags: ['infra', 'routes'],
+      }),
+      getInfraByIdSpeedLimitTags: build.query<
+        GetInfraByIdSpeedLimitTagsApiResponse,
+        GetInfraByIdSpeedLimitTagsApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/speed_limit_tags/` }),
+        providesTags: ['infra'],
+      }),
+      getInfraByIdSwitchTypes: build.query<
+        GetInfraByIdSwitchTypesApiResponse,
+        GetInfraByIdSwitchTypesApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/switch_types/` }),
+        providesTags: ['infra'],
+      }),
+      postInfraByIdUnlock: build.mutation<
+        PostInfraByIdUnlockApiResponse,
+        PostInfraByIdUnlockApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/unlock/`, method: 'POST' }),
+        invalidatesTags: ['infra'],
+      }),
+      getInfraByIdVoltages: build.query<
+        GetInfraByIdVoltagesApiResponse,
+        GetInfraByIdVoltagesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/infra/${queryArg.id}/voltages/`,
+          params: { include_rolling_stock_modes: queryArg.includeRollingStockModes },
+        }),
+        providesTags: ['infra'],
+      }),
+      getLayersLayerByLayerSlugMvtAndViewSlug: build.query<
+        GetLayersLayerByLayerSlugMvtAndViewSlugApiResponse,
+        GetLayersLayerByLayerSlugMvtAndViewSlugApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/layers/layer/${queryArg.layerSlug}/mvt/${queryArg.viewSlug}/`,
+          params: { infra: queryArg.infra },
+        }),
+        providesTags: ['layers'],
+      }),
+      getLayersTileByLayerSlugAndViewSlugZXY: build.query<
+        GetLayersTileByLayerSlugAndViewSlugZXYApiResponse,
+        GetLayersTileByLayerSlugAndViewSlugZXYApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/layers/tile/${queryArg.layerSlug}/${queryArg.viewSlug}/${queryArg.z}/${queryArg.x}/${queryArg.y}/`,
+          params: { infra: queryArg.infra },
+        }),
+        providesTags: ['layers'],
       }),
       getLightRollingStock: build.query<
         GetLightRollingStockApiResponse,
@@ -294,6 +283,13 @@ const injectedRtkApi = api
       postPathfinding: build.mutation<PostPathfindingApiResponse, PostPathfindingApiArg>({
         query: (queryArg) => ({ url: `/pathfinding/`, method: 'POST', body: queryArg.pathQuery }),
       }),
+      deletePathfindingById: build.mutation<
+        DeletePathfindingByIdApiResponse,
+        DeletePathfindingByIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.id}/`, method: 'DELETE' }),
+        invalidatesTags: ['pathfinding'],
+      }),
       getPathfindingById: build.query<GetPathfindingByIdApiResponse, GetPathfindingByIdApiArg>({
         query: (queryArg) => ({ url: `/pathfinding/${queryArg.id}/` }),
         providesTags: ['pathfinding'],
@@ -306,77 +302,12 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['pathfinding'],
       }),
-      deletePathfindingById: build.mutation<
-        DeletePathfindingByIdApiResponse,
-        DeletePathfindingByIdApiArg
+      getPathfindingByPathIdCatenaries: build.query<
+        GetPathfindingByPathIdCatenariesApiResponse,
+        GetPathfindingByPathIdCatenariesApiArg
       >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.id}/`, method: 'DELETE' }),
-        invalidatesTags: ['pathfinding'],
-      }),
-      postRollingStock: build.mutation<PostRollingStockApiResponse, PostRollingStockApiArg>({
-        query: (queryArg) => ({
-          url: `/rolling_stock/`,
-          method: 'POST',
-          body: queryArg.rollingStockUpsertPayload,
-          params: { locked: queryArg.locked },
-        }),
-        invalidatesTags: ['rolling_stock'],
-      }),
-      getRollingStockById: build.query<GetRollingStockByIdApiResponse, GetRollingStockByIdApiArg>({
-        query: (queryArg) => ({ url: `/rolling_stock/${queryArg.id}/` }),
-        providesTags: ['rolling_stock'],
-      }),
-      patchRollingStockById: build.mutation<
-        PatchRollingStockByIdApiResponse,
-        PatchRollingStockByIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.id}/`,
-          method: 'PATCH',
-          body: queryArg.rollingStockUpsertPayload,
-        }),
-        invalidatesTags: ['rolling_stock'],
-      }),
-      deleteRollingStockById: build.mutation<
-        DeleteRollingStockByIdApiResponse,
-        DeleteRollingStockByIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.id}/`,
-          method: 'DELETE',
-          params: { force: queryArg.force },
-        }),
-        invalidatesTags: ['rolling_stock'],
-      }),
-      patchRollingStockByIdLocked: build.mutation<
-        PatchRollingStockByIdLockedApiResponse,
-        PatchRollingStockByIdLockedApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.id}/locked/`,
-          method: 'PATCH',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['rolling_stock'],
-      }),
-      postRollingStockByIdLivery: build.mutation<
-        PostRollingStockByIdLiveryApiResponse,
-        PostRollingStockByIdLiveryApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.id}/livery/`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['rolling_stock', 'rolling_stock_livery'],
-      }),
-      postProjects: build.mutation<PostProjectsApiResponse, PostProjectsApiArg>({
-        query: (queryArg) => ({
-          url: `/projects/`,
-          method: 'POST',
-          body: queryArg.projectCreateRequest,
-        }),
-        invalidatesTags: ['projects'],
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathId}/catenaries/` }),
+        providesTags: ['infra'],
       }),
       getProjects: build.query<GetProjectsApiResponse, GetProjectsApiArg>({
         query: (queryArg) => ({
@@ -391,6 +322,21 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['projects'],
+      }),
+      postProjects: build.mutation<PostProjectsApiResponse, PostProjectsApiArg>({
+        query: (queryArg) => ({
+          url: `/projects/`,
+          method: 'POST',
+          body: queryArg.projectCreateRequest,
+        }),
+        invalidatesTags: ['projects'],
+      }),
+      deleteProjectsByProjectId: build.mutation<
+        DeleteProjectsByProjectIdApiResponse,
+        DeleteProjectsByProjectIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}/`, method: 'DELETE' }),
+        invalidatesTags: ['projects'],
       }),
       getProjectsByProjectId: build.query<
         GetProjectsByProjectIdApiResponse,
@@ -410,35 +356,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['projects'],
       }),
-      deleteProjectsByProjectId: build.mutation<
-        DeleteProjectsByProjectIdApiResponse,
-        DeleteProjectsByProjectIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}/`, method: 'DELETE' }),
-        invalidatesTags: ['projects'],
-      }),
-      getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
-        query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
-        providesTags: ['timetable'],
-      }),
-      getTimetableByIdConflicts: build.query<
-        GetTimetableByIdConflictsApiResponse,
-        GetTimetableByIdConflictsApiArg
-      >({
-        query: (queryArg) => ({ url: `/timetable/${queryArg.id}/conflicts/` }),
-        providesTags: ['timetable'],
-      }),
-      postProjectsByProjectIdStudies: build.mutation<
-        PostProjectsByProjectIdStudiesApiResponse,
-        PostProjectsByProjectIdStudiesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/`,
-          method: 'POST',
-          body: queryArg.studyUpsertRequest,
-        }),
-        invalidatesTags: ['studies'],
-      }),
       getProjectsByProjectIdStudies: build.query<
         GetProjectsByProjectIdStudiesApiResponse,
         GetProjectsByProjectIdStudiesApiArg
@@ -455,6 +372,27 @@ const injectedRtkApi = api
           },
         }),
         providesTags: ['studies'],
+      }),
+      postProjectsByProjectIdStudies: build.mutation<
+        PostProjectsByProjectIdStudiesApiResponse,
+        PostProjectsByProjectIdStudiesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/`,
+          method: 'POST',
+          body: queryArg.studyUpsertRequest,
+        }),
+        invalidatesTags: ['studies'],
+      }),
+      deleteProjectsByProjectIdStudiesAndStudyId: build.mutation<
+        DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse,
+        DeleteProjectsByProjectIdStudiesAndStudyIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/`,
+          method: 'DELETE',
+        }),
+        invalidatesTags: ['studies'],
       }),
       getProjectsByProjectIdStudiesAndStudyId: build.query<
         GetProjectsByProjectIdStudiesAndStudyIdApiResponse,
@@ -476,27 +414,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['studies'],
       }),
-      deleteProjectsByProjectIdStudiesAndStudyId: build.mutation<
-        DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse,
-        DeleteProjectsByProjectIdStudiesAndStudyIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/`,
-          method: 'DELETE',
-        }),
-        invalidatesTags: ['studies'],
-      }),
-      postProjectsByProjectIdStudiesAndStudyIdScenarios: build.mutation<
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
-        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
-          method: 'POST',
-          body: queryArg.scenarioRequest,
-        }),
-        invalidatesTags: ['scenarios'],
-      }),
       getProjectsByProjectIdStudiesAndStudyIdScenarios: build.query<
         GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
         GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
@@ -511,14 +428,16 @@ const injectedRtkApi = api
         }),
         providesTags: ['scenarios'],
       }),
-      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.query<
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
-        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
+      postProjectsByProjectIdStudiesAndStudyIdScenarios: build.mutation<
+        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse,
+        PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
+          method: 'POST',
+          body: queryArg.scenarioRequest,
         }),
-        providesTags: ['scenarios'],
+        invalidatesTags: ['scenarios'],
       }),
       deleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.mutation<
         DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
@@ -529,6 +448,15 @@ const injectedRtkApi = api
           method: 'DELETE',
         }),
         invalidatesTags: ['scenarios'],
+      }),
+      getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.query<
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
+        GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+        }),
+        providesTags: ['scenarios'],
       }),
       patchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId: build.mutation<
         PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse,
@@ -541,47 +469,76 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenarios'],
       }),
-      getPathfindingByPathIdCatenaries: build.query<
-        GetPathfindingByPathIdCatenariesApiResponse,
-        GetPathfindingByPathIdCatenariesApiArg
-      >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathId}/catenaries/` }),
-        providesTags: ['infra'],
+      postRollingStock: build.mutation<PostRollingStockApiResponse, PostRollingStockApiArg>({
+        query: (queryArg) => ({
+          url: `/rolling_stock/`,
+          method: 'POST',
+          body: queryArg.rollingStockUpsertPayload,
+          params: { locked: queryArg.locked },
+        }),
+        invalidatesTags: ['rolling_stock'],
       }),
-      getTrainScheduleById: build.query<
-        GetTrainScheduleByIdApiResponse,
-        GetTrainScheduleByIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/` }),
-        providesTags: ['train_schedule'],
-      }),
-      deleteTrainScheduleById: build.mutation<
-        DeleteTrainScheduleByIdApiResponse,
-        DeleteTrainScheduleByIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/`, method: 'DELETE' }),
-        invalidatesTags: ['train_schedule'],
-      }),
-      patchTrainScheduleById: build.mutation<
-        PatchTrainScheduleByIdApiResponse,
-        PatchTrainScheduleByIdApiArg
+      deleteRollingStockById: build.mutation<
+        DeleteRollingStockByIdApiResponse,
+        DeleteRollingStockByIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/train_schedule/${queryArg.id}/`,
+          url: `/rolling_stock/${queryArg.id}/`,
+          method: 'DELETE',
+          params: { force: queryArg.force },
+        }),
+        invalidatesTags: ['rolling_stock'],
+      }),
+      getRollingStockById: build.query<GetRollingStockByIdApiResponse, GetRollingStockByIdApiArg>({
+        query: (queryArg) => ({ url: `/rolling_stock/${queryArg.id}/` }),
+        providesTags: ['rolling_stock'],
+      }),
+      patchRollingStockById: build.mutation<
+        PatchRollingStockByIdApiResponse,
+        PatchRollingStockByIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/rolling_stock/${queryArg.id}/`,
+          method: 'PATCH',
+          body: queryArg.rollingStockUpsertPayload,
+        }),
+        invalidatesTags: ['rolling_stock'],
+      }),
+      postRollingStockByIdLivery: build.mutation<
+        PostRollingStockByIdLiveryApiResponse,
+        PostRollingStockByIdLiveryApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/rolling_stock/${queryArg.id}/livery/`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['rolling_stock', 'rolling_stock_livery'],
+      }),
+      patchRollingStockByIdLocked: build.mutation<
+        PatchRollingStockByIdLockedApiResponse,
+        PatchRollingStockByIdLockedApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/rolling_stock/${queryArg.id}/locked/`,
           method: 'PATCH',
           body: queryArg.body,
         }),
-        invalidatesTags: ['train_schedule'],
+        invalidatesTags: ['rolling_stock'],
       }),
-      getTrainScheduleByIdResult: build.query<
-        GetTrainScheduleByIdResultApiResponse,
-        GetTrainScheduleByIdResultApiArg
+      postSearch: build.mutation<PostSearchApiResponse, PostSearchApiArg>({
+        query: (queryArg) => ({ url: `/search/`, method: 'POST', body: queryArg.body }),
+      }),
+      getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
+        query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
+        providesTags: ['timetable'],
+      }),
+      getTimetableByIdConflicts: build.query<
+        GetTimetableByIdConflictsApiResponse,
+        GetTimetableByIdConflictsApiArg
       >({
-        query: (queryArg) => ({
-          url: `/train_schedule/${queryArg.id}/result/`,
-          params: { path_id: queryArg.pathId },
-        }),
-        providesTags: ['train_schedule'],
+        query: (queryArg) => ({ url: `/timetable/${queryArg.id}/conflicts/` }),
+        providesTags: ['timetable'],
       }),
       getTrainScheduleResults: build.query<
         GetTrainScheduleResultsApiResponse,
@@ -604,253 +561,61 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['train_schedule'],
       }),
+      deleteTrainScheduleById: build.mutation<
+        DeleteTrainScheduleByIdApiResponse,
+        DeleteTrainScheduleByIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/`, method: 'DELETE' }),
+        invalidatesTags: ['train_schedule'],
+      }),
+      getTrainScheduleById: build.query<
+        GetTrainScheduleByIdApiResponse,
+        GetTrainScheduleByIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/` }),
+        providesTags: ['train_schedule'],
+      }),
+      patchTrainScheduleById: build.mutation<
+        PatchTrainScheduleByIdApiResponse,
+        PatchTrainScheduleByIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedule/${queryArg.id}/`,
+          method: 'PATCH',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['train_schedule'],
+      }),
+      getTrainScheduleByIdResult: build.query<
+        GetTrainScheduleByIdResultApiResponse,
+        GetTrainScheduleByIdResultApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/train_schedule/${queryArg.id}/result/`,
+          params: { path_id: queryArg.pathId },
+        }),
+        providesTags: ['train_schedule'],
+      }),
+      getVersion: build.query<GetVersionApiResponse, GetVersionApiArg>({
+        query: () => ({ url: `/version/` }),
+      }),
     }),
     overrideExisting: false,
   });
 export { injectedRtkApi as osrdEditoastApi };
-export type GetHealthApiResponse = unknown;
-export type GetHealthApiArg = void;
-export type GetVersionApiResponse = /** status 200 Return the service version */ {
-  git_describe: string | null;
+export type PostDocumentsApiResponse = /** status 201 The key of the added document */ {
+  document_key?: number;
 };
-export type GetVersionApiArg = void;
-export type PostSearchApiResponse =
-  /** status 200 Search results, the structure of the returned objects depend on their type */ (
-    | SearchTrackResult
-    | SearchOperationalPointResult
-    | SearchSignalResult
-    | SearchStudyResult
-    | SearchProjectResult
-    | SearchScenarioResult
-  )[];
-export type PostSearchApiArg = {
-  /** number of results */
-  pageSize?: number;
-  /** Search query */
-  body: {
-    object?: string;
-    query?: SearchQuery;
-    page?: number;
-    page_size?: number;
-  };
+export type PostDocumentsApiArg = void;
+export type DeleteDocumentsByKeyApiResponse = unknown;
+export type DeleteDocumentsByKeyApiArg = {
+  /** A key identifying the document */
+  key: number;
 };
-export type GetLayersLayerByLayerSlugMvtAndViewSlugApiResponse =
-  /** status 200 Successful Response */ ViewMetadata;
-export type GetLayersLayerByLayerSlugMvtAndViewSlugApiArg = {
-  layerSlug: string;
-  viewSlug: string;
-  infra: number;
-};
-export type GetLayersTileByLayerSlugAndViewSlugZXYApiResponse = unknown;
-export type GetLayersTileByLayerSlugAndViewSlugZXYApiArg = {
-  layerSlug: string;
-  viewSlug: string;
-  z: number;
-  x: number;
-  y: number;
-  infra: number;
-};
-export type GetInfraApiResponse = /** status 200 The infra list */ {
-  count: number;
-  next: any;
-  previous: any;
-  results?: Infra[];
-};
-export type GetInfraApiArg = void;
-export type PostInfraApiResponse = /** status 201 The created infra */ Infra;
-export type PostInfraApiArg = {
-  /** Name of the infra to create */
-  body: {
-    name?: string;
-  };
-};
-export type GetInfraByIdApiResponse = /** status 200 Information about the retrieved infra */ Infra;
-export type GetInfraByIdApiArg = {
-  /** infra id */
-  id: number;
-};
-export type DeleteInfraByIdApiResponse = unknown;
-export type DeleteInfraByIdApiArg = {
-  /** infra id */
-  id: number;
-};
-export type PostInfraByIdApiResponse =
-  /** status 200 An array containing infos about the operations processed */ OperationResult[];
-export type PostInfraByIdApiArg = {
-  /** infra id */
-  id: number;
-  /** Operations to do on the infra */
-  body: Operation[];
-};
-export type PutInfraByIdApiResponse = /** status 200 The updated infra */ Infra;
-export type PutInfraByIdApiArg = {
-  /** infra id */
-  id: number;
-  /** the name we want to give to the infra */
-  body: {
-    name?: string;
-  };
-};
-export type PostInfraByIdLoadApiResponse = unknown;
-export type PostInfraByIdLoadApiArg = {
-  /** infra id */
-  id: number;
-};
-export type GetInfraByIdRailjsonApiResponse =
-  /** status 200 The infra in railjson format */ RailjsonFile;
-export type GetInfraByIdRailjsonApiArg = {
-  /** Infra ID */
-  id: number;
-};
-export type PostInfraRailjsonApiResponse = /** status 201 The imported infra id */ {
-  id?: string;
-};
-export type PostInfraRailjsonApiArg = {
-  /** Infra name */
-  name: string;
-  generateData?: boolean;
-  /** Railjson infra */
-  railjsonFile: RailjsonFile;
-};
-export type GetInfraByIdErrorsApiResponse = /** status 200 A paginated list of errors */ {
-  count?: number;
-  next?: number | null;
-  previous?: number | null;
-  results?: InfraError[];
-};
-export type GetInfraByIdErrorsApiArg = {
-  /** infra id */
-  id: number;
-  /** The page number */
-  page?: number;
-  /** The number of item per page */
-  pageSize?: number;
-  /** The type of error to filter on */
-  errorType?: InfraErrorType;
-  /** errors and warnings that only part of a given object */
-  objectId?: string;
-  /** Whether the response should include errors or warnings */
-  level?: 'errors' | 'warnings' | 'all';
-};
-export type GetInfraByIdSwitchTypesApiResponse = /** status 200 A list of switch types */ object[];
-export type GetInfraByIdSwitchTypesApiArg = {
-  /** infra id */
-  id: number;
-};
-export type PostInfraRefreshApiResponse =
-  /** status 200 A list thats contains the ID of the infras that were refreshed* */ number[];
-export type PostInfraRefreshApiArg = {
-  /** A list of infra ID */
-  infras?: number[];
-  /** Force the refresh of the layers */
-  force?: boolean;
-};
-export type GetInfraByIdLinesAndLineCodeBboxApiResponse =
-  /** status 200 The BBox of the line */ Zone;
-export type GetInfraByIdLinesAndLineCodeBboxApiArg = {
-  /** infra id */
-  id: number;
-  /** a line code */
-  lineCode: number;
-};
-export type PostInfraByIdLockApiResponse = unknown;
-export type PostInfraByIdLockApiArg = {
-  /** infra id */
-  id: number;
-};
-export type PostInfraByIdUnlockApiResponse = unknown;
-export type PostInfraByIdUnlockApiArg = {
-  /** infra id */
-  id: number;
-};
-export type GetInfraByIdSpeedLimitTagsApiResponse = /** status 200 Tags list */ string[];
-export type GetInfraByIdSpeedLimitTagsApiArg = {
-  /** Infra id */
-  id: number;
-};
-export type GetInfraByIdVoltagesApiResponse = /** status 200 Voltages list */ string[];
-export type GetInfraByIdVoltagesApiArg = {
-  /** Infra ID */
-  id: number;
-  /** include rolling stocks modes or not */
-  includeRollingStockModes?: boolean;
-};
-export type GetInfraByIdAttachedAndTrackIdApiResponse =
-  /** status 200 All objects attached to the given track (arranged by types) */ {
-    [key: string]: string[];
-  };
-export type GetInfraByIdAttachedAndTrackIdApiArg = {
-  /** Infra ID */
-  id: number;
-  /** Track ID */
-  trackId: string;
-};
-export type GetInfraByIdRoutesAndWaypointTypeWaypointIdApiResponse =
-  /** status 200 All routes that starting and ending by the given waypoint */ {
-    starting?: string[];
-    ending?: string[];
-  };
-export type GetInfraByIdRoutesAndWaypointTypeWaypointIdApiArg = {
-  /** Infra ID */
-  id: number;
-  /** Type of the waypoint */
-  waypointType: 'Detector' | 'BufferStop';
-  /** The waypoint id */
-  waypointId: string;
-};
-export type GetInfraByIdRoutesTrackRangesApiResponse =
-  /** status 200 Foreach route, the track ranges through which it passes or an error */ (
-    | RouteTrackRangesNotFoundError
-    | RouteTrackRangesCantComputePathError
-    | RouteTrackRangesComputed
-  )[];
-export type GetInfraByIdRoutesTrackRangesApiArg = {
-  /** Infra ID */
-  id: number;
-  routes: string;
-};
-export type PostInfraByIdPathfindingApiResponse =
-  /** status 200 Paths, containing track ranges, detectors and switches with their directions. If no path is found, an empty list is returned. */ {
-    track_ranges?: DirectionalTrackRange[];
-    detectors?: string[];
-    switches_directions?: {
-      [key: string]: string;
-    };
-  }[];
-export type PostInfraByIdPathfindingApiArg = {
-  /** Infra ID */
-  id: number;
-  /** Maximum number of paths to return */
-  number?: number;
-  /** Starting and ending track location */
-  body: {
-    starting?: TrackLocation & {
-      direction?: Direction;
-    };
-    ending?: TrackLocation;
-  };
-};
-export type PostInfraByIdObjectsAndObjectTypeApiResponse = /** status 200 No content */ {
-  railjson: Railjson;
-  geographic: Geometry;
-  schematic: Geometry;
-}[];
-export type PostInfraByIdObjectsAndObjectTypeApiArg = {
-  /** Infra id */
-  id: number;
-  /** The type of the object */
-  objectType: ObjectType;
-  /** List of object id's */
-  body: string[];
-};
-export type PostInfraByIdCloneApiResponse = /** status 201 The duplicated infra id */ {
-  id?: number;
-};
-export type PostInfraByIdCloneApiArg = {
-  /** Infra id */
-  id: number;
-  /** New infra name */
-  name: string;
+export type GetDocumentsByKeyApiResponse = unknown;
+export type GetDocumentsByKeyApiArg = {
+  /** A key identifying the document */
+  key: number;
 };
 export type GetElectricalProfileSetApiResponse =
   /** status 200 The list of ids and names of electrical profile sets available */ {
@@ -877,20 +642,226 @@ export type GetElectricalProfileSetByIdLevelOrderApiArg = {
   /** Electrical profile set ID */
   id: number;
 };
-export type GetDocumentsByKeyApiResponse = unknown;
-export type GetDocumentsByKeyApiArg = {
-  /** A key identifying the document */
-  key: number;
+export type GetHealthApiResponse = unknown;
+export type GetHealthApiArg = void;
+export type GetInfraApiResponse = /** status 200 The infra list */ {
+  count: number;
+  next: any;
+  previous: any;
+  results?: Infra[];
 };
-export type DeleteDocumentsByKeyApiResponse = unknown;
-export type DeleteDocumentsByKeyApiArg = {
-  /** A key identifying the document */
-  key: number;
+export type GetInfraApiArg = void;
+export type PostInfraApiResponse = /** status 201 The created infra */ Infra;
+export type PostInfraApiArg = {
+  /** Name of the infra to create */
+  body: {
+    name?: string;
+  };
 };
-export type PostDocumentsApiResponse = /** status 201 The key of the added document */ {
-  document_key?: number;
+export type PostInfraRailjsonApiResponse = /** status 201 The imported infra id */ {
+  id?: string;
 };
-export type PostDocumentsApiArg = void;
+export type PostInfraRailjsonApiArg = {
+  /** Infra name */
+  name: string;
+  generateData?: boolean;
+  /** Railjson infra */
+  railjsonFile: RailjsonFile;
+};
+export type PostInfraRefreshApiResponse =
+  /** status 200 A list thats contains the ID of the infras that were refreshed* */ number[];
+export type PostInfraRefreshApiArg = {
+  /** A list of infra ID */
+  infras?: number[];
+  /** Force the refresh of the layers */
+  force?: boolean;
+};
+export type DeleteInfraByIdApiResponse = unknown;
+export type DeleteInfraByIdApiArg = {
+  /** infra id */
+  id: number;
+};
+export type GetInfraByIdApiResponse = /** status 200 Information about the retrieved infra */ Infra;
+export type GetInfraByIdApiArg = {
+  /** infra id */
+  id: number;
+};
+export type PostInfraByIdApiResponse =
+  /** status 200 An array containing infos about the operations processed */ OperationResult[];
+export type PostInfraByIdApiArg = {
+  /** infra id */
+  id: number;
+  /** Operations to do on the infra */
+  body: Operation[];
+};
+export type PutInfraByIdApiResponse = /** status 200 The updated infra */ Infra;
+export type PutInfraByIdApiArg = {
+  /** infra id */
+  id: number;
+  /** the name we want to give to the infra */
+  body: {
+    name?: string;
+  };
+};
+export type GetInfraByIdAttachedAndTrackIdApiResponse =
+  /** status 200 All objects attached to the given track (arranged by types) */ {
+    [key: string]: string[];
+  };
+export type GetInfraByIdAttachedAndTrackIdApiArg = {
+  /** Infra ID */
+  id: number;
+  /** Track ID */
+  trackId: string;
+};
+export type PostInfraByIdCloneApiResponse = /** status 201 The duplicated infra id */ {
+  id?: number;
+};
+export type PostInfraByIdCloneApiArg = {
+  /** Infra id */
+  id: number;
+  /** New infra name */
+  name: string;
+};
+export type GetInfraByIdErrorsApiResponse = /** status 200 A paginated list of errors */ {
+  count?: number;
+  next?: number | null;
+  previous?: number | null;
+  results?: InfraError[];
+};
+export type GetInfraByIdErrorsApiArg = {
+  /** infra id */
+  id: number;
+  /** The page number */
+  page?: number;
+  /** The number of item per page */
+  pageSize?: number;
+  /** The type of error to filter on */
+  errorType?: InfraErrorType;
+  /** errors and warnings that only part of a given object */
+  objectId?: string;
+  /** Whether the response should include errors or warnings */
+  level?: 'errors' | 'warnings' | 'all';
+};
+export type GetInfraByIdLinesAndLineCodeBboxApiResponse =
+  /** status 200 The BBox of the line */ Zone;
+export type GetInfraByIdLinesAndLineCodeBboxApiArg = {
+  /** infra id */
+  id: number;
+  /** a line code */
+  lineCode: number;
+};
+export type PostInfraByIdLoadApiResponse = unknown;
+export type PostInfraByIdLoadApiArg = {
+  /** infra id */
+  id: number;
+};
+export type PostInfraByIdLockApiResponse = unknown;
+export type PostInfraByIdLockApiArg = {
+  /** infra id */
+  id: number;
+};
+export type PostInfraByIdObjectsAndObjectTypeApiResponse = /** status 200 No content */ {
+  geographic: Geometry;
+  railjson: Railjson;
+  schematic: Geometry;
+}[];
+export type PostInfraByIdObjectsAndObjectTypeApiArg = {
+  /** Infra id */
+  id: number;
+  /** The type of the object */
+  objectType: ObjectType;
+  /** List of object id's */
+  body: string[];
+};
+export type PostInfraByIdPathfindingApiResponse =
+  /** status 200 Paths, containing track ranges, detectors and switches with their directions. If no path is found, an empty list is returned. */ {
+    detectors?: string[];
+    switches_directions?: {
+      [key: string]: string;
+    };
+    track_ranges?: DirectionalTrackRange[];
+  }[];
+export type PostInfraByIdPathfindingApiArg = {
+  /** Infra ID */
+  id: number;
+  /** Maximum number of paths to return */
+  number?: number;
+  /** Starting and ending track location */
+  body: {
+    ending?: TrackLocation;
+    starting?: TrackLocation & {
+      direction?: Direction;
+    };
+  };
+};
+export type GetInfraByIdRailjsonApiResponse =
+  /** status 200 The infra in railjson format */ RailjsonFile;
+export type GetInfraByIdRailjsonApiArg = {
+  /** Infra ID */
+  id: number;
+};
+export type GetInfraByIdRoutesTrackRangesApiResponse =
+  /** status 200 Foreach route, the track ranges through which it passes or an error */ (
+    | RouteTrackRangesNotFoundError
+    | RouteTrackRangesCantComputePathError
+    | RouteTrackRangesComputed
+  )[];
+export type GetInfraByIdRoutesTrackRangesApiArg = {
+  /** Infra ID */
+  id: number;
+  routes: string;
+};
+export type GetInfraByIdRoutesAndWaypointTypeWaypointIdApiResponse =
+  /** status 200 All routes that starting and ending by the given waypoint */ {
+    ending?: string[];
+    starting?: string[];
+  };
+export type GetInfraByIdRoutesAndWaypointTypeWaypointIdApiArg = {
+  /** Infra ID */
+  id: number;
+  /** Type of the waypoint */
+  waypointType: 'Detector' | 'BufferStop';
+  /** The waypoint id */
+  waypointId: string;
+};
+export type GetInfraByIdSpeedLimitTagsApiResponse = /** status 200 Tags list */ string[];
+export type GetInfraByIdSpeedLimitTagsApiArg = {
+  /** Infra id */
+  id: number;
+};
+export type GetInfraByIdSwitchTypesApiResponse = /** status 200 A list of switch types */ object[];
+export type GetInfraByIdSwitchTypesApiArg = {
+  /** infra id */
+  id: number;
+};
+export type PostInfraByIdUnlockApiResponse = unknown;
+export type PostInfraByIdUnlockApiArg = {
+  /** infra id */
+  id: number;
+};
+export type GetInfraByIdVoltagesApiResponse = /** status 200 Voltages list */ string[];
+export type GetInfraByIdVoltagesApiArg = {
+  /** Infra ID */
+  id: number;
+  /** include rolling stocks modes or not */
+  includeRollingStockModes?: boolean;
+};
+export type GetLayersLayerByLayerSlugMvtAndViewSlugApiResponse =
+  /** status 200 Successful Response */ ViewMetadata;
+export type GetLayersLayerByLayerSlugMvtAndViewSlugApiArg = {
+  layerSlug: string;
+  viewSlug: string;
+  infra: number;
+};
+export type GetLayersTileByLayerSlugAndViewSlugZXYApiResponse = unknown;
+export type GetLayersTileByLayerSlugAndViewSlugZXYApiArg = {
+  layerSlug: string;
+  viewSlug: string;
+  z: number;
+  x: number;
+  y: number;
+  infra: number;
+};
 export type GetLightRollingStockApiResponse = /** status 200 The rolling stock list */ {
   count?: number;
   next?: any;
@@ -914,6 +885,11 @@ export type PostPathfindingApiArg = {
   /** Path information */
   pathQuery: PathQuery;
 };
+export type DeletePathfindingByIdApiResponse = unknown;
+export type DeletePathfindingByIdApiArg = {
+  /** Path ID */
+  id: number;
+};
 export type GetPathfindingByIdApiResponse = /** status 200 The retrieved path */ Path;
 export type GetPathfindingByIdApiArg = {
   /** Path ID */
@@ -926,59 +902,18 @@ export type PutPathfindingByIdApiArg = {
   /** Updated Path */
   pathQuery: PathQuery;
 };
-export type DeletePathfindingByIdApiResponse = unknown;
-export type DeletePathfindingByIdApiArg = {
-  /** Path ID */
-  id: number;
-};
-export type PostRollingStockApiResponse = /** status 200 The created rolling stock */ RollingStock;
-export type PostRollingStockApiArg = {
-  /** whether or not the rolling_stock can be edited/deleted. */
-  locked?: boolean;
-  rollingStockUpsertPayload: RollingStockUpsertPayload;
-};
-export type GetRollingStockByIdApiResponse =
-  /** status 200 The rolling stock information */ RollingStock;
-export type GetRollingStockByIdApiArg = {
-  /** Rolling Stock ID */
-  id: number;
-};
-export type PatchRollingStockByIdApiResponse =
-  /** status 200 The updated rolling stock */ RollingStock;
-export type PatchRollingStockByIdApiArg = {
-  /** Rolling Stock ID */
-  id: number;
-  rollingStockUpsertPayload: RollingStockUpsertPayload;
-};
-export type DeleteRollingStockByIdApiResponse = /** status 204 No content */ undefined;
-export type DeleteRollingStockByIdApiArg = {
-  /** rolling_stock id */
-  id: number;
-  /** force the deletion even if it’s used */
-  force?: boolean;
-};
-export type PatchRollingStockByIdLockedApiResponse = unknown;
-export type PatchRollingStockByIdLockedApiArg = {
-  /** Rolling_stock id */
-  id: number;
-  /** New locked value */
-  body: {
-    locked?: boolean;
+export type GetPathfindingByPathIdCatenariesApiResponse =
+  /** status 200 A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list. */ {
+    catenary_ranges?: CatenaryRange[];
+    warnings?: {
+      catenary_id?: string;
+      overlapping_ranges?: TrackRange[];
+      type?: 'CatenaryOverlap';
+    }[];
   };
-};
-export type PostRollingStockByIdLiveryApiResponse =
-  /** status 200 The rolling stock livery */ RollingStockLivery;
-export type PostRollingStockByIdLiveryApiArg = {
-  /** Rolling Stock ID */
-  id: number;
-  body: {
-    name?: string;
-    images?: Blob[];
-  };
-};
-export type PostProjectsApiResponse = /** status 201 The created project */ ProjectResult;
-export type PostProjectsApiArg = {
-  projectCreateRequest: ProjectCreateRequest;
+export type GetPathfindingByPathIdCatenariesApiArg = {
+  /** The path's id */
+  pathId: number;
 };
 export type GetProjectsApiResponse = /** status 200 the project list */ {
   count?: number;
@@ -1005,6 +940,15 @@ export type GetProjectsApiArg = {
   /** Number of elements by page */
   pageSize?: number;
 };
+export type PostProjectsApiResponse = /** status 201 The created project */ ProjectResult;
+export type PostProjectsApiArg = {
+  projectCreateRequest: ProjectCreateRequest;
+};
+export type DeleteProjectsByProjectIdApiResponse = unknown;
+export type DeleteProjectsByProjectIdApiArg = {
+  /** project id you want to delete */
+  projectId: number;
+};
 export type GetProjectsByProjectIdApiResponse = /** status 200 The project info */ ProjectResult;
 export type GetProjectsByProjectIdApiArg = {
   /** project id you want to retrieve */
@@ -1017,35 +961,6 @@ export type PatchProjectsByProjectIdApiArg = {
   projectId: number;
   /** The fields you want to update */
   projectPatchRequest: ProjectPatchRequest;
-};
-export type DeleteProjectsByProjectIdApiResponse = unknown;
-export type DeleteProjectsByProjectIdApiArg = {
-  /** project id you want to delete */
-  projectId: number;
-};
-export type GetTimetableByIdApiResponse =
-  /** status 200 The timetable content */ TimetableWithSchedulesDetails;
-export type GetTimetableByIdApiArg = {
-  /** Timetable ID */
-  id: number;
-};
-export type GetTimetableByIdConflictsApiResponse =
-  /** status 200 The timetable conflicts content */ {
-    train_ids: number[];
-    train_names: string[];
-    start_time: string;
-    end_time: string;
-    conflict_type: string;
-  }[];
-export type GetTimetableByIdConflictsApiArg = {
-  /** Timetable ID */
-  id: number;
-};
-export type PostProjectsByProjectIdStudiesApiResponse =
-  /** status 201 The created operational study */ StudyResult;
-export type PostProjectsByProjectIdStudiesApiArg = {
-  projectId: number;
-  studyUpsertRequest: StudyUpsertRequest;
 };
 export type GetProjectsByProjectIdStudiesApiResponse = /** status 200 the studies list */ {
   count?: number;
@@ -1073,6 +988,19 @@ export type GetProjectsByProjectIdStudiesApiArg = {
   /** Number of elements by page */
   pageSize?: number;
 };
+export type PostProjectsByProjectIdStudiesApiResponse =
+  /** status 201 The created operational study */ StudyResult;
+export type PostProjectsByProjectIdStudiesApiArg = {
+  projectId: number;
+  studyUpsertRequest: StudyUpsertRequest;
+};
+export type DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse = unknown;
+export type DeleteProjectsByProjectIdStudiesAndStudyIdApiArg = {
+  /** project id refered to the operational study */
+  projectId: number;
+  /** study id you want to delete */
+  studyId: number;
+};
 export type GetProjectsByProjectIdStudiesAndStudyIdApiResponse =
   /** status 200 The operational study info */ StudyResult;
 export type GetProjectsByProjectIdStudiesAndStudyIdApiArg = {
@@ -1090,20 +1018,6 @@ export type PatchProjectsByProjectIdStudiesAndStudyIdApiArg = {
   studyId: number;
   /** The fields you want to update */
   studyUpsertRequest: StudyUpsertRequest;
-};
-export type DeleteProjectsByProjectIdStudiesAndStudyIdApiResponse = unknown;
-export type DeleteProjectsByProjectIdStudiesAndStudyIdApiArg = {
-  /** project id refered to the operational study */
-  projectId: number;
-  /** study id you want to delete */
-  studyId: number;
-};
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
-  /** status 201 The created scenario */ ScenarioResult;
-export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
-  projectId: number;
-  studyId: number;
-  scenarioRequest: ScenarioRequest;
 };
 export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
   /** status 200 list of scenarios */ {
@@ -1127,14 +1041,12 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
   /** Number of elements by page */
   pageSize?: number;
 };
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 200 The operational study info */ ScenarioResult;
-export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
-  /** project id refered to the scenario */
+export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
+  /** status 201 The created scenario */ ScenarioResult;
+export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
   projectId: number;
   studyId: number;
-  /** scenario id you want to retrieve */
-  scenarioId: number;
+  scenarioRequest: ScenarioRequest;
 };
 export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse = unknown;
 export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
@@ -1143,6 +1055,15 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg 
   /** study id refered to the scenario */
   studyId: number;
   /** scenario id you want to delete */
+  scenarioId: number;
+};
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
+  /** status 200 The operational study info */ ScenarioResult;
+export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
+  /** project id refered to the scenario */
+  projectId: number;
+  studyId: number;
+  /** scenario id you want to retrieve */
   scenarioId: number;
 };
 export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
@@ -1157,27 +1078,109 @@ export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg =
   /** The fields you want to update */
   scenarioPatchRequest: ScenarioPatchRequest;
 };
-export type GetPathfindingByPathIdCatenariesApiResponse =
-  /** status 200 A list of ranges associated to catenary modes. When a catenary overlapping another is found, a warning is added to the list. */ {
-    catenary_ranges?: CatenaryRange[];
-    warnings?: {
-      type?: 'CatenaryOverlap';
-      catenary_id?: string;
-      overlapping_ranges?: TrackRange[];
-    }[];
+export type PostRollingStockApiResponse = /** status 200 The created rolling stock */ RollingStock;
+export type PostRollingStockApiArg = {
+  /** whether or not the rolling_stock can be edited/deleted. */
+  locked?: boolean;
+  rollingStockUpsertPayload: RollingStockUpsertPayload;
+};
+export type DeleteRollingStockByIdApiResponse = /** status 204 No content */ undefined;
+export type DeleteRollingStockByIdApiArg = {
+  /** rolling_stock id */
+  id: number;
+  /** force the deletion even if it’s used */
+  force?: boolean;
+};
+export type GetRollingStockByIdApiResponse =
+  /** status 200 The rolling stock information */ RollingStock;
+export type GetRollingStockByIdApiArg = {
+  /** Rolling Stock ID */
+  id: number;
+};
+export type PatchRollingStockByIdApiResponse =
+  /** status 200 The updated rolling stock */ RollingStock;
+export type PatchRollingStockByIdApiArg = {
+  /** Rolling Stock ID */
+  id: number;
+  rollingStockUpsertPayload: RollingStockUpsertPayload;
+};
+export type PostRollingStockByIdLiveryApiResponse =
+  /** status 200 The rolling stock livery */ RollingStockLivery;
+export type PostRollingStockByIdLiveryApiArg = {
+  /** Rolling Stock ID */
+  id: number;
+  body: {
+    images?: Blob[];
+    name?: string;
   };
-export type GetPathfindingByPathIdCatenariesApiArg = {
-  /** The path's id */
+};
+export type PatchRollingStockByIdLockedApiResponse = unknown;
+export type PatchRollingStockByIdLockedApiArg = {
+  /** Rolling_stock id */
+  id: number;
+  /** New locked value */
+  body: {
+    locked?: boolean;
+  };
+};
+export type PostSearchApiResponse =
+  /** status 200 Search results, the structure of the returned objects depend on their type */ (
+    | SearchTrackResult
+    | SearchOperationalPointResult
+    | SearchSignalResult
+    | SearchStudyResult
+    | SearchProjectResult
+    | SearchScenarioResult
+  )[];
+export type PostSearchApiArg = {
+  /** Search query */
+  body: {
+    object?: string;
+    page?: number;
+    page_size?: number;
+    query?: SearchQuery;
+  };
+};
+export type GetTimetableByIdApiResponse =
+  /** status 200 The timetable content */ TimetableWithSchedulesDetails;
+export type GetTimetableByIdApiArg = {
+  /** Timetable ID */
+  id: number;
+};
+export type GetTimetableByIdConflictsApiResponse =
+  /** status 200 The timetable conflicts content */ {
+    conflict_type: string;
+    end_time: string;
+    start_time: string;
+    train_ids: number[];
+    train_names: string[];
+  }[];
+export type GetTimetableByIdConflictsApiArg = {
+  /** Timetable ID */
+  id: number;
+};
+export type GetTrainScheduleResultsApiResponse =
+  /** status 200 The train schedules results */ SimulationReport[];
+export type GetTrainScheduleResultsApiArg = {
+  /** Path id used to project the train path */
   pathId: number;
+  /** List of train schedule ids to return the results of */
+  trainIds: string;
+};
+export type PostTrainScheduleStandaloneSimulationApiResponse =
+  /** status 201 The ids of the train_schedules created */ number[];
+export type PostTrainScheduleStandaloneSimulationApiArg = {
+  /** The list of train schedules to simulate */
+  body: TrainSchedule[];
+};
+export type DeleteTrainScheduleByIdApiResponse = unknown;
+export type DeleteTrainScheduleByIdApiArg = {
+  /** Train schedule ID */
+  id: number;
 };
 export type GetTrainScheduleByIdApiResponse =
   /** status 200 The train schedule info */ TrainSchedule;
 export type GetTrainScheduleByIdApiArg = {
-  /** Train schedule ID */
-  id: number;
-};
-export type DeleteTrainScheduleByIdApiResponse = unknown;
-export type DeleteTrainScheduleByIdApiArg = {
   /** Train schedule ID */
   id: number;
 };
@@ -1196,110 +1199,28 @@ export type GetTrainScheduleByIdResultApiArg = {
   /** Path id used to project the train path */
   pathId: number;
 };
-export type GetTrainScheduleResultsApiResponse =
-  /** status 200 The train schedules results */ SimulationReport[];
-export type GetTrainScheduleResultsApiArg = {
-  /** Path id used to project the train path */
-  pathId: number;
-  /** List of train schedule ids to return the results of */
-  trainIds: string;
+export type GetVersionApiResponse = /** status 200 Return the service version */ {
+  git_describe: string | null;
 };
-export type PostTrainScheduleStandaloneSimulationApiResponse =
-  /** status 201 The ids of the train_schedules created */ number[];
-export type PostTrainScheduleStandaloneSimulationApiArg = {
-  /** The list of train schedules to simulate */
-  body: TrainSchedule[];
+export type GetVersionApiArg = void;
+export type TrackRange = {
+  begin?: number;
+  end?: number;
+  track?: string;
 };
-export type SearchTrackResult = {
-  infra_id: number;
-  line_code: number;
-  line_name: string;
-};
-export type Point3D = number[];
-export type MultiPoint = {
-  type: 'MultiPoint';
-  coordinates: Point3D[];
-};
-export type TrackLocation = {
-  track: string;
-  offset: number;
-};
-export type SearchOperationalPointResult = {
-  obj_id: string;
-  infra_id?: string;
-  name: string;
-  uic?: number;
-  trigram: string;
-  ch: string;
-  geographic: MultiPoint;
-  schematic: MultiPoint;
-  track_sections: TrackLocation[];
-};
-export type Point = {
-  type: 'Point';
-  coordinates: Point3D;
-};
-export type SearchSignalResult = {
-  label: string;
-  infra_id?: number;
-  aspects?: string[];
-  systems?: string[];
-  type?: string;
-  line_code: number;
-  line_name: string;
-  geographic: Point;
-  schematic: Point;
-};
-export type SearchStudyResult = {
-  id: number;
-  project_id: number;
-  name: string;
-  scenarios_count?: number;
-  description?: string;
-  last_modification: string;
-  tags?: string[];
-};
-export type SearchProjectResult = {
-  id: number;
-  image?: number;
-  name: string;
-  studies_count?: number;
-  description: string;
-  last_modification: string;
-  tags?: any;
-};
-export type SearchScenarioResult = {
-  id: number;
-  study_id: number;
-  electrical_profile_set_id?: number;
-  name: string;
-  trains_count?: number;
-  description?: string;
-  last_modification: string;
-  infra_id: number;
-  infra_name?: string;
-  tags?: string[];
-};
-export type SearchQuery = (boolean | number | number | string | SearchQuery)[] | null;
-export type ViewMetadata = {
-  type?: string;
-  name?: string;
-  promotedId?: object;
-  scheme?: string;
-  tiles?: string[];
-  attribution?: string;
-  minzoom?: number;
-  maxzoom?: number;
+export type ElectricalProfile = {
+  power_class?: string;
+  track_ranges?: TrackRange[];
+  value?: string;
 };
 export type Infra = {
-  id: number;
-  name: string;
-  version: string;
-  railjson_version: string;
-  generated_version: string | null;
   created: string;
-  modified: string;
+  generated_version: string | null;
+  id: number;
   locked: boolean;
+  modified: string;
+  name: string;
+  railjson_version: string;
   state:
     | 'NOT_LOADED'
     | 'INITIALIZING'
@@ -1312,6 +1233,21 @@ export type Infra = {
     | 'CACHED'
     | 'TRANSIENT_ERROR'
     | 'ERROR';
+  version: string;
+};
+export type RailjsonFile = {
+  buffer_stops?: any;
+  catenaries?: any;
+  detectors?: any;
+  operational_points?: any;
+  routes?: any;
+  signals?: any;
+  speed_sections?: any;
+  switch_types?: any;
+  switches?: any;
+  track_section_links?: any;
+  track_sections?: any;
+  version?: string;
 };
 export type ObjectType =
   | 'TrackSection'
@@ -1326,68 +1262,63 @@ export type ObjectType =
   | 'OperationalPoint'
   | 'Catenary';
 export type DeleteOperation = {
-  operation_type: 'DELETE';
-  obj_type: ObjectType;
   obj_id: string;
+  obj_type: ObjectType;
+  operation_type: 'DELETE';
 };
 export type Railjson = {
   id: string;
   [key: string]: any;
 };
 export type OperationObject = {
-  operation_type: 'CREATE' | 'UPDATE';
   obj_type: ObjectType;
+  operation_type: 'CREATE' | 'UPDATE';
   railjson: Railjson;
 };
 export type OperationResult = DeleteOperation | OperationObject;
 export type RailjsonObject = {
-  operation_type: 'CREATE';
   obj_type: ObjectType;
+  operation_type: 'CREATE';
   railjson: Railjson;
 };
 export type Patch = {
+  from?: string;
   op: 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
   path: string;
   value?: object;
-  from?: string;
 };
 export type Patches = Patch[];
 export type UpdateOperation = {
-  operation_type: 'UPDATE';
-  obj_type: ObjectType;
   obj_id?: string;
+  obj_type: ObjectType;
+  operation_type: 'UPDATE';
   railjson_patch: Patches;
 };
 export type Operation = RailjsonObject | DeleteOperation | UpdateOperation;
-export type RailjsonFile = {
-  version?: string;
-  operational_points?: any;
-  routes?: any;
-  switch_types?: any;
-  switches?: any;
-  track_section_links?: any;
-  track_sections?: any;
-  signals?: any;
-  buffer_stops?: any;
-  speed_sections?: any;
-  catenaries?: any;
-  detectors?: any;
+export type Point3D = number[];
+export type Point = {
+  coordinates: Point3D;
+  type: 'Point';
 };
 export type LineString = {
-  type: 'LineString';
   coordinates: Point3D[];
+  type: 'LineString';
 };
 export type Polygon = {
-  type: 'Polygon';
   coordinates: Point3D[][];
+  type: 'Polygon';
+};
+export type MultiPoint = {
+  coordinates: Point3D[];
+  type: 'MultiPoint';
 };
 export type MultiLineString = {
-  type: 'MultiLineString';
   coordinates: Point3D[][];
+  type: 'MultiLineString';
 };
 export type MultiPolygon = {
-  type: 'MultiPolygon';
   coordinates: Point3D[][][];
+  type: 'MultiPolygon';
 };
 export type Geometry = Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon;
 export type InfraErrorType =
@@ -1410,19 +1341,30 @@ export type InfraErrorType =
   | 'unused_port';
 export type InfraError = {
   geographic?: Geometry | null;
-  schematic?: object | null;
   information: {
-    obj_id: string;
-    obj_type: 'TrackSection' | 'Signal' | 'BufferStop' | 'Detector' | 'Switch' | 'Route';
     error_type: InfraErrorType;
     field?: string;
     is_warning: boolean;
+    obj_id: string;
+    obj_type: 'TrackSection' | 'Signal' | 'BufferStop' | 'Detector' | 'Switch' | 'Route';
   };
+  schematic?: object | null;
 };
 export type BoundingBox = number[][];
 export type Zone = {
   geo?: BoundingBox;
   sch?: BoundingBox;
+};
+export type Direction = 'START_TO_STOP' | 'STOP_TO_START';
+export type DirectionalTrackRange = {
+  begin: number;
+  direction: Direction;
+  end: number;
+  track: string;
+};
+export type TrackLocation = {
+  offset?: number;
+  track?: string;
 };
 export type RouteTrackRangesNotFoundError = {
   type: 'NotFound';
@@ -1430,60 +1372,53 @@ export type RouteTrackRangesNotFoundError = {
 export type RouteTrackRangesCantComputePathError = {
   type: 'CantComputePath';
 };
-export type Direction = 'START_TO_STOP' | 'STOP_TO_START';
-export type DirectionalTrackRange = {
-  track: string;
-  begin: number;
-  end: number;
-  direction: Direction;
-};
 export type RouteTrackRangesComputed = {
-  type: 'Computed';
   track_ranges: DirectionalTrackRange[];
+  type: 'Computed';
 };
-export type TrackRange = {
-  track?: string;
-  begin?: number;
-  end?: number;
-};
-export type ElectricalProfile = {
-  value?: string;
-  power_class?: string;
-  track_ranges?: TrackRange[];
+export type ViewMetadata = {
+  attribution?: string;
+  maxzoom?: number;
+  minzoom?: number;
+  name?: string;
+  promotedId?: object;
+  scheme?: string;
+  tiles?: string[];
+  type?: string;
 };
 export type SpeedDependantPower = {
-  speeds: number[];
   powers: number[];
+  speeds: number[];
 };
 export type Catenary = {
+  efficiency: number;
   energy_source_type: 'Catenary';
   max_input_power: SpeedDependantPower;
   max_output_power: SpeedDependantPower;
-  efficiency: number;
 };
 export type EnergyStorage = {
   capacity: number;
-  soc: number;
-  soc_min: number;
-  soc_max: number;
   refill_law: {
-    tau: number;
     soc_ref: number;
+    tau: number;
   } | null;
+  soc: number;
+  soc_max: number;
+  soc_min: number;
 };
 export type PowerPack = {
+  efficiency: number;
   energy_source_type: 'PowerPack';
+  energy_storage: EnergyStorage;
   max_input_power: SpeedDependantPower;
   max_output_power: SpeedDependantPower;
-  energy_storage: EnergyStorage;
-  efficiency: number;
 };
 export type Battery = {
+  efficiency: number;
   energy_source_type: 'Battery';
+  energy_storage: EnergyStorage;
   max_input_power: SpeedDependantPower;
   max_output_power: SpeedDependantPower;
-  energy_storage: EnergyStorage;
-  efficiency: number;
 };
 export type EnergySource =
   | ({
@@ -1496,35 +1431,21 @@ export type EnergySource =
       energy_source_type: 'Battery';
     } & Battery);
 export type RollingStockBase = {
-  railjson_version: string;
-  name: string;
-  locked?: boolean;
-  length: number;
-  max_speed: number;
-  startup_time: number;
-  startup_acceleration: number;
+  base_power_class: string;
   comfort_acceleration: number;
+  electrical_power_startup_time: number | null;
+  energy_sources: EnergySource[];
+  features: string[];
   gamma: {
     type: 'CONST' | 'MAX';
     value: number;
   };
   inertia_coefficient: number;
-  features: string[];
-  mass: number;
-  rolling_resistance: {
-    A: number;
-    B: number;
-    C: number;
-    type: 'davis';
-  };
+  length: number;
   loading_gauge: 'G1' | 'G2' | 'GA' | 'GB' | 'GB1' | 'GC' | 'FR3.3' | 'FR3.3/GB/G2' | 'GLOTT';
-  base_power_class: string;
-  power_restrictions: {
-    [key: string]: string;
-  };
-  energy_sources: EnergySource[];
-  electrical_power_startup_time: number | null;
-  raise_pantograph_time: number | null;
+  locked?: boolean;
+  mass: number;
+  max_speed: number;
   metadata: {
     detail: string;
     family: string;
@@ -1536,15 +1457,27 @@ export type RollingStockBase = {
     type: string;
     unit: string;
   };
+  name: string;
+  power_restrictions: {
+    [key: string]: string;
+  };
+  railjson_version: string;
+  raise_pantograph_time: number | null;
+  rolling_resistance: {
+    A: number;
+    B: number;
+    C: number;
+    type: 'davis';
+  };
+  startup_acceleration: number;
+  startup_time: number;
 };
 export type RollingStockLivery = {
+  compound_image_id: number | null;
   id: number;
   name: string;
-  compound_image_id: number | null;
 };
 export type LightRollingStock = RollingStockBase & {
-  id: number;
-  liveries: RollingStockLivery[];
   effort_curves: {
     default_mode: string;
     modes: {
@@ -1553,63 +1486,198 @@ export type LightRollingStock = RollingStockBase & {
       };
     };
   };
+  id: number;
+  liveries: RollingStockLivery[];
 };
 export type GeoJsonObject = {
   coordinates: number[][];
   type: string;
 };
-export type TrackSectionLocation = {
-  track_section: string;
-  offset: number;
-};
 export type GeoJsonPosition = {
   coordinates: number[];
   type: string;
 };
+export type TrackSectionLocation = {
+  offset: number;
+  track_section: string;
+};
 export type PathStep = {
-  id?: string;
-  name?: string;
-  suggestion: boolean;
   duration: number;
-  path_offset: number;
-  location: TrackSectionLocation;
-  sch: GeoJsonPosition;
   geo: GeoJsonPosition;
+  id?: string;
+  location: TrackSectionLocation;
+  name?: string;
+  path_offset: number;
+  sch: GeoJsonPosition;
+  suggestion: boolean;
 };
 export type Path = {
-  id: number;
-  owner: string;
   created: string;
-  length: number;
+  curves: {
+    position: number;
+    radius: number;
+  }[];
   geographic: GeoJsonObject;
+  id: number;
+  length: number;
+  owner: string;
   schematic: GeoJsonObject;
   slopes: {
     gradient: number;
     position: number;
   }[];
-  curves: {
-    radius: number;
-    position: number;
-  }[];
   steps: PathStep[];
 };
 export type PathWaypoint = {
-  track_section: string;
   geo_coordinate?: number[];
   offset?: number;
+  track_section: string;
 };
 export type PathQuery = {
   infra: number;
+  rolling_stocks: number[];
   steps: {
     duration: number;
     waypoints: PathWaypoint[];
   }[];
-  rolling_stocks: number[];
+};
+export type CatenaryRange = {
+  begin?: number;
+  end?: number;
+  mode?: string;
+};
+export type ProjectResult = {
+  budget?: number;
+  creation_date?: string;
+  description?: string;
+  funders?: string;
+  id?: number;
+  image?: number | null;
+  last_modification?: string;
+  name?: string;
+  objectives?: string;
+  studies_count?: number;
+  tags?: string[];
+};
+export type ProjectCreateRequest = {
+  budget?: number;
+  description?: string;
+  funders?: string;
+  image?: number;
+  name: string;
+  objectives?: string;
+  tags?: string[];
+};
+export type ProjectPatchRequest = {
+  budget?: number;
+  description?: string;
+  funders?: string;
+  image?: number;
+  name?: string;
+  objectives?: string;
+  tags?: string[];
+};
+export type StudyResult = {
+  actual_end_date: string | null;
+  budget: number;
+  business_code: string;
+  creation_date: string;
+  description: string;
+  expected_end_date: string | null;
+  id: number;
+  last_modification: string;
+  name: string;
+  project_id: number;
+  scenarios_count: number;
+  service_code: string;
+  start_date: string | null;
+  state?: 'started' | 'inProgress' | 'finish';
+  study_type?:
+    | 'timeTables'
+    | 'flowRate'
+    | 'parkSizing'
+    | 'garageRequirement'
+    | 'operationOrSizing'
+    | 'operability'
+    | 'strategicPlanning'
+    | 'chartStability'
+    | 'disturbanceTests';
+  tags: string[];
+};
+export type StudyUpsertRequest = {
+  actual_end_date?: string | null;
+  budget?: number;
+  business_code?: string;
+  description?: string;
+  expected_end_date?: string | null;
+  name: string;
+  service_code?: string;
+  start_date?: string | null;
+  state?: 'started' | 'inProgress' | 'finish';
+  study_type?:
+    | 'timeTables'
+    | 'flowRate'
+    | 'parkSizing'
+    | 'garageRequirement'
+    | 'operationOrSizing'
+    | 'operability'
+    | 'strategicPlanning'
+    | 'chartStability'
+    | 'disturbanceTests';
+  tags: string[];
+};
+export type ScenarioListResult = {
+  creation_date?: string;
+  description?: string;
+  electrical_profile_set_id?: number | null;
+  electrical_profile_set_name?: string | null;
+  id?: number;
+  infra_id?: number;
+  infra_name?: string;
+  last_modification?: string;
+  name?: string;
+  study_id?: number;
+  tags?: string[];
+  timetable_id?: number;
+  trains_count?: number;
+};
+export type ScenarioResult = {
+  creation_date?: string;
+  description?: string;
+  electrical_profile_set_id?: number | null;
+  electrical_profile_set_name?: string | null;
+  id?: number;
+  infra_id?: number;
+  infra_name?: string;
+  last_modification?: string;
+  name?: string;
+  study_id?: number;
+  tags?: string[];
+  timetable_id?: number;
+  trains_count?: number;
+  trains_schedules?: {
+    departure_time?: string;
+    id?: number;
+    train_name?: string;
+    train_path?: number;
+  }[];
+};
+export type ScenarioRequest = {
+  description?: string;
+  electrical_profile_set_id?: number;
+  infra_id: number;
+  name: string;
+  tags?: string[];
+};
+export type ScenarioPatchRequest = {
+  description?: string;
+  name?: string;
+  tags?: string[];
 };
 export type Comfort = 'AC' | 'HEATING' | 'STANDARD';
 export type EffortCurve = {
-  speeds?: number[];
   max_efforts?: number[];
+  speeds?: number[];
 };
 export type ConditionalEffortCurve = {
   cond?: {
@@ -1638,58 +1706,88 @@ export type RollingStock = RollingStockUpsertPayload & {
 export type RollingStockUsage = {
   rolling_stock_id: number;
   usage: {
-    train_schedule_id: number;
-    train_name: string;
     project_id: number;
     project_name: string;
-    study_id: number;
-    study_name: string;
     scenario_id: number;
     scenario_name: string;
+    study_id: number;
+    study_name: string;
+    train_name: string;
+    train_schedule_id: number;
   };
 };
-export type ProjectResult = {
-  id?: number;
-  name?: string;
-  objectives?: string;
-  description?: string;
-  funders?: string;
-  budget?: number;
-  image?: number | null;
-  creation_date?: string;
-  last_modification?: string;
-  studies_count?: number;
-  tags?: string[];
+export type SearchTrackResult = {
+  infra_id: number;
+  line_code: number;
+  line_name: string;
 };
-export type ProjectCreateRequest = {
+export type SearchOperationalPointResult = {
+  ch: string;
+  geographic: MultiPoint;
+  infra_id?: string;
   name: string;
-  objectives?: string;
+  obj_id: string;
+  schematic: MultiPoint;
+  track_sections: {
+    position: number;
+    track: string;
+  }[];
+  trigram: string;
+  uic?: number;
+};
+export type SearchSignalResult = {
+  aspects?: string[];
+  geographic: Point;
+  infra_id?: number;
+  label: string;
+  line_code: number;
+  line_name: string;
+  schematic: Point;
+  systems?: string[];
+  type?: string;
+};
+export type SearchStudyResult = {
   description?: string;
-  funders?: string;
-  budget?: number;
-  image?: number;
+  id: number;
+  last_modification: string;
+  name: string;
+  project_id: number;
+  scenarios_count?: number;
   tags?: string[];
 };
-export type ProjectPatchRequest = {
-  name?: string;
-  objectives?: string;
-  description?: string;
-  funders?: string;
-  budget?: number;
+export type SearchProjectResult = {
+  description: string;
+  id: number;
   image?: number;
-  tags?: string[];
+  last_modification: string;
+  name: string;
+  studies_count?: number;
+  tags?: any;
 };
+export type SearchScenarioResult = {
+  description?: string;
+  electrical_profile_set_id?: number;
+  id: number;
+  infra_id: number;
+  infra_name?: string;
+  last_modification: string;
+  name: string;
+  study_id: number;
+  tags?: string[];
+  trains_count?: number;
+};
+export type SearchQuery = (boolean | number | number | string | SearchQuery)[] | null;
 export type AllowanceTimePerDistanceValue = {
-  value_type: 'time_per_distance';
   minutes: number;
+  value_type: 'time_per_distance';
 };
 export type AllowanceTimeValue = {
-  value_type: 'time';
   seconds: number;
+  value_type: 'time';
 };
 export type AllowancePercentValue = {
-  value_type: 'percentage';
   percentage: number;
+  value_type: 'percentage';
 };
 export type AllowanceValue =
   | ({
@@ -1708,15 +1806,15 @@ export type RangeAllowance = {
 };
 export type EngineeringAllowance = {
   allowance_type: 'engineering';
-  distribution: 'MARECO' | 'LINEAR';
   capacity_speed_limit?: number;
+  distribution: 'MARECO' | 'LINEAR';
 } & RangeAllowance;
 export type StandardAllowance = {
   allowance_type: 'standard';
-  default_value: AllowanceValue;
-  ranges: RangeAllowance[];
-  distribution: 'MARECO' | 'LINEAR';
   capacity_speed_limit?: number;
+  default_value: AllowanceValue;
+  distribution: 'MARECO' | 'LINEAR';
+  ranges: RangeAllowance[];
 };
 export type Allowance =
   | ({
@@ -1734,191 +1832,71 @@ export type PowerRestrictionRange = {
   power_restriction_code: string;
 };
 export type TrainScheduleSummary = {
-  id: number;
-  train_name: string;
-  timetable_id?: number;
-  rolling_stock_id?: number;
+  allowances?: Allowance[];
+  arrival_time: number;
+  comfort?: Comfort;
   departure_time: number;
-  path_id?: number;
+  id: number;
   initial_speed?: number;
   labels: string[];
-  allowances?: Allowance[];
-  speed_limit_tags?: string;
-  comfort?: Comfort;
-  options?: TrainScheduleOptions | null;
-  power_restriction_ranges?: PowerRestrictionRange[] | null;
-  arrival_time: number;
   mechanical_energy_consumed: {
     base?: number;
     eco?: number;
   };
-  stops_count?: number;
+  options?: TrainScheduleOptions | null;
+  path_id?: number;
   path_length?: number;
+  power_restriction_ranges?: PowerRestrictionRange[] | null;
+  rolling_stock_id?: number;
+  speed_limit_tags?: string;
+  stops_count?: number;
+  timetable_id?: number;
+  train_name: string;
 };
 export type TimetableWithSchedulesDetails = {
   id: number;
   name: string;
   train_schedule_summaries: TrainScheduleSummary[];
 };
-export type StudyResult = {
-  id: number;
-  name: string;
-  project_id: number;
-  description: string;
-  budget: number;
-  tags: string[];
-  service_code: string;
-  business_code: string;
-  creation_date: string;
-  last_modification: string;
-  scenarios_count: number;
-  start_date: string | null;
-  expected_end_date: string | null;
-  actual_end_date: string | null;
-  state?: 'started' | 'inProgress' | 'finish';
-  study_type?:
-    | 'timeTables'
-    | 'flowRate'
-    | 'parkSizing'
-    | 'garageRequirement'
-    | 'operationOrSizing'
-    | 'operability'
-    | 'strategicPlanning'
-    | 'chartStability'
-    | 'disturbanceTests';
-};
-export type StudyUpsertRequest = {
-  name: string;
-  service_code?: string;
-  business_code?: string;
-  description?: string;
-  budget?: number;
-  tags: string[];
-  start_date?: string | null;
-  expected_end_date?: string | null;
-  actual_end_date?: string | null;
-  state?: 'started' | 'inProgress' | 'finish';
-  study_type?:
-    | 'timeTables'
-    | 'flowRate'
-    | 'parkSizing'
-    | 'garageRequirement'
-    | 'operationOrSizing'
-    | 'operability'
-    | 'strategicPlanning'
-    | 'chartStability'
-    | 'disturbanceTests';
-};
-export type ScenarioResult = {
-  id?: number;
-  name?: string;
-  study_id?: number;
-  description?: string;
-  tags?: string[];
-  infra_id?: number;
-  infra_name?: string;
-  electrical_profile_set_id?: number | null;
-  electrical_profile_set_name?: string | null;
-  creation_date?: string;
-  last_modification?: string;
-  timetable_id?: number;
-  trains_count?: number;
-  trains_schedules?: {
-    id?: number;
-    train_name?: string;
-    departure_time?: string;
-    train_path?: number;
-  }[];
-};
-export type ScenarioRequest = {
-  name: string;
-  description?: string;
-  tags?: string[];
-  infra_id: number;
-  electrical_profile_set_id?: number;
-};
-export type ScenarioListResult = {
-  id?: number;
-  name?: string;
-  study_id?: number;
-  description?: string;
-  tags?: string[];
-  infra_id?: number;
-  infra_name?: string;
-  electrical_profile_set_id?: number | null;
-  electrical_profile_set_name?: string | null;
-  creation_date?: string;
-  last_modification?: string;
-  timetable_id?: number;
-  trains_count?: number;
-};
-export type ScenarioPatchRequest = {
-  name?: string;
-  description?: string;
-  tags?: string[];
-};
-export type CatenaryRange = {
-  begin?: number;
-  end?: number;
-  mode?: string;
-};
-export type TrainSchedule = {
-  train_name?: string;
-  timetable?: number;
-  rolling_stock?: number;
-  departure_time?: number;
-  path?: number;
-  initial_speed?: number;
-  labels?: string[];
-  scheduled_points?: {
-    path_offset: number;
-    time: number;
-  }[];
-  allowances?: Allowance[];
-  speed_limit_tags?: string;
-  comfort?: Comfort;
-  options?: TrainScheduleOptions | null;
-  power_restriction_ranges?: PowerRestrictionRange[] | null;
-};
 export type SpaceTimePosition = {
-  time: number;
   position: number;
+  time: number;
 };
 export type SimulationReportByTrain = {
-  speeds: (SpaceTimePosition & {
-    speed: number;
-  })[];
   head_positions: SpaceTimePosition[][];
-  tail_positions: SpaceTimePosition[][];
-  stops: {
-    id: number;
-    name: string;
-    time: number;
-    position: number;
-    duration: number;
-    line_code: number;
-    track_number: number;
-    line_name: string;
-    track_name: string;
-  }[];
+  mechanical_energy_consumed: number;
   route_aspects: {
-    signal_id: string;
-    route_id: string;
-    time_start: number;
-    time_end: number;
-    position_start: number;
-    position_end: number;
-    color: number;
-    blinking: boolean;
     aspect_label: string;
+    blinking: boolean;
+    color: number;
+    position_end: number;
+    position_start: number;
+    route_id: string;
+    signal_id: string;
+    time_end: number;
+    time_start: number;
   }[];
   signals: {
-    signal_id: number;
     aspects: string[];
     geo_position: number[];
     schema_position: number[];
+    signal_id: number;
   }[];
-  mechanical_energy_consumed: number;
+  speeds: (SpaceTimePosition & {
+    speed: number;
+  })[];
+  stops: {
+    duration: number;
+    id: number;
+    line_code: number;
+    line_name: string;
+    name: string;
+    position: number;
+    time: number;
+    track_name: string;
+    track_number: number;
+  }[];
+  tail_positions: SpaceTimePosition[][];
 };
 export type Electrified = {
   mode: string;
@@ -1935,8 +1913,6 @@ export type NonElectrified = {
   object_type: 'NonElectrified';
 };
 export type ElectrificationRange = {
-  start: number;
-  stop: number;
   electrificationUsage:
     | ({
         object_type: 'Electrified';
@@ -1947,33 +1923,53 @@ export type ElectrificationRange = {
     | ({
         object_type: 'NonElectrified';
       } & NonElectrified);
-};
-export type PowerRestrictionRangeItem = {
   start: number;
   stop: number;
+};
+export type PowerRestrictionRangeItem = {
   code: string;
   handled: boolean;
+  start: number;
+  stop: number;
 };
 export type SimulationReport = {
-  id: number;
-  name: string;
-  labels: string[];
-  path: number;
-  vmax: {
-    position: number;
-    speed: number;
-  }[];
-  slopes: {
-    position: number;
-    gradient: number;
-  }[];
+  base: SimulationReportByTrain;
   curves: {
     position: number;
     radius: number;
   }[];
-  base: SimulationReportByTrain;
   eco?: SimulationReportByTrain;
-  speed_limit_tags?: string;
   electrification_ranges: ElectrificationRange[];
+  id: number;
+  labels: string[];
+  name: string;
+  path: number;
   power_restriction_ranges: PowerRestrictionRangeItem[];
+  slopes: {
+    gradient: number;
+    position: number;
+  }[];
+  speed_limit_tags?: string;
+  vmax: {
+    position: number;
+    speed: number;
+  }[];
+};
+export type TrainSchedule = {
+  allowances?: Allowance[];
+  comfort?: Comfort;
+  departure_time?: number;
+  initial_speed?: number;
+  labels?: string[];
+  options?: TrainScheduleOptions | null;
+  path?: number;
+  power_restriction_ranges?: PowerRestrictionRange[] | null;
+  rolling_stock?: number;
+  scheduled_points?: {
+    path_offset: number;
+    time: number;
+  }[];
+  speed_limit_tags?: string;
+  timetable?: number;
+  train_name?: string;
 };


### PR DESCRIPTION
Part of #3625 

* Sets up utoipa
* Provides the command `openapi` that generates the OpenApi
* That command uses `OpenApiMerger` that can take/reject/replace some parts of the old OpenApi by new ones that are generated using utoipa
* Adds a CI check to ensure that `openapi.json` is up to date. **HOWEVER** that increases the CI execution time by 5 minutes. Alternatively we could make that check an editoast unit test to avoid an unnecessary build but by doing so we would need to `include_str!` the whole OpenApi file, which would then increase the binary size 🤷 

Also adds [pretty_assertions](https://crates.io/crates/pretty_assertions) as a dev dependency. It's a drop in replacement of `assert_eq!` that shows a diff on failure (it's **very** useful for comparing JSON docs :grin:).

The minimal procedure to add the required annotations is shown there: #4620 

[1]: The RTK generation script will be updated later as it also requires changes to the CI and that PR is big enough.

Resolves #4578 