### PR TITLE
front: intervals editor, display additionnal read-only data

### DIFF
--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -64,11 +64,6 @@ export default function ManageTrainSchedule() {
       { pathId: pathFindingID as number },
       { skip: !pathFindingID }
     );
-
-  const rollingStockHasPowerRestictions = useMemo(() => {
-    if (!rollingStock) return false;
-    return !isEmpty(rollingStock.power_restrictions);
-  }, [rollingStock]);
 
   const tabRollingStock = {
     title: rollingStock ? (
@@ -150,9 +145,10 @@ export default function ManageTrainSchedule() {
             <SpeedLimitByTagSelector />
           </div>
         </div>
-        {rollingStock && rollingStockHasPowerRestictions && (
+        {rollingStock && !isEmpty(rollingStock.power_restrictions) && (
           <PowerRestrictionsSelector
-            rollingStock={rollingStock}
+            rollingStockModes={rollingStock.effort_curves.modes}
+            rollingStockPowerRestrictions={rollingStock.power_restrictions}
             pathCatenaryRanges={pathWithCatenaries.catenary_ranges}
           />
         )}

--- a/front/src/common/IntervalsDataViz/style.scss
+++ b/front/src/common/IntervalsDataViz/style.scss
@@ -10,6 +10,7 @@ $tooltip-padding: 1em;
 $dataviz-height: 7em;
 $scaling-height: 1px;
 $scaling-y-width: 1.5em;
+$spacer-height: 3px;
 $resize-width: 3px;
 
 // lighten ~ mix with white function
@@ -26,6 +27,19 @@ $resize-width: 3px;
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+@mixin horizontal-row {
+  border: 0 dotted;
+  border-left-width: 1px;
+  border-right-width: 1px;
+
+  &.start-visible {
+    border-left-style: solid;
+  }
+  &.end-visible {
+    border-right-style: solid;
+  }
 }
 
 .linear-metadata {
@@ -79,8 +93,6 @@ $resize-width: 3px;
         }
       }
 
-
-
       .tools {
         display: flex;
         flex-direction: column;
@@ -122,20 +134,10 @@ $resize-width: 3px;
 
         .data {
           @include unselectable;
+          @include horizontal-row;
           display: flex;
           flex-wrap: nowrap;
-          flex-direction: row;
           position: relative;
-          border: 0 dotted;
-          border-left-width: 1px;
-          border-right-width: 1px;
-
-          &.start-visible {
-            border-left-style: solid;
-          }
-          &.end-visible {
-            border-right-style: solid;
-          }
 
           &.dragging {
             cursor: grabbing;
@@ -217,6 +219,52 @@ $resize-width: 3px;
               font-size: medium;
               padding-left: 3px;
               color: var(--coolgray11);
+            }
+          }
+        }
+
+        .spacer {
+          @include horizontal-row;
+          height: $spacer-height;
+        }
+
+        .additional-data {
+          @include horizontal-row;
+          display: flex;
+          background: mixw($color, 0.9);
+
+          div.item {
+            background: mixw($color, 0.9);
+            display: flex;
+
+            div.value {
+              @include unselectable;
+              width: calc(100% - $resize-width);
+              flex-grow: 1;
+              text-align: center;
+              white-space: nowrap;
+              span {
+                display: block;
+                font-size: 0.8em;
+              }
+
+              &.no-data {
+                background-color: mixw($color, 0.9);
+                background-image: repeating-linear-gradient(
+                  45deg,
+                  $color-nodata,
+                  $color-nodata 1px,
+                  transparent 2px,
+                  transparent 10px
+                );
+              }
+            }
+
+            div.resize {
+              width: 1px;
+              height: 100%;
+              z-index: 2;
+              background-color: #fff;
             }
           }
         }

--- a/front/src/common/IntervalsEditor/IntervalsEditor.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditor.tsx
@@ -16,6 +16,7 @@ import { LinearMetadataItem, OperationalPoint } from 'common/IntervalsDataViz/ty
 import IntervalsEditorTootlip from './IntervalsEditorTooltip';
 import IntervalsEditorCommonForm from './IntervalsEditorCommonForm';
 import {
+  AdditionalDataItem,
   INTERVALS_EDITOR_TOOLS,
   INTERVAL_TYPES,
   IntervalItem,
@@ -29,6 +30,7 @@ import IntervalsEditorSelectForm from './IntervalsEditorSelectForm';
 import { createEmptySegmentAt, removeSegment } from './utils';
 
 type IntervalsEditorProps = {
+  additionalData?: AdditionalDataItem[];
   defaultValue: number | string;
   emptyValue?: unknown;
   operationalPoints?: OperationalPoint[];
@@ -64,6 +66,7 @@ type IntervalsEditorProps = {
  */
 const IntervalsEditor = (props: IntervalsEditorProps) => {
   const {
+    additionalData,
     data = [],
     defaultValue,
     emptyValue = undefined,
@@ -180,6 +183,7 @@ const IntervalsEditor = (props: IntervalsEditorProps) => {
       <div className="content">
         <div className="dataviz">
           <LinearMetadataDataviz
+            additionalData={additionalData}
             creating={selectedTool === INTERVALS_EDITOR_TOOLS.ADD_TOOL}
             data={resizingData}
             emptyValue={emptyValue}

--- a/front/src/common/IntervalsEditor/types.ts
+++ b/front/src/common/IntervalsEditor/types.ts
@@ -7,6 +7,7 @@ export enum INTERVAL_TYPES {
 }
 
 export type IntervalItem = LinearMetadataItem<{ value: number | string; unit?: string }>;
+export type AdditionalDataItem = LinearMetadataItem<{ value: number | string }>;
 
 export enum INTERVALS_EDITOR_TOOLS {
   ADD_TOOL = 'add-tool',

--- a/front/src/stories/IntervalsEditor.stories.tsx
+++ b/front/src/stories/IntervalsEditor.stories.tsx
@@ -6,6 +6,7 @@ import { LinearMetadataItem, OperationalPoint } from 'common/IntervalsDataViz/ty
 import { notEmpty } from 'common/IntervalsDataViz/utils';
 import IntervalsEditor from 'common/IntervalsEditor/IntervalsEditor';
 import {
+  AdditionalDataItem,
   INTERVAL_TYPES,
   IntervalItem,
   IntervalsEditorToolsConfig,
@@ -16,6 +17,13 @@ const operationalPoints: OperationalPoint[] = [
   { id: 'b', position: 10000, name: 'b' },
   { id: 'c', position: 22000, name: 'c' },
   { id: 'd', position: 25000, name: 'd' },
+];
+
+const additionalData: AdditionalDataItem[] = [
+  { begin: 0, end: 10000, value: '25000V' },
+  { begin: 10000, end: 20000, value: '' },
+  { begin: 20000, end: 22000, value: '1500V' },
+  { begin: 22000, end: 25000, value: '25000V' },
 ];
 
 const dataNumber = [
@@ -93,6 +101,7 @@ const IntervalsEditorWrapper: React.FC<IntervalsEditorProps> = (props) => {
       return (
         <IntervalsEditor
           {...props}
+          additionalData={additionalData}
           data={data as LinearMetadataItem<{ value: number | string }>[]}
           intervalType={intervalType}
           operationalPoints={operationalPoints}


### PR DESCRIPTION
closes #4902 

The intervals editor can now display additional read-only information
![image](https://github.com/osrd-project/osrd/assets/45000526/c6f27e4c-16cc-4a3a-895e-c257f989c10c)
![image](https://github.com/osrd-project/osrd/assets/45000526/9a511ad7-8779-410f-942e-5149bf9b2f71)
