### PR TITLE
actions: print the logs after the integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -91,6 +91,10 @@ jobs:
           cd front
           yarn e2e-tests
 
+      - name: Print logs
+        run: docker compose logs
+        if: always()
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
Allows easier debugging of failed tests.