### PR TITLE
front: infraID management in editor #5377

### DIFF
--- a/front/src/applications/editor/tools/pointEdition/components.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components.tsx
@@ -234,6 +234,7 @@ export const PointEditionLeftPanel: FC<{ type: EditoastType }> = <Entity extends
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const res: any = await dispatch(
             save(
+              infraID,
               state.entity.properties.id !== NEW_ENTITY_ID
                 ? {
                     update: [

--- a/front/src/applications/editor/tools/rangeEdition/components.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components.tsx
@@ -260,6 +260,7 @@ export const RangeEditionLeftPanel: FC = () => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const res: any = await dispatch(
                 save(
+                  infraID,
                   !isNew
                     ? {
                         update: [

--- a/front/src/applications/editor/tools/routeEdition/components/EditRouteMetadata.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/EditRouteMetadata.tsx
@@ -97,7 +97,7 @@ export const EditRouteMetadataPanel: FC<{ state: EditRouteMetadataState }> = ({ 
                 title={t('Editor.tools.routes-edition.delete-route')}
                 onConfirm={async () => {
                   setIsLoading(true);
-                  await dispatch(save({ delete: [initialRouteEntity] as EditorEntity[] }));
+                  await dispatch(save(infraID, { delete: [initialRouteEntity] as EditorEntity[] }));
                   setIsLoading(false);
                   addSuccessNotification({
                     title: '',
@@ -158,7 +158,7 @@ export const EditRouteMetadataPanel: FC<{ state: EditRouteMetadataState }> = ({ 
           onClick={async () => {
             setIsLoading(true);
             await dispatch(
-              save({
+              save(infraID, {
                 update: [
                   {
                     source: initialRouteEntity,

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -192,12 +192,12 @@ const SelectionTool: Tool<SelectionState> = {
         isDisabled({ state }) {
           return !state.selection.length;
         },
-        onClick({ openModal, closeModal, forceRender, state, setState, dispatch, t }) {
+        onClick({ infraID, openModal, closeModal, forceRender, state, setState, dispatch, t }) {
           openModal(
             <ConfirmModal
               title={t('Editor.tools.select-items.actions.delete-selection')}
               onConfirm={async () => {
-                await dispatch<ReturnType<typeof save>>(save({ delete: state.selection }));
+                await dispatch<ReturnType<typeof save>>(save(infraID, { delete: state.selection }));
                 setState({ ...state, selection: [] });
                 closeModal();
                 forceRender();

--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -179,6 +179,7 @@ export const CustomSchemaField: FC<FieldProps> = (props) => {
 export const SwitchEditionLeftPanel: FC = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const infraID = useSelector(getInfraID);
   const { state, setState, editorState } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<SwitchEditionState>;
@@ -252,6 +253,7 @@ export const SwitchEditionLeftPanel: FC = () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const res: any = await dispatch(
             save(
+              infraID,
               !isNew
                 ? {
                     update: [

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -348,6 +348,7 @@ export const TrackEditionLayers: FC = () => {
 export const TrackEditionLeftPanel: FC = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const infraID = useSelector(getInfraID);
   const { state, setState } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<TrackEditionState>;
@@ -362,6 +363,7 @@ export const TrackEditionLeftPanel: FC = () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const res: any = await dispatch(
             save(
+              infraID,
               track.properties.id !== NEW_ENTITY_ID
                 ? {
                     update: [


### PR DESCRIPTION
See issue #5377 

infraID was read from the store with selectors that used the `mode` property to know where to read it, but the save function read it directly from the simulation store. To avoid bad behavior, I propagate the infraID to the save function.