### PR TITLE
front: intervals editor - fix 2 bugs

### DIFF
--- a/front/src/common/BootstrapSNCF/SelectImprovedSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/SelectImprovedSNCF.tsx
@@ -100,7 +100,7 @@ function SelectImproved<T extends string | SelectOptionObject>({
           </button>
         </span>
       )),
-    [filteredOptions]
+    [filteredOptions, selectItem]
   );
 
   const shouldDisplayNewInputValue =

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -199,7 +199,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
    * => we recompute the additionalData4viz
    */
   useEffect(() => {
-    if (fullLength > 0) {
+    if (fullLength > 0 && additionalData.length > 0) {
       const croppedAdditionalData = cropForDatavizViewbox(
         additionalData,
         viewBox
@@ -452,6 +452,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
             {additionalData4viz.map((item, index) => (
               <div
                 className="item"
+                key={`${item.begin}-${item.end}-${item.value}`}
                 style={{
                   width: `${((item.end - item.begin) / fullLength) * 100}%`,
                 }}


### PR DESCRIPTION
closes #5008 

- re-renders in loop if additionalData is not provided
- select form does update the correct interval (and not the first selected)