### PR TITLE
editoast: add utoipa annotations for GET /version

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2594,6 +2594,14 @@ components:
       - operation_type
       - obj_type
       - railjson_patch
+    Version:
+      properties:
+        git_describe:
+          nullable: true
+          type: string
+      required:
+      - git_describe
+      type: object
     ViewMetadata:
       properties:
         attribution:
@@ -4696,13 +4704,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  git_describe:
-                    nullable: true
-                    type: string
-                required:
-                - git_describe
-                type: object
+                $ref: '#/components/schemas/Version'
           description: Return the service version
 tags:
 - description: Infra

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1244,9 +1244,7 @@ export type GetTrainScheduleByIdResultApiArg = {
   /** Path id used to project the train path */
   pathId: number;
 };
-export type GetVersionApiResponse = /** status 200 Return the service version */ {
-  git_describe: string | null;
-};
+export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;
 export type TrackRange = {
   begin?: number;
@@ -2116,4 +2114,7 @@ export type TrainSchedule = {
   speed_limit_tags?: string;
   timetable?: number;
   train_name?: string;
+};
+export type Version = {
+  git_describe: string | null;
 };


### PR DESCRIPTION
Part of #3625, #4580 

To merge **AFTER** #4591 


1. Add the Utopia annotations on the endpoint(s)
2. Add the `ToSchema` / `ToParams` / `ToResponse` derive macros where necessary
3. Add the endpoint and the new components in `crate::views::OpenApiRoot`
4. Generate the RTK file
5. Test that the front still works or fix it