### PR TITLE
front: rolling-stock-editor: fix small bugs

### DIFF
--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorCurves.tsx
@@ -38,10 +38,10 @@ export default function RollingStockEditorCurves(props: {
         }
       | undefined
     )[][] =
-      speedsList !== undefined && effortsList !== undefined
+      speedsList && effortsList
         ? effortsList.map((effort, index) => [
-            { value: (speedsList[index] * 3.6).toString() },
-            { value: (effort / 10).toString() },
+            { value: Math.round(speedsList[index] * 3.6).toString() },
+            { value: Math.round(effort / 10).toString() },
           ])
         : [];
 

--- a/front/src/applications/rollingStockEditor/components/RollingStockEditorFormHelpers.tsx
+++ b/front/src/applications/rollingStockEditor/components/RollingStockEditorFormHelpers.tsx
@@ -151,7 +151,7 @@ const RollingStockEditorParameterFormColumn = ({
               handleType={(type) => {
                 setRollingStockValues({
                   ...rollingStockValues,
-                  [property.title]: type.value,
+                  [property.title]: Number(type.value) || 0,
                 } as SetStateAction<RollingStockParametersValues>);
                 setOptionValue(type.type as string);
               }}

--- a/front/src/applications/rollingStockEditor/consts.ts
+++ b/front/src/applications/rollingStockEditor/consts.ts
@@ -145,7 +145,7 @@ export const RollingStockSchemaProperties: SchemaProperty[] = [
     type: 'number',
     min: 0,
     max: 100000000,
-    units: ['kg', 't'],
+    units: ['t', 'kg'],
     side: 'left',
   },
   {

--- a/front/src/common/BootstrapSNCF/InputGroupSNCF.scss
+++ b/front/src/common/BootstrapSNCF/InputGroupSNCF.scss
@@ -13,6 +13,7 @@
   }
 }
 .input-group {
+  z-index: auto !important;
   .btn-sm {
     font-size: 0.8rem;
   }


### PR DESCRIPTION
closes #4786 

- show mass in tons by default
- add z-index to input group
- fix resistance coefficient inputs
- round values in curve table