### PR TITLE
scripts: fix windows support

### DIFF
--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -3,6 +3,8 @@
 # This script should be compatible with MSYS, the compatibility layer used by
 # Git for Windows. Absolute paths which should not be converted to windows paths
 # have to start with //, see https://github.com/git-for-windows/git/issues/1387
+# On windows, docker cp does not like leading double / on the container path.
+# As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
 
@@ -31,5 +33,5 @@ echo "  size: ${SIZE}"
 DATE=$(date "+%G_%m_%d")
 
 FILE_PATH="${OUTPUT_DIR}/osrd_${DATE}_sha1_${SHA1}.backup"
-docker cp osrd-postgres://tmp/osrd.backup "${FILE_PATH}"
+docker cp osrd-postgres:tmp/osrd.backup "${FILE_PATH}"
 echo "Your backup is ready here: '${FILE_PATH}'"

--- a/scripts/generate-infra.sh
+++ b/scripts/generate-infra.sh
@@ -3,6 +3,8 @@
 # This script should be compatible with MSYS, the compatibility layer used by
 # Git for Windows. Absolute paths which should not be converted to windows paths
 # have to start with //, see https://github.com/git-for-windows/git/issues/1387
+# On windows, docker cp does not like leading double / on the container path.
+# As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
 
@@ -12,12 +14,12 @@ infra_name="${1:-small_infra}"
 
 echo "Loading $infra_name"
 python3 python/railjson_generator/railjson_generator/scripts/generate.py /tmp/generated_infras/
-docker cp "/tmp/generated_infras/${infra_name}/infra.json" osrd-editoast://tmp/infra.json
+docker cp "/tmp/generated_infras/${infra_name}/infra.json" osrd-editoast:tmp/infra.json
 docker exec osrd-editoast editoast import-railjson "${infra_name}" //tmp/infra.json
 
 echo "Generate layers"
 docker exec osrd-editoast editoast generate
 
 echo "Loading example rolling stock"
-docker cp editoast/src/tests/example_rolling_stock_1.json osrd-editoast://tmp/stock.json
+docker cp editoast/src/tests/example_rolling_stock_1.json osrd-editoast:tmp/stock.json
 docker exec osrd-editoast editoast import-rolling-stock //tmp/stock.json

--- a/scripts/load-backup.sh
+++ b/scripts/load-backup.sh
@@ -3,6 +3,8 @@
 # This script should be compatible with MSYS, the compatibility layer used by
 # Git for Windows. Absolute paths which should not be converted to windows paths
 # have to start with //, see https://github.com/git-for-windows/git/issues/1387
+# On windows, docker cp does not like leading double / on the container path.
+# As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
 
@@ -68,7 +70,7 @@ docker exec osrd-postgres sh -c 'cat /docker-entrypoint-initdb.d/init.sql | tail
 docker exec osrd-postgres psql -f //tmp/init.sql > /dev/null
 
 # Copy needed files to the container
-docker cp "$BACKUP_PATH" osrd-postgres://tmp/backup-osrd
+docker cp "$BACKUP_PATH" osrd-postgres:tmp/backup-osrd
 
 # restoring the backend can partialy fail, and that's sometimes ok
 echo "Restore backup..."


### PR DESCRIPTION
On windows, docker cp does not like leading double / on the container side path.