### PR TITLE
editoast: add an electrical profiles delete view

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2741,6 +2741,20 @@ paths:
       tags:
       - electrical_profiles
   /electrical_profile_set/{id}/:
+    delete:
+      parameters:
+      - description: Electrical profile set ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: No content
+      summary: Delete the set of electrical profiles with the given id
+      tags:
+      - electrical_profiles
     get:
       parameters:
       - description: Electrical profile set ID

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -944,6 +944,21 @@ paths:
                 items:
                   $ref: "#/components/schemas/ElectricalProfile"
 
+    delete:
+      tags:
+        - electrical_profiles
+      summary: Delete the set of electrical profiles with the given id
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: Electrical profile set ID
+          required: true
+      responses:
+        204:
+          description: No content
+
   /electrical_profile_set/{id}/level_order/:
     get:
       tags:

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -9,13 +9,15 @@ pub mod tests {
         RollingStockLiveryModel, RollingStockModel, Scenario, SimulationOutput,
         SimulationOutputChangeset, Study, Timetable, TrainSchedule,
     };
-    use crate::schema::RailJson;
+    use crate::schema::electrical_profiles::{ElectricalProfile, ElectricalProfileSetData};
+    use crate::schema::{RailJson, TrackRange};
     use crate::views::infra::InfraForm;
     use crate::DbPool;
 
     use actix_web::web::Data;
     use chrono::Utc;
     use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+    use diesel_json::Json as DieselJson;
     use futures::executor;
     use postgis_diesel::types::LineString;
     use rstest::*;
@@ -307,6 +309,26 @@ pub mod tests {
             db_pool,
         )
         .await
+    }
+
+    #[fixture]
+    pub async fn dummy_electrical_profile_set(
+        db_pool: Data<DbPool>,
+    ) -> TestFixture<ElectricalProfileSet> {
+        let ep_set_data = ElectricalProfileSetData {
+            levels: vec![ElectricalProfile {
+                value: "A".to_string(),
+                power_class: "1".to_string(),
+                track_ranges: vec![TrackRange::default()],
+            }],
+            level_order: Default::default(),
+        };
+        let ep_set = ElectricalProfileSet {
+            id: None,
+            name: Some("test".to_string()),
+            data: Some(DieselJson::new(ep_set_data.clone())),
+        };
+        TestFixture::create(ep_set, db_pool).await
     }
 
     #[fixture]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -46,7 +46,7 @@ use futures_util::FutureExt;
 use infra_cache::InfraCache;
 use log::{error, info, warn};
 use map::MapLayers;
-use models::electrical_profile::ElectricalProfileSet;
+use models::electrical_profiles::ElectricalProfileSet;
 use models::{Retrieve, RollingStockModel};
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use sentry::ClientInitGuard;
@@ -434,8 +434,7 @@ async fn electrical_profile_set_list(
     for electrical_profile_set in electrical_profile_sets {
         println!(
             "{:<2} - {}",
-            electrical_profile_set.id.unwrap(),
-            electrical_profile_set.name.unwrap()
+            electrical_profile_set.id, electrical_profile_set.name
         );
     }
     Ok(())

--- a/editoast/src/models/electrical_profiles.rs
+++ b/editoast/src/models/electrical_profiles.rs
@@ -6,7 +6,6 @@ use crate::diesel::ExpressionMethods;
 use crate::diesel::QueryDsl;
 use crate::models::Identifiable;
 use crate::DieselJson;
-use derivative::Derivative;
 use diesel::result::Error as DieselError;
 use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
 use editoast_derive::Model;
@@ -17,7 +16,6 @@ use serde::{Deserialize, Serialize};
     Debug,
     Default,
     Deserialize,
-    Derivative,
     Identifiable,
     Insertable,
     Model,
@@ -52,11 +50,41 @@ impl ElectricalProfileSet {
     }
 }
 
