### PR TITLE
front: intervals editor, fix the scale

### DIFF
--- a/front/src/common/IntervalsDataViz/Scales.tsx
+++ b/front/src/common/IntervalsDataViz/Scales.tsx
@@ -1,58 +1,144 @@
 import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 
-import { roundNumber, shortNumber } from './utils';
+import { isRoundKm, roundNumber, shortNumber } from './utils';
 
+const MIN_DISTANCE_TO_EXTREMITY = 20; // in px
+
+/**
+ * Given a value, return the absolute position (in px) corresponding to it on the graph.
+ * If the value is not in the interval [begin, end], return 0.
+ */
+const getPositionFromValue = (
+  value: number,
+  begin: number,
+  end: number,
+  graphWidth: number,
+  leftPadding: number
+) =>
+  value > begin && value < end ? ((value - begin) * graphWidth) / (end - begin) + leftPadding : 0;
+
+/**
+ * Complete scale for the intervals editor
+ * - smart ticks, rounded by km (1km, 3km, etc)
+ * - ticks for the extremities are always displayed (begin/end)
+ * - ticks which are too close to the extremities are removed
+ * - ticks number is adapted to the screen width (even if the window is resized)
+ */
 export const ResizingScale = ({
   begin,
   end,
-  className,
+  wrapper,
 }: {
   begin: number;
   end: number;
-  className?: string;
+  wrapper: HTMLElement;
 }) => {
-  const [ticksCount, setTicksCount] = useState<number>(10);
+  const [ticks, setTicks] = useState<{ position: number; value: number; isExtremity: boolean }[]>(
+    []
+  );
 
-  const inf = roundNumber(begin, true);
-  const sup = roundNumber(end, false);
-  const step = roundNumber((end - begin) / ticksCount / 2, true);
+  const computeTicks = (_begin: number, _end: number, _wrapper: HTMLElement) => {
+    const graphWidth = wrapper.offsetWidth;
+    const leftPadding = wrapper.offsetLeft;
 
-  /** redraw the scale when window resized horizontally */
+    // compute the number of ticks, knowing that space between 2 ticks should be 200px
+    const ticksCount = Math.round(graphWidth / 200);
+
+    // compute the default step between 2 values (we want to display only value in km)
+    let step = roundNumber((_end - _begin) / ticksCount / 1000) * 1000;
+    if (step === 0) step = 1000;
+
+    // compute the ticks (value and position)
+    const newTicks = [{ value: _begin, position: leftPadding, isExtremity: true }];
+
+    // find the first tick value (first integer above begin (in km) or begin if it is x km)
+    let index = isRoundKm(begin) ? 1 : 0;
+    const firstTick = isRoundKm(begin) ? _begin : roundNumber(begin / 1000, true) * 1000;
+
+    // check the second tick is not too close to the first one
+    const secondTickPosition = getPositionFromValue(
+      step * index + firstTick,
+      _begin,
+      _end,
+      graphWidth,
+      leftPadding
+    );
+    if (secondTickPosition - leftPadding < MIN_DISTANCE_TO_EXTREMITY) {
+      index += 1;
+    }
+
+    // compute the interior ticks
+    while (index * step + firstTick < _end) {
+      newTicks.push({
+        value: step * index + firstTick,
+        position: getPositionFromValue(
+          step * index + firstTick,
+          _begin,
+          _end,
+          graphWidth,
+          leftPadding
+        ),
+        isExtremity: false,
+      });
+      index += 1;
+    }
+
+    // check before last tick is not too close to the last tick
+    if (
+      newTicks[newTicks.length - 1].position - leftPadding >
+      graphWidth - MIN_DISTANCE_TO_EXTREMITY
+    ) {
+      newTicks.pop();
+    }
+
+    newTicks.push({ value: _end, position: graphWidth + leftPadding, isExtremity: true });
+    return newTicks;
+  };
+
+  useEffect(() => {
+    const newTicks = computeTicks(begin, end, wrapper);
+    setTicks(newTicks);
+  }, [begin, end, wrapper]);
+
+  /**
+   * When the window is resized horizontally
+   * => we recompute the operationalPoints4viz
+   */
   useEffect(() => {
     const debounceResize = () => {
       let debounceTimeoutId;
       clearTimeout(debounceTimeoutId);
       debounceTimeoutId = setTimeout(() => {
-        const graphWidth = document.getElementById('linear-metadata-dataviz-content')?.offsetWidth;
-        if (graphWidth) {
-          setTicksCount(Math.round(graphWidth / 100));
-        }
+        const newTicks = computeTicks(begin, end, wrapper);
+        setTicks(newTicks);
       }, 15);
     };
     window.addEventListener('resize', debounceResize);
     return () => {
       window.removeEventListener('resize', debounceResize);
     };
-  }, []);
+  }, [begin, end, wrapper]);
 
   return (
-    <div className={`scale ${className}`}>
-      <div className="axis-values">
-        {Array(ticksCount)
-          .fill(0)
-          .map((_, i) => (
-            <div key={i}>
-              {i === 0 && <span className="bottom-axis-value">{shortNumber(inf)}</span>}
-              <span>{shortNumber(((sup - inf) / ticksCount) * i + step + inf)}</span>
-              {i === ticksCount - 1 && <span className="top-axis-value">{shortNumber(sup)}</span>}
-            </div>
-          ))}
-      </div>
+    <div className="scale resizing-scale-x">
+      {ticks.map(({ position, value, isExtremity }, i) => (
+        <div
+          key={i}
+          style={{ position: 'absolute', left: `${position}px` }}
+          className={cx(isExtremity && 'is-extremity', i === 0 && 'is-begin')}
+        >
+          <span>{shortNumber(value)}</span>
+        </div>
+      ))}
     </div>
   );
 };
 
