### PR TITLE
python: bump version for railjson_generator

### DIFF
--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "railjson_generator"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 


### PR DESCRIPTION
Since railjson_generator is used as a dependency (e.g. for tests/), a new version allows to trigger updates and pull changes from commits such as e0a1bb79d957ce12778f991b3e679e9ba4111c9c.