-#[derive(Debug, Default, Queryable, Identifiable, Serialize, Deserialize)]
+#[derive(Debug, Queryable, Identifiable, Serialize, Deserialize, PartialEq)]
 #[diesel(table_name = electrical_profile_set)]
 pub struct LightElectricalProfileSet {
-    #[diesel(deserialize_as = i64)]
-    pub id: Option<i64>,
-    #[diesel(deserialize_as = String)]
-    pub name: Option<String>,
+    pub id: i64,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fixtures::tests::{
+        db_pool, dummy_electrical_profile_set, electrical_profile_set, TestFixture,
+    };
+    use crate::DbPool;
+    use actix_web::web::Data;
+    use rstest::rstest;
+
+    #[rstest]
+    async fn test_list_light(
+        db_pool: Data<DbPool>,
+        #[future] electrical_profile_set: TestFixture<ElectricalProfileSet>,
+        #[future] dummy_electrical_profile_set: TestFixture<ElectricalProfileSet>,
+    ) {
+        let set_1 = electrical_profile_set.await;
+        let set_2 = dummy_electrical_profile_set.await;
+        let mut conn = db_pool.get().await.unwrap();
+        let list = ElectricalProfileSet::list_light(&mut conn).await.unwrap();
+
+        assert!(list.contains(&LightElectricalProfileSet {
+            id: set_1.model.id.unwrap(),
+            name: set_1.model.name.clone().unwrap(),
+        }));
+        assert!(list.contains(&LightElectricalProfileSet {
+            id: set_2.model.id.unwrap(),
+            name: set_2.model.name.clone().unwrap(),
+        }));
+    }
 }

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -1,5 +1,5 @@
 mod documents;
-pub mod electrical_profile;
+pub mod electrical_profiles;
 pub mod infra;
 pub mod infra_objects;
 pub mod pathfinding;
@@ -19,7 +19,7 @@ use diesel_async::AsyncPgConnection as PgConnection;
 
 pub use self::pathfinding::*;
 pub use documents::Document;
