### PR TITLE
editoast: remove useless cargo sparse index config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
It's now the default