### PR TITLE
editoast: use std::io::IsTerminal instead of atty

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -494,17 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,7 +1094,6 @@ dependencies = [
  "actix-web",
  "async-std",
  "async-trait",
- "atty",
  "chashmap",
  "chrono",
  "clap",
@@ -1659,15 +1647,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1878,7 +1857,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -1895,7 +1874,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.11",
  "windows-sys",
 ]
@@ -2229,7 +2208,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -64,7 +64,6 @@ osm4routing = "0.5.8"
 osmpbfreader = "0.16.0"
 itertools = "0.11.0"
 utoipa = { version = "3.5.0", features = ["actix_extras", "chrono", "uuid"] }
-atty = "0.2.14"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -47,7 +47,7 @@ use sentry::ClientInitGuard;
 use std::env;
 use std::error::Error;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, IsTerminal};
 use std::process::exit;
 use views::infra::InfraApiError;
 
@@ -75,7 +75,7 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
     match client.color {
         Color::Never => colored::control::set_override(false),
         Color::Always => colored::control::set_override(true),
-        Color::Auto => colored::control::set_override(atty::is(atty::Stream::Stderr)),
+        Color::Auto => colored::control::set_override(std::io::stderr().is_terminal()),
     }
 
     match client.command {


### PR DESCRIPTION
atty is unmaintained since 2021, and the standard library IsTerminal is now stable.

Fixes [#190](https://github.com/osrd-project/osrd/security/dependabot/190)