### PR TITLE
core: spacing requirements: gracefuly handle faulty signaling

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation(testFixtures(project(":envelope-sim")))
 
     // kotlin
+    implementation libs.kotlin.logging
     implementation libs.kotlin.stdlib
     implementation libs.kotlinx.coroutines.core
     testImplementation libs.kotlin.test


### PR DESCRIPTION
A faulty signal may always display a non-constraining state, regardless of the state of zones ahead. In this case, use the time the zone is first occupied as the requirement start time.

This change also introduces various checks, including a state machine which ensure signaling behaves as expected.

Fixes #4735