### PR TITLE
editoast: remove .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
It isn't necessary anymore as the sparse protocol is now the default.