### PR TITLE
front: rolling-stock-editor: fix several bugs

### DIFF
--- a/front/public/locales/en/rollingstock.json
+++ b/front/public/locales/en/rollingstock.json
@@ -56,6 +56,9 @@
   "messages": {
     "success": "Group",
     "failure": "Operation failed",
+    "invalidForm": "Invalid form",
+    "missingName": "Please fill the name of the new rolling stock",
+    "missingEffortCurves": "Please fill in at least one effort-speed curve",
     "rollingStockAdded": "Rolling stock added",
     "rollingStockUpdated": "Rolling stock updated",
     "rollingStockDeleted": "Rolling stock deleted",

--- a/front/public/locales/fr/rollingstock.json
+++ b/front/public/locales/fr/rollingstock.json
@@ -57,6 +57,9 @@
   "messages": {
     "success": "Opération réussie",
     "failure": "Opération échouée",
+    "invalidForm": "Formulaire incomplet",
+    "missingName": "Veuillez renseigner un nom",
+    "missingEffortCurves": "Veuillez renseigner une courbe effort-vitesse",
     "rollingStockAdded": "Le matériel roulant a été ajouté.",
     "rollingStockUpdated": "Le matériel roulant a été mis à jour.",
     "rollingStockDeleted": "Le matériel roulant a été supprimé.",

--- a/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
+++ b/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
@@ -39,7 +39,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
 
   const [openedRollingStockCardId, setOpenedRollingStockCardId] = useState<number>();
 
-  const { data: selectedRollingStock } = osrdEditoastApi.useGetRollingStockByIdQuery(
+  const { data: selectedRollingStock } = osrdEditoastApi.endpoints.getRollingStockById.useQuery(
     {
       id: openedRollingStockCardId as number,
     },
@@ -50,7 +50,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
 
   const resetRollingstockCurvesParams = () => {
     dispatch(updateComfortLvl(STANDARD_COMFORT_LEVEL));
-    dispatch(updateTractionMode(''));
+    dispatch(updateTractionMode(null));
     dispatch(updateElectricalProfile(null));
     dispatch(updatePowerRestriction(null));
   };
@@ -171,6 +171,7 @@ export default function RollingStockEditor({ rollingStocks }: RollingStockEditor
             type="button"
             className="btn btn-primary mb-4"
             onClick={() => {
+              resetRollingstockCurvesParams();
               setIsAdding(true);
               setOpenedRollingStockCardId(undefined);
             }}

--- a/front/src/common/SelectorSNCF.tsx
+++ b/front/src/common/SelectorSNCF.tsx
@@ -1,5 +1,5 @@
 import { isNull } from 'lodash';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdArrowRight } from 'react-icons/md';
 import { getTranslationKey } from 'utils/strings';
@@ -13,6 +13,7 @@ export default function SelectorSNCF<T extends string | null, K extends string>(
   borderClass: string;
   title: K;
   itemsList: T[];
+  permanentItems?: T[];
   selectedItem?: T;
   hoveredItem?: string | null;
   onItemSelected?: (value: T) => void;
@@ -26,6 +27,7 @@ export default function SelectorSNCF<T extends string | null, K extends string>(
     borderClass,
     title,
     itemsList,
+    permanentItems,
     selectedItem,
     hoveredItem,
     onItemSelected,
@@ -43,39 +45,39 @@ export default function SelectorSNCF<T extends string | null, K extends string>(
       </div>
       <div className="d-flex align-items-center position-relative">
         <div className={cx(`${mainClass}-itemslist`, borderClass, 'overflow-auto', 'p-2')}>
-          {useMemo(
-            () =>
-              itemsList.map((item, index: number) => (
-                <div
-                  className={cx(`${mainClass}-item`, 'd-flex', 'mb-1', borderClass, {
-                    selected: item === selectedItem,
-                    hovered: item === hoveredItem && item !== null,
-                  })}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => {
-                    if (onItemSelected) onItemSelected(item);
-                  }}
-                  onMouseOver={() => {
-                    if (onItemHovered) onItemHovered(item);
-                  }}
-                  onFocus={() => {
-                    if (onItemHovered) onItemHovered(item);
-                  }}
-                  key={`selector-${title}-${index}`}
-                >
-                  <div className={`${mainClass}-item-name pt-1 pl-3`}>
-                    {!isNull(item)
-                      ? t(getTranslationKey(translationList, String(item)))
-                      : t('unspecified')}
-                  </div>
-                  {onItemRemoved && (
+          {itemsList.map(
+            (item, index: number) => (
+              <div
+                className={cx(`${mainClass}-item`, 'd-flex', 'mb-1', borderClass, {
+                  selected: item === selectedItem,
+                  hovered: item === hoveredItem && item !== null,
+                })}
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  if (onItemSelected) onItemSelected(item);
+                }}
+                onMouseOver={() => {
+                  if (onItemHovered) onItemHovered(item);
+                }}
+                onFocus={() => {
+                  if (onItemHovered) onItemHovered(item);
+                }}
+                key={`selector-${title}-${index}`}
+              >
+                <div className={`${mainClass}-item-name pt-1 pl-3`}>
+                  {!isNull(item)
+                    ? t(getTranslationKey(translationList, String(item)))
+                    : t('unspecified')}
+                </div>
+                {((permanentItems && !permanentItems.includes(item)) || !permanentItems) &&
+                  onItemRemoved && (
                     <div className={`${mainClass}-trash-icon`}>
                       <FaTrash onClick={() => onItemRemoved(item, title)} />
                     </div>
                   )}
-                </div>
-              )),
+              </div>
+            ),
             [itemsList, selectedItem, hoveredItem]
           )}
         </div>

--- a/front/src/modules/rollingStock/components/rollingStockEditor/AddRollingstockParam.tsx
+++ b/front/src/modules/rollingStock/components/rollingStockEditor/AddRollingstockParam.tsx
@@ -11,11 +11,13 @@ export default function AddRollingstockParam({
   listName,
   allOptionsList,
   displayedLists,
+  disabled,
   updateDisplayedLists,
 }: {
   listName: string;
   allOptionsList: string[] | (string | null)[];
   displayedLists: RollingStockSelectorParams;
+  disabled?: boolean;
   updateDisplayedLists: (arg: string) => void;
 }) {
   const COMFORT_LEVELS_KEY: keyof RollingStockSelectorParams = 'comfortLevels';
@@ -48,14 +50,14 @@ export default function AddRollingstockParam({
       <button
         type="button"
         className={cx('rollingstock-selector-buttons', 'mb-2', {
-          disabled: (!optionsList || optionsList.length < 1) && listName !== 'tractionModes',
+          disabled: disabled || (optionsList.length < 1 && listName !== 'tractionModes'),
         })}
         onClick={() => setIsSelectVisible(true)}
       >
         <RiAddFill />
       </button>
       {isSelectVisible && (
-        <div className="rollingstock-editor-select">
+        <div className="selector-select">
           <SelectImprovedSNCF
             options={optionsList}
             onChange={(e) => {

--- a/front/src/modules/rollingStock/consts.ts
+++ b/front/src/modules/rollingStock/consts.ts
@@ -5,7 +5,7 @@ export const STANDARD_COMFORT_LEVEL: Comfort = 'STANDARD';
 
 export const DEFAULT_SELECTORS_CLASSNAME = 'selector-SNCF';
 
-type EffortCurves = {
+export type EffortCurves = {
   modes: {
     [key: string]: {
       curves: ConditionalEffortCurve[];
@@ -81,7 +81,7 @@ export type RollingStockParametersValues = {
   rollingResistanceC: number;
   electricalPowerStartupTime: number | null;
   raisePantographTime: number | null;
-  defaultMode: string;
+  defaultMode: string | null;
   effortCurves: EffortCurves;
 };
 

--- a/front/src/reducers/rollingstockEditor/index.ts
+++ b/front/src/reducers/rollingstockEditor/index.ts
@@ -13,14 +13,14 @@ export interface RsEditorCurvesState {
   comfortLvl: Comfort;
   electricalProfile: string | null;
   powerRestriction: string | null;
-  tractionMode: string;
+  tractionMode: string | null;
 }
 
 export const initialState: RsEditorCurvesState = {
   comfortLvl: STANDARD_COMFORT_LEVEL,
   electricalProfile: null,
   powerRestriction: null,
-  tractionMode: '',
+  tractionMode: null,
 };
 
 export default function reducer(inputState: RsEditorCurvesState | undefined, action: AnyAction) {
@@ -54,7 +54,7 @@ export function updateComfortLvl(comfortLvl: Comfort) {
   };
 }
 
-export function updateTractionMode(tractionMode: string) {
+export function updateTractionMode(tractionMode: string | null) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: TRACTION_MODE,

--- a/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
+++ b/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
@@ -19,8 +19,10 @@
     }
   }
   &-form {
-    overflow-y: scroll;
+    height: 100%;
+    justify-content: space-between;
     max-height: 88vh;
+    overflow-y: scroll;
     > .rollingstock-header {
       @media screen and (min-width: 1024px) {
         height: 3rem;
@@ -91,6 +93,7 @@
       }
     }
     &-container {
+      height: 100%;
       .tab-content {
         background-color: var(--white);
         border-radius: 0.5rem;
@@ -208,156 +211,155 @@
       width: 38%;
     }
   }
-}
 
-.defaultImageRSEditor img {
-  max-height: 2rem;
-}
+  .defaultImageRSEditor img {
+    max-height: 2rem;
+  }
 
-.rollingstock-editor-spreadsheet {
-  width: 40%;
-  height: 20.75rem;
-  overflow: auto;
-  tr:not(:first-child) .Spreadsheet__header,
-  tr:first-child .Spreadsheet__header:first-child {
-    width: 2rem;
-    border: solid 1px var(--coolgray3);
-  }
-  tr:not(:first-child) .Spreadsheet__header {
-    background-color: var(--white);
-  }
-  tr:first-child .Spreadsheet__header {
-    color: var(--blue);
-    white-space: normal !important;
-  }
-}
-
-.rollingstock-editor-curves {
-  background-color: var(--white);
-  .rollingstock-body {
-    width: 60%;
-    border: none;
+  .rollingstock-editor-spreadsheet {
+    width: 40%;
     height: 20.75rem;
-    .curves-container {
-      height: 20.75rem;
+    overflow: auto;
+    tr:not(:first-child) .Spreadsheet__header,
+    tr:first-child .Spreadsheet__header:first-child {
+      width: 2rem;
+      border: solid 1px var(--coolgray3);
+    }
+    tr:not(:first-child) .Spreadsheet__header {
+      background-color: var(--white);
+    }
+    tr:first-child .Spreadsheet__header {
+      color: var(--blue);
+      white-space: normal !important;
     }
   }
-}
 
-@media screen and (max-width: 1040px) {
   .rollingstock-editor-curves {
-    flex-direction: column-reverse;
+    background-color: var(--white);
     .rollingstock-body {
-      margin-bottom: 1rem;
+      width: 60%;
+      border: none;
+      height: 20.75rem;
+      .curves-container {
+        height: 20.75rem;
+      }
+    }
+  }
+
+  @media screen and (max-width: 1040px) {
+    .rollingstock-editor-curves {
+      flex-direction: column-reverse;
+      .rollingstock-body {
+        margin-bottom: 1rem;
+        width: 100%;
+      }
+    }
+
+    .rollingstock-editor-spreadsheet {
+      padding-right: 1rem;
+      height: 100%;
       width: 100%;
     }
   }
 
-  .rollingstock-editor-spreadsheet {
-    padding-right: 1rem;
-    height: 100%;
-    width: 100%;
-  }
-}
-
-// .rollingstock-editor-selectors {
-.selector-SNCF {
-  width: 13rem;
-  &-title {
-    width: 90%;
-  }
-  &-itemslist {
-    z-index: 1;
-    cursor: pointer;
-    background-color: var(--coolgray1);
-    border-radius: 0.3rem 0.3rem 0 0;
-    height: 10.5rem;
-    width: 90%;
-  }
-  &-trash-icon {
-    visibility: hidden;
-  }
-  &-item {
-    color: var(--coolgray11);
-    background-color: var(--white);
-    border-radius: 0.3rem;
-    justify-content: space-between;
-    &.selected {
-      &.selector-blue {
-        outline: 0.13rem solid var(--blue);
-      }
-      &.selector-pink {
-        outline: 0.13rem solid #fd2f7e;
-      }
+  .selector-SNCF {
+    width: 13rem;
+    &-title {
+      width: 90%;
     }
-    &.hovered {
-      outline: 0.13rem solid #fd2f7e80;
-      &.selector-blue {
-        outline: 0.13rem solid #30338380;
+    &-itemslist {
+      z-index: 1;
+      cursor: pointer;
+      background-color: var(--coolgray1);
+      border-radius: 0.3rem 0.3rem 0 0;
+      height: 10.5rem;
+      width: 90%;
+    }
+    &-trash-icon {
+      visibility: hidden;
+    }
+    &-item {
+      color: var(--coolgray11);
+      background-color: var(--white);
+      border-radius: 0.3rem;
+      justify-content: space-between;
+      &.selected {
+        &.selector-blue {
+          outline: 0.13rem solid var(--blue);
+        }
+        &.selector-pink {
+          outline: 0.13rem solid #fd2f7e;
+        }
       }
-      .selector-SNCF-trash-icon {
-        color: var(--red);
-        visibility: visible;
-        width: 2.5rem;
-        border-radius: 0 0.3rem 0.3rem 0;
-        text-align: center;
-        padding-top: 0.1rem;
-        &:hover {
-          color: var(--white);
-          background-color: var(--red);
+      &.hovered {
+        outline: 0.13rem solid #fd2f7e80;
+        &.selector-blue {
+          outline: 0.13rem solid #30338380;
+        }
+        .selector-SNCF-trash-icon {
+          color: var(--red);
+          visibility: visible;
+          width: 2.5rem;
+          border-radius: 0 0.3rem 0.3rem 0;
+          text-align: center;
+          padding-top: 0.1rem;
+          &:hover {
+            color: var(--white);
+            background-color: var(--red);
+          }
         }
       }
     }
-  }
-  &-arrow {
-    position: absolute;
-    display: flex;
-    align-items: center;
-    right: -2.7rem;
-    height: 100%;
-    font-size: 7rem;
-    color: var(--coolgray1);
-  }
-}
+    &-arrow {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      right: -2.7rem;
+      height: 100%;
+      font-size: 7rem;
+      color: var(--coolgray1);
+    }
 
-.selector-container {
-  margin-right: 1rem;
-  &:last-child {
-    .selector-SNCF-arrow {
-      visibility: hidden;
+    .selector-select {
+      position: absolute;
+      z-index: 2;
+      width: 22rem;
     }
   }
-  &:first-child {
-    margin-right: 2rem;
-    .selector-SNCF-arrow {
-      visibility: hidden;
+
+  .selector-container {
+    margin-right: 1rem;
+    &:last-child {
+      .selector-SNCF-arrow {
+        visibility: hidden;
+      }
+    }
+    &:first-child {
+      margin-right: 2rem;
+      .selector-SNCF-arrow {
+        visibility: hidden;
+      }
+    }
+    &:nth-child(4) {
+      .selector-SNCF-itemslist {
+        height: 12.75rem;
+        border-radius: 0.3rem;
+      }
     }
   }
-  &:nth-child(4) {
-    .selector-SNCF-itemslist {
-      height: 12.75rem;
-      border-radius: 0.3rem;
+
+  .rollingstock-selector-buttons {
+    border: none;
+    cursor: pointer;
+    background-color: #82be00;
+    border-radius: 0 0 0.3rem 0.3rem;
+    width: 90%;
+    text-align: center;
+    font-size: x-large;
+    &.disabled {
+      background-color: var(--coolgray1);
+      color: var(--coolgray3);
+      pointer-events: none;
     }
   }
-}
-
-.rollingstock-selector-buttons {
-  border: none;
-  cursor: pointer;
-  background-color: #82be00;
-  border-radius: 0 0 0.3rem 0.3rem;
-  width: 90%;
-  text-align: center;
-  font-size: x-large;
-  &.disabled {
-    background-color: var(--coolgray1);
-    color: var(--coolgray3);
-    pointer-events: none;
-  }
-}
-
-.rollingstock-editor-select {
-  position: absolute;
-  z-index: 2;
-  width: 22rem;
 }


### PR DESCRIPTION
closes #5077, closes #5075, closes #5076

- prevent the user from creating a rolling stock without name or effort curves
- when creating a rolling stock, do not create any empty mode by default
- prevent the user from deleting the standard comfort
- allow the user to create real thermal train

### Acceptance criteria
- [x] you cannot add a rolling stock without name (and an error message is displayed
- [x] you cannot add a rolling stock without effort curves (try to create a new rolling stock)
- [x] when you create a new rolling stock, by default in the effort curve tab
  - [x] no traction mode is created by default
  - [x] you can't delete the standard comfort
- [x] if you update a train and add it thermal mode, then the train is tagged as thermal
- [x] you can still update and create a rolling stock (everything is working)  