### PR TITLE
editoast: fix train schedules endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -326,6 +326,7 @@ components:
             - engineering
             type: string
           capacity_speed_limit:
+            default: -1
             format: double
             type: number
           distribution:
@@ -2015,6 +2016,7 @@ components:
           - standard
           type: string
         capacity_speed_limit:
+          default: -1
           format: double
           type: number
         default_value:
@@ -2274,12 +2276,131 @@ components:
         train_name:
           type: string
       type: object
+    TrainScheduleBatchItem:
+      properties:
+        allowances:
+          default: []
+          items:
+            $ref: '#/components/schemas/Allowance'
+          type: array
+        comfort:
+          $ref: '#/components/schemas/Comfort'
+        departure_time:
+          format: float
+          type: number
+        initial_speed:
+          format: float
+          type: number
+        labels:
+          default: []
+          items:
+            type: string
+          type: array
+        options:
+          allOf:
+          - $ref: '#/components/schemas/TrainScheduleOptions'
+          nullable: true
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          items:
+            $ref: '#/components/schemas/PowerRestrictionRange'
+          nullable: true
+          type: array
+        rolling_stock:
+          type: integer
+        scheduled_points:
+          default: []
+          items:
+            properties:
+              path_offset:
+                description: Offset in meters from the start of the path at which the train must be.
+                format: float
+                type: number
+              time:
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+                format: float
+                type: number
+            required:
+            - path_offset
+            - time
+            type: object
+          type: array
+        speed_limit_tags:
+          description: Train category for speed limits
+          nullable: true
+          type: string
+        train_name:
+          type: string
+      required:
+      - train_name
+      - departure_time
+      - initial_speed
+      - rolling_stock
+      type: object
     TrainScheduleOptions:
       description: Options for the standalone simulation
       properties:
         ignore_electrical_profiles:
           nullable: true
           type: boolean
+      type: object
+    TrainSchedulePatch:
+      properties:
+        allowances:
+          items:
+            $ref: '#/components/schemas/Allowance'
+          type: array
+        comfort:
+          $ref: '#/components/schemas/Comfort'
+        departure_time:
+          format: float
+          type: number
+        id:
+          type: integer
+        initial_speed:
+          format: float
+          type: number
+        labels:
+          items:
+            type: string
+          type: array
+        options:
+          allOf:
+          - $ref: '#/components/schemas/TrainScheduleOptions'
+          nullable: true
+        path_id:
+          type: integer
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          items:
+            $ref: '#/components/schemas/PowerRestrictionRange'
+          nullable: true
+          type: array
+        rolling_stock_id:
+          type: integer
+        scheduled_points:
+          items:
+            properties:
+              path_offset:
+                description: Offset in meters from the start of the path at which the train must be.
+                format: float
+                type: number
+              time:
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+                format: float
+                type: number
+            required:
+            - path_offset
+            - time
+            type: object
+          type: array
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+        train_name:
+          type: string
+      required:
+      - id
       type: object
     TrainScheduleResult:
       properties:
@@ -4562,6 +4683,23 @@ paths:
       summary: Delete multiple train schedule
       tags:
       - train_schedule
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              items:
+                $ref: '#/components/schemas/TrainSchedulePatch'
+              minimum: 1
+              type: array
+        description: A list of changes. Each changeset contains the corresponding train id
+        required: true
+      responses:
+        '200':
+          description: The train schedule was updated successfully
+      summary: Update train schedules and run a simulation accordingly
+      tags:
+      - train_schedule
   /train_schedule/results/:
     get:
       parameters:
@@ -4596,10 +4734,21 @@ paths:
         content:
           application/json:
             schema:
-              items:
-                $ref: '#/components/schemas/TrainSchedule'
-              minItems: 1
-              type: array
+              properties:
+                path:
+                  type: integer
+                schedules:
+                  items:
+                    $ref: '#/components/schemas/TrainScheduleBatchItem'
+                  minItems: 1
+                  type: array
+                timetable:
+                  type: integer
+              required:
+              - timetable
+              - path
+              - schedules
+              type: object
         description: The list of train schedules to simulate
         required: true
       responses:
@@ -4647,29 +4796,6 @@ paths:
                 $ref: '#/components/schemas/TrainSchedule'
           description: The train schedule info
       summary: Retrieve a train schedule
