### PR TITLE
core:  fix allowance space search discontinuities

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeSpeedCap.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeSpeedCap.java
@@ -1,22 +1,27 @@
 package fr.sncf.osrd.envelope;
 
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import fr.sncf.osrd.envelope_utils.CmpOperator;
+import java.util.Collection;
+import java.util.HashSet;
 
 public class EnvelopeSpeedCap {
     /** Adds a global speed limit to an envelope */
     public static Envelope from(
             Envelope base,
-            Iterable<EnvelopeAttr> attrs,
+            Collection<EnvelopeAttr> attrs,
             double speedLimit
     ) {
         var cursor = new EnvelopeCursor(base, false);
         var builder = OverlayEnvelopeBuilder.forward(base);
+        var envelopeAttrs = new HashSet<>(attrs);
+        envelopeAttrs.add(EnvelopeProfile.CONSTANT_SPEED);
         while (cursor.findSpeed(speedLimit, CmpOperator.STRICTLY_HIGHER)) {
             var startPos = cursor.getPosition();
 
             var partBuilder = new EnvelopePartBuilder();
-            partBuilder.setAttrs(attrs);
+            partBuilder.setAttrs(envelopeAttrs);
             partBuilder.initEnvelopePart(startPos, speedLimit, 1);
 
             var hasNotReachedEnd = cursor.findSpeed(speedLimit, CmpOperator.STRICTLY_LOWER);

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.java
@@ -7,6 +7,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.EnvelopeAttr;
 import fr.sncf.osrd.envelope.EnvelopePhysics;
 import fr.sncf.osrd.envelope.SearchableEnvelope;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import fr.sncf.osrd.envelope_utils.ExcludeFromGeneratedCodeCoverage;
 import java.util.Arrays;
 import java.util.Collections;
@@ -106,19 +107,6 @@ public final class EnvelopePart implements SearchableEnvelope {
         );
     }
 
-    /** Creates an envelope part by generating step times from speeds and positions */
-    public static EnvelopePart generateTimes(
-            double[] positions,
-            double[] speeds
-    ) {
-        return new EnvelopePart(
-                new HashMap<>(),
-                positions,
-                speeds,
-                computeTimes(positions, speeds)
-        );
-    }
-
     // endregion
 
     // region ATTRS
@@ -165,6 +153,7 @@ public final class EnvelopePart implements SearchableEnvelope {
      * (which should be avoided when possible) */
     private void runSanityChecks() {
         assert attrs != null : "missing attributes";
+        assert hasAttr(EnvelopeProfile.class) : "missing EnvelopeProfile attribute";
         assert positions.length > 0 : "attempted to create an empty EnvelopePart";
         assert positions.length == speeds.length : "there must be the same number of point and speeds";
         assert timeDeltas.length == positions.length - 1 : "there must be as many timeDeltas as gaps between points";

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopeConstraint.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/constraints/EnvelopeConstraint.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.envelope.part.constraints;
 import static fr.sncf.osrd.envelope.EnvelopeCursor.NextStepResult.NEXT_PART;
 import static fr.sncf.osrd.envelope.EnvelopeCursor.NextStepResult.NEXT_REACHED_END;
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.*;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
 
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.EnvelopeCursor;
@@ -32,9 +33,9 @@ public class EnvelopeConstraint implements EnvelopePartConstraint {
         var envelopeSpeed = part.interpolateSpeed(stepIndex, position);
         cursor = new EnvelopeCursor(envelope, direction < 0, partIndex, stepIndex, position);
         return switch (type) {
-            case CEILING -> envelopeSpeed >= speed;
-            case FLOOR -> envelopeSpeed <= speed;
-            case EQUAL -> envelopeSpeed == speed;
+            case CEILING -> envelopeSpeed > speed || areSpeedsEqual(envelopeSpeed, speed);
+            case FLOOR -> envelopeSpeed < speed || areSpeedsEqual(envelopeSpeed, speed);
+            case EQUAL -> areSpeedsEqual(envelopeSpeed, speed);
         };
     }
 

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -14,6 +14,7 @@ import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraint;
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange;
@@ -157,7 +158,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             var range = ranges.get(i);
             var percentage = range.value.getAllowanceRatio(
                     envelopeRegion.getTimeBetween(range.beginPos, range.endPos),
-                    range.beginPos - range.endPos
+                    range.endPos - range.beginPos
             );
             rangePercentages[i] = new RangePercentage(range, percentage);
         }
@@ -401,6 +402,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             EnvelopeDeceleration.decelerate(
                     context, envelopeSection.getBeginPos(), imposedBeginSpeed, constrainedBuilder, 1
             );
+            partBuilder.setAttr(EnvelopeProfile.BRAKING);
             lastIntersection = constrainedBuilder.lastIntersection;
         } else if (imposedBeginSpeed < envelopeSection.getBeginSpeed()) {
             constraints.add(new EnvelopeConstraint(envelopeTarget, CEILING));
@@ -412,6 +414,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             EnvelopeAcceleration.accelerate(
                     context, envelopeSection.getBeginPos(), imposedBeginSpeed, constrainedBuilder, 1
             );
+            partBuilder.setAttr(EnvelopeProfile.ACCELERATING);
             lastIntersection = constrainedBuilder.lastIntersection;
         }
         if (lastIntersection == 0) {
@@ -449,6 +452,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             EnvelopeAcceleration.accelerate(
                     context, envelopeSection.getEndPos(), imposedEndSpeed, constrainedBuilder, -1
             );
+            partBuilder.setAttr(EnvelopeProfile.ACCELERATING);
             lastIntersection = constrainedBuilder.lastIntersection;
         } else if (imposedEndSpeed < envelopeSection.getEndSpeed()) {
             constraints.add(new EnvelopeConstraint(envelopeTarget, CEILING));
@@ -459,6 +463,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             EnvelopeDeceleration.decelerate(
                     context, envelopeSection.getEndPos(), imposedEndSpeed, constrainedBuilder, -1
             );
+            partBuilder.setAttr(EnvelopeProfile.BRAKING);
             lastIntersection = constrainedBuilder.lastIntersection;
         }
         if (lastIntersection == 0) {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
@@ -52,6 +52,7 @@ public final class CoastingGenerator {
 
         // coast backwards from the end position until the base curve is met
         var backwardPartBuilder = new EnvelopePartBuilder();
+        backwardPartBuilder.setAttr(EnvelopeProfile.COASTING);
         var constrainedBuilder = new ConstrainedEnvelopePartBuilder(
                 backwardPartBuilder,
                 new SpeedConstraint(0, FLOOR),

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/ConstraintBuilderTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/ConstraintBuilderTest.java
@@ -5,12 +5,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import fr.sncf.osrd.envelope.EnvelopeTestUtils.TestAttr;
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
-import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePartConsumer;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint;
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 
@@ -27,13 +27,11 @@ public class ConstraintBuilderTest {
     //   0  1  2  3  4  5  6  7  8  9  10
 
     private ConstrainedEnvelopePartBuilder wrap(EnvelopePartConsumer sink) {
-        var envelopeFloor = Envelope.make(EnvelopePart.generateTimes(
-                List.of(),
+        var envelopeFloor = Envelope.make(EnvelopeTestUtils.generateTimes(
                 new double[] {0, 3, 4, 5, 6, 7, 10},
                 new double[] {0, 0, 1, 2, 1, 0, 0}
         ));
-        var envelopeCeiling = Envelope.make(EnvelopePart.generateTimes(
-                List.of(),
+        var envelopeCeiling = Envelope.make(EnvelopeTestUtils.generateTimes(
                 new double[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
                 new double[] {2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2}
         ));
@@ -53,6 +51,7 @@ public class ConstraintBuilderTest {
         var builder = wrap(partBuilder);
         builder.setAttrs(List.of(TestAttr.A));
         builder.setAttr(TestAttr.B);
+        builder.setAttr(EnvelopeProfile.ACCELERATING);
         assertTrue(builder.initEnvelopePart(2, 0, 1));
         assertFalse(builder.addStep(5, 1));
         var part = partBuilder.build();

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeBuilderTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeBuilderTest.java
@@ -2,18 +2,17 @@ package fr.sncf.osrd.envelope;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import fr.sncf.osrd.envelope.part.EnvelopePart;
 import org.junit.jupiter.api.Test;
 
 public class EnvelopeBuilderTest {
     @Test
     public void testEnvelopeBuilder() {
         var builder = new EnvelopeBuilder();
-        builder.addPart(EnvelopePart.generateTimes(
+        builder.addPart(EnvelopeTestUtils.generateTimes(
                 new double[]{0, 1},
                 new double[]{10, 20}
         ));
-        builder.addPart(EnvelopePart.generateTimes(
+        builder.addPart(EnvelopeTestUtils.generateTimes(
                 new double[]{1, 2},
                 new double[]{20, 30}
         ));
@@ -24,11 +23,11 @@ public class EnvelopeBuilderTest {
     @Test
     public void testEnvelopeBuilderReversed() {
         var builder = new EnvelopeBuilder();
-        builder.addPart(EnvelopePart.generateTimes(
+        builder.addPart(EnvelopeTestUtils.generateTimes(
                 new double[]{1, 2},
                 new double[]{20, 30}
         ));
-        builder.addPart(EnvelopePart.generateTimes(
+        builder.addPart(EnvelopeTestUtils.generateTimes(
                 new double[]{0, 1},
                 new double[]{10, 20}
         ));

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeCursorTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeCursorTest.java
@@ -2,21 +2,20 @@ package fr.sncf.osrd.envelope;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import fr.sncf.osrd.envelope.part.EnvelopePart;
 import org.junit.jupiter.api.Test;
 
 
 public class EnvelopeCursorTest {
     public static final Envelope FLAT_ENVELOPE = Envelope.make(
-            EnvelopePart.generateTimes(
+            EnvelopeTestUtils.generateTimes(
                     new double[]{1, 3, 4},
                     new double[]{4, 4, 4}
             ),
-            EnvelopePart.generateTimes(
+            EnvelopeTestUtils.generateTimes(
                     new double[]{4, 6},
                     new double[]{4, 4}
             ),
-            EnvelopePart.generateTimes(
+            EnvelopeTestUtils.generateTimes(
                     new double[]{6, 8, 10},
                     new double[]{4, 4, 4}
             )

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartSliceTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartSliceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import fr.sncf.osrd.envelope.EnvelopeTestUtils.TestAttr;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 
@@ -14,12 +15,12 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceIndex() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3, 5},
                 new double[] {3, 4, 4}
         );
         var ep2 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3},
                 new double[] {3, 4}
         );
@@ -31,7 +32,7 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceIndexFull() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3, 5},
                 new double[] {3, 3, 4}
         );
@@ -43,7 +44,7 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceIndexEmpty() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3, 5},
                 new double[] {3, 3, 4}
         );
@@ -54,7 +55,7 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceOffsetEmpty() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3, 5},
                 new double[] {3, 3, 4}
         );
@@ -65,7 +66,7 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceOffsetFull() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1.5, 3, 5},
                 new double[] {3, 3, 4}
         );
@@ -76,13 +77,13 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceOffsetInterpolate() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.BRAKING),
                 new double[] {0, 3},
                 new double[] {3.46, 0}
         );
         var slice = ep1.slice(Double.NEGATIVE_INFINITY, 2);
         var expectedSlice = new EnvelopePart(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.BRAKING),
                 new double[] {0, 2},
                 new double[] {3.46, 2},
                 new double[] {0.73}
@@ -93,13 +94,13 @@ public class EnvelopePartSliceTest {
     @Test
     void sliceWithImposedSpeeds() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {1, 3, 5},
                 new double[] {3, 3, 4}
         );
         var slice = ep1.sliceWithSpeeds(2, 3, 4, 3.5);
         var expectedSlice = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
                 new double[] {2, 3, 4},
                 new double[] {3, 3, 3.5}
         );

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -3,7 +3,6 @@ package fr.sncf.osrd.envelope;
 import static fr.sncf.osrd.envelope.EnvelopePhysics.getPartMechanicalEnergyConsumed;
 import static org.junit.jupiter.api.Assertions.*;
 
-import fr.sncf.osrd.envelope.EnvelopeTestUtils.TestAttr;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.*;
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue;
@@ -15,26 +14,26 @@ class EnvelopePartTest {
     @Test
     void toStringTest() {
         var part = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(EnvelopeProfile.ACCELERATING),
                 new double[]{1.5, 5},
                 new double[]{3, 4}
         );
-        assertEquals("EnvelopePart { TestAttr=A }", part.toString());
+        assertEquals("EnvelopePart { EnvelopeProfile=ACCELERATING }", part.toString());
     }
 
     @Test
     void getAttrTest() {
         var part = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(EnvelopeProfile.ACCELERATING),
                 new double[]{1.5, 5},
                 new double[]{3, 4}
         );
-        assertEquals(TestAttr.A, part.getAttr(TestAttr.class));
+        assertEquals(EnvelopeProfile.ACCELERATING, part.getAttr(EnvelopeProfile.class));
     }
 
     @Test
     void interpolateSpeedTest() {
-        var ep = EnvelopePart.generateTimes(
+        var ep = EnvelopeTestUtils.generateTimes(
                 new double[]{1.5, 5},
                 new double[]{3, 4}
         );
@@ -45,7 +44,7 @@ class EnvelopePartTest {
 
     @Test
     void findStep() {
-        var ep = EnvelopePart.generateTimes(
+        var ep = EnvelopeTestUtils.generateTimes(
                 new double[]{1.5, 3, 5},
                 new double[]{3, 4, 4}
         );
@@ -71,17 +70,17 @@ class EnvelopePartTest {
     @Test
     void testEquals() {
         var ep1 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(EnvelopeProfile.ACCELERATING),
                 new double[]{1.5, 3, 5},
                 new double[]{3, 4, 4}
         );
         var ep2 = EnvelopePart.generateTimes(
-                List.of(TestAttr.A),
+                List.of(EnvelopeProfile.ACCELERATING),
                 new double[]{1.5, 3, 5},
                 new double[]{3, 4, 4}
         );
         var ep3 = EnvelopePart.generateTimes(
-                List.of(TestAttr.B),
+                List.of(EnvelopeProfile.COASTING),
                 new double[]{1.5, 3, 5},
                 new double[]{3, 4, 4}
         );

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeSpeedCapTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeSpeedCapTest.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.envelope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 
@@ -11,6 +12,7 @@ public class EnvelopeSpeedCapTest {
     void testSimpleCap() {
         var inputEnvelope = Envelope.make(
                 EnvelopePart.generateTimes(
+                        List.of(EnvelopeProfile.COASTING),
                         new double[] {0, 2, 4},
                         new double[] {0, 2, 0}
                 )
@@ -19,14 +21,17 @@ public class EnvelopeSpeedCapTest {
 
         var expectedEnvelope = Envelope.make(
                 EnvelopePart.generateTimes(
+                        List.of(EnvelopeProfile.COASTING),
                         new double[] {0, 0.5},
                         new double[] {0, 1}
                 ),
                 EnvelopePart.generateTimes(
+                        List.of(EnvelopeProfile.CONSTANT_SPEED),
                         new double[] {0.5, 3.5},
                         new double[] {1, 1}
                 ),
                 EnvelopePart.generateTimes(
+                        List.of(EnvelopeProfile.COASTING),
                         new double[] {3.5, 4},
                         new double[] {1, 0}
                 )
@@ -43,7 +48,7 @@ public class EnvelopeSpeedCapTest {
     @Test
     void testFlatCap() {
         var inputEnvelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 1},
                         new double[] {2, 2}
                 )
@@ -51,7 +56,7 @@ public class EnvelopeSpeedCapTest {
         var cappedEnvelope = EnvelopeSpeedCap.from(inputEnvelope, List.of(), 1);
 
         var expectedEnvelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 1},
                         new double[] {1, 1}
                 )
@@ -62,12 +67,12 @@ public class EnvelopeSpeedCapTest {
     @Test
     void testOpenEndCap() {
         var envelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 2},
                         new double[] {0, 2}
                 ),
                 // this part should be completely hidden away
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {2, 4},
                         new double[] {2, 2}
                 )
@@ -75,11 +80,11 @@ public class EnvelopeSpeedCapTest {
         var cappedEnvelope = EnvelopeSpeedCap.from(envelope, List.of(), 1);
 
         var expectedEnvelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 0.5},
                         new double[] {0, 1}
                 ),
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0.5, 4},
                         new double[] {1, 1}
                 )
@@ -90,23 +95,23 @@ public class EnvelopeSpeedCapTest {
     @Test
     void testOpenBeginCap() {
         var envelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 2},
                         new double[] {2, 2}
                 ),
                 // this part should be completely hidden away
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {2, 4},
                         new double[] {2, 0}
                 )
         );
         var cappedEnvelope = EnvelopeSpeedCap.from(envelope, List.of(), 1);
         var expectedEnvelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 3.5},
                         new double[] {1, 1}
                 ),
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {3.5, 4},
                         new double[] {1, 0}
                 )
@@ -117,7 +122,7 @@ public class EnvelopeSpeedCapTest {
     @Test
     void testMultipleCaps() {
         var envelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 2, 4},
                         new double[] {2, 0, 2}
                 )
@@ -125,15 +130,15 @@ public class EnvelopeSpeedCapTest {
         var cappedEnvelope = EnvelopeSpeedCap.from(envelope, List.of(), 1);
 
         var expectedEnvelope = Envelope.make(
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {0, 1.5},
                         new double[] {1, 1}
                 ),
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {1.5, 2, 2.5},
                         new double[] {1, 0, 1}
                 ),
-                EnvelopePart.generateTimes(
+                EnvelopeTestUtils.generateTimes(
                         new double[] {2.5, 4},
                         new double[] {1, 1}
                 )

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 public class EnvelopeTest {
     @Test
     void testContinuity() {
-        var partA = EnvelopePart.generateTimes(new double[] {0, 1}, new double[] {1, 1});
-        var partB = EnvelopePart.generateTimes(new double[] {2, 3}, new double[] {1, 1});
-        var partC = EnvelopePart.generateTimes(new double[] {1, 2}, new double[] {2, 2});
-        var partD = EnvelopePart.generateTimes(new double[] {1, 2}, new double[] {1, 1});
+        var partA = EnvelopeTestUtils.generateTimes(new double[] {0, 1}, new double[] {1, 1});
+        var partB = EnvelopeTestUtils.generateTimes(new double[] {2, 3}, new double[] {1, 1});
+        var partC = EnvelopeTestUtils.generateTimes(new double[] {1, 2}, new double[] {2, 2});
+        var partD = EnvelopeTestUtils.generateTimes(new double[] {1, 2}, new double[] {1, 1});
         assertThrows(RuntimeException.class, () -> Envelope.make(partA, partB));
         assertTrue(Envelope.make(partA, partD).continuous);
         assertFalse(Envelope.make(partA, partC).continuous);
@@ -20,7 +20,7 @@ public class EnvelopeTest {
 
     @Test
     void testIterator() {
-        var a = EnvelopePart.generateTimes(new double[] { 0, 2 }, new double[] { 2, 2 });
+        var a = EnvelopeTestUtils.generateTimes(new double[] { 0, 2 }, new double[] { 2, 2 });
         var envelope = Envelope.make(a);
         var res = new ArrayList<EnvelopePart>();
         envelope.iterator().forEachRemaining(res::add);
@@ -30,8 +30,8 @@ public class EnvelopeTest {
 
     @Test
     void testMinMaxSpeed() {
-        final var partA = EnvelopePart.generateTimes(new double[] { 0, 2 }, new double[] { 1, 2 });
-        final var partB = EnvelopePart.generateTimes(new double[] { 2, 4 }, new double[] { 4, 3 });
+        final var partA = EnvelopeTestUtils.generateTimes(new double[] { 0, 2 }, new double[] { 1, 2 });
+        final var partB = EnvelopeTestUtils.generateTimes(new double[] { 2, 4 }, new double[] { 4, 3 });
         final var envelope = Envelope.make(partA, partB);
 
         assertEquals(1, partA.getMinSpeed());
@@ -45,8 +45,8 @@ public class EnvelopeTest {
 
     @Test
     void testInterpolateSpeed() {
-        var partA = EnvelopePart.generateTimes(new double[] { 0, 2 }, new double[] { 1, 2 });
-        var partB = EnvelopePart.generateTimes(new double[] { 2, 3 }, new double[] { 2, 4 });
+        var partA = EnvelopeTestUtils.generateTimes(new double[] { 0, 2 }, new double[] { 1, 2 });
+        var partB = EnvelopeTestUtils.generateTimes(new double[] { 2, 3 }, new double[] { 2, 4 });
         var envelope = Envelope.make(partA, partB);
 
         assertEquals(1, envelope.interpolateSpeed(0));
@@ -56,8 +56,8 @@ public class EnvelopeTest {
 
     @Test
     void testInterpolateTime() {
-        var partA = EnvelopePart.generateTimes(new double[] { 0, 2 }, new double[] { 1, 1 });
-        var partB = EnvelopePart.generateTimes(new double[] { 2, 4 }, new double[] { 1, 1 });
+        var partA = EnvelopeTestUtils.generateTimes(new double[] { 0, 2 }, new double[] { 1, 1 });
+        var partB = EnvelopeTestUtils.generateTimes(new double[] { 2, 4 }, new double[] { 1, 1 });
         var envelope = Envelope.make(partA, partB);
 
         assertEquals(1, partA.interpolateTotalTime(1));

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.java
@@ -112,7 +112,6 @@ public class TrainPhysicsIntegratorTest {
         for (int i = 0; i < 60; i++) {
             step = TrainPhysicsIntegrator.step(context, position, speed, Action.COAST, +1);
             position += step.positionDelta;
-            var prevSpeed = step.startSpeed;
             speed = step.endSpeed;
         }
         // it should be stopped
@@ -130,7 +129,8 @@ public class TrainPhysicsIntegratorTest {
         EnvelopeDeceleration.decelerate(context, 0, 10, constrainedBuilder, 1);
         var acceleration = Envelope.make(builder.build());
         // starting a coasting phase in a braking phase must result in a null EnvelopePart
-        var failedCoast = coastFromBeginning(acceleration, context, 0);
+        var speed = acceleration.interpolateSpeed(0);
+        var failedCoast = coastFromBeginning(acceleration, context, 0, speed);
         assertNull(failedCoast);
     }
 }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegratorTest.java
@@ -127,6 +127,7 @@ public class TrainPhysicsIntegratorTest {
                 new SpeedConstraint(0, EnvelopePartConstraintType.FLOOR)
         );
         EnvelopeDeceleration.decelerate(context, 0, 10, constrainedBuilder, 1);
+        builder.setAttr(EnvelopeProfile.BRAKING);
         var acceleration = Envelope.make(builder.build());
         // starting a coasting phase in a braking phase must result in a null EnvelopePart
         var speed = acceleration.interpolateSpeed(0);

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeShape.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeShape.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.envelope;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -14,7 +15,7 @@ public enum EnvelopeShape {
     public static EnvelopeShape fromStep(EnvelopePart part, int stepIndex) {
         var beginSpeed = part.getBeginSpeed(stepIndex);
         var endSpeed = part.getEndSpeed(stepIndex);
-        if (beginSpeed == endSpeed)
+        if (areSpeedsEqual(beginSpeed, endSpeed))
             return CONSTANT;
         else if (beginSpeed < endSpeed)
             return INCREASING;

--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope/EnvelopeTestUtils.java
@@ -2,13 +2,16 @@ package fr.sncf.osrd.envelope;
 
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.CEILING;
 import static fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType.FLOOR;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
 
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint;
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint;
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
 import org.junit.jupiter.api.Assertions;
+import java.util.Collections;
 import java.util.List;
 
 public class EnvelopeTestUtils {
@@ -89,8 +92,8 @@ public class EnvelopeTestUtils {
     }
 
     /** Creates a flat envelope part */
-    public static EnvelopePart makeFlatPart(TestAttr attr, double beginPos, double endPos, double speed) {
-        return makeFlatPart(List.of(attr), beginPos, endPos, speed);
+    public static EnvelopePart makeFlatPart(EnvelopeAttr attr, double beginPos, double endPos, double speed) {
+        return makeFlatPart(List.of(attr, EnvelopeProfile.CONSTANT_SPEED), beginPos, endPos, speed);
     }
 
     /** Creates a flat envelope part */
@@ -100,6 +103,23 @@ public class EnvelopeTestUtils {
                 attrs,
                 new double[]{beginPos, endPos},
                 new double[]{speed, speed}
+        );
+    }
+
+    /** Creates an envelope part by generating step times from speeds and positions */
+    public static EnvelopePart generateTimes(double[] positions, double[] speeds) {
+        //Input a default compulsory EnvelopeProfile attribute. This is not physically correct in some cases. If so,
+        //use generateTimes with attributes argument.
+        var envelopeProfile = EnvelopeProfile.BRAKING;
+        if (areSpeedsEqual(speeds[0], speeds[speeds.length - 1])) {
+            envelopeProfile = EnvelopeProfile.CONSTANT_SPEED;
+        } else if (speeds[0] < speeds[speeds.length - 1]) {
+            envelopeProfile = EnvelopeProfile.ACCELERATING;
+        }
+        return EnvelopePart.generateTimes(
+                Collections.singleton(envelopeProfile),
+                positions,
+                speeds
         );
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
+++ b/core/src/main/java/fr/sncf/osrd/stdcm/graph/STDCMSimulations.java
@@ -137,7 +137,7 @@ public class STDCMSimulations {
      */
     private static Envelope makeSinglePointEnvelope(double speed) {
         return Envelope.make(new EnvelopePart(
-                Map.of(),
+                Map.of(EnvelopeProfile.class, EnvelopeProfile.CONSTANT_SPEED),
                 new double[]{0},
                 new double[]{speed},
                 new double[]{}

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -276,7 +276,6 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
                     signalsPerTrack,
                     builder
                 )
-                builder
 
                 // check if the zone is a release zone
                 if (releaseIndex < oldReleasePoints.size && oldEndDet.detector!! == oldReleasePoints[releaseIndex]) {

--- a/core/src/test/java/fr/sncf/osrd/envelope_sim_infra/MRSPTest.java
+++ b/core/src/test/java/fr/sncf/osrd/envelope_sim_infra/MRSPTest.java
@@ -76,30 +76,30 @@ public class MRSPTest {
                 Arguments.of(path, REALISTIC_FAST_TRAIN, false, TRAIN_TAG2,
                         Envelope.make(
                                 // No speed section at first => train speed limit
-                                makeFlatPart(List.of(TRAIN_LIMIT, CONSTANT_SPEED), 0, POSITION1, MAX_SPEED),
+                                makeFlatPart(TRAIN_LIMIT, 0, POSITION1, MAX_SPEED),
                                 // Speed section with incorrect train tag => speed 1
-                                makeFlatPart(List.of(SPEED_LIMIT, CONSTANT_SPEED), POSITION1, POSITION2, SPEED1),
+                                makeFlatPart(SPEED_LIMIT, POSITION1, POSITION2, SPEED1),
                                 // Speed section with correct train tag => speed 3
-                                makeFlatPart(List.of(SPEED_LIMIT, CONSTANT_SPEED), POSITION2, POSITION3, SPEED3),
+                                makeFlatPart(SPEED_LIMIT, POSITION2, POSITION3, SPEED3),
                                 // No speed section at end => train speed limit
-                                makeFlatPart(List.of(TRAIN_LIMIT, CONSTANT_SPEED), POSITION3, pathLength, MAX_SPEED))),
+                                makeFlatPart(TRAIN_LIMIT, POSITION3, pathLength, MAX_SPEED))),
 
                 // Multiple speed sections with rolling stock length
                 Arguments.of(path, REALISTIC_FAST_TRAIN, true, null,
                         Envelope.make(
                                 // No speed section at first => train speed limit
-                                makeFlatPart(List.of(TRAIN_LIMIT, CONSTANT_SPEED), 0, POSITION1, MAX_SPEED),
+                                makeFlatPart(TRAIN_LIMIT, 0, POSITION1, MAX_SPEED),
                                 // Speed section with incorrect train tag: speed 1
-                                makeFlatPart(List.of(SPEED_LIMIT, CONSTANT_SPEED), POSITION1,
-                                        POSITION2 + REALISTIC_FAST_TRAIN.length, SPEED1),
+                                makeFlatPart(SPEED_LIMIT, POSITION1, POSITION2 + REALISTIC_FAST_TRAIN.length,
+                                        SPEED1),
                                 // Rolling stock length > speedSection2 length => speedSection2 not taken into account
                                 // No speed section at end => train speed limit
-                                makeFlatPart(List.of(TRAIN_LIMIT, CONSTANT_SPEED),
-                                        POSITION2 + REALISTIC_FAST_TRAIN.length, pathLength, MAX_SPEED))),
+                                makeFlatPart(TRAIN_LIMIT, POSITION2 + REALISTIC_FAST_TRAIN.length, pathLength,
+                                        MAX_SPEED))),
 
                 // No speed sections taken into account: speedSection1 speed2 > train maxSpeed, speedSection2 speed 0m/s
                 Arguments.of(path, REALISTIC_FAST_TRAIN, false, TRAIN_TAG1,
-                        Envelope.make(makeFlatPart(List.of(TRAIN_LIMIT, CONSTANT_SPEED), 0, pathLength, MAX_SPEED))));
+                        Envelope.make(makeFlatPart(TRAIN_LIMIT, 0, pathLength, MAX_SPEED))));
     }
 }
 

--- a/core/src/test/java/fr/sncf/osrd/standalone_sim/StandaloneSimTests.java
+++ b/core/src/test/java/fr/sncf/osrd/standalone_sim/StandaloneSimTests.java
@@ -3,7 +3,7 @@ package fr.sncf.osrd.standalone_sim;
 import static fr.sncf.osrd.standalone_sim.StandaloneSim.generateAllowanceFromScheduledPoints;
 
 import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope.EnvelopeTestUtils;
 import fr.sncf.osrd.train.ScheduledPoint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,7 +13,7 @@ import java.util.List;
 public class StandaloneSimTests {
     @Test
     public void generateAllowanceFromOneScheduledPoint() {
-        var envelopeFloor = Envelope.make(EnvelopePart.generateTimes(
+        var envelopeFloor = Envelope.make(EnvelopeTestUtils.generateTimes(
                 new double[] {0, 1, 2, 3, 4, 5, 6},
                 new double[] {1, 1, 1, 1, 1, 1, 1}
         ));
@@ -32,7 +32,7 @@ public class StandaloneSimTests {
 
     @Test
     public void generateAllowanceFromMultipleScheduledPoints() {
-        var envelopeFloor = Envelope.make(EnvelopePart.generateTimes(
+        var envelopeFloor = Envelope.make(EnvelopeTestUtils.generateTimes(
                 new double[] {0, 1, 2, 3, 4, 5, 6},
                 new double[] {1, 1, 1, 1, 1, 1, 1}
         ));
@@ -56,7 +56,7 @@ public class StandaloneSimTests {
 
     @Test
     public void generateAllowanceFromNoScheduledPoints() {
-        var envelopeFloor = Envelope.make(EnvelopePart.generateTimes(
+        var envelopeFloor = Envelope.make(EnvelopeTestUtils.generateTimes(
                 new double[] {0, 1, 2, 3, 4, 5, 6},
                 new double[] {1, 1, 1, 1, 1, 1, 1}
         ));

--- a/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.java
+++ b/core/src/test/java/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.java
@@ -6,7 +6,7 @@ import static fr.sncf.osrd.stdcm.STDCMHelpers.meters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import fr.sncf.osrd.envelope.Envelope;
-import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope.EnvelopeTestUtils;
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock;
 import fr.sncf.osrd.sim_infra.api.InterlockingInfraKt;
 import fr.sncf.osrd.standalone_sim.result.ResultTrain;
@@ -52,7 +52,7 @@ public class BlockAvailabilityLegacyAdapterTests {
                 List.of(blocks.get(0)),
                 0,
                 meters(1),
-                Envelope.make(EnvelopePart.generateTimes(new double[]{0., 1.}, new double[]{100., 100.})),
+                Envelope.make(EnvelopeTestUtils.generateTimes(new double[]{0., 1.}, new double[]{100., 100.})),
                 42
         );
         var expected = new BlockAvailabilityInterface.Unavailable(42 + 20, 0);

--- a/tests/tests/regression_tests_data/search_space_discontinuity_2.json
+++ b/tests/tests/regression_tests_data/search_space_discontinuity_2.json
@@ -1,0 +1,105 @@
+{
+    "error_type": "SCHEDULE",
+    "code": 500,
+    "error": "{\"type\":\"\",\"context\":{\"trace\":[{\"index\":1}]},\"message\":\"Failed to converge when computing allowances because of a discontinuity in the search space\"}",
+    "infra_name": "small_infra",
+    "path_payload": {
+        "infra": 2,
+        "name": "foo",
+        "steps": [
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TD0",
+                        "offset": 19619.352684339327
+                    }
+                ]
+            },
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TD0",
+                        "offset": 10328.66897321028
+                    }
+                ]
+            },
+            {
+                "duration": 0,
+                "waypoints": [
+                    {
+                        "track_section": "TC1",
+                        "offset": 942.2893869744591
+                    }
+                ]
+            },
+            {
+                "duration": 1,
+                "waypoints": [
+                    {
+                        "track_section": "TA6",
+                        "offset": 7228.631133548441
+                    }
+                ]
+            }
+        ]
+    },
+    "schedule_payload": {
+        "timetable": 477,
+        "path": 6191,
+        "schedules": [
+            {
+                "train_name": "foo",
+                "labels": [],
+                "departure_time": 49769,
+                "allowances": [
+                    {
+                        "allowance_type": "standard",
+                        "default_value": {
+                            "value_type": "percentage",
+                            "percentage": 13.909647137885917
+                        },
+                        "ranges": [
+                            {
+                                "begin_position": 0,
+                                "end_position": 16060.88634445774,
+                                "value": {
+                                    "value_type": "time",
+                                    "seconds": 36.46246472629868
+                                }
+                            }
+                        ],
+                        "capacity_speed_limit": 6.2294818613912595,
+                        "distribution": "MARECO"
+                    },
+                    {
+                        "allowance_type": "engineering",
+                        "begin_position": 12524.41472909032,
+                        "end_position": 21770.18710487399,
+                        "value": {
+                            "value_type": "time",
+                            "seconds": 28.070954818841923
+                        },
+                        "capacity_speed_limit": 1.7874897194090011,
+                        "distribution": "MARECO"
+                    },
+                    {
+                        "allowance_type": "engineering",
+                        "begin_position": 12952.70669585063,
+                        "end_position": 19291.81886826793,
+                        "value": {
+                            "value_type": "time",
+                            "seconds": 11.462972603693293
+                        },
+                        "capacity_speed_limit": 9.850164632606985,
+                        "distribution": "LINEAR"
+                    }
+                ],
+                "initial_speed": 0,
+                "rolling_stock_id": 449,
+                "speed_limit_category": "foo"
+            }
+        ]
+    }
+}

--- a/tests/tests/regression_tests_data/search_space_discontinuity_3.json
+++ b/tests/tests/regression_tests_data/search_space_discontinuity_3.json
@@ -1,0 +1,94 @@
+{
+    "error_type": "SCHEDULE",
+    "code": 500,
+    "error": "{\"status\":500,\"type\":\"allowance_convergence\",\"context\":{\"trace\":[{\"index\":1}],\"url\":\"http://localhost:8080/standalone_simulation\"},\"message\":\"Failed to converge when computing allowances because of a discontinuity in the search space\"}",
+    "infra_name": "small_infra",
+    "path_payload": {
+        "infra": 5,
+        "name": "foo",
+        "steps": [
+            {
+                "duration": 201.26315724275267,
+                "waypoints": [
+                    {
+                        "track_section": "TC0",
+                        "offset": 552.2236003214992
+                    }
+                ]
+            },
+            {
+                "duration": 438.6125451117886,
+                "waypoints": [
+                    {
+                        "track_section": "TC0",
+                        "offset": 71.51179397666198
+                    }
+                ]
+            },
+            {
+                "duration": 905.27207511261,
+                "waypoints": [
+                    {
+                        "track_section": "TA6",
+                        "offset": 982.414023681425
+                    }
+                ]
+            },
+            {
+                "duration": 1,
+                "waypoints": [
+                    {
+                        "track_section": "TA0",
+                        "offset": 1375.331921836674
+                    }
+                ]
+            }
+        ]
+    },
+    "schedule_payload": {
+        "timetable": 357,
+        "path": 6918,
+        "schedules": [
+            {
+                "train_name": "foo",
+                "labels": [],
+                "departure_time": 25812,
+                "allowances": [
+                    {
+                        "allowance_type": "standard",
+                        "default_value": {
+                            "value_type": "time_per_distance",
+                            "minutes": 6.5231844502540675
+                        },
+                        "ranges": [
+                            {
+                                "begin_position": 0,
+                                "end_position": 7321.423229665372,
+                                "value": {
+                                    "value_type": "time",
+                                    "seconds": 24.50736878607825
+                                }
+                            }
+                        ],
+                        "capacity_speed_limit": 4.032742864899781,
+                        "distribution": "MARECO"
+                    },
+                    {
+                        "allowance_type": "engineering",
+                        "begin_position": 30.507061762109494,
+                        "end_position": 10137.834504522636,
+                        "value": {
+                            "value_type": "time",
+                            "seconds": 36.224369091662
+                        },
+                        "capacity_speed_limit": 6.7015598167476504,
+                        "distribution": "MARECO"
+                    }
+                ],
+                "initial_speed": 0,
+                "rolling_stock_id": 449,
+                "speed_limit_category": "foo"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Couple of coasting problems for Mareco allowances, creating discontinuities in the search space for a solution validating said allowance.
First discontinuity was due to `coastFromBeginning` not starting at the `startSpeed` found when `coastFromEnd` never reaches the envelope. The solutions would then always fluctuate between braking=>coasting and coasting=>braking, but never with any solution in the middle.
Second discontinuity was due to `EnvelopePart` not always having an `EnvelopeProfile` attribute, in this case, the `Braking` one: coasting opportunities were not found because of that (braking opportunities are found by firstly checking if said `EnvelopePart` has a `Braking` attribute). It is now compulsory.

Comparison between doubles played a small part in this: a PR will be arriving to use `areSpeedsEqual` everywhere (as long as I find all the comparisons).