### PR TITLE
core: stdcm: stabilize running time computations

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
@@ -172,7 +172,7 @@ public final class EnvelopePart implements SearchableEnvelope {
         assert checkNaNFree(timeDeltas) : "NaNs in timeDeltas";
         assert checkPositive(speeds) : "negative speeds";
         assert checkPositive(timeDeltas) : "negative timeDeltas";
-        assert checkNonZero(timeDeltas) : "zero timeDeltas";
+        assert checkStrictlyMonotonicIncreasing(positions) : "positions aren't strictly increasing";
     }
 
     private static boolean checkNaNFree(double[] values) {
@@ -185,13 +185,6 @@ public final class EnvelopePart implements SearchableEnvelope {
     private static boolean checkPositive(double[] values) {
         for (var val : values)
             if (val < 0)
-                return false;
-        return true;
-    }
-
-    private static boolean checkNonZero(double[] values) {
-        for (var val : values)
-            if (val == 0.0)
                 return false;
         return true;
     }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -14,7 +14,7 @@ public final class TrainPhysicsIntegrator {
     // we need the tolerance to be higher than this
     public static final double POSITION_EPSILON = 1E-2;
     // A speed lower than this value will be considered zero
-    public static final double SPEED_EPSILON = 1E-6;
+    public static final double SPEED_EPSILON = 1E-5;
 
     private final PhysicsRollingStock rollingStock;
     private final PhysicsPath path;
@@ -170,5 +170,15 @@ public final class TrainPhysicsIntegrator {
                 currentSpeed, newSpeed,
                 acceleration, directionSign
         );
+    }
+
+    /** Returns true if the positions are less than an epsilon away */
+    public static boolean arePositionsEqual(double a, double b) {
+        return Math.abs(a - b) < POSITION_EPSILON;
+    }
+
+    /** Returns true if the positions are closer than an epsilon */
+    public static boolean areSpeedsEqual(double a, double b) {
+        return Math.abs(a - b) < SPEED_EPSILON;
     }
 }

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -2,6 +2,7 @@ package fr.sncf.osrd.envelope_sim.allowances;
 
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
 import static java.lang.Double.NaN;
 import static java.lang.Math.abs;
 
@@ -351,11 +352,11 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
         if (leftPart != null) {
             builder.addPart(leftPart);
             leftPartEndSpeed = leftPart.getEndSpeed();
-            assert abs(coreEnvelope.interpolateSpeed(leftPartEndPos) - leftPartEndSpeed) < 1e-6;
+            assert areSpeedsEqual(coreEnvelope.interpolateSpeed(leftPartEndPos), leftPartEndSpeed);
         }
         if (rightPart != null) {
             rightPartBeginSpeed = rightPart.getBeginSpeed();
-            assert abs(coreEnvelope.interpolateSpeed(rightPartBeginPos) - rightPartBeginSpeed) < 1e-6;
+            assert areSpeedsEqual(coreEnvelope.interpolateSpeed(rightPartBeginPos), rightPartBeginSpeed);
         }
 
         // We force the left part end speed and right part begin speed, to avoid epsilon differences

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
@@ -74,8 +74,13 @@ public class MaxEffortEnvelope {
                     EnvelopeAcceleration.accelerate(context, startPosition, startSpeed, overlayBuilder, 1);
                     cursor.findPosition(overlayBuilder.getLastPos());
 
+                    if (overlayBuilder.lastIntersection == 0) {
+                        // Train stopped while trying to catch up
+                        throw new OSRDError(ErrorType.ImpossibleSimulationError);
+                    }
+
                     // check that the train was actually slowed down by the ramp
-                    if (partBuilder.stepCount() > 1)
+                    if (partBuilder.stepCount() > 0)
                         // if the part has more than one point, add it
                         builder.addPart(partBuilder.build());
                     else {

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.java
@@ -126,7 +126,7 @@ public class STDCMStandardAllowance {
         var allowance = new MarecoAllowance(
                 0,
                 envelope.getEndPos(),
-                1,
+                0,
                 makeAllowanceRanges(standardAllowance, envelope.getEndPos(), rangeTransitions)
         );
         return allowance.apply(envelope, context);


### PR DESCRIPTION
The changes have been made on the same branch to stabilize everything until the fuzzer is stable. This ensures that we don't have partial fixes (see https://github.com/osrd-project/osrd/pull/5362) and we don't create new bugs with the fixes.

It now seems stable, I've run 2500 tests on a real infra and the only errors reported were unrelated to running time computations (I'll open issues for those).

Changes include:
1. Envelopes can now have zero time delta (may happen in corner cases that are hard to get rid of), we still check that the positions are strictly increasing
2. Align envelope slicing with part transitions when splitting an envelope into different stdcm edges
3. Refine some epsilon tolerance, with a new utility function for comparaisons
4. Remove capacity speed limit for STDCM standard allowance

Fixes https://github.com/osrd-project/osrd/issues/5329 
Fixes #5372 