### PR TITLE
front: rollingstockeditor: fix hidden dupplicated RS when locked filter is checked

### DIFF
--- a/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
+++ b/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
@@ -31,6 +31,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
   const [isLoading, setIsLoading] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
+  const [isDuplicating, setIsDuplicating] = useState(false);
   const dispatch = useDispatch();
 
   const [openedRollingStockCardId, setOpenedRollingStockCardId] = useState<number>();
@@ -84,6 +85,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
                     isCondensed
                     rollingStock={selectedRollingStock}
                     setIsEditing={setIsEditing}
+                    setIsDuplicating={setIsDuplicating}
                     isRollingStockLocked={selectedRollingStock.locked as boolean}
                   />
                 </div>
@@ -181,6 +183,8 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
           setFilteredRollingStockList={setFilteredRollingStockList}
           filteredRollingStockList={filteredRollingStockList}
           setIsLoading={setIsLoading}
+          mustResetFilters={isDuplicating}
+          setMustResetFilters={setIsDuplicating}
         />
         {displayList()}
       </div>

--- a/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
@@ -98,6 +98,8 @@ type SearchRollingStockProps = {
   filteredRollingStockList: LightRollingStock[];
   setIsLoading?: (isLoading: boolean) => void;
   isSuccess?: boolean;
+  mustResetFilters?: boolean;
+  setMustResetFilters?: (mustResetFilters: boolean) => void;
 };
 
 const SearchRollingStock = ({
@@ -106,6 +108,8 @@ const SearchRollingStock = ({
   filteredRollingStockList,
   setIsLoading,
   isSuccess,
+  mustResetFilters,
+  setMustResetFilters,
 }: SearchRollingStockProps) => {
   const { t } = useTranslation('rollingStockEditor');
 
@@ -149,6 +153,16 @@ const SearchRollingStock = ({
     setFilteredRollingStockList(newFilteredRollingStock);
   }
 
+  const resetFilters = () => {
+    setFilters({
+      text: '',
+      elec: false,
+      thermal: false,
+      locked: false,
+      notLocked: false,
+    });
+  };
+
   useEffect(() => {
     handleRollingStockLoaded();
   }, [isSuccess]);
@@ -160,8 +174,15 @@ const SearchRollingStock = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, rollingStocks]);
 
+  useEffect(() => {
+    if (mustResetFilters && setMustResetFilters) {
+      resetFilters();
+      setMustResetFilters(false);
+    }
+  }, [mustResetFilters]);
+
   return (
-    <div className="row no-gutters">
+    <div className="row no-gutters rollingstock-editor-filters">
       <div className="col-md-4 mb-3">
         <InputSNCF
           id="searchfilter"

--- a/front/src/modules/rollingStock/components/rollingStockEditor/RollingStockEditorButtons.tsx
+++ b/front/src/modules/rollingStock/components/rollingStockEditor/RollingStockEditorButtons.tsx
@@ -11,6 +11,7 @@ import RollingStockEditorFormModal from 'modules/rollingStock/components/rolling
 type RollingStockEditorButtonsProps = {
   rollingStock: RollingStock;
   setIsEditing: (isEditing: boolean) => void;
+  setIsDuplicating: (isDuplicating: boolean) => void;
   setOpenedRollingStockCardId: React.Dispatch<React.SetStateAction<number | undefined>>;
   isRollingStockLocked: boolean;
   isCondensed: boolean;
@@ -19,6 +20,7 @@ type RollingStockEditorButtonsProps = {
 function RollingStockEditorButtons({
   rollingStock,
   setIsEditing,
+  setIsDuplicating,
   setOpenedRollingStockCardId,
   isRollingStockLocked,
   isCondensed,
@@ -71,6 +73,7 @@ function RollingStockEditorButtons({
       .then((res) => {
         setOpenedRollingStockCardId(res.id);
         setIsEditing(true);
+        setIsDuplicating(true);
         dispatch(
           setSuccess({
             title: t('messages.success'),

--- a/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
+++ b/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
@@ -208,6 +208,10 @@
       width: 38%;
     }
   }
+
+  &-filters {
+    z-index: 110;
+  }
 }
 
 .defaultImageRSEditor img {


### PR DESCRIPTION
- add rollingstock-editor-filters class in _rollingStockEditor.scss
- set z-index: 110 in rollingstock-editor-filters class

close #5005 