### PR TITLE
editoast: avoid stackoverflow by calling subfitxures explicitely

### DIFF
--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -98,7 +98,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Test and coverage
-        run: cargo tarpaulin --release -r ./editoast --out Xml -- --test-threads 1
+        run: cargo tarpaulin -r ./editoast --out Xml -- --test-threads 1
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -153,7 +153,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets --manifest-path=editoast/Cargo.toml -- -D warnings
-          
+
       - name: Documentation check
         run: cargo doc --manifest-path editoast/Cargo.toml
         env:

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -29,18 +29,12 @@ $ cargo run -- runserver
 
 ## Tests
 
-In order to run tests, you need to have a postgresql database running. 
+In order to run tests, you need to have a postgresql database running.
 
 To avoid thread conflicts while accessing the database, use the `--test-threads=1` option.
 
-Finally, with target debug, the test threads overflow their stack. To avoid this, you can either increase the stack size with the `RUST_MIN_STACK` environment variable or use the release target.
-
 ```sh
-cargo test --release -- --test-threads=1
-
-# or
-
-RUST_MIN_STACK=8388608 cargo test -- --test-threads=1
+cargo test -- --test-threads=1
 ```
 
 ## Useful tools

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -186,15 +186,11 @@ pub mod tests {
     }
 
     #[fixture]
-    pub async fn scenario_fixture_set(
-        db_pool: Data<DbPool>,
-        #[future] empty_infra: TestFixture<Infra>,
-        #[future] timetable: TestFixture<Timetable>,
-        #[future] study_fixture_set: StudyFixtureSet,
-    ) -> ScenarioFixtureSet {
-        let StudyFixtureSet { project, study } = study_fixture_set.await;
-        let empty_infra = empty_infra.await;
-        let timetable = timetable.await;
+    pub async fn scenario_fixture_set() -> ScenarioFixtureSet {
+        let project = project(db_pool());
+        let StudyFixtureSet { project, study } = study_fixture_set(db_pool(), project).await;
+        let empty_infra = empty_infra(db_pool()).await;
+        let timetable = timetable(db_pool()).await;
         let scenario_model = Scenario {
             name: Some(String::from("scenario_γ")),
             infra_id: Some(empty_infra.id()),
@@ -203,7 +199,7 @@ pub mod tests {
             creation_date: Some(Utc::now().naive_utc()),
             ..Scenario::default()
         };
-        let scenario = TestFixture::create(scenario_model, db_pool.clone()).await;
+        let scenario = TestFixture::create(scenario_model, db_pool().clone()).await;
         ScenarioFixtureSet {
             project,
             study,


### PR DESCRIPTION
Nesting too many #[fixtures] can cause a stackoverflow. We limit them on one particularly complex fixture that caused trouble.