### PR TITLE
core: fix pathfinding response waypoints

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathWaypointResult.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/response/PathWaypointResult.java
@@ -65,6 +65,9 @@ public class PathWaypointResult {
      * Check if two steps result are at the same location
      */
     public boolean isDuplicate(PathWaypointResult other) {
+        // Don't merge user-defined waypoints even if they're on the same location
+        if (!suggestion && !other.suggestion)
+            return false;
         return Math.abs(pathOffset - other.pathOffset) < 0.001;
     }
 


### PR DESCRIPTION
In the application, we assume that the number of waypoints given as input to the PF must match the number of waypoints output (unsuggested) by core.

When two waypoints are at the same location, they are merged into a single unsuggested waypoint. This PR fixes this.

Merge this after: #4655 