### PR TITLE
front: intervals editor, fix bugs

### DIFF
--- a/front/public/locales/en/common/common.json
+++ b/front/public/locales/en/common/common.json
@@ -1,0 +1,13 @@
+{
+  "actions": {
+    "add": "Add",
+    "delete": "Remove",
+    "reset": "Reset",
+    "split": "Split",
+    "translate": "Translate",
+    "zoom-in": "Zoom in",
+    "zoom-out": "Zoom out"
+  },
+  "begin": "Start",
+  "end": "End"
+}

--- a/front/public/locales/fr/common/common.json
+++ b/front/public/locales/fr/common/common.json
@@ -1,0 +1,13 @@
+{
+  "actions": {
+    "add": "Ajouter",
+    "delete": "Supprimer",
+    "reset": "Réinitialiser",
+    "split": "Couper en deux",
+    "translate": "Translater",
+    "zoom-in": "Agrandir",
+    "Zoom-out": "Réduire"
+  },
+  "begin": "Début",
+  "end": "Fin"
+}

--- a/front/src/common/IntervalsDataViz/data.ts
+++ b/front/src/common/IntervalsDataViz/data.ts
@@ -462,6 +462,40 @@ export function splitAt<T>(
 }
 
 /**
+ * Create a new empty segment
+ *
+ * @param linearMetadata The linear metadata we work on
+ * @param distance The distance where we split the linear metadata and create a new empty segment
+ * @param valueField Name of the field on which we need to do the viz
+ * @param defaultValue The default value used for the new segment
+ * @returns A new linear metadata with two more segments (1 filled with default value and the existing splitted one)
+ * @throws An error when linear metadata is empty, or when the distance is outside
+ */
+export function createEmptySegmentAt<T>(
+  linearMetadata: Array<LinearMetadataItem<T>>,
+  distance: number,
+  valueField: string,
+  defaultValue: unknown
+): Array<LinearMetadataItem<T>> {
+  if (linearMetadata.length < 1) throw new Error('linear metadata is empty');
+  if (distance >= (last(linearMetadata)?.end || 0) || distance <= 0)
+    throw new Error('split point is outside the geometry');
+
+  return linearMetadata
+    .map((item) => {
+      if (item.begin <= distance && distance <= item.end) {
+        return [
+          { ...item, begin: item.begin, end: distance },
+          { ...item, begin: distance, end: distance + 1, [valueField]: defaultValue },
+          { ...item, begin: distance + 1, end: item.end },
+        ];
+      }
+      return [item];
+    })
+    .flat();
+}
+
+/**
  * Create a new segment
  *
  * @param linearMetadata The linear metadata we work on

--- a/front/src/common/IntervalsEditor/IntervalsEditor.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditor.tsx
@@ -1,58 +1,54 @@
-import { BsFillTrashFill } from 'react-icons/bs';
-import { IoIosAdd, IoIosSave } from 'react-icons/io';
-import React, { useState, useRef, useCallback, useMemo } from 'react';
-import { LinearMetadataDataviz } from 'common/IntervalsDataViz/dataviz';
-
-import { TbZoomIn, TbZoomOut, TbZoomCancel, TbScissors, TbArrowsHorizontal } from 'react-icons/tb';
+import React, { useState, useRef, useMemo, useEffect } from 'react';
+import { isNil, max } from 'lodash';
 
 import {
   LinearMetadataItem,
-  createSegmentAt,
-  fixLinearMetadataItems,
-  getLineStringDistance,
+  createEmptySegmentAt,
   getZoomedViewBox,
   removeSegment,
   resizeSegment,
   splitAt,
   transalteViewBox,
 } from 'common/IntervalsDataViz/data';
+import { LinearMetadataDataviz } from 'common/IntervalsDataViz/dataviz';
+import { tooltipPosition } from 'common/IntervalsDataViz/utils';
 
-import { FieldProps } from '@rjsf/core';
-import { isNil, max as fnMax, cloneDeep } from 'lodash';
-
-import { tooltipPosition, notEmpty } from 'common/IntervalsDataViz/utils';
-import { ValueOf } from 'utils/types';
-import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
-import { useTranslation } from 'react-i18next';
-import SelectSNCF from 'common/BootstrapSNCF/SelectSNCF';
 import IntervalsEditorTootlip from './IntervalsEditorTooltip';
+import IntervalsEditorCommonForm from './IntervalsEditorCommonForm';
+import {
+  INTERVALS_EDITOR_TOOLS,
+  INTERVAL_TYPES,
+  IntervalItem,
+  IntervalsEditorTool,
+  IntervalsEditorToolsConfig,
+} from './types';
+import ZoomButtons from './ZoomButtons';
+import ToolButtons from './IntervalsEditorToolButtons';
+import IntervalsEditorMarginForm from './IntervalsEditorMarginForm';
+import IntervalsEditorSelectForm from './IntervalsEditorSelectForm';
 
-export const TOOLS = Object.freeze({
-  cutTool: Symbol('cutTool'),
-  deleteTool: Symbol('deleteTool'),
-  translateTool: Symbol('translateTool'),
-  addTool: Symbol('addTool'),
-});
-
-type IntervalsEditorParams = {
-  cutTool?: boolean;
-  deleteTool?: boolean;
-  translateTool?: boolean;
-  addTool?: boolean;
+type IntervalsEditorProps = {
+  defaultValue: number | string;
+  setData: (newData: IntervalItem[]) => void;
   showValues?: boolean;
-};
+  title?: string;
+  toolsConfig?: IntervalsEditorToolsConfig;
+  totalLength: number;
+} & (
+  | {
+      intervalType: INTERVAL_TYPES.NUMBER_WITH_UNIT;
+      data: LinearMetadataItem<{ value: number | string; unit: string }>[];
+      defaultUnit?: string;
+      fieldLabel: string;
+      units: string[];
+    }
+  | {
+      intervalType: INTERVAL_TYPES.SELECT;
+      data: LinearMetadataItem<{ value: number | string }>[];
+      selectOptions: string[];
+    }
+);
 
-type IntervalsEditorMetaProps = {
-  params?: IntervalsEditorParams;
-  valueField: string;
-  values?: string[];
-  defaultValue?: number;
-  units?: string[];
-  defaultUnit?: string;
-  onChange: (newData: LinearMetadataItem[]) => void;
-};
-
-type IntervalsEditorProps = IntervalsEditorMetaProps & FieldProps;
 /**
  * A tool to quickly set intervals on a linear range
  *
@@ -60,132 +56,96 @@ type IntervalsEditorProps = IntervalsEditorMetaProps & FieldProps;
  */
 export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
   const {
-    name,
-    formContext,
-    formData,
-    onChange,
-    params,
-    valueField,
-    units,
-    defaultUnit,
-    values,
+    data = [],
     defaultValue,
+    intervalType,
+    setData,
+    showValues = false,
+    title,
+    totalLength,
+    toolsConfig = {
+      cutTool: false,
+      deleteTool: false,
+      translateTool: false,
+      addTool: false,
+    },
   } = props;
