### PR TITLE
front: fix several bugs on power restrictions selector

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -72,6 +72,7 @@
   "pathfindingStatus": "Pathfinding state",
   "pleaseWait": "Please wait…",
   "powerRestriction": "Power restriction code",
+  "powerRestrictionExplanationText": "By default, the simulation will use the nominal power.",
   "restartPathfinding": "Restart search",
   "rollingstock": "Rolling stock",
   "simulation": "Simulation",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -72,6 +72,7 @@
   "pathfindingStatus": "Statut recherche d’itinéraire",
   "pleaseWait": "Veuillez patientez…",
   "powerRestriction": "Code de restriction de puissance",
+  "powerRestrictionExplanationText": "Si aucune restriction de puissance n'est renseignée sur un intervalle, le calcul de marche sera réalisé en utilisant la puissance nominale.",
   "restartPathfinding": "Relancer la recherche",
   "rollingstock": "Matériel",
   "simulation": "Simulation",

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -5,7 +5,6 @@ import { Position, Feature } from 'geojson';
 import {
   Allowance,
   AllowanceValue,
-  CatenaryRange,
   Comfort,
   ElectrificationRange,
   Electrified,
@@ -178,7 +177,6 @@ export interface OsrdConfState {
   infraID?: number;
   switchTypes?: SwitchType[];
   pathfindingID?: number;
-  pathWithCatenaries?: CatenaryRange[];
   shouldRunPathfinding: boolean;
   timetableID?: number;
   rollingStockID?: number;

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -350,10 +350,12 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           <div
             className="hover-x"
             style={{
-              position: 'absolute',
+              borderLeft: '2px dotted',
               height: '100%',
               left: `${hoverAtx}px`,
-              borderLeft: '2px dotted',
+              pointerEvents: 'none',
+              position: 'absolute',
+              zIndex: 3,
             }}
           />
         )}

--- a/front/src/reducers/osrdconf/index.ts
+++ b/front/src/reducers/osrdconf/index.ts
@@ -16,7 +16,7 @@ import {
 import { formatIsoDate } from 'utils/date';
 import { ValueOf } from 'utils/types';
 import { sec2time, time2sec } from 'utils/timeManipulation';
-import { Allowance, CatenaryRange, Path, osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { Allowance, Path, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { SwitchType, ThunkAction } from '../../types';
 
 /* eslint-disable default-case */
@@ -37,7 +37,6 @@ export const UPDATE_SCENARIO_ID = 'osrdconf/UPDATE_SCENARIO_ID';
 export const UPDATE_INFRA_ID = 'osrdconf/UPDATE_INFRA_ID';
 export const UPDATE_SWITCH_TYPES = 'osrdconf/UPDATE_SWITCH_TYPES';
 export const UPDATE_PATHFINDING_ID = 'osrdconf/UPDATE_PATHFINDING_ID';
-export const UPDATE_PATH_WITH_CATENARIES = 'osrdconf/UPDATE_PATH_WITH_CATENARIES';
 export const UPDATE_SHOULD_RUN_PATHFINDING = 'osrdconf/UPDATE_SHOULD_RUN_PATHFINDING';
 export const UPDATE_TIMETABLE_ID = 'osrdconf/UPDATE_TIMETABLE_ID';
 export const UPDATE_ROLLINGSTOCK_ID = 'osrdconf/UPDATE_ROLLINGSTOCK_ID';
@@ -187,9 +186,6 @@ export default function reducer(inputState: OsrdMultiConfState | undefined, acti
         draft[section].pathfindingID = action.pathfindingID;
         // reset power restriction ranges
         draft[section].powerRestrictionRanges = [];
-        break;
-      case UPDATE_PATH_WITH_CATENARIES:
-        draft[section].pathWithCatenaries = action.pathWithCatenaries;
         break;
       case UPDATE_SHOULD_RUN_PATHFINDING:
         draft[section].shouldRunPathfinding = action.shouldRunPathfinding;
@@ -461,14 +457,6 @@ export function updatePathfindingID(pathfindingID?: number) {
     dispatch({
       type: UPDATE_PATHFINDING_ID,
       pathfindingID,
-    });
-  };
-}
-export function updatePathWithCatenaries(pathWithCatenaries?: CatenaryRange[]) {
-  return (dispatch: Dispatch) => {
-    dispatch({
-      type: UPDATE_PATH_WITH_CATENARIES,
-      pathWithCatenaries,
     });
   };
 }

--- a/front/src/reducers/osrdconf/selectors.ts
+++ b/front/src/reducers/osrdconf/selectors.ts
@@ -36,7 +36,6 @@ export const getScenarioID = (state: RootState) => getSection(state).scenarioID;
 export const getInfraID = (state: RootState) => getSection(state).infraID;
 export const getSwitchTypes = (state: RootState) => getSection(state).switchTypes;
 export const getPathfindingID = (state: RootState) => getSection(state).pathfindingID;
-export const getPathWithCatenaries = (state: RootState) => getSection(state).pathWithCatenaries;
 export const getShouldRunPathfinding = (state: RootState) => getSection(state).shouldRunPathfinding;
 export const getTimetableID = (state: RootState) => getSection(state).timetableID;
 export const getRollingStockID = (state: RootState) => getSection(state).rollingStockID;


### PR DESCRIPTION
closes #4864 and closes #4867 

- don't display the power restrictions selector if the rolling stock is not electric or doesn't have any power restrictions
- allow users to select an interval item even if they click on the hover line
- clean: remove the path catenary from the store