### PR TITLE
editoast: add macros schemas! and routes!

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "openssl",
  "osm4routing",
  "osmpbfreader",
+ "paste",
  "pathfinding",
  "pointy",
  "postgis_diesel",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -69,6 +69,7 @@ osm4routing = "0.5.8"
 osmpbfreader = "0.16.0"
 itertools = "0.11.0"
 utoipa = { version = "3.5.0", features = ["actix_extras", "chrono", "uuid"] }
+paste = "1.0.14"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -152,6 +152,39 @@ components:
         curve:
           $ref: '#/components/schemas/EffortCurve'
       type: object
+    Conflict:
+      properties:
+        conflict_type:
+          $ref: '#/components/schemas/ConflictType'
+        end_time:
+          format: int64
+          minimum: 0
+          type: integer
+        start_time:
+          format: int64
+          minimum: 0
+          type: integer
+        train_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
+        train_names:
+          items:
+            type: string
+          type: array
+      required:
+      - train_ids
+      - train_names
+      - start_time
+      - end_time
+      - conflict_type
+      type: object
+    ConflictType:
+      enum:
+      - Spacing
+      - Routing
+      type: string
     DeleteOperation:
       properties:
         obj_id:
@@ -2148,11 +2181,34 @@ components:
       - trains
       type: object
     TimetableImportPathLocation:
-      discriminator:
-        propertyName: type
       oneOf:
-      - $ref: '#/components/schemas/TrackOffsetLocation'
-      - $ref: '#/components/schemas/OperationalPointLocation'
+      - properties:
+          offset:
+            format: double
+            type: number
+          track_section:
+            type: string
+          type:
+            enum:
+            - track_offset
+            type: string
+        required:
+        - track_section
+        - offset
+        - type
+        type: object
+      - properties:
+          type:
+            enum:
+            - operational_point
+            type: string
+          uic:
+            format: int64
+            type: integer
+        required:
+        - uic
+        - type
+        type: object
     TimetableImportPathSchedule:
       properties:
         arrival_time:
@@ -4502,12 +4558,15 @@ paths:
       - stdcm
   /timetable/{id}/:
     get:
+      description: Return a specific timetable with its associated schedules
       parameters:
-      - description: Timetable ID
+      - description: Timetable id
         in: path
         name: id
         required: true
         schema:
+          format: int64
+          minimum: 0
           type: integer
       responses:
         '200':
@@ -4515,8 +4574,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimetableWithSchedulesDetails'
-          description: The timetable content
-      summary: Retrieve a timetable and its train schedules
+          description: Timetable with schedules
+        '404':
+          description: Timetable not found
+      summary: Return a specific timetable with its associated schedules
       tags:
       - timetable
     post:
@@ -4547,12 +4608,17 @@ paths:
       - timetable
   /timetable/{id}/conflicts/:
     get:
+      description: |-
+        Compute spacing conflicts for a given timetable
+        TODO: This should compute itinary conflicts too
       parameters:
-      - description: Timetable ID
+      - description: Timetable id
         in: path
         name: id
         required: true
         schema:
+          format: int64
+          minimum: 0
           type: integer
       responses:
         '200':
@@ -4560,31 +4626,10 @@ paths:
             application/json:
               schema:
                 items:
-                  properties:
-                    conflict_type:
-                      type: string
-                    end_time:
-                      type: string
-                    start_time:
-                      type: string
-                    train_ids:
-                      items:
-                        type: number
-                      type: array
-                    train_names:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - train_ids
-                  - train_names
-                  - start_time
-                  - end_time
-                  - conflict_type
-                  type: object
+                  $ref: '#/components/schemas/Conflict'
                 type: array
-          description: The timetable conflicts content
-      summary: Retrieve all conflicts for a specific timetable
+          description: Spacing conflicts
+      summary: Compute spacing conflicts for a given timetable
       tags:
       - timetable
   /train_schedule/:
