### PR TITLE
Add model v2 macro to editoast

### DIFF
--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -1,0 +1,648 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ops::{Deref, DerefMut},
+};
+
+use darling::{
+    ast,
+    util::{self, PathList},
+    FromDeriveInput, FromField, FromMeta, Result,
+};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::DeriveInput;
+
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+enum Identifier {
+    Field(syn::Ident),
+    Compound(Vec<syn::Ident>),
+}
+
+impl Identifier {
+    fn get_field<'a>(&self, config: &'a ModelConfig) -> Option<&'a ModelField> {
+        match self {
+            Self::Field(ident) => config.fields.get(ident),
+            Self::Compound(_) => None,
+        }
+    }
+
+    fn get_idents(&self) -> Vec<syn::Ident> {
+        match self {
+            Self::Field(ident) => vec![ident.clone()],
+            Self::Compound(idents) => idents.clone(),
+        }
+    }
+
+    fn get_ident_lvalue(&self) -> TokenStream {
+        match self {
+            Self::Field(ident) => quote! { #ident },
+            Self::Compound(idents) => {
+                quote! { (#(#idents),*) }
+            }
+        }
+    }
+
+    fn type_expr(&self, config: &ModelConfig) -> TokenStream {
+        match self {
+            Self::Field(_) => {
+                let ty = &self.get_field(config).unwrap().ty;
+                quote! { #ty }
+            }
+            Self::Compound(idents) => {
+                let ty = idents
+                    .iter()
+                    .map(|ident| &config.fields.get(ident).unwrap().ty);
+                quote! { (#(#ty),*) }
+            }
+        }
+    }
+}
+
+fn extract_ident_of_path(path: &syn::Path) -> Result<syn::Ident> {
+    let mut segments = path.segments.iter();
+    let first = segments.next().unwrap();
+    if segments.next().is_some() {
+        Err(darling::Error::custom(
+            "Model: unexpected path in 'identifier' expression",
+        ))
+    } else {
+        Ok(first.ident.clone())
+    }
+}
+
+impl darling::FromMeta for Identifier {
+    fn from_expr(expr: &syn::Expr) -> Result<Self> {
+        match expr {
+            syn::Expr::Path(path) => Ok(Identifier::Field(extract_ident_of_path(&path.path)?)),
+            syn::Expr::Tuple(tuple) => {
+                let mut idents = Vec::new();
+                for expr in tuple.elems.iter() {
+                    match expr {
+                        syn::Expr::Path(path) => {
+                            idents.push(extract_ident_of_path(&path.path)?);
+                        }
+                        _ => return Err(darling::Error::custom(
+                            "Model: invalid compound 'identifier' expression: must be a tuple of idents",
+                        )),
+                    }
+                }
+                Ok(Identifier::Compound(idents))
+            }
+            _ => Err(darling::Error::custom(
+                "Model: invalid 'identifier' expression",
+            )),
+        }
+    }
+}
+
+#[derive(FromDeriveInput, Debug)]
+#[darling(
+    attributes(model),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_named)
+)]
+struct ModelOptions {
+    table: syn::Path,
+    #[darling(default)]
+    row: GeneratedType,
+    #[darling(default)]
+    changeset: GeneratedType,
+    #[darling(multiple, rename = "identifier")]
+    identifiers: Vec<Identifier>,
+    #[darling(default)]
+    preferred: Option<Identifier>,
+    data: ast::Data<util::Ignored, ModelFieldOption>,
+}
+
+#[derive(FromMeta, Default, Debug, PartialEq)]
+struct GeneratedType {
+    #[darling(default)]
+    type_name: Option<String>,
+    #[darling(default)]
+    derive: PathList,
+    #[darling(default)]
+    public: bool,
+}
+
+#[derive(FromField, Debug)]
+#[darling(attributes(model), forward_attrs(allow, doc, cfg))]
+struct ModelFieldOption {
+    ident: Option<syn::Ident>,
+    ty: syn::Type,
+    #[darling(default)]
+    builder_fn: Option<syn::Ident>,
+    #[darling(default)]
+    column: Option<String>,
+    #[darling(default)]
+    builder_skip: bool,
+    #[darling(default)]
+    identifier: bool,
+    #[darling(default)]
+    preferred: bool,
+    #[darling(default)]
+    primary: bool,
+    #[darling(default)]
+    json: bool,
+    #[darling(default)]
+    geo: bool,
+}
+
+#[derive(Debug, PartialEq)]
+struct ModelConfig {
+    model: syn::Ident,
+    table: syn::Path,
+    fields: Fields,
+    row: GeneratedType,
+    changeset: GeneratedType,
+    identifiers: HashSet<Identifier>, // identifiers ⊆ fields
+    preferred_identifier: Identifier, // preferred_identifier ∈ identifiers
+    primary_field: Identifier,        // primary_field ∈ identifiers
+}
+
+#[derive(Debug, PartialEq, Clone)]
+struct ModelField {
+    ident: syn::Ident,
+    column: String,
+    builder_ident: syn::Ident,
+    ty: syn::Type,
+    builder_skip: bool,
+    identifier: bool,
+    preferred: bool,
+    primary: bool,
+    json: bool,
+    geo: bool,
+}
+
+impl From<ModelFieldOption> for ModelField {
+    fn from(value: ModelFieldOption) -> Self {
+        let ident = value.ident.expect("Model only works for named structs");
+        let column = value.column.unwrap_or_else(|| ident.to_string());
+        let builder_ident = value.builder_fn.unwrap_or_else(|| ident.clone());
+        Self {
+            ident,
+            builder_ident,
+            column,
+            ty: value.ty,
+            builder_skip: value.builder_skip,
+            identifier: value.identifier,
+            preferred: value.preferred,
+            primary: value.primary,
+            json: value.json,
+            geo: value.geo,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct Fields(Vec<ModelField>);
+
+impl Deref for Fields {
+    type Target = Vec<ModelField>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Fields {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Fields {
+    fn get(&self, ident: &syn::Ident) -> Option<&ModelField> {
+        self.iter().find(|field| &field.ident == ident)
+    }
+}
+
+impl ModelConfig {
+    fn new(options: ModelOptions, model_name: syn::Ident) -> Self {
+        let row = GeneratedType {
+            type_name: options.row.type_name.or(Some(format!("{}Row", model_name))),
+            ..options.row
+        };
+        let changeset = GeneratedType {
+            type_name: options
+                .changeset
+                .type_name
+                .or(Some(format!("{}Changeset", model_name))),
+            ..options.changeset
+        };
+
+        // transform fields
+        let fields = Fields(
+            options
+                .data
+                .take_struct()
+                .expect("Model: only named structs are supported")
+                .fields
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        );
+        let first_field = &fields
+            .first()
+            .expect("Model: at least one field is required")
+            .ident;
+        let field_map: HashMap<_, _> = fields
+            .iter()
+            .map(|field| (field.ident.clone(), field.clone()))
+            .collect();
+
+        // collect identifiers from struct-level annotations...
+        let mut identifiers: HashSet<_> = options
+            .identifiers
+            .iter()
+            .cloned()
+            .chain(
+                // ... and those at the field-level
+                field_map
+                    .values()
+                    .filter(|field| field.identifier)
+                    .map(|field| Identifier::Field(field.ident.clone())),
+            )
+            .collect();
+
+        // collect of infer the primary key field
+        let primary_field = match field_map
+            .values()
+            .filter(|field| field.primary)
+            .collect::<Vec<_>>()
+            .as_slice()
+        {
+            [pf] => Identifier::Field(pf.ident.clone()),
+            [] => {
+                let id = Ident::new("id", Span::call_site());
+                Identifier::Field(
+                    field_map
+                        .get(&id)
+                        .map(|f| f.ident.clone())
+                        .unwrap_or_else(|| first_field.clone()),
+                )
+            }
+            _ => panic!("Model: multiple primary fields found"),
+        };
+
+        // collect or infer the preferred identifier field
+        let preferred_identifier = match (
+            options.preferred.as_ref(),
+            field_map
+                .values()
+                .filter(|field| field.primary)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        ) {
+            (Some(id), []) => id.clone(),
+            (None, [field]) => Identifier::Field(field.ident.clone()),
+            (None, []) => primary_field.clone(),
+            _ => panic!("Model: conflicting preferred field declarations"),
+        };
+
+        identifiers.insert(primary_field.clone());
+        identifiers.insert(preferred_identifier.clone());
+
+        Self {
+            model: model_name,
+            table: options.table,
+            fields,
+            identifiers,
+            preferred_identifier,
+            primary_field,
+            row,
+            changeset,
+        }
+    }
+
+    fn iter_fields(&self) -> impl Iterator<Item = &ModelField> {
+        self.fields.iter()
+    }
+
+    fn is_primary(&self, field: &ModelField) -> bool {
+        match &self.primary_field {
+            Identifier::Field(ident) => ident == &field.ident,
+            Identifier::Compound(_) => false,
+        }
+    }
+
+    fn table_name(&self) -> syn::Ident {
+        let table = self
+            .table
+            .segments
+            .last()
+            .expect("Model: invalid table value");
+        table.ident.clone()
+    }
+
+    fn make_model_decl(&self, vis: &syn::Visibility) -> TokenStream {
+        let model = &self.model;
+        let table = &self.table;
+        let (field, (ty, column)): (Vec<_>, (Vec<_>, Vec<_>)) = self
+            .iter_fields()
+            .map(|field| (&field.ident, (&field.ty, &field.column)))
+            .unzip();
+        let (cs_field, (cs_ty, cs_column)): (Vec<_>, (Vec<_>, Vec<_>)) = self
+            .iter_fields()
+            .filter(|f| !self.is_primary(f))
+            .map(|field| (&field.ident, (&field.ty, &field.column)))
+            .unzip();
+        let cs_ident = self.changeset.ident();
+        let cs_derive = &self.changeset.derive;
+        let cs_pub = if self.changeset.public {
+            quote! { pub }
+        } else {
+            quote! {}
+        };
+        let row_ident = self.row.ident();
+        let row_derive = &self.row.derive;
+        let row_pub = if self.row.public {
+            quote! { pub }
+        } else {
+            quote! {}
+        };
+        quote! {
+            #[automatically_derived]
+            impl crate::modelsv2::Model for #model {
+                type Row = #row_ident;
+                type Changeset = #cs_ident;
+            }
+
+            #[derive(Queryable, QueryableByName, #(#row_derive),*)]
+            #[diesel(table_name = #table)]
+            #vis struct #row_ident {
+                #(#[diesel(column_name = #column)] #row_pub #field: #ty),*
+            }
+
+            #[derive(Default, Queryable, AsChangeset, Insertable, #(#cs_derive),*)]
+            #[diesel(table_name = #table)]
+            #vis struct #cs_ident {
+                #(#[diesel(deserialize_as = #cs_ty, column_name = #cs_column)] #cs_pub #cs_field: Option<#cs_ty>),*
+            }
+        }
+    }
+
+    fn make_builder(&self, changeset: bool) -> TokenStream {
+        let (fields, (fns, (types, bodies))): (Vec<_>, (Vec<_>, (Vec<_>, Vec<_>))) = self
+            .iter_fields()
+            .filter(|f| !self.is_primary(f))
+            .filter(|field| !field.builder_skip)
+            .map(|field| {
+                let ident = &field.ident;
+                let body = if changeset {
+                    quote! { self.#ident = Some(#ident) }
+                } else {
+                    quote! { self.changeset.#ident = Some(#ident) }
+                };
+                (ident, (&field.builder_ident, (&field.ty, body)))
+            })
+            .unzip();
+
+        let impl_decl = if changeset {
+            let tn = self.changeset.ident();
+            quote! { impl #tn }
+        } else {
+            let tn = &self.model;
+            quote! { impl<'a> crate::modelsv2::Patch<'a, #tn> }
+        };
+
+        quote! {
+            #[automatically_derived]
+            #impl_decl {
+                #(
+                    #[allow(unused)]
+                    #[must_use = "builder methods are intended to be chained"]
+                    pub fn #fns(mut self, #fields: #types) -> Self {
+                        #bodies;
+                        self
+                    }
+                )*
+            }
+        }
+    }
+
+    fn make_identifiers_impls(&self) -> TokenStream {
+        let model = &self.model;
+        let (idents, ty): (Vec<_>, Vec<_>) = self
+            .identifiers
+            .iter()
+            .map(|id| (id.get_idents(), id.type_expr(self)))
+            .unzip();
+        let prefer_ty = self.preferred_identifier.type_expr(self);
+        quote! {
+            #(#[automatically_derived] impl crate::models::Identifiable<#ty> for #model {
+                fn get_id(&self) -> #ty {
+                    (#(self.#idents.clone()),*)
+                }
+            })*
+            #[automatically_derived]
+            impl crate::models::PreferredId<#prefer_ty> for #model {}
+        }
+    }
+
+    fn make_from_impls(&self) -> TokenStream {
+        let model = &self.model;
+        let field: Vec<_> = self.iter_fields().map(|field| &field.ident).collect();
+        let cs_field: Vec<_> = self
+            .iter_fields()
+            .filter(|f| !self.is_primary(f))
+            .map(|field| &field.ident)
+            .collect();
+        let row_ident = self.row.ident();
+        let cs_ident = self.changeset.ident();
+        quote! {
+            #[automatically_derived]
+            impl From<#row_ident> for #model {
+                fn from(row: #row_ident) -> Self {
+                    Self {
+                        #( #field: row.#field ),*
+                    }
+                }
+            }
+
+            #[automatically_derived]
+            impl From<#model> for #cs_ident {
+                fn from(model: #model) -> Self {
+                    Self {
+                        #( #cs_field: Some(model.#cs_field) ),*
+                    }
+                }
+            }
+        }
+    }
+
+    fn make_model_traits_impl(&self) -> TokenStream {
+        let model = &self.model;
+        let table_mod = &self.table;
+        let table_name = self.table_name();
+        let row_ident = self.row.ident();
+        let cs_ident = self.changeset.ident();
+        let (ty, (ident, filter)): (Vec<_>, (Vec<_>, Vec<_>)) = self
+            .identifiers
+            .iter()
+            .map(|id| {
+                let (ident, column): (Vec<_>, Vec<_>) = id
+                    .get_idents()
+                    .into_iter()
+                    .map(|ident| {
+                        let field = self.fields.get(&ident).unwrap();
+                        let column = Ident::new(&field.column, Span::call_site());
+                        (ident, column)
+                    })
+                    .unzip();
+                let filters = quote! { #(filter(dsl::#column.eq(#ident))).* };
+                (id.type_expr(self), (id.get_ident_lvalue(), filters))
+            })
+            .unzip();
+        let Identifier::Field(pk) = &self.primary_field else {
+            panic!("Model: primary field must be a single field - should not happen");
+        };
+        quote! {
+            #(
+                #[automatically_derived]
+                #[async_trait::async_trait]
+                impl crate::modelsv2::Retrieve<#ty> for #model {
+                    async fn retrieve(
+                        conn: &mut diesel_async::AsyncPgConnection,
+                        #ident: #ty,
+                    ) -> crate::error::Result<Option<#model>> {
+                        use diesel::prelude::*;
+                        use diesel_async::RunQueryDsl;
+                        use #table_mod::dsl;
+                        dsl::#table_name
+                            .#filter
+                            .first::<#row_ident>(conn)
+                            .await
+                            .map(Into::into)
+                            .optional()
+                            .map_err(Into::into)
+                    }
+                }
+
+                #[automatically_derived]
+                #[async_trait::async_trait]
+                impl crate::modelsv2::Update<#ty, #model> for #cs_ident {
+                    async fn update(
+                        self,
+                        conn: &mut diesel_async::AsyncPgConnection,
+                        #ident: #ty,
+                    ) -> crate::error::Result<Option<#model>> {
+                        use diesel::prelude::*;
+                        use diesel_async::RunQueryDsl;
+                        use #table_mod::dsl;
+                        diesel::update(dsl::#table_name.#filter)
+                            .set(&self)
+                            .get_result::<#row_ident>(conn)
+                            .await
+                            .map(Into::into)
+                            .optional()
+                            .map_err(Into::into)
+                    }
+                }
+
+                #[automatically_derived]
+                #[async_trait::async_trait]
+                impl crate::modelsv2::DeleteStatic<#ty> for #model {
+                    async fn delete_static(
+                        conn: &mut diesel_async::AsyncPgConnection,
+                        #ident: #ty,
+                    ) -> crate::error::Result<bool> {
+                        use diesel::prelude::*;
+                        use diesel_async::RunQueryDsl;
+                        use #table_mod::dsl;
+                        diesel::delete(dsl::#table_name.#filter)
+                            .execute(conn)
+                            .await
+                            .map(|n| n == 1)
+                            .map_err(Into::into)
+                    }
+                }
+            )*
+
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Create<#model> for #cs_ident {
+                async fn create(
+                    self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                ) -> crate::error::Result<#model> {
+                    use diesel_async::RunQueryDsl;
+                    diesel::insert_into(#table_mod::table)
+                        .values(&self)
+                        .get_result::<#row_ident>(conn)
+                        .await
+                        .map(Into::into)
+                        .map_err(Into::into)
+                }
+            }
+
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Delete for #model {
+                async fn delete(
+                    &self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                ) -> crate::error::Result<bool> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    let id = self.#pk;
+                    diesel::delete(#table_mod::table.find(id))
+                        .execute(conn)
+                        .await
+                        .map(|n| n == 1)
+                        .map_err(Into::into)
+                }
+            }
+        }
+    }
+}
+
+impl GeneratedType {
+    fn ident(&self) -> Ident {
+        Ident::new(self.type_name.as_ref().unwrap(), Span::call_site())
+    }
+}
+
+pub fn model(input: &DeriveInput) -> Result<TokenStream> {
+    let model_name = &input.ident;
+    let model_vis = &input.vis;
+    let options = ModelOptions::from_derive_input(input)?;
+    let config = ModelConfig::new(options, model_name.clone());
+
+    let identifiers_impls = config.make_identifiers_impls();
+    let model_decl = config.make_model_decl(model_vis);
+    let from_impls = config.make_from_impls();
+
+    let cs_builder = config.make_builder(true);
+    let patch_builder = config.make_builder(false);
+
+    let model_impls = config.make_model_traits_impl();
+
+    Ok(quote! {
+        #identifiers_impls
+        #model_decl
+        #from_impls
+        #cs_builder
+        #patch_builder
+        #model_impls
+    })
+}
+
+#[cfg(test)]
+#[test]
+fn test_construction() {
+    let input = syn::parse_quote! {
+        #[derive(Clone, Model)]
+        #[model(table = crate::tables::osrd_infra_document)]
+        #[model(row(type_name = "DocumentRow", derive(Debug)))]
+        #[model(changeset(type_name = "DocumentChangeset", public, derive(Debug)))] // fields are public
+        struct Document {
+            #[model(column = "id", preferred, primary)]
+            id_: i64,
+            #[model(identifier, json, geo)]
+            content_type: String,
+            data: Vec<u8>,
+        }
+    };
+    let _ = model(&input).expect("should generate");
+}

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -10,6 +10,7 @@ mod generated_data;
 mod infra_cache;
 mod map;
 mod models;
