### PR TITLE
Front: ManageTrainSchedule: Fix translation in OperationalStudies

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -90,7 +90,7 @@
   "tabs": {
     "rollingStock": "Rolling stock",
     "pathFinding": "Route",
-    "allowances": "Margins",
+    "allowances": "Allowances",
     "simulationSettings": "Simulation settings",
     "addingSettings": "Adding settings"
   },


### PR DESCRIPTION
 - Changed "Margins" to "Allowances" in manageTrainSchedule.json

close #5316 