### PR TITLE
docker-compose: fix a database startup race condition

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -15,7 +15,7 @@ services:
       - "psql_data:/var/lib/postgresql/data"
       - "./init_db.sql:/docker-entrypoint-initdb.d/init.sql"
     healthcheck:
-      test: ["CMD", "sh", "-c", '[ "$$(cat /proc/1/cmdline)" = postgres ] && pg_isready']
+      test: ["CMD", "pg_isready", "-d", "postgres://osrd:password@localhost/osrd"]
       start_period: 4s
       interval: 5s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "psql_data:/var/lib/postgresql/data"
       - "./init_db.sql:/docker-entrypoint-initdb.d/init.sql"
     healthcheck:
-      test: ["CMD", "sh", "-c", '[ "$$(cat /proc/1/cmdline | tr ''\0'' ''\n'' | tail -n 1)" = postgres ] && pg_isready']
+      test: ["CMD", "pg_isready", "-d", "postgres://osrd:password@postgres/osrd"]
       start_period: 4s
       interval: 5s
 


### PR DESCRIPTION
The previous health check ensured that the init script had completed, and the database server was ready to receive commands on the local unix socket (that's what pg_isready does unless told otherwise).

This change instructs pg_isready to connect using TCP, which makes the health check work just like postgres clients running in other containers.