### PR TITLE
editoast: add smart merge to openapi merger

### DIFF
--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -21,28 +21,6 @@ tags:
     description: Train Schedule
 
 paths:
-  /health/:
-    get:
-      responses:
-        200:
-          description: Check if Editoast is running correctly
-
-  /version/:
-    get:
-      responses:
-        200:
-          description: Return the service version
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  git_describe:
-                    type: string
-                    nullable: true
-                required:
-                  - git_describe
-
   /search/:
     post:
       summary: Generic search endpoint

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -87,9 +87,8 @@ impl OpenApiRoot {
             .to_json()
             .expect("the openapi should generate properly");
         OpenApiMerger::new(manual, generated)
-            .replace("paths/health/")
-            .replace("paths/version")
-            .replace("components/schemas/Version")
+            .smart_merge()
+            .add_trailing_slash_to_paths()
             .finish()
     }
 }


### PR DESCRIPTION
This new function merges legacy with automatically generated openAPI.
It takes all components and endpoints generated by utoipa and adds them, if new, and replaces them if existing, to the legacy file.

Bonus: Add trailing slashes to all endpoints (needed for the deployed instance)