### PR TITLE
core: allow bimode rollingstocks on non-electrified tracks

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.java
@@ -37,7 +37,7 @@ public record ElectrificationConstraints(
      * because it needs electrified tracks and isn't compatible with the catenaries in some range
      */
     private static Set<Pathfinding.Range> getBlockedRanges(RollingStock stock, PathProperties path) {
-        if (stock.isThermal())
+        if (!stock.isElectricOnly())
             return Set.of();
 
         var res = new HashSet<Pathfinding.Range>();

--- a/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
+++ b/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
@@ -298,10 +298,10 @@ public class RollingStock implements PhysicsRollingStock {
     }
 
     /**
-     * Return whether this rolling stock's default mode is thermal
+     * Return whether this rolling stock can only use electrified tracks
      */
-    public boolean isThermal() {
-        return !modes.get(defaultMode).isElectric();
+    public boolean isElectricOnly() {
+        return modes.values().stream().allMatch(mode -> mode.isElectric);
     }
 
     /**


### PR DESCRIPTION
Fix #5300 