### PR TITLE
core: use rounding when converting from double to long

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -36,7 +36,7 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
         val ZERO = Distance(millimeters = 0L)
         @JvmStatic
         @JvmName("fromMeters")
-        fun fromMeters(meters: Double) = Distance(millimeters = (meters * 1_000.0).toLong())
+        fun fromMeters(meters: Double) = Distance(millimeters = (Math.round(meters * 1_000.0)))
         @JvmStatic
         @JvmName("toMeters")
         fun toMeters(distance: Distance) = distance.meters
@@ -61,7 +61,7 @@ value class Distance(val millimeters: Long) : Comparable<Distance> {
     }
 }
 
-val Double.meters: Distance get() = Distance((this * 1000).toLong())
+val Double.meters: Distance get() = Distance.fromMeters(this)
 val Int.meters: Distance get() = Distance(this.toLong() * 1000)
 
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
@@ -41,5 +41,5 @@ value class Duration(val milliseconds: Long) : Comparable<Duration> {
     }
 }
  
-val Double.seconds: Duration get() = Duration((this * 1000).toLong())
+val Double.seconds: Duration get() = Duration(Math.round(this * 1000))
 val Int.seconds: Duration get() = Duration(this.toLong() * 1000)

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -18,7 +18,7 @@ value class Speed(val millimetersPerSecond: ULong) {
     companion object {
         @JvmStatic
         fun fromMetersPerSecond(metersPerSecond: Double): Speed {
-            return Speed(millimetersPerSecond = (metersPerSecond * multiplier).toULong())
+            return Speed(millimetersPerSecond = Math.round(metersPerSecond * multiplier).toULong())
         }
 
         @JvmStatic
@@ -29,4 +29,4 @@ value class Speed(val millimetersPerSecond: ULong) {
     }
 }
 
-val Double.metersPerSecond: Distance get() = Distance((this * multiplier).toLong())
+val Double.metersPerSecond: Distance get() = Distance(Math.round(this * multiplier))

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.infra.implementation.tracks.directed;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.POSITION_EPSILON;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableRangeMap;
 import com.google.common.collect.Range;
@@ -10,7 +12,6 @@ import fr.sncf.osrd.infra.api.tracks.directed.DiTrackEdge;
 import fr.sncf.osrd.infra.api.tracks.undirected.NeutralSection;
 import fr.sncf.osrd.infra.api.tracks.undirected.Detector;
 import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint;
-import fr.sncf.osrd.infra.api.tracks.undirected.OperationalPoint;
 import fr.sncf.osrd.infra.api.tracks.undirected.SpeedLimits;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackLocation;
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection;
@@ -38,14 +39,18 @@ public class TrackRangeView {
 
     /** Constructor */
     public TrackRangeView(double begin, double end, DiTrackEdge track) {
-        if (begin < end) {
-            this.begin = begin;
-            this.end = end;
-        } else {
-            this.begin = end;
-            this.end = begin;
+        if (begin > end) {
+            var tmp = begin;
+            begin = end;
+            end = tmp;
         }
-        assert end <= track.getEdge().getLength();
+        var trackLength = track.getEdge().getLength();
+        if (end > trackLength) {
+            assert Math.abs(end - trackLength) < POSITION_EPSILON;
+            end = trackLength;
+        }
+        this.begin = begin;
+        this.end = end;
         assert begin >= 0;
         this.track = track;
     }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
@@ -112,7 +112,7 @@ private fun computeSignalAspectChangeEvents(
             val signal = pathSignal.signal
             val aspect = simulatedAspects[signal] ?: continue
             if (signalAspects[signal]!! == aspect) continue
-            signalAspectChangeEvents[pathSignal]!!.add(SignalAspectChangeEvent(aspect, (event.time * 1000).toLong()))
+            signalAspectChangeEvents[pathSignal]!!.add(SignalAspectChangeEvent(aspect, Math.round(event.time * 1000)))
             signalAspects[signal] = aspect
         }
     }


### PR DESCRIPTION
This prevents off-by-one errors in the few places where we convert back and forth from one to the other. Most notably, when saving the pathfinding result in the db and re-loading it to run standalone simulations.