-  // Wich segment area is visible
+
+  // Which segment areas are visible
   const [viewBox, setViewBox] = useState<[number, number] | null>(null);
   // Ref for the tooltip
   const tooltipRef = useRef<HTMLDivElement | null>(null);
-  // Wich segment is hovered
+  // Which segment is hovered
   const [hovered, setHovered] = useState<{ index: number; point: number } | null>(null);
   // Mode of the dataviz
-  const [mode, setMode] = useState<'dragging' | 'resizing' | 'creating' | null>(null);
+  const [mode, setMode] = useState<'dragging' | 'resizing' | null>(null);
 
-  // Fix the data (sort, fix gap, ...)
-  const [data, setData] = useState<Array<LinearMetadataItem>>(formData);
+  // Data to display
+  const [resizingData, setResizingData] = useState<Array<LinearMetadataItem>>(data);
+  useEffect(() => setResizingData(data), [data]);
 
-  // Wich segment is selected
+  // Which segment is selected
   const [selected, setSelected] = useState<number | null>(null);
+
   // For mouse click / doubleClick
   const [clickTimeout, setClickTimeout] = useState<number | null>(null);
   const [clickPrevent, setClickPrevent] = useState<boolean>(false);
-  const [selectedTool, setSelectedTool] = useState<ValueOf<typeof TOOLS> | null>(null);
+  const [selectedTool, setSelectedTool] = useState<IntervalsEditorTool | null>(null);
 
