### PR TITLE
core: fix spacing requirements for the first zone after a signal

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -207,7 +207,7 @@ private fun spacingRequirements(
         if (lastConstrainingZone == null)
             continue
 
-        for (zoneIndex in signalZoneOffset until lastConstrainingZone) {
+        for (zoneIndex in signalZoneOffset .. lastConstrainingZone) {
             val prevRequiredTime = zoneRequirementTimes[zoneIndex]
             zoneRequirementTimes[zoneIndex] = min(sightTime, prevRequiredTime)
         }


### PR DESCRIPTION
Closes  #4709