@@ -4763,13 +4808,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  git_describe:
-                    nullable: true
-                    type: string
-                required:
-                - git_describe
-                type: object
+                $ref: '#/components/schemas/Version'
           description: Return the core service version
 tags:
 - description: Infra

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -230,8 +230,7 @@ async fn runserver(
             .service(
                 scope(&args.root_path)
                     .service(views::routes())
-                    .service(views::study_routes())
-                    .service(views::version_routes()),
+                    .service(views::study_routes()),
             )
     });
 

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -1,13 +1,369 @@
 //! Provides [OpenApiMerger] that can be used to merge our old manually written
 //! OpenAPI with the new generated one incrementally in order to avoid protential
 //! breaking changes.
-//!
-//! This module is meant to be deleted at the end of the OpenAPI replacement
-//! process.
 
-use std::path::Path;
+use std::{
+    collections::{BTreeMap, VecDeque},
+    path::Path,
+};
 
+use actix_web::dev::HttpServiceFactory;
 use serde_json::Value as Json;
+use utoipa::{
+    openapi::{
+        path::PathItemBuilder, schema::AnyOf, AllOf, Array, Object, OneOf, PathItem, RefOr, Schema,
+    },
+    ToSchema,
+};
+
+pub struct Routes<F: HttpServiceFactory> {
+    pub service: F,
+    pub paths: OpenApiPathScope,
+}
+
+#[derive(Debug)]
+pub struct OpenApiPathScope {
+    pub prefix: Option<&'static str>,
+    pub paths: VecDeque<Dispatch>,
+}
+
+#[allow(unused)]
+pub enum Dispatch {
+    Path(&'static str, PathItem),
+    Scope(Box<OpenApiPathScope>),
+}
+
+impl std::fmt::Debug for Dispatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Dispatch::Path(p, _) => write!(f, "Path({p:?})"),
+            Dispatch::Scope(r) => write!(f, "Scope({:?})", *r),
+        }
+    }
+}
+
+impl<F: HttpServiceFactory> std::fmt::Debug for Routes<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Routes")
+            .field("service", &"<unprintable>")
+            .field("paths", &self.paths)
+            .finish()
+    }
+}
+
+#[allow(unused)]
+impl OpenApiPathScope {
+    pub fn new(prefix: Option<&'static str>) -> Self {
+        Self {
+            prefix,
+            paths: VecDeque::new(),
+        }
+    }
+
+    pub fn route(mut self, openapi_path: &'static str, openapi_pathitem: PathItem) -> Self {
+        self.paths
+            .push_back(Dispatch::Path(openapi_path, openapi_pathitem));
+        self
+    }
+
+    pub fn scope(mut self, scope: Self) -> Self {
+        self.paths.push_back(Dispatch::Scope(Box::new(scope)));
+        self
+    }
+
+    pub fn into_flat_path_list(self) -> Vec<(String, PathItem)> {
+        let prefix = self.prefix.unwrap_or_default();
+        let mut paths = Vec::new();
+
+        fn concat_path<A: AsRef<str>, B: AsRef<str>>(a: A, b: B) -> String {
+            let (a, b) = (a.as_ref(), b.as_ref());
+            match (a.ends_with('/'), b.starts_with('/')) {
+                (true, true) => format!("{}{}", a, &b[1..]),
+                (false, false) => format!("{}/{}", a, b),
+                _ => format!("{}{}", a, b),
+            }
+        }
+
+        for item in self.paths {
+            match item {
+                Dispatch::Path(path, pathitem) => paths.push((concat_path(prefix, path), pathitem)),
+                Dispatch::Scope(scope) => paths.append(
+                    &mut scope
+                        .into_flat_path_list()
+                        .into_iter()
+                        .map(|(path, pathitem)| (concat_path(prefix, path), pathitem))
+                        .collect(),
+                ),
+            }
+        }
+        paths
+    }
+}
+
+pub(super) fn merge_path_items(a: PathItem, b: PathItem) -> PathItem {
+    let mut builder = PathItemBuilder::new()
+        .summary(a.summary.or(b.summary))
+        .description(a.description.or(b.description))
+        .parameters(match (a.parameters, b.parameters) {
+            (Some(a), Some(b)) => Some(a.into_iter().chain(b).collect()),
+            (Some(p), None) | (None, Some(p)) => Some(p),
+            (None, None) => None,
+        })
+        .servers(match (a.servers, b.servers) {
+            (Some(a), Some(b)) => Some(a.into_iter().chain(b).collect()),
+            (Some(s), None) | (None, Some(s)) => Some(s),
+            (None, None) => None,
+        });
+    let mut operations: BTreeMap<_, _> = a.operations;
+    for (method, operation) in b.operations {
+        if operations.contains_key(&method) {
+            log::warn!(
+                "duplicate operation for method {}",
+                serde_json::to_string(&method).unwrap() // PathItemType does not implement Display or Debug :(
+            );
+        }
+        operations.insert(method, operation);
+    }
+    for (method, operation) in operations {
+        builder = builder.operation(method, operation);
+    }
+    builder.build()
+}
+
+impl<F: HttpServiceFactory> HttpServiceFactory for Routes<F> {
+    fn register(self, config: &mut actix_web::dev::AppService) {
+        self.service.register(config);
+    }
+}
+
+/// A macro that given a tree of routes, generates the corresponding [Routes]
+/// object which also includes both the actix service and the routes' OpenAPI info
+///
+/// Note that you cannot have more than 12 services at the same scope level
+/// because HttpServiceFactory is not implemented for tuples with more than 12
+/// services (actix's fault, not mine, I swear 🥺). If you need more than 12
+/// services just group them within parentheses. A scope counts as one service.
+///
+/// That macro will generate a funciton `fn routes() -> Routes` that you can use
+/// inside another `routes!` invocation to include all the routes of another
+/// module. This is useful to split the routes in multiple files.
+///
+/// Also note that the order of the services will be kept the same, so you might
+/// encounter the classic actix issue that the first route that matches a request
+/// will be used instead of the one you expect because of the order of the services.
+///
+/// Finally, all the endpoints used in this macro **MUST** be annotated using
+/// `#[utoipa::path(...)]`, even if left empty.
+///
+/// # Example
+/// ```
+/// routes! {
+///     "/infra" => {
+///         cache_status,
+///         "/{infra}" => {
+///             load,
+///             get,
+///             (s1, s2, s3, s4, s5, s6, s7, s8, s9, "/s" => { s10 }, s11, s12),
+///         },
+///         sub_module::routes(),
+///         other_endpoint
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! routes {
+    // TODO: apply the same pattern than schemas! with the three item types: ident, &path and expr
+
+    // end of recursion, return the built expression
+    (@routes [$($routes:expr)*]) => { ($($routes),*) };
+    (@paths [$p:expr]) => { $p };
+
+    // collect the endpoint and continue
+    (@routes [$($acc:expr)*] $route:ident , $($rest:tt)*) => {
+        $crate::routes!(@routes [$($acc)* $route] $($rest)*)
+    };
+    // retrieve the openapi data of the endpoint and continue
+    (@paths [$p:expr] $route:ident , $($rest:tt)*) => {
+        $crate::routes!(@paths
+            [paste::paste! {
+                $p.route(
+                    <[<__path_ $route>] as utoipa::Path>::path(),
+                    <[<__path_ $route>] as utoipa::Path>::path_item(None)
+                )
+            }]
+            $($rest)*
+        )
+    };
+
+    // create a scope, recurse within the scope, and continue collecting at the same level
+    (@routes [$($acc:expr)*] $prefix:literal => {$($tt:tt)+} , $($rest:tt)*) => {
+        $crate::routes!(@routes [$($acc)* actix_web::web::scope($prefix).service(
+            $crate::routes!(@routes [] $($tt)+)
+        )] $($rest)*)
+    };
+    // ditto
+    (@paths [$p:expr] $prefix:literal => {$($tt:tt)+} , $($rest:tt)*) => {
+        $crate::routes!(@paths [$p.scope(
+            $crate::routes!(@paths [$crate::views::openapi::OpenApiPathScope::new(Some($prefix))] $($tt)+)
+        )] $($rest)*)
+    };
+
+    // FIXME: add memoization to avoid calling routes() twice
+    // call the routes() function for the submodule and collect just the service
+    (@routes [$($acc:expr)*] $sub:ident ::routes() , $($rest:tt)*) => {
+        $crate::routes!(@routes [$($acc)* $sub::routes().service] $($rest)*)
+    };
+    // call the routes() function for the submodule and collect just the openapi description
+    (@paths [$p:expr] $sub:ident ::routes() , $($rest:tt)*) => {
+        $crate::routes!(@paths [$p.scope($sub::routes().paths)] $($rest)*)
+    };
+
+    // tuple of services, just recurse within the tuple and continue parsing the same level
+    (@routes [$($acc:expr)*] ($($tt:tt)*) , $($rest:tt)*) => {
+        $crate::routes!(@routes [$($acc)*
+            $crate::routes!(@routes [] $($tt)*)
+        ] $($rest)*)
+    };
+    (@paths [$p:expr] ($($tt:tt)*) , $($rest:tt)*) => {
+        $crate::routes!(@paths [$p.scope(
+            $crate::routes!(@paths [$crate::views::openapi::OpenApiPathScope::new(None)] $($tt)*)
+         )] $($rest)*)
+    };
+
+    // handles a terminating term without a trailing comma
+    (@routes [$($acc:expr)*] $route:ident) => { $crate::routes!(@routes [$($acc)*] $route ,) };
+    (@paths [$p:expr] $route:ident) => { $crate::routes!(@paths [$p] $route ,) };
+    (@routes [$($acc:expr)*] $prefix:literal => {$($tt:tt)+}) => { $crate::routes!(@routes [$($acc)*] $prefix => {$($tt)+} ,) };
+    (@paths [$p:expr] $prefix:literal => {$($tt:tt)+}) => { $crate::routes!(@paths [$p] $prefix => {$($tt)+} ,) };
+    (@routes [$($acc:expr)*] $sub:ident ::routes()) => { $crate::routes!(@routes [$($acc)*] $sub ::routes() ,) };
+    (@paths [$p:expr] $sub:ident ::routes()) => { $crate::routes!(@paths [$p] $sub ::routes() ,) };
+    (@routes [$($acc:expr)*] ($($tt:tt)*)) => { $crate::routes!(@routes [$($acc)*] ($($tt)*) ,) };
+    (@paths [$p:expr] ($($tt:tt)*)) => { $crate::routes!(@paths [$p] ($($tt)*) ,) };
+
+    // error handling to avoid falling back to the macro entry point and get recursion errors
+    (@routes $($tt:tt)*) => { compile_error!(stringify!("routes!: could not parse @routes: " $($tt)*)) };
+    (@paths $($tt:tt)*) => { compile_error!(stringify!("routes!: could not parse @paths: " $($tt)*)) };
+
+    // entry point
+    ($($tt:tt)*) => {
+        pub fn routes() -> $crate::views::openapi::Routes<impl actix_web::dev::HttpServiceFactory>  {
+            $crate::views::openapi::Routes {
+                service: $crate::routes!(@routes [] $($tt)*),
+                paths: $crate::routes!(@paths [$crate::views::openapi::OpenApiPathScope::new(None)] $($tt)*)
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LocalSchemas {
+    pub schemas: BTreeMap<String, RefOr<Schema>>,
+}
+
+impl LocalSchemas {
+    pub fn schema<'__s, S: ToSchema<'__s>>(mut self) -> Self {
+        let (name, schema) = S::schema();
+        self.schemas.insert(name.to_owned(), schema);
+        self
+    }
+
+    pub fn include(mut self, other: Self) -> Self {
+        self.schemas.extend(other.schemas);
+        self
+    }
+}
+
+impl IntoIterator for LocalSchemas {
+    type Item = (String, RefOr<Schema>);
+    type IntoIter = std::collections::btree_map::IntoIter<String, RefOr<Schema>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.schemas.into_iter()
+    }
+}
+
+/// A macro that given a list of schemas, generates a function `fn schemas() -> LocalSchemas`
+/// that returns the list of schemas
+///
+/// That way you don't have to import every schema in views/mod.rs to include them
+/// in the top openapi annotation.
+///
+/// You can include schemas in another module my preceding them with `&`.
+///
+/// You can also use expressions that return a [LocalSchemas] object–such as
+/// another `schema()` call, to forward it through the module hierarchy.
+///
+/// **YOU HAVE TO LEAVE A TRAILING COMMA AFTER THE LAST ITEM!!!**
+///
+/// # Example
+///
+/// ```
+/// schemas! {
+///     MySchema,
+///     &nested::module::Schema,
+///     &crate::Schema,
+///     sub_module::schemas(),
+///     AnotherScheman,
+/// }
+/// ```
+#[macro_export]
+macro_rules! schemas {
+    (@build [$b:expr]) => { $b };
+
+    (@build [$b:expr] $schema:ident , $($rest:tt)*) => {
+        $crate::schemas!(@build [$b.schema::<$schema>()] $($rest)*)
+    };
+
+    (@build [$b:expr] & $schema:path , $($rest:tt)*) => {
+        $crate::schemas!(@build [$b.schema::<$schema>()] $($rest)*)
+    };
+
+    (@build [$b:expr] $sub:expr , $($rest:tt)*) => {
+        $crate::schemas!(@build [$b.include($sub)] $($rest)*)
+    };
+
+    (@build [$b:expr] $($tt:tt)*) => { compile_error!(stringify!("schemas!: invalid specifier: " $($tt)*)) };
+
+    ($($tt:tt)*) => {
+        pub fn schemas() -> $crate::views::openapi::LocalSchemas {
+            $crate::schemas!(@build [$crate::views::openapi::LocalSchemas::default()] $($tt)*)
+        }
+    };
+}
+
+pub(super) fn remove_discriminator(schema: &mut RefOr<Schema>) {
+    match schema {
+        RefOr::T(Schema::AllOf(AllOf {
+            items,
+            discriminator,
+            ..
+        }))
+        | RefOr::T(Schema::AnyOf(AnyOf {
+            items,
+            discriminator,
+            ..
+        }))
+        | RefOr::T(Schema::OneOf(OneOf {
+            items,
+            discriminator,
+            ..
+        })) => {
+            let _ = discriminator.take();
+            for item in items.iter_mut() {
+                remove_discriminator(item);
+            }
+        }
+        RefOr::T(Schema::Object(Object { properties, .. })) => {
+            for property in properties.values_mut() {
+                remove_discriminator(property);
+            }
+        }
+        RefOr::T(Schema::Array(Array { items, .. })) => {
+            remove_discriminator(items);
+        }
+        _ => (),
+    }
+}
 
 pub(super) struct OpenApiMerger {
     old: Json,

--- a/front/src/applications/operationalStudies/components/Scenario/Timetable.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/Timetable.tsx
@@ -21,14 +21,19 @@ import { OsrdSimulationState, ScheduledTrain } from 'reducers/osrdsimulation/typ
 import { RootState } from 'reducers';
 import { updateTrainScheduleIDsToModify } from 'reducers/osrdconf';
 import { valueToInterval } from 'utils/numbers';
-import { GetTimetableByIdApiResponse, Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import {
+  Conflict,
+  GetTimetableByIdApiResponse,
+  Infra,
+  osrdEditoastApi,
+} from 'common/api/osrdEditoastApi';
 import { durationInSeconds } from 'utils/timeManipulation';
 import { getSelectedTrainId } from 'reducers/osrdsimulation/selectors';
 import { isEmpty } from 'lodash';
 import { BsFillExclamationTriangleFill } from 'react-icons/bs';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import ConflictsList, { Conflict } from 'modules/conflict/components/ConflictsList';
+import ConflictsList from 'modules/conflict/components/ConflictsList';
 import getSimulationResults from './getSimulationResults';
 import TimetableTrainCard from './TimetableTrainCard';
 import findTrainsDurationsIntervals from '../ManageTrainSchedule/helpers/trainsDurationsIntervals';

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1209,9 +1209,9 @@ export type PostStdcmApiArg = {
   };
 };
 export type GetTimetableByIdApiResponse =
-  /** status 200 The timetable content */ TimetableWithSchedulesDetails;
+  /** status 200 Timetable with schedules */ TimetableWithSchedulesDetails;
 export type GetTimetableByIdApiArg = {
-  /** Timetable ID */
+  /** Timetable id */
   id: number;
 };
 export type PostTimetableByIdApiResponse = unknown;
@@ -1220,16 +1220,9 @@ export type PostTimetableByIdApiArg = {
   id: number;
   body: TimetableImportItem[];
 };
-export type GetTimetableByIdConflictsApiResponse =
-  /** status 200 The timetable conflicts content */ {
-    conflict_type: string;
-    end_time: string;
-    start_time: string;
-    train_ids: number[];
-    train_names: string[];
-  }[];
+export type GetTimetableByIdConflictsApiResponse = /** status 200 Spacing conflicts */ Conflict[];
 export type GetTimetableByIdConflictsApiArg = {
-  /** Timetable ID */
+  /** Timetable id */
   id: number;
 };
 export type DeleteTrainScheduleApiResponse = unknown;
@@ -1282,9 +1275,7 @@ export type GetTrainScheduleByIdResultApiArg = {
 };
 export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;
-export type GetVersionCoreApiResponse = /** status 200 Return the core service version */ {
-  git_describe: string | null;
-};
+export type GetVersionCoreApiResponse = /** status 200 Return the core service version */ Version;
 export type GetVersionCoreApiArg = void;
 export type TrackRange = {
   begin?: number;
@@ -2051,22 +2042,16 @@ export type TimetableWithSchedulesDetails = {
   name: string;
   train_schedule_summaries: TrainScheduleSummary[];
 };
-export type TrackOffsetLocation = {
-  offset: number;
-  track_section: string;
-  type: 'track_offset';
-};
-export type OperationalPointLocation = {
-  type: 'operational_point';
-  uic: number;
-};
 export type TimetableImportPathLocation =
-  | ({
+  | {
+      offset: number;
+      track_section: string;
       type: 'track_offset';
-    } & TrackOffsetLocation)
-  | ({
+    }
+  | {
       type: 'operational_point';
-    } & OperationalPointLocation);
+      uic: number;
+    };
 export type TimetableImportPathSchedule = {
   arrival_time: string;
   departure_time: string;
@@ -2085,6 +2070,14 @@ export type TimetableImportItem = {
   path: TimetableImportPathStep[];
   rolling_stock: string;
   trains: TimetableImportTrain[];
+};
+export type ConflictType = 'Spacing' | 'Routing';
+export type Conflict = {
+  conflict_type: ConflictType;
+  end_time: number;
+  start_time: number;
+  train_ids: number[];
+  train_names: string[];
 };
 export type TrainSchedulePatch = {
   allowances?: Allowance[];

--- a/front/src/modules/conflict/components/ConflictsList.tsx
+++ b/front/src/modules/conflict/components/ConflictsList.tsx
@@ -3,14 +3,7 @@ import cx from 'classnames';
 import { BsLightningFill } from 'react-icons/bs';
 import { useTranslation } from 'react-i18next';
 import { sec2time } from 'utils/timeManipulation';
-
-export type Conflict = {
-  train_ids: number[];
-  conflict_type: string;
-  start_time: string;
-  end_time: string;
-  train_names: string[];
-};
+import { Conflict } from 'common/api/osrdEditoastApi';
 
 type ConflictTableProps = {
   conflicts: Conflict[];
@@ -32,8 +25,8 @@ function ConflictCard({ conflict }: { conflict: Conflict }) {
         <p className="card-text">{t(`${conflict.conflict_type}`)}</p>
       </div>
       <div className="conflict-times">
-        <div className="card-text start-time">{sec2time(Number(conflict.start_time))}</div>
-        <div className="card-text end-time">{sec2time(Number(conflict.end_time))}</div>
+        <div className="card-text start-time">{sec2time(conflict.start_time)}</div>
+        <div className="card-text end-time">{sec2time(conflict.end_time)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
Part of #3625, to merge before #4802

* macro `routes!` to replace `actix::services!` and `actix::web::scope` + endpoint listing in views::OpenApiRoot
* macro `schemas!` that does the same for schemas
* deletes the `discriminator:` property because it conflicts with RTK
* also adds the crate `paste` for ident interpolation