### PR TITLE
Create slice STDCM and simulation#5272

### DIFF
--- a/front/src/Store.ts
+++ b/front/src/Store.ts
@@ -1,5 +1,5 @@
 import { legacy_createStore as createStore, combineReducers } from 'redux';
-import { configureStore, createListenerMiddleware, Middleware } from '@reduxjs/toolkit';
+import { configureStore, Middleware } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import { persistStore, getStoredState } from 'redux-persist';
 import { Config } from '@redux-devtools/extension';
@@ -11,8 +11,6 @@ import persistedReducer, {
   RootState,
   persistConfig,
 } from 'reducers';
-import { registerSimulationUpdateInfraIDListeners } from 'reducers/osrdconf2/simulationConf';
-import { registerStdcmUpdateInfraIDListeners } from 'reducers/osrdconf2/stdcmConf';
 
 const reduxDevToolsOptions: Config = {
   serialize: {
@@ -22,25 +20,13 @@ const reduxDevToolsOptions: Config = {
   },
 };
 
-const buildListenerMiddleware = () => {
-  const listener = createListenerMiddleware();
-  registerSimulationUpdateInfraIDListeners(listener);
-  registerStdcmUpdateInfraIDListeners(listener);
-
-  return listener;
-};
-
 const middlewares: Middleware[] = [thunk, osrdEditoastApi.middleware];
 
 const store = configureStore({
   reducer: persistedReducer,
   devTools: reduxDevToolsOptions,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false })
-      // As mentionned in the Doc(https://redux-toolkit.js.org/api/createListenerMiddleware), Since this can receive actions with functions inside,
-      // listenerMiddleware should go before the serializability check middleware
-      .prepend(buildListenerMiddleware().middleware)
-      .concat(...middlewares),
+    getDefaultMiddleware({ serializableCheck: false }).concat(...middlewares),
 });
 
 const persistor = persistStore(store);

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -17,7 +17,7 @@ import Map from './Map';
 import NavButtons from './nav';
 import EditorContext from './context';
 import TOOLS from './tools/tools';
