### PR TITLE
scripts: fix msys (Git Bash) compatibility

### DIFF
--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# This script should be compatible with MSYS, the compatibility layer used by
+# Git for Windows. Absolute paths which should not be converted to windows paths
+# have to start with //, see https://github.com/git-for-windows/git/issues/1387
+
 set -e
 
 OUTPUT_DIR="."
@@ -15,17 +19,17 @@ fi
 
 # Generating the backup
 echo "Generating the backup... (it can take some time)"
-docker exec osrd-postgres pg_dump -d osrd -F c -Z 9 -f /tmp/osrd.backup > /dev/null
+docker exec osrd-postgres pg_dump -d osrd -F c -Z 9 -f //tmp/osrd.backup > /dev/null
 
 # Get metadata
 echo Collecting backup information...
-SHA1=$(docker exec osrd-postgres sha1sum /tmp/osrd.backup | cut -d' ' -f1)
-SIZE=$(docker exec osrd-postgres du -sh /tmp/osrd.backup | cut -f1)
+SHA1=$(docker exec osrd-postgres sha1sum //tmp/osrd.backup | cut -d' ' -f1)
+SIZE=$(docker exec osrd-postgres du -sh //tmp/osrd.backup | cut -f1)
 echo "  sha1: ${SHA1}"
 echo "  size: ${SIZE}"
 
 DATE=$(date "+%G_%m_%d")
 
 FILE_PATH="${OUTPUT_DIR}/osrd_${DATE}_sha1_${SHA1}.backup"
-docker cp osrd-postgres:/tmp/osrd.backup "${FILE_PATH}"
+docker cp osrd-postgres://tmp/osrd.backup "${FILE_PATH}"
 echo "Your backup is ready here: '${FILE_PATH}'"

--- a/scripts/generate-infra.sh
+++ b/scripts/generate-infra.sh
@@ -1,5 +1,9 @@
 #! /bin/sh
 
+# This script should be compatible with MSYS, the compatibility layer used by
+# Git for Windows. Absolute paths which should not be converted to windows paths
+# have to start with //, see https://github.com/git-for-windows/git/issues/1387
+
 set -e
 
 cd "$(dirname "$0")/.."
@@ -8,12 +12,12 @@ infra_name="${1:-small_infra}"
 
 echo "Loading $infra_name"
 python3 python/railjson_generator/railjson_generator/scripts/generate.py /tmp/generated_infras/
-docker cp "/tmp/generated_infras/${infra_name}/infra.json" osrd-editoast:/tmp/infra.json
-docker exec osrd-editoast editoast import-railjson "${infra_name}" /tmp/infra.json
+docker cp "/tmp/generated_infras/${infra_name}/infra.json" osrd-editoast://tmp/infra.json
+docker exec osrd-editoast editoast import-railjson "${infra_name}" //tmp/infra.json
 
 echo "Generate layers"
 docker exec osrd-editoast editoast generate
 
 echo "Loading example rolling stock"
-docker cp editoast/src/tests/example_rolling_stock_1.json osrd-editoast:/tmp/stock.json
-docker exec osrd-editoast editoast import-rolling-stock /tmp/stock.json
+docker cp editoast/src/tests/example_rolling_stock_1.json osrd-editoast://tmp/stock.json
+docker exec osrd-editoast editoast import-rolling-stock //tmp/stock.json

--- a/scripts/load-backup.sh
+++ b/scripts/load-backup.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# This script should be compatible with MSYS, the compatibility layer used by
+# Git for Windows. Absolute paths which should not be converted to windows paths
+# have to start with //, see https://github.com/git-for-windows/git/issues/1387
+
 set -e
 
 # Check arguments
@@ -61,14 +65,14 @@ fi
 echo "Initialize new database..."
 # Here I remove the first line of the script cause the user already exists
 docker exec osrd-postgres sh -c 'cat /docker-entrypoint-initdb.d/init.sql | tail -n 1 > /tmp/init.sql'
-docker exec osrd-postgres psql -f /tmp/init.sql > /dev/null
+docker exec osrd-postgres psql -f //tmp/init.sql > /dev/null
 
 # Copy needed files to the container
-docker cp "$BACKUP_PATH" osrd-postgres:/tmp/backup-osrd
+docker cp "$BACKUP_PATH" osrd-postgres://tmp/backup-osrd
 
 # restoring the backend can partialy fail, and that's sometimes ok
 echo "Restore backup..."
-docker exec osrd-postgres pg_restore --if-exists -c -d osrd -x /tmp/backup-osrd > /dev/null
+docker exec osrd-postgres pg_restore --if-exists -c -d osrd -x //tmp/backup-osrd > /dev/null
 
 # analyze db for performances
 echo "Analyze for performances..."


### PR DESCRIPTION
Git bash, the shell that comes with git for windows, includes a ported over version of bash. This version of bash is compiled with MSYS, a compatibility layer related to MinGW. This compatibility layer converts unix paths to Windows paths as programs are executed.

This works pretty well, except when a path really should not be converted. Docker commands are a notable example. Without annotation, this command:

```sh
docker cp my-container:/folder/data /folder/host-data
```

will be converted to

```sh
docker cp my-container:C:\folder\data C:\folder\host-data
```

Paths which should not be converted have to start with a double slash:

```sh
docker cp my-container://folder/data /folder/host-data
```

will be converted to

```sh
docker cp my-container://folder/data C:\folder\host-data
```