### PR TITLE
editoast: bump debian base image

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo install --locked --path .
 
-FROM debian:bullseye-slim as runner
+FROM debian:bookworm-slim as runner
 
 RUN apt update -yqq && \
     apt install -yqq --no-install-recommends libpq-dev curl ca-certificates libgeos-dev libjemalloc2 && \


### PR DESCRIPTION
The build is based on the bookworm debian version. This avoids link editing errors (e.g. libssl3).