### PR TITLE
front: editor, remove direction field on range in catenary form

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/components.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components.tsx
@@ -151,25 +151,27 @@ export const TrackRangesList: FC = () => {
                   </div>
                   <div className="flex-grow-1 flex-shrink-1">
                     <EntitySumUp entity={trackState.track} />
-                    <div>
-                      <select
-                        id="filterLevel"
-                        className="form-control"
-                        value={range.applicable_directions}
-                        onChange={(e) => {
-                          const newEntity = cloneDeep(entity);
-                          const newRange = (newEntity.properties.track_ranges || [])[i];
-                          newRange.applicable_directions = e.target.value as ApplicableDirection;
-                          setState({ entity: newEntity, hoveredItem: null });
-                        }}
-                      >
-                        {APPLICABLE_DIRECTIONS.map((direction) => (
-                          <option key={direction} value={direction}>
-                            {t(`Editor.directions.${direction}`)}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
+                    {entity.objType !== 'Catenary' && (
+                      <div>
+                        <select
+                          id="filterLevel"
+                          className="form-control"
+                          value={range.applicable_directions}
+                          onChange={(e) => {
+                            const newEntity = cloneDeep(entity);
+                            const newRange = (newEntity.properties.track_ranges || [])[i];
+                            newRange.applicable_directions = e.target.value as ApplicableDirection;
+                            setState({ entity: newEntity, hoveredItem: null });
+                          }}
+                        >
+                          {APPLICABLE_DIRECTIONS.map((direction) => (
+                            <option key={direction} value={direction}>
+                              {t(`Editor.directions.${direction}`)}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
                   </div>
                 </>
               )}


### PR DESCRIPTION
closes #4493 

Before fix
![image](https://github.com/osrd-project/osrd/assets/45000526/b985670f-3972-4aeb-88fe-952da2c7c62e)

After fix
![image](https://github.com/osrd-project/osrd/assets/45000526/c95e8ac5-83ac-4865-9239-526ae7d975c5)
