### PR TITLE
front: disable elevation on map by default

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -69,7 +69,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
   const switchTypes = useSelector(getSwitchTypes);
   const editorState = useSelector((state: { editor: EditorState }) => state.editor);
   const showOSM = useSelector(getShowOSM);
-  const terrain3DExagerration = useSelector(getTerrain3DExaggeration);
+  const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);
   const extendedContext = useMemo<ExtendedEditorContextType<CommonToolState>>(
     () => ({
       ...context,
@@ -193,7 +193,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
           attributionControl={false}
           touchZoomRotate
           maxPitch={85}
-          terrain={{ source: 'terrain', exaggeration: terrain3DExagerration }}
+          terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
           doubleClickZoom={false}
           interactive
           cursor={cursor}
@@ -264,7 +264,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
               <Hillshade
                 mapStyle={mapStyle}
                 layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-                display={terrain3DExagerration > 0}
+                display={terrain3DExaggeration > 0}
               />
             </>
           )}

--- a/front/src/applications/operationalStudies/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/applications/operationalStudies/components/ManageTrainSchedule/Map.tsx
@@ -51,7 +51,7 @@ import { getMapMouseEventNearestFeature } from '../../../../utils/mapHelper';
 function Map() {
   const { viewport, mapSearchMarker, mapStyle, mapTrackSources, showOSM, layersSettings } =
     useSelector((state: RootState) => state.map);
-  const terrain3DExagerration = useSelector(getTerrain3DExaggeration);
+  const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);
   const [idHover, setIdHover] = useState<string | undefined>(undefined);
   const [snappedPoint, setSnappedPoint] = useState<NearestPointOnLine>();
   const { urlLat = '', urlLon = '', urlZoom = '', urlBearing = '', urlPitch = '' } = useParams();
@@ -189,7 +189,7 @@ function Map() {
         interactiveLayerIds={defineInteractiveLayers()}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExagerration }}
+        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
       >
         <VirtualLayers />
         <AttributionControl position="bottom-right" customAttribution={CUSTOM_ATTRIBUTION} />

--- a/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
+++ b/front/src/applications/operationalStudies/components/SimulationResults/SimulationResultsMap.tsx
@@ -106,7 +106,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
   );
   const simulation = useSelector((state: RootState) => state.osrdsimulation.simulation.present);
   const selectedTrain = useSelector(getSelectedTrain);
-  const terrain3DExagerration = useSelector(getTerrain3DExaggeration);
+  const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);
   const [geojsonPath, setGeojsonPath] = useState<Feature<LineString>>();
   const [selectedTrainHoverPosition, setTrainHoverPosition] = useState<TrainPosition>();
   const [otherTrainsHoverPosition, setOtherTrainsHoverPosition] = useState<TrainPosition[]>([]);
@@ -398,7 +398,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
         interactiveLayerIds={interactiveLayerIds}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExagerration }}
+        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
         onLoad={handleLoadFinished}
       >
         <VirtualLayers />
@@ -421,7 +421,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
             <Hillshade
               mapStyle={mapStyle}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-              display={terrain3DExagerration > 0}
+              display={terrain3DExaggeration > 0}
             />
           </>
         )}

--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -47,7 +47,7 @@ import 'common/Map/Map.scss';
 function Map() {
   const { viewport, mapSearchMarker, mapStyle, mapTrackSources, showOSM, layersSettings } =
     useSelector((state: RootState) => state.map);
-  const terrain3DExagerration = useSelector(getTerrain3DExaggeration);
+  const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);
   const mapRef = useRef<MapRef | null>(null);
   const [idHover, setIdHover] = useState<string | undefined>(undefined);
   const { urlLat, urlLon, urlZoom, urlBearing, urlPitch } = useParams();
@@ -128,7 +128,7 @@ function Map() {
         interactiveLayerIds={defineInteractiveLayers()}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExagerration }}
+        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
       >
         <VirtualLayers />
         <AttributionControl customAttribution={CUSTOM_ATTRIBUTION} />
@@ -150,7 +150,7 @@ function Map() {
             <Hillshade
               mapStyle={mapStyle}
               layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
-              display={terrain3DExagerration > 0}
+              display={terrain3DExaggeration > 0}
             />
           </>
         )}

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -39,6 +39,7 @@ const mapWhiteList = [
   'layersSettings',
   'userPreference',
   'signalsSettings',
+  'terrain3DExaggeration',
 ];
 
 const userWhiteList = ['account'];

--- a/front/src/reducers/map/index.ts
+++ b/front/src/reducers/map/index.ts
@@ -49,7 +49,7 @@ export interface MapState {
   showIGNCadastre: boolean;
   showOSM: boolean;
   showOSMtracksections: boolean;
-  terrain3DExagerration: number;
+  terrain3DExaggeration: number;
   viewport: Viewport;
   featureInfoHoverID: unknown;
   featureInfoClickID: unknown;
@@ -89,7 +89,7 @@ export const initialState: MapState = {
   showIGNCadastre: false,
   showOSM: true,
   showOSMtracksections: false,
-  terrain3DExagerration: 1,
+  terrain3DExaggeration: 0,
   viewport: {
     latitude: 48.32,
     longitude: 2.44,
@@ -181,7 +181,7 @@ export default function reducer(inputState: MapState | undefined, action: AnyAct
         draft.signalsSettings = action.signalsSettings;
         break;
       case UPDATE_TERRAIN_3D_EXAGGERATION:
-        draft.terrain3DExagerration = action.terrain3DExagerration;
+        draft.terrain3DExaggeration = action.terrain3DExaggeration;
         break;
     }
   });
@@ -287,12 +287,12 @@ export function updateShowOSMtracksections(showOSMtracksections: MapState['showO
 }
 
 export function updateTerrain3DExaggeration(
-  terrain3DExagerration: MapState['terrain3DExagerration']
+  terrain3DExaggeration: MapState['terrain3DExaggeration']
 ) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: UPDATE_TERRAIN_3D_EXAGGERATION,
-      terrain3DExagerration,
+      terrain3DExaggeration,
     });
   };
 }

--- a/front/src/reducers/map/selectors.ts
+++ b/front/src/reducers/map/selectors.ts
@@ -25,9 +25,9 @@ export const getShowOSMtracksections = makeSubSelector<MapState, 'showOSMtrackse
   getMap,
   'showOSMtracksections'
 );
-export const getTerrain3DExaggeration = makeSubSelector<MapState, 'terrain3DExagerration'>(
+export const getTerrain3DExaggeration = makeSubSelector<MapState, 'terrain3DExaggeration'>(
   getMap,
-  'terrain3DExagerration'
+  'terrain3DExaggeration'
 );
 export const getViewport = makeSubSelector<MapState, 'viewport'>(getMap, 'viewport');
 export const getFeatureInfoHoverID = makeSubSelector<MapState, 'featureInfoHoverID'>(


### PR DESCRIPTION
closes #5013 

- set terrain3DExaggeration to 0 by default
- correct a typo: terrain3DExaggerration -> terrain3DExaggeration