### PR TITLE
front: fix power restriction selector warnings

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/PowerRestrictionsSelector.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/PowerRestrictionsSelector.tsx
@@ -129,7 +129,11 @@ const PowerRestrictionsSelector = ({
 
   /** Check the compatibility between the powerRestrictionRanges and the catenaries */
   useEffect(() => {
-    if (!isEmpty(pathCatenaryRanges) && !isEmpty(powerRestrictionRanges)) {
+    if (
+      !isEmpty(rollingStockPowerRestrictions) &&
+      !isEmpty(pathCatenaryRanges) &&
+      !isEmpty(powerRestrictionRanges)
+    ) {
       powerRestrictionRanges.forEach((powerRestrictionRange) => {
         // find path ranges crossed or included in the power restriction range
         pathCatenaryRanges.forEach((pathCatenaryRange) => {


### PR DESCRIPTION
closes #4866 

The bug has been reopened because even if the rolling stock does not have any power restriction, when opening the simulation parameter tab, some warnings would pop.
This PR removes the warnings notifications if the rolling stock has no power restriction.