### PR TITLE
editoast: Generation performance

### DIFF
--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -273,7 +273,10 @@ async fn generate(
             infra.id.unwrap()
         );
         let infra_cache = InfraCache::load(&mut conn, &infra).await?;
-        if infra.refresh(&mut conn, args.force, &infra_cache).await? {
+        if infra
+            .refresh(pool.clone(), args.force, &infra_cache)
+            .await?
+        {
             build_redis_pool_and_invalidate_all_cache(redis_config.clone(), infra.id.unwrap())
                 .await;
             info!(
@@ -324,7 +327,7 @@ async fn import_railjson(
     // Generate only if the was set
     if args.generate {
         let infra_cache = InfraCache::load(&mut conn, &infra).await?;
-        infra.refresh(&mut conn, true, &infra_cache).await?;
+        infra.refresh(pool, true, &infra_cache).await?;
         info!(
             "✅ Infra {}[{}] generated data refreshed!",
             infra.name.unwrap().bold(),

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -276,7 +276,7 @@ pub mod tests {
             .test_transaction::<_, Error, _>(|conn| {
                 async move {
                     let infra = infra.create_conn(conn).await.unwrap();
-                    fn_test(conn, infra);
+                    fn_test(conn, infra).await;
                     Ok(())
                 }
                 .scope_boxed()

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -158,7 +158,7 @@ async fn refresh(
     for infra in infras_list {
         let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
         if infra
-            .refresh(&mut conn, query_params.force, &infra_cache)
+            .refresh(db_pool.clone(), query_params.force, &infra_cache)
             .await?
         {
             refreshed_infra.push(infra.id.unwrap());

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -155,7 +155,7 @@ async fn post_railjson(
         .map_err(|_| InfraApiError::NotFound { infra_id })?;
     if params.generate_data {
         let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
-        infra.refresh(&mut conn, true, &infra_cache).await?;
+        infra.refresh(db_pool, true, &infra_cache).await?;
     }
 
     Ok(Json(PostRailjsonResponse {


### PR DESCRIPTION
In order to get stable runtimes, I imported once and ran 3 times with railjson for France

`cargo run --release -- --clear infra_id`
`cargo run --release -- --generate infra_id`

Before: 82 seconds
After: 63 seconds

The gain is not that significant. The greatest bottleneck is the execution of `generate_speed_section_layer.sql`. This must be probably improved by trying to factorize the speed sections to reduce the number of sections. But that would be a different request.

Closes #4861