-import { getInfraID, getSwitchTypes } from '../../reducers/osrdconf/selectors';
+import { getInfraID } from '../../reducers/osrdconf/selectors';
 import TOOL_TYPES from './tools/toolTypes';
 import { EditorState } from './tools/types';
 import {
@@ -29,6 +29,7 @@ import {
 } from './tools/editorContextTypes';
 import { switchProps } from './tools/switchProps';
 import { CommonToolState } from './tools/commonToolState';
+import { useSwitchTypes } from './tools/switchEdition/types';
 
 const Editor: FC = () => {
   const { t } = useTranslation();
@@ -37,8 +38,8 @@ const Editor: FC = () => {
   const { openModal, closeModal } = useModal();
   const { urlInfra } = useParams();
   const infraID = useSelector(getInfraID);
-  const switchTypes = useSelector(getSwitchTypes);
   const editorState = useSelector((state: { editor: EditorState }) => state.editor);
+  const switchTypes = useSwitchTypes();
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const [toolAndState, setToolAndState] = useState<FullTool<any>>({
     tool: TOOLS[TOOL_TYPES.SELECTION],

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -27,10 +27,11 @@ import { getMapMouseEventNearestFeature } from '../../utils/mapHelper';
 import EditorContext from './context';
 import { EditorState, LAYER_TO_EDITOAST_DICT, LAYERS_SET, LayerType } from './tools/types';
 import { getEntity } from './data/api';
-import { getInfraID, getSwitchTypes } from '../../reducers/osrdconf/selectors';
+import { getInfraID } from '../../reducers/osrdconf/selectors';
 import { getShowOSM, getTerrain3DExaggeration } from '../../reducers/map/selectors';
 import { CommonToolState } from './tools/commonToolState';
 import { EditorContextType, ExtendedEditorContextType, Tool } from './tools/editorContextTypes';
+import { useSwitchTypes } from './tools/switchEdition/types';
 
 interface MapProps<S extends CommonToolState = CommonToolState> {
   t: TFunction;
@@ -67,7 +68,7 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
   });
   const context = useContext(EditorContext) as EditorContextType<CommonToolState>;
   const infraID = useSelector(getInfraID);
-  const switchTypes = useSelector(getSwitchTypes);
+  const switchTypes = useSwitchTypes();
   const editorState = useSelector((state: { editor: EditorState }) => state.editor);
   const showOSM = useSelector(getShowOSM);
   const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);

--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../../types';
 import colors from '../../../../common/Map/Consts/colors';
 import GeoJSONs from '../../../../common/Map/Layers/GeoJSONs';
-import { PortEndPointCandidate, SwitchEditionState } from './types';
+import { PortEndPointCandidate, SwitchEditionState, useSwitchTypes } from './types';
 import EditorForm from '../../components/EditorForm';
 import { save } from '../../../../reducers/editor';
 import {
@@ -42,7 +42,7 @@ import {
 import { flattenEntity, NEW_ENTITY_ID } from '../../data/utils';
 import EntitySumUp from '../../components/EntitySumUp';
 import { getEntity } from '../../data/api';
-import { getInfraID, getSwitchTypes } from '../../../../reducers/osrdconf/selectors';
+import { getInfraID } from '../../../../reducers/osrdconf/selectors';
 import { getMap } from '../../../../reducers/map/selectors';
 import { ExtendedEditorContextType } from '../editorContextTypes';
 
@@ -187,7 +187,7 @@ export const SwitchEditionLeftPanel: FC = () => {
   // Retrieve base JSON schema:
   const baseSchema = editorState.editorSchema.find((e) => e.objType === 'Switch')?.schema;
   // Retrieve proper data
-  const switchTypes = useSelector(getSwitchTypes);
+  const switchTypes = useSwitchTypes();
   const switchTypesDict = useMemo(() => keyBy(switchTypes, 'id'), [switchTypes]);
   const switchTypeOptions = useMemo(
     () =>
@@ -308,7 +308,7 @@ export const SwitchEditionLeftPanel: FC = () => {
 export const SwitchEditionLayers: FC = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const switchTypes = useSelector(getSwitchTypes);
+  const switchTypes = useSwitchTypes();
   const infraID = useSelector(getInfraID);
   const {
     renderingFingerprint,

--- a/front/src/applications/editor/tools/switchEdition/types.ts
+++ b/front/src/applications/editor/tools/switchEdition/types.ts
@@ -1,6 +1,9 @@
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { Position } from 'geojson';
+import { useSelector } from 'react-redux';
+import { getInfraID } from 'reducers/osrdconf/selectors';
 
-import { EndPoint, SwitchEntity } from '../../../../types';
+import { EndPoint, SwitchEntity, SwitchType } from '../../../../types';
 import { CommonToolState } from '../commonToolState';
 
 export type PortEndPointCandidate = {
@@ -22,4 +25,13 @@ export type SwitchEditionState = CommonToolState & {
         onSelect: (candidate: PortEndPointCandidate) => void;
         hoveredPoint: PortEndPointCandidate | null;
       };
+};
+
+export const useSwitchTypes = () => {
+  const infraID = useSelector(getInfraID);
+  if (infraID) {
+    const { data } = osrdEditoastApi.endpoints.getInfraByIdSwitchTypes.useQuery({ id: infraID });
+    return (data || []) as SwitchType[];
+  }
+  return [];
 };

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -180,7 +180,7 @@ export interface OsrdConfState {
   departureTime: string;
   destination?: PointOnMap;
   vias: PointOnMap[];
-  suggeredVias: Path['steps'];
+  suggeredVias: Path['steps'] | PointOnMap[];
   trainCompo: undefined;
   geojson?: Path;
   originDate?: string;

--- a/front/src/common/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/common/ScenarioExplorer/ScenarioExplorer.tsx
@@ -11,6 +11,7 @@ import { updateInfraID, updateTimetableID } from 'reducers/osrdconf';
 import { TrainScheduleSummary, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { getDocument } from 'common/api/documentApi';
 import { getTimetableID } from 'reducers/osrdconf/selectors';
+import { useOsrdConfContext } from 'common/osrdConfContext';
 import ScenarioExplorerModal from './ScenarioExplorerModal';
 import { ScenarioExplorerProps } from './ScenarioExplorerTypes';
 
@@ -24,6 +25,9 @@ export default function ScenarioExplorer({
   const { openModal } = useModal();
   const timetableID = useSelector(getTimetableID);
   const [imageUrl, setImageUrl] = useState<string>();
+  const {
+    slice: { actions: osrdConfActions },
+  } = useOsrdConfContext();
 
   const { data: projectDetails } = osrdEditoastApi.useGetProjectsByProjectIdQuery(
     { projectId: globalProjectId as number },
@@ -70,6 +74,8 @@ export default function ScenarioExplorer({
     if (scenarioDetails?.timetable_id) {
       dispatch(updateTimetableID(scenarioDetails.timetable_id));
       dispatch(updateInfraID(scenarioDetails.infra_id));
+      // TODO remove when completely separate simulationconf and stdcmconf
+      dispatch(osrdConfActions.updateInfraID(scenarioDetails.infra_id));
     }
   }, [scenarioDetails]);
 

--- a/front/src/common/osrdConfContext.tsx
+++ b/front/src/common/osrdConfContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react';
+import { Outlet } from 'react-router-dom';
+import { simulationConfSliceType } from 'reducers/osrdconf2/simulationConf';
+import { stdcmConfSliceType } from 'reducers/osrdconf2/stdcmConf';
+
+export type OsrdConfType = simulationConfSliceType | stdcmConfSliceType | null;
+type Props = { osrdConfSlice: OsrdConfType };
+
+const OsrdConfContext = createContext<OsrdConfType>(null);
+
+export const useOsrdConfContext = () => {
+  const context = useContext(OsrdConfContext);
+  if (!context) {
+    throw new Error('useOsrdConfContext must be used within a OsrdConfContext.Provider');
+  }
+  return context;
+};
+
+export const OsrdConfContextLayout = ({ osrdConfSlice }: Props) => (
+  <OsrdConfContext.Provider value={osrdConfSlice}>
+    <Outlet />
+  </OsrdConfContext.Provider>
+);
+
+export default OsrdConfContext;

--- a/front/src/common/osrdConfContext.tsx
+++ b/front/src/common/osrdConfContext.tsx
@@ -1,10 +1,14 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import { Outlet } from 'react-router-dom';
 import { simulationConfSliceType } from 'reducers/osrdconf2/simulationConf';
+import { simulationConfSelectorsType } from 'reducers/osrdconf2/simulationConf/selectors';
 import { stdcmConfSliceType } from 'reducers/osrdconf2/stdcmConf';
+import { stdcmConfSelectorsType } from 'reducers/osrdconf2/stdcmConf/selectors';
 
-export type OsrdConfType = simulationConfSliceType | stdcmConfSliceType | null;
-type Props = { osrdConfSlice: OsrdConfType };
+export type OsrdConfType = {
+  slice: simulationConfSliceType | stdcmConfSliceType;
+  selectors: simulationConfSelectorsType | stdcmConfSelectorsType;
+} | null;
 
 const OsrdConfContext = createContext<OsrdConfType>(null);
 
@@ -16,10 +20,17 @@ export const useOsrdConfContext = () => {
   return context;
 };
 
-export const OsrdConfContextLayout = ({ osrdConfSlice }: Props) => (
-  <OsrdConfContext.Provider value={osrdConfSlice}>
-    <Outlet />
-  </OsrdConfContext.Provider>
-);
+type Props = {
+  slice: NonNullable<OsrdConfType>['slice'];
+  selectors: NonNullable<OsrdConfType>['selectors'];
+};
+export const OsrdConfContextLayout = ({ slice, selectors }: Props) => {
+  const value = useMemo(() => ({ slice, selectors }), [slice, selectors]);
+  return (
+    <OsrdConfContext.Provider value={value}>
+      <Outlet />
+    </OsrdConfContext.Provider>
+  );
+};
 
 export default OsrdConfContext;

--- a/front/src/main/app.jsx
+++ b/front/src/main/app.jsx
@@ -20,8 +20,8 @@ import HomeRollingStockEditor from 'applications/rollingStockEditor/Home';
 import { getIsUserLogged } from 'reducers/user/userSelectors';
 import { attemptLoginOnLaunch } from 'reducers/user';
 import { OsrdConfContextLayout } from 'common/osrdConfContext';
-import { simulationConfSlice } from 'reducers/osrdconf2/simulationConf';
-import { stdcmConfSlice } from 'reducers/osrdconf2/stdcmConf';
+import { simulationConfSlice, simulationConfSliceActions } from 'reducers/osrdconf2/simulationConf';
+import { stdcmConfSlice, stdcmConfSliceActions } from 'reducers/osrdconf2/stdcmConf';
 
 import('@sncf/bootstrap-sncf.metier.reseau/dist/css/bootstrap-sncf.min.css');
 export default function App() {
@@ -51,7 +51,12 @@ export default function App() {
             <Routes>
               <Route
                 path="/operational-studies"
-                element={<OsrdConfContextLayout osrdConfSlice={simulationConfSlice} />}
+                element={
+                  <OsrdConfContextLayout
+                    slice={simulationConfSlice}
+                    selectors={simulationConfSliceActions}
+                  />
+                }
               >
                 <Route path="/operational-studies" element={<HomeOperationalStudies />} />
                 <Route path="/operational-studies/project" element={<Project />} />
@@ -61,7 +66,11 @@ export default function App() {
               <Route path="/map/*" element={<HomeMap />} />
               <Route path="/editor/*" element={<HomeEditor />} />
               <Route path="/rolling-stock-editor/*" element={<HomeRollingStockEditor />} />
-              <Route element={<OsrdConfContextLayout osrdConfSlice={stdcmConfSlice} />}>
+              <Route
+                element={
+                  <OsrdConfContextLayout slice={stdcmConfSlice} selectors={stdcmConfSliceActions} />
+                }
+              >
                 <Route path="/stdcm/*" element={<HomeStdcm />} />
               </Route>
               <Route path="/*" element={<Home />} />

--- a/front/src/main/app.jsx
+++ b/front/src/main/app.jsx
@@ -19,6 +19,9 @@ import Scenario from 'applications/operationalStudies/views/Scenario';
 import HomeRollingStockEditor from 'applications/rollingStockEditor/Home';
 import { getIsUserLogged } from 'reducers/user/userSelectors';
 import { attemptLoginOnLaunch } from 'reducers/user';
+import { OsrdConfContextLayout } from 'common/osrdConfContext';
+import { simulationConfSlice } from 'reducers/osrdconf2/simulationConf';
+import { stdcmConfSlice } from 'reducers/osrdconf2/stdcmConf';
 
 import('@sncf/bootstrap-sncf.metier.reseau/dist/css/bootstrap-sncf.min.css');
 export default function App() {
@@ -46,7 +49,10 @@ export default function App() {
           <ModalProvider>
             <NotificationsState />
             <Routes>
-              <Route path="/operational-studies">
+              <Route
+                path="/operational-studies"
+                element={<OsrdConfContextLayout osrdConfSlice={simulationConfSlice} />}
+              >
                 <Route path="/operational-studies" element={<HomeOperationalStudies />} />
                 <Route path="/operational-studies/project" element={<Project />} />
                 <Route path="/operational-studies/study" element={<Study />} />
@@ -55,7 +61,9 @@ export default function App() {
               <Route path="/map/*" element={<HomeMap />} />
               <Route path="/editor/*" element={<HomeEditor />} />
               <Route path="/rolling-stock-editor/*" element={<HomeRollingStockEditor />} />
-              <Route path="/stdcm/*" element={<HomeStdcm />} />
+              <Route element={<OsrdConfContextLayout osrdConfSlice={stdcmConfSlice} />}>
+                <Route path="/stdcm/*" element={<HomeStdcm />} />
+              </Route>
               <Route path="/*" element={<Home />} />
             </Routes>
           </ModalProvider>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
@@ -12,7 +12,7 @@ import ModalFooterSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalFooterSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { Spinner } from 'common/Loader';
 import { ArrayElement } from 'utils/types';
-import { Path } from 'common/api/osrdEditoastApi';
+import { Path, PathStep } from 'common/api/osrdEditoastApi';
 
 type Props = {
   inverseOD: () => void;
@@ -30,7 +30,7 @@ export default function ModalSugerredVias({
   pathfindingInProgress,
 }: Props) {
   const dispatch = useDispatch();
-  const suggeredVias = useSelector(getSuggeredVias);
+  const suggeredVias = useSelector(getSuggeredVias) as PathStep[];
   const vias = useSelector(getVias);
 
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -4,7 +4,11 @@ import createCompressor from 'redux-persist-transform-compress';
 import { createFilter } from 'redux-persist-transform-filter';
 import storage from 'redux-persist/lib/storage'; // defaults to localStorage
 
-import { OsrdConfState, OsrdMultiConfState } from 'applications/operationalStudies/consts';
+import {
+  OsrdConfState,
+  OsrdMultiConfState,
+  OsrdStdcmConfState,
+} from 'applications/operationalStudies/consts';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 
@@ -25,6 +29,8 @@ import rollingstockeditorReducer, {
   RsEditorCurvesState,
   initialState as rsEditorCurvesInitialState,
 } from './rollingstockEditor';
+import stdcmConfReducer, { stdcmConfInitialState } from './osrdconf2/stdcmConf';
+import simulationConfReducer, { simulationConfInitialState } from './osrdconf2/simulationConf';
 
 const compressor = createCompressor({
   whitelist: ['rollingstock'],
@@ -76,6 +82,8 @@ export interface RootState {
   map: MapState;
   editor: EditorState;
   main: MainState;
+  stdcmconf: OsrdStdcmConfState;
+  simulationconf: OsrdConfState;
   osrdconf: OsrdMultiConfState;
   osrdsimulation: OsrdSimulationState;
   [osrdEditoastApi.reducerPath]: ReturnType<typeof osrdEditoastApi.reducer>;
@@ -87,6 +95,8 @@ export const rootInitialState: RootState = {
   map: mapInitialState,
   editor: editorInitialState,
   main: mainInitialState,
+  stdcmconf: stdcmConfInitialState,
+  simulationconf: simulationConfInitialState,
   osrdconf: osrdconfInitialState,
   osrdsimulation: osrdSimulationInitialState,
   [osrdEditoastApi.reducerPath]: {} as ReturnType<typeof osrdEditoastApi.reducer>,
@@ -107,6 +117,8 @@ export const rootReducer: ReducersMapObject<RootState> = {
   map: mapReducer,
   editor: editorReducer,
   main: mainReducer,
+  stdcmconf: stdcmConfReducer,
+  simulationconf: simulationConfReducer,
   osrdconf: persistReducer(osrdconfPersistConfig, osrdconfReducer) as unknown as Reducer<
     OsrdMultiConfState,
     AnyAction

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -29,8 +29,11 @@ import rollingstockeditorReducer, {
   RsEditorCurvesState,
   initialState as rsEditorCurvesInitialState,
 } from './rollingstockEditor';
-import stdcmConfReducer, { stdcmConfInitialState } from './osrdconf2/stdcmConf';
-import simulationConfReducer, { simulationConfInitialState } from './osrdconf2/simulationConf';
+import stdcmConfReducer, { stdcmConfInitialState, stdcmConfSlice } from './osrdconf2/stdcmConf';
+import simulationConfReducer, {
+  simulationConfInitialState,
+  simulationConfSlice,
+} from './osrdconf2/simulationConf';
 
 const compressor = createCompressor({
   whitelist: ['rollingstock'],
@@ -82,8 +85,8 @@ export interface RootState {
   map: MapState;
   editor: EditorState;
   main: MainState;
-  stdcmconf: OsrdStdcmConfState;
-  simulationconf: OsrdConfState;
+  [stdcmConfSlice.name]: OsrdStdcmConfState;
+  [simulationConfSlice.name]: OsrdConfState;
   osrdconf: OsrdMultiConfState;
   osrdsimulation: OsrdSimulationState;
   [osrdEditoastApi.reducerPath]: ReturnType<typeof osrdEditoastApi.reducer>;
@@ -95,8 +98,8 @@ export const rootInitialState: RootState = {
   map: mapInitialState,
   editor: editorInitialState,
   main: mainInitialState,
-  stdcmconf: stdcmConfInitialState,
-  simulationconf: simulationConfInitialState,
+  [stdcmConfSlice.name]: stdcmConfInitialState,
+  [simulationConfSlice.name]: simulationConfInitialState,
   osrdconf: osrdconfInitialState,
   osrdsimulation: osrdSimulationInitialState,
   [osrdEditoastApi.reducerPath]: {} as ReturnType<typeof osrdEditoastApi.reducer>,
@@ -117,8 +120,8 @@ export const rootReducer: ReducersMapObject<RootState> = {
   map: mapReducer,
   editor: editorReducer,
   main: mainReducer,
-  stdcmconf: stdcmConfReducer,
-  simulationconf: simulationConfReducer,
+  [stdcmConfSlice.name]: stdcmConfReducer,
+  [simulationConfSlice.name]: simulationConfReducer,
   osrdconf: persistReducer(osrdconfPersistConfig, osrdconfReducer) as unknown as Reducer<
     OsrdMultiConfState,
     AnyAction

--- a/front/src/reducers/osrdconf2/common/index.ts
+++ b/front/src/reducers/osrdconf2/common/index.ts
@@ -1,0 +1,359 @@
+import {
+  ActionReducerMapBuilder,
+  CaseReducer,
+  ListenerMiddlewareInstance,
+  PayloadAction,
+  PrepareAction,
+} from '@reduxjs/toolkit';
+import { OsrdConfState, PointOnMap } from 'applications/operationalStudies/consts';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { Draft } from 'immer';
+import { omit } from 'lodash';
+import { formatIsoDate } from 'utils/date';
+import { sec2time, time2sec } from 'utils/timeManipulation';
+import type { simulationConfSliceActionsType } from '../simulationConf';
+import type { stdcmConfSliceActionsType } from '../stdcmConf';
+
+const ORIGIN_TIME_BOUND_DEFAULT_DIFFERENCE = 7200;
+
+export const defaultCommonConf: OsrdConfState = {
+  name: '',
+  trainCount: 1,
+  trainDelta: 15,
+  trainStep: 2,
+  allowances: [],
+  usingElectricalProfiles: true,
+  labels: [],
+  projectID: undefined,
+  studyID: undefined,
+  scenarioID: undefined,
+  infraID: undefined,
+  switchTypes: undefined,
+  pathfindingID: undefined,
+  timetableID: undefined,
+  rollingStockID: undefined,
+  rollingStockComfort: 'STANDARD' as const,
+  powerRestrictionRanges: [],
+  speedLimitByTag: undefined,
+  origin: undefined,
+  initialSpeed: 0,
+  departureTime: '08:00:00',
+  shouldRunPathfinding: true,
+  originDate: formatIsoDate(new Date()),
+  originTime: '08:00:00',
+  originUpperBoundDate: formatIsoDate(new Date()),
+  originUpperBoundTime: '10:00:00',
+  originLinkedBounds: true,
+  destination: undefined,
+  destinationDate: formatIsoDate(new Date()),
+  destinationTime: undefined,
+  vias: [],
+  suggeredVias: [],
+  trainCompo: undefined,
+  geojson: undefined,
+  featureInfoClick: { displayPopup: false },
+  gridMarginBefore: 0,
+  gridMarginAfter: 0,
+  trainScheduleIDsToModify: undefined,
+};
+
+type CommonOsrdConfReducersType<S extends OsrdConfState> = {
+  ['updateName']: CaseReducer<S, PayloadAction<S['name']>>;
+  ['updateTrainCount']: CaseReducer<S, PayloadAction<S['trainCount']>>;
+  ['updateTrainDelta']: CaseReducer<S, PayloadAction<OsrdConfState['trainDelta']>>;
+  ['updateTrainStep']: CaseReducer<S, PayloadAction<S['trainStep']>>;
+  ['updateAllowances']: CaseReducer<S, PayloadAction<S['allowances']>>;
+  ['toggleUsingElectricalProfiles']: CaseReducer<S>;
+  ['updateLabels']: CaseReducer<S, PayloadAction<S['labels']>>;
+  ['updateProjectID']: CaseReducer<S, PayloadAction<S['projectID']>>;
+  ['updateStudyID']: CaseReducer<S, PayloadAction<S['studyID']>>;
+  ['updateScenarioID']: CaseReducer<S, PayloadAction<S['scenarioID']>>;
+  ['updateInfraID']: CaseReducer<S, PayloadAction<S['infraID']>>;
+  ['updateSwitchTypes']: CaseReducer<S, PayloadAction<S['switchTypes']>>;
+  ['updatePathfindingID']: CaseReducer<S, PayloadAction<S['pathfindingID']>>;
+  ['updateShouldRunPathfinding']: CaseReducer<S, PayloadAction<S['shouldRunPathfinding']>>;
+  ['updateTimetableID']: CaseReducer<S, PayloadAction<S['timetableID']>>;
+  ['updateRollingStockID']: CaseReducer<S, PayloadAction<S['rollingStockID']>>;
+  ['updateRollingStockComfort']: CaseReducer<S, PayloadAction<S['rollingStockComfort']>>;
+  ['updateSpeedLimitByTag']: CaseReducer<S, PayloadAction<S['speedLimitByTag']>>;
+  ['updateOrigin']: CaseReducer<S, PayloadAction<S['origin']>>;
+  ['updateInitialSpeed']: CaseReducer<S, PayloadAction<S['initialSpeed']>>;
+  ['updateDepartureTime']: CaseReducer<S, PayloadAction<S['departureTime']>>;
+  ['updateOriginTime']: CaseReducer<S, PayloadAction<S['originTime']>>;
+  ['updateOriginUpperBoundTime']: CaseReducer<S, PayloadAction<S['originUpperBoundTime']>>;
+  ['toggleOriginLinkedBounds']: CaseReducer<S>;
+  ['updateOriginDate']: CaseReducer<S, PayloadAction<S['originDate']>>;
+  ['updateOriginUpperBoundDate']: CaseReducer<S, PayloadAction<S['originUpperBoundDate']>>;
+  ['replaceVias']: CaseReducer<S, PayloadAction<S['vias']>>;
+  ['updateVias']: CaseReducer<S, PayloadAction<PointOnMap>>;
+  ['updateViaStopTime']: {
+    reducer: CaseReducer<S, PayloadAction<S['vias']>>;
+    prepare: PrepareAction<S['vias']>;
+  };
+  ['permuteVias']: {
+    reducer: CaseReducer<S, PayloadAction<S['vias']>>;
+    prepare: PrepareAction<S['vias']>;
+  };
+  ['updateSuggeredVias']: CaseReducer<S, PayloadAction<S['suggeredVias']>>;
+  ['deleteVias']: CaseReducer<S, PayloadAction<number>>;
+  ['deleteItinerary']: CaseReducer<S>;
+  ['updateDestination']: CaseReducer<S, PayloadAction<S['destination']>>;
+  ['updateDestinationDate']: CaseReducer<S, PayloadAction<S['destinationDate']>>;
+  ['updateDestinationTime']: CaseReducer<S, PayloadAction<S['destinationTime']>>;
+  ['updateItinerary']: CaseReducer<S, PayloadAction<S['geojson']>>;
+  ['updateFeatureInfoClickOSRD']: {
+    reducer: CaseReducer<S, PayloadAction<S['featureInfoClick']>>;
+    prepare: PrepareAction<S['featureInfoClick']>;
+  };
+  ['updateGridMarginBefore']: CaseReducer<S, PayloadAction<S['gridMarginBefore']>>;
+  ['updateGridMarginAfter']: CaseReducer<S, PayloadAction<S['gridMarginAfter']>>;
+  ['updatePowerRestrictionRanges']: CaseReducer<S, PayloadAction<S['powerRestrictionRanges']>>;
+  ['updateTrainScheduleIDsToModify']: CaseReducer<S, PayloadAction<S['trainScheduleIDsToModify']>>;
+};
+
+export function buildCommonOsrdConfReducers<
+  S extends OsrdConfState
+>(): CommonOsrdConfReducersType<S> {
+  return {
+    updateName(state: Draft<S>, action: PayloadAction<S['name']>) {
+      state.name = action.payload;
+    },
+    updateTrainCount(state: Draft<S>, action: PayloadAction<S['trainCount']>) {
+      state.trainCount = action.payload;
+    },
+    updateTrainDelta(state: Draft<S>, action: PayloadAction<OsrdConfState['trainDelta']>) {
+      state.trainDelta = action.payload;
+    },
+    updateTrainStep(state: Draft<S>, action: PayloadAction<S['trainStep']>) {
+      state.trainStep = action.payload;
+    },
+    updateAllowances(state: Draft<S>, action: PayloadAction<S['allowances']>) {
+      state.allowances = action.payload;
+    },
+    toggleUsingElectricalProfiles(state: Draft<S>) {
+      state.usingElectricalProfiles = !state.usingElectricalProfiles;
+    },
+    updateLabels(state: Draft<S>, action: PayloadAction<S['labels']>) {
+      state.labels = action.payload;
+    },
+    updateProjectID(state: Draft<S>, action: PayloadAction<S['projectID']>) {
+      state.projectID = action.payload;
+    },
+    updateStudyID(state: Draft<S>, action: PayloadAction<S['studyID']>) {
+      state.studyID = action.payload;
+    },
+    updateScenarioID(state: Draft<S>, action: PayloadAction<S['scenarioID']>) {
+      state.scenarioID = action.payload;
+    },
+    // TODO REWORK use listener or createThunk ?
+    updateInfraID(state: Draft<S>, action: PayloadAction<S['infraID']>) {
+      state.infraID = action.payload;
+    },
+    updateSwitchTypes(state: Draft<S>, action: PayloadAction<S['switchTypes']>) {
+      state.switchTypes = action.payload;
+    },
+    updatePathfindingID(state: Draft<S>, action: PayloadAction<S['pathfindingID']>) {
+      state.pathfindingID = action.payload;
+      // TODO, move it to rtk listener
+      state.powerRestrictionRanges = [];
+    },
+    updateShouldRunPathfinding(state: Draft<S>, action: PayloadAction<S['shouldRunPathfinding']>) {
+      state.shouldRunPathfinding = action.payload;
+    },
+    updateTimetableID(state: Draft<S>, action: PayloadAction<S['timetableID']>) {
+      state.timetableID = action.payload;
+    },
+    updateRollingStockID(state: Draft<S>, action: PayloadAction<S['rollingStockID']>) {
+      state.rollingStockID = action.payload;
+    },
+    updateRollingStockComfort(state: Draft<S>, action: PayloadAction<S['rollingStockComfort']>) {
+      state.rollingStockComfort = action.payload;
+    },
+    updateSpeedLimitByTag(state: Draft<S>, action: PayloadAction<S['speedLimitByTag']>) {
+      state.speedLimitByTag = action.payload;
+    },
+    updateOrigin(state: Draft<S>, action: PayloadAction<S['origin']>) {
+      state.origin = action.payload;
+    },
+    updateInitialSpeed(state: Draft<S>, action: PayloadAction<S['initialSpeed']>) {
+      state.initialSpeed = action.payload;
+    },
+    updateDepartureTime(state: Draft<S>, action: PayloadAction<S['departureTime']>) {
+      state.departureTime = action.payload;
+    },
+    // TODO TEST undefined value
+    updateOriginTime(state: Draft<S>, action: PayloadAction<S['originTime']>) {
+      if (action.payload) {
+        const newOriginTimeSeconds = time2sec(action.payload);
+        const { originLinkedBounds, originTime, originUpperBoundTime } = state;
+        if (originLinkedBounds) {
+          const difference =
+            originTime && originUpperBoundTime
+              ? time2sec(originUpperBoundTime) - time2sec(originTime)
+              : ORIGIN_TIME_BOUND_DEFAULT_DIFFERENCE;
+          state.originUpperBoundTime = sec2time(newOriginTimeSeconds + difference);
+        }
+        if (
+          state.originUpperBoundTime &&
+          time2sec(action.payload) > time2sec(state.originUpperBoundTime)
+        ) {
+          state.originTime = state.originUpperBoundTime;
+        } else {
+          state.originTime = action.payload;
+        }
+      }
+    },
+    // TODO TEST undefined value
+    updateOriginUpperBoundTime(state: Draft<S>, action: PayloadAction<S['originUpperBoundTime']>) {
+      if (action.payload) {
+        const newOriginUpperBoundTimeSeconds = time2sec(action.payload);
+        if (state.originLinkedBounds) {
+          const difference =
+            state.originTime && state.originUpperBoundTime
+              ? time2sec(state.originUpperBoundTime) - time2sec(state.originTime)
+              : ORIGIN_TIME_BOUND_DEFAULT_DIFFERENCE;
+          state.originTime = sec2time(newOriginUpperBoundTimeSeconds - difference);
+        }
+        if (state.originTime && time2sec(action.payload) < time2sec(state.originTime)) {
+          state.originUpperBoundTime = state.originTime;
+        } else {
+          state.originUpperBoundTime = action.payload;
+        }
+      }
+    },
+    toggleOriginLinkedBounds(state: Draft<S>) {
+      state.originLinkedBounds = !state.originLinkedBounds;
+    },
+    updateOriginDate(state: Draft<S>, action: PayloadAction<S['originDate']>) {
+      state.originDate = action.payload;
+    },
+    updateOriginUpperBoundDate(state: Draft<S>, action: PayloadAction<S['originUpperBoundDate']>) {
+      state.originUpperBoundDate = action.payload;
+    },
+    replaceVias(state: Draft<S>, action: PayloadAction<S['vias']>) {
+      state.vias = action.payload;
+    },
+    updateVias(state: Draft<S>, action: PayloadAction<PointOnMap>) {
+      state.vias.push(action.payload);
+    },
+    // TODO TEST prepare
+    updateViaStopTime: {
+      reducer: (state: Draft<S>, action: PayloadAction<S['vias']>) => {
+        state.vias = action.payload;
+      },
+      prepare: (vias: PointOnMap[], index: number, value: number) => {
+        const newVias = Array.from(vias);
+        newVias[index] = { ...newVias[index], duration: value };
+        return { payload: newVias };
+      },
+    },
+    // TODO TEST prepare
+    permuteVias: {
+      reducer: (state: Draft<S>, action: PayloadAction<S['vias']>) => {
+        state.vias = action.payload;
+      },
+      prepare: (vias: PointOnMap[], from: number, to: number) => {
+        const newVias = Array.from(vias);
+        const itemToPermute = newVias.slice(from, from + 1);
+        newVias.splice(from, 1); // Remove it from array
+        newVias.splice(to, 0, itemToPermute[0]); // Replace to right position
+        return { payload: newVias };
+      },
+    },
+    updateSuggeredVias(state: Draft<S>, action: PayloadAction<S['suggeredVias']>) {
+      state.suggeredVias = action.payload;
+    },
+    deleteVias(state: Draft<S>, action: PayloadAction<number>) {
+      state.vias.splice(action.payload, 1);
+    },
+    deleteItinerary(state: Draft<S>) {
+      state.origin = undefined;
+      state.vias = [];
+      state.destination = undefined;
+      state.geojson = undefined;
+      state.originTime = undefined;
+      state.pathfindingID = undefined;
+    },
+    updateDestination(state: Draft<S>, action: PayloadAction<S['destination']>) {
+      state.destination = action.payload;
+    },
+    updateDestinationDate(state: Draft<S>, action: PayloadAction<S['destinationDate']>) {
+      state.destinationDate = action.payload;
+    },
+    updateDestinationTime(state: Draft<S>, action: PayloadAction<S['destinationTime']>) {
+      state.destinationTime = action.payload;
+    },
+    updateItinerary(state: Draft<S>, action: PayloadAction<S['geojson']>) {
+      state.geojson = action.payload;
+    },
+    updateFeatureInfoClickOSRD: {
+      reducer: (state: Draft<S>, action: PayloadAction<S['featureInfoClick']>) => {
+        state.featureInfoClick = action.payload;
+      },
+      prepare: (featureInfoClick: S['featureInfoClick']) => ({
+        payload: {
+          ...featureInfoClick,
+          feature: omit(featureInfoClick.feature, ['_vectorTileFeature']),
+        },
+      }),
+    },
+    updateGridMarginBefore(state: Draft<S>, action: PayloadAction<S['gridMarginBefore']>) {
+      state.gridMarginBefore = action.payload;
+    },
+    updateGridMarginAfter(state: Draft<S>, action: PayloadAction<S['gridMarginAfter']>) {
+      state.gridMarginAfter = action.payload;
+    },
+    updatePowerRestrictionRanges(
+      state: Draft<S>,
+      action: PayloadAction<S['powerRestrictionRanges']>
+    ) {
+      state.powerRestrictionRanges = action.payload;
+    },
+    updateTrainScheduleIDsToModify(
+      state: Draft<S>,
+      action: PayloadAction<S['trainScheduleIDsToModify']>
+    ) {
+      state.trainScheduleIDsToModify = action.payload;
+    },
+  };
+}
+
+/**
+ *
+ */
+export function addCommonOsrdConfMatchers<S extends OsrdConfState>(
+  builder: ActionReducerMapBuilder<S>
+) {
+  return builder
+    .addMatcher(
+      osrdEditoastApi.endpoints.getInfraByIdSwitchTypes.matchPending,
+      (state: Draft<S>) => {
+        state.switchTypes = [];
+      }
+    )
+    .addMatcher(
+      osrdEditoastApi.endpoints.getInfraByIdSwitchTypes.matchFulfilled,
+      (state: Draft<S>, action) => {
+        state.switchTypes = action.payload as S['switchTypes'];
+      }
+    );
+}
+
+export function registerUpdateInfraIDListener(
+  listener: ListenerMiddlewareInstance,
+  updateInfraID:
+    | simulationConfSliceActionsType['updateInfraID']
+    | stdcmConfSliceActionsType['updateInfraID']
+) {
+  listener.startListening({
+    actionCreator: updateInfraID,
+    effect: (action, listenerApi) => {
+      const infraID = action.payload;
+      if (infraID) {
+        listenerApi.dispatch(
+          osrdEditoastApi.endpoints.getInfraByIdSwitchTypes.initiate({ id: infraID })
+        );
+      }
+    },
+  });
+}

--- a/front/src/reducers/osrdconf2/common/selectors.ts
+++ b/front/src/reducers/osrdconf2/common/selectors.ts
@@ -1,0 +1,52 @@
+import { OsrdConfState } from 'applications/operationalStudies/consts';
+import { RootState } from 'reducers';
+import { makeSubSelector } from 'utils/selectors';
+import { simulationConfSliceType } from '../simulationConf';
+import { stdcmConfSliceType } from '../stdcmConf';
+
+const buildCommonConfSelectors = (slice: simulationConfSliceType | stdcmConfSliceType) => {
+  const getConf = (state: RootState) => state[slice.name];
+  const makeOsrdConfSelector = makeSubSelector<OsrdConfState>(getConf);
+  return {
+    getConf,
+    getName: makeOsrdConfSelector('name'),
+    getTrainCount: makeOsrdConfSelector('trainCount'),
+    getTrainDelta: makeOsrdConfSelector('trainDelta'),
+    getTrainStep: makeOsrdConfSelector('trainStep'),
+    getAllowances: makeOsrdConfSelector('allowances'),
+    getUsingElectricalProfiles: makeOsrdConfSelector('usingElectricalProfiles'),
+    getLabels: makeOsrdConfSelector('labels'),
+    getProjectID: makeOsrdConfSelector('projectID'),
+    getStudyID: makeOsrdConfSelector('studyID'),
+    getScenarioID: makeOsrdConfSelector('scenarioID'),
+    getInfraID: makeOsrdConfSelector('infraID'),
+    getSwitchTypes: makeOsrdConfSelector('switchTypes'),
+    getPathfindingID: makeOsrdConfSelector('pathfindingID'),
+    getTimetableID: makeOsrdConfSelector('timetableID'),
+    getRollingStockID: makeOsrdConfSelector('rollingStockID'),
+    getRollingStockComfort: makeOsrdConfSelector('rollingStockComfort'),
+    getSpeedLimitByTag: makeOsrdConfSelector('speedLimitByTag'),
+    getOrigin: makeOsrdConfSelector('origin'),
+    getDepartureTime: makeOsrdConfSelector('departureTime'),
+    getInitialSpeed: makeOsrdConfSelector('initialSpeed'),
+    getOriginDate: makeOsrdConfSelector('originDate'),
+    getOriginTime: makeOsrdConfSelector('originTime'),
+    getOriginUpperBoundDate: makeOsrdConfSelector('originUpperBoundDate'),
+    getOriginUpperBoundTime: makeOsrdConfSelector('originUpperBoundTime'),
+    getOriginLinkedBounds: makeOsrdConfSelector('originLinkedBounds'),
+    getDestination: makeOsrdConfSelector('destination'),
+    getDestinationDate: makeOsrdConfSelector('destinationDate'),
+    getDestinationTime: makeOsrdConfSelector('destinationTime'),
+    getVias: makeOsrdConfSelector('vias'),
+    getSuggeredVias: makeOsrdConfSelector('suggeredVias'),
+    getTrainCompo: makeOsrdConfSelector('trainCompo'),
+    getGeojson: makeOsrdConfSelector('geojson'),
+    getFeatureInfoClick: makeOsrdConfSelector('featureInfoClick'),
+    getGridMarginBefore: makeOsrdConfSelector('gridMarginBefore'),
+    getGridMarginAfter: makeOsrdConfSelector('gridMarginAfter'),
+    getPowerRestrictionRanges: makeOsrdConfSelector('powerRestrictionRanges'),
+    getTrainScheduleIDsToModify: makeOsrdConfSelector('trainScheduleIDsToModify'),
+  };
+};
+
+export default buildCommonConfSelectors;

--- a/front/src/reducers/osrdconf2/common/testUtils.ts
+++ b/front/src/reducers/osrdconf2/common/testUtils.ts
@@ -1,0 +1,673 @@
+import {
+  OsrdConfState,
+  PointOnMap,
+  PowerRestrictionRange,
+} from 'applications/operationalStudies/consts';
+import { Allowance, Path } from 'common/api/osrdEditoastApi';
+import { omit } from 'lodash';
+import { createStoreWithoutMiddleware } from 'Store';
+import { SwitchType } from 'types';
+import { defaultCommonConf } from '.';
+import { simulationConfSliceType } from '../simulationConf';
+import { stdcmConfSliceType } from '../stdcmConf';
+
+function createStore(
+  slice: simulationConfSliceType | stdcmConfSliceType,
+  initialStateExtra: Partial<OsrdConfState> = {}
+) {
+  return createStoreWithoutMiddleware({
+    [slice.name]: { ...defaultCommonConf, ...initialStateExtra },
+  });
+}
+
+function osrdCommonConfTestDataBuilder() {
+  return {
+    buildEngineeringAllowance: (): Allowance => ({
+      allowance_type: 'engineering',
+      capacity_speed_limit: 5,
+      distribution: 'MARECO',
+      begin_position: 2,
+      end_position: 4,
+      value: {
+        value_type: 'time_per_distance',
+        minutes: 3,
+      },
+    }),
+    buildStandardAllowance: (): Allowance => ({
+      allowance_type: 'standard',
+      capacity_speed_limit: 5,
+      distribution: 'LINEAR',
+      ranges: [
+        {
+          begin_position: 1,
+          end_position: 2,
+          value: {
+            value_type: 'time',
+            seconds: 10,
+          },
+        },
+      ],
+      default_value: {
+        value_type: 'time_per_distance',
+        minutes: 3,
+      },
+    }),
+    buildWitchTypes: (): SwitchType => ({
+      id: 'test-id',
+      ports: ['A', 'B', 'C'],
+      groups: {
+        A: [
+          {
+            src: 'source',
+            dst: 'destination',
+            bidirectionnal: false,
+          },
+        ],
+      },
+    }),
+    buildPointOnMap: (fields?: Partial<PointOnMap>): PointOnMap => ({
+      id: 'test',
+      name: 'point',
+      ...fields,
+    }),
+    buildGeoJson: (): Path => ({
+      created: '10/10/2023',
+      curves: [{ position: 10, radius: 2 }],
+      geographic: {
+        coordinates: [
+          [1, 2],
+          [3, 4],
+        ],
+        type: 'type-test',
+      },
+      id: 1,
+      length: 10,
+      owner: 'test',
+      schematic: {
+        coordinates: [
+          [1, 2],
+          [3, 4],
+        ],
+        type: 'type-test',
+      },
+      slopes: [
+        {
+          gradient: 5,
+          position: 2,
+        },
+      ],
+      steps: [
+        {
+          duration: 2,
+          geo: {
+            coordinates: [1, 2],
+            type: 'type-test',
+          },
+          id: 'toto',
+          location: {
+            offset: 12,
+            track_section: 'iti',
+          },
+          name: 'test',
+          path_offset: 42,
+          sch: {
+            coordinates: [1, 2],
+            type: 'type-test',
+          },
+          suggestion: true,
+        },
+      ],
+    }),
+    buildFeatureInfoClick: (
+      featureInfoClickFields?: Partial<OsrdConfState['featureInfoClick']>
+    ): OsrdConfState['featureInfoClick'] => ({
+      displayPopup: true,
+      ...featureInfoClickFields,
+    }),
+    buildPowerRestrictionRanges: (): PowerRestrictionRange[] => [
+      {
+        value: 'test',
+        begin: 1,
+        end: 2,
+      },
+    ],
+  };
+}
+
+const testCommonReducers = (slice: simulationConfSliceType | stdcmConfSliceType) => {
+  const testDataBuilder = osrdCommonConfTestDataBuilder();
+
+  it('should handle updateName', () => {
+    const store = createStore(slice);
+    const newName = 'New Simulation Name';
+    store.dispatch(slice.actions.updateName(newName));
+
+    const state = store.getState()[slice.name];
+    expect(state.name).toBe(newName);
+  });
+
+  it('should handle updateTrainCount', () => {
+    const store = createStore(slice);
+    const newTrainCount = 5;
+    store.dispatch(slice.actions.updateTrainCount(newTrainCount));
+
+    const state = store.getState()[slice.name];
+    expect(state.trainCount).toBe(newTrainCount);
+  });
+
+  it('should handle update', () => {
+    const store = createStore(slice);
+    const newTrainDelta = 5;
+    store.dispatch(slice.actions.updateTrainDelta(newTrainDelta));
+
+    const state = store.getState()[slice.name];
+    expect(state.trainDelta).toBe(newTrainDelta);
+  });
+
+  it('should handle updateTrainStep', () => {
+    const store = createStore(slice);
+    const newTrainStep = 5;
+    store.dispatch(slice.actions.updateTrainStep(newTrainStep));
+
+    const state = store.getState()[slice.name];
+    expect(state.trainStep).toBe(newTrainStep);
+  });
+
+  it('should handle updateAllowances', () => {
+    const store = createStore(slice);
+    const newAllowances: Allowance[] = [
+      testDataBuilder.buildEngineeringAllowance(),
+      testDataBuilder.buildStandardAllowance(),
+    ];
+    store.dispatch(slice.actions.updateAllowances(newAllowances));
+
+    const state = store.getState()[slice.name];
+    expect(state.allowances).toBe(newAllowances);
+  });
+
+  it('should handle toggleUsingElectricalProfiles', () => {
+    const store = createStore(slice);
+    store.dispatch(slice.actions.toggleUsingElectricalProfiles());
+
+    let state = store.getState()[slice.name];
+    expect(state.usingElectricalProfiles).toBe(false);
+
+    store.dispatch(slice.actions.toggleUsingElectricalProfiles());
+    state = store.getState()[slice.name];
+    expect(state.usingElectricalProfiles).toBe(true);
+  });
+
+  it('should handle updateLabels', () => {
+    const store = createStore(slice);
+    const newLabels = ['A', 'B'];
+    store.dispatch(slice.actions.updateLabels(newLabels));
+    const state = store.getState()[slice.name];
+    expect(state.labels).toBe(newLabels);
+  });
+
+  it('should handle updateProjectID', () => {
+    const store = createStore(slice);
+    const newProjectID = 5;
+    store.dispatch(slice.actions.updateProjectID(newProjectID));
+    const state = store.getState()[slice.name];
+    expect(state.projectID).toBe(newProjectID);
+  });
+
+  it('should handle updateStudyID', () => {
+    const store = createStore(slice);
+    const newStudyID = 5;
+    store.dispatch(slice.actions.updateStudyID(newStudyID));
+    const state = store.getState()[slice.name];
+    expect(state.studyID).toBe(newStudyID);
+  });
+
+  it('should handle updateScenarioID', () => {
+    const store = createStore(slice);
+    const newScenarioID = 5;
+    store.dispatch(slice.actions.updateScenarioID(newScenarioID));
+    const state = store.getState()[slice.name];
+    expect(state.scenarioID).toBe(newScenarioID);
+  });
+
+  describe('should handle updateInfraID', () => {
+    it('should update infraID', () => {
+      const store = createStore(slice);
+      const newInfraID = 5;
+      store.dispatch(slice.actions.updateInfraID(newInfraID));
+      const state = store.getState()[slice.name];
+      expect(state.infraID).toBe(newInfraID);
+    });
+  });
+
+  it('should handle updateSwitchTypes', () => {
+    const store = createStore(slice);
+    const newSwitchTypes: SwitchType[] = [testDataBuilder.buildWitchTypes()];
+    store.dispatch(slice.actions.updateSwitchTypes(newSwitchTypes));
+    const state = store.getState()[slice.name];
+    expect(state.switchTypes).toBe(newSwitchTypes);
+  });
+
+  it('should handle updatePathfindingID', () => {
+    const store = createStore(slice);
+    const newPathfindingID = 1;
+    store.dispatch(slice.actions.updatePathfindingID(newPathfindingID));
+    const state = store.getState()[slice.name];
+    expect(state.pathfindingID).toBe(newPathfindingID);
+    expect(state.powerRestrictionRanges).toStrictEqual([]);
+  });
+
+  it('should handle updateShouldRunPathfinding', () => {
+    const store = createStore(slice);
+    const newShouldRunPathfinding = false;
+    store.dispatch(slice.actions.updateShouldRunPathfinding(newShouldRunPathfinding));
+    const state = store.getState()[slice.name];
+    expect(state.shouldRunPathfinding).toBe(newShouldRunPathfinding);
+  });
+
+  it('should handle updateTimetableID', () => {
+    const store = createStore(slice);
+    const newTimetableID = 1;
+    store.dispatch(slice.actions.updateTimetableID(newTimetableID));
+    const state = store.getState()[slice.name];
+    expect(state.timetableID).toBe(newTimetableID);
+  });
+
+  it('should handle updateRollingStockID', () => {
+    const store = createStore(slice);
+    const newRollingStockID = 1;
+    store.dispatch(slice.actions.updateRollingStockID(newRollingStockID));
+    const state = store.getState()[slice.name];
+    expect(state.rollingStockID).toBe(newRollingStockID);
+  });
+
+  it('should handle updateRollingStockComfort', () => {
+    const store = createStore(slice);
+    const newRollingStockComfort = 'AC';
+    store.dispatch(slice.actions.updateRollingStockComfort(newRollingStockComfort));
+    const state = store.getState()[slice.name];
+    expect(state.rollingStockComfort).toBe(newRollingStockComfort);
+  });
+
+  it('should handle updateSpeedLimitByTag', () => {
+    const store = createStore(slice);
+    const newSpeedLimitByTag = 'test-tag';
+    store.dispatch(slice.actions.updateSpeedLimitByTag(newSpeedLimitByTag));
+    const state = store.getState()[slice.name];
+    expect(state.speedLimitByTag).toBe(newSpeedLimitByTag);
+  });
+
+  it('should handle updateOrigin', () => {
+    const store = createStore(slice);
+    const newOrigin = testDataBuilder.buildPointOnMap();
+    store.dispatch(slice.actions.updateOrigin(newOrigin));
+    const state = store.getState()[slice.name];
+    expect(state.origin).toBe(newOrigin);
+  });
+
+  it('should handle updateInitialSpeed', () => {
+    const store = createStore(slice);
+    const newInitialSpeed = 50;
+    store.dispatch(slice.actions.updateInitialSpeed(newInitialSpeed));
+    const state = store.getState()[slice.name];
+    expect(state.initialSpeed).toBe(newInitialSpeed);
+  });
+
+  it('should handle updateDepartureTime', () => {
+    const store = createStore(slice);
+    const newDepartureTime = '09:00:00';
+    store.dispatch(slice.actions.updateDepartureTime(newDepartureTime));
+    const state = store.getState()[slice.name];
+    expect(state.departureTime).toBe(newDepartureTime);
+  });
+
+  describe('should handle updateOriginTime', () => {
+    it('should update only itself if not linked', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: false,
+        originUpperBoundTime: '15:30:00',
+        originTime: '11:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginTime('08:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('08:00:00');
+      expect(state.originUpperBoundTime).toBe('15:30:00');
+    });
+
+    it('should update originUpperBoundTime if linked, and keep the difference between the two', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originUpperBoundTime: '15:30:00',
+        originTime: '11:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginTime('08:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('08:00:00');
+      expect(state.originUpperBoundTime).toBe('12:30:00');
+    });
+
+    it('should use the default difference when originTime is not defined', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originUpperBoundTime: '15:30:00',
+        originTime: undefined,
+      });
+
+      store.dispatch(slice.actions.updateOriginTime('08:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('08:00:00');
+      expect(state.originUpperBoundTime).toBe('10:00:00');
+    });
+
+    it('should use the default difference when originUpperBoundTime is not defined', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originUpperBoundTime: undefined,
+        originTime: '10:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginTime('08:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('08:00:00');
+      expect(state.originUpperBoundTime).toBe('10:00:00');
+    });
+
+    it('lower bound should not go above upper bound when unlinked', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: false,
+        originUpperBoundTime: '12:00:00',
+        originTime: '10:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginTime('13:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('12:00:00');
+      expect(state.originUpperBoundTime).toBe('12:00:00');
+    });
+  });
+
+  describe('should handle updateOriginUpperBoundTime', () => {
+    it('should update only itself if not linked', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: false,
+        originTime: '11:00:00',
+        originUpperBoundTime: '15:30:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginUpperBoundTime('20:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('11:00:00');
+      expect(state.originUpperBoundTime).toBe('20:00:00');
+    });
+
+    it('should update originTime if linked, keeping the current difference between the two', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originTime: '11:00:00',
+        originUpperBoundTime: '14:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginUpperBoundTime('20:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('17:00:00');
+      expect(state.originUpperBoundTime).toBe('20:00:00');
+    });
+
+    it('should use default difference if originTime not defined', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originTime: undefined,
+        originUpperBoundTime: '14:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginUpperBoundTime('20:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('18:00:00');
+      expect(state.originUpperBoundTime).toBe('20:00:00');
+    });
+
+    it('should use default difference if originUpperBoundTime not defined', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: true,
+        originUpperBoundTime: undefined,
+      });
+
+      store.dispatch(slice.actions.updateOriginUpperBoundTime('20:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('18:00:00');
+      expect(state.originUpperBoundTime).toBe('20:00:00');
+    });
+
+    it('upper bound should not go below lower bonud when unlinked', () => {
+      const store = createStore(slice, {
+        originLinkedBounds: false,
+        originTime: '14:00:00',
+        originUpperBoundTime: '18:00:00',
+      });
+
+      store.dispatch(slice.actions.updateOriginUpperBoundTime('12:00:00'));
+
+      const state = store.getState()[slice.name];
+      expect(state.originTime).toBe('14:00:00');
+      expect(state.originUpperBoundTime).toBe('14:00:00');
+    });
+  });
+
+  describe('should handle toggleOriginLinkedBounds', () => {
+    it('set to false if true ', () => {
+      const store = createStore(slice, { originLinkedBounds: true });
+      store.dispatch(slice.actions.toggleOriginLinkedBounds());
+      const state = store.getState()[slice.name];
+      expect(state.originLinkedBounds).toBe(false);
+    });
+
+    it('set to true if false ', () => {
+      const store = createStore(slice, { originLinkedBounds: false });
+
+      store.dispatch(slice.actions.toggleOriginLinkedBounds());
+      const state = store.getState()[slice.name];
+      expect(state.originLinkedBounds).toBe(true);
+    });
+  });
+
+  it('should handle updateOriginDate', () => {
+    const store = createStore(slice);
+    const newOriginDate = '13/12/2023';
+    store.dispatch(slice.actions.updateOriginDate(newOriginDate));
+    const state = store.getState()[slice.name];
+    expect(state.originDate).toBe(newOriginDate);
+  });
+
+  it('should handle updateOriginUpperBoundDate', () => {
+    const store = createStore(slice);
+    const newOriginUpperBoundDate = '13/12/2023';
+    store.dispatch(slice.actions.updateOriginUpperBoundDate(newOriginUpperBoundDate));
+    const state = store.getState()[slice.name];
+    expect(state.originUpperBoundDate).toBe(newOriginUpperBoundDate);
+  });
+
+  it('should handle replaceVias', () => {
+    const store = createStore(slice);
+    const newVias: PointOnMap[] = [testDataBuilder.buildPointOnMap()];
+    store.dispatch(slice.actions.replaceVias(newVias));
+    const state = store.getState()[slice.name];
+    expect(state.vias).toBe(newVias);
+  });
+
+  it('should handle updateVias', () => {
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const store = createStore(slice, {
+      vias: [via1],
+    });
+
+    store.dispatch(slice.actions.updateVias(via2));
+    const state = store.getState()[slice.name];
+    expect(state.vias).toStrictEqual([via1, via2]);
+  });
+
+  it('should handle updateViaStopTime', () => {
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const vias = [via1, via2];
+    const store = createStore(slice, { vias });
+
+    store.dispatch(slice.actions.updateViaStopTime(vias, 0, 5));
+    const state = store.getState()[slice.name];
+    expect(state.vias).toStrictEqual([
+      { id: 'via-1', name: 'point', duration: 5 },
+      { id: 'via-2', name: 'point' },
+    ] as PointOnMap[]);
+  });
+
+  it('should handle permuteVias', () => {
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const vias = [via1, via2];
+    const store = createStore(slice, { vias });
+
+    store.dispatch(slice.actions.permuteVias(vias, 0, 1));
+    const state = store.getState()[slice.name];
+    expect(state.vias).toStrictEqual([
+      { id: 'via-2', name: 'point' },
+      { id: 'via-1', name: 'point' },
+    ] as PointOnMap[]);
+  });
+
+  it('should handle updateSuggeredVias', () => {
+    const store = createStore(slice);
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const vias = [via1, via2];
+    store.dispatch(slice.actions.updateSuggeredVias(vias));
+    const state = store.getState()[slice.name];
+    expect(state.suggeredVias).toStrictEqual(vias);
+  });
+
+  it('should handle deleteVias', () => {
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const vias = [via1, via2];
+    const store = createStore(slice, { vias });
+
+    store.dispatch(slice.actions.deleteVias(0));
+    const state = store.getState()[slice.name];
+    expect(state.vias).toStrictEqual([via2]);
+  });
+
+  it('should handle deleteItinerary', () => {
+    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
+    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    const vias = [via1, via2];
+
+    const store = createStore(slice, {
+      origin: via1,
+      vias,
+      destination: via2,
+      geojson: testDataBuilder.buildGeoJson(),
+      originTime: '08:00:00',
+      pathfindingID: 1,
+    });
+
+    store.dispatch(slice.actions.deleteItinerary());
+    const state = store.getState()[slice.name];
+    expect(state.origin).toBe(undefined);
+    expect(state.vias).toStrictEqual([]);
+    expect(state.destination).toBe(undefined);
+    expect(state.geojson).toBe(undefined);
+    expect(state.originTime).toBe(undefined);
+    expect(state.pathfindingID).toBe(undefined);
+  });
+
+  it('should handle destination', () => {
+    const store = createStore(slice);
+    const newDestination = testDataBuilder.buildPointOnMap({ id: 'via-2' });
+    store.dispatch(slice.actions.updateDestination(newDestination));
+    const state = store.getState()[slice.name];
+    expect(state.destination).toBe(newDestination);
+  });
+
+  it('should handle updateDestinationDate', () => {
+    const store = createStore(slice);
+    const newDestinationDate = '10/10/2023';
+    store.dispatch(slice.actions.updateDestinationDate(newDestinationDate));
+    const state = store.getState()[slice.name];
+    expect(state.destinationDate).toBe(newDestinationDate);
+  });
+
+  it('should handle updateDestinationTime', () => {
+    const store = createStore(slice);
+    const newDestinationTime = '10:10:30';
+    store.dispatch(slice.actions.updateDestinationTime(newDestinationTime));
+    const state = store.getState()[slice.name];
+    expect(state.destinationTime).toBe(newDestinationTime);
+  });
+
+  it('should handle updateItinerary', () => {
+    const store = createStore(slice);
+    const newItinerary = testDataBuilder.buildGeoJson();
+    store.dispatch(slice.actions.updateItinerary(newItinerary));
+    const state = store.getState()[slice.name];
+    expect(state.geojson).toBe(newItinerary);
+  });
+
+  it('should handle updateFeatureInfoClickOSRD', () => {
+    const initialFeatureInfoClick = testDataBuilder.buildFeatureInfoClick({
+      displayPopup: true,
+    });
+    const store = createStore(slice, {
+      featureInfoClick: initialFeatureInfoClick,
+    });
+    const newfeatureClick = testDataBuilder.buildFeatureInfoClick({
+      displayPopup: false,
+      feature: omit(initialFeatureInfoClick.feature, ['_vectorTileFeature']),
+    });
+    store.dispatch(slice.actions.updateFeatureInfoClickOSRD(newfeatureClick));
+    const state = store.getState()[slice.name];
+    expect(state.featureInfoClick).toStrictEqual(newfeatureClick);
+  });
+
+  it('should handle updateGridMarginBefore', () => {
+    const store = createStore(slice);
+    const newGridMarginBefore = 5;
+    store.dispatch(slice.actions.updateGridMarginBefore(newGridMarginBefore));
+    const state = store.getState()[slice.name];
+    expect(state.gridMarginBefore).toStrictEqual(newGridMarginBefore);
+  });
+
+  it('should handle updateGridMarginAfter', () => {
+    const store = createStore(slice);
+    const newGridMarginAfter = 5;
+    store.dispatch(slice.actions.updateGridMarginAfter(newGridMarginAfter));
+    const state = store.getState()[slice.name];
+    expect(state.gridMarginAfter).toStrictEqual(newGridMarginAfter);
+  });
+
+  it('should handle updatePowerRestrictionRanges', () => {
+    const store = createStore(slice);
+    const newPowerRestrictionRanges = testDataBuilder.buildPowerRestrictionRanges();
+    store.dispatch(slice.actions.updatePowerRestrictionRanges(newPowerRestrictionRanges));
+    const state = store.getState()[slice.name];
+    expect(state.powerRestrictionRanges).toStrictEqual(newPowerRestrictionRanges);
+  });
+
+  it('should handle updateTrainScheduleIDsToModify', () => {
+    const store = createStore(slice);
+    const newTrainScheduleIDsToModify = [10, 2];
+    store.dispatch(slice.actions.updateTrainScheduleIDsToModify(newTrainScheduleIDsToModify));
+    const state = store.getState()[slice.name];
+    expect(state.trainScheduleIDsToModify).toStrictEqual(newTrainScheduleIDsToModify);
+  });
+};
+
+export default testCommonReducers;

--- a/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
@@ -1,0 +1,142 @@
+import {
+  OsrdConfState,
+  PointOnMap,
+  PowerRestrictionRange,
+} from 'applications/operationalStudies/consts';
+import { Allowance, Path } from 'common/api/osrdEditoastApi';
+import { Feature } from 'geojson';
+import { SwitchType } from 'types';
+
+export default function commonConfBuilder() {
+  return {
+    buildEngineeringAllowance: (): Allowance => ({
+      allowance_type: 'engineering',
+      capacity_speed_limit: 5,
+      distribution: 'MARECO',
+      begin_position: 2,
+      end_position: 4,
+      value: {
+        value_type: 'time_per_distance',
+        minutes: 3,
+      },
+    }),
+    buildStandardAllowance: (): Allowance => ({
+      allowance_type: 'standard',
+      capacity_speed_limit: 5,
+      distribution: 'LINEAR',
+      ranges: [
+        {
+          begin_position: 1,
+          end_position: 2,
+          value: {
+            value_type: 'time',
+            seconds: 10,
+          },
+        },
+      ],
+      default_value: {
+        value_type: 'time_per_distance',
+        minutes: 3,
+      },
+    }),
+    buildWitchType: (): SwitchType => ({
+      id: 'test-id',
+      ports: ['A', 'B', 'C'],
+      groups: {
+        A: [
+          {
+            src: 'source',
+            dst: 'destination',
+            bidirectionnal: false,
+          },
+        ],
+      },
+    }),
+    buildPointOnMap: (fields?: Partial<PointOnMap>): PointOnMap => ({
+      id: 'test',
+      name: 'point',
+      ...fields,
+    }),
+    buildGeoJson: (): Path => ({
+      created: '10/10/2023',
+      curves: [{ position: 10, radius: 2 }],
+      geographic: {
+        coordinates: [
+          [1, 2],
+          [3, 4],
+        ],
+        type: 'type-test',
+      },
+      id: 1,
+      length: 10,
+      owner: 'test',
+      schematic: {
+        coordinates: [
+          [1, 2],
+          [3, 4],
+        ],
+        type: 'type-test',
+      },
+      slopes: [
+        {
+          gradient: 5,
+          position: 2,
+        },
+      ],
+      steps: [
+        {
+          duration: 2,
+          geo: {
+            coordinates: [1, 2],
+            type: 'type-test',
+          },
+          id: 'toto',
+          location: {
+            offset: 12,
+            track_section: 'iti',
+          },
+          name: 'test',
+          path_offset: 42,
+          sch: {
+            coordinates: [1, 2],
+            type: 'type-test',
+          },
+          suggestion: true,
+        },
+      ],
+    }),
+    buildFeatureInfoClick: (
+      featureInfoClickFields?: Partial<OsrdConfState['featureInfoClick']>
+    ): OsrdConfState['featureInfoClick'] => ({
+      displayPopup: true,
+      feature: {
+        type: 'Feature',
+        _geometry: {
+          type: 'LineString',
+          coordinates: [12, 45],
+        },
+        properties: {
+          title: 'test',
+          toto: 'toto',
+        },
+        id: 'test',
+        _vectorTileFeature: {
+          id: 10,
+          type: 1,
+          extent: 15,
+          properties: {
+            name: 'test',
+          },
+        },
+      } as unknown as Feature,
+      ...featureInfoClickFields,
+    }),
+    buildPowerRestrictionRanges: (): PowerRestrictionRange[] => [
+      {
+        value: 'test',
+        begin: 1,
+        end: 2,
+      },
+    ],
+  };
+}

--- a/front/src/reducers/osrdconf2/simulationConf/index.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/index.ts
@@ -1,28 +1,16 @@
-import { createSlice, ListenerMiddlewareInstance } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import { OsrdConfState } from 'applications/operationalStudies/consts';
-import {
-  defaultCommonConf,
-  buildCommonOsrdConfReducers,
-  addCommonOsrdConfMatchers,
-  registerUpdateInfraIDListener,
-} from '../common';
+import { defaultCommonConf, buildCommonConfReducers } from '../common';
 
 export const simulationConfInitialState = defaultCommonConf;
 
 export const simulationConfSlice = createSlice({
-  name: 'simulationconf',
+  name: 'simulationConf',
   initialState: simulationConfInitialState,
-  reducers: { ...buildCommonOsrdConfReducers<OsrdConfState>() },
-  extraReducers: (builder) => {
-    addCommonOsrdConfMatchers(builder);
-  },
+  reducers: { ...buildCommonConfReducers<OsrdConfState>() },
 });
 
 export const simulationConfSliceActions = simulationConfSlice.actions;
-
-export function registerSimulationUpdateInfraIDListeners(listener: ListenerMiddlewareInstance) {
-  registerUpdateInfraIDListener(listener, simulationConfSliceActions.updateInfraID);
-}
 
 export type simulationConfSliceType = typeof simulationConfSlice;
 

--- a/front/src/reducers/osrdconf2/simulationConf/index.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/index.ts
@@ -1,0 +1,31 @@
+import { createSlice, ListenerMiddlewareInstance } from '@reduxjs/toolkit';
+import { OsrdConfState } from 'applications/operationalStudies/consts';
+import {
+  defaultCommonConf,
+  buildCommonOsrdConfReducers,
+  addCommonOsrdConfMatchers,
+  registerUpdateInfraIDListener,
+} from '../common';
+
+export const simulationConfInitialState = defaultCommonConf;
+
+export const simulationConfSlice = createSlice({
+  name: 'simulationconf',
+  initialState: simulationConfInitialState,
+  reducers: { ...buildCommonOsrdConfReducers<OsrdConfState>() },
+  extraReducers: (builder) => {
+    addCommonOsrdConfMatchers(builder);
+  },
+});
+
+export const simulationConfSliceActions = simulationConfSlice.actions;
+
+export function registerSimulationUpdateInfraIDListeners(listener: ListenerMiddlewareInstance) {
+  registerUpdateInfraIDListener(listener, simulationConfSliceActions.updateInfraID);
+}
+
+export type simulationConfSliceType = typeof simulationConfSlice;
+
+export type simulationConfSliceActionsType = typeof simulationConfSliceActions;
+
+export default simulationConfSlice.reducer;

--- a/front/src/reducers/osrdconf2/simulationConf/selectors.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/selectors.ts
@@ -1,0 +1,8 @@
+import { simulationConfSlice } from '.';
+import buildCommonConfSelectors from '../common/selectors';
+
+const selectors = buildCommonConfSelectors(simulationConfSlice);
+
+export type simulationConfSelectorsType = ReturnType<typeof buildCommonConfSelectors>;
+
+export default selectors;

--- a/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
@@ -1,0 +1,21 @@
+import { OsrdConfState } from 'applications/operationalStudies/consts';
+import { createStoreWithoutMiddleware } from 'Store';
+
+import { describe, expect } from 'vitest';
+import { simulationConfInitialState, simulationConfSlice } from '.';
+import testCommonReducers from '../common/testUtils';
+
+const createStore = (initialStateExtra?: OsrdConfState) =>
+  createStoreWithoutMiddleware({
+    simulationconf: initialStateExtra,
+  });
+
+describe('simulationConfReducer', () => {
+  it('should return initial state', () => {
+    const store = createStore();
+    const state = store.getState().simulationconf;
+    expect(state).toEqual(simulationConfInitialState);
+  });
+
+  testCommonReducers(simulationConfSlice);
+});

--- a/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
@@ -3,19 +3,19 @@ import { createStoreWithoutMiddleware } from 'Store';
 
 import { describe, expect } from 'vitest';
 import { simulationConfInitialState, simulationConfSlice } from '.';
-import testCommonReducers from '../common/testUtils';
+import testCommonConfReducers from '../common/tests/utils';
 
 const createStore = (initialStateExtra?: OsrdConfState) =>
   createStoreWithoutMiddleware({
-    simulationconf: initialStateExtra,
+    [simulationConfSlice.name]: initialStateExtra,
   });
 
 describe('simulationConfReducer', () => {
   it('should return initial state', () => {
     const store = createStore();
-    const state = store.getState().simulationconf;
+    const state = store.getState()[simulationConfSlice.name];
     expect(state).toEqual(simulationConfInitialState);
   });
 
-  testCommonReducers(simulationConfSlice);
+  testCommonConfReducers(simulationConfSlice);
 });

--- a/front/src/reducers/osrdconf2/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/index.ts
@@ -1,0 +1,57 @@
+import { createSlice, ListenerMiddlewareInstance, PayloadAction } from '@reduxjs/toolkit';
+import { DEFAULT_STDCM_MODE, OsrdStdcmConfState } from 'applications/operationalStudies/consts';
+import { Draft } from 'immer';
+import {
+  defaultCommonConf,
+  buildCommonOsrdConfReducers,
+  registerUpdateInfraIDListener,
+  addCommonOsrdConfMatchers,
+} from '../common';
+
+export const stdcmConfInitialState: OsrdStdcmConfState = {
+  maximumRunTime: 43200,
+  stdcmMode: DEFAULT_STDCM_MODE,
+  standardStdcmAllowance: undefined,
+  ...defaultCommonConf,
+};
+
+export const stdcmConfSlice = createSlice({
+  name: 'stdcmconf',
+  initialState: stdcmConfInitialState,
+  reducers: {
+    ...buildCommonOsrdConfReducers<OsrdStdcmConfState>(),
+    updateMaximumRunTime(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['maximumRunTime']>
+    ) {
+      state.maximumRunTime = action.payload;
+    },
+    updateStdcmMode(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['stdcmMode']>
+    ) {
+      state.stdcmMode = action.payload;
+    },
+    updateStdcmStandardAllowance(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['standardStdcmAllowance']>
+    ) {
+      state.standardStdcmAllowance = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    addCommonOsrdConfMatchers(builder);
+  },
+});
+
+export const stdcmConfSliceActions = stdcmConfSlice.actions;
+
+export function registerStdcmUpdateInfraIDListeners(listener: ListenerMiddlewareInstance) {
+  registerUpdateInfraIDListener(listener, stdcmConfSliceActions.updateInfraID);
+}
+
+export type stdcmConfSliceType = typeof stdcmConfSlice;
+
+export type stdcmConfSliceActionsType = typeof stdcmConfSliceActions;
+
+export default stdcmConfSlice.reducer;

--- a/front/src/reducers/osrdconf2/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/index.ts
@@ -1,12 +1,7 @@
-import { createSlice, ListenerMiddlewareInstance, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { DEFAULT_STDCM_MODE, OsrdStdcmConfState } from 'applications/operationalStudies/consts';
 import { Draft } from 'immer';
-import {
-  defaultCommonConf,
-  buildCommonOsrdConfReducers,
-  registerUpdateInfraIDListener,
-  addCommonOsrdConfMatchers,
-} from '../common';
+import { defaultCommonConf, buildCommonConfReducers } from '../common';
 
 export const stdcmConfInitialState: OsrdStdcmConfState = {
   maximumRunTime: 43200,
@@ -16,10 +11,10 @@ export const stdcmConfInitialState: OsrdStdcmConfState = {
 };
 
 export const stdcmConfSlice = createSlice({
-  name: 'stdcmconf',
+  name: 'stdcmConf',
   initialState: stdcmConfInitialState,
   reducers: {
-    ...buildCommonOsrdConfReducers<OsrdStdcmConfState>(),
+    ...buildCommonConfReducers<OsrdStdcmConfState>(),
     updateMaximumRunTime(
       state: Draft<OsrdStdcmConfState>,
       action: PayloadAction<OsrdStdcmConfState['maximumRunTime']>
@@ -39,16 +34,9 @@ export const stdcmConfSlice = createSlice({
       state.standardStdcmAllowance = action.payload;
     },
   },
-  extraReducers: (builder) => {
-    addCommonOsrdConfMatchers(builder);
-  },
 });
 
 export const stdcmConfSliceActions = stdcmConfSlice.actions;
-
-export function registerStdcmUpdateInfraIDListeners(listener: ListenerMiddlewareInstance) {
-  registerUpdateInfraIDListener(listener, stdcmConfSliceActions.updateInfraID);
-}
 
 export type stdcmConfSliceType = typeof stdcmConfSlice;
 

--- a/front/src/reducers/osrdconf2/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/selectors.ts
@@ -1,0 +1,15 @@
+import { RootState } from 'reducers';
+import { stdcmConfSlice } from '.';
+import buildCommonConfSelectors from '../common/selectors';
+
+const selectors = {
+  ...buildCommonConfSelectors(stdcmConfSlice),
+  getStdcmMode: (state: RootState) => state[stdcmConfSlice.name].stdcmMode,
+  getStandardStdcmAllowance: (state: RootState) =>
+    state[stdcmConfSlice.name].standardStdcmAllowance,
+  getMaximumRunTime: (state: RootState) => state[stdcmConfSlice.name].maximumRunTime,
+};
+
+export type stdcmConfSelectorsType = typeof selectors;
+
+export default selectors;

--- a/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
@@ -1,0 +1,74 @@
+import {
+  OsrdStdcmConfState,
+  StandardAllowance,
+  STDCM_MODES,
+} from 'applications/operationalStudies/consts';
+import { createStoreWithoutMiddleware } from 'Store';
+
+import { describe, expect } from 'vitest';
+import { stdcmConfInitialState, stdcmConfSlice, stdcmConfSliceActions } from '.';
+import testCommonReducers from '../common/testUtils';
+
+const createStore = (initialStateExtra?: Partial<OsrdStdcmConfState>) =>
+  createStoreWithoutMiddleware({
+    simulationconf: {
+      ...stdcmConfInitialState,
+      ...initialStateExtra,
+    },
+  });
+
+function stdcmConfTestDataBuilder() {
+  return {
+    buildPercentageStandardAllowance: (value: number): StandardAllowance => ({
+      value,
+      type: 'percentage',
+    }),
+    buildTimeStandardAllowance: (value: number): StandardAllowance => ({
+      value,
+      type: 'time',
+    }),
+  };
+}
+
+describe('stdcmConfReducers', () => {
+  const testDataBuilder = stdcmConfTestDataBuilder();
+
+  it('should return initial state', () => {
+    const store = createStore();
+    const state = store.getState().stdcmconf;
+    expect(state).toEqual(stdcmConfInitialState);
+  });
+
+  it('should handle updateMaximumRunTime', () => {
+    const store = createStore();
+    const newMaximumRunTime = 10;
+    store.dispatch(stdcmConfSliceActions.updateMaximumRunTime(newMaximumRunTime));
+
+    const state = store.getState().stdcmconf;
+    expect(state.maximumRunTime).toBe(newMaximumRunTime);
+  });
+
+  it('should handle updateStdcmMode', () => {
+    const store = createStore({
+      stdcmMode: STDCM_MODES.byDestination,
+    });
+    const newStdcmMode = STDCM_MODES.byOrigin;
+    store.dispatch(stdcmConfSliceActions.updateStdcmMode(newStdcmMode));
+
+    const state = store.getState().stdcmconf;
+    expect(state.stdcmMode).toBe(newStdcmMode);
+  });
+
+  it('should handle updateStdcmStandardAllowance', () => {
+    const store = createStore({
+      standardStdcmAllowance: testDataBuilder.buildTimeStandardAllowance(10),
+    });
+    const newStdcmMode = testDataBuilder.buildPercentageStandardAllowance(5);
+    store.dispatch(stdcmConfSliceActions.updateStdcmStandardAllowance(newStdcmMode));
+
+    const state = store.getState().stdcmconf;
+    expect(state.standardStdcmAllowance).toBe(newStdcmMode);
+  });
+
+  testCommonReducers(stdcmConfSlice);
+});

--- a/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
@@ -7,11 +7,11 @@ import { createStoreWithoutMiddleware } from 'Store';
 
 import { describe, expect } from 'vitest';
 import { stdcmConfInitialState, stdcmConfSlice, stdcmConfSliceActions } from '.';
-import testCommonReducers from '../common/testUtils';
+import testCommonConfReducers from '../common/tests/utils';
 
 const createStore = (initialStateExtra?: Partial<OsrdStdcmConfState>) =>
   createStoreWithoutMiddleware({
-    simulationconf: {
+    [stdcmConfSlice.name]: {
       ...stdcmConfInitialState,
       ...initialStateExtra,
     },
@@ -35,7 +35,7 @@ describe('stdcmConfReducers', () => {
 
   it('should return initial state', () => {
     const store = createStore();
-    const state = store.getState().stdcmconf;
+    const state = store.getState()[stdcmConfSlice.name];
     expect(state).toEqual(stdcmConfInitialState);
   });
 
@@ -44,7 +44,7 @@ describe('stdcmConfReducers', () => {
     const newMaximumRunTime = 10;
     store.dispatch(stdcmConfSliceActions.updateMaximumRunTime(newMaximumRunTime));
 
-    const state = store.getState().stdcmconf;
+    const state = store.getState()[stdcmConfSlice.name];
     expect(state.maximumRunTime).toBe(newMaximumRunTime);
   });
 
@@ -52,23 +52,32 @@ describe('stdcmConfReducers', () => {
     const store = createStore({
       stdcmMode: STDCM_MODES.byDestination,
     });
+
+    const stateBefore = store.getState()[stdcmConfSlice.name];
+    expect(stateBefore.stdcmMode).toBe(STDCM_MODES.byDestination);
+
     const newStdcmMode = STDCM_MODES.byOrigin;
     store.dispatch(stdcmConfSliceActions.updateStdcmMode(newStdcmMode));
 
-    const state = store.getState().stdcmconf;
-    expect(state.stdcmMode).toBe(newStdcmMode);
+    const stateAfter = store.getState()[stdcmConfSlice.name];
+    expect(stateAfter.stdcmMode).toBe(newStdcmMode);
   });
 
   it('should handle updateStdcmStandardAllowance', () => {
+    const initialTimeStandardAllowance = testDataBuilder.buildTimeStandardAllowance(10);
     const store = createStore({
-      standardStdcmAllowance: testDataBuilder.buildTimeStandardAllowance(10),
+      standardStdcmAllowance: initialTimeStandardAllowance,
     });
-    const newStdcmMode = testDataBuilder.buildPercentageStandardAllowance(5);
-    store.dispatch(stdcmConfSliceActions.updateStdcmStandardAllowance(newStdcmMode));
 
-    const state = store.getState().stdcmconf;
-    expect(state.standardStdcmAllowance).toBe(newStdcmMode);
+    const stateBefore = store.getState()[stdcmConfSlice.name];
+    expect(stateBefore.standardStdcmAllowance).toBe(initialTimeStandardAllowance);
+
+    const newStandardAllowance = testDataBuilder.buildPercentageStandardAllowance(5);
+    store.dispatch(stdcmConfSliceActions.updateStdcmStandardAllowance(newStandardAllowance));
+
+    const stateAfter = store.getState()[stdcmConfSlice.name];
+    expect(stateAfter.standardStdcmAllowance).toBe(newStandardAllowance);
   });
 
-  testCommonReducers(stdcmConfSlice);
+  testCommonConfReducers(stdcmConfSlice);
 });


### PR DESCRIPTION
Closes #5272

### Description
This marks the initial phase of decoupling the simulation functionality from `stdcm`. We are introducing two separate slices to handle each aspect independently. While we haven't completely replaced `osrdconf` at this stage, we've integrated it alongside our two new state slices. The end goal is to gradually deplete `osrdconf` and fully transition to the new slices.

### Key Highlights:
1. **Common Reducers Object** : We've created a shared reducers object that both slices will utilize, promoting code modularity and maintainability.
2. **updateSwitchTypes Action Refactoring** : Instead of triggering the action each time the infrastructure ID changes, which was leading to unnecessary calls, we've now streamlined it. We directly invoke the RTK query to fetch switch types precisely when and where they are needed.
3. osrdConf context :  We've implemented a react context to specify from which slice (stdcmconf or simulationconf), a component have to call a osrdconf actions 
4. **Testing** : We've added tests for both of the new slices.

### How to test ?

1. Start the application.
2. Inspect the Redux store to verify the presence of two new fields: `stdcmconf` and `simulationconf` in the state.
3. Navigate to the stdcm view and examine the `stdcmconf` state to confirm the existence of an `infraID`. In contrast, inspect the `simulationconf` state to verify the absence of infraID.


### Next step
Find a way to test the interactions between `updateInfraID`, `getInfraByIdSwitchTypes`. This involves mocking the RTK query for efficient testing. Following resources can help : 
  - https://dev.to/ifeanyichima/-testing-components-with-a-request-for-rtk-query-using-msw-and-react-testing-library-5a8n
  - https://remarkablemark.medium.com/how-to-test-redux-toolkit-query-with-jest-and-react-testing-library-cc02c0528fcf
  - https://gustavocd.dev/posts/testing-rtk-query-with-msw/

Additionally, we plan to replace occurrences of osrdConf.simulationConf with simulationConf and osrdConf.stdcmConf with stdcmConf in the store to maintain consistency and clarity (as noted in issues #5273 and #5274).