-      tags:
-      - train_schedule
-    patch:
-      parameters:
-      - description: Train schedule ID
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              items:
-                $ref: '#/components/schemas/TrainSchedule'
-              type: array
-        description: Train schedule fields
-        required: true
-      responses:
-        '200':
-          description: The train schedule was updated successfully
-      summary: Update a train_schedule and run a simulation accordingly
       tags:
       - train_schedule
   /train_schedule/{id}/result/:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -1938,29 +1938,6 @@ paths:
       responses:
         204:
           description: No content
-    patch:
-      tags:
-        - train_schedule
-      summary: Update a train_schedule and run a simulation accordingly
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Train schedule ID
-          required: true
-      requestBody:
-        description: Train schedule fields
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/TrainSchedule"
-        required: true
-      responses:
-        200:
-          description: The train schedule was updated successfully
 
   /train_schedule/{id}/result/:
     get:
@@ -2009,6 +1986,25 @@ paths:
       responses:
         204:
           description: No content
+
+    patch:
+      tags:
+        - train_schedule
+      summary: Update train schedules and run a simulation accordingly
+      requestBody:
+        description: A list of changes. Each changeset contains the corresponding train id
+        content:
+          application/json:
+            schema:
+              type: array
+              minimum: 1
+              items:
+                $ref: "#/components/schemas/TrainSchedulePatch"
+        required: true
+      responses:
+        200:
+          description: The train schedule was updated successfully
+
   /train_schedule/results/:
     get:
       tags:
@@ -2048,10 +2044,18 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              minItems: 1
-              items:
-                $ref: "#/components/schemas/TrainSchedule"
+              type: object
+              required: [timetable, path, schedules]
+              properties:
+                timetable:
+                  type: integer
+                path:
+                  type: integer
+                schedules:
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: "#/components/schemas/TrainScheduleBatchItem"
         required: true
       responses:
         201:
@@ -3768,6 +3772,116 @@ components:
               items:
                 $ref: "#/components/schemas/Point3D"
 
