### PR TITLE
front: Fix #5380

### DIFF
--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -3,7 +3,7 @@ import { FieldProps } from '@rjsf/core';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import Select from 'react-select';
-import { first, last, keyBy } from 'lodash';
+import { first, last, keyBy, debounce } from 'lodash';
 import { FaTimesCircle, FaMapMarkedAlt } from 'react-icons/fa';
 import SchemaField from '@rjsf/core/lib/components/fields/SchemaField';
 import { Layer, Popup, Source } from 'react-map-gl/maplibre';
@@ -269,7 +269,7 @@ export const SwitchEditionLeftPanel: FC = () => {
               entity: { ...entityToSave, properties: { ...entityToSave.properties, id: `${id}` } },
             });
         }}
-        onChange={(entity) => {
+        onChange={debounce((entity) => {
           const flatSwitch = entity as FlatSwitchEntity;
           setState({
             ...state,
@@ -279,7 +279,7 @@ export const SwitchEditionLeftPanel: FC = () => {
               geometry: flatSwitch.geometry,
             },
           });
-        }}
+        }, 200)}
       >
         <div className="text-right">
           <button
@@ -451,8 +451,11 @@ export const SwitchEditionLayers: FC = () => {
         <Layer {...layerProps} />
         <Layer {...nameLayerProps} />
       </Source>
+
+      {/* Map popin of the edited switch */}
       {geometryState.entity && (
         <Popup
+          focusAfterOpen={false}
           className="popup py-2"
           anchor="bottom"
           longitude={geometryState.entity.geometry.coordinates[0]}


### PR DESCRIPTION
See issue #5380 

When the switch popin on the map is recreate, it takes the focus so we lost the focus on the input.
Adding also a debounce on the onChange of EditFOrm to avoid the blink effect.