### PR TITLE
editoast: config: change test profile's opt-level

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -65,16 +65,16 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
+          args: --manifest-path editoast/Cargo.toml --verbose -- --test-threads 1
 
       - name: Check openapi.yaml sync
-        run: diff <(cargo run --release --manifest-path editoast/Cargo.toml -- openapi) editoast/openapi.yaml
+        run: diff <(cargo run --manifest-path editoast/Cargo.toml --profile test -- openapi) editoast/openapi.yaml
 
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
 
       - name: Coverage
-        run: cargo tarpaulin --release -r ./editoast --out Xml -- --test-threads 1
+        run: cargo tarpaulin -r ./editoast --out Xml -- --test-threads 1
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -8,6 +8,9 @@ license = "LGPL-3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.test]
+opt-level = 1
+
 [dependencies]
 async-trait = "0.1"
 chashmap = "2.2.2"

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -33,14 +33,8 @@ In order to run tests, you need to have a postgresql database running.
 
 To avoid thread conflicts while accessing the database, use the `--test-threads=1` option.
 
-Finally, with target debug, the test threads overflow their stack. To avoid this, you can either increase the stack size with the `RUST_MIN_STACK` environment variable or use the release target.
-
 ```sh
-cargo test --release -- --test-threads=1
-
-# or
-
-RUST_MIN_STACK=8388608 cargo test -- --test-threads=1
+cargo test -- --test-threads=1
 ```
 
 ## Useful tools


### PR DESCRIPTION
Set opt-level to 1 in test profile so that `cargo test` does not overflow its stack without additional arguments. 
Also, tests (and CI) should run faster than with `--release`