### PR TITLE
front: infra-editor: bug: switch types are updated when changing infra

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -58,8 +58,9 @@ const Editor: FC = () => {
         state,
       });
     },
-    [infraID, setToolAndState]
+    [infraID, switchTypes, setToolAndState]
   );
+
   const setToolState = useCallback(
     <S extends CommonToolState>(stateOrReducer: Partial<S> | Reducer<S>) => {
       setToolAndState((s) => ({


### PR DESCRIPTION
closes #4476