### PR TITLE
codeowners: remove infra schema from front maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 /front                                                   @osrd-project/front-maintainers
 /front/src/common/api/osrdEditoastApi.ts
 /front/src/common/api/osrdMiddlewareApi.ts
+/front/src/reducers/osrdconf/infra_schema.json
 
 # --- EDITOAST ---
 /editoast                                                @osrd-project/editoast-maintainers


### PR DESCRIPTION
This file is generated by osrd_schema.
The CI checks the file is always up to date