+    TrainSchedulePatch:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: integer
+        train_name:
+          type: string
+        rolling_stock_id:
+          type: integer
+        departure_time:
+          type: number
+          format: float
+        path_id:
+          type: integer
+        initial_speed:
+          type: number
+          format: float
+        labels:
+          type: array
+          items:
+            type: string
+        scheduled_points:
+          type: array
+          items:
+            type: object
+            required: [path_offset, time]
+            properties:
+              path_offset:
+                type: number
+                format: float
+                description: Offset in meters from the start of the path at which the train must be.
+              time:
+                type: number
+                format: float
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+        allowances:
+          type: array
+          items:
+            $ref: "#/components/schemas/Allowance"
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+        comfort:
+          $ref: "#/components/schemas/Comfort"
+        options:
+          allOf:
+            - $ref: "#/components/schemas/TrainScheduleOptions"
+          nullable: true
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          type: array
+          items:
+            $ref: "#/components/schemas/PowerRestrictionRange"
+          nullable: true
+    TrainScheduleBatchItem:
+      type: object
+      required: [train_name, departure_time, initial_speed, rolling_stock]
+      properties:
+        train_name:
+          type: string
+        labels:
+          type: array
+          default: []
+          items:
+            type: string
+        departure_time:
+          type: number
+          format: float
+        initial_speed:
+          type: number
+          format: float
+        allowances:
+          default: []
+          type: array
+          items:
+            $ref: "#/components/schemas/Allowance"
+        scheduled_points:
+          default: []
+          type: array
+          items:
+            type: object
+            required: [path_offset, time]
+            properties:
+              path_offset:
+                type: number
+                format: float
+                description: Offset in meters from the start of the path at which the train must be.
+              time:
+                type: number
+                format: float
+                description: Time in seconds (elapsed since the train's departure) at which the train must be.
+        comfort:
+          $ref: "#/components/schemas/Comfort"
+        speed_limit_tags:
+          description: Train category for speed limits
+          type: string
+          nullable: true
+        power_restriction_ranges:
+          description: A list of ranges along the train path where power restrictions apply.
+          type: array
+          items:
+            $ref: "#/components/schemas/PowerRestrictionRange"
+          nullable: true
+        options:
+          allOf:
+            - $ref: "#/components/schemas/TrainScheduleOptions"
+          nullable: true
+        rolling_stock:
+          type: integer
     TrainSchedule:
       type: object
       properties:
@@ -4003,6 +4117,7 @@ components:
         capacity_speed_limit:
           type: number
           format: double
+          default: -1
       required: [allowance_type, default_value, ranges, distribution]
 
     EngineeringAllowance:
@@ -4018,6 +4133,7 @@ components:
             capacity_speed_limit:
               type: number
               format: double
+              default: -1
           required: [allowance_type, distribution]
         - $ref: "#/components/schemas/RangeAllowance"
 

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -38,7 +38,7 @@ pub struct TrainSchedule {
     #[diesel(deserialize_as = i64)]
     pub id: Option<i64>,
     pub train_name: String,
-    pub labels: JsonValue,
+    pub labels: DieselJson<Vec<String>>,
     pub departure_time: f64,
     pub initial_speed: f64,
     #[derivative(Default(value = "DieselJson(Default::default())"))]
@@ -67,7 +67,7 @@ impl Identifiable for TrainSchedule {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Queryable, Insertable, AsChangeset, Model)]
+#[derive(Clone, Default, Debug, Deserialize, Queryable, Insertable, AsChangeset, Model)]
 #[model(table = "osrd_infra_trainschedule")]
 #[model(update)]
 #[diesel(belongs_to(Timetable))]
@@ -77,8 +77,8 @@ pub struct TrainScheduleChangeset {
     pub id: Option<i64>,
     #[diesel(deserialize_as = String)]
     pub train_name: Option<String>,
-    #[diesel(deserialize_as = JsonValue)]
-    pub labels: Option<JsonValue>,
+    #[diesel(deserialize_as = DieselJson<Vec<String>>)]
+    pub labels: Option<DieselJson<Vec<String>>>,
     #[diesel(deserialize_as = f64)]
     pub departure_time: Option<f64>,
     #[diesel(deserialize_as = f64)]
@@ -369,8 +369,12 @@ pub struct RangeAllowance {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 
 pub struct EngineeringAllowance {
+    begin_position: f64,
+    end_position: f64,
+    value: AllowanceValue,
     distribution: AllowanceDistribution,
-    capacity_speed_limit: Option<f64>,
+    #[serde(default = "default_capacity_speed_limit")]
+    capacity_speed_limit: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -378,7 +382,12 @@ pub struct StandardAllowance {
     default_value: AllowanceValue,
     ranges: Vec<RangeAllowance>,
     distribution: AllowanceDistribution,
-    capacity_speed_limit: Option<f64>,
+    #[serde(default = "default_capacity_speed_limit")]
+    capacity_speed_limit: f64,
+}
+
+fn default_capacity_speed_limit() -> f64 {
+    -1.0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/editoast/src/tests/small_infra/stdcm/test_1/stdcm_post_expected_response.json
+++ b/editoast/src/tests/small_infra/stdcm/test_1/stdcm_post_expected_response.json
@@ -113,7 +113,7 @@
     },
     "simulation": {
         "id": null,
-        "labels": null,
+        "labels": [],
         "path": 156,
         "name": "",
         "vmax": [

--- a/editoast/src/views/train_schedule/simulation_report.rs
+++ b/editoast/src/views/train_schedule/simulation_report.rs
@@ -25,7 +25,7 @@ use diesel::prelude::*;
 pub struct SimulationReport {
     // TODO: check if there is better way to do that than using Option
     id: Option<i64>,
-    labels: JsonValue,
+    labels: Vec<String>,
     path: i64,
     name: String,
     vmax: JsonValue,
@@ -111,12 +111,12 @@ pub async fn create_simulation_report(
 
     Ok(SimulationReport {
         id: train_schedule.id,
-        labels: train_schedule.labels,
+        labels: train_schedule.labels.0,
         path: train_schedule.path_id,
         name: train_schedule.train_name,
         vmax: simulation_output_cs.mrsp.unwrap(),
-        slopes: (*train_path.slopes).clone(), // diesel_json does not support into inner
-        curves: (*train_path.curves).clone(),
+        slopes: train_path.slopes.0, // diesel_json does not support into inner
+        curves: train_path.curves.0,
         base,
         eco,
         speed_limit_tags: train_schedule.speed_limit_tags,

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -560,6 +560,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/train_schedule/`, method: 'DELETE', body: queryArg.body }),
         invalidatesTags: ['train_schedule'],
       }),
+      patchTrainSchedule: build.mutation<PatchTrainScheduleApiResponse, PatchTrainScheduleApiArg>({
+        query: (queryArg) => ({ url: `/train_schedule/`, method: 'PATCH', body: queryArg.body }),
+        invalidatesTags: ['train_schedule'],
+      }),
       getTrainScheduleResults: build.query<
         GetTrainScheduleResultsApiResponse,
         GetTrainScheduleResultsApiArg
@@ -594,17 +598,6 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/` }),
         providesTags: ['train_schedule'],
-      }),
-      patchTrainScheduleById: build.mutation<
-        PatchTrainScheduleByIdApiResponse,
-        PatchTrainScheduleByIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/train_schedule/${queryArg.id}/`,
-          method: 'PATCH',
-          body: queryArg.body,
-        }),
-        invalidatesTags: ['train_schedule'],
       }),
       getTrainScheduleByIdResult: build.query<
         GetTrainScheduleByIdResultApiResponse,
@@ -1204,6 +1197,11 @@ export type DeleteTrainScheduleApiArg = {
     ids: number[];
   };
 };
+export type PatchTrainScheduleApiResponse = unknown;
+export type PatchTrainScheduleApiArg = {
+  /** A list of changes. Each changeset contains the corresponding train id */
+  body: TrainSchedulePatch[];
+};
 export type GetTrainScheduleResultsApiResponse =
   /** status 200 The train schedules results */ SimulationReport[];
 export type GetTrainScheduleResultsApiArg = {
@@ -1216,7 +1214,11 @@ export type PostTrainScheduleStandaloneSimulationApiResponse =
   /** status 201 The ids of the train_schedules created */ number[];
 export type PostTrainScheduleStandaloneSimulationApiArg = {
   /** The list of train schedules to simulate */
-  body: TrainSchedule[];
+  body: {
+    path: number;
+    schedules: TrainScheduleBatchItem[];
+    timetable: number;
+  };
 };
 export type DeleteTrainScheduleByIdApiResponse = unknown;
 export type DeleteTrainScheduleByIdApiArg = {
@@ -1228,13 +1230,6 @@ export type GetTrainScheduleByIdApiResponse =
 export type GetTrainScheduleByIdApiArg = {
   /** Train schedule ID */
   id: number;
-};
-export type PatchTrainScheduleByIdApiResponse = unknown;
-export type PatchTrainScheduleByIdApiArg = {
-  /** Train schedule ID */
-  id: number;
-  /** Train schedule fields */
-  body: TrainSchedule[];
 };
 export type GetTrainScheduleByIdResultApiResponse =
   /** status 200 The train schedule result */ SimulationReport;
@@ -2028,6 +2023,24 @@ export type TimetableWithSchedulesDetails = {
   name: string;
   train_schedule_summaries: TrainScheduleSummary[];
 };
+export type TrainSchedulePatch = {
+  allowances?: Allowance[];
+  comfort?: Comfort;
+  departure_time?: number;
+  id: number;
+  initial_speed?: number;
+  labels?: string[];
+  options?: TrainScheduleOptions | null;
+  path_id?: number;
+  power_restriction_ranges?: PowerRestrictionRange[] | null;
+  rolling_stock_id?: number;
+  scheduled_points?: {
+    path_offset: number;
+    time: number;
+  }[];
+  speed_limit_tags?: string;
+  train_name?: string;
+};
 export type SpaceTimePosition = {
   position: number;
   time: number;
@@ -2096,6 +2109,22 @@ export type SimulationReport = {
     position: number;
     speed: number;
   }[];
+};
+export type TrainScheduleBatchItem = {
+  allowances?: Allowance[];
+  comfort?: Comfort;
+  departure_time: number;
+  initial_speed: number;
+  labels?: string[];
+  options?: TrainScheduleOptions | null;
+  power_restriction_ranges?: PowerRestrictionRange[] | null;
+  rolling_stock: number;
+  scheduled_points?: {
+    path_offset: number;
+    time: number;
+  }[];
+  speed_limit_tags?: string | null;
+  train_name: string;
 };
 export type TrainSchedule = {
   allowances?: Allowance[];


### PR DESCRIPTION
## Observation

The train schedule endpoints are not working correctly and are not ready to be used by the front yet.
This PR aims to improve the endpoints' quality so we can finalize the migration.

## What is done in this PR?

#### Patch

- Make the openapi consistent with the code
- Add `web::block` around the transaction
- Allow train schedules with different paths
- Batch calls to core by path
- Delete old simulation output in a single query
- Fix association between new simulation output and patched train schedules

#### Standalone Simulation

- Add missing default fields
- Make the openapi consistent with the code
- Fix engineering allowances schema