### PR TITLE
editoast: speed up layer generation

### DIFF
--- a/editoast/src/generated_data/sql/generate_backside_pantograph_dead_section_layer.sql
+++ b/editoast/src/generated_data/sql/generate_backside_pantograph_dead_section_layer.sql
@@ -12,53 +12,49 @@ WITH track_ranges AS (
 ),
 sliced_tracks AS (
     SELECT track_ranges.dead_section_id,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
+        ST_LineSubstring(
+            tracks_layer.geographic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
+        ST_LineSubstring(
+            tracks_layer.schematic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS sch
     FROM track_ranges
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = track_ranges.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_backsidepantographdeadsectionlayer (obj_id, infra_id, geographic, schematic)
 SELECT dead_section_id,

--- a/editoast/src/generated_data/sql/generate_buffer_stop_layer.sql
+++ b/editoast/src/generated_data/sql/generate_buffer_stop_layer.sql
@@ -2,37 +2,27 @@ WITH collect AS (
     SELECT buffer_stops.obj_id AS buffer_stop_id,
         (buffer_stops.data->>'position')::float AS buffer_stop_position,
         (tracks.data->>'length')::float AS track_length,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_bufferstopmodel AS buffer_stops
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = buffer_stops.data->>'track'
         AND tracks.infra_id = buffer_stops.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE buffer_stops.infra_id = $1
+),
+collect2 AS (
+    SELECT buffer_stop_id,
+        LEAST(
+            GREATEST(buffer_stop_position / track_length, 0.),
+            1.
+        ) AS norm_pos
+    FROM collect
 )
 INSERT INTO osrd_infra_bufferstoplayer (obj_id, infra_id, geographic, schematic)
-SELECT buffer_stop_id,
+SELECT collect.buffer_stop_id,
     $1,
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_geo,
-            LEAST(
-                GREATEST(buffer_stop_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    ),
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_sch,
-            LEAST(
-                GREATEST(buffer_stop_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    )
-FROM collect ON CONFLICT (infra_id, obj_id) DO
-UPDATE
-SET geographic = EXCLUDED.geographic,
-    schematic = EXCLUDED.schematic
+    ST_LineInterpolatePoint(track_geo, norm_pos),
+    ST_LineInterpolatePoint(track_sch, norm_pos)
+FROM collect
+    INNER JOIN collect2 ON collect.buffer_stop_id = collect2.buffer_stop_id

--- a/editoast/src/generated_data/sql/generate_catenary_layer.sql
+++ b/editoast/src/generated_data/sql/generate_catenary_layer.sql
@@ -12,53 +12,49 @@ WITH track_ranges AS (
 ),
 sliced_tracks AS (
     SELECT track_ranges.catenary_id,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
+        ST_LineSubstring(
+            tracks_layer.geographic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
+        ST_LineSubstring(
+            tracks_layer.schematic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS sch
     FROM track_ranges
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = track_ranges.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_catenarylayer (obj_id, infra_id, geographic, schematic)
 SELECT catenary_id,

--- a/editoast/src/generated_data/sql/generate_dead_section_layer.sql
+++ b/editoast/src/generated_data/sql/generate_dead_section_layer.sql
@@ -12,53 +12,49 @@ WITH track_ranges AS (
 ),
 sliced_tracks AS (
     SELECT track_ranges.dead_section_id,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
+        ST_LineSubstring(
+            tracks_layer.geographic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
+        ST_LineSubstring(
+            tracks_layer.schematic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS sch
     FROM track_ranges
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = track_ranges.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_deadsectionlayer (obj_id, infra_id, geographic, schematic)
 SELECT dead_section_id,

--- a/editoast/src/generated_data/sql/generate_detector_layer.sql
+++ b/editoast/src/generated_data/sql/generate_detector_layer.sql
@@ -2,34 +2,27 @@ WITH collect AS (
     SELECT detectors.obj_id AS detector_id,
         (detectors.data->>'position')::float AS detector_position,
         (tracks.data->>'length')::float AS track_length,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_detectormodel AS detectors
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = detectors.data->>'track'
         AND tracks.infra_id = detectors.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE detectors.infra_id = $1
+),
+collect2 AS (
+    SELECT detector_id,
+        LEAST(
+            GREATEST(detector_position / track_length, 0.),
+            1.
+        ) AS norm_pos
+    FROM collect
 )
 INSERT INTO osrd_infra_detectorlayer (obj_id, infra_id, geographic, schematic)
-SELECT detector_id,
+SELECT collect.detector_id,
     $1,
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_geo,
-            LEAST(
-                GREATEST(detector_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    ),
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_sch,
-            LEAST(
-                GREATEST(detector_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    )
+    ST_LineInterpolatePoint(track_geo, norm_pos),
+    ST_LineInterpolatePoint(track_sch, norm_pos)
 FROM collect
+    INNER JOIN collect2 ON collect.detector_id = collect2.detector_id

--- a/editoast/src/generated_data/sql/generate_lpv_panel_layer.sql
+++ b/editoast/src/generated_data/sql/generate_lpv_panel_layer.sql
@@ -30,35 +30,31 @@ WITH panels AS (
 collect AS (
     SELECT panels.sc_id,
         panels.data,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
-                LEAST(
-                    GREATEST(
-                        panels.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    panels.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
-                LEAST(
-                    GREATEST(
-                        panels.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.schematic,
+            LEAST(
+                GREATEST(
+                    panels.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS sch
     FROM panels
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = panels.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_lpvpanellayer (obj_id, infra_id, geographic, schematic, data)
 SELECT sc_id,

--- a/editoast/src/generated_data/sql/generate_operational_point_layer.sql
+++ b/editoast/src/generated_data/sql/generate_operational_point_layer.sql
@@ -9,35 +9,31 @@ WITH ops AS (
 ),
 collect AS (
     SELECT ops.op_id,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
-                LEAST(
-                    GREATEST(
-                        ops.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    ops.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
-                LEAST(
-                    GREATEST(
-                        ops.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.schematic,
+            LEAST(
+                GREATEST(
+                    ops.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS sch
     FROM ops
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = ops.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_operationalpointlayer (obj_id, infra_id, geographic, schematic)
 SELECT op_id,

--- a/editoast/src/generated_data/sql/generate_speed_section_layer.sql
+++ b/editoast/src/generated_data/sql/generate_speed_section_layer.sql
@@ -12,53 +12,49 @@ WITH track_ranges AS (
 ),
 sliced_tracks AS (
     SELECT track_ranges.speed_id,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
+        ST_LineSubstring(
+            tracks_layer.geographic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
+        ST_LineSubstring(
+            tracks_layer.schematic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS sch
     FROM track_ranges
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = track_ranges.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_speedsectionlayer (obj_id, infra_id, geographic, schematic)
 SELECT speed_id,

--- a/editoast/src/generated_data/sql/generate_switch_layer.sql
+++ b/editoast/src/generated_data/sql/generate_switch_layer.sql
@@ -1,11 +1,13 @@
 WITH collect AS (
     SELECT switches.obj_id AS switch_id,
         jsonb_path_query_first(switches.data->'ports', '$.*')->>'endpoint' AS ep,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_switchmodel AS switches
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = jsonb_path_query_first(switches.data->'ports', '$.*')->>'track'
         AND tracks.infra_id = switches.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE switches.infra_id = $1
 )
 INSERT INTO osrd_infra_switchlayer (obj_id, infra_id, geographic, schematic)
@@ -13,12 +15,12 @@ SELECT switch_id,
     $1,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_geo), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_geo), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_geo)
+        WHEN 'END' THEN ST_EndPoint(track_geo)
     END,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_sch), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_sch), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_sch)
+        WHEN 'END' THEN ST_EndPoint(track_sch)
     END
 FROM collect

--- a/editoast/src/generated_data/sql/generate_track_section_link_layer.sql
+++ b/editoast/src/generated_data/sql/generate_track_section_link_layer.sql
@@ -1,11 +1,13 @@
 WITH collect AS (
     SELECT links.obj_id AS link_id,
         links.data->'dst'->>'endpoint' AS ep,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_tracksectionlinkmodel AS links
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = links.data->'dst'->>'track'
         AND tracks.infra_id = links.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE links.infra_id = $1
 )
 INSERT INTO osrd_infra_tracksectionlinklayer (obj_id, infra_id, geographic, schematic)
@@ -13,12 +15,12 @@ SELECT link_id,
     $1,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_geo), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_geo), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_geo)
+        WHEN 'END' THEN ST_EndPoint(track_geo)
     END,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_sch), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_sch), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_sch)
+        WHEN 'END' THEN ST_EndPoint(track_sch)
     END
 FROM collect

--- a/editoast/src/generated_data/sql/insert_lpv_panel_layer.sql
+++ b/editoast/src/generated_data/sql/insert_lpv_panel_layer.sql
@@ -33,35 +33,31 @@ WITH panels AS (
 collect AS (
     SELECT panels.sc_id,
         panels.data,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
-                LEAST(
-                    GREATEST(
-                        panels.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    panels.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
-                LEAST(
-                    GREATEST(
-                        panels.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.schematic,
+            LEAST(
+                GREATEST(
+                    panels.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS sch
     FROM panels
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = panels.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_lpvpanellayer (obj_id, infra_id, geographic, schematic, data)
 SELECT sc_id,

--- a/editoast/src/generated_data/sql/insert_operational_point_layer.sql
+++ b/editoast/src/generated_data/sql/insert_operational_point_layer.sql
@@ -10,35 +10,31 @@ WITH ops AS (
 ),
 collect AS (
     SELECT ops.op_id,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
-                LEAST(
-                    GREATEST(
-                        ops.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.geographic,
+            LEAST(
+                GREATEST(
+                    ops.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineInterpolatePoint(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
-                LEAST(
-                    GREATEST(
-                        ops.position / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+        ST_LineInterpolatePoint(
+            tracks_layer.schematic,
+            LEAST(
+                GREATEST(
+                    ops.position / (tracks.data->'length')::float,
+                    0.
+                ),
+                1.
+            )
         ) AS sch
     FROM ops
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = ops.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_operationalpointlayer (obj_id, infra_id, geographic, schematic)
 SELECT op_id,

--- a/editoast/src/generated_data/sql/insert_speed_section_layer.sql
+++ b/editoast/src/generated_data/sql/insert_speed_section_layer.sql
@@ -13,53 +13,49 @@ WITH track_ranges AS (
 ),
 sliced_tracks AS (
     SELECT track_ranges.speed_id,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'geo'),
+        ST_LineSubstring(
+            tracks_layer.geographic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS geo,
-        ST_Transform(
-            ST_LineSubstring(
-                ST_GeomFromGeoJSON(tracks.data->'sch'),
+        ST_LineSubstring(
+            tracks_layer.schematic,
+            GREATEST(
+                LEAST(
+                    track_ranges.slice_end / (tracks.data->'length')::float,
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    1.
+                ),
+                0.
+            ),
+            LEAST(
                 GREATEST(
-                    LEAST(
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        1.
-                    ),
+                    track_ranges.slice_begin / (tracks.data->'length')::float,
+                    track_ranges.slice_end / (tracks.data->'length')::float,
                     0.
                 ),
-                LEAST(
-                    GREATEST(
-                        track_ranges.slice_begin / (tracks.data->'length')::float,
-                        track_ranges.slice_end / (tracks.data->'length')::float,
-                        0.
-                    ),
-                    1.
-                )
-            ),
-            3857
+                1.
+            )
         ) AS sch
     FROM track_ranges
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = track_ranges.track_id
         AND tracks.infra_id = $1
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
 )
 INSERT INTO osrd_infra_speedsectionlayer (obj_id, infra_id, geographic, schematic)
 SELECT speed_id,

--- a/editoast/src/generated_data/sql/insert_update_buffer_stop_layer.sql
+++ b/editoast/src/generated_data/sql/insert_update_buffer_stop_layer.sql
@@ -2,38 +2,31 @@ WITH collect AS (
     SELECT buffer_stops.obj_id AS buffer_stop_id,
         (buffer_stops.data->>'position')::float AS buffer_stop_position,
         (tracks.data->>'length')::float AS track_length,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_bufferstopmodel AS buffer_stops
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = buffer_stops.data->>'track'
         AND tracks.infra_id = buffer_stops.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE buffer_stops.infra_id = $1
         AND buffer_stops.obj_id = ANY($2)
+),
+collect2 AS (
+    SELECT buffer_stop_id,
+        LEAST(
+            GREATEST(buffer_stop_position / track_length, 0.),
+            1.
+        ) AS norm_pos
+    FROM collect
 )
 INSERT INTO osrd_infra_bufferstoplayer (obj_id, infra_id, geographic, schematic)
-SELECT buffer_stop_id,
+SELECT collect.buffer_stop_id,
     $1,
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_geo,
-            LEAST(
-                GREATEST(buffer_stop_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    ),
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_sch,
-            LEAST(
-                GREATEST(buffer_stop_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    )
-FROM collect ON CONFLICT (infra_id, obj_id) DO
+    ST_LineInterpolatePoint(track_geo, norm_pos),
+    ST_LineInterpolatePoint(track_sch, norm_pos)
+FROM collect
+    INNER JOIN collect2 ON collect.buffer_stop_id = collect2.buffer_stop_id ON CONFLICT (infra_id, obj_id) DO
 UPDATE
 SET geographic = EXCLUDED.geographic,
     schematic = EXCLUDED.schematic

--- a/editoast/src/generated_data/sql/insert_update_detector_layer.sql
+++ b/editoast/src/generated_data/sql/insert_update_detector_layer.sql
@@ -2,38 +2,31 @@ WITH collect AS (
     SELECT detectors.obj_id AS detector_id,
         (detectors.data->>'position')::float AS detector_position,
         (tracks.data->>'length')::float AS track_length,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_detectormodel AS detectors
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = detectors.data->>'track'
         AND tracks.infra_id = detectors.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE detectors.infra_id = $1
         AND detectors.obj_id = ANY($2)
+),
+collect2 AS (
+    SELECT detector_id,
+        LEAST(
+            GREATEST(detector_position / track_length, 0.),
+            1.
+        ) AS norm_pos
+    FROM collect
 )
 INSERT INTO osrd_infra_detectorlayer (obj_id, infra_id, geographic, schematic)
-SELECT detector_id,
+SELECT collect.detector_id,
     $1,
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_geo,
-            LEAST(
-                GREATEST(detector_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    ),
-    ST_Transform(
-        ST_LineInterpolatePoint(
-            track_sch,
-            LEAST(
-                GREATEST(detector_position / track_length, 0.),
-                1.
-            )
-        ),
-        3857
-    )
-FROM collect ON CONFLICT (infra_id, obj_id) DO
+    ST_LineInterpolatePoint(track_geo, norm_pos),
+    ST_LineInterpolatePoint(track_sch, norm_pos)
+FROM collect
+    INNER JOIN collect2 ON collect.detector_id = collect2.detector_id ON CONFLICT (infra_id, obj_id) DO
 UPDATE
 SET geographic = EXCLUDED.geographic,
     schematic = EXCLUDED.schematic

--- a/editoast/src/generated_data/sql/insert_update_switch_layer.sql
+++ b/editoast/src/generated_data/sql/insert_update_switch_layer.sql
@@ -1,11 +1,13 @@
 WITH collect AS (
     SELECT switches.obj_id AS switch_id,
         jsonb_path_query_first(switches.data->'ports', '$.*')->>'endpoint' AS ep,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_switchmodel AS switches
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = jsonb_path_query_first(switches.data->'ports', '$.*')->>'track'
         AND tracks.infra_id = switches.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE switches.infra_id = $1
         AND switches.obj_id = ANY($2)
 )
@@ -14,13 +16,13 @@ SELECT switch_id,
     $1,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_geo), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_geo), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_geo)
+        WHEN 'END' THEN ST_EndPoint(track_geo)
     END,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_sch), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_sch), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_sch)
+        WHEN 'END' THEN ST_EndPoint(track_sch)
     END
 FROM collect ON CONFLICT (infra_id, obj_id) DO
 UPDATE

--- a/editoast/src/generated_data/sql/insert_update_track_section_link_layer.sql
+++ b/editoast/src/generated_data/sql/insert_update_track_section_link_layer.sql
@@ -1,11 +1,13 @@
 WITH collect AS (
     SELECT links.obj_id AS link_id,
         links.data->'dst'->>'endpoint' AS ep,
-        ST_GeomFromGeoJSON(tracks.data->'geo') AS track_geo,
-        ST_GeomFromGeoJSON(tracks.data->'sch') AS track_sch
+        tracks_layer.geographic AS track_geo,
+        tracks_layer.schematic AS track_sch
     FROM osrd_infra_tracksectionlinkmodel AS links
         INNER JOIN osrd_infra_tracksectionmodel AS tracks ON tracks.obj_id = links.data->'dst'->>'track'
         AND tracks.infra_id = links.infra_id
+        INNER JOIN osrd_infra_tracksectionlayer AS tracks_layer ON tracks.obj_id = tracks_layer.obj_id
+        AND tracks.infra_id = tracks_layer.infra_id
     WHERE links.infra_id = $1
         AND links.obj_id = ANY($2)
 )
@@ -14,13 +16,13 @@ SELECT link_id,
     $1,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_geo), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_geo), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_geo)
+        WHEN 'END' THEN ST_EndPoint(track_geo)
     END,
     CASE
         ep
-        WHEN 'BEGIN' THEN ST_Transform(ST_StartPoint(track_sch), 3857)
-        WHEN 'END' THEN ST_Transform(ST_EndPoint(track_sch), 3857)
+        WHEN 'BEGIN' THEN ST_StartPoint(track_sch)
+        WHEN 'END' THEN ST_EndPoint(track_sch)
     END
 FROM collect ON CONFLICT (infra_id, obj_id) DO
 UPDATE


### PR DESCRIPTION
Uses track section layer avoiding using st_transform.

## Benchmark

|                  | Old Version   |   New version |
| ---------------- | ------------- | ------------- |
| Track section    |      3.99s    |       4.43s   |
| Speed section    |    160.21s    |      60.99s   |
| Signal           |      3.17s    |       3.43s   |
| Switch           |      2.13s    |       0.52s   |
| Buffer stop      |      0.35s    |       0.20s   |
| Catenary         |     10.02s    |       3.96s   |
| Detector         |     11.11s    |       3.17s   |
| Operational point|      4.53s    |       1.42s   |
| Track link       |      1.25s    |       0.29s   |
| Lpv panel        |      5.08s    |       2.21s   |
| Dead section     |      1.22s    |       0.63s   |
| **TOTAL**        |    **203s**   |     **81.2s** |