-pub use electrical_profile::ElectricalProfileSet;
+pub use electrical_profiles::ElectricalProfileSet;
 pub use infra::{Infra, RAILJSON_VERSION};
 pub use projects::{Ordering, Project, ProjectWithStudies};
 pub use rolling_stock::{

--- a/editoast/src/tests/electrical_profile_set.json
+++ b/editoast/src/tests/electrical_profile_set.json
@@ -1,5 +1,5 @@
 {
-  "id": 1065409816,
+  "id": null,
   "name": "outer space infra",
   "data": {
     "levels": [

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::models::electrical_profile::{ElectricalProfileSet, LightElectricalProfileSet};
+use crate::models::electrical_profiles::{ElectricalProfileSet, LightElectricalProfileSet};
 use crate::models::{Create, Retrieve};
 use crate::schema::electrical_profiles::ElectricalProfileSetData;
 use crate::DbPool;
@@ -18,8 +18,8 @@ pub fn routes() -> impl HttpServiceFactory {
     web::scope("/electrical_profile_set").service((
         list,
         get,
-        post_electrical_profile,
         get_level_order,
+        post_electrical_profile,
     ))
 }
 
@@ -45,6 +45,21 @@ async fn get(
     Ok(Json(ep_set.data.unwrap().0))
 }
 
+/// Return the electrical profile value order for this set
+#[get("/{electrical_profile_set}/level_order")]
+async fn get_level_order(
+    db_pool: Data<DbPool>,
+    electrical_profile_set: Path<i64>,
+) -> Result<Json<HashMap<String, Vec<String>>>> {
+    let electrical_profile_set_id = electrical_profile_set.into_inner();
+    let ep_set = ElectricalProfileSet::retrieve(db_pool, electrical_profile_set_id)
+        .await?
+        .ok_or(ElectricalProfilesError::NotFound {
+            electrical_profile_set_id,
+        })?;
+    Ok(Json(ep_set.data.unwrap().0.level_order))
+}
+
 #[derive(Deserialize)]
 struct ElectricalProfileQueryArgs {
     name: String,
@@ -65,21 +80,6 @@ async fn post_electrical_profile(
     Ok(Json(ep_set.create(db_pool).await.unwrap()))
 }
 
-/// Return the electrical profile value order for this set
-#[get("/{electrical_profile_set}/level_order")]
-async fn get_level_order(
-    db_pool: Data<DbPool>,
-    electrical_profile_set: Path<i64>,
-) -> Result<Json<HashMap<String, Vec<String>>>> {
-    let electrical_profile_set_id = electrical_profile_set.into_inner();
-    let ep_set = ElectricalProfileSet::retrieve(db_pool, electrical_profile_set_id)
-        .await?
-        .ok_or(ElectricalProfilesError::NotFound {
-            electrical_profile_set_id,
-        })?;
-    Ok(Json(ep_set.data.unwrap().0.level_order))
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "electrical_profiles")]
 pub enum ElectricalProfilesError {
@@ -91,129 +91,101 @@ pub enum ElectricalProfilesError {
 
 #[cfg(test)]
 mod tests {
-    use super::ElectricalProfileSet;
-    use crate::client::PostgresConfig;
-    use crate::fixtures::tests::{db_pool, TestFixture};
-    use crate::models::Retrieve;
+    use super::*;
+    use crate::fixtures::tests::{
+        db_pool, dummy_electrical_profile_set, electrical_profile_set, TestFixture,
+    };
     use crate::schema::electrical_profiles::ElectricalProfile;
     use crate::views::tests::create_test_service;
-    use crate::DbPool;
     use actix_http::StatusCode;
-    use actix_web::http::header::ContentType;
     use actix_web::test as actix_test;
     use actix_web::test::TestRequest;
     use actix_web::test::{call_service, read_body_json};
-    use actix_web::web::Data;
-    use diesel::result::Error;
-    use diesel_async::scoped_futures::{ScopedBoxFuture, ScopedFutureExt};
-    use diesel_async::{AsyncConnection, AsyncPgConnection as PgConnection, RunQueryDsl};
-    use diesel_json::Json as DieselJson;
+
+    use crate::schema::TrackRange;
     use rstest::rstest;
 
-    use crate::tables::electrical_profile_set::dsl;
-
-    use crate::schema::electrical_profiles::ElectricalProfileSetData;
-    use crate::schema::TrackRange;
-
-    async fn test_ep_set_transaction<'a, F>(fn_test: F)
-    where
-        F: for<'r> FnOnce(&'r mut PgConnection) -> ScopedBoxFuture<'a, 'r, ()> + Send + 'a,
-    {
-        let mut conn = PgConnection::establish(&PostgresConfig::default().url())
-            .await
-            .unwrap();
-        let _ = conn
-            .test_transaction::<_, Error, _>(|conn| {
-                async move {
-                    diesel::delete(dsl::electrical_profile_set)
-                        .execute(conn)
-                        .await?;
-                    let ep_set_data = ElectricalProfileSetData {
-                        levels: vec![ElectricalProfile {
-                            value: "A".to_string(),
-                            power_class: "1".to_string(),
-                            track_ranges: vec![TrackRange::default()],
-                        }],
-                        level_order: Default::default(),
-                    };
-                    let ep_set = ElectricalProfileSet {
-                        id: Some(1),
-                        name: Some("test".to_string()),
-                        data: Some(DieselJson::new(ep_set_data.clone())),
-                    };
-                    let ep_set_2 = ElectricalProfileSet {
-                        id: Some(2),
-                        name: Some("test_2".to_string()),
-                        data: Some(DieselJson::new(ep_set_data)),
-                    };
-
-                    diesel::insert_into(dsl::electrical_profile_set)
-                        .values(&[ep_set, ep_set_2])
-                        .execute(conn)
-                        .await
-                        .unwrap();
-
-                    fn_test(conn).await;
-                    Ok(())
-                }
-                .scope_boxed()
-            })
-            .await;
-    }
-
     #[rstest]
-    async fn test_query_list() {
-        test_ep_set_transaction(|conn| {
-            async {
-                let list = ElectricalProfileSet::list_light(conn).await.unwrap();
-                assert_eq!(list.len(), 2);
-                let (ep_set_1, ep_set_2) = (&list[0], &list[1]);
-                assert_eq!(ep_set_1.id.unwrap(), 1);
-                assert_eq!(ep_set_1.name.as_ref().unwrap(), "test");
-                assert_eq!(ep_set_2.id.unwrap(), 2);
-                assert_eq!(ep_set_2.name.as_ref().unwrap(), "test_2");
-            }
-            .scope_boxed()
-        })
-        .await;
-    }
+    async fn test_list(
+        #[future] electrical_profile_set: TestFixture<ElectricalProfileSet>,
+        #[future] dummy_electrical_profile_set: TestFixture<ElectricalProfileSet>,
+    ) {
+        let _set_1 = electrical_profile_set.await;
+        let _set_2 = dummy_electrical_profile_set.await;
 
-    #[rstest]
-    async fn test_query_retrieve() {
-        test_ep_set_transaction(|conn| {
-            async {
-                let ep_set = ElectricalProfileSet::retrieve_conn(conn, 1).await.unwrap();
-                let ep_set_data = ep_set.unwrap().data.unwrap();
-                assert_eq!(ep_set_data.0.levels[0].value, "A");
-            }
-            .scope_boxed()
-        })
-        .await;
-    }
-
-    #[actix_test]
-    async fn test_view_list() {
         let app = create_test_service().await;
         let req = TestRequest::get()
             .uri("/electrical_profile_set")
             .to_request();
         let response = call_service(&app, req).await;
         assert_eq!(response.status(), StatusCode::OK);
+
+        assert!(
+            read_body_json::<Vec<LightElectricalProfileSet>, _>(response)
+                .await
+                .len()
+                >= 2
+        );
     }
 
     #[actix_test]
-    async fn test_view_get_none() {
+    async fn test_get_none() {
         let app = create_test_service().await;
         let req = TestRequest::get()
             .uri("/electrical_profile_set/666")
-            .append_header(ContentType::json())
             .to_request();
         let response = call_service(&app, req).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[rstest]
-    async fn test_post_electrical_profile(db_pool: Data<DbPool>) {
+    async fn test_get_some(
+        #[future] dummy_electrical_profile_set: TestFixture<ElectricalProfileSet>,
+    ) {
+        let profile_set = dummy_electrical_profile_set.await;
+
+        let app = create_test_service().await;
+        let req = TestRequest::get()
+            .uri(&format!("/electrical_profile_set/{}", profile_set.id()))
+            .to_request();
+        let response = call_service(&app, req).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[actix_test]
+    async fn test_get_level_order_none() {
+        let app = create_test_service().await;
+        let req = TestRequest::get()
+            .uri("/electrical_profile_set/666/level_order")
+            .to_request();
+        let response = call_service(&app, req).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[rstest]
+    async fn test_get_level_order_some(
+        #[future] electrical_profile_set: TestFixture<ElectricalProfileSet>,
+    ) {
+        let profile_set = electrical_profile_set.await;
+        let app = create_test_service().await;
+        let req = TestRequest::get()
+            .uri(&format!(
+                "/electrical_profile_set/{}/level_order",
+                profile_set.id()
+            ))
+            .to_request();
+        let response = call_service(&app, req).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let level_order = read_body_json::<HashMap<String, Vec<String>>, _>(response).await;
+        assert_eq!(level_order.len(), 1);
+        assert_eq!(
+            level_order.get("25000").unwrap(),
+            &vec!["25000", "22500", "20000"]
+        );
+    }
+
+    #[rstest]
+    async fn test_post(db_pool: Data<DbPool>) {
         let app = create_test_service().await;
         let ep_set = ElectricalProfileSetData {
             levels: vec![ElectricalProfile {
@@ -226,7 +198,6 @@ mod tests {
         let req = TestRequest::post()
             .uri("/electrical_profile_set/?name=elec")
             .set_json(ep_set)
-            .append_header(ContentType::json())
             .to_request();
 
         let response = call_service(&app, req).await;
@@ -237,16 +208,5 @@ mod tests {
             infra: None,
         };
         assert_eq!(created_ep_set.model.name.clone().unwrap(), "elec");
-    }
-
-    #[actix_test]
-    async fn test_view_get_level_order_none() {
-        let app = create_test_service().await;
-        let req = TestRequest::get()
-            .uri("/electrical_profile_set/666/level_order")
-            .append_header(ContentType::json())
-            .to_request();
-        let response = call_service(&app, req).await;
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/editoast/src/views/train_schedule/mod.rs
+++ b/editoast/src/views/train_schedule/mod.rs
@@ -32,7 +32,7 @@ use crate::core::simulation::{
 use simulation_report::SimulationReport;
 use thiserror::Error;
 
-use crate::models::electrical_profile::ElectricalProfileSet;
+use crate::models::electrical_profiles::ElectricalProfileSet;
 
 pub mod projection;
 pub mod simulation_report;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -55,6 +55,13 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['electrical_profiles'],
       }),
+      deleteElectricalProfileSetById: build.mutation<
+        DeleteElectricalProfileSetByIdApiResponse,
+        DeleteElectricalProfileSetByIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/electrical_profile_set/${queryArg.id}/`, method: 'DELETE' }),
+        invalidatesTags: ['electrical_profiles'],
+      }),
       getElectricalProfileSetById: build.query<
         GetElectricalProfileSetByIdApiResponse,
         GetElectricalProfileSetByIdApiArg
@@ -655,6 +662,11 @@ export type PostElectricalProfileSetApiResponse =
   /** status 200 The list of ids and names of electrical profile sets available */ ElectricalProfile;
 export type PostElectricalProfileSetApiArg = {
   name: string;
+};
+export type DeleteElectricalProfileSetByIdApiResponse = unknown;
+export type DeleteElectricalProfileSetByIdApiArg = {
+  /** Electrical profile set ID */
+  id: number;
 };
 export type GetElectricalProfileSetByIdApiResponse =
   /** status 200 The list of electrical profiles in the set */ ElectricalProfile[];


### PR DESCRIPTION
closes #5181 

This PR doesn't do only that I have to admit
The first commit cleans the code a little, moves the tests to using fixtures and adds some tests
The second adds the endpoint, tested and documented in the openapi