### PR TITLE
core: add departure time to all time-related values in cli

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultOccupancyTiming.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultOccupancyTiming.java
@@ -22,23 +22,7 @@ public class ResultOccupancyTiming {
         this.timeTailFree = timeTailFree;
     }
 
-    /**
-     * Finds the occupancy on a given section
-     * @param startPosition the start of the target region
-     * @param endPosition the end of the target region
-     * @param headPositions the envelope of the head of the train
-     * @param trainLength the length of the train
-     * @return the occupancy times for this section
-     */
-    public static ResultOccupancyTiming fromPositions(
-            double startPosition,
-            double endPosition,
-            ArrayList<ResultPosition> headPositions,
-            double trainLength
-    ) {
-        var timeHeadOccupy = interpolateTime(startPosition, headPositions);
-        var pathLength = headPositions.get(headPositions.size() - 1).pathOffset;
-        var timeTailFree = interpolateTime(Math.min(pathLength, endPosition + trainLength), headPositions);
-        return new ResultOccupancyTiming(timeHeadOccupy, timeTailFree);
+    public ResultOccupancyTiming withAddedTime(double timeToAdd) {
+        return new ResultOccupancyTiming(timeHeadOccupy + timeToAdd, timeTailFree + timeToAdd);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultSpeed.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultSpeed.java
@@ -14,4 +14,8 @@ public class ResultSpeed {
         this.speed = speed;
         this.position = position;
     }
+
+    public ResultSpeed withAddedTime(double timeToAdd) {
+        return new ResultSpeed(time + timeToAdd, speed, position);
+    }
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultStops.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultStops.java
@@ -15,4 +15,8 @@ public class ResultStops {
         this.position = position;
         this.duration = duration;
     }
+
+    public ResultStops withAddedTime(double timeToAdd) {
+        return new ResultStops(time + timeToAdd, position, duration);
+    }
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.standalone_sim.result;
 
+import com.google.common.collect.Maps;
 import com.squareup.moshi.Json;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
@@ -30,6 +31,10 @@ public class ResultTrain {
             this.offset = offset;
             this.state = state;
         }
+
+        public SignalSighting withAddedTime(double timeToAdd) {
+            return new SignalSighting(signal, time + timeToAdd, offset, state);
+        }
     }
 
     @Json(name = "signal_sightings")
@@ -51,6 +56,10 @@ public class ResultTrain {
             this.time = time;
             this.offset = offset;
             this.isEntry = isEntry;
+        }
+
+        public ZoneUpdate withAddedTime(double timeToAdd) {
+            return new ZoneUpdate(zone, time + timeToAdd, offset, isEntry);
         }
     }
 
@@ -76,6 +85,10 @@ public class ResultTrain {
             assert !Double.isNaN(endTime);
             assert Double.isFinite(beginTime);
             assert Double.isFinite(endTime);
+        }
+
+        public SpacingRequirement withAddedTime(double timeToAdd) {
+            return new SpacingRequirement(zone, beginTime + timeToAdd, endTime + timeToAdd);
         }
     }
 
@@ -131,6 +144,10 @@ public class ResultTrain {
             this.beginTime = beginTime;
             this.zones = zones;
         }
+
+        public RoutingRequirement withAddedTime(double timeToAdd) {
+            return new RoutingRequirement(route, beginTime + timeToAdd, zones);
+        }
     }
 
     @Json(name = "routing_requirements")
@@ -163,8 +180,16 @@ public class ResultTrain {
 
     /** Shift the position curve by a given departure time */
     public ResultTrain withDepartureTime(Double departureTime) {
-        return new ResultTrain(speeds, headPositions.stream().map(pos -> pos.withAddedTime(departureTime)).toList(),
-                stops, routeOccupancies, mechanicalEnergyConsumed, signalSightings, zoneUpdates,
-                spacingRequirements, routingRequirements);
+        return new ResultTrain(
+                speeds.stream().map(speed -> speed.withAddedTime(departureTime)).toList(),
+                headPositions.stream().map(pos -> pos.withAddedTime(departureTime)).toList(),
+                stops.stream().map(stop -> stop.withAddedTime(departureTime)).toList(),
+                Maps.transformValues(routeOccupancies, occ -> occ.withAddedTime(departureTime)),
+                mechanicalEnergyConsumed,
+                signalSightings.stream().map(sighting -> sighting.withAddedTime(departureTime)).toList(),
+                zoneUpdates.stream().map(update -> update.withAddedTime(departureTime)).toList(),
+                spacingRequirements.stream().map(req -> req.withAddedTime(departureTime)).toList(),
+                routingRequirements.stream().map(req -> req.withAddedTime(departureTime)).toList()
+        );
     }
 }


### PR DESCRIPTION
I added the departure time given in the CLI schedules to all values of the results which where time-related. It was incoherent before that