### PR TITLE
core: stdcm: memoize simulateBlock

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/BlockSimulationParameters.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/BlockSimulationParameters.java
@@ -1,0 +1,4 @@
+package fr.sncf.osrd.stdcm.graph;
+
+public record BlockSimulationParameters(Integer blockId, double initialSpeed, long start, Long stop) {
+}

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.java
@@ -2,9 +2,7 @@ package fr.sncf.osrd.stdcm.graph;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.sim_infra.impl.BlockInfraImplKt;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -163,17 +161,15 @@ public class STDCMEdgeBuilder {
     /** Returns the envelope to be used for the new edges */
     private Envelope getEnvelope() {
         if (envelope == null)
-            envelope = STDCMSimulations.simulateBlock(
+            envelope = graph.stdcmSimulations.simulateBlock(
                     graph.rawInfra,
                     graph.blockInfra,
-                    blockId,
-                    startSpeed,
-                    startOffset,
                     graph.rollingStock,
                     graph.comfort,
                     graph.timeStep,
-                    STDCMUtils.getStopOnBlock(graph, blockId, startOffset, waypointIndex),
-                    graph.tag
+                    graph.tag,
+                    new BlockSimulationParameters(blockId, startSpeed, startOffset,
+                            STDCMUtils.getStopOnBlock(graph, blockId, startOffset, waypointIndex))
             );
         return envelope;
     }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMGraph.java
@@ -29,6 +29,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
     public final RollingStock rollingStock;
     public final RollingStock.Comfort comfort;
     public final double timeStep;
+    STDCMSimulations stdcmSimulations;
     final List<STDCMStep> steps;
     final DelayManager delayManager;
     final AllowanceManager allowanceManager;
@@ -55,6 +56,7 @@ public class STDCMGraph implements Graph<STDCMNode, STDCMEdge> {
         this.rollingStock = rollingStock;
         this.comfort = comfort;
         this.timeStep = timeStep;
+        this.stdcmSimulations = new STDCMSimulations();
         this.steps = steps;
         this.delayManager = new DelayManager(minScheduleTimeStart, maxRunTime, blockAvailability, this);
         this.allowanceManager = new AllowanceManager(this);

--- a/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.java
@@ -20,7 +20,7 @@ public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterfac
 
     /** Simple record used to group together a block and the offset of its start on the given path */
     private record BlockWithOffset(
-            Integer blockID,
+            Integer blockId,
             Long pathOffset
     ){}
 
@@ -73,7 +73,7 @@ public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterfac
         double minimumDelay = 0;
         long conflictOffset = 0;
         for (var blockWithOffset : getBlocksInRange(blocks, startOffset, endOffset)) {
-            for (var unavailableSegment : unavailableSpace.get(blockWithOffset.blockID)) {
+            for (var unavailableSegment : unavailableSpace.get(blockWithOffset.blockId)) {
                 var trainInBlock = getTimeTrainInBlock(
                         unavailableSegment,
                         blockWithOffset,
@@ -109,7 +109,7 @@ public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterfac
                 minimumDelay += recursiveDelay.duration;
         }
         var pathLength = blocks.stream()
-                .mapToLong(block -> blockInfra.getBlockLength(block.blockID))
+                .mapToLong(block -> blockInfra.getBlockLength(block.blockId))
                 .sum();
         conflictOffset = Math.max(0, Math.min(pathLength, conflictOffset));
         return new Unavailable(minimumDelay, conflictOffset);
@@ -127,7 +127,7 @@ public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterfac
         double maximumDelay = Double.POSITIVE_INFINITY;
         double timeOfNextOccupancy = Double.POSITIVE_INFINITY;
         for (var blockWithOffset : getBlocksInRange(blocks, startOffset, endOffset)) {
-            for (var block : unavailableSpace.get(blockWithOffset.blockID)) {
+            for (var block : unavailableSpace.get(blockWithOffset.blockId)) {
                 var timeTrainInBlock = getTimeTrainInBlock(
                         block,
                         blockWithOffset,
@@ -157,7 +157,7 @@ public class BlockAvailabilityLegacyAdapter implements BlockAvailabilityInterfac
         return blocks.stream()
                 .filter(r -> r.pathOffset() < end)
                 .filter(r ->
-                        r.pathOffset() + blockInfra.getBlockLength(r.blockID) > start)
+                        r.pathOffset() + blockInfra.getBlockLength(r.blockId) > start)
                 .toList();
     }
 


### PR DESCRIPTION
Add computed block envelopes to STDCMGraph. Only compute block envelopes which have not been already computed.
Makes [this test](https://github.com/osrd-project/osrd/blob/ech/add-large-timetable-tests/core/src/test/java/fr/sncf/osrd/stdcm/PerformanceTests.java#L97-L140) pass in 3mn8s (was not passing beforehand).