### PR TITLE
core: kt-infra: migrate pathfinding heuristic

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/LegacyRemainingDistanceEstimator.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/LegacyRemainingDistanceEstimator.java
@@ -1,0 +1,88 @@
+package fr.sncf.osrd.api.pathfinding;
+
+import fr.sncf.osrd.geom.Point;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.reporting.exceptions.OSRDError;
+import fr.sncf.osrd.reporting.exceptions.ErrorType;
+import fr.sncf.osrd.utils.graph.functional_interfaces.AStarHeuristic;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/** This is a function object that estimates the remaining distance to the closest target point,
+ * using geo data. It is used as heuristic for A*. */
+public class LegacyRemainingDistanceEstimator implements AStarHeuristic<SignalingRoute> {
+
+    private final Collection<Point> targets;
+    private final double remainingDistance;
+
+    /** Targets closer than this threshold will be merged together */
+    private static final double distanceThreshold = 1.;
+
+    /** Constructor */
+    public LegacyRemainingDistanceEstimator(
+            Collection<Pathfinding.EdgeLocation<SignalingRoute>> edgeLocations,
+            double remainingDistance
+    ) {
+        targets = new ArrayList<>();
+        for (var edgeLocation : edgeLocations) {
+            var point = routeOffsetToPoint(edgeLocation.edge(), edgeLocation.offset());
+            var skip = false;
+            for (var otherPoint : targets) {
+                if (point.distanceAsMeters(otherPoint) < distanceThreshold) {
+                    skip = true; // Avoid adding duplicate geo points to the target list
+                    break;
+                }
+            }
+            if (!skip)
+                targets.add(point);
+        }
+        this.remainingDistance = remainingDistance;
+    }
+
+    /** Converts a route and offset from its start into a geo point */
+    private static Point routeOffsetToPoint(SignalingRoute route, double pointOffset) {
+        for (var trackRange : route.getInfraRoute().getTrackRanges()) {
+            if (pointOffset <= trackRange.getLength()) {
+                var trackLocation = trackRange.offsetLocation(pointOffset);
+                var normalizedOffset = trackLocation.offset() / trackLocation.track().getLength();
+                var geo = trackLocation.track().getGeo();
+                if (geo == null)
+                    return new Point(0, 0);
+                return geo.interpolateNormalized(normalizedOffset);
+            }
+            pointOffset -= trackRange.getLength();
+        }
+        throw new OSRDError(ErrorType.InvalidRouteNoOffset);
+    }
+
+    /** Compute the minimum geo distance between two steps */
+    public static double minDistanceBetweenSteps(
+            Collection<Pathfinding.EdgeLocation<SignalingRoute>> step1,
+            Collection<Pathfinding.EdgeLocation<SignalingRoute>> step2
+    ) {
+        var step1Points = step1.stream()
+                .map(loc -> routeOffsetToPoint(loc.edge(), loc.offset()))
+                .toList();
+        var step2Points = step2.stream()
+                .map(loc -> routeOffsetToPoint(loc.edge(), loc.offset()))
+                .toList();
+
+        var res = Double.POSITIVE_INFINITY;
+        for (var point1: step1Points) {
+            for (var point2: step2Points) {
+                res = Double.min(res, point1.distanceAsMeters(point2));
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public double apply(SignalingRoute signalingRoute, double offset) {
+        var res = Double.POSITIVE_INFINITY;
+        var point = routeOffsetToPoint(signalingRoute, offset);
+        for (var target : targets)
+            res = Double.min(res, point.distanceAsMeters(target));
+        return res + remainingDistance;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingRoutesEndpoint.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.api.pathfinding;
 
-import static fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator.minDistanceBetweenSteps;
+import static fr.sncf.osrd.api.pathfinding.LegacyRemainingDistanceEstimator.minDistanceBetweenSteps;
 
 import fr.sncf.osrd.api.ExceptionHandler;
 import fr.sncf.osrd.api.InfraManager;
@@ -132,7 +132,8 @@ public class PathfindingRoutesEndpoint implements Take {
         // Setup estimators foreach intermediate steps
         var remainingDistanceEstimators = new ArrayList<AStarHeuristic<SignalingRoute>>();
         for (int i = 0; i < waypoints.size() - 1; i++) {
-            remainingDistanceEstimators.add(new RemainingDistanceEstimator(waypoints.get(i + 1), stepMinDistance[i]));
+            remainingDistanceEstimators.add(new LegacyRemainingDistanceEstimator(waypoints.get(i + 1),
+                    stepMinDistance[i]));
         }
         return remainingDistanceEstimators;
     }

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingUtils.java
@@ -1,15 +1,10 @@
-package fr.sncf.osrd.api.pathfinding.constraints;
+package fr.sncf.osrd.api.pathfinding;
 
 import static fr.sncf.osrd.sim_infra.api.PathKt.buildPathFrom;
 import static fr.sncf.osrd.utils.KtToJavaConverter.toIntList;
 
-import fr.sncf.osrd.sim_infra.api.BlockInfra;
-import fr.sncf.osrd.sim_infra.api.Path;
-import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
-import fr.sncf.osrd.sim_infra.api.TrackChunk;
-import fr.sncf.osrd.sim_infra.impl.PathImpl;
+import fr.sncf.osrd.sim_infra.api.*;
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList;
-import fr.sncf.osrd.utils.units.Distance;
 
 public class PathfindingUtils {
 

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.api.pathfinding.constraints;
 
-import static fr.sncf.osrd.api.pathfinding.constraints.PathfindingUtils.makePath;
+import static fr.sncf.osrd.api.pathfinding.PathfindingUtils.makePath;
 
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/LoadingGaugeConstraints.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/LoadingGaugeConstraints.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.api.pathfinding.constraints;
 
-import static fr.sncf.osrd.api.pathfinding.constraints.PathfindingUtils.makePath;
+import static fr.sncf.osrd.api.pathfinding.PathfindingUtils.makePath;
 
 import fr.sncf.osrd.sim_infra.api.BlockInfra;
 import fr.sncf.osrd.sim_infra.api.Path;

--- a/core/src/test/java/fr/sncf/osrd/Helpers.java
+++ b/core/src/test/java/fr/sncf/osrd/Helpers.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd;
 
 import static fr.sncf.osrd.api.SignalingSimulatorKt.makeSignalingSimulator;
+import static fr.sncf.osrd.utils.KtToJavaConverter.toIntList;
 
 import com.squareup.moshi.JsonAdapter;
 import fr.sncf.osrd.api.FullInfra;
@@ -12,6 +13,12 @@ import fr.sncf.osrd.railjson.schema.infra.RJSInfra;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
+import fr.sncf.osrd.sim_infra.api.LoadedSignalingInfraKt;
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
+import fr.sncf.osrd.sim_infra.api.Route;
+import fr.sncf.osrd.sim_infra.api.SignalingSystem;
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList;
+import fr.sncf.osrd.utils.indexing.StaticIdxList;
 import fr.sncf.osrd.utils.moshi.MoshiUtils;
 import java.io.File;
 import java.io.IOException;
@@ -96,5 +103,39 @@ public class Helpers {
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /** returns the blocks on the given routes */
+    public static List<Integer> getBlocksOnRoutes(FullInfra infra, List<String> names) {
+        var res = new ArrayList<Integer>();
+        var routes = new MutableStaticIdxArrayList<Route>();
+        for (var name: names)
+            routes.add(getRouteFromName(infra.rawInfra(), name));
+        var routeBlocks = LoadedSignalingInfraKt.getRouteBlocks(
+                infra.rawInfra(),
+                infra.blockInfra(),
+                routes,
+                getSignalingSystem(infra)
+        );
+        for (var blockList : routeBlocks)
+            res.addAll(toIntList(blockList));
+        return res;
+    }
+
+    /** Finds the id of the route with the given name */
+    private static int getRouteFromName(RawSignalingInfra infra, String name) {
+        for (int i = 0; i < infra.getRoutes(); i++) {
+            if (name.equals(infra.getRouteName(i)))
+                return i;
+        }
+        throw new RuntimeException("Can't find the given route");
+    }
+
+    /** Returns the idx list of signaling systems */
+    private static StaticIdxList<SignalingSystem> getSignalingSystem(FullInfra infra) {
+        var res = new MutableStaticIdxArrayList<SignalingSystem>();
+        for (int i = 0; i < infra.signalingSimulator().getSigModuleManager().getSignalingSystems(); i++)
+            res.add(i);
+        return res;
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.api.pathfinding;
 
+import static fr.sncf.osrd.Helpers.getBlocksOnRoutes;
 import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.getBlockLength;
 import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.makePath;
 import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.makePathWaypoint;
@@ -196,39 +197,5 @@ public class PathfindingResultConverterTest {
             totalLength += infra.rawInfra().getTrackChunkLength(toValue(dirChunk));
         }
         assertEquals(length, totalLength);
-    }
-
-    /** returns the blocks on the given routes */
-    private static List<Integer> getBlocksOnRoutes(FullInfra infra, List<String> names) {
-        var res = new ArrayList<Integer>();
-        var routes = new MutableStaticIdxArrayList<Route>();
-        for (var name: names)
-            routes.add(getRouteFromName(infra.rawInfra(), name));
-        var routeBlocks = LoadedSignalingInfraKt.getRouteBlocks(
-                infra.rawInfra(),
-                infra.blockInfra(),
-                routes,
-                getSignalingSystem(infra)
-        );
-        for (var blockList : routeBlocks)
-            res.addAll(toIntList(blockList));
-        return res;
-    }
-
-    /** Finds the id of the route with the given name */
-    private static int getRouteFromName(RawSignalingInfra infra, String name) {
-        for (int i = 0; i < infra.getRoutes(); i++) {
-            if (name.equals(infra.getRouteName(i)))
-                return i;
-        }
-        throw new RuntimeException("Can't find the given route");
-    }
-
-    /** Returns the idx list of signaling systems */
-    private static StaticIdxList<SignalingSystem> getSignalingSystem(FullInfra infra) {
-        var res = new MutableStaticIdxArrayList<SignalingSystem>();
-        for (int i = 0; i < infra.signalingSimulator().getSigModuleManager().getSignalingSystems(); i++)
-            res.add(i);
-        return res;
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/api/pathfinding/RemainingDistanceEstimatorTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/pathfinding/RemainingDistanceEstimatorTest.java
@@ -1,0 +1,97 @@
+package fr.sncf.osrd.api.pathfinding;
+
+import static fr.sncf.osrd.Helpers.getBlocksOnRoutes;
+import static fr.sncf.osrd.api.pathfinding.PathfindingUtils.makePath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Iterables;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.Helpers;
+import fr.sncf.osrd.api.FullInfra;
+import fr.sncf.osrd.sim_infra.api.Path;
+import fr.sncf.osrd.utils.graph.Pathfinding;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RemainingDistanceEstimatorTest {
+
+    private FullInfra smallInfra;
+    private int block;
+    private Path path;
+
+    @BeforeAll
+    public void setUp() {
+        smallInfra = Helpers.getSmallInfra();
+        block = getBlocksOnRoutes(smallInfra, List.of(
+                "rt.DA2->DA6_1"
+        )).get(0);
+        path = makePath(smallInfra.blockInfra(), smallInfra.rawInfra(), block);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testRemainingDistanceEstimatorArgs")
+    public void testRemainingDistanceEstimator(
+            Collection<Pathfinding.EdgeLocation<Integer>> edgeLocations,
+            double remainingDistance,
+            double expectedDistance,
+            double blockOffset
+    ) {
+        var estimator = new RemainingDistanceEstimator(smallInfra.rawInfra(), smallInfra.blockInfra(), edgeLocations,
+                remainingDistance);
+        assertEquals(expectedDistance, estimator.apply(block, blockOffset));
+    }
+
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "called implicitly by MethodSource")
+    private Stream<Arguments> testRemainingDistanceEstimatorArgs() {
+        var points = path.getGeo().getPoints();
+        return Stream.of(
+                // Test same point
+                Arguments.of(
+                        List.of(new Pathfinding.EdgeLocation<>(block, 0)),
+                        0,
+                        0,
+                        0
+                ),
+                // Test same point with non-null remaining distance
+                Arguments.of(
+                        List.of(new Pathfinding.EdgeLocation<>(block, 0)),
+                        10,
+                        10,
+                        0
+                ),
+                // Test with target at the end of the edge
+                Arguments.of(
+                        List.of(new Pathfinding.EdgeLocation<>(block, path.getLength())),
+                        0,
+                        points.get(0).distanceAsMeters(Iterables.getLast(points)),
+                        0
+                ),
+                // Test multiple targets
+                Arguments.of(
+                        List.of(
+                                new Pathfinding.EdgeLocation<>(block, 0),
+                                new Pathfinding.EdgeLocation<>(block, path.getLength())
+                        ),
+                        0,
+                        0,
+                        0
+                ),
+                // Test with an offset on the block
+                Arguments.of(
+                        List.of(
+                                new Pathfinding.EdgeLocation<>(block, path.getLength())
+                        ),
+                        0,
+                        0,
+                        path.getLength()
+                )
+        );
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.java
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
 import com.google.common.graph.ImmutableNetwork;
 import fr.sncf.osrd.Helpers;
-import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator;
+import fr.sncf.osrd.api.pathfinding.LegacyRemainingDistanceEstimator;
 import fr.sncf.osrd.infra.api.reservation.DiDetector;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra.implementation.signaling.modules.bal3.BAL3;
@@ -30,7 +30,7 @@ public class AStarTests {
         var lastRoute = infra.findSignalingRoute("rt.DH1_2->buffer_stop.7", "BAL3");
         var origin = Set.of(new Pathfinding.EdgeLocation<>(firstRoute, 0));
         var destination = Set.of(new Pathfinding.EdgeLocation<>(lastRoute, 0));
-        var remainingDistanceEstimator = new RemainingDistanceEstimator(destination, 0.);
+        var remainingDistanceEstimator = new LegacyRemainingDistanceEstimator(destination, 0.);
         var seen = new HashSet<SignalingRoute>();
         new Pathfinding<>(new GraphAdapter<>(graph))
                 .setEdgeToLength(x -> x.getInfraRoute().getLength())


### PR DESCRIPTION
Fixes https://github.com/osrd-project/osrd/issues/4257

The old heuristic class has been renamed to `LegacyRemainingDistanceEstimator`, a new version has been added using blocks and the new infra interfaces. 