+mod modelsv2;
 mod schema;
 mod tables;
 mod views;

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -47,8 +47,20 @@ crate::schemas! {
     rolling_stock::schemas(),
 }
 
-pub trait Identifiable {
-    fn get_id(&self) -> i64;
+pub trait Identifiable<T = i64>
+where
+    T: Clone,
+{
+    fn get_id(&self) -> T;
+}
+
+pub trait PreferredId<T>: Identifiable<T>
+where
+    T: Clone,
+{
+    fn id(&self) -> T {
+        self.get_id()
+    }
 }
 
 impl<T: diesel::Identifiable<Id = i64> + Clone> Identifiable for T {

--- a/editoast/src/models/projects.rs
+++ b/editoast/src/models/projects.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use crate::models::TextArray;
-use crate::models::{Delete, Document, Identifiable, Retrieve};
+use crate::models::{Delete, Identifiable, Retrieve};
+use crate::modelsv2::{DeleteStatic, Document};
 use crate::tables::project;
 use crate::views::pagination::{Paginate, PaginatedResponse};
 use crate::DbPool;
@@ -189,7 +190,7 @@ impl Project {
 
         if let Some(image) = image_to_delete {
             // We don't check the result. We don't want to throw an error if the image is used in another project.
-            let _ = Document::delete_conn(conn, image).await;
+            let _ = Document::delete_static(conn, image).await;
         }
 
         Ok(Some(project_obj))
@@ -212,7 +213,7 @@ impl Delete for Project {
         // Delete image if any
         if let Some(image) = project_obj.image.unwrap() {
             // We don't check the result. We don't want to throw an error if the image is used in another project.
-            let _ = Document::delete_conn(conn, image).await;
+            let _ = Document::delete_static(conn, image).await;
         };
         Ok(true)
     }
@@ -241,7 +242,7 @@ impl Update for Project {
 
         if let Some(image) = image_to_delete {
             // We don't check the result. We don't want to throw an error if the image is used in another project.
-            let _ = Document::delete_conn(conn, image).await;
+            let _ = Document::delete_static(conn, image).await;
         }
 
         Ok(Some(project_obj))

--- a/editoast/src/models/rolling_stock/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock/rolling_stock_livery.rs
@@ -1,6 +1,7 @@
 use crate::diesel::{delete, QueryDsl};
 use crate::error::Result;
-use crate::models::{Delete, Document, Identifiable};
+use crate::models::{Delete, Identifiable};
+use crate::modelsv2::Document;
 use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLivery;
 use crate::tables::rolling_stock_livery;
 use async_trait::async_trait;
@@ -63,7 +64,8 @@ impl Delete for RollingStockLiveryModel {
         };
         // Delete compound_image if any
         if let Some(image_id) = livery.compound_image_id {
-            let _ = Document::delete_conn(conn, image_id).await;
+            use crate::modelsv2::DeleteStatic;
+            let _ = Document::delete_static(conn, image_id).await;
         };
         Ok(true)
     }

--- a/editoast/src/modelsv2/documents.rs
+++ b/editoast/src/modelsv2/documents.rs
@@ -1,0 +1,13 @@
+//! This module manage documents in the database.
+//!
+//! Each document is identified by a unique key (`i64`).
+
+use editoast_derive::ModelV2;
+
+#[derive(Debug, Default, Clone, ModelV2)]
+#[model(table = crate::tables::document)]
+pub struct Document {
+    pub id: i64,
+    pub content_type: String,
+    pub data: Vec<u8>,
+}

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -1,0 +1,281 @@
+pub mod documents;
+
+pub use documents::Document;
+
+use async_trait::async_trait;
+use diesel::{pg::Pg, result::Error::NotFound, AsChangeset, QueryableByName};
+
+use crate::error::{EditoastError, Result};
+
+pub use crate::models::{Identifiable, PreferredId};
+
+/// A struct that can be saved to and read from the database using diesel's interface
+///
+/// The `Self::Row` type is a struct that precisely maps the columns of the
+/// table that represents this model. It's used to read the rows returned
+/// by the SQL queries performed on this model.
+///
+/// The `Self::Changeset` type is a struct `Option`-ally maps the columns
+/// of the table. It represents the values that might or might not be given
+/// to an INSERT or UPDATE statement.
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+// FIXME: that Clone requirement is not necessary, see problematic line below
+pub trait Model: Clone + Sized + Send {
+    type Row: QueryableByName<Pg> + Into<Self> + Send;
+    type Changeset: AsChangeset + Default + From<Self> + Send;
+
+    /// Returns an empty changeset for this model
+    fn changeset() -> Self::Changeset {
+        Self::Changeset::default()
+    }
+
+    /// Returns an empty [Patch] referencing this instance of the model
+    fn patch(&mut self) -> Patch<Self> {
+        Patch {
+            model: self,
+            changeset: Self::Changeset::default(),
+        }
+    }
+
+    fn into_changeset(self) -> Self::Changeset {
+        self.into()
+    }
+
+    fn from_row(row: Self::Row) -> Self {
+        row.into()
+    }
+}
+
+/// A couple ([Model] mutable reference, a [Model] changeset instance)
+///
+/// This struct is useful for several things:
+///
+/// * Provides a function [Patch::apply] that applies the changeset to the model
+///     row and updates the model instance with the new values
+/// * Takes the model instance as a mutable reference ensuring no concurrent
+///     modification can be made to the instance
+/// * The `Model` derive macro generates a builder similar to the changeset
+///     for `Patch<'a, YourModel>` as well making this struct easier to use.
+///
+/// # Example
+///
+/// ```
+/// let mut doc = Document::retrieve(&mut conn, 1).await?.unwrap();
+/// doc.patch().title("new title").apply(&mut conn).await?;
+/// assert_eq!(doc.title, "new title");
+/// ```
+///
+/// See [Model::patch]
+///
+/// Also checkout [Save] and [Save::save] that provide another way to modify
+/// [Model] instances.
+#[allow(unused)]
+pub struct Patch<'a, T: Model> {
+    model: &'a mut T,
+    changeset: T::Changeset,
+}
+
+#[allow(unused)]
+impl<'a, M: Model> Patch<'a, M> {
+    /// Applies the patch changeset to update the model instance's row and updates
+    /// the model reference with its new values
+    ///
+    /// If this method is not implemented for your model for whatever reason, just
+    /// use [Save::save].
+    async fn apply<K>(self, conn: &mut diesel_async::AsyncPgConnection) -> Result<()>
+    where
+        for<'b> K: Send + Clone + 'b,
+        M: Model + Identifiable<K> + Send,
+        <M as Model>::Changeset: Update<K, M> + Send,
+    {
+        let id: K = self.model.get_id();
+        let updated: M = self.changeset.update_or_fail(conn, id, || NotFound).await?;
+        *self.model = updated;
+        Ok(())
+    }
+}
+
+/// Describes how a [Model] can be retrieved from the database
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait]
+pub trait Retrieve<K>: Sized
+where
+    for<'async_trait> K: Send + 'async_trait,
+{
+    /// Retrieves the row #`id` and deserializes it as a model instance
+    async fn retrieve(conn: &mut diesel_async::AsyncPgConnection, id: K) -> Result<Option<Self>>;
+
+    /// Just like [Retrieve::retrieve] but returns `Err(fail())` if the row was not found
+    async fn retrieve_or_fail<E, F>(
+        conn: &'async_trait mut diesel_async::AsyncPgConnection,
+        id: K,
+        fail: F,
+    ) -> Result<Self>
+    where
+        E: EditoastError,
+        F: FnOnce() -> E + Send + 'async_trait,
+    {
+        match Self::retrieve(conn, id).await {
+            Ok(Some(obj)) => Ok(obj),
+            Ok(None) => Err(fail().into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Describes how a [Model] can be updated in the database
+///
+/// The models that implement this trait also implement [Save] which provide
+/// a convenient way to update a model instance.
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait]
+pub trait Update<K, Row>: Sized
+where
+    for<'async_trait> K: Send + 'async_trait,
+    Row: Send,
+{
+    /// Updates the row #`id` with the changeset values and returns the updated model
+    async fn update(self, conn: &mut diesel_async::AsyncPgConnection, id: K)
+        -> Result<Option<Row>>;
+
+    /// Just like [Update::update] but returns `Err(fail())` if the row was not found
+    async fn update_or_fail<E: EditoastError, F: FnOnce() -> E + Send>(
+        self,
+        conn: &'async_trait mut diesel_async::AsyncPgConnection,
+        id: K,
+        fail: F,
+    ) -> Result<Row> {
+        match self.update(conn, id).await {
+            Ok(Some(obj)) => Ok(obj),
+            Ok(None) => Err(fail().into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Describes how a [Model] can be persisted to the database
+///
+/// This trait is automatically implemented for all models that implement
+/// [Update].
+#[async_trait]
+pub trait Save<K: Send>: Sized {
+    /// Persists the model instance to the database
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut doc = Document::retrieve(&mut conn, 1).await?.unwrap();
+    /// doc.title = "new title".to_string();
+    /// doc.save(&mut conn).await?;
+    /// assert_eq!(doc.title, "new title");
+    /// ```
+    async fn save(&mut self, conn: &mut diesel_async::AsyncPgConnection) -> Result<()>;
+}
+
+#[async_trait]
+impl<'a, K, M> Save<K> for M
+where
+    for<'async_trait> K: Send + Clone + 'async_trait,
+    M: Model + Identifiable<K> + Clone + Send + 'a,
+    <M as Model>::Changeset: Update<K, M> + Send,
+{
+    async fn save(&mut self, conn: &mut diesel_async::AsyncPgConnection) -> Result<()> {
+        let id = self.get_id();
+        let changeset = <M as Model>::Changeset::from(self.clone()); // FIXME: I don't like that clone, maybe a ChangesetOwned/Changeset pair would work?
+        *self = changeset.update_or_fail(conn, id, || NotFound).await?;
+        Ok(())
+    }
+}
+
+/// Describes how a [Model] can be created in the database
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait]
+pub trait Create<Row: Send>: Sized {
+    /// Creates a new row in the database with the values of the changeset and
+    /// returns the created model instance
+    async fn create(self, conn: &mut diesel_async::AsyncPgConnection) -> Result<Row>;
+
+    /// Just like [Create::create] but discards the error if any and returns `Err(fail())` instead
+    async fn create_or_fail<E: EditoastError, F: FnOnce() -> E + Send>(
+        self,
+        conn: &'async_trait mut diesel_async::AsyncPgConnection,
+        fail: F,
+    ) -> Result<Row> {
+        match self.create(conn).await {
+            Ok(obj) => Ok(obj),
+            Err(_) => Err(fail().into()),
+        }
+    }
+}
+
+/// Describes how a [Model] can be deleted from the database
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+// NOTE: I'd argue that taking an &self is better than a borrow here
+// as one might want to access the values of the model after deletion
+#[async_trait]
+pub trait Delete: Sized {
+    /// Deletes the row corresponding to this model instance
+    ///
+    /// Returns `true` if the row was deleted, `false` if it didn't exist
+    async fn delete(&self, conn: &mut diesel_async::AsyncPgConnection) -> Result<bool>;
+
+    /// Just like [Delete::delete] but returns `Err(fail())` if the row didn't exist
+    async fn delete_or_fail<E, F>(
+        &self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        fail: F,
+    ) -> Result<()>
+    where
+        E: EditoastError,
+        F: FnOnce() -> E + Send + 'async_trait,
+    {
+        match self.delete(conn).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(fail().into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Describes how a [Model] can be deleted from the database
+///
+/// This trait is similar to [Delete] but it doesn't take a reference to the model
+/// instance. This is useful for models that don't have to be retrieved before deletion.
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait]
+pub trait DeleteStatic<K>: Sized
+where
+    for<'async_trait> K: Send + 'async_trait,
+{
+    /// Deletes the row #`id` from the database
+    async fn delete_static(conn: &mut diesel_async::AsyncPgConnection, id: K) -> Result<bool>;
+
+    /// Just like [DeleteStatic::delete_static] but returns `Err(fail())` if the row didn't exist
+    async fn delete_static_or_fail<E, F>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        id: K,
+        fail: F,
+    ) -> Result<()>
+    where
+        E: EditoastError,
+        F: FnOnce() -> E + Send + 'async_trait,
+    {
+        match Self::delete_static(conn, id).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(fail().into()),
+            Err(e) => Err(e),
+        }
+    }
+}


### PR DESCRIPTION
Part of #4184

* `ModelV2` derive macro
* Retrieve, Update, Create, Delete, DeleteStatic, Save traits
* `Patch<'a, Model>` objects
* Builder generation
* Previsional attributes `json` and `geo`
* Partial port of the `Document` model
  * only the tests use the old model because it would otherwise require two similar but different `TestFixture` objects

Things left to do:

* Batch operations : #5055 
* `InfraModel` : #4807 
* Implement `#[model(json)]` attribute macro
* Maybe `geo` as well
* Add a `#[model(to_string)]` attribute macro
* Add a `#[model(diesel(...))]` directive to forward diesel configuration at both type and field level (useful for `belongs_to` among other things)
* Design a way to directly include foreign refs in the model struct (e.g.: have a `study: Study` field in the `Project` model instead of a `project_id` in `Study`)

Schema (may be probably 100% accurate, more or less):

(The red tag means that it's generated by the macro, the export deleted the text :cry:)

![OSRD Model](https://github.com/osrd-project/osrd/assets/20309655/409ca970-b93d-4197-9ae4-dcd0ac6e769b)
