### PR TITLE
core: do not try extending neutral sections if thermal

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ElectrificationRange.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.standalone_sim.result;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.RangeMap;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
@@ -8,6 +9,7 @@ import fr.sncf.osrd.envelope_sim.electrification.Electrified;
 import fr.sncf.osrd.envelope_sim.electrification.Neutral;
 import fr.sncf.osrd.envelope_sim.electrification.NonElectrified;
 import fr.sncf.osrd.train.RollingStock;
+import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -54,6 +56,18 @@ public class ElectrificationRange {
             public int hashCode() {
                 return Objects.hash(mode, modeHandled, profile, profileHandled);
             }
+
+            @Override
+            @ExcludeFromGeneratedCodeCoverage
+            public String toString() {
+                return MoreObjects.toStringHelper(this)
+                        .add("mode", mode)
+                        .add("modeHandled", modeHandled)
+                        .add("profile", profile)
+                        .add("profileHandled", profileHandled)
+                        .toString();
+            }
+
         }
 
         public static class NeutralUsage extends ElectrificationUsage {
@@ -70,6 +84,14 @@ public class ElectrificationRange {
 
             public int hashCode() {
                 return Objects.hash(isLowerPantograph);
+            }
+
+            @Override
+            @ExcludeFromGeneratedCodeCoverage
+            public String toString() {
+                return MoreObjects.toStringHelper(this)
+                        .add("isLowerPantograph", isLowerPantograph)
+                        .toString();
             }
         }
 

--- a/python/api/osrd_infra/migrations/0046_fill_rolling_stock_system_times.py
+++ b/python/api/osrd_infra/migrations/0046_fill_rolling_stock_system_times.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("osrd_infra", "0045_railjson_3_4_0"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                update
+                    osrd_infra_rollingstock as rs
+                set
+                    electrical_power_startup_time = 5.0,
+                    raise_pantograph_time = 15.0
+                where 
+                    (rs.electrical_power_startup_time is null or rs.raise_pantograph_time is null)
+                    and exists (
+                        select
+                            1
+                        from
+                            jsonb_each(rs.effort_curves->'modes') as m
+                        where
+                            (m.value->'is_electric')::boolean
+                    )
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
close: #4816 

This PR adds a test for a thermal train on an infrastructure with neutral sections.
It also fixes the `addNeutralSystemTimes` method

It also adds a django migration that fills in some empty rolling stock attributes if any in the db 