### PR TITLE
front: fix bug on stdcm (setup originUpperBoundTime in the store)

### DIFF
--- a/front/src/reducers/__tests__/osrdconf.spec.ts
+++ b/front/src/reducers/__tests__/osrdconf.spec.ts
@@ -85,6 +85,7 @@ describe('osrdconfReducer', () => {
           simulationConf: {
             originLinkedBounds: true,
             originTime: '10:00:00',
+            originUpperBoundTime: undefined,
           },
         },
       });

--- a/front/src/reducers/osrdconf/index.ts
+++ b/front/src/reducers/osrdconf/index.ts
@@ -97,7 +97,7 @@ const defaultCommonConf = {
   originDate: formatIsoDate(new Date()),
   originTime: '08:00:00',
   originUpperBoundDate: formatIsoDate(new Date()),
-  originUpperBoundTime: undefined,
+  originUpperBoundTime: '10:00:00',
   originLinkedBounds: true,
   destination: undefined,
   destinationDate: formatIsoDate(new Date()),


### PR DESCRIPTION
closes #4737 