### PR TITLE
Fix #4245 : Impossible to create or edit switches

### DIFF
--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -90,7 +90,6 @@ export const TrackSectionEndpointSelector: FC<FieldProps> = ({
           portId,
           hoveredPoint: null,
           onSelect: (hoveredPoint: PortEndPointCandidate) => {
-            setState({ ...state, portEditionState: { type: 'idle' } });
             onChange({
               endpoint: hoveredPoint.endPoint,
               track: hoveredPoint.trackSectionId,
@@ -171,7 +170,6 @@ export const TrackSectionEndpointSelector: FC<FieldProps> = ({
 export const CustomSchemaField: FC<FieldProps> = (props) => {
   const { name = '' } = props;
   if (name.indexOf(FLAT_SWITCH_PORTS_PREFIX) !== 0) return <SchemaField {...props} />;
-
   return <TrackSectionEndpointSelector {...props} />;
 };
 
@@ -273,6 +271,7 @@ export const SwitchEditionLeftPanel: FC = () => {
           const flatSwitch = entity as FlatSwitchEntity;
           setState({
             ...state,
+            portEditionState: { type: 'idle' },
             entity: {
               ...flatSwitchToSwitch(switchType, flatSwitch),
               geometry: flatSwitch.geometry,
@@ -394,6 +393,7 @@ export const SwitchEditionLayers: FC = () => {
       },
     });
   }, [trackStatus, mousePosition, t]);
+
   const [geometryState, setGeometryState] = useState<
     { type: 'loading'; entity?: undefined } | { type: 'ready'; entity?: SwitchEntity }
   >({ type: 'ready' });

--- a/front/src/applications/editor/tools/switchEdition/utils.ts
+++ b/front/src/applications/editor/tools/switchEdition/utils.ts
@@ -46,7 +46,7 @@ export function getSwitchTypeJSONSchema(
           ...iter,
           [`${FLAT_SWITCH_PORTS_PREFIX}${port}`]: {
             title: `Port ${port}`,
-            $ref: '#/definitions/TrackEndpoint',
+            $ref: '#/$defs/TrackEndpoint',
           },
         }),
         {}

--- a/front/src/common/IntervalsDataViz/data.ts
+++ b/front/src/common/IntervalsDataViz/data.ts
@@ -1,15 +1,5 @@
 import { Feature, Point, LineString, Position } from 'geojson';
-import {
-  last,
-  differenceWith,
-  cloneDeep,
-  isEqual,
-  isArray,
-  isNil,
-  isObject,
-  isEmpty,
-  sortBy,
-} from 'lodash';
+import { last, differenceWith, cloneDeep, isEqual, isArray, isNil, isEmpty, sortBy } from 'lodash';
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import { utils } from '@rjsf/core';
 import lineSplit from '@turf/line-split';
@@ -660,41 +650,6 @@ export function getClosestOperationalPoint(
   );
   const closestPoint = sortedOperationalPoints[0];
   return Math.abs(position - closestPoint.positionInPx) <= 10 ? closestPoint : null;
-}
-
-/**
- * Given a JSON schema, return the props name that are a linear metadata.
- * A Linear metadata is an array type with a ref
- * The ref should contains a begin & end
- */
-export function getLinearMetadataProperties(schema: JSONSchema7): Array<string> {
-  return Object.keys(schema?.properties || {})
-    .map((prop) => {
-      const propSchema = (schema?.properties || {})[prop] as JSONSchema7;
-      /* eslint-disable dot-notation */
-      if (
-        LINEAR_METADATA_FIELDS.includes(prop) &&
-        propSchema.type === 'array' &&
-        isObject(propSchema.items) &&
-        (propSchema.items as JSONSchema7)['$ref']
-      ) {
-        const refName = ((propSchema.items as JSONSchema7)['$ref'] || '').replace(
-          '#/definitions/',
-          ''
-        );
-        const refSchema = (schema.definitions || {})[refName] as JSONSchema7;
-        /* eslint-enable dot-notation */
-        if (
-          refSchema &&
-          refSchema.properties &&
-          refSchema.properties.begin &&
-          refSchema.properties.end
-        )
-          return prop;
-      }
-      return null;
-    })
-    .filter((n) => n !== null) as Array<string>;
 }
 
 /**


### PR DESCRIPTION
This PR fix the issue #4245 (closes #4245).

The root cause was due to some concurrent setState in the lifecycle of the switch form. By remove the one in the "onSelection", it fixes the issue.

Moreover, I saw that the json_schema has been changed, so I also fixed that (ie. rename of `definitions` to `$defs`) 