### PR TITLE
editoast: add utoipa annotations for GET /health

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2790,6 +2790,10 @@ paths:
     get:
       responses:
         '200':
+          content:
+            text/plain:
+              schema:
+                type: string
           description: Check if Editoast is running correctly
   /infra/:
     get:

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -59,7 +59,7 @@ pub fn study_routes() -> impl HttpServiceFactory {
 #[openapi(
     info(description = "My Api description"),
     tags(),
-    paths(),
+    paths(health),
     components(schemas(), responses())
 )]
 pub struct OpenApiRoot;
@@ -86,10 +86,17 @@ impl OpenApiRoot {
         let generated = openapi
             .to_json()
             .expect("the openapi should generate properly");
-        OpenApiMerger::new(manual, generated).finish()
+        OpenApiMerger::new(manual, generated)
+            .replace("paths/health/")
+            .finish()
     }
 }
 
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Check if Editoast is running correctly", body = String)
+    )
+)]
 #[get("/health")]
 async fn health(db_pool: Data<DbPool>, redis_client: Data<RedisClient>) -> Result<&'static str> {
     block::<_, Result<_>>(move || {


### PR DESCRIPTION
Part of https://github.com/osrd-project/osrd/issues/3625, https://github.com/osrd-project/osrd/issues/4580

`/health` endpoint is auto-generated by utoipa, and `openapi.yaml` generated accordingly.

`osrdEditoastApi.ts` was not changed after generation.