### PR TITLE
fix playwright test

### DIFF
--- a/front/tests/pages/rollingstock-modal-model.ts
+++ b/front/tests/pages/rollingstock-modal-model.ts
@@ -62,6 +62,7 @@ class PlaywrightRollingstockModalPage {
   }
 
   getRollingStockInfoComfort() {
+    this.page.waitForSelector('.rollingstock-info-comfort');
     return this.getRollingstockMiniCard.locator('.rollingstock-info-comfort');
   }
 }


### PR DESCRIPTION
Added a line to wait for the `.rollingstock-info-comfort` selector to be loaded before testing the comfort level.