### PR TITLE
front: display message when creating a train and rolling stock has no restriction power

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -76,6 +76,7 @@
   "pleaseWait": "Please wait…",
   "powerRestriction": "Power restriction code",
   "powerRestrictionExplanationText": "By default, the simulation will use the nominal power.",
+  "powerRestrictionEmptyExplanationText": "The selected rolling stock does not have any power restrictions. You can edit it in the rolling stock editor.",
   "restartPathfinding": "Restart search",
   "rollingstock": "Rolling stock",
   "simulation": "Simulation",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -76,6 +76,7 @@
   "pleaseWait": "Veuillez patientez…",
   "powerRestriction": "Code de restriction de puissance",
   "powerRestrictionExplanationText": "Si aucune restriction de puissance n'est renseignée sur un intervalle, le calcul de marche sera réalisé en utilisant la puissance nominale.",
+  "powerRestrictionEmptyExplanationText": "Le matériel roulant sélectionné ne possède pas de restrictions de puissance. Vous pouvez en créer dans l'éditeur de matériel roulant.",
   "restartPathfinding": "Relancer la recherche",
   "rollingstock": "Matériel",
   "simulation": "Simulation",

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,6 +28,7 @@ import pahtFindingPic from 'assets/pictures/components/pathfinding.svg';
 import allowancesPic from 'assets/pictures/components/allowances.svg';
 import simulationSettings from 'assets/pictures/components/simulationSettings.svg';
 import MemoRollingStock2Img from 'modules/rollingStock/components/RollingStockSelector/RollingStock2Img';
+import { isElectric } from 'modules/rollingStock/helpers/utils';
 
 export default function ManageTrainSchedule() {
   const dispatch = useDispatch();
@@ -144,7 +144,7 @@ export default function ManageTrainSchedule() {
             <SpeedLimitByTagSelector />
           </div>
         </div>
-        {rollingStock && !isEmpty(rollingStock.power_restrictions) && (
+        {rollingStock && isElectric(rollingStock) && (
           <PowerRestrictionsSelector
             rollingStockModes={rollingStock.effort_curves.modes}
             rollingStockPowerRestrictions={rollingStock.power_restrictions}

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
@@ -10,7 +10,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setFailure, setSuccess } from 'reducers/main';
 import Tabs, { TabProps } from 'common/Tabs';
 import RollingStockEditorFormModal from 'modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormModal';
-import getRollingStockEditorDefaultValues, {
+import {
+  getRollingStockEditorDefaultValues,
   getDefaultRollingStockMode,
   rollingStockEditorQueryArg,
 } from 'modules/rollingStock/helpers/utils';

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { Comfort, RollingStock, RollingStockUpsertPayload } from 'common/api/osrdEditoastApi';
-import { isNull } from 'lodash';
+import { isNull, some } from 'lodash';
 import {
   EffortCurves,
   RollingStockParametersValues,
@@ -64,7 +64,7 @@ export const getDefaultRollingStockMode = (
   },
 });
 
-const getRollingStockEditorDefaultValues = (
+export const getRollingStockEditorDefaultValues = (
   selectedMode: string | null,
   rollingStockData?: RollingStock
 ): RollingStockParametersValues => {
@@ -185,4 +185,5 @@ export const orderSelectorList = (list: (string | null)[]) => {
     : list.sort();
 };
 
-export default getRollingStockEditorDefaultValues;
+export const isElectric = (rollingStock: RollingStock) =>
+  some(Object.values(rollingStock.effort_curves.modes), (effortCurve) => effortCurve.is_electric);

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/PowerRestrictionsSelector.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/PowerRestrictionsSelector.tsx
@@ -182,18 +182,24 @@ const PowerRestrictionsSelector = ({
       <div className="osrd-config-item-container text-muted">
         <img width="32px" className="mr-2" src={icon} alt="PowerRestrictionIcon" />
         <span>{t('powerRestriction')}</span>
-        <p className="mb-1 mt-1">{t('powerRestrictionExplanationText')}</p>
-        <IntervalsEditor
-          additionalData={formattedPathCatenaryRanges}
-          intervalType={INTERVAL_TYPES.SELECT}
-          data={powerRestrictionRanges}
-          defaultValue={NO_POWER_RESTRICTION}
-          emptyValue={NO_POWER_RESTRICTION}
-          operationalPoints={electrificationChangePoints}
-          selectOptions={powerRestrictionOptions}
-          setData={editPowerRestrictionRanges}
-          totalLength={pathLength}
-        />
+        {!isEmpty(rollingStockPowerRestrictions) ? (
+          <>
+            <p className="mb-1 mt-1">{t('powerRestrictionExplanationText')}</p>
+            <IntervalsEditor
+              additionalData={formattedPathCatenaryRanges}
+              intervalType={INTERVAL_TYPES.SELECT}
+              data={powerRestrictionRanges}
+              defaultValue={NO_POWER_RESTRICTION}
+              emptyValue={NO_POWER_RESTRICTION}
+              operationalPoints={electrificationChangePoints}
+              selectOptions={powerRestrictionOptions}
+              setData={editPowerRestrictionRanges}
+              totalLength={pathLength}
+            />
+          </>
+        ) : (
+          <p className="pt-1">{t('powerRestrictionEmptyExplanationText')}</p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
closes #4866 

Added a message if a rolling stock does not have any restriction power

![image](https://github.com/osrd-project/osrd/assets/45000526/c79cffdb-b119-44e7-9afe-fd4b5ca437ad)