-  const { t } = useTranslation();
-
-  // Get the distance of the geometry
-  const distance = useMemo(() => {
-    if (!isNil(formContext.length)) {
-      return formContext.length;
-    }
-    if (formContext.geometry?.type === 'LineString') {
-      return getLineStringDistance(formContext.geometry);
-    }
-    return 0;
-  }, [formContext]);
-
-  const fixedData = useMemo(
-    () => fixLinearMetadataItems(formData?.filter(notEmpty), distance),
-    [formData, distance]
-  );
-
-  /**
-   * Main Callback: the wrapper will recieve a list on intervals with values
-   */
-  const customOnChange = useCallback(
-    (newData: Array<LinearMetadataItem>) => {
-      onChange(newData.filter((e) => (valueField ? !isNil(e[valueField]) : true)));
-    },
-    [onChange, valueField]
-  );
-
-  /**
-   * Resize segment after specific input (it does not trigger a callback for controlled input behavior, we choosed to let the user manually confirm it)
-   */
-  const resizeSegmentByInput = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>, context: 'begin' | 'end') => {
-      if (!isNil(selected)) {
-        const gap = parseFloat(e.target.value) - data[selected][context];
-        const result = resizeSegment(data, selected, gap, context, false);
-        const fixedResults = fixLinearMetadataItems(result.result?.filter(notEmpty), distance);
-        setData(fixedResults);
-      }
-    },
-    [selected]
-  );
-
-  const toggleSelectedTool = (tool: symbol) => {
+  const toggleSelectedTool = (tool: IntervalsEditorTool) => {
     setSelectedTool(selectedTool === tool ? null : tool);
   };
 
   const dataVizParams = useMemo(
-    () => ({ ticks: true, stringValues: isNil(units), showValues: params?.showValues }),
-    [params]
+    () => ({
+      ticks: true,
+      stringValues: intervalType !== INTERVAL_TYPES.NUMBER_WITH_UNIT,
+      showValues,
+    }),
+    [showValues]
   );
+
+  let formContent;
+  if (selected && data[selected]) {
+    if (intervalType === INTERVAL_TYPES.NUMBER_WITH_UNIT) {
+      const { fieldLabel, units } = props;
+      formContent = (
+        <IntervalsEditorMarginForm
+          data={data}
+          fieldLabel={fieldLabel}
+          interval={data[selected]}
+          selectedIntervalIndex={selected}
+          setData={setData}
+          units={units}
+        />
+      );
+    } else {
+      const { selectOptions } = props;
+      formContent = (
+        <IntervalsEditorSelectForm
+          data={data}
+          interval={data[selected]}
+          selectedIntervalIndex={selected}
+          setData={setData}
+          selectOptions={selectOptions}
+        />
+      );
+    }
+  }
 
   return (
     <div className="linear-metadata">
       <div className="header">
         <div>
-          <h4 className="control-label m-0">{`${name} ${valueField} ${
-            units ? `(${units.join(' / ')})` : ``
-          }`}</h4>
+          <h4 className="control-label m-0">{title}</h4>
         </div>
-        <div>
-          <div className="zoom-horizontal">
-            <button
-              title={t('common.zoom-in')}
-              type="button"
-              className="btn btn-sm btn-outline-secondary"
-              onClick={() => setViewBox(getZoomedViewBox(data, viewBox, 'IN'))}
-            >
-              <TbZoomIn />
-            </button>
-            <button
-              title={t('common.zoom-reset')}
-              type="button"
-              disabled={viewBox === null}
-              className="btn btn-sm btn-outline-secondary"
-              onClick={() => setViewBox(null)}
-            >
-              <TbZoomCancel />
-            </button>
-            <button
-              title={t('common.zoom-out')}
-              type="button"
-              disabled={viewBox === null}
-              className="btn btn-sm btn-outline-secondary"
-              onClick={() => setViewBox(getZoomedViewBox(data, viewBox, 'OUT'))}
-            >
-              <TbZoomOut />
-            </button>
-          </div>
-        </div>
+        <ZoomButtons data={data} setViewBox={setViewBox} viewBox={viewBox} />
       </div>
       <div className="content">
         <div className="dataviz">
           <LinearMetadataDataviz
-            data={data}
-            field={valueField}
+            creating={selectedTool === INTERVALS_EDITOR_TOOLS.ADD_TOOL}
+            data={resizingData}
             viewBox={viewBox}
             highlighted={[hovered ? hovered.index : -1, selected ?? -1].filter((e) => e > -1)}
             onMouseEnter={(_e, _item, index, point) => {
@@ -201,12 +161,13 @@ export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
               }
             }}
             onClick={(_e, _item, index, point) => {
-              if (mode === null && !isNil(_item[valueField])) {
+              const item = _item as IntervalItem;
+              if (mode === null && !isNil(item.value)) {
                 const timer = window.setTimeout(() => {
                   if (!clickPrevent) {
                     // case when you click on the already selected item => reset
                     // you can't select a blank interval
-                    if (!isNil(_item[valueField])) {
+                    if (!isNil(item.value)) {
                       setSelected((old) => ((old ?? -1) === index ? null : index));
                       setHovered(null);
                     }
@@ -215,20 +176,18 @@ export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
                 }, 50) as number;
                 setClickTimeout(timer);
               }
-              if (selectedTool === TOOLS.cutTool) {
+              if (selectedTool === INTERVALS_EDITOR_TOOLS.CUT_TOOL) {
                 if (clickTimeout) clearTimeout(clickTimeout);
                 setClickPrevent(true);
                 const newData = splitAt(data, point);
                 setData(newData);
-                customOnChange(newData);
               }
-              if (selectedTool === TOOLS.deleteTool) {
-                const newData = removeSegment(data, index, distance);
+              if (selectedTool === INTERVALS_EDITOR_TOOLS.DELETE_TOOL) {
+                const newData = removeSegment(data, index, totalLength);
                 setClickPrevent(false);
                 setData(newData);
                 setSelected(null);
-                customOnChange(newData);
-                toggleSelectedTool(TOOLS.deleteTool);
+                toggleSelectedTool(INTERVALS_EDITOR_TOOLS.DELETE_TOOL);
               }
             }}
             onWheel={(e, _item, _index, point) => {
@@ -242,16 +201,17 @@ export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
             onResize={(index, gap, finalized) => {
               setMode(!finalized ? 'resizing' : null);
               try {
-                const result = resizeSegment(fixedData, index, gap, 'end');
-                if (finalized) customOnChange(result.result);
-                else {
-                  setData(result.result);
+                const { result, newIndexMapping } = resizeSegment(data, index, gap, 'end');
+                if (finalized) {
+                  setData(result);
+                } else {
+                  setResizingData(result);
 
                   // if index has changed, we need to impact the index modification
-                  if (hovered && result.newIndexMapping[hovered.index] === null) {
-                    setHovered({ ...hovered, index: fnMax([0, hovered.index - 1]) || 0 });
+                  if (hovered && newIndexMapping[hovered.index] === null) {
+                    setHovered({ ...hovered, index: max([0, hovered.index - 1]) || 0 });
                   }
-                  if (selected && result.newIndexMapping[selected] === null) {
+                  if (selected && newIndexMapping[selected] === null) {
                     setSelected(null);
                   }
                 }
@@ -260,101 +220,17 @@ export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
                 console.warn(e);
               }
             }}
-            onCreate={(finalized) => {
-              setMode(!finalized ? 'creating' : null);
-              let newIntervalIndex = null;
-              try {
-                let result = cloneDeep(data);
-                if (hovered && selectedTool === TOOLS.addTool) {
-                  const filteredCurrentResults = result.filter((e) =>
-                    valueField ? !isNil(e[valueField]) : true
-                  );
-                  result = createSegmentAt(
-                    filteredCurrentResults,
-                    hovered.point - 1,
-                    hovered.point,
-                    distance,
-                    {
-                      fieldName: valueField,
-                      defaultValue: defaultValue || (values ? '' : 0),
-                      tagNew: true,
-                    }
-                  );
-                  toggleSelectedTool(TOOLS.addTool);
-
-                  newIntervalIndex = result.findIndex((intervalCloned) => intervalCloned.new);
-                  delete result[newIntervalIndex].new;
-                  setData(result);
-                }
-                customOnChange(result);
-              } catch (e) {
-                // TODO: should we display it ?
-                console.warn(e);
-              }
-              return newIntervalIndex;
+            onCreate={(point) => {
+              const newData = createEmptySegmentAt(data, point, 'value', defaultValue);
+              setData(newData);
             }}
             params={dataVizParams}
           />
-          <div className="btn-group-vertical">
-            <div className="tools">
-              {params?.addTool && (
-                <button
-                  className={`${
-                    selectedTool === TOOLS.addTool ? 'btn-selected' : 'btn'
-                  } btn-sm btn-outline-secondary`}
-                  type="button"
-                  title={t('common.add')}
-                  onClick={() => {
-                    toggleSelectedTool(TOOLS.addTool);
-                  }}
-                >
-                  <IoIosAdd />
-                </button>
-              )}
-              {params?.translateTool && (
-                <button
-                  className={`${
-                    selectedTool === TOOLS.translateTool ? 'btn-selected' : 'btn'
-                  } btn-sm btn-outline-secondary`}
-                  type="button"
-                  title={t('common.pan')}
-                  onClick={() => {
-                    toggleSelectedTool(TOOLS.translateTool);
-                  }}
-                >
-                  <TbArrowsHorizontal />
-                </button>
-              )}
-              {params?.cutTool && (
-                <button
-                  className={`${
-                    selectedTool === TOOLS.cutTool ? 'btn-selected' : 'btn'
-                  } btn-sm btn-outline-secondary`}
-                  type="button"
-                  title={t('common.select')}
-                  onClick={() => {
-                    toggleSelectedTool(TOOLS.cutTool);
-                  }}
-                >
-                  <TbScissors />
-                </button>
-              )}
-              {params?.deleteTool && (
-                <button
-                  className={`${
-                    selectedTool === TOOLS.deleteTool ? 'btn-selected' : 'btn'
-                  } btn-sm btn-outline-secondary`}
-                  type="button"
-                  title={t('common.delete')}
-                  onClick={() => {
-                    toggleSelectedTool(TOOLS.deleteTool);
-                  }}
-                >
-                  <BsFillTrashFill />
-                </button>
-              )}
-            </div>
-          </div>
+          <ToolButtons
+            selectedTool={selectedTool}
+            toolsConfig={toolsConfig}
+            toggleSelectedTool={toggleSelectedTool}
+          />
         </div>
 
         {/* Data visualisation tooltip when item is hovered */}
@@ -364,105 +240,18 @@ export const IntervalsEditor: React.FC<IntervalsEditorProps> = (props) => {
           </div>
         )}
 
-        {/* Flex dedicated edition */}
+        {/* Basic interval form */}
         {!isNil(selected) && data[selected] && (
           <div className="flexValuesEdition">
             <div className="flexValues">
-              <div>
-                <InputSNCF
-                  type="number"
-                  id="item-begin"
-                  label={t('begin')}
-                  onChange={(e) => {
-                    resizeSegmentByInput(e, 'begin');
-                  }}
-                  max={data[selected].end}
-                  value={data[selected].begin}
-                  isFlex
-                  noMargin
-                  sm
-                />
-                <InputSNCF
-                  type="number"
-                  id="item-end"
-                  label={t('end')}
-                  onChange={(e) => {
-                    resizeSegmentByInput(e, 'end');
-                  }}
-                  min={data[selected].begin}
-                  value={data[selected].end}
-                  isFlex
-                  noMargin
-                  sm
-                />
-              </div>
-              <div>
-                {values && values.length > 1 ? (
-                  <div className="flexValuesEditionSelect">
-                    <SelectSNCF
-                      id="item-valueField"
-                      options={values}
-                      labelKey="label"
-                      onChange={(e) => {
-                        const result = cloneDeep(data);
-                        if (result && result[selected]) {
-                          result[selected][valueField] = e.target.value;
-                          setData(result as LinearMetadataItem[]);
-                        }
-                      }}
-                      sm
-                      value={(data[selected][valueField] as string) || values[0]}
-                    />
-                  </div>
-                ) : (
-                  <InputSNCF
-                    type="number"
-                    id="item-valueField"
-                    label={valueField}
-                    onChange={(e) => {
-                      const result = cloneDeep(data);
-                      if (result && result[selected]) {
-                        result[selected][valueField] = parseFloat(e.target.value);
-                        setData(result as LinearMetadataItem[]);
-                      }
-                    }}
-                    value={data[selected][valueField] as number}
-                    noMargin
-                    sm
-                    isFlex
-                  />
-                )}
-                {units && units.length > 1 && (
-                  <div className="flexValuesEditionSelect">
-                    <SelectSNCF
-                      id="item-unit"
-                      options={units}
-                      labelKey="label"
-                      onChange={(e) => {
-                        const result = cloneDeep(data);
-                        result[selected].unit = e.target.value;
-                        setData(result as LinearMetadataItem[]);
-                      }}
-                      sm
-                      value={(data[selected].unit as string) || defaultUnit}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-            <div>
-              <button
-                className="btn"
-                type="button"
-                onClick={() => {
-                  customOnChange(data);
-                }}
-              >
-                <span className="mr-2">
-                  <IoIosSave />
-                </span>
-                {t('save')}
-              </button>
+              <IntervalsEditorCommonForm
+                data={data}
+                interval={data[selected]}
+                selectedIntervalIndex={selected}
+                setData={setData}
+                totalLength={totalLength}
+              />
+              {formContent}
             </div>
           </div>
         )}

--- a/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
+import { fixLinearMetadataItems, resizeSegment } from 'common/IntervalsDataViz/data';
+import { notEmpty } from 'common/IntervalsDataViz/utils';
+import { IntervalItem } from './types';
+
+type IntervalsEditorFormProps = {
+  data: IntervalItem[];
+  interval: IntervalItem;
+  selectedIntervalIndex: number;
+  setData: (newData: IntervalItem[]) => void;
+  totalLength: number;
+};
+
+const IntervalsEditorCommonForm = ({
+  data,
+  interval,
+  selectedIntervalIndex,
+  setData,
+  totalLength,
+}: IntervalsEditorFormProps) => {
+  const { t } = useTranslation('common/common');
+
+  /**
+   * Resize segment from inputs
+   */
+  // TODO: fix bug
+  const resizeSegmentByInput = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    context: 'begin' | 'end'
+  ) => {
+    const gap = parseFloat(e.target.value) - interval[context];
+    const { result } = resizeSegment(data, selectedIntervalIndex, gap, context, false);
+    const fixedResults = fixLinearMetadataItems(result.filter(notEmpty), totalLength);
+    setData(fixedResults);
+  };
+
+  return (
+    <div>
+      <InputSNCF
+        type="number"
+        id="item-begin"
+        label={t('begin')}
+        onChange={(e) => {
+          resizeSegmentByInput(e, 'begin');
+        }}
+        max={interval.end}
+        value={interval.begin}
+        isFlex
+        noMargin
+        sm
+      />
+      <InputSNCF
+        type="number"
+        id="item-end"
+        label={t('end')}
+        onChange={(e) => {
+          resizeSegmentByInput(e, 'end');
+        }}
+        min={interval.begin}
+        value={interval.end}
+        isFlex
+        noMargin
+        sm
+      />
+    </div>
+  );
+};
+
+export default React.memo(IntervalsEditorCommonForm);

--- a/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import SelectSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
+import { cloneDeep } from 'lodash';
+import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
+import { IntervalItem } from './types';
+
+type IntervalsEditorMarginFormProps = {
+  data: IntervalItem[];
+  defaultUnit?: string;
+  fieldLabel?: string;
+  interval: IntervalItem;
+  selectedIntervalIndex: number;
+  setData: (newData: IntervalItem[]) => void;
+  units: string[];
+};
+
+const IntervalsEditorMarginForm = ({
+  data,
+  defaultUnit,
+  fieldLabel,
+  interval,
+  selectedIntervalIndex,
+  setData,
+  units,
+}: IntervalsEditorMarginFormProps) => (
+  <div>
+    <InputSNCF
+      type="number"
+      id="item-valueField"
+      label={fieldLabel}
+      onChange={(e) => {
+        const result = cloneDeep(data);
+        if (result && result[selectedIntervalIndex]) {
+          result[selectedIntervalIndex].value = parseFloat(e.target.value);
+          setData(result as IntervalItem[]);
+        }
+      }}
+      value={interval.value as number}
+      noMargin
+      sm
+      isFlex
+    />
+    {units.length > 1 && (
+      <div className="flexValuesEditionSelect">
+        <SelectSNCF
+          options={units}
+          onChange={(newUnit) => {
+            const result = cloneDeep(data);
+            result[selectedIntervalIndex].unit = newUnit;
+            setData(result as IntervalItem[]);
+          }}
+          sm
+          selectedValue={(interval.unit as string) || defaultUnit || units[0]}
+        />
+      </div>
+    )}
+  </div>
+);
+
+export default IntervalsEditorMarginForm;

--- a/front/src/common/IntervalsEditor/IntervalsEditorSelectForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorSelectForm.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import SelectSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
+import { cloneDeep } from 'lodash';
+import { IntervalItem } from './types';
+
+type IntervalsEditorSelectFormProps = {
+  data: IntervalItem[];
+  interval: IntervalItem;
+  selectedIntervalIndex: number;
+  setData: (newData: IntervalItem[]) => void;
+  selectOptions: string[];
+};
+
+const IntervalsEditorSelectForm = ({
+  data,
+  interval,
+  selectedIntervalIndex,
+  setData,
+  selectOptions,
+}: IntervalsEditorSelectFormProps) => (
+  <div className="flexValuesEditionSelect">
+    <SelectSNCF
+      options={selectOptions}
+      onChange={(newValue) => {
+        const result = cloneDeep(data);
+        if (result[selectedIntervalIndex]) {
+          result[selectedIntervalIndex].value = newValue;
+          setData(result);
+        }
+      }}
+      sm
+      selectedValue={(interval.value as string) || selectOptions[0]}
+    />
+  </div>
+);
+
+export default IntervalsEditorSelectForm;

--- a/front/src/common/IntervalsEditor/IntervalsEditorToolButtons.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorToolButtons.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { ReactI18NextChild, useTranslation } from 'react-i18next';
+import { IoIosAdd } from 'react-icons/io';
+import { TbArrowsHorizontal, TbScissors } from 'react-icons/tb';
+import { BsFillTrashFill } from 'react-icons/bs';
+import { INTERVALS_EDITOR_TOOLS, IntervalsEditorTool, IntervalsEditorToolsConfig } from './types';
+
+const ToolButton = ({
+  selectedTool,
+  tool,
+  title,
+  icon,
+  toggleSelectedTool,
+}: {
+  selectedTool: IntervalsEditorTool | null;
+  tool: IntervalsEditorTool;
+  title: string;
+  icon: ReactI18NextChild;
+  toggleSelectedTool: (tool: IntervalsEditorTool) => void;
+}) => (
+  <button
+    className={`${selectedTool === tool ? 'btn-selected' : 'btn'} btn-sm btn-outline-secondary`}
+    type="button"
+    title={title}
+    onClick={() => {
+      toggleSelectedTool(tool);
+    }}
+  >
+    {icon}
+  </button>
+);
+
+type ToolButtonsProps = {
+  selectedTool: IntervalsEditorTool | null;
+  toolsConfig: IntervalsEditorToolsConfig;
+  toggleSelectedTool: (tool: IntervalsEditorTool) => void;
+};
+
+const ToolButtons = ({ selectedTool, toolsConfig, toggleSelectedTool }: ToolButtonsProps) => {
+  const { t } = useTranslation('common/common');
+
+  return (
+    <div className="btn-group-vertical">
+      <div className="tools">
+        {toolsConfig.addTool && (
+          <ToolButton
+            selectedTool={selectedTool}
+            tool={INTERVALS_EDITOR_TOOLS.ADD_TOOL}
+            title={t('actions.add')}
+            icon={<IoIosAdd />}
+            toggleSelectedTool={toggleSelectedTool}
+          />
+        )}
+        {toolsConfig.translateTool && (
+          <ToolButton
+            selectedTool={selectedTool}
+            tool={INTERVALS_EDITOR_TOOLS.TRANSLATE_TOOL}
+            title={t('actions.translate')}
+            icon={<TbArrowsHorizontal />}
+            toggleSelectedTool={toggleSelectedTool}
+          />
+        )}
+        {toolsConfig.cutTool && (
+          <ToolButton
+            selectedTool={selectedTool}
+            tool={INTERVALS_EDITOR_TOOLS.CUT_TOOL}
+            title={t('actions.split')}
+            icon={<TbScissors />}
+            toggleSelectedTool={toggleSelectedTool}
+          />
+        )}
+        {toolsConfig.deleteTool && (
+          <ToolButton
+            selectedTool={selectedTool}
+            tool={INTERVALS_EDITOR_TOOLS.DELETE_TOOL}
+            title={t('actions.delete')}
+            icon={<BsFillTrashFill />}
+            toggleSelectedTool={toggleSelectedTool}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ToolButtons;

--- a/front/src/common/IntervalsEditor/ZoomButtons.tsx
+++ b/front/src/common/IntervalsEditor/ZoomButtons.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TbZoomCancel, TbZoomIn, TbZoomOut } from 'react-icons/tb';
+import { getZoomedViewBox } from 'common/IntervalsDataViz/data';
+import { IntervalItem } from './types';
+
+type ZoomButtonProps = {
+  data: IntervalItem[];
+  setViewBox: (viewBox: [number, number] | null) => void;
+  viewBox: [number, number] | null;
+};
+
+const ZoomButtons = ({ data, setViewBox, viewBox }: ZoomButtonProps) => {
+  const { t } = useTranslation('common/common');
+
+  return (
+    <div>
+      <div className="zoom-horizontal">
+        <button
+          title={t('actions.zoom-in')}
+          type="button"
+          className="btn btn-sm btn-outline-secondary"
+          onClick={() => setViewBox(getZoomedViewBox(data, viewBox, 'IN'))}
+        >
+          <TbZoomIn />
+        </button>
+        <button
+          title={t('actions.reset')}
+          type="button"
+          disabled={viewBox === null}
+          className="btn btn-sm btn-outline-secondary"
+          onClick={() => setViewBox(null)}
+        >
+          <TbZoomCancel />
+        </button>
+        <button
+          title={t('actions.zoom-out')}
+          type="button"
+          disabled={viewBox === null}
+          className="btn btn-sm btn-outline-secondary"
+          onClick={() => setViewBox(getZoomedViewBox(data, viewBox, 'OUT'))}
+        >
+          <TbZoomOut />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ZoomButtons;

--- a/front/src/common/IntervalsEditor/types.ts
+++ b/front/src/common/IntervalsEditor/types.ts
@@ -1,0 +1,27 @@
+import { LinearMetadataItem } from 'common/IntervalsDataViz/data';
+
+export enum INTERVAL_TYPES {
+  NUMBER_WITH_UNIT = 'number-with-unit',
+  SELECT = 'select',
+}
+
+export type IntervalItem = LinearMetadataItem<{ value: number | string; unit?: string }>;
+
+export enum INTERVALS_EDITOR_TOOLS {
+  ADD_TOOL = 'add-tool',
+  CUT_TOOL = 'cut-tool',
+  DELETE_TOOL = 'delete-tool',
+  TRANSLATE_TOOL = 'translate-tool',
+}
+export type IntervalsEditorTool =
+  | INTERVALS_EDITOR_TOOLS.ADD_TOOL
+  | INTERVALS_EDITOR_TOOLS.CUT_TOOL
+  | INTERVALS_EDITOR_TOOLS.DELETE_TOOL
+  | INTERVALS_EDITOR_TOOLS.TRANSLATE_TOOL;
+
+export type IntervalsEditorToolsConfig = {
+  cutTool?: boolean;
+  deleteTool?: boolean;
+  translateTool?: boolean;
+  addTool?: boolean;
+};

--- a/front/src/stories/IntervalsEditor.stories.tsx
+++ b/front/src/stories/IntervalsEditor.stories.tsx
@@ -1,67 +1,103 @@
-import { FieldProps } from '@rjsf/core';
-import { LinearMetadataItem } from 'common/IntervalsDataViz/data';
-import { IntervalsEditor } from 'common/IntervalsEditor/IntervalsEditor';
 import React, { useState } from 'react';
 import 'stories/storybook.css';
 
+import { LinearMetadataItem, fixLinearMetadataItems } from 'common/IntervalsDataViz/data';
+import { notEmpty } from 'common/IntervalsDataViz/utils';
+import { IntervalsEditor } from 'common/IntervalsEditor/IntervalsEditor';
+import {
+  INTERVAL_TYPES,
+  IntervalItem,
+  IntervalsEditorToolsConfig,
+} from 'common/IntervalsEditor/types';
+
 const formDataBase = [
   { begin: 0, end: 6000 },
-  { begin: 6000, end: 7000, gradient: 3 },
-  { begin: 7000, end: 8000, gradient: 6 },
-  { begin: 8000, end: 9000, gradient: 3 },
+  { begin: 6000, end: 7000, value: 3 },
+  { begin: 7000, end: 8000, value: 6 },
+  { begin: 8000, end: 9000, value: 3 },
   { begin: 9000, end: 14000 },
-  { begin: 14000, end: 15000, gradient: -3 },
-  { begin: 15000, end: 16000, gradient: -6 },
-  { begin: 16000, end: 17000, gradient: -3 },
+  { begin: 14000, end: 15000, value: -3 },
+  { begin: 15000, end: 16000, value: -6 },
+  { begin: 16000, end: 17000, value: -3 },
   { begin: 17000, end: 25000 },
 ];
 
 const formDataBaseCategories = [
   { begin: 0, end: 6000 },
-  { begin: 6000, end: 7000, power: 'U3' },
-  { begin: 7000, end: 8000, power: 'U5' },
-  { begin: 8000, end: 9000, power: 'U4' },
+  { begin: 6000, end: 7000, value: 'U3' },
+  { begin: 7000, end: 8000, value: 'U5' },
+  { begin: 8000, end: 9000, value: 'U4' },
   { begin: 9000, end: 14000 },
-  { begin: 14000, end: 15000, power: 'U1' },
-  { begin: 15000, end: 16000, power: 'U3' },
-  { begin: 16000, end: 17000, power: 'U3' },
+  { begin: 14000, end: 15000, value: 'U1' },
+  { begin: 15000, end: 16000, value: 'U3' },
+  { begin: 16000, end: 17000, value: 'U3' },
   { begin: 17000, end: 25000 },
 ];
 
-const formContextSample = {
-  geometry: {
-    coordinates: [
-      [-0.296, 49.5],
-      [-0.172, 49.5],
-    ],
-    type: 'LineString',
-  },
-  length: 25000,
-  isCreation: false,
+type IntervalsEditorProps = {
+  defaultValue: number | string;
+  defaultUnit?: string;
+  exampleData: IntervalItem[];
+  fieldLabel: string;
+  intervalType: INTERVAL_TYPES.NUMBER_WITH_UNIT | INTERVAL_TYPES.SELECT;
+  toolsConfig?: IntervalsEditorToolsConfig;
+  title?: string;
+  totalLength: number;
+  selectOptions?: string[];
+  units: string[];
 };
 
-const IntervalsEditorWrapper: React.FC<FieldProps> = (props) => {
-  const { formContext, params, valueField, defaultValue, dataBase, values } = props;
-  const [mockedData, setMockedData] = useState<LinearMetadataItem[] | null>(dataBase);
-  const onChange = (newData: LinearMetadataItem[]) => {
-    setMockedData(newData);
-  };
+const IntervalsEditorWrapper: React.FC<IntervalsEditorProps> = (props) => {
+  const {
+    defaultValue,
+    exampleData,
+    fieldLabel,
+    intervalType,
+    selectOptions,
+    title,
+    toolsConfig,
+    totalLength,
+    units = [],
+  } = props;
+  const [data, setData] = useState<IntervalItem[]>(
+    fixLinearMetadataItems(exampleData.filter(notEmpty), totalLength)
+  );
+
+  if (intervalType === INTERVAL_TYPES.NUMBER_WITH_UNIT) {
+    return (
+      <IntervalsEditor
+        {...props}
+        data={data as LinearMetadataItem<{ value: number | string; unit: string }>[]}
+        defaultValue={defaultValue}
+        fieldLabel={fieldLabel}
+        intervalType={intervalType}
+        setData={setData}
+        showValues
+        title={title}
+        totalLength={totalLength}
+        toolsConfig={toolsConfig}
+        units={units}
+      />
+    );
+  }
   return (
     <IntervalsEditor
       {...props}
-      formContext={formContext}
-      formData={mockedData}
-      params={params}
-      valueField={valueField}
-      onChange={onChange}
-      defaultValue={defaultValue as number}
-      values={values}
+      data={data as LinearMetadataItem<{ value: number | string }>[]}
+      defaultValue={defaultValue}
+      intervalType={intervalType}
+      setData={setData}
+      showValues
+      title={title}
+      totalLength={totalLength}
+      toolsConfig={toolsConfig}
+      selectOptions={selectOptions || []}
     />
   );
 };
 
 export default {
-  title: 'IntervalsDemonstrator',
+  title: 'Common/IntervalsDemonstrator',
   component: IntervalsEditorWrapper,
   argTypes: {
     onChange: { description: 'Value sent back to wrapper', action: 'onChange' },
@@ -70,37 +106,36 @@ export default {
 
 export const ByContinousValues = {
   args: {
-    formContext: formContextSample,
-    valueField: 'gradient',
-    params: {
+    defaultValue: 5,
+    exampleData: formDataBase,
+    fieldLabel: 'gradient',
+    intervalType: INTERVAL_TYPES.NUMBER_WITH_UNIT,
+    title: 'Gradient on path',
+    toolsConfig: {
       deleteTool: true,
       translateTool: false,
       cutTool: true,
       addTool: true,
-      showValues: true,
     },
+    totalLength: 25000,
     units: ['s', 'm'],
-    name: 'linearMetaData',
-    defaultValue: null,
-    dataBase: formDataBase,
-  },
+  } as IntervalsEditorProps,
 };
 
 export const ByCategories = {
   args: {
-    formContext: formContextSample,
-    valueField: 'power',
-    params: {
+    defaultValue: 'U1',
+    exampleData: formDataBaseCategories,
+    fieldLabel: 'value',
+    intervalType: INTERVAL_TYPES.SELECT,
+    selectOptions: ['U1', 'U2', 'U3', 'U4', 'U5'],
+    title: 'Power restrictions on path',
+    toolsConfig: {
       deleteTool: true,
       translateTool: false,
       cutTool: true,
       addTool: true,
-      showValues: true,
     },
-    units: null,
-    name: 'linearMetaData',
-    defaultValue: null,
-    dataBase: formDataBaseCategories,
-    values: ['U1', 'U2', 'U3', 'U4', 'U5'],
-  },
+    totalLength: 25000,
+  } as IntervalsEditorProps,
 };


### PR DESCRIPTION
![image](https://github.com/osrd-project/osrd/assets/45000526/3f69bb4f-9b8f-4ffa-be16-6e27731890df)

This PR modifies the intervals editor component:
- create separated components for the zoom buttons, the tool buttons and the interval forms
- rename and clean some of props of the component
- fix the creating behavior
- implement strong types on the component and use the field "value" to store the interval value (replace the "fieldName" prop)
  -> if interval is a NUMBER_WITH_UNIT interval, then it should have 2 fields (value and unit). Otherwise, it only has a value field

You can test the component on storybook:
- [ ] you should be able to create new intervals (with button + on the right side, click and drag to the right)
- [ ] you should be able to split and delete intervals (unchanged behavior)
- [ ] with the wheel, you should be able to zoom in and zoom out
- [ ] you should be able to extend an interval thanks to the side bar of each interval (white div around each interval)
- [ ] when you select an interval, the correct value form should open (either only a select or an number input+unit select) and should work

closes #4623 