### PR TITLE
core: kt-infra: stdcm: migrate availability legacy adapter

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
@@ -81,16 +81,22 @@ interface RoutingInfra : ReservationInfra {
     fun getChunksOnRoute(route: RouteId): DirStaticIdxList<TrackChunk>
     @JvmName("getRoutesOnTrackChunk")
     fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxList<Route>
+    @JvmName("getRoutesStartingAtDet")
+    fun getRoutesStartingAtDet(dirDetector: DirDetectorId): StaticIdxList<Route>
+    @JvmName("getRoutesEndingAtDet")
+    fun getRoutesEndingAtDet(dirDetector: DirDetectorId): StaticIdxList<Route>
 }
 
 fun ReservationInfra.findZonePath(entry: DirDetectorId, exit: DirDetectorId): ZonePathId? {
     return findZonePath(entry, exit, mutableStaticIdxArrayListOf(), mutableStaticIdxArrayListOf())
 }
 
+@JvmName("getRouteEntry")
 fun RoutingInfra.getRouteEntry(route: RouteId): DirDetectorId {
     return getZonePathEntry(getRoutePath(route).first())
 }
 
+@JvmName("getRouteExit")
 fun RoutingInfra.getRouteExit(route: RouteId): DirDetectorId {
     return getZonePathExit(getRoutePath(route).last())
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
@@ -44,4 +44,14 @@ fun RawSignalingInfra.getLogicalSignalName(signal: LogicalSignalId): String? {
     return getPhysicalSignalName(getPhysicalSignal(signal))
 }
 
+/** Returns the length of a route  */
+@JvmName("getRouteLength")
+fun RawSignalingInfra.getRouteLength(route: RouteId): Distance {
+    var res = 0.meters
+    for (zonePath in getRoutePath(route)) {
+        res += getZonePathLength(zonePath)
+    }
+    return res
+}
+
 typealias RawInfra = RawSignalingInfra

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -393,7 +393,33 @@ class RawInfraBuilderImpl : RawInfraBuilder {
             operationalPointPartPool,
             makeTrackNameMap(),
             makeRouteNameMap(),
+            makeDetEntryToRouteMap(),
+            makeDetExitToRouteMap()
         )
+    }
+
+    /** Create the mapping from each dir detector to routes that start there */
+    private fun makeDetEntryToRouteMap(): Map<DirStaticIdx<Detector>, StaticIdxList<Route>> {
+        val res = HashMap<DirStaticIdx<Detector>, MutableStaticIdxArrayList<Route>>()
+        for (routeId in routePool) {
+            val firstZonePath = routePool[routeId].path.first()
+            val entry = zonePathPool[firstZonePath].entry
+            res.computeIfAbsent(entry) { mutableStaticIdxArrayListOf() }
+                .add(routeId)
+        }
+        return res
+    }
+
+    /** Create the mapping from each dir detector to routes that end there */
+    private fun makeDetExitToRouteMap(): Map<DirStaticIdx<Detector>, StaticIdxList<Route>> {
+        val res = HashMap<DirStaticIdx<Detector>, MutableStaticIdxArrayList<Route>>()
+        for (routeId in routePool) {
+            val lastZonePath = routePool[routeId].path.last()
+            val exit = zonePathPool[lastZonePath].exit
+            res.computeIfAbsent(exit) { mutableStaticIdxArrayListOf() }
+                .add(routeId)
+        }
+        return res
     }
 
     /** Create the mapping from track name to id */

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -136,6 +136,8 @@ class RawInfraImpl(
     val operationalPointPartPool: StaticPool<OperationalPointPart, OperationalPointPartDescriptor>,
     val trackSectionNameMap: Map<String, TrackSectionId>,
     val routeNameMap: Map<String, RouteId>,
+    val dirDetEntryToRouteMap: Map<DirDetectorId, StaticIdxList<Route>>,
+    val dirDetExitToRouteMap: Map<DirDetectorId, StaticIdxList<Route>>
 ) : RawInfra {
     override val trackNodes: StaticIdxSpace<TrackNode>
         get() = trackNodePool.space()
@@ -247,6 +249,14 @@ class RawInfraImpl(
 
     override fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxList<Route> {
         return trackChunkPool[trackChunk.value].routes.get(trackChunk.direction)
+    }
+
+    override fun getRoutesStartingAtDet(dirDetector: DirDetectorId): StaticIdxList<Route> {
+        return dirDetEntryToRouteMap.getOrDefault(dirDetector, MutableStaticIdxArrayList())
+    }
+
+    override fun getRoutesEndingAtDet(dirDetector: DirDetectorId): StaticIdxList<Route> {
+        return dirDetExitToRouteMap.getOrDefault(dirDetector, MutableStaticIdxArrayList())
     }
 
     private val zoneDetectors: IdxMap<ZoneId, MutableList<DirDetectorId>> = IdxMap()

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
@@ -42,7 +42,7 @@ fun BlockPathElement.toBlockList() : StaticIdxList<Block> {
 
 
 private fun filterBlocks(
-    allowedSignalingSystems: StaticIdxList<SignalingSystem>,
+    allowedSignalingSystems: StaticIdxList<SignalingSystem>?,
     blockInfra: BlockInfra,
     blocks: StaticIdxList<Block>,
     routePath: StaticIdxList<ZonePath>,
@@ -51,7 +51,8 @@ private fun filterBlocks(
     val remainingZonePaths = routePath.size - routeOffset
     val res = mutableStaticIdxArrayListOf<Block>()
     blockLoop@ for (block in blocks) {
-        if (!allowedSignalingSystems.contains(blockInfra.getBlockSignalingSystem(block)))
+        if (allowedSignalingSystems != null
+            && !allowedSignalingSystems.contains(blockInfra.getBlockSignalingSystem(block)))
             continue
         val blockPath = blockInfra.getBlockPath(block)
         if (blockPath.size > remainingZonePaths)
@@ -68,7 +69,7 @@ private fun filterBlocks(
 private fun findRouteBlocks(
     signalingInfra: RawSignalingInfra,
     blockInfra: BlockInfra,
-    allowedSignalingSystems: StaticIdxList<SignalingSystem>,
+    allowedSignalingSystems: StaticIdxList<SignalingSystem>?,
     previousPaths: List<BlockPathElement>?,
     route: RouteId,
     routeIndex: Int,
@@ -138,7 +139,7 @@ fun recoverBlocks(
     sigInfra: RawSignalingInfra,
     blockInfra: BlockInfra,
     routes: StaticIdxList<Route>,
-    allowedSigSystems: StaticIdxList<SignalingSystem>
+    allowedSigSystems: StaticIdxList<SignalingSystem>?
 ): List<BlockPathElement> {
     var candidates: List<BlockPathElement>? = null
 

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.java
@@ -18,10 +18,7 @@ import fr.sncf.osrd.railjson.schema.geom.RJSLineString;
 import fr.sncf.osrd.railjson.schema.infra.RJSRoutePath;
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange;
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
-import fr.sncf.osrd.sim_infra.api.BlockInfra;
-import fr.sncf.osrd.sim_infra.api.Path;
-import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
-import fr.sncf.osrd.sim_infra.api.TrackChunk;
+import fr.sncf.osrd.sim_infra.api.*;
 import fr.sncf.osrd.utils.Direction;
 import fr.sncf.osrd.utils.DistanceRangeMap;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -252,7 +249,7 @@ public class PathfindingResultConverter {
         if (startOffset == null)
             startOffset = 0L;
         if (endOffset == null)
-            endOffset = getRouteLength(infra, route);
+            endOffset = RawSignalingInfraKt.getRouteLength(infra, route);
         return new RJSRoutePath(
                 infra.getRouteName(route),
                 makeRJSTrackRanges(infra, route, startOffset, endOffset),
@@ -312,13 +309,6 @@ public class PathfindingResultConverter {
             }
         }
         return res;
-    }
-
-    /** Returns the route length */
-    private static long getRouteLength(RawSignalingInfra infra, int route) {
-        return toIntList(infra.getRoutePath(route)).stream()
-                .mapToLong(infra::getZonePathLength)
-                .sum();
     }
 
     /** Returns the offset of the range start on the given route */

--- a/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/stdcm/STDCMEndpoint.java
@@ -20,7 +20,7 @@ import fr.sncf.osrd.standalone_sim.ScheduleMetadataExtractor;
 import fr.sncf.osrd.standalone_sim.result.ResultEnvelopePoint;
 import fr.sncf.osrd.standalone_sim.result.StandaloneSimResult;
 import fr.sncf.osrd.stdcm.preprocessing.implementation.RouteAvailabilityLegacyAdapter;
-import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.LegacyUnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
 import fr.sncf.osrd.train.TrainStop;
@@ -93,7 +93,7 @@ public class STDCMEndpoint implements Take {
             // Build the unavailable space
             // temporary workaround, to remove with new signaling
             occupancies = addWarningOccupancies(infra, occupancies);
-            var unavailableSpace = UnavailableSpaceBuilder.computeUnavailableSpace(
+            var unavailableSpace = LegacyUnavailableSpaceBuilder.computeUnavailableSpace(
                     infra,
                     occupancies,
                     rollingStock,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/LegacyOccupancyBlock.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/LegacyOccupancyBlock.java
@@ -1,0 +1,11 @@
+package fr.sncf.osrd.stdcm;
+
+/** The given element is unavailable from timeStart until timeEnd,
+ * in the space between distanceStart and distanceEnd.
+ * Distances are relative to the start of the route. */
+public record LegacyOccupancyBlock(
+        double timeStart,
+        double timeEnd,
+        double distanceStart,
+        double distanceEnd
+){}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/OccupancySegment.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/OccupancySegment.java
@@ -2,10 +2,10 @@ package fr.sncf.osrd.stdcm;
 
 /** The given element is unavailable from timeStart until timeEnd,
  * in the space between distanceStart and distanceEnd.
- * Distances are relative to the start of the route. */
-public record OccupancyBlock(
+ * Distances are relative to the start of the element. */
+public record OccupancySegment(
         double timeStart,
         double timeEnd,
-        double distanceStart,
-        double distanceEnd
+        long distanceStart,
+        long distanceEnd
 ){}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.java
@@ -1,0 +1,189 @@
+package fr.sncf.osrd.stdcm.preprocessing.implementation;
+
+import com.google.common.collect.Multimap;
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
+import fr.sncf.osrd.sim_infra.api.BlockInfra;
+import fr.sncf.osrd.stdcm.OccupancySegment;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface;
+import fr.sncf.osrd.utils.units.Distance;
+import java.util.ArrayList;
+import java.util.List;
+
+/** This class implements the RouteAvailabilityInterface using the legacy block occupancy data.
+ * It's meant to be removed once the rest of the "signaling sim - stdcm" pipeline is implemented. */
+public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterface {
+
+    private final BlockInfra blockInfra;
+    private final Multimap<Integer, OccupancySegment> unavailableSpace; // keys are block ids
+
+    /** Simple record used to group together a block and the offset of its start on the given path */
+    private record BlockWithOffset(
+            Integer blockID,
+            Long pathOffset
+    ){}
+
+    /** Constructor */
+    public BlockAvailabilityLegacyAdapter(
+            BlockInfra blockInfra,
+            Multimap<Integer, OccupancySegment> unavailableSpace
+    ) {
+        this.blockInfra = blockInfra;
+        this.unavailableSpace = unavailableSpace;
+    }
+
+    @Override
+    public Availability getAvailability(
+            List<Integer> blocks,
+            double startOffsetMeters,
+            double endOffsetMeters,
+            EnvelopeTimeInterpolate envelope,
+            double startTime
+    ) {
+        assert Math.abs((endOffsetMeters - startOffsetMeters) - envelope.getEndPos()) < 1e-5;
+        long startOffset = Distance.fromMeters(startOffsetMeters);
+        long endOffset = Distance.fromMeters(endOffsetMeters);
+        var blocksWithOffsets = makeBlocksWithOffsets(blocks);
+        var unavailability = findMinimumDelay(blocksWithOffsets, startOffset, endOffset, envelope, startTime);
+        if (unavailability != null)
+            return unavailability;
+        return findMaximumDelay(blocksWithOffsets, startOffset, endOffset, envelope, startTime);
+    }
+
+    /** Create pairs of (block, offset) */
+    private List<BlockWithOffset> makeBlocksWithOffsets(List<Integer> blocks) {
+        long offset = 0;
+        var res = new ArrayList<BlockWithOffset>();
+        for (var block : blocks) {
+            var length = blockInfra.getBlockLength(block);
+            res.add(new BlockWithOffset(block, offset));
+            offset += length;
+        }
+        return res;
+    }
+
+    /** Find the minimum delay needed to avoid any conflict.
+     * Returns 0 if the train isn't currently causing any conflict. */
+    Unavailable findMinimumDelay(
+            List<BlockWithOffset> blocks,
+            long startOffset,
+            long endOffset,
+            EnvelopeTimeInterpolate envelope,
+            double startTime
+    ) {
+        double minimumDelay = 0;
+        long conflictOffset = 0;
+        for (var blockWithOffset : getBlocksInRange(blocks, startOffset, endOffset)) {
+            for (var unavailableSegment : unavailableSpace.get(blockWithOffset.blockID)) {
+                var trainInBlock = getTimeTrainInBlock(
+                        unavailableSegment,
+                        blockWithOffset,
+                        startOffset,
+                        envelope,
+                        startTime
+                );
+                if (trainInBlock == null)
+                    continue;
+                if (trainInBlock.start < unavailableSegment.timeEnd()
+                        && trainInBlock.end > unavailableSegment.timeStart()) {
+                    var blockMinimumDelay = unavailableSegment.timeEnd() - trainInBlock.start;
+                    if (blockMinimumDelay > minimumDelay) {
+                        minimumDelay = blockMinimumDelay;
+                        if (trainInBlock.start <= unavailableSegment.timeStart()) {
+                            // The train enters the block before it's unavailable: conflict at end location
+                            conflictOffset = blockWithOffset.pathOffset() + unavailableSegment.distanceEnd();
+                        } else {
+                            // The train enters the block when it's already unavailable: conflict at start location
+                            conflictOffset = blockWithOffset.pathOffset() + unavailableSegment.distanceStart();
+                        }
+                    }
+                }
+            }
+        }
+        if (minimumDelay == 0)
+            return null;
+        if (Double.isFinite(minimumDelay)) {
+            // We need to add delay, a recursive call is needed to detect new conflicts
+            // that may appear with the added delay
+            var recursiveDelay = findMinimumDelay(blocks, startOffset, endOffset, envelope, startTime + minimumDelay);
+            if (recursiveDelay != null) // The recursive call returns null if there is no new conflict
+                minimumDelay += recursiveDelay.duration;
+        }
+        var pathLength = blocks.stream()
+                .mapToLong(block -> blockInfra.getBlockLength(block.blockID))
+                .sum();
+        conflictOffset = Math.max(0, Math.min(pathLength, conflictOffset));
+        return new Unavailable(minimumDelay, conflictOffset);
+    }
+
+    /** Find the maximum amount of delay that can be added to the train without causing conflict.
+     * Cannot be called if the train is currently causing a conflict. */
+    Available findMaximumDelay(
+            List<BlockWithOffset> blocks,
+            long startOffset,
+            long endOffset,
+            EnvelopeTimeInterpolate envelope,
+            double startTime
+    ) {
+        double maximumDelay = Double.POSITIVE_INFINITY;
+        double timeOfNextOccupancy = Double.POSITIVE_INFINITY;
+        for (var blockWithOffset : getBlocksInRange(blocks, startOffset, endOffset)) {
+            for (var block : unavailableSpace.get(blockWithOffset.blockID)) {
+                var timeTrainInBlock = getTimeTrainInBlock(
+                        block,
+                        blockWithOffset,
+                        startOffset,
+                        envelope,
+                        startTime
+                );
+                if (timeTrainInBlock == null || timeTrainInBlock.start >= block.timeEnd())
+                    continue; // The block is occupied before we enter it
+                assert timeTrainInBlock.start <= block.timeStart();
+                var maxDelayForBlock = block.timeStart() - timeTrainInBlock.end;
+                if (maxDelayForBlock < maximumDelay) {
+                    maximumDelay = maxDelayForBlock;
+                    timeOfNextOccupancy = block.timeStart();
+                }
+            }
+        }
+        return new Available(maximumDelay, timeOfNextOccupancy);
+    }
+
+    /** Returns the list of blocks in the given interval on the path */
+    private List<BlockWithOffset> getBlocksInRange(
+            List<BlockWithOffset> blocks,
+            long start,
+            long end
+    ) {
+        return blocks.stream()
+                .filter(r -> r.pathOffset() < end)
+                .filter(r ->
+                        r.pathOffset() + blockInfra.getBlockLength(r.blockID) > start)
+                .toList();
+    }
+
+    /** Returns the time interval during which the train is on the given blocK. */
+    private static TimeInterval getTimeTrainInBlock(
+            OccupancySegment unavailableSegment,
+            BlockWithOffset block,
+            long startOffset,
+            EnvelopeTimeInterpolate envelope,
+            double startTime
+    ) {
+        var startBlockOffsetOnEnvelope = block.pathOffset() - startOffset;
+        // Offsets on the envelope
+        var blockEnterOffset = Distance.toMeters(startBlockOffsetOnEnvelope + unavailableSegment.distanceStart());
+        var blockExitOffset = Distance.toMeters(startBlockOffsetOnEnvelope + unavailableSegment.distanceEnd());
+
+        if (blockEnterOffset > envelope.getEndPos() || blockExitOffset < 0)
+            return null;
+
+        var enterTime = startTime + envelope.interpolateTotalTimeClamp(blockEnterOffset);
+        var exitTime = startTime + envelope.interpolateTotalTimeClamp(blockExitOffset);
+        return new TimeInterval(enterTime, exitTime);
+    }
+
+    private record TimeInterval(
+            double start,
+            double end
+    ) {}
+}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/LegacyUnavailableSpaceBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/LegacyUnavailableSpaceBuilder.java
@@ -1,0 +1,86 @@
+package fr.sncf.osrd.stdcm.preprocessing.implementation;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import fr.sncf.osrd.api.stdcm.STDCMRequest;
+import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
+import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
+import fr.sncf.osrd.stdcm.LegacyOccupancyBlock;
+import fr.sncf.osrd.train.RollingStock;
+import java.util.Collection;
+
+public class LegacyUnavailableSpaceBuilder {
+
+    /** Only used when we have missing signal data */
+    private static final double DEFAULT_SIGHT_DISTANCE = 400;
+
+    /** Computes the unavailable space for each route, i.e.
+     * the times and positions where the *head* of the train cannot be.
+     * This considers existing occupancy blocks, the length of the train,
+     * and the routes that must be left available behind the train
+     *
+     * <br/>
+     * This is the first step to compute STDCM, the goal is to get rid of railway rules and extra complexity
+     * as soon as possible. After this step we can look for a single curve that avoids unavailable blocks. */
+    public static Multimap<SignalingRoute, LegacyOccupancyBlock> computeUnavailableSpace(
+            SignalingInfra infra,
+            Collection<STDCMRequest.RouteOccupancy> occupancies,
+            RollingStock rollingStock,
+            double marginToAddBeforeEachBlock,
+            double marginToAddAfterEachBlock
+    ) {
+
+        Multimap<SignalingRoute, LegacyOccupancyBlock> res = HashMultimap.create();
+
+        for (var occupancy : occupancies) {
+
+            var routeGraph = infra.getSignalingRouteGraph();
+            var currentRoute = infra.findSignalingRoute(occupancy.id, "BAL3");
+            var startRouteNode = routeGraph.incidentNodes(currentRoute).nodeU();
+            var endRouteNode = routeGraph.incidentNodes(currentRoute).nodeV();
+            var length = currentRoute.getInfraRoute().getLength();
+            var timeStart = occupancy.startOccupancyTime - marginToAddBeforeEachBlock;
+            var timeEnd = occupancy.endOccupancyTime + marginToAddAfterEachBlock;
+
+            //Generating current block occupancy
+            var block = new LegacyOccupancyBlock(timeStart, timeEnd, 0, length);
+            res.put(currentRoute, block);
+
+            //Generating sight Distance occupancy
+            var predecessorRoutes = routeGraph.inEdges(startRouteNode);
+            for (var predecessorRoute : predecessorRoutes) {
+                var preBlockLength = predecessorRoute.getInfraRoute().getLength();
+                double sightDistance = DEFAULT_SIGHT_DISTANCE;
+                if (predecessorRoute.getExitSignal() != null)
+                    sightDistance = predecessorRoute.getExitSignal().getSightDistance();
+                var previousBlock = new LegacyOccupancyBlock(
+                        timeStart,
+                        timeEnd,
+                        Math.max(0, preBlockLength - sightDistance),
+                        preBlockLength
+                );
+                res.put(predecessorRoute, previousBlock);
+            }
+
+            //Generating successorRoute occupancy
+            var successorRoutes = routeGraph.outEdges(endRouteNode);
+            for (var successorRoute : successorRoutes) {
+                var successorBlockLength = successorRoute.getInfraRoute().getLength();
+                var successorBlock = new LegacyOccupancyBlock(timeStart, timeEnd, 0, successorBlockLength);
+                res.put(successorRoute, successorBlock);
+            }
+
+            //Generating rollingStock length occupancy
+            for (var successorRoute : successorRoutes) {
+                var endSuccessorRoutesNode = routeGraph.incidentNodes(successorRoute).nodeV();
+                var secondSuccessorRoutes = routeGraph.outEdges(endSuccessorRoutesNode);
+                for (var secondSuccessorRoute : secondSuccessorRoutes) {
+                    var end = Math.min(rollingStock.getLength(), secondSuccessorRoute.getInfraRoute().getLength());
+                    var secondSuccessorBlock = new LegacyOccupancyBlock(timeStart, timeEnd, 0, end);
+                    res.put(secondSuccessorRoute, secondSuccessorBlock);
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/RouteAvailabilityLegacyAdapter.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Multimap;
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
+import fr.sncf.osrd.stdcm.LegacyOccupancyBlock;
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.RouteAvailabilityInterface;
 import java.util.List;
 
@@ -12,11 +12,11 @@ import java.util.List;
  * It's meant to be removed once the rest of the "signaling sim - stdcm" pipeline is implemented. */
 public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterface {
 
-    private final Multimap<SignalingRoute, OccupancyBlock> unavailableSpace;
+    private final Multimap<SignalingRoute, LegacyOccupancyBlock> unavailableSpace;
 
     /** Constructor */
     public RouteAvailabilityLegacyAdapter(
-            Multimap<SignalingRoute, OccupancyBlock> unavailableSpace
+            Multimap<SignalingRoute, LegacyOccupancyBlock> unavailableSpace
     ) {
         this.unavailableSpace = unavailableSpace;
     }
@@ -133,7 +133,7 @@ public class RouteAvailabilityLegacyAdapter implements RouteAvailabilityInterfac
 
     /** Returns the time interval during which the train is on the given blocK. */
     private static TimeInterval timeTrainInBlock(
-            OccupancyBlock block,
+            LegacyOccupancyBlock block,
             TrainPath.LocatedElement<SignalingRoute> route,
             double startOffset,
             EnvelopeTimeInterpolate envelope,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/UnavailableSpaceBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/UnavailableSpaceBuilder.java
@@ -1,86 +1,149 @@
 package fr.sncf.osrd.stdcm.preprocessing.implementation;
 
+import static fr.sncf.osrd.sim_infra.api.RawSignalingInfraKt.getRouteLength;
+import static fr.sncf.osrd.utils.KtToJavaConverter.toIntList;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.stdcm.STDCMRequest;
-import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
-import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
-import fr.sncf.osrd.stdcm.OccupancyBlock;
-import fr.sncf.osrd.train.RollingStock;
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
+import fr.sncf.osrd.sim_infra.api.BlockInfra;
+import fr.sncf.osrd.sim_infra.api.InterlockingInfraKt;
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
+import fr.sncf.osrd.sim_infra.api.Route;
+import fr.sncf.osrd.sim_infra.utils.BlockRecoveryKt;
+import fr.sncf.osrd.stdcm.OccupancySegment;
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList;
+import fr.sncf.osrd.utils.units.Distance;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 public class UnavailableSpaceBuilder {
+    private static final long SIGHT_DISTANCE = Distance.fromMeters(400);
 
-    /** Only used when we have missing signal data */
-    private static final double DEFAULT_SIGHT_DISTANCE = 400;
-
-    /** Computes the unavailable space for each route, i.e.
+    /** Computes the unavailable space for each block, i.e.
      * the times and positions where the *head* of the train cannot be.
-     * This considers existing occupancy blocks, the length of the train,
-     * and the routes that must be left available behind the train
-     *
+     * This considers existing occupancy segments, the length of the train,
+     * and the blocks that must be left available behind the train
      * <br/>
      * This is the first step to compute STDCM, the goal is to get rid of railway rules and extra complexity
-     * as soon as possible. After this step we can look for a single curve that avoids unavailable blocks. */
-    public static Multimap<SignalingRoute, OccupancyBlock> computeUnavailableSpace(
-            SignalingInfra infra,
+     * as soon as possible. After this step we can look for a single curve that avoids unavailable segment. */
+    public static Multimap<Integer, OccupancySegment> computeUnavailableSpace(
+            RawSignalingInfra infra,
+            BlockInfra blockInfra,
             Collection<STDCMRequest.RouteOccupancy> occupancies,
-            RollingStock rollingStock,
+            PhysicsRollingStock rollingStock,
             double marginToAddBeforeEachBlock,
             double marginToAddAfterEachBlock
     ) {
 
-        Multimap<SignalingRoute, OccupancyBlock> res = HashMultimap.create();
+        Multimap<Integer, OccupancySegment> unavailableSpace = HashMultimap.create();
 
         for (var occupancy : occupancies) {
-
-            var routeGraph = infra.getSignalingRouteGraph();
-            var currentRoute = infra.findSignalingRoute(occupancy.id, "BAL3");
-            var startRouteNode = routeGraph.incidentNodes(currentRoute).nodeU();
-            var endRouteNode = routeGraph.incidentNodes(currentRoute).nodeV();
-            var length = currentRoute.getInfraRoute().getLength();
+            var route = infra.getRouteFromName(occupancy.id);
+            var length = getRouteLength(infra, route);
             var timeStart = occupancy.startOccupancyTime - marginToAddBeforeEachBlock;
             var timeEnd = occupancy.endOccupancyTime + marginToAddAfterEachBlock;
 
             //Generating current block occupancy
-            var block = new OccupancyBlock(timeStart, timeEnd, 0, length);
-            res.put(currentRoute, block);
+            addRouteOccupancy(unavailableSpace, infra, blockInfra, route, timeStart, timeEnd, 0, length);
 
             //Generating sight Distance occupancy
-            var predecessorRoutes = routeGraph.inEdges(startRouteNode);
+            var predecessorRoutes = getPreviousRoutes(infra, route);
             for (var predecessorRoute : predecessorRoutes) {
-                var preBlockLength = predecessorRoute.getInfraRoute().getLength();
-                double sightDistance = DEFAULT_SIGHT_DISTANCE;
-                if (predecessorRoute.getExitSignal() != null)
-                    sightDistance = predecessorRoute.getExitSignal().getSightDistance();
-                var previousBlock = new OccupancyBlock(
+                var preBlockLength = getRouteLength(infra, predecessorRoute);
+                addRouteOccupancy(
+                        unavailableSpace,
+                        infra,
+                        blockInfra,
+                        predecessorRoute,
                         timeStart,
                         timeEnd,
-                        Math.max(0, preBlockLength - sightDistance),
+                        Math.max(0, preBlockLength - SIGHT_DISTANCE),
                         preBlockLength
                 );
-                res.put(predecessorRoute, previousBlock);
+                var previousBlock = new OccupancySegment(
+                        timeStart,
+                        timeEnd,
+                        Math.max(0, preBlockLength - SIGHT_DISTANCE),
+                        preBlockLength
+                );
+                unavailableSpace.put(predecessorRoute, previousBlock);
             }
 
             //Generating successorRoute occupancy
-            var successorRoutes = routeGraph.outEdges(endRouteNode);
+            var successorRoutes = getNextRoutes(infra, route);
             for (var successorRoute : successorRoutes) {
-                var successorBlockLength = successorRoute.getInfraRoute().getLength();
-                var successorBlock = new OccupancyBlock(timeStart, timeEnd, 0, successorBlockLength);
-                res.put(successorRoute, successorBlock);
+                var successorBlockLength = getRouteLength(infra, successorRoute);
+                addRouteOccupancy(
+                        unavailableSpace,
+                        infra,
+                        blockInfra,
+                        successorRoute,
+                        timeStart,
+                        timeEnd,
+                        0,
+                        successorBlockLength
+                );
             }
 
             //Generating rollingStock length occupancy
             for (var successorRoute : successorRoutes) {
-                var endSuccessorRoutesNode = routeGraph.incidentNodes(successorRoute).nodeV();
-                var secondSuccessorRoutes = routeGraph.outEdges(endSuccessorRoutesNode);
+                var secondSuccessorRoutes = getNextRoutes(infra, successorRoute);
                 for (var secondSuccessorRoute : secondSuccessorRoutes) {
-                    var end = Math.min(rollingStock.getLength(), secondSuccessorRoute.getInfraRoute().getLength());
-                    var secondSuccessorBlock = new OccupancyBlock(timeStart, timeEnd, 0, end);
-                    res.put(secondSuccessorRoute, secondSuccessorBlock);
+                    var end = Math.min(
+                            Distance.fromMeters(rollingStock.getLength()),
+                            getRouteLength(infra, secondSuccessorRoute)
+                    );
+                    addRouteOccupancy(unavailableSpace, infra, blockInfra, secondSuccessorRoute,
+                            timeStart, timeEnd, 0, end);
                 }
             }
         }
-        return res;
+        return unavailableSpace;
+    }
+
+    /** Sets the occupancy for a route interval, adding entries to any matching block.
+     * This is a significant oversimplification, but it keeps the same behavior as before the kt infra migration,
+     * making testing easier. This whole class is to be deleted when moving to a more accurate behavior.  */
+    private static void addRouteOccupancy(
+            Multimap<Integer, OccupancySegment> res,
+            RawSignalingInfra infra,
+            BlockInfra blockInfra,
+            int route,
+            double timeStart,
+            double timeEnd,
+            long distanceStart,
+            long distanceEnd
+    ) {
+        var routeList = new MutableStaticIdxArrayList<Route>();
+        routeList.add(route);
+        for (var blockPath : BlockRecoveryKt.recoverBlocks(infra, blockInfra, routeList, null)) {
+            var blockList = BlockRecoveryKt.toBlockList(blockPath);
+            long routeOffset = 0;
+            for (var blockId : toIntList(blockList)) {
+                var blockLength = blockInfra.getBlockLength(blockId);
+                var start = Math.max(0, distanceStart - routeOffset);
+                var end = Math.min(blockLength, distanceEnd - routeOffset);
+                if (start < end) {
+                    var newSegment = new OccupancySegment(timeStart, timeEnd, start, end);
+                    res.put(blockId, newSegment);
+                }
+                routeOffset += blockLength;
+            }
+        }
+    }
+
+    /** Returns the routes that lead into the given one */
+    private static Set<Integer> getPreviousRoutes(RawSignalingInfra infra, int route) {
+        var entry = InterlockingInfraKt.getRouteEntry(infra, route);
+        return new HashSet<>(toIntList(infra.getRoutesEndingAtDet(entry)));
+    }
+
+    /** Returns the routes that follow the given one */
+    private static Set<Integer> getNextRoutes(RawSignalingInfra infra, int route) {
+        var exit = InterlockingInfraKt.getRouteExit(infra, route);
+        return new HashSet<>(toIntList(infra.getRoutesStartingAtDet(exit)));
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.java
@@ -1,0 +1,122 @@
+package fr.sncf.osrd.stdcm.preprocessing.interfaces;
+
+import com.google.common.base.Objects;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate;
+import java.util.List;
+
+/** Abstract interface used to request the availability of path sections */
+@SuppressFBWarnings(
+        value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+        justification = "The classes aren't used yet. This should be removed by the end of the migration."
+)
+public interface BlockAvailabilityInterface {
+
+    /** Request availability information about a section of the path.
+     * <br/>
+     * Can return either an instance of either type:
+     * <ul>
+     * <li>Available: the section is available </li>
+     * <li>Unavailable: the section isn't available </li>
+     * <li>NotEnoughLookahead: the train path needs to extend further, it depends on a directional choice </li>
+     * </ul>
+     * More details are given in the instances.
+     * <br/>
+     * Note: every position refers to the position of the head of the train.
+     * The implementation of RouteAvailabilityInterface must account for train length, sight distance,
+     * and similar factors.
+     *
+     * @param routes List of route IDs taken by the train
+     * @param startOffset Start of the section to check for availability, as an offset from the start of the path
+     * @param endOffset End of the section to check for availability, as an offset from the start of the path
+     * @param envelope Envelope describing the position of the train at any moment.
+     *                 Must be exactly `(endOffset - startOffset) long.
+     * @param startTime Time at which the train is at `startOffset`.
+     * @return An Availability instance.
+     */
+    Availability getAvailability(
+            List<Integer> routes,
+            double startOffset,
+            double endOffset,
+            EnvelopeTimeInterpolate envelope,
+            double startTime
+    );
+
+    /** Represents the availability of the requested section */
+    abstract sealed class Availability
+            permits Available, Unavailable, NotEnoughLookahead
+    {}
+
+    /** The requested section is available.
+     * <br/>
+     * For example: a train enter the section at t=10, sees a signal 42s after entering the section,
+     * and the signal is green until t=100. The result would be:
+     * <ul>
+     * <li>maximumDelay = 100 - 42 - 10 = 48
+     * <li>timeOfNextConflict = 100
+     * </ul>
+     */
+    final class Available extends Availability {
+        /** The train can use the section now and up to `maximumDelay` later without conflict */
+        public final double maximumDelay;
+
+        /** Earliest time any resource used by the train is reused by another one */
+        public final double timeOfNextConflict;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Available available = (Available) o;
+            return Double.compare(available.maximumDelay, maximumDelay) == 0
+                    && Double.compare(available.timeOfNextConflict, timeOfNextConflict) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(maximumDelay, timeOfNextConflict);
+        }
+
+        public Available(double maximumDelay, double timeOfNextConflict) {
+            this.maximumDelay = maximumDelay;
+            this.timeOfNextConflict = timeOfNextConflict;
+        }
+    }
+
+    /** The requested section isn't available yet */
+    final class Unavailable extends Availability {
+        /** Minimum delay to add to the departure time to avoid any conflict */
+        public final double duration;
+
+        /** Exact offset of the first conflict encountered. It's always the offset that marks either the border of an
+         * unavailable section.
+         * <br/>
+         * It's either the offset where we start using a ressource before it's available,
+         * or the offset where the train would have released a ressource it has kept for too long. */
+        public final double firstConflictOffset;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Unavailable that = (Unavailable) o;
+            return Double.compare(that.duration, duration) == 0
+                    && Double.compare(that.firstConflictOffset, firstConflictOffset) == 0;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(duration, firstConflictOffset);
+        }
+
+        public Unavailable(double duration, double firstConflictOffset) {
+            this.duration = duration;
+            this.firstConflictOffset = firstConflictOffset;
+        }
+    }
+
+    /** The availability of the requested section can't be determined,
+     * the path needs to extend further. The availability depends
+     * on the route taken by the train after the end of the given path. */
+    final class NotEnoughLookahead extends Availability {}
+}

--- a/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
@@ -29,7 +29,7 @@ public class BacktrackingTests {
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                route, new OccupancyBlock(runTime + 1, POSITIVE_INFINITY, 0, 1000)
+                route, new LegacyOccupancyBlock(runTime + 1, POSITIVE_INFINITY, 0, 1000)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -59,7 +59,7 @@ public class BacktrackingTests {
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                lastRoute, new OccupancyBlock(runTime + 10, POSITIVE_INFINITY, 0, 10)
+                lastRoute, new LegacyOccupancyBlock(runTime + 10, POSITIVE_INFINITY, 0, 10)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -87,7 +87,7 @@ public class BacktrackingTests {
         var runTime = firstRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(runTime + 10, POSITIVE_INFINITY, 0, 1000)
+                firstRoute, new LegacyOccupancyBlock(runTime + 10, POSITIVE_INFINITY, 0, 1000)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
@@ -26,7 +26,7 @@ public class DepartureTimeShiftTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(0, 3600, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(0, 3600, 0, 100)
         );
 
         var res = new STDCMPathfindingBuilder()
@@ -54,9 +54,9 @@ public class DepartureTimeShiftTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(0, 1200, 0, 100),
-                secondRoute, new OccupancyBlock(1200, 2400, 0, 100),
-                secondRoute, new OccupancyBlock(2400, 3600, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(0, 1200, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(1200, 2400, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(2400, 3600, 0, 100)
         );
 
         var res = new STDCMPathfindingBuilder()
@@ -144,7 +144,7 @@ public class DepartureTimeShiftTests {
         var lastRoute = infraBuilder.addRoute("d", "e", 1000);
         var infra = infraBuilder.build();
 
-        var occupancyGraph = ImmutableMultimap.of(delayedRoute, new OccupancyBlock(
+        var occupancyGraph = ImmutableMultimap.of(delayedRoute, new LegacyOccupancyBlock(
                 0,
                 10000,
                 0,
@@ -182,11 +182,11 @@ public class DepartureTimeShiftTests {
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2, null, null);
         assert firstRouteEnvelope != null;
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(
+                firstRoute, new LegacyOccupancyBlock(
                         firstRouteEnvelope.getTotalTime() + 10,
                         POSITIVE_INFINITY,
                         0, 100),
-                secondRoute, new OccupancyBlock(0, 3600, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(0, 3600, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -222,8 +222,8 @@ public class DepartureTimeShiftTests {
         var thirdRoute = infraBuilder.addRoute("c", "d");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(300, 500, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 500, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(300, 500, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 500, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -257,8 +257,8 @@ public class DepartureTimeShiftTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(300, 500, 0, 100),
-                secondRoute, new OccupancyBlock(0, 500, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(300, 500, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 500, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -292,7 +292,7 @@ public class DepartureTimeShiftTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(300, 500, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(300, 500, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -332,9 +332,9 @@ public class DepartureTimeShiftTests {
         var forthRoute = infraBuilder.addRoute("d", "e");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(1200, POSITIVE_INFINITY, 0, 100),
-                secondRoute, new OccupancyBlock(600, POSITIVE_INFINITY, 0, 100),
-                forthRoute, new OccupancyBlock(0, 1000, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(1200, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(600, POSITIVE_INFINITY, 0, 100),
+                forthRoute, new LegacyOccupancyBlock(0, 1000, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -373,11 +373,11 @@ public class DepartureTimeShiftTests {
         var forthRoute = infraBuilder.addRoute("d", "e");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 200, 0, 100),
-                firstRoute, new OccupancyBlock(500, POSITIVE_INFINITY, 0, 100),
-                secondRoute, new OccupancyBlock(0, 400, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 600, 0, 100),
-                forthRoute, new OccupancyBlock(0, 800, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(0, 200, 0, 100),
+                firstRoute, new LegacyOccupancyBlock(500, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 400, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 600, 0, 100),
+                forthRoute, new LegacyOccupancyBlock(0, 800, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -412,11 +412,11 @@ public class DepartureTimeShiftTests {
         var thirdRoute = infraBuilder.addRoute("c", "d");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(300, 600, 0, 100),
-                secondRoute, new OccupancyBlock(900, 1200, 0, 100),
-                secondRoute, new OccupancyBlock(1500, 1800, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 1200, 0, 100),
-                thirdRoute, new OccupancyBlock(1500, POSITIVE_INFINITY, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(300, 600, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(900, 1200, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(1500, 1800, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 1200, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(1500, POSITIVE_INFINITY, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -441,7 +441,7 @@ public class DepartureTimeShiftTests {
         var lastRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 1000, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(0, 1000, 0, 100)
         );
         double timeStep = 2;
         var res1 = new STDCMPathfindingBuilder()

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -44,8 +44,9 @@ public class EngineeringAllowanceTests {
         var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + 10, POSITIVE_INFINITY, 0, 1_000),
-                thirdRoute, new OccupancyBlock(0, timeThirdRouteFree + 30, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(firstRouteEnvelope.getTotalTime() + 10, POSITIVE_INFINITY,
+                        0, 1_000),
+                thirdRoute, new LegacyOccupancyBlock(0, timeThirdRouteFree + 30, 0, 100)
         );
         double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
@@ -97,9 +98,9 @@ public class EngineeringAllowanceTests {
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
+                firstRoute, new LegacyOccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
                         POSITIVE_INFINITY, 0, 1_000),
-                lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000)
+                lastRoute, new LegacyOccupancyBlock(0, timeLastRouteFree, 0, 1_000)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -157,10 +158,10 @@ public class EngineeringAllowanceTests {
         var timeThirdRouteOccupied = firstRouteEnvelope.getTotalTime() + 5 + secondRouteEnvelope.getTotalTime() * 2;
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
+                firstRoute, new LegacyOccupancyBlock(firstRouteEnvelope.getTotalTime() + timeStep,
                         POSITIVE_INFINITY, 0, 1_000),
-                lastRoute, new OccupancyBlock(0, timeLastRouteFree, 0, 1_000),
-                thirdRoute, new OccupancyBlock(timeThirdRouteOccupied, POSITIVE_INFINITY, 0, 1_000)
+                lastRoute, new LegacyOccupancyBlock(0, timeLastRouteFree, 0, 1_000),
+                thirdRoute, new LegacyOccupancyBlock(timeThirdRouteOccupied, POSITIVE_INFINITY, 0, 1_000)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -203,7 +204,7 @@ public class EngineeringAllowanceTests {
         var timeThirdRouteFree = lastRouteEntryTime + 3600 * 2 + 60;
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                thirdRoute, new OccupancyBlock(0, timeThirdRouteFree, 0, 1)
+                thirdRoute, new LegacyOccupancyBlock(0, timeThirdRouteFree, 0, 1)
         );
         double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
@@ -246,11 +247,11 @@ public class EngineeringAllowanceTests {
         var forthRoute = infraBuilder.addRoute("d", "e", 2_000, 20);
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 600, 0, 100),
-                firstRoute, new OccupancyBlock(2_000, POSITIVE_INFINITY, 0, 100),
-                secondRoute, new OccupancyBlock(0, 1200, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 1800, 0, 100),
-                forthRoute, new OccupancyBlock(0, 4_000, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(0, 600, 0, 100),
+                firstRoute, new LegacyOccupancyBlock(2_000, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 1200, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 1800, 0, 100),
+                forthRoute, new LegacyOccupancyBlock(0, 4_000, 0, 100)
         );
         double timeStep = 2;
         var res = new STDCMPathfindingBuilder()
@@ -291,8 +292,8 @@ public class EngineeringAllowanceTests {
         );
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(300, POSITIVE_INFINITY, 0, 1_000),
-                routes.get(2), new OccupancyBlock(0, 3600, 0, 1_000)
+                routes.get(0), new LegacyOccupancyBlock(300, POSITIVE_INFINITY, 0, 1_000),
+                routes.get(2), new LegacyOccupancyBlock(0, 3600, 0, 1_000)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -329,8 +330,8 @@ public class EngineeringAllowanceTests {
         );
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(300, 3600, 0, 1),
-                routes.get(2), new OccupancyBlock(0, 3600, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(300, 3600, 0, 1),
+                routes.get(2), new LegacyOccupancyBlock(0, 3600, 0, 1)
         );
         double timeStep = 2;
         var res = new STDCMPathfindingBuilder()

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -16,7 +16,7 @@ import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
 import fr.sncf.osrd.stdcm.graph.LegacySTDCMSimulations;
-import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.LegacyUnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
 import fr.sncf.osrd.train.TrainStop;
@@ -28,7 +28,7 @@ import java.util.Set;
 
 public class STDCMHelpers {
     /** Make the occupancy multimap of a train going from point A to B starting at departureTime */
-    public static Multimap<SignalingRoute, OccupancyBlock> makeOccupancyFromPath(
+    public static Multimap<SignalingRoute, LegacyOccupancyBlock> makeOccupancyFromPath(
             FullInfra infra,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> startLocations,
             Set<Pathfinding.EdgeLocation<SignalingRoute>> endLocations,
@@ -62,7 +62,7 @@ public class STDCMHelpers {
                     departureTime + entry.getValue().timeTailFree
             ));
         }
-        return UnavailableSpaceBuilder.computeUnavailableSpace(
+        return LegacyUnavailableSpaceBuilder.computeUnavailableSpace(
                 infra.java(),
                 occupancies,
                 REALISTIC_FAST_TRAIN,
@@ -99,7 +99,7 @@ public class STDCMHelpers {
 
     /** Returns how long the longest occupancy block lasts, which is the minimum delay we need to add
      * between two identical trains */
-    public static double getMaxOccupancyLength(Multimap<SignalingRoute, OccupancyBlock> occupancies) {
+    public static double getMaxOccupancyLength(Multimap<SignalingRoute, LegacyOccupancyBlock> occupancies) {
         double maxOccupancyLength = 0;
         for (var route : occupancies.keySet()) {
             var endTime = 0.;
@@ -129,14 +129,14 @@ public class STDCMHelpers {
     }
 
     /** Checks that the result don't cross in an occupied section */
-    static void occupancyTest(STDCMResult res, ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph) {
+    static void occupancyTest(STDCMResult res, ImmutableMultimap<SignalingRoute, LegacyOccupancyBlock> occupancyGraph) {
         occupancyTest(res, occupancyGraph, 0);
     }
 
     /** Checks that the result don't cross in an occupied section, with a certain tolerance for float inaccuracies */
     static void occupancyTest(
             STDCMResult res,
-            ImmutableMultimap<SignalingRoute, OccupancyBlock> occupancyGraph,
+            ImmutableMultimap<SignalingRoute, LegacyOccupancyBlock> occupancyGraph,
             double tolerance
     ) {
         var envelopeWrapper = new EnvelopeStopWrapper(res.envelope(), res.stopResults());

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.java
@@ -33,7 +33,7 @@ public class STDCMPathfindingBuilder {
     private RollingStock rollingStock = TestTrains.REALISTIC_FAST_TRAIN;
     private double startTime = 0;
     private RollingStock.Comfort comfort = RollingStock.Comfort.STANDARD;
-    Multimap<SignalingRoute, OccupancyBlock> unavailableTimes = ImmutableMultimap.of();
+    Multimap<SignalingRoute, LegacyOccupancyBlock> unavailableTimes = ImmutableMultimap.of();
     double timeStep = 2.;
     double maxDepartureDelay = 3600 * 2;
     double maxRunTime = Double.POSITIVE_INFINITY;
@@ -86,7 +86,7 @@ public class STDCMPathfindingBuilder {
 
     /** Sets at which times each section of routes are unavailable. By default, everything is available */
     public STDCMPathfindingBuilder setUnavailableTimes(
-            Multimap<SignalingRoute, OccupancyBlock> unavailableTimes
+            Multimap<SignalingRoute, LegacyOccupancyBlock> unavailableTimes
     ) {
         this.unavailableTimes = unavailableTimes;
         return this;

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMPathfindingTests.java
@@ -43,10 +43,10 @@ public class STDCMPathfindingTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 50, 0, 100),
-                firstRoute, new OccupancyBlock(10000, POSITIVE_INFINITY, 0, 100),
-                secondRoute, new OccupancyBlock(0, 50, 0, 100),
-                secondRoute, new OccupancyBlock(10000, POSITIVE_INFINITY, 0, 100));
+                firstRoute, new LegacyOccupancyBlock(0, 50, 0, 100),
+                firstRoute, new LegacyOccupancyBlock(10000, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 50, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(10000, POSITIVE_INFINITY, 0, 100));
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartTime(100)
@@ -90,10 +90,10 @@ public class STDCMPathfindingTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 99, 0, 100),
-                firstRoute, new OccupancyBlock(101, POSITIVE_INFINITY, 0, 100),
-                secondRoute, new OccupancyBlock(0, 50, 0, 100),
-                secondRoute, new OccupancyBlock(1000, POSITIVE_INFINITY, 0, 100));
+                firstRoute, new LegacyOccupancyBlock(0, 99, 0, 100),
+                firstRoute, new LegacyOccupancyBlock(101, POSITIVE_INFINITY, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 50, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(1000, POSITIVE_INFINITY, 0, 100));
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
                 .setStartTime(100)
@@ -116,7 +116,7 @@ public class STDCMPathfindingTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(0, 10, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(0, 10, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -151,10 +151,10 @@ public class STDCMPathfindingTests {
         infraBuilder.addRoute("d", "e");
         var infra = infraBuilder.build();
         var occupancyGraph1 = ImmutableMultimap.of(
-                routeTop, new OccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
+                routeTop, new LegacyOccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
         );
         var occupancyGraph2 = ImmutableMultimap.of(
-                routeBottom, new OccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
+                routeBottom, new LegacyOccupancyBlock(0, POSITIVE_INFINITY, 0, 100)
         );
 
         var firstRoute = infra.findSignalingRoute("a->b", "BAL3");
@@ -317,7 +317,7 @@ public class STDCMPathfindingTests {
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 100)))
                 .setUnavailableTimes(ImmutableMultimap.of(
-                        route, new OccupancyBlock(0, 1000, 0, 100)
+                        route, new LegacyOccupancyBlock(0, 1000, 0, 100)
                 ))
                 .setMaxDepartureDelay(1000 + timeStep)
                 .setMaxRunTime(100)
@@ -342,7 +342,7 @@ public class STDCMPathfindingTests {
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 10)))
                 .setUnavailableTimes(ImmutableMultimap.of(
-                        route, new OccupancyBlock(0, POSITIVE_INFINITY, 99_000, 100_000)
+                        route, new LegacyOccupancyBlock(0, POSITIVE_INFINITY, 99_000, 100_000)
                 ))
                 .run();
         assertNotNull(res);
@@ -364,7 +364,7 @@ public class STDCMPathfindingTests {
                 .setStartLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 0)))
                 .setEndLocations(Set.of(new Pathfinding.EdgeLocation<>(route, 10)))
                 .setUnavailableTimes(ImmutableMultimap.of(
-                        route, new OccupancyBlock(300, POSITIVE_INFINITY, 0, 100_000)
+                        route, new LegacyOccupancyBlock(300, POSITIVE_INFINITY, 0, 100_000)
                 ))
                 .run();
         assertNotNull(res);
@@ -398,8 +398,8 @@ public class STDCMPathfindingTests {
         var infra = infraBuilder.build();
         var runTime = STDCMHelpers.getRoutesRunTime(routes);
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(300, 3600, 0, 1),
-                routes.get(2), new OccupancyBlock(0, 3600, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(300, 3600, 0, 1),
+                routes.get(2), new LegacyOccupancyBlock(0, 3600, 0, 1)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -430,7 +430,7 @@ public class STDCMPathfindingTests {
         var routes = List.of(infraBuilder.addRoute("a", "b"));
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(300, 3600, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(300, 3600, 0, 1)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StandardAllowanceTests.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableMultimap;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.utils.graph.Pathfinding;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -119,7 +118,7 @@ public class StandardAllowanceTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(0, 3600, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(0, 3600, 0, 100)
         );
         var allowance = new AllowanceValue.Percentage(20);
 
@@ -151,7 +150,7 @@ public class StandardAllowanceTests {
         var route = infraBuilder.addRoute("a", "b", 10_000);
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                route, new OccupancyBlock(0, 3600, 5_000, 10_000)
+                route, new LegacyOccupancyBlock(0, 3600, 5_000, 10_000)
         );
         var allowance = new AllowanceValue.Percentage(20);
 
@@ -197,8 +196,8 @@ public class StandardAllowanceTests {
         );
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(120, POSITIVE_INFINITY, 0, 1_000),
-                routes.get(2), new OccupancyBlock(0, 1000, 0, 1_000)
+                routes.get(0), new LegacyOccupancyBlock(120, POSITIVE_INFINITY, 0, 1_000),
+                routes.get(2), new LegacyOccupancyBlock(0, 1000, 0, 1_000)
         );
         var allowance = new AllowanceValue.Percentage(20);
 
@@ -241,8 +240,8 @@ public class StandardAllowanceTests {
         );
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(60, POSITIVE_INFINITY, 0, 1),
-                routes.get(2), new OccupancyBlock(0, 1000, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(60, POSITIVE_INFINITY, 0, 1),
+                routes.get(2), new LegacyOccupancyBlock(0, 1000, 0, 1)
         );
         var allowance = new AllowanceValue.Percentage(20);
 
@@ -320,10 +319,10 @@ public class StandardAllowanceTests {
         var infra = infraBuilder.build();
         var allowance = new AllowanceValue.Percentage(100);
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 200, 0, 100),
-                secondRoute, new OccupancyBlock(0, 600, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 1200, 0, 100),
-                forthRoute, new OccupancyBlock(0, 2000, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(0, 200, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 600, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 1200, 0, 100),
+                forthRoute, new LegacyOccupancyBlock(0, 2000, 0, 100)
         );
         var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -364,8 +363,8 @@ public class StandardAllowanceTests {
         );
         var infra = infraBuilder.build();
         var occupancyGraph = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(120, POSITIVE_INFINITY, 0, 1_000),
-                routes.get(2), new OccupancyBlock(0, 1000, 0, 1_000)
+                routes.get(0), new LegacyOccupancyBlock(120, POSITIVE_INFINITY, 0, 1_000),
+                routes.get(2), new LegacyOccupancyBlock(0, 1000, 0, 1_000)
         );
         var allowance = new AllowanceValue.TimePerDistance(60);
 
@@ -462,10 +461,10 @@ public class StandardAllowanceTests {
         var infra = infraBuilder.build();
         var allowance = new AllowanceValue.TimePerDistance(15);
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(0, 200, 0, 100),
-                secondRoute, new OccupancyBlock(0, 600, 0, 100),
-                thirdRoute, new OccupancyBlock(0, 1200, 0, 100),
-                forthRoute, new OccupancyBlock(0, 2000, 0, 100)
+                firstRoute, new LegacyOccupancyBlock(0, 200, 0, 100),
+                secondRoute, new LegacyOccupancyBlock(0, 600, 0, 100),
+                thirdRoute, new LegacyOccupancyBlock(0, 1200, 0, 100),
+                forthRoute, new LegacyOccupancyBlock(0, 2000, 0, 100)
         );
         var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -509,8 +508,8 @@ public class StandardAllowanceTests {
         if (isTimePerDistance)
             allowance = new AllowanceValue.TimePerDistance(120);
         var occupancyGraph = ImmutableMultimap.of(
-                firstRoute, new OccupancyBlock(2_000 + timeStep, POSITIVE_INFINITY, 0, 1_000),
-                secondRoute, new OccupancyBlock(0, 2_000 - timeStep, 0, 1_000)
+                firstRoute, new LegacyOccupancyBlock(2_000 + timeStep, POSITIVE_INFINITY, 0, 1_000),
+                secondRoute, new LegacyOccupancyBlock(0, 2_000 - timeStep, 0, 1_000)
         );
         var res = runWithAndWithoutAllowance(new STDCMPathfindingBuilder()
                 .setInfra(infra)

--- a/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/StopTests.java
@@ -151,7 +151,7 @@ public class StopTests {
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
         var unavailableTimes = ImmutableMultimap.of(
-                secondRoute, new OccupancyBlock(100_000, POSITIVE_INFINITY, 0, 100)
+                secondRoute, new LegacyOccupancyBlock(100_000, POSITIVE_INFINITY, 0, 100)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -177,8 +177,8 @@ public class StopTests {
         );
         var infra = infraBuilder.build();
         var occupancy = ImmutableMultimap.of(
-                routes.get(2), new OccupancyBlock(0, 12_000, 0, 1),
-                routes.get(2), new OccupancyBlock(12_010, POSITIVE_INFINITY, 0, 1)
+                routes.get(2), new LegacyOccupancyBlock(0, 12_000, 0, 1),
+                routes.get(2), new LegacyOccupancyBlock(12_010, POSITIVE_INFINITY, 0, 1)
         );
         var res = new STDCMPathfindingBuilder()
                 .setInfra(infra)
@@ -224,9 +224,9 @@ public class StopTests {
                 infraBuilder.addRoute("d", "e", 1, 20)
         );
         var occupancy = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
-                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
-                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
+                routes.get(3), new LegacyOccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new LegacyOccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
         );
         double timeStep = 2;
         var infra = infraBuilder.build();
@@ -273,8 +273,8 @@ public class StopTests {
                 infraBuilder.addRoute("d", "e", 1, 20)
         );
         var occupancy = ImmutableMultimap.of(
-                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
-                routes.get(3), new OccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
+                routes.get(3), new LegacyOccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new LegacyOccupancyBlock(1_220, POSITIVE_INFINITY, 0, 1)
         );
         double timeStep = 2;
         var infra = infraBuilder.build();
@@ -329,9 +329,9 @@ public class StopTests {
                 infraBuilder.addRoute("d", "e", 1, 20)
         );
         var occupancy = ImmutableMultimap.of(
-                routes.get(0), new OccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
-                routes.get(3), new OccupancyBlock(0, 1_200, 0, 1),
-                routes.get(3), new OccupancyBlock(1_300, POSITIVE_INFINITY, 0, 1)
+                routes.get(0), new LegacyOccupancyBlock(10, POSITIVE_INFINITY, 0, 1),
+                routes.get(3), new LegacyOccupancyBlock(0, 1_200, 0, 1),
+                routes.get(3), new LegacyOccupancyBlock(1_300, POSITIVE_INFINITY, 0, 1)
         );
         double timeStep = 2;
         var infra = infraBuilder.build();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.java
@@ -1,0 +1,57 @@
+package fr.sncf.osrd.stdcm.preprocessing;
+
+import static fr.sncf.osrd.Helpers.getBlocksOnRoutes;
+import static fr.sncf.osrd.Helpers.getSmallInfra;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Iterables;
+import fr.sncf.osrd.api.stdcm.STDCMRequest;
+import fr.sncf.osrd.envelope.Envelope;
+import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.SimpleRollingStock;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.BlockAvailabilityLegacyAdapter;
+import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+public class BlockAvailabilityLegacyAdapterTests {
+
+    /** This is just a simple smoke test, the class is expected to be replaced very soon
+     * so there's no need for extended testing */
+    @Test
+    public void simpleUnavailableRouteTest() {
+        var infra = getSmallInfra();
+        var routes = List.of(
+                "rt.DA0->DA6",
+                "rt.DA6->DC6"
+        );
+        var blocks = getBlocksOnRoutes(infra, routes);
+
+        double startOccupancy = 42;
+        double endOccupancy = 84;
+
+        var unavailableSpace = UnavailableSpaceBuilder.computeUnavailableSpace(
+                infra.rawInfra(),
+                infra.blockInfra(),
+                List.of(new STDCMRequest.RouteOccupancy(
+                        routes.get(1),
+                        startOccupancy,
+                        endOccupancy
+                )),
+                SimpleRollingStock.STANDARD_TRAIN,
+                10,
+                20
+        );
+        var adapter = new BlockAvailabilityLegacyAdapter(infra.blockInfra(), unavailableSpace);
+        var res = adapter.getAvailability(
+                List.of(Iterables.getLast(blocks)),
+                0,
+                1,
+                Envelope.make(EnvelopePart.generateTimes(new double[]{0., 1.}, new double[]{100., 100.})),
+                42
+        );
+        var expected = new BlockAvailabilityInterface.Unavailable(42 + 20, 0);
+        assertEquals(expected, res);
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/UnavailableSpaceBuilderTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/UnavailableSpaceBuilderTests.java
@@ -1,12 +1,14 @@
-package fr.sncf.osrd.stdcm;
+package fr.sncf.osrd.stdcm.preprocessing;
 
-import static fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder.computeUnavailableSpace;
+import static fr.sncf.osrd.stdcm.preprocessing.implementation.LegacyUnavailableSpaceBuilder.computeUnavailableSpace;
 import static fr.sncf.osrd.train.TestTrains.REALISTIC_FAST_TRAIN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.api.stdcm.STDCMRequest;
+import fr.sncf.osrd.stdcm.DummyRouteGraphBuilder;
+import fr.sncf.osrd.stdcm.LegacyOccupancyBlock;
 import org.junit.jupiter.api.Test;
 import java.util.Set;
 
@@ -33,14 +35,14 @@ public class UnavailableSpaceBuilderTests {
         );
         assertEquals(
                 Set.of(
-                        new OccupancyBlock(0, 100, 0, 1000) // base occupancy
+                        new LegacyOccupancyBlock(0, 100, 0, 1000) // base occupancy
                 ),
                 res.get(firstRoute)
         );
         assertEquals(
                 Set.of(
                         // If the train is in this area, the previous route would be "yellow", causing a conflict
-                        new OccupancyBlock(0, 100, 0, 1000)
+                        new LegacyOccupancyBlock(0, 100, 0, 1000)
 
                         // Margin added to the base occupancy to account for the train length,
                         // it can be removed if this test fails as it overlaps with the previous one
@@ -66,13 +68,13 @@ public class UnavailableSpaceBuilderTests {
         assertEquals(
                 Set.of(
                         // Entering this area would cause the train to see a signal that isn't green
-                        new OccupancyBlock(0, 100, 1000 - 400, 1000)
+                        new LegacyOccupancyBlock(0, 100, 1000 - 400, 1000)
                 ),
                 res.get(firstRoute)
         );
         assertEquals(
                 Set.of(
-                        new OccupancyBlock(0, 100, 0, 1000) // base occupancy
+                        new LegacyOccupancyBlock(0, 100, 0, 1000) // base occupancy
                 ),
                 res.get(secondRoute)
         );
@@ -104,7 +106,7 @@ public class UnavailableSpaceBuilderTests {
         );
         assertEquals(
                 Set.of(
-                        new OccupancyBlock(0, 100, 0, 1000) // base occupancy
+                        new LegacyOccupancyBlock(0, 100, 0, 1000) // base occupancy
                 ),
                 res.get(a1)
         );
@@ -115,7 +117,7 @@ public class UnavailableSpaceBuilderTests {
         assertEquals(
                 Set.of(
                         // If the train is in this area, the previous route would be "yellow", causing a conflict
-                        new OccupancyBlock(0, 100, 0, 1000)
+                        new LegacyOccupancyBlock(0, 100, 0, 1000)
 
                         // Margin added to the base occupancy to account for the train length,
                         // it can be removed if this test fails as it overlaps with the previous one
@@ -145,7 +147,7 @@ public class UnavailableSpaceBuilderTests {
                         // The second route can't be occupied in that time because it would cause a "yellow" state
                         // in the first one (conflict), and this accounts for the extra margin needed in the third
                         // route caused by the train length
-                        new OccupancyBlock(0, 100, 0, REALISTIC_FAST_TRAIN.getLength())
+                        new LegacyOccupancyBlock(0, 100, 0, REALISTIC_FAST_TRAIN.getLength())
                 ),
                 res.get(thirdRoute)
         );
@@ -168,13 +170,13 @@ public class UnavailableSpaceBuilderTests {
         // (20s before and 60s after)
         assertEquals(
                 Set.of(
-                        new OccupancyBlock(80, 260, 0, 1000)
+                        new LegacyOccupancyBlock(80, 260, 0, 1000)
                 ),
                 res.get(firstRoute)
         );
         assertEquals(
                 Set.of(
-                        new OccupancyBlock(80, 260, 0, 1000)
+                        new LegacyOccupancyBlock(80, 260, 0, 1000)
                 ),
                 res.get(secondRoute)
         );


### PR DESCRIPTION
Fixes #4265 

* Renamed the legacy classes to write new ones. `OccupancyBlock` has been renamed to `OccupancySegment` to avoid ambiguity with infra blocks. The legacy classes are still in use. 
* `UnavailableSpaceBuilder` has been mostly rewritten to output block occupancy. But the actual behavior remains unchanged for easier testing: the aspect cascade is based on routes. This is technically wrong, but behavior changes are avoided in this migration.
* `BlockAvailabilityAdapter` has been adapted to kt infra interfaces and block elements.

**This version behaves in the same way as the previous one**, for easier testing. This means that some computations are semantically wrong, such as the spacing requirements. This class will be the replaced very soon after the infra migration. 