### PR TITLE
editoast: Add ROOT_PATH support

### DIFF
--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -61,6 +61,9 @@ pub struct RunserverArgs {
     pub sentry_dsn: Option<String>,
     #[arg(long, env = "SENTRY_ENV")]
     pub sentry_env: Option<String>,
+    #[derivative(Default(value = r#""".into()"#))]
+    #[clap(long, env = "ROOT_PATH", default_value_t = String::new())]
+    pub root_path: String,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -22,7 +22,7 @@ use crate::schema::RailJson;
 use crate::views::infra::InfraForm;
 use actix_cors::Cors;
 use actix_web::middleware::{Condition, Logger, NormalizePath};
-use actix_web::web::{block, Data, JsonConfig, PayloadConfig};
+use actix_web::web::{block, scope, Data, JsonConfig, PayloadConfig};
 use actix_web::{App, HttpServer};
 use chashmap::CHashMap;
 use clap::Parser;
@@ -166,7 +166,11 @@ async fn runserver(
             .app_data(Data::new(args.map_layers_config.clone()))
             .app_data(Data::new(SearchConfig::parse()))
             .app_data(Data::new(core_client))
-            .service((views::routes(), views::study_routes()))
+            .service(
+                scope(&args.root_path)
+                    .service(views::routes())
+                    .service(views::study_routes()),
+            )
     });
 
     // Run server


### PR DESCRIPTION
Needed to have the same as api `ROOT_PATH` parameter in order to have a clean deployment in the SNCF SI.