### PR TITLE
core: kt-infra: Add a way to generate an EnvelopeSimContext

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/RangeMapUtils.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_utils/RangeMapUtils.java
@@ -34,7 +34,7 @@ public class RangeMapUtils {
     }
 
     /**
-     * Return the first map updated with another, using a merge function to fuse the values of intersecting ranges
+     * Returns the first map updated with another, using a merge function to fuse the values of intersecting ranges
      */
     public static <T, U> TreeRangeMap<Double, T> updateRangeMap(RangeMap<Double, T> map, RangeMap<Double, U> update,
                                              BiFunction<T, U, T> mergeFunction) {

--- a/core/kt-osrd-sim-infra/build.gradle
+++ b/core/kt-osrd-sim-infra/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
     implementation project(path: ':osrd-geom')
+    implementation project(path: ':envelope-sim')
     ksp project(':kt-fast-collections-generator')
 
     api project(":kt-osrd-utils")

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/Path.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/Path.kt
@@ -41,9 +41,9 @@ interface Path {
     fun getSpeedLimits(trainTag: String?): DistanceRangeMap<Speed>
     @JvmName("getLength")
     fun getLength(): Distance
-
     @JvmName("getTrackLocationAtOffset")
     fun getTrackLocationAtOffset(pathOffset: Distance): TrackLocation
+    fun getElectricalProfiles(mapping: HashMap<String, DistanceRangeMap<String>>): DistanceRangeMap<String>
 }
 
 /** Build a Path from chunks and offsets, filtering the chunks outside the offsets */

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -38,6 +38,9 @@ interface TrackProperties {
     fun getTrackChunkSpeedSections(trackChunk: DirTrackChunkId, trainTag: String?): DistanceRangeMap<Speed>
     @JvmName("getTrackChunkGeom")
     fun getTrackChunkGeom(trackChunk: TrackChunkId): LineString
+    fun getTrackChunkElectricalProfile(
+        trackChunk: TrackChunkId, mapping: HashMap<String, DistanceRangeMap<String>>
+    ): DistanceRangeMap<String>
 
     // Operational points
     fun getTrackChunkOperationalPointParts(trackChunk: TrackChunkId): StaticIdxList<OperationalPointPart>

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
@@ -1,10 +1,33 @@
 package fr.sncf.osrd.sim_infra.impl
 
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.api.LoadedSignalInfra
+import fr.sncf.osrd.sim_infra.api.LogicalSignal
+import fr.sncf.osrd.sim_infra.api.LogicalSignalId
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.api.SignalingSystemId
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackChunkId
+import fr.sncf.osrd.sim_infra.api.ZonePath
 import fr.sncf.osrd.utils.Direction
-import fr.sncf.osrd.utils.indexing.*
-import fr.sncf.osrd.utils.units.*
-import java.lang.AssertionError
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.DirStaticIdxList
+import fr.sncf.osrd.utils.indexing.IdxMap
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxList
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArraySet
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxList
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.StaticIdxSpace
+import fr.sncf.osrd.utils.indexing.StaticPool
+import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.DistanceList
 
 class BlockDescriptor(
     val startAtBufferStop: Boolean,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathImpl.kt
@@ -77,6 +77,10 @@ data class PathImpl(
         throw RuntimeException("The given path offset is larger than the path length")
     }
 
+    override fun getElectricalProfiles(mapping: HashMap<String, DistanceRangeMap<String>>): DistanceRangeMap<String> {
+        return getRangeMapFromUndirected { chunkId -> infra.getTrackChunkElectricalProfile(chunkId, mapping) }
+    }
+
     private fun projectLineString(getData: (chunkId: TrackChunkId) -> LineString): LineString {
         fun getDirData(dirChunkId: DirTrackChunkId): LineString {
             val data = getData(dirChunkId.value)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -224,6 +224,23 @@ class RawInfraImpl(
         return res
     }
 
+    override fun getTrackChunkElectricalProfile(
+        trackChunk: TrackChunkId, mapping: HashMap<String, DistanceRangeMap<String>>
+    ): DistanceRangeMap<String> {
+        val chunkOffset = getTrackChunkOffset(trackChunk)
+        val trackId = getTrackFromChunk(trackChunk)
+        val trackName = getTrackSectionName(trackId)
+        var profilesOnChunk = distanceRangeMapOf<String>()
+        if (mapping.containsKey(trackName)) {
+            val trackProfiles = mapping[trackName]!!
+            profilesOnChunk = trackProfiles.subMap(
+                chunkOffset, chunkOffset + getTrackChunkLength(trackChunk)
+            )
+            profilesOnChunk.shiftPositions(-chunkOffset)
+        }
+        return profilesOnChunk
+    }
+
     override fun getRoutesOnTrackChunk(trackChunk: DirTrackChunkId): StaticIdxList<Route> {
         return trackChunkPool[trackChunk.value].routes.get(trackChunk.direction)
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/EnvelopeTrainPathUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/EnvelopeTrainPathUtils.kt
@@ -1,0 +1,31 @@
+package fr.sncf.osrd.sim_infra.utils
+
+import fr.sncf.osrd.envelope_sim.electrification.Electrification
+import fr.sncf.osrd.envelope_sim.electrification.Electrified
+import fr.sncf.osrd.envelope_sim.electrification.Neutral
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.impl.NeutralSection
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.units.Distance
+
+
+/**
+ * Builds the ElectrificationMap
+ */
+fun buildElectrificationMap(path: Path): DistanceRangeMap<Electrification> {
+    val res: DistanceRangeMap<Electrification> = DistanceRangeMapImpl()
+    res.put(Distance.ZERO, path.getLength(), NonElectrified())
+    res.updateMap(
+        path.getCatenary()
+    ) { _: Electrification?, catenaryMode: String ->
+        if (catenaryMode == "") NonElectrified() else Electrified(catenaryMode)
+    }
+    res.updateMap(
+        path.getNeutralSections()
+    ) { electrification: Electrification?, neutralSection: NeutralSection ->
+        Neutral(neutralSection.lowerPantograph, electrification)
+    }
+    return res
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -1,6 +1,7 @@
-package fr.sncf.osrd.utils;
+package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.utils.units.Distance
+import java.util.function.BiFunction
 
 interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
@@ -35,6 +36,18 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
     /** Get the value at the given offset, if there is any.
      * On exact transition offsets, the value for the higher offset is used. */
     fun get(offset: Distance): T?
+
+    /** Returns a deep copy of the map */
+    fun clone(): DistanceRangeMap<T>
+
+    /** Returns a new DistanceRangeMap of the ranges between lower and upper */
+    fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T>
+
+    /** Updates the map with another one, using a merge function to fuse the values of intersecting ranges*/
+    fun <U> updateMap(
+        update: DistanceRangeMap<U>,
+        updateFunction: BiFunction<T, U, T>
+    )
 }
 
 fun <T> distanceRangeMapOf(): DistanceRangeMap<T> {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.utils
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.MutableDistanceArrayList
+import java.util.function.BiFunction
 import kotlin.math.min
 
 data class DistanceRangeMapImpl<T>(
@@ -75,6 +76,32 @@ data class DistanceRangeMapImpl<T>(
                 return entry.value
         }
         return null
+    }
+
+    override fun clone(): DistanceRangeMap<T> {
+        val res = DistanceRangeMapImpl<T>()
+        for (entry in this) {
+            res.put(entry.lower, entry.upper, entry.value)
+        }
+        return res
+    }
+
+    override fun subMap(lower: Distance, upper: Distance): DistanceRangeMap<T> {
+        assert(lower < upper)
+        val res = this.clone()
+        res.truncate(lower, upper)
+        return res
+    }
+
+    override fun <U> updateMap(update: DistanceRangeMap<U>, updateFunction: BiFunction<T, U, T>) {
+        for ((updateLower, updateUpper, updateValue) in update) {
+            for ((subMapLower, subMapUpper, subMapValue) in this.subMap(updateLower, updateUpper)) {
+                this.put(
+                    subMapLower, subMapUpper,
+                    updateFunction.apply(subMapValue, updateValue)
+                )
+            }
+        }
     }
 
     /** Merges adjacent values, removes 0-length ranges */

--- a/core/src/main/java/fr/sncf/osrd/api/ElectricalProfileSetManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ElectricalProfileSetManager.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api;
 
 import com.squareup.moshi.JsonDataException;
-import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping;
+import fr.sncf.osrd.external_generated_inputs.LegacyElectricalProfileMapping;
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
@@ -48,7 +48,7 @@ public class ElectricalProfileSetManager extends APIClient {
 
             logger.info("Parsing electrical profile set {} into model", profileSetId);
             cacheEntry.setStatus(CacheStatus.PARSING_MODEL);
-            var mapping = new ElectricalProfileMapping();
+            var mapping = new LegacyElectricalProfileMapping();
             mapping.parseRJS(rjsProfileSet);
 
             logger.info("Electrical profile set {} parsed", profileSetId);
@@ -67,7 +67,7 @@ public class ElectricalProfileSetManager extends APIClient {
     /**
      * Return the electrical profile set corresponding to the given id, in a ready-to-use format.
      */
-    public ElectricalProfileMapping getProfileMap(String profileSetId) {
+    public LegacyElectricalProfileMapping getProfileMap(String profileSetId) {
         if (profileSetId == null) {
             return null;
         }
@@ -93,9 +93,9 @@ public class ElectricalProfileSetManager extends APIClient {
 
     protected static class CacheEntry {
         protected CacheStatus status;
-        private ElectricalProfileMapping mapping;
+        private LegacyElectricalProfileMapping mapping;
 
-        CacheEntry(ElectricalProfileMapping mapping) {
+        CacheEntry(LegacyElectricalProfileMapping mapping) {
             this.mapping = mapping;
             this.status = CacheStatus.INITIALIZING;
         }

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingUtils.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingUtils.java
@@ -1,10 +1,15 @@
 package fr.sncf.osrd.api.pathfinding;
 
 import static fr.sncf.osrd.sim_infra.api.PathKt.buildPathFrom;
+import static fr.sncf.osrd.utils.KtToJavaConverter.toIntList;
 
 import fr.sncf.osrd.sim_infra.api.BlockInfra;
 import fr.sncf.osrd.sim_infra.api.Path;
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
+import fr.sncf.osrd.api.FullInfra;
+import fr.sncf.osrd.sim_infra.api.*;
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList;
+import java.util.List;
 
 public class PathfindingUtils {
 
@@ -16,5 +21,26 @@ public class PathfindingUtils {
     public static Path makePath(BlockInfra blockInfra, RawSignalingInfra rawInfra, Integer blockIdx,
                                 long beginOffset, long endOffset) {
         return buildPathFrom(rawInfra, blockInfra.getTrackChunksFromBlock(blockIdx), beginOffset, endOffset);
+    }
+
+
+    /**
+     * @param infra FullInfra
+     * @param blockIds the blocks in the order they are encountered
+     * @param offsetFirstBlock the path offset on the first block in millimeters
+     * @return corresponding path
+     */
+    public static Path makePathFromBlocks(FullInfra infra,
+                                          List<Integer> blockIds,
+                                          long offsetFirstBlock) {
+        var chunks = new MutableDirStaticIdxArrayList<TrackChunk>();
+        long totalLength = 0;
+        for (var blockId : blockIds) {
+            for (var zoneId : toIntList(infra.blockInfra().getBlockPath(blockId))) {
+                chunks.addAll(infra.rawInfra().getZonePathChunks(zoneId));
+                totalLength += infra.rawInfra().getZonePathLength(zoneId);
+            }
+        }
+        return buildPathFrom(infra.rawInfra(), chunks, offsetFirstBlock, totalLength);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.java
@@ -1,118 +1,87 @@
 package fr.sncf.osrd.envelope_sim_infra;
 
-import static fr.sncf.osrd.envelope_utils.RangeMapUtils.mergeRanges;
-import static fr.sncf.osrd.envelope_utils.RangeMapUtils.updateRangeMap;
+import static fr.sncf.osrd.sim_infra.utils.EnvelopeTrainPathUtilsKt.buildElectrificationMap;
+import static fr.sncf.osrd.utils.units.Distance.toMeters;
 
 import com.carrotsearch.hppc.DoubleArrayList;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
-import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPath;
 import fr.sncf.osrd.envelope_sim.electrification.Electrification;
-import fr.sncf.osrd.envelope_sim.electrification.Electrified;
-import fr.sncf.osrd.envelope_sim.electrification.Neutral;
-import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
-import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping;
-import fr.sncf.osrd.infra.api.tracks.undirected.NeutralSection;
-import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
-import fr.sncf.osrd.infra_state.api.TrainPath;
+import fr.sncf.osrd.kt_external_generated_inputs.ElectricalProfileMapping;
+import fr.sncf.osrd.sim_infra.api.Path;
+import fr.sncf.osrd.utils.DistanceRangeMap;
 import java.util.HashMap;
-import java.util.List;
 
 public class EnvelopeTrainPath {
-    /** Create EnvelopePath from a list of TrackRangeView, with no electrical profile */
-    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath) {
-        return from(trackSectionPath, null);
+    /**
+     * Create EnvelopePath from a path, with no electrical profile
+     */
+    public static EnvelopeSimPath from(Path path) {
+        return from(path, null);
     }
 
-    /** Create EnvelopePath from a list of TrackRangeView */
-    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath,
-                                       ElectricalProfileMapping electricalProfileMapping) {
+    /**
+     * Create EnvelopePath from a path and a ElectricalProfileMapping
+     */
+    public static EnvelopeSimPath from(Path path, ElectricalProfileMapping electricalProfileMapping) {
         var gradePositions = new DoubleArrayList();
         gradePositions.add(0);
         var gradeValues = new DoubleArrayList();
-        var catenaries = TreeRangeMap.<Double, String>create();
-        var neutralSections = TreeRangeMap.<Double, NeutralSection>create();
-        double length = 0;
-
-        for (var range : trackSectionPath) {
-            if (range.getLength() > 0) {
-                // Add grades
-                var grades = range.getGradients().subRangeMap(Range.closed(0., range.getLength())).asMapOfRanges();
-                for (var entry : grades.entrySet()) {
-                    gradePositions.add(length + entry.getKey().upperEndpoint());
-                    gradeValues.add(entry.getValue());
-                }
-                // Add catenaries
-                var catenariesInRange = range.getCatenaryVoltages().subRangeMap(Range.closed(0., range.getLength()));
-                transferRangeMap(catenariesInRange, catenaries, length);
-
-                // Add neutral sections
-                var neutralInRange = range.getNeutralSections().subRangeMap(Range.closed(0., range.getLength()));
-                transferRangeMap(neutralInRange, neutralSections, length);
-
-                // Update length
-                length += range.getLength();
-            }
-        }
-        if (gradeValues.isEmpty()) {
-            gradePositions.add(length);
-            gradeValues.add(0);
+        for (var range : path.getGradients()) {
+            gradePositions.add(toMeters(range.getUpper()));
+            gradeValues.add(range.getValue());
         }
 
-        var electrificationMap = buildElectrificationMap(mergeRanges(catenaries), mergeRanges(neutralSections), length);
-
-        var electrificationMapByPowerClass = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        DistanceRangeMap<Electrification> distanceElectrificationMap = buildElectrificationMap(path);
+        var distanceElectrificationMapByPowerClass = new HashMap<String, DistanceRangeMap<Electrification>>();
         if (electricalProfileMapping != null) {
-            var profileMap = electricalProfileMapping.getProfilesOnPath(trackSectionPath);
-            electrificationMapByPowerClass = buildElectrificationMapByPowerClass(electrificationMap, profileMap);
+            var profileMap = electricalProfileMapping.getProfilesOnPath(path);
+            distanceElectrificationMapByPowerClass = buildElectrificationMapByPowerClass(
+                    distanceElectrificationMap,
+                    profileMap);
         }
-        return new EnvelopeSimPath(length, gradePositions.toArray(), gradeValues.toArray(), electrificationMap,
-                electrificationMapByPowerClass);
+
+        //Convert the maps to fit the needs of EnvelopeSimPath
+        var electrificationMap = convertElectrificationMap(distanceElectrificationMap);
+        var electrificationMapByPowerClass = convertElectrificationMapByPowerClass(
+                distanceElectrificationMapByPowerClass);
+        return new EnvelopeSimPath(toMeters(path.getLength()), gradePositions.toArray(), gradeValues.toArray(),
+                electrificationMap, electrificationMapByPowerClass);
     }
 
-    /** Create EnvelopePath from a train path */
-    public static EnvelopeSimPath from(TrainPath trainsPath, ElectricalProfileMapping electricalProfileMapping) {
-        return from(TrainPath.removeLocation(trainsPath.trackRangePath()), electricalProfileMapping);
-    }
-
-    /** Create EnvelopePath from a train path, with no electrical profile */
-    public static EnvelopeSimPath from(TrainPath trainsPath) {
-        return from(trainsPath, null);
-    }
-
-    private static <T> void transferRangeMap(RangeMap<Double, T> source, RangeMap<Double, T> dest,
-                                             double offset) {
-        for (var entry : source.asMapOfRanges().entrySet()) {
-            var range = entry.getKey();
-            var value = entry.getValue();
-            dest.put(Range.closedOpen(range.lowerEndpoint() + offset, range.upperEndpoint() + offset), value);
+    private static HashMap<String, DistanceRangeMap<Electrification>> buildElectrificationMapByPowerClass(
+            DistanceRangeMap<Electrification> electrificationMap,
+            HashMap<String, DistanceRangeMap<String>> profileMap) {
+        var res = new HashMap<String, DistanceRangeMap<Electrification>>();
+        for (var entry : profileMap.entrySet()) {
+            var electrificationMapWithProfiles = electrificationMap.clone();
+            electrificationMapWithProfiles.updateMap(
+                    entry.getValue(),
+                    Electrification::withElectricalProfile
+            );
+            res.put(entry.getKey(), electrificationMapWithProfiles);
         }
+        return res;
     }
 
-    private static ImmutableRangeMap<Double, Electrification> buildElectrificationMap(
-            RangeMap<Double, String> catenaryModes,
-            RangeMap<Double, NeutralSection> neutralSections,
-            double length) {
+    /** Converts an ElectrificationMap as a DistanceRangeMap into a RangeMap*/
+    private static ImmutableRangeMap<Double, Electrification> convertElectrificationMap(
+            DistanceRangeMap<Electrification> map) {
         TreeRangeMap<Double, Electrification> res = TreeRangeMap.create();
-        res.put(Range.closed(0.0, length), new NonElectrified());
-        res = updateRangeMap(res, catenaryModes,
-                (e, catenaryMode) -> catenaryMode.equals("") ? new NonElectrified() : new Electrified(catenaryMode));
-        res = updateRangeMap(res, neutralSections,
-                (electrification, neutralSection) -> new Neutral(neutralSection.lowerPantograph(), electrification));
+        for (var entry : map.asList()) {
+            res.put(Range.closedOpen(toMeters(entry.getLower()), toMeters(entry.getUpper())), entry.getValue());
+        }
         return ImmutableRangeMap.copyOf(res);
     }
 
-    private static HashMap<String, ImmutableRangeMap<Double, Electrification>> buildElectrificationMapByPowerClass(
-            ImmutableRangeMap<Double, Electrification> electrificationMap,
-            HashMap<String, RangeMap<Double, String>> profileMap) {
+    /** Converts an ElectrificationMapByPowerClass as a DistanceRangeMap into a RangeMap*/
+    private static HashMap<String, ImmutableRangeMap<Double, Electrification>> convertElectrificationMapByPowerClass(
+            HashMap<String, DistanceRangeMap<Electrification>> electrificationMapByPowerClass) {
         var res = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
-        for (var entry : profileMap.entrySet()) {
-            var withElectricalProfiles = ImmutableRangeMap.copyOf(
-                    updateRangeMap(electrificationMap, mergeRanges(entry.getValue()),
-                            Electrification::withElectricalProfile));
-            res.put(entry.getKey(), withElectricalProfiles);
+        for (var entry : electrificationMapByPowerClass.entrySet()) {
+            res.put(entry.getKey(), convertElectrificationMap(entry.getValue()));
         }
         return res;
     }

--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/LegacyEnvelopeTrainPath.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/LegacyEnvelopeTrainPath.java
@@ -1,0 +1,119 @@
+package fr.sncf.osrd.envelope_sim_infra;
+
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.mergeRanges;
+import static fr.sncf.osrd.envelope_utils.RangeMapUtils.updateRangeMap;
+
+import com.carrotsearch.hppc.DoubleArrayList;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
+import fr.sncf.osrd.envelope_sim.EnvelopeSimPath;
+import fr.sncf.osrd.envelope_sim.electrification.Electrification;
+import fr.sncf.osrd.envelope_sim.electrification.Electrified;
+import fr.sncf.osrd.envelope_sim.electrification.Neutral;
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
+import fr.sncf.osrd.external_generated_inputs.LegacyElectricalProfileMapping;
+import fr.sncf.osrd.infra.api.tracks.undirected.NeutralSection;
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
+import fr.sncf.osrd.infra_state.api.TrainPath;
+import java.util.HashMap;
+import java.util.List;
+
+public class LegacyEnvelopeTrainPath {
+    /** Create EnvelopePath from a list of TrackRangeView, with no electrical profile */
+    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath) {
+        return from(trackSectionPath, null);
+    }
+
+    /** Create EnvelopePath from a list of TrackRangeView */
+    public static EnvelopeSimPath from(List<TrackRangeView> trackSectionPath,
+                                       LegacyElectricalProfileMapping electricalProfileMapping) {
+        var gradePositions = new DoubleArrayList();
+        gradePositions.add(0);
+        var gradeValues = new DoubleArrayList();
+        var catenaries = TreeRangeMap.<Double, String>create();
+        var neutralSections = TreeRangeMap.<Double, NeutralSection>create();
+        double length = 0;
+
+        for (var range : trackSectionPath) {
+            if (range.getLength() > 0) {
+                // Add grades
+                var grades = range.getGradients().subRangeMap(Range.closed(0., range.getLength())).asMapOfRanges();
+                for (var entry : grades.entrySet()) {
+                    gradePositions.add(length + entry.getKey().upperEndpoint());
+                    gradeValues.add(entry.getValue());
+                }
+                // Add catenaries
+                var catenariesInRange = range.getCatenaryVoltages().subRangeMap(Range.closed(0., range.getLength()));
+                transferRangeMap(catenariesInRange, catenaries, length);
+
+                // Add neutral sections
+                var neutralInRange = range.getNeutralSections().subRangeMap(Range.closed(0., range.getLength()));
+                transferRangeMap(neutralInRange, neutralSections, length);
+
+                // Update length
+                length += range.getLength();
+            }
+        }
+        if (gradeValues.isEmpty()) {
+            gradePositions.add(length);
+            gradeValues.add(0);
+        }
+
+        var electrificationMap = buildElectrificationMap(mergeRanges(catenaries), mergeRanges(neutralSections), length);
+
+        var electrificationMapByPowerClass = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        if (electricalProfileMapping != null) {
+            var profileMap = electricalProfileMapping.getProfilesOnPath(trackSectionPath);
+            electrificationMapByPowerClass = buildElectrificationMapByPowerClass(electrificationMap, profileMap);
+        }
+        return new EnvelopeSimPath(length, gradePositions.toArray(), gradeValues.toArray(), electrificationMap,
+                electrificationMapByPowerClass);
+    }
+
+    /** Create EnvelopePath from a train path */
+    public static EnvelopeSimPath from(TrainPath trainsPath, LegacyElectricalProfileMapping electricalProfileMapping) {
+        return from(TrainPath.removeLocation(trainsPath.trackRangePath()), electricalProfileMapping);
+    }
+
+    /** Create EnvelopePath from a train path, with no electrical profile */
+    public static EnvelopeSimPath from(TrainPath trainsPath) {
+        return from(trainsPath, null);
+    }
+
+    private static <T> void transferRangeMap(RangeMap<Double, T> source, RangeMap<Double, T> dest,
+                                             double offset) {
+        for (var entry : source.asMapOfRanges().entrySet()) {
+            var range = entry.getKey();
+            var value = entry.getValue();
+            dest.put(Range.closedOpen(range.lowerEndpoint() + offset, range.upperEndpoint() + offset), value);
+        }
+    }
+
+    private static ImmutableRangeMap<Double, Electrification> buildElectrificationMap(
+            RangeMap<Double, String> catenaryModes,
+            RangeMap<Double, NeutralSection> neutralSections,
+            double length) {
+        TreeRangeMap<Double, Electrification> res = TreeRangeMap.create();
+        res.put(Range.closed(0.0, length), new NonElectrified());
+        res = updateRangeMap(res, catenaryModes,
+                (e, catenaryMode) -> catenaryMode.equals("") ? new NonElectrified() : new Electrified(catenaryMode));
+        res = updateRangeMap(res, neutralSections,
+                (electrification, neutralSection) -> new Neutral(neutralSection.lowerPantograph(), electrification));
+        return ImmutableRangeMap.copyOf(res);
+    }
+
+    private static HashMap<String, ImmutableRangeMap<Double, Electrification>> buildElectrificationMapByPowerClass(
+            ImmutableRangeMap<Double, Electrification> electrificationMap,
+            HashMap<String, RangeMap<Double, String>> profileMap) {
+        var res = new HashMap<String, ImmutableRangeMap<Double, Electrification>>();
+        for (var entry : profileMap.entrySet()) {
+            var withElectricalProfiles = ImmutableRangeMap.copyOf(
+                    updateRangeMap(electrificationMap, mergeRanges(entry.getValue()),
+                            Electrification::withElectricalProfile));
+            res.put(entry.getKey(), withElectricalProfiles);
+        }
+        return res;
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/external_generated_inputs/LegacyElectricalProfileMapping.java
+++ b/core/src/main/java/fr/sncf/osrd/external_generated_inputs/LegacyElectricalProfileMapping.java
@@ -14,7 +14,7 @@ import java.util.List;
  * The electrical profiles model the power loss along catenaries depending on the position and the power class of
  * the rolling stock used
  */
-public class ElectricalProfileMapping {
+public class LegacyElectricalProfileMapping {
     /**
      * Internal representation: {"power class": {"track section": {"range": "electrical profile value"}}}
      */
@@ -25,7 +25,6 @@ public class ElectricalProfileMapping {
      */
     public void parseRJS(RJSElectricalProfileSet rjsProfileSet) {
         assert mapping.isEmpty();
-
         for (var rjsProfile : rjsProfileSet.levels) {
             var trackMapping = mapping.computeIfAbsent(rjsProfile.powerClass, k -> new HashMap<>());
             for (var trackRange : rjsProfile.trackRanges) {

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
+import fr.sncf.osrd.envelope_sim_infra.LegacyEnvelopeTrainPath
 import fr.sncf.osrd.infra_state.api.TrainPath
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.ZoneStatus
@@ -126,7 +126,7 @@ fun run(
     val routeOccupancies = routeOccupancies(zoneOccupationChangeEvents, rawInfra, envelopeWithStops)
 
     // Compute energy consumed
-    val envelopePath = EnvelopeTrainPath.from(trainPath)
+    val envelopePath = LegacyEnvelopeTrainPath.from(trainPath)
     val mechanicalEnergyConsumed =
         EnvelopePhysics.getMechanicalEnergyConsumed(envelope, envelopePath, schedule.rollingStock)
 

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -11,9 +11,9 @@ import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.LegacyEnvelopeTrainPath;
 import fr.sncf.osrd.envelope_sim_infra.LegacyMRSP;
-import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping;
+import fr.sncf.osrd.external_generated_inputs.LegacyElectricalProfileMapping;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.railjson.parser.RJSStandaloneTrainScheduleParser;
@@ -125,7 +125,7 @@ public class StandaloneSim {
     /** Parse some railJSON arguments and run a standalone simulation */
     public static StandaloneSimResult runFromRJS(
             FullInfra infra,
-            ElectricalProfileMapping electricalProfileMap,
+            LegacyElectricalProfileMapping electricalProfileMap,
             RJSTrainPath rjsTrainPath,
             HashMap<String, RollingStock> rollingStocks,
             List<RJSStandaloneTrainSchedule> rjsSchedules,
@@ -133,7 +133,7 @@ public class StandaloneSim {
     ) {
         // Parse trainPath
         var trainPath = TrainPathBuilder.from(infra.java(), rjsTrainPath);
-        var envelopePath = EnvelopeTrainPath.from(trainPath, electricalProfileMap);
+        var envelopePath = LegacyEnvelopeTrainPath.from(trainPath, electricalProfileMap);
 
         // Parse train schedules
         var trainSchedules = new ArrayList<StandaloneTrainSchedule>();

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/AllowanceManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/AllowanceManager.java
@@ -33,7 +33,7 @@ public class AllowanceManager {
             return null; // No space to try the allowance
         var context = makeAllowanceContext(affectedEdges);
         var oldEnvelope = STDCMUtils.mergeEnvelopes(affectedEdges);
-        var newEnvelope = STDCMSimulations.findEngineeringAllowance(context, oldEnvelope, neededDelay);
+        var newEnvelope = LegacySTDCMSimulations.findEngineeringAllowance(context, oldEnvelope, neededDelay);
         if (newEnvelope == null)
             return null; // We couldn't find an envelope
         var newPreviousEdge = makeNewEdges(affectedEdges, newEnvelope);
@@ -101,7 +101,8 @@ public class AllowanceManager {
         var firstOffset = edges.get(0).route().getInfraRoute().getLength() - edges.get(0).envelope().getEndPos();
         for (var edge : edges)
             routes.add(edge.route());
-        return STDCMSimulations.makeSimContext(routes, firstOffset, graph.rollingStock, graph.comfort, graph.timeStep);
+        return LegacySTDCMSimulations.makeSimContext(
+                routes, firstOffset, graph.rollingStock, graph.comfort, graph.timeStep);
     }
 
     /** Find on which edges to run the allowance */

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/BacktrackingManager.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/BacktrackingManager.java
@@ -56,7 +56,7 @@ public class BacktrackingManager {
      * The start time and any data related to delays will be updated accordingly.
      * */
     private STDCMEdge rebuildEdgeBackward(STDCMEdge old, double endSpeed) {
-        var newEnvelope = STDCMSimulations.simulateBackwards(
+        var newEnvelope = LegacySTDCMSimulations.simulateBackwards(
                 old.route(),
                 endSpeed,
                 old.envelopeStartOffset(),

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
@@ -134,7 +134,7 @@ public class STDCMEdgeBuilder {
     /** Creates all edges that can be accessed on the given route, using all the parameters specified. */
     public Collection<STDCMEdge> makeAllEdges() {
         if (envelope == null)
-            envelope = STDCMSimulations.simulateRoute(
+            envelope = LegacySTDCMSimulations.simulateRoute(
                     route,
                     startSpeed,
                     startOffset,

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.java
@@ -126,7 +126,7 @@ public class STDCMPathfinding {
             double searchTimeRange
     ) {
         var envelope = range.edge().envelope();
-        var timeEnd = STDCMSimulations.interpolateTime(
+        var timeEnd = LegacySTDCMSimulations.interpolateTime(
                 envelope,
                 range.edge().envelopeStartOffset(),
                 range.offset(),

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Iterables;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.stdcm.STDCMResult;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.LegacyEnvelopeTrainPath;
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
@@ -37,7 +37,7 @@ public class STDCMPostProcessing {
         var ranges = makeEdgeRange(path);
         var routeRanges = makeRouteRanges(ranges);
         var routeWaypoints = makeRouteWaypoints(path);
-        var physicsPath = EnvelopeTrainPath.from(makeTrackRanges(ranges));
+        var physicsPath = LegacyEnvelopeTrainPath.from(makeTrackRanges(ranges));
         var mergedEnvelopes = STDCMUtils.mergeEnvelopeRanges(ranges);
         var departureTime = computeDepartureTime(ranges, startTime);
         var stops = makeStops(ranges);

--- a/core/src/main/kotlin/fr/sncf/osrd/kt_external_generated_inputs/ElectricalProfileMapping.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/kt_external_generated_inputs/ElectricalProfileMapping.kt
@@ -1,0 +1,50 @@
+package fr.sncf.osrd.kt_external_generated_inputs
+
+import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
+
+/**
+ * A mapping from track sections to electrical profile values
+ * The electrical profiles model the power loss along catenaries depending on the position and the power class of
+ * the rolling stock used
+ */
+
+class ElectricalProfileMapping {
+    /**
+     * Internal representation: {"power class": {"track section": {"range": "electrical profile value"}}}
+     */
+    var mapping = HashMap<String, HashMap<String, DistanceRangeMap<String>>>()
+
+    /**
+     * Parse the rjs profiles and store them in the internal mapping.
+     */
+    fun parseRJS(rjsProfileSet: RJSElectricalProfileSet) {
+        assert(mapping.isEmpty())
+        for (rjsProfile in rjsProfileSet.levels) {
+            val trackMapping: HashMap<String, DistanceRangeMap<String>> =
+                mapping.computeIfAbsent(
+                    rjsProfile.powerClass
+                ) { _: String? -> HashMap() }
+            for (trackRange in rjsProfile.trackRanges) {
+                val rangeMapping = trackMapping.computeIfAbsent(
+                    trackRange.trackSectionID
+                ) { k: String? -> DistanceRangeMapImpl() }
+                rangeMapping.put(fromMeters(trackRange.begin), fromMeters(trackRange.end), rjsProfile.value)
+            }
+        }
+    }
+
+    /** Returns the electrical profiles encountered on a path */
+    fun getProfilesOnPath(path: Path): HashMap<String, DistanceRangeMap<String>> {
+        val res = HashMap<String, DistanceRangeMap<String>>()
+        for (entry in mapping.entries) {
+            val powerClass = entry.key
+            val byTrackMapping: HashMap<String, DistanceRangeMap<String>> = entry.value
+            res.put(powerClass, path.getElectricalProfiles(byTrackMapping))
+        }
+        return res
+    }
+}

--- a/core/src/test/java/fr/sncf/osrd/api/ElectricalProfileSetManagerTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ElectricalProfileSetManagerTest.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api;
 
-import static fr.sncf.osrd.external_generated_inputs.ElectricalProfileMappingTest.verifyProfileMap;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static fr.sncf.osrd.external_generated_inputs.LegacyElectricalProfileMappingTest.verifyProfileMap;
 
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;

--- a/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/pathfinding/PathfindingResultConverterTest.java
@@ -1,18 +1,16 @@
 package fr.sncf.osrd.api.pathfinding;
 
 import static fr.sncf.osrd.Helpers.getBlocksOnRoutes;
-import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.makePath;
-import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.makePathWaypoint;
+import static fr.sncf.osrd.api.pathfinding.PathfindingResultConverter.*;
 import static fr.sncf.osrd.utils.KtToJavaConverter.toIntList;
 import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toDirection;
 import static fr.sncf.osrd.utils.indexing.DirStaticIdxKt.toValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import fr.sncf.osrd.Helpers;
 import fr.sncf.osrd.api.FullInfra;
+import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection;
+import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl;
 import fr.sncf.osrd.sim_infra.impl.PathImpl;
 import fr.sncf.osrd.utils.Direction;
 import fr.sncf.osrd.utils.graph.Pathfinding;
@@ -33,7 +31,8 @@ public class PathfindingResultConverterTest {
         ));
         var ranges = new ArrayList<Pathfinding.EdgeRange<Integer>>();
         for (var block : blocks) {
-            ranges.add(new Pathfinding.EdgeRange<>(block, 0, infra.blockInfra().getBlockLength(block)));
+            ranges.add(new Pathfinding.EdgeRange<>(block, 0,
+                    infra.blockInfra().getBlockLength(block)));
         }
         var path = makePath(infra.rawInfra(), infra.blockInfra(), ranges);
         var pathImpl = (PathImpl) path;

--- a/core/src/test/java/fr/sncf/osrd/external_generated_inputs/LegacyElectricalProfileMappingTest.java
+++ b/core/src/test/java/fr/sncf/osrd/external_generated_inputs/LegacyElectricalProfileMappingTest.java
@@ -24,12 +24,12 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-public class ElectricalProfileMappingTest {
+public class LegacyElectricalProfileMappingTest {
 
     /**
      * Check that a profile map is coherent
      */
-    public static void verifyProfileMap(ElectricalProfileMapping profileMap) {
+    public static void verifyProfileMap(LegacyElectricalProfileMapping profileMap) {
         assertNotEquals(0, profileMap.mapping.size());
         for (var byTrack : profileMap.mapping.entrySet()) {
             assertNotEquals(0, byTrack.getValue().size());
@@ -44,7 +44,7 @@ public class ElectricalProfileMappingTest {
         var profileSet = Helpers.getExampleElectricalProfiles("small_infra/external_generated_inputs.json");
         assert profileSet.levels.size() > 0;
 
-        var profileMap = new ElectricalProfileMapping();
+        var profileMap = new LegacyElectricalProfileMapping();
         profileMap.parseRJS(profileSet);
 
         verifyProfileMap(profileMap);
@@ -55,7 +55,7 @@ public class ElectricalProfileMappingTest {
     public void testGetProfileByPathSingleTrackInfra() {
         var rjsElectricalProfiles = getRjsElectricalProfileSet();
 
-        var profileMap = new ElectricalProfileMapping();
+        var profileMap = new LegacyElectricalProfileMapping();
         profileMap.parseRJS(rjsElectricalProfiles);
 
         var rjsInfra = makeSingleTrackRJSInfra();
@@ -81,7 +81,7 @@ public class ElectricalProfileMappingTest {
     public void testGetProfileByPathSmallInfra() throws IOException, URISyntaxException {
         var rjsElectricalProfiles = getExampleElectricalProfiles("small_infra/external_generated_inputs.json");
 
-        var profileMap = new ElectricalProfileMapping();
+        var profileMap = new LegacyElectricalProfileMapping();
         profileMap.parseRJS(rjsElectricalProfiles);
 
         var rjsInfra = getExampleInfra("small_infra/infra.json");

--- a/core/src/test/java/fr/sncf/osrd/infra_state/TrainPathTests.java
+++ b/core/src/test/java/fr/sncf/osrd/infra_state/TrainPathTests.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.LegacyEnvelopeTrainPath;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.infra_state.api.TrainPath;
@@ -171,7 +171,7 @@ public class TrainPathTests {
                 new TrackLocation(track, 10),
                 new TrackLocation(track, 100)
         );
-        var envelopePath = EnvelopeTrainPath.from(TrainPath.removeLocation(path.trackRangePath()));
+        var envelopePath = LegacyEnvelopeTrainPath.from(TrainPath.removeLocation(path.trackRangePath()));
         assertEquals(30, envelopePath.getAverageGrade(0, 20));
         assertEquals(0, envelopePath.getAverageGrade(20, 50));
         assertEquals(-10, envelopePath.getAverageGrade(50, 70));

--- a/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/BacktrackingTests.java
@@ -5,7 +5,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
+import fr.sncf.osrd.stdcm.graph.LegacySTDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ public class BacktrackingTests {
          */
         var infraBuilder = new DummyRouteGraphBuilder();
         var route = infraBuilder.addRoute("a", "b", 1000);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(route, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(route, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -53,7 +53,7 @@ public class BacktrackingTests {
         infraBuilder.addRoute("b", "c", 10);
         infraBuilder.addRoute("c", "d", 10);
         var lastRoute = infraBuilder.addRoute("d", "e", 10);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();
@@ -81,7 +81,7 @@ public class BacktrackingTests {
         var infraBuilder = new DummyRouteGraphBuilder();
         var firstRoute = infraBuilder.addRoute("a", "b", 1000);
         var secondRoute = infraBuilder.addRoute("b", "c", 100, 5);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
         var runTime = firstRouteEnvelope.getTotalTime();

--- a/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.java
@@ -6,7 +6,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
+import fr.sncf.osrd.stdcm.graph.LegacySTDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -178,7 +178,7 @@ public class DepartureTimeShiftTests {
         var firstRoute = infraBuilder.addRoute("a", "b");
         var secondRoute = infraBuilder.addRoute("b", "c");
         var infra = infraBuilder.build();
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2, null, null);
         assert firstRouteEnvelope != null;
         var occupancyGraph = ImmutableMultimap.of(

--- a/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.java
@@ -5,7 +5,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableMultimap;
-import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
+import fr.sncf.osrd.stdcm.graph.LegacySTDCMSimulations;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.utils.graph.Pathfinding;
 import org.junit.jupiter.api.Test;
@@ -35,10 +35,10 @@ public class EngineeringAllowanceTests {
         var firstRoute = infraBuilder.addRoute("a", "b", 1_000, 30);
         var secondRoute = infraBuilder.addRoute("b", "c", 10_000, 30);
         var thirdRoute = infraBuilder.addRoute("c", "d", 100, 30);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = LegacySTDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeThirdRouteFree = firstRouteEnvelope.getTotalTime() + secondRouteEnvelope.getTotalTime();
@@ -88,10 +88,10 @@ public class EngineeringAllowanceTests {
         infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = LegacySTDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;
@@ -147,10 +147,10 @@ public class EngineeringAllowanceTests {
         final var thirdRoute = infraBuilder.addRoute("c", "d", 1_000, 20);
         infraBuilder.addRoute("d", "e", 1_000, 20);
         var lastRoute = infraBuilder.addRoute("e", "f", 1_000, 20);
-        var firstRouteEnvelope = STDCMSimulations.simulateRoute(firstRoute, 0, 0,
+        var firstRouteEnvelope = LegacySTDCMSimulations.simulateRoute(firstRoute, 0, 0,
                 REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert firstRouteEnvelope != null;
-        var secondRouteEnvelope = STDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
+        var secondRouteEnvelope = LegacySTDCMSimulations.simulateRoute(secondRoute, firstRouteEnvelope.getEndSpeed(),
                 0, REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
         assert secondRouteEnvelope != null;
         var timeLastRouteFree = firstRouteEnvelope.getTotalTime() + 120 + secondRouteEnvelope.getTotalTime() * 3;

--- a/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/STDCMHelpers.java
@@ -8,14 +8,14 @@ import com.google.common.collect.Multimap;
 import fr.sncf.osrd.api.FullInfra;
 import fr.sncf.osrd.api.stdcm.STDCMRequest;
 import fr.sncf.osrd.DriverBehaviour;
-import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath;
+import fr.sncf.osrd.envelope_sim_infra.LegacyEnvelopeTrainPath;
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra;
 import fr.sncf.osrd.infra.api.signaling.SignalingRoute;
 import fr.sncf.osrd.infra_state.api.TrainPath;
 import fr.sncf.osrd.infra_state.implementation.TrainPathBuilder;
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper;
 import fr.sncf.osrd.standalone_sim.StandaloneSim;
-import fr.sncf.osrd.stdcm.graph.STDCMSimulations;
+import fr.sncf.osrd.stdcm.graph.LegacySTDCMSimulations;
 import fr.sncf.osrd.stdcm.preprocessing.implementation.UnavailableSpaceBuilder;
 import fr.sncf.osrd.train.RollingStock;
 import fr.sncf.osrd.train.StandaloneTrainSchedule;
@@ -38,7 +38,7 @@ public class STDCMHelpers {
         var result = StandaloneSim.run(
                 infra,
                 trainPath,
-                EnvelopeTrainPath.from(trainPath),
+                LegacyEnvelopeTrainPath.from(trainPath),
                 List.of(new StandaloneTrainSchedule(
                         REALISTIC_FAST_TRAIN,
                         0,
@@ -119,7 +119,7 @@ public class STDCMHelpers {
         double time = 0;
         double speed = 0;
         for (var route : routes) {
-            var envelope = STDCMSimulations.simulateRoute(route, speed, 0,
+            var envelope = LegacySTDCMSimulations.simulateRoute(route, speed, 0,
                     REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2., null, null);
             assert envelope != null;
             time += envelope.getTotalTime();

--- a/core/src/test/kotlin/fr/sncf/osrd/kt_external_generated_inputs/ElectricalProfileMappingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/kt_external_generated_inputs/ElectricalProfileMappingTest.kt
@@ -1,0 +1,63 @@
+package fr.sncf.osrd.kt_external_generated_inputs
+
+import fr.sncf.osrd.Helpers
+import fr.sncf.osrd.utils.*
+import org.junit.jupiter.api.Test
+import fr.sncf.osrd.utils.units.meters
+import org.assertj.core.api.Assertions.assertThat
+
+class ElectricalProfileMappingTest {
+   @Test
+   fun testRJSParsing() {
+      val powerClass1TrackTA0 = DistanceRangeMapImpl<String>()
+      powerClass1TrackTA0.put(0.meters, 1_600.meters, "A")
+      powerClass1TrackTA0.put(1_600.meters, 1_800.meters, "B")
+      powerClass1TrackTA0.put(1_800.meters, 2_000.meters, "A")
+      val powerClass1TrackTA1 = DistanceRangeMapImpl<String>()
+      powerClass1TrackTA1.put(0.meters, 1_950.meters, "B")
+      val powerClass1Map = hashMapOf<String, DistanceRangeMap<String>>(Pair("TA0", powerClass1TrackTA0),
+         Pair("TA1", powerClass1TrackTA1))
+
+      val powerClass2TrackTA0 = DistanceRangeMapImpl<String>()
+      powerClass2TrackTA0.put(0.meters, 2_000.meters, "C")
+      val powerClass2TrackTA1 = DistanceRangeMapImpl<String>()
+      powerClass2TrackTA1.put(0.meters, 1_950.meters, "D")
+      val powerClass2Map = hashMapOf<String, DistanceRangeMap<String>>(Pair("TA0", powerClass2TrackTA0),
+         Pair("TA1", powerClass2TrackTA1))
+
+      val expectedProfileMapping = hashMapOf(Pair("1", powerClass1Map), Pair("2", powerClass2Map))
+
+      val rjsElectricalProfiles = getRjsElectricalProfileMapping_1()
+      val profileMap = ElectricalProfileMapping()
+      profileMap.parseRJS(rjsElectricalProfiles)
+
+      assertThat(profileMap.mapping).isEqualTo(expectedProfileMapping)
+   }
+
+   @Test
+   fun testGetProfilesOnPath() {
+      // GIVEN
+      val infra = Helpers.getSmallInfra()
+      val rjsElectricalProfiles = getRjsElectricalProfileMapping_1()
+      val profileMap = ElectricalProfileMapping()
+      profileMap.parseRJS(rjsElectricalProfiles)
+      val path = pathFromTracks(infra.rawInfra, listOf("TA0", "TA1"), Direction.INCREASING, 1_000.meters, 3_500.meters)
+
+      val powerClass1Map = DistanceRangeMapImpl<String>()
+      powerClass1Map.put(0.meters, 600.meters, "A")
+      powerClass1Map.put(600.meters, 800.meters, "B")
+      powerClass1Map.put(800.meters, 1_000.meters, "A")
+      powerClass1Map.put(1_000.meters, 2_500.meters, "B")
+
+      val powerClass2Map = DistanceRangeMapImpl<String>()
+      powerClass2Map.put(0.meters, 1_000.meters, "C")
+      powerClass2Map.put(1_000.meters, 2_500.meters, "D")
+      val expectedProfileMapping = hashMapOf(Pair("1", powerClass1Map), Pair("2", powerClass2Map))
+
+      // WHEN
+      val profilesOnPath = profileMap.getProfilesOnPath(path)
+
+      // THEN
+      assertThat(profilesOnPath).isEqualTo(expectedProfileMapping)
+   }
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
@@ -1,0 +1,274 @@
+package fr.sncf.osrd.sim_infra_adapter
+
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.Range
+import fr.sncf.osrd.Helpers
+import fr.sncf.osrd.envelope_sim.electrification.Electrification
+import fr.sncf.osrd.envelope_sim.electrification.Electrified
+import fr.sncf.osrd.envelope_sim.electrification.Neutral
+import fr.sncf.osrd.envelope_sim.electrification.NonElectrified
+import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
+import fr.sncf.osrd.kt_external_generated_inputs.ElectricalProfileMapping
+import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
+import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSApplicableDirectionsTrackRange
+import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSCatenary
+import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSlope
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.getRjsElectricalProfileMapping_1
+import fr.sncf.osrd.utils.getRjsElectricalProfileMapping_2
+import fr.sncf.osrd.utils.pathFromTracks
+import fr.sncf.osrd.utils.units.meters
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class EnvelopeTrainPathTest {
+
+    @Test
+    fun envelopeFromPathTestAverageGrades() {
+        val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")!!
+        for (track in rjsInfra.trackSections) {
+            if (track.id.equals("TA0")) {
+                track.slopes = listOf(
+                    RJSSlope(0.0, 1_000.0, 5.0),
+                    RJSSlope(1_000.0, 2_000.0, 15.0),
+                )
+            }
+            if (track.id.equals("TA1")) {
+                track.slopes = listOf(
+                    RJSSlope(0.0, 1_000.0, 10.0),
+                    RJSSlope(1_000.0, 1_950.0, 25.0),
+                )
+            }
+        }
+
+        val infra = Helpers.fullInfraFromRJS(rjsInfra)
+        val path = pathFromTracks(infra.rawInfra, listOf("TA0", "TA1"), Direction.INCREASING, 500.meters, 3_500.meters)
+        val envelopeSimPath = EnvelopeTrainPath.from(path)
+        Assertions.assertEquals(5.0, envelopeSimPath.getAverageGrade(0.0, 500.0))
+        Assertions.assertEquals(15.0, envelopeSimPath.getAverageGrade(500.0, 1500.0))
+        Assertions.assertEquals(10.0, envelopeSimPath.getAverageGrade(1500.0, 2500.0))
+        Assertions.assertEquals(25.0, envelopeSimPath.getAverageGrade(2500.0, 3000.0))
+        Assertions.assertEquals(11.0, envelopeSimPath.getAverageGrade(0.0, 2500.0))
+        Assertions.assertEquals(10.0, envelopeSimPath.getAverageGrade(300.0, 700.0))
+    }
+
+    @ParameterizedTest
+    @MethodSource("electrificationMapArguments")
+    fun envelopeFromPathTestElectrificationMap(
+        tracks: List<String>,
+        direction: Direction,
+        expectedMap: ImmutableRangeMap<Double, Electrification>
+    ) {
+        val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")!!
+        rjsInfra.catenaries = listOf(
+            RJSCatenary(
+                "", listOf(
+                    RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 0.0, 800.0),
+                )
+            ),
+            RJSCatenary(
+                "1500", listOf(
+                    RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 800.0, 2_000.0),
+                    RJSApplicableDirectionsTrackRange("TA1", ApplicableDirection.BOTH, 0.0, 1_000.0)
+                )
+            ),
+            RJSCatenary(
+                "25000", listOf(
+                    RJSApplicableDirectionsTrackRange("TA1", ApplicableDirection.BOTH, 1_100.0, 1_950.0)
+                )
+            )
+            //and there is already a deadSection on TA0 from 1900 to 1950 in the Direction.INCREASING
+        )
+        val infra = Helpers.fullInfraFromRJS(rjsInfra)
+        val path = pathFromTracks(infra.rawInfra, tracks, direction, 500.meters, 3_600.meters)
+        val envelopeSimPath = EnvelopeTrainPath.from(path)
+
+        assertThat(envelopeSimPath.getElectrificationMap(null, null, null))
+            .isEqualTo(expectedMap)
+    }
+
+    @Test
+    fun envelopeFromPathTestElectrificationMapByPowerClassIncreasingDirection() {
+        val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")!!
+        rjsInfra.catenaries = listOf(
+            RJSCatenary(
+                "", listOf(
+                    RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 0.0, 1500.0),
+                )
+            ),
+            RJSCatenary(
+                "1500", listOf(
+                    RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 1500.0, 2_000.0),
+                    RJSApplicableDirectionsTrackRange("TA1", ApplicableDirection.BOTH, 0.0, 500.0)
+                )
+            ),
+            RJSCatenary(
+                "25000", listOf(
+                    RJSApplicableDirectionsTrackRange("TA1", ApplicableDirection.BOTH, 500.0, 1_950.0)
+                )
+            )
+            //and there is already a deadSection on TA0 from 1900 to 1950 in the Direction.INCREASING
+        )
+
+        val infra = Helpers.fullInfraFromRJS(rjsInfra)
+        val rjsElectricalProfiles = getRjsElectricalProfileMapping_1()
+        val profileMap = ElectricalProfileMapping()
+        profileMap.parseRJS(rjsElectricalProfiles)
+        val path = pathFromTracks(infra.rawInfra, listOf("TA0", "TA1"), Direction.INCREASING, 1_000.meters, 3_500.meters)
+        val envelopeSimPath = EnvelopeTrainPath.from(path, profileMap)
+        val electrificationByPowerClass = envelopeSimPath.getElectrificationMap(
+            "1",
+            null,
+            null
+        )
+        val expected = ImmutableRangeMap.Builder<Double, Electrification>()
+
+        putInElectrificationMapByPowerClass(
+            expected,
+            0.0, 500.0, NonElectrified(), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            500.0, 600.0, Electrified("1500"), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            600.0, 800.0, Electrified("1500"), "B"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            800.0, 900.0, Electrified("1500"), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            900.0, 950.0, Neutral(true, Electrified("1500")), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            950.0, 1000.0, Electrified("1500"), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            1_000.0, 1_500.0, Electrified("1500"), "B"
+        )
+        putInElectrificationMapByPowerClass(
+            expected,
+            1_500.0, 2_500.0, Electrified("25000"), "B"
+        )
+        assertThat(electrificationByPowerClass).isEqualTo(expected.build())
+    }
+
+    @Test
+    fun envelopeFromPathTestElectrificationMapByPowerClassDecreasingDirection() {
+        val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")!!
+        rjsInfra.catenaries = listOf(
+            RJSCatenary(
+                "1500",
+                listOf(
+                    RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 0.0, 2_000.0),
+                    RJSApplicableDirectionsTrackRange("TA1", ApplicableDirection.BOTH, 0.0, 1_950.0),
+                    RJSApplicableDirectionsTrackRange("TA2", ApplicableDirection.BOTH, 0.0, 1_950.0),
+                ),
+            ),
+        )
+
+        val infra = Helpers.fullInfraFromRJS(rjsInfra)
+        val rjsElectricalProfiles = getRjsElectricalProfileMapping_2()
+        val profileMap = ElectricalProfileMapping()
+        profileMap.parseRJS(rjsElectricalProfiles)
+        val path = pathFromTracks(infra.rawInfra, listOf("TA2", "TA1", "TA0"), Direction.DECREASING, 1_000.meters, 5_000.meters)
+        val envelopeSimPath = EnvelopeTrainPath.from(path, profileMap)
+        val electrificationPowerClass1 = envelopeSimPath.getElectrificationMap(
+            "1", null, null
+        )
+        val expectedElectrificationPowerClass1 = ImmutableRangeMap.Builder<Double, Electrification>()
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            0.0, 700.0, Electrified("1500"), "B"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            700.0, 2_600.0, Electrified("1500"), "A"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            2_600.0, 3_300.0, Electrified("1500"), "B"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            3_300.0, 4_000.0, Electrified("1500"), "A"
+        )
+
+        assertThat(electrificationPowerClass1).isEqualTo(expectedElectrificationPowerClass1.build())
+
+        val electrificationPowerClass2 = envelopeSimPath.getElectrificationMap(
+            "2", null, null
+        )
+        val expectedElectrificationPowerClass2 = ImmutableRangeMap.Builder<Double, Electrification>()
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            0.0, 950.0, Electrified("1500"), "C"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            950.0, 2_700.0, Electrified("1500"), "D"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            2_700.0, 3_000.0, Electrified("1500"), "C"
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            3_000.0, 4_000.0, Electrified("1500"), "D"
+        )
+
+        assertThat(electrificationPowerClass2).isEqualTo(expectedElectrificationPowerClass2.build())
+    }
+
+    companion object {
+        @JvmStatic
+        private fun electrificationMapArguments(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    listOf("TA0", "TA1"),
+                    Direction.INCREASING,
+                    ImmutableRangeMap.Builder<Double, Electrification>()
+                        .put(Range.closedOpen(0.0, 300.0), NonElectrified())
+                        .put(Range.closedOpen(300.0, 1400.0), Electrified("1500"))
+                        .put(Range.closedOpen(1400.0, 1450.0), Neutral(true, Electrified("1500")))
+                        .put(Range.closedOpen(1450.0, 2500.0), Electrified("1500"))
+                        .put(Range.closedOpen(2500.0, 2600.0), NonElectrified())
+                        .put(Range.closedOpen(2600.0, 3100.0), Electrified("25000"))
+                        .build()
+                ),
+                Arguments.of(
+                    listOf("TA1", "TA0"),
+                    Direction.DECREASING,
+                    ImmutableRangeMap.Builder<Double, Electrification>()
+                        .put(Range.closedOpen(0.0, 350.0), Electrified("25000"))
+                        .put(Range.closedOpen(350.0, 450.0), NonElectrified())
+                        .put(Range.closedOpen(450.0, 2650.0), Electrified("1500"))
+                        .put(Range.closedOpen(2650.0, 3100.0), NonElectrified())
+                        .build()
+                ),
+            )
+        }
+    }
+}
+
+/** Puts the specified Electrification with according electricalProfile in the range lower upper */
+private fun putInElectrificationMapByPowerClass(
+    expectedElectrificationMapByPowerClass: ImmutableRangeMap.Builder<Double, Electrification>,
+    lower: Double,
+    upper: Double,
+    electrification: Electrification,
+    electricalProfile: String,
+) {
+    val elecWithProfile = electrification.withElectricalProfile(electricalProfile)
+    expectedElectrificationMapByPowerClass.put(Range.closedOpen(lower, upper), elecWithProfile)
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathTests.kt
@@ -20,7 +20,6 @@ import fr.sncf.osrd.utils.units.Speed.Companion.fromMetersPerSecond
 import fr.sncf.osrd.utils.units.meters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.Map
 import kotlin.math.absoluteValue
 import kotlin.test.assertEquals
 
@@ -308,7 +307,7 @@ class PathTests {
     @Test
     fun testSmallInfraSpeedLimits() {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")!!
-        val speedSection = RJSSpeedSection("speedSection", 30.0, Map.of("trainTag", 42.42),
+        val speedSection = RJSSpeedSection("speedSection", 30.0, mapOf(Pair("trainTag", 42.42)),
             listOf(RJSApplicableDirectionsTrackRange("TA0", ApplicableDirection.BOTH, 0.0, 400.0)))
         rjsInfra.speedSections.add(speedSection)
         val infra = Helpers.fullInfraFromRJS(rjsInfra)

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/ElectricalProfileMappingUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/ElectricalProfileMappingUtils.kt
@@ -1,0 +1,73 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet
+import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSTrackRange
+
+fun getRjsElectricalProfileMapping_1(): RJSElectricalProfileSet {
+    return RJSElectricalProfileSet(
+        listOf(
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "A", "1",
+                listOf(
+                    RJSTrackRange("TA0", 0.0, 1_600.0),
+                    RJSTrackRange("TA0", 1_800.0, 2_000.0),
+                )
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "B", "1",
+                listOf(
+                    RJSTrackRange("TA0", 1_600.0, 1_800.0),
+                    RJSTrackRange("TA1", 0.0, 1_950.0),
+                )
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "C", "2",
+                listOf(RJSTrackRange("TA0", 0.0, 2_000.0))
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "D", "2",
+                listOf(
+                    RJSTrackRange("TA1", 0.0, 1_950.0),
+                )
+            ),
+        )
+    )
+}
+
+fun getRjsElectricalProfileMapping_2(): RJSElectricalProfileSet {
+    return RJSElectricalProfileSet(
+        listOf(
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "A", "1",
+                listOf(
+                    RJSTrackRange("TA0", 0.0, 1_600.0),
+                    RJSTrackRange("TA1", 300.0, 1_950.0),
+                    RJSTrackRange("TA2", 0.0, 250.0),
+                )
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "B", "1",
+                listOf(
+                    RJSTrackRange("TA0", 1_600.0, 2_000.0),
+                    RJSTrackRange("TA1", 0.0, 300.0),
+                    RJSTrackRange("TA2", 250.0, 1_950.0),
+                )
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "C", "2",
+                listOf(
+                    RJSTrackRange("TA0", 1_900.0, 2_000.0),
+                    RJSTrackRange("TA1", 0.0, 200.0),
+                    RJSTrackRange("TA2", 0.0, 1_950.0),
+                )
+            ),
+            RJSElectricalProfileSet.RJSElectricalProfile(
+                "D", "2",
+                listOf(
+                    RJSTrackRange("TA0", 0.0, 1_900.0),
+                    RJSTrackRange("TA1", 200.0, 1_950.0),
+                )
+            )
+        )
+    )
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -1,0 +1,18 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.Distance
+
+
+/** Build a path from track ids */
+fun pathFromTracks(infra: LocationInfra, trackIds: List<String>,
+                           dir: Direction, start: Distance, end: Distance
+): Path {
+    val chunkList = mutableDirStaticIdxArrayListOf<TrackChunk>()
+    trackIds
+        .map { id ->  infra.getTrackSectionFromName(id)!! }
+        .flatMap { track -> infra.getTrackSectionChunks(track).dirIter(dir) }
+        .forEach { dirChunk -> chunkList.add(dirChunk) }
+    return buildPathFrom(infra, chunkList, start, end)
+}


### PR DESCRIPTION
Renamed EnvelopeTrainPath to LegacyEnvelopeTrainPath. 
Created a new EnvelopeTrainPath where it is possible to create an envelopeSimPath from a Path.

close #4261 