+/**
+ * Simple scale with ticks for the begin and the end.
+ * Ticks are bolded if they are the real extremities of the whole graph.
+ */
 export const SimpleScale = ({
   className,
   begin,
@@ -77,22 +163,22 @@ export const SimpleScale = ({
   return (
     <div className={`scale ${className}`}>
       <div className="axis-values">
-        <p
+        <span
           className={cx(
             (min === undefined || (min !== undefined && min === begin)) && 'font-weight-bold'
           )}
           title={`${inf}`}
         >
           {shortNumber(inf)}
-        </p>
-        <p
+        </span>
+        <span
           className={cx(
             (max === undefined || (max !== undefined && max === end)) && 'font-weight-bold'
           )}
           title={`${sup}`}
         >
           {shortNumber(sup)}
-        </p>
+        </span>
       </div>
     </div>
   );

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -402,11 +402,11 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
       </div>
 
       {/* Display the X axis */}
-      {options.resizingScale ? (
+      {options.resizingScale && wrapper.current ? (
         <ResizingScale
           begin={head(data4viz)?.begin || 0}
           end={last(data4viz)?.end || 0}
-          className="scale-x"
+          wrapper={wrapper.current}
         />
       ) : (
         <SimpleScale

--- a/front/src/common/IntervalsDataViz/style.scss
+++ b/front/src/common/IntervalsDataViz/style.scss
@@ -250,38 +250,8 @@ $resize-width: 3px;
                 top: 0;
                 width: 100%;
                 text-align: center;
-
-                span.bottom-axis-value {
-                  position: absolute;
-                  font-weight: bold;
-                  top: .7em;
-                  left:0%;
-                  transform: translateX(-45%);
-                  width:100%;
-                }
-
-                span.top-axis-value {
-                  position: absolute;
-                  font-weight: bold;
-                  top: .7em;
-                  right:0%;
-                  transform: translateX(45%);
-                  width:100%;
-                }
-
-                &:before{
-                  content: "";
-                  position: absolute;
-                  top: -.2em;
-                  width: 1px;
-                  left: 50%; /* Center the tick horizontally */
-                  transform: translateX(-50%); /* Adjust for exact centering */
-                  height: 0.4em;
-                  background-color: black;
-                }
               }
             }
-
           }
           &.scale-y {
             flex-direction: column-reverse;
@@ -300,41 +270,42 @@ $resize-width: 3px;
                 width: 100%;
                 height: 100%;
                 text-align: center;
-
-                span.bottom-axis-value {
-                  position: absolute;
-                  font-weight: bold;
-                  right: 50%;
-                  bottom:-0.8em;
-                  transform: translateX(50%);
-                }
-
-                span.top-axis-value {
-                  position: absolute;
-                  font-weight: bold;
-                  right: 50%;
-                  top:-0.8em;
-                  transform: translateX(50%);
-                }
-
-                &:before{
-                  content: "";
-                  position: absolute;
-                  right: 0em;
-                  width: 0.3em;
-                  top: 50%; /* Center the tick horizontally */
-                  transform: translateY(-50%); /* Adjust for exact centering */
-                  height: 0.01em;
-                  background-color: black;
-                }
-
-
               }
               p {
                 font-size: 0.6em;
                 margin-bottom: 0;
               }
             }
+          }
+          &.resizing-scale-x {
+            border-top: $scaling-height solid;
+            height: 50px;
+            width: 100%;
+            div {
+              height: 50px;
+              text-align: center;
+
+              &:before{
+                content: "";
+                position: absolute;
+                top: -.2em;
+                width: 1px;
+                height: 0.4em;
+                background-color: black;
+              }
+
+              &.is-extremity {
+                font-weight: bold;
+              }
+
+              span {
+                position: absolute;
+                left: 50%;
+                transform: translateX(-50%);
+                top: 0.75em;
+              }
+            }
+
           }
         }
       }

--- a/front/src/common/IntervalsDataViz/utils.ts
+++ b/front/src/common/IntervalsDataViz/utils.ts
@@ -27,7 +27,7 @@ export function shortNumber(value: unknown): string {
   if (isNil(num)) return '';
 
   if (Math.abs(num) < 1000) {
-    return `${num}`;
+    return `${Math.round(num)}`;
   }
 
   const sign = num < 0 ? '-' : '';
@@ -62,6 +62,14 @@ export function roundNumber(value: number, upper = false): number {
   const round = Math.round(value);
   if (upper) return round < value ? round + 1 : round;
   return round > value ? round - 1 : round;
+}
+
+/**
+ * Given a value, test if it is a round km value
+ * Ex: 1km true, 1.3km false
+ */
+export function isRoundKm(value: number) {
+  return value % 1000 === 0;
 }
 
 /**


### PR DESCRIPTION
closes #4732 
![image](https://github.com/osrd-project/osrd/assets/45000526/8acb4e18-4b42-461f-afb2-c5daaa19e4f3)

The scale now works correctly:
- the ticks are smart (km rounded), even if you drag/zoom
- the ticks are well spaced and located at the right position (you can check this with the hover or by editing the extremities of a segment)
- if a tick is closer too 20px to the first or the last tick, it is removed
- the scale resize when you resized the window