### PR TITLE
font: display kps

### DIFF
--- a/front/src/common/Map/Consts/colors.ts
+++ b/front/src/common/Map/Consts/colors.ts
@@ -36,31 +36,19 @@ const colors: Record<string, Theme> = {
       text: '#555555',
       halo: '#eee',
     },
-    psl: {
-      pointtext: '#5b5b5b',
-      pointhalo: '#ffffff',
-      detailtext: '#555555',
-      detailhalo: '#ffffff',
-      text: '#4d4f53',
-      halo: '#ffffff',
-    },
     mapmarker: {
       text: '#0088ce',
       circle: '#0088ce',
+    },
+    neutral_sections: {
+      lower_pantograph: '#ff0000',
+      switch_off: '#000000',
     },
     op: {
       circle: '#82be00',
       text: '#202258',
       minitext: '#333',
       halo: '#eee',
-    },
-    sign: {
-      text: '#333333',
-      halo: '#ffffff',
-    },
-    pk: {
-      circle: '#162873',
-      text: '#142c90',
     },
     platform: {
       fill: '#e05206',
@@ -81,9 +69,13 @@ const colors: Record<string, Theme> = {
       color750V: '#86cf00',
       colorOther: '#000000',
     },
-    neutral_sections: {
-      lower_pantograph: '#ff0000',
-      switch_off: '#000000',
+    psl: {
+      pointtext: '#5b5b5b',
+      pointhalo: '#ffffff',
+      detailtext: '#555555',
+      detailhalo: '#ffffff',
+      text: '#4d4f53',
+      halo: '#ffffff',
     },
     radio: {
       text: '#5596c8',
@@ -101,6 +93,15 @@ const colors: Record<string, Theme> = {
     },
     routes: {
       text: '#e05206',
+      halo: '#ffffff',
+    },
+    rk: {
+      circle: '#162873',
+      text: '#4d4f53',
+      halo: '#ffffff',
+    },
+    sign: {
+      text: '#333333',
       halo: '#ffffff',
     },
     signal: {
@@ -187,31 +188,19 @@ const colors: Record<string, Theme> = {
       text: '#4895ef',
       halo: '#0b011d',
     },
-    psl: {
-      pointtext: '#eeeeee',
-      pointhalo: '#3a86ff',
-      detailtext: '#3a86ff',
-      detailhalo: '#0b011d',
-      text: '#3a86ff',
-      halo: '#000000',
-    },
     mapmarker: {
       text: '#ffaa39',
       circle: '#ffaa39',
+    },
+    neutral_sections: {
+      lower_pantograph: '#ff0000',
+      switch_off: '#000000',
     },
     op: {
       circle: '#82be00',
       text: '#4895ef',
       minitext: '#4895ef',
       halo: '#0b011d',
-    },
-    sign: {
-      text: '#eeeeee',
-      halo: '#333333',
-    },
-    pk: {
-      circle: '#8338ec',
-      text: '#8338ec',
     },
     platform: {
       fill: '#f1c453',
@@ -232,9 +221,13 @@ const colors: Record<string, Theme> = {
       color750V: '#86cf00',
       colorOther: '#FFFFFF',
     },
-    neutral_sections: {
-      lower_pantograph: '#ff0000',
-      switch_off: '#000000',
+    psl: {
+      pointtext: '#eeeeee',
+      pointhalo: '#3a86ff',
+      detailtext: '#3a86ff',
+      detailhalo: '#0b011d',
+      text: '#3a86ff',
+      halo: '#000000',
     },
     radio: {
       text: '#5596c8',
@@ -250,9 +243,18 @@ const colors: Record<string, Theme> = {
     railyard: {
       text: '#8095c3',
     },
+    rk: {
+      circle: '#8338ec',
+      text: '#8338ec',
+      halo: '#8338ec',
+    },
     routes: {
       text: '#e05206',
       halo: '#ffffff',
+    },
+    sign: {
+      text: '#eeeeee',
+      halo: '#333333',
     },
     signal: {
       text: '#eeeeee',
@@ -330,31 +332,19 @@ const colors: Record<string, Theme> = {
       text: bpLight,
       halo: bpBg,
     },
-    psl: {
-      pointtext: bpLight,
-      pointhalo: bpBg,
-      detailtext: bpLight,
-      detailhalo: bpBg,
-      text: bpLight,
-      halo: bpBg,
-    },
     mapmarker: {
       text: bpMedium,
       circle: bpLight,
+    },
+    neutral_sections: {
+      lower_pantograph: '#ff0000',
+      switch_off: '#000000',
     },
     op: {
       circle: bpLight,
       text: bpLight,
       minitext: bpLight,
       halo: bpBg,
-    },
-    sign: {
-      text: bpLight,
-      halo: bpBg,
-    },
-    pk: {
-      circle: bpLight,
-      text: bpLight,
     },
     platform: {
       fill: bpMedium,
@@ -375,9 +365,13 @@ const colors: Record<string, Theme> = {
       color750V: bpLight,
       colorOther: bpLight,
     },
-    neutral_sections: {
-      lower_pantograph: '#ff0000',
-      switch_off: '#000000',
+    psl: {
+      pointtext: bpLight,
+      pointhalo: bpBg,
+      detailtext: bpLight,
+      detailhalo: bpBg,
+      text: bpLight,
+      halo: bpBg,
     },
     radio: {
       text: bpMedium,
@@ -393,7 +387,16 @@ const colors: Record<string, Theme> = {
     railyard: {
       text: bpLight,
     },
+    rk: {
+      circle: bpLight,
+      text: bpLight,
+      halo: bpLight,
+    },
     routes: {
+      text: bpLight,
+      halo: bpBg,
+    },
+    sign: {
       text: bpLight,
       halo: bpBg,
     },

--- a/front/src/common/Map/Consts/colors.ts
+++ b/front/src/common/Map/Consts/colors.ts
@@ -49,7 +49,9 @@ const colors: Record<string, Theme> = {
       circle: '#0088ce',
     },
     op: {
+      circle: '#82be00',
       text: '#202258',
+      minitext: '#333',
       halo: '#eee',
     },
     sign: {
@@ -198,7 +200,9 @@ const colors: Record<string, Theme> = {
       circle: '#ffaa39',
     },
     op: {
+      circle: '#82be00',
       text: '#4895ef',
+      minitext: '#4895ef',
       halo: '#0b011d',
     },
     sign: {
@@ -339,7 +343,9 @@ const colors: Record<string, Theme> = {
       circle: bpLight,
     },
     op: {
+      circle: bpLight,
       text: bpLight,
+      minitext: bpLight,
       halo: bpBg,
     },
     sign: {

--- a/front/src/common/Map/Consts/colors.ts
+++ b/front/src/common/Map/Consts/colors.ts
@@ -23,6 +23,11 @@ const colors: Record<string, Theme> = {
     electricbox: {
       text: '#b42222',
     },
+    kp: {
+      circle: '#162873',
+      text: '#4d4f53',
+      halo: '#ffffff',
+    },
     kvb: {
       color: '#ffc700',
     },
@@ -93,11 +98,6 @@ const colors: Record<string, Theme> = {
     },
     routes: {
       text: '#e05206',
-      halo: '#ffffff',
-    },
-    rk: {
-      circle: '#162873',
-      text: '#4d4f53',
       halo: '#ffffff',
     },
     sign: {
@@ -175,6 +175,11 @@ const colors: Record<string, Theme> = {
     electricbox: {
       text: '#b42222',
     },
+    kp: {
+      circle: '#8338ec',
+      text: '#8338ec',
+      halo: '#8338ec',
+    },
     kvb: {
       color: '#ffc700',
     },
@@ -242,11 +247,6 @@ const colors: Record<string, Theme> = {
     },
     railyard: {
       text: '#8095c3',
-    },
-    rk: {
-      circle: '#8338ec',
-      text: '#8338ec',
-      halo: '#8338ec',
     },
     routes: {
       text: '#e05206',
@@ -319,6 +319,11 @@ const colors: Record<string, Theme> = {
     electricbox: {
       text: bpLight,
     },
+    kp: {
+      circle: bpLight,
+      text: bpLight,
+      halo: bpLight,
+    },
     kvb: {
       color: bpLight,
     },
@@ -386,11 +391,6 @@ const colors: Record<string, Theme> = {
     },
     railyard: {
       text: bpLight,
-    },
-    rk: {
-      circle: bpLight,
-      text: bpLight,
-      halo: bpLight,
     },
     routes: {
       text: bpLight,

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -62,6 +62,7 @@ const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
           colors,
           minzoom: 12,
           sourceLayer: 'buffer_stops',
+          fieldName: 'extensions_sncf_kp',
         })}
         id="chartis/osrd_bufferstop_kp/geo"
         layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -15,20 +15,17 @@ export function getBufferStopsLayerProps(params: { sourceTable?: string }): Omit
       'text-field': '{extensions_sncf_kp}',
       'text-font': ['Roboto Condensed'],
       'text-size': 10,
-      'text-offset': [0, 1.2],
+      'text-offset': [1, 0.2],
       'icon-image': 'HEURTOIR',
       'icon-size': 0.2,
-      'text-anchor': 'center',
+      'text-anchor': 'left',
       'icon-rotation-alignment': 'viewport',
       'icon-allow-overlap': false,
       'icon-ignore-placement': false,
       'text-allow-overlap': false,
     },
     paint: {
-      'text-color': '#555',
-      'text-halo-width': 2,
-      'text-halo-color': 'rgba(255,255,255,0.75)',
-      'text-halo-blur': 1,
+      'text-color': '#333',
     },
   };
 

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -6,14 +6,13 @@ import { RootState } from 'reducers';
 import { Theme, OmitLayer } from 'types';
 import { MAP_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
-import configKPLabelLayer from './configKPLabelLayer';
 
 export function getBufferStopsLayerProps(params: { sourceTable?: string }): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
     minzoom: 12,
     layout: {
-      'text-field': ['slice', ['get', 'id'], 11],
+      'text-field': '{extensions_sncf_kp}',
       'text-font': ['Roboto Condensed'],
       'text-size': 10,
       'text-offset': [0, 1.2],
@@ -42,7 +41,7 @@ interface BufferStopsProps {
   layerOrder: number;
 }
 
-const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
+const BufferStops: FC<BufferStopsProps> = ({ layerOrder }) => {
   const infraID = useSelector(getInfraID);
   const { layersSettings } = useSelector((state: RootState) => state.map);
 
@@ -55,16 +54,6 @@ const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
       <OrderedLayer
         {...getBufferStopsLayerProps({ sourceTable: 'buffer_stops' })}
         id="chartis/osrd_bufferstop/geo"
-        layerOrder={layerOrder}
-      />
-      <OrderedLayer
-        {...configKPLabelLayer({
-          colors,
-          fieldName: 'extensions_sncf_kp',
-          minzoom: 12,
-          sourceLayer: 'buffer_stops',
-        })}
-        id="chartis/osrd_bufferstop_kp/geo"
         layerOrder={layerOrder}
       />
     </Source>

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -60,9 +60,9 @@ const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
       <OrderedLayer
         {...configKPLabelLayer({
           colors,
+          fieldName: 'extensions_sncf_kp',
           minzoom: 12,
           sourceLayer: 'buffer_stops',
-          fieldName: 'extensions_sncf_kp',
         })}
         id="chartis/osrd_bufferstop_kp/geo"
         layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -6,6 +6,7 @@ import { RootState } from 'reducers';
 import { Theme, OmitLayer } from 'types';
 import { MAP_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
+import configRKLabelLayer from './configRKLabelLayer';
 
 export function getBufferStopsLayerProps(params: { sourceTable?: string }): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
@@ -23,7 +24,6 @@ export function getBufferStopsLayerProps(params: { sourceTable?: string }): Omit
       'icon-allow-overlap': false,
       'icon-ignore-placement': false,
       'text-allow-overlap': false,
-      visibility: 'visible',
     },
     paint: {
       'text-color': '#555',
@@ -42,19 +42,28 @@ interface BufferStopsProps {
   layerOrder: number;
 }
 
-const BufferStops: FC<BufferStopsProps> = ({ layerOrder }) => {
+const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
   const infraID = useSelector(getInfraID);
   const { layersSettings } = useSelector((state: RootState) => state.map);
 
   return layersSettings.bufferstops ? (
     <Source
-      id="osrd_bufferstoplayer_geo"
+      id="osrd_bufferstop_geo"
       type="vector"
       url={`${MAP_URL}/layer/buffer_stops/mvt/geo/?infra=${infraID}`}
     >
       <OrderedLayer
         {...getBufferStopsLayerProps({ sourceTable: 'buffer_stops' })}
-        id="chartis/osrd_bufferstoplayer/geo"
+        id="chartis/osrd_bufferstop/geo"
+        layerOrder={layerOrder}
+      />
+      <OrderedLayer
+        {...configRKLabelLayer({
+          colors,
+          minzoom: 12,
+          sourceLayer: 'buffer_stops',
+        })}
+        id="chartis/osrd_bufferstop_rk/geo"
         layerOrder={layerOrder}
       />
     </Source>

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -6,7 +6,7 @@ import { RootState } from 'reducers';
 import { Theme, OmitLayer } from 'types';
 import { MAP_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
-import configRKLabelLayer from './configRKLabelLayer';
+import configKPLabelLayer from './configKPLabelLayer';
 
 export function getBufferStopsLayerProps(params: { sourceTable?: string }): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
@@ -58,12 +58,12 @@ const BufferStops: FC<BufferStopsProps> = ({ colors, layerOrder }) => {
         layerOrder={layerOrder}
       />
       <OrderedLayer
-        {...configRKLabelLayer({
+        {...configKPLabelLayer({
           colors,
           minzoom: 12,
           sourceLayer: 'buffer_stops',
         })}
-        id="chartis/osrd_bufferstop_rk/geo"
+        id="chartis/osrd_bufferstop_kp/geo"
         layerOrder={layerOrder}
       />
     </Source>

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -8,6 +8,7 @@ import { MAP_URL } from 'common/Map/const';
 
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import { getInfraID } from 'reducers/osrdconf/selectors';
+import configKPLabelLayer from './configKPLabelLayer';
 
 export function getDetectorsLayerProps(params: {
   colors: Theme;
@@ -74,6 +75,15 @@ const Detectors: FC<DetectorsProps> = ({ colors, layerOrder }) => {
     >
       <OrderedLayer {...layerPoint} id="chartis/osrd_detectors/geo" layerOrder={layerOrder} />
       <OrderedLayer {...layerName} id="chartis/osrd_detectors_name/geo" layerOrder={layerOrder} />
+      <OrderedLayer
+        {...configKPLabelLayer({
+          colors,
+          minzoom: 10,
+          sourceLayer: 'detectors',
+        })}
+        id="chartis/osrd_detectors_kp/geo"
+        layerOrder={layerOrder}
+      />
     </Source>
   ) : null;
 };

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -8,7 +8,6 @@ import { MAP_URL } from 'common/Map/const';
 
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import { getInfraID } from 'reducers/osrdconf/selectors';
-import configKPLabelLayer from './configKPLabelLayer';
 
 export function getDetectorsLayerProps(params: {
   colors: Theme;
@@ -34,13 +33,13 @@ export function getDetectorsNameLayerProps(params: {
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
     layout: {
-      'text-field': ['slice', ['get', 'id'], 9],
+      'text-field': '{extensions_sncf_kp}',
       'text-font': ['Roboto Condensed'],
       'text-size': 10,
       'text-anchor': 'left',
-      'text-allow-overlap': true,
+      'text-allow-overlap': false,
       'text-ignore-placement': false,
-      'text-offset': [1, 0.2],
+      'text-offset': [0.5, 0.2],
       visibility: 'visible',
     },
     paint: {
@@ -75,16 +74,6 @@ const Detectors: FC<DetectorsProps> = ({ colors, layerOrder }) => {
     >
       <OrderedLayer {...layerPoint} id="chartis/osrd_detectors/geo" layerOrder={layerOrder} />
       <OrderedLayer {...layerName} id="chartis/osrd_detectors_name/geo" layerOrder={layerOrder} />
-      <OrderedLayer
-        {...configKPLabelLayer({
-          colors,
-          fieldName: 'extensions_sncf_kp',
-          minzoom: 10,
-          sourceLayer: 'detectors',
-        })}
-        id="chartis/osrd_detectors_kp/geo"
-        layerOrder={layerOrder}
-      />
     </Source>
   ) : null;
 };

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -80,6 +80,7 @@ const Detectors: FC<DetectorsProps> = ({ colors, layerOrder }) => {
           colors,
           minzoom: 10,
           sourceLayer: 'detectors',
+          fieldName: 'extensions_sncf_kp',
         })}
         id="chartis/osrd_detectors_kp/geo"
         layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -38,9 +38,9 @@ export function getDetectorsNameLayerProps(params: {
       'text-font': ['Roboto Condensed'],
       'text-size': 10,
       'text-anchor': 'left',
-      'text-allow-overlap': false,
+      'text-allow-overlap': true,
       'text-ignore-placement': false,
-      'text-offset': [0.75, 0.1],
+      'text-offset': [1, 0.2],
       visibility: 'visible',
     },
     paint: {
@@ -78,9 +78,9 @@ const Detectors: FC<DetectorsProps> = ({ colors, layerOrder }) => {
       <OrderedLayer
         {...configKPLabelLayer({
           colors,
+          fieldName: 'extensions_sncf_kp',
           minzoom: 10,
           sourceLayer: 'detectors',
-          fieldName: 'extensions_sncf_kp',
         })}
         id="chartis/osrd_detectors_kp/geo"
         layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -149,6 +149,7 @@ function getSignalLayers(context: LayerContext, prefix: string): LayerProps[] {
     { ...getPointLayerProps(context), id: `${prefix}geo/signal-point` },
     {
       ...configKPLabelLayer({
+        bottomOffset: 6.5,
         colors: context.colors,
         fieldName: 'extensions_sncf_kp',
         minzoom: 12,

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -44,6 +44,7 @@ import {
 import { getPSLSignsLayerProps, getPSLSignsMastLayerProps } from './extensions/SNCF/SNCF_PSL_SIGNS';
 import { LayerContext } from './types';
 import { getCatenariesProps, getCatenariesTextParams } from './Catenaries';
+import configKPLabelLayer from './configKPLabelLayer';
 import OrderedLayer from './OrderedLayer';
 
 const SIGNAL_TYPE_KEY = 'extensions_sncf_installation_type';
@@ -146,6 +147,17 @@ function getSignalLayers(context: LayerContext, prefix: string): LayerProps[] {
   return [
     { ...getSignalMatLayerProps(context), id: `${prefix}geo/signal-mat` },
     { ...getPointLayerProps(context), id: `${prefix}geo/signal-point` },
+    {
+      ...configKPLabelLayer({
+        colors: context.colors,
+        fieldName: 'extensions_sncf_kp',
+        minzoom: 12,
+        isSignalisation: true,
+        sourceLayer: context.sourceTable || '',
+      }),
+      id: `${prefix}geo/signal-kp`,
+      filter: ['in', 'extensions_sncf_installation_type', ...context.symbolsList],
+    } as LayerProps,
   ].concat(
     context.symbolsList.map((symbol) => {
       const props = getSignalLayerProps(context, symbol);
@@ -211,6 +223,15 @@ function getPSLSignsLayers(context: LayerContext, prefix: string): LayerProps[] 
       ...getPSLSignsMastLayerProps(context),
       id: `${prefix}geo/psl-signs-mast`,
       minzoom: POINT_ENTITIES_MIN_ZOOM,
+    },
+    {
+      ...configKPLabelLayer({
+        colors: context.colors,
+        minzoom: 9.5,
+        isSignalisation: true,
+        sourceLayer: 'psl_signs',
+      }),
+      id: `${prefix}geo/psl-signs-kp`,
     },
   ];
 }

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -146,9 +146,9 @@ export default function OperationalPoints(props: Props) {
         <OrderedLayer
           {...configKPLabelLayer({
             colors,
+            fieldName: 'extensions_sncf_kp',
             minzoom: 9.5,
             sourceLayer: 'operational_points',
-            fieldName: 'extensions_sncf_kp',
           })}
           id="chartis/osrd_operational_point_kp/geo"
           layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -18,18 +18,18 @@ export default function OperationalPoints(props: PlatformProps) {
   const { layersSettings } = useSelector((state: RootState) => state.map);
   const infraID = useSelector(getInfraID);
   const { colors, layerOrder } = props;
-  const layerPoint: LayerProps = {
+  const point: LayerProps = {
     type: 'circle',
     'source-layer': 'operational_points',
     paint: {
-      'circle-stroke-color': '#82be00',
+      'circle-stroke-color': colors.op.circle,
       'circle-stroke-width': 2,
       'circle-color': 'rgba(255, 255, 255, 0)',
       'circle-radius': 3,
     },
   };
 
-  const layerName: LayerProps = {
+  const name: LayerProps = {
     type: 'symbol',
     'source-layer': 'operational_points',
     minzoom: 9.5,
@@ -43,9 +43,8 @@ export default function OperationalPoints(props: PlatformProps) {
           'case',
           ['in', ['get', 'extensions_sncf_ch'], ['literal', ['BV', '00']]],
           '',
-          ['concat', '\n', ['get', 'extensions_sncf_ch_long_label']],
+          ['concat', ' ', ['get', 'extensions_sncf_ch']],
         ],
-        // ['concat', '\n', ['get', 'uic']],
       ],
       'text-font': ['Roboto Condensed'],
       'text-size': 12,
@@ -54,6 +53,7 @@ export default function OperationalPoints(props: PlatformProps) {
       'text-allow-overlap': false,
       'text-ignore-placement': false,
       'text-offset': [0.75, 0.1],
+      'text-max-width': 32,
       visibility: 'visible',
     },
     paint: {
@@ -64,7 +64,32 @@ export default function OperationalPoints(props: PlatformProps) {
     },
   };
 
-  const layerNameShort: LayerProps = {
+  const yardName: LayerProps = {
+    type: 'symbol',
+    'source-layer': 'operational_points',
+    minzoom: 9.5,
+    filter: ['!', ['in', ['get', 'extensions_sncf_ch'], ['literal', ['BV', '00']]]],
+    layout: {
+      'text-field': '{extensions_sncf_ch_long_label}',
+      'text-font': ['Roboto Condensed'],
+      'text-size': 10,
+      'text-anchor': 'left',
+      'text-justify': 'left',
+      'text-allow-overlap': false,
+      'text-ignore-placement': true,
+      'text-offset': [0.85, 1.1],
+      'text-max-width': 32,
+      visibility: 'visible',
+    },
+    paint: {
+      'text-color': colors.op.minitext,
+      'text-halo-width': 2,
+      'text-halo-color': colors.op.halo,
+      'text-halo-blur': 1,
+    },
+  };
+
+  const trigram: LayerProps = {
     type: 'symbol',
     'source-layer': 'operational_points',
     maxzoom: 9.5,
@@ -82,7 +107,7 @@ export default function OperationalPoints(props: PlatformProps) {
         ],
       ],
       'text-font': ['Roboto Condensed'],
-      'text-size': 10,
+      'text-size': 11,
       'text-anchor': 'left',
       'text-allow-overlap': true,
       'text-ignore-placement': false,
@@ -104,19 +129,20 @@ export default function OperationalPoints(props: PlatformProps) {
         type="vector"
         url={`${MAP_URL}/layer/operational_points/mvt/geo/?infra=${infraID}`}
       >
+        <OrderedLayer {...point} id="chartis/osrd_operational_point/geo" layerOrder={layerOrder} />
         <OrderedLayer
-          {...layerPoint}
-          id="chartis/osrd_operational_point/geo"
-          layerOrder={layerOrder}
-        />
-        <OrderedLayer
-          {...layerNameShort}
+          {...name}
           id="chartis/osrd_operational_point_name_short/geo"
           layerOrder={layerOrder}
         />
         <OrderedLayer
-          {...layerName}
+          {...trigram}
           id="chartis/osrd_operational_point_name/geo"
+          layerOrder={layerOrder}
+        />
+        <OrderedLayer
+          {...yardName}
+          id="chartis/osrd_operational_point_yardname/geo"
           layerOrder={layerOrder}
         />
       </Source>

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -146,7 +146,7 @@ export default function OperationalPoints(props: Props) {
         <OrderedLayer
           {...configKPLabelLayer({
             colors,
-            fieldName: 'extensions_sncf_kp',
+            fieldName: 'kp',
             minzoom: 9.5,
             sourceLayer: 'operational_points',
           })}

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -7,6 +7,7 @@ import { Theme } from 'types';
 import { MAP_URL } from 'common/Map/const';
 
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
+import configRKLabelLayer from 'common/Map/Layers/configRKLabelLayer';
 import { getInfraID } from 'reducers/osrdconf/selectors';
 
 interface PlatformProps {
@@ -54,7 +55,6 @@ export default function OperationalPoints(props: PlatformProps) {
       'text-ignore-placement': false,
       'text-offset': [0.75, 0.1],
       'text-max-width': 32,
-      visibility: 'visible',
     },
     paint: {
       'text-color': colors.op.text,
@@ -79,7 +79,6 @@ export default function OperationalPoints(props: PlatformProps) {
       'text-ignore-placement': true,
       'text-offset': [0.85, 1.1],
       'text-max-width': 32,
-      visibility: 'visible',
     },
     paint: {
       'text-color': colors.op.minitext,
@@ -112,7 +111,6 @@ export default function OperationalPoints(props: PlatformProps) {
       'text-allow-overlap': true,
       'text-ignore-placement': false,
       'text-offset': [0.75, 0.1],
-      visibility: 'visible',
     },
     paint: {
       'text-color': colors.op.text,
@@ -143,6 +141,15 @@ export default function OperationalPoints(props: PlatformProps) {
         <OrderedLayer
           {...yardName}
           id="chartis/osrd_operational_point_yardname/geo"
+          layerOrder={layerOrder}
+        />
+        <OrderedLayer
+          {...configRKLabelLayer({
+            colors,
+            minzoom: 9.5,
+            sourceLayer: 'operational_points',
+          })}
+          id={`chartis/osrd_operational_point_rk/${geomType}`}
           layerOrder={layerOrder}
         />
       </Source>

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -10,12 +10,12 @@ import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import configKPLabelLayer from 'common/Map/Layers/configKPLabelLayer';
 import { getInfraID } from 'reducers/osrdconf/selectors';
 
-interface PlatformProps {
+interface Props {
   colors: Theme;
   layerOrder: number;
 }
 
-export default function OperationalPoints(props: PlatformProps) {
+export default function OperationalPoints(props: Props) {
   const { layersSettings } = useSelector((state: RootState) => state.map);
   const infraID = useSelector(getInfraID);
   const { colors, layerOrder } = props;
@@ -148,6 +148,7 @@ export default function OperationalPoints(props: PlatformProps) {
             colors,
             minzoom: 9.5,
             sourceLayer: 'operational_points',
+            fieldName: 'extensions_sncf_kp',
           })}
           id="chartis/osrd_operational_point_kp/geo"
           layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -7,7 +7,7 @@ import { Theme } from 'types';
 import { MAP_URL } from 'common/Map/const';
 
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
-import configRKLabelLayer from 'common/Map/Layers/configRKLabelLayer';
+import configKPLabelLayer from 'common/Map/Layers/configKPLabelLayer';
 import { getInfraID } from 'reducers/osrdconf/selectors';
 
 interface PlatformProps {
@@ -144,12 +144,12 @@ export default function OperationalPoints(props: PlatformProps) {
           layerOrder={layerOrder}
         />
         <OrderedLayer
-          {...configRKLabelLayer({
+          {...configKPLabelLayer({
             colors,
             minzoom: 9.5,
             sourceLayer: 'operational_points',
           })}
-          id={`chartis/osrd_operational_point_rk/${geomType}`}
+          id="chartis/osrd_operational_point_kp/geo"
           layerOrder={layerOrder}
         />
       </Source>

--- a/front/src/common/Map/Layers/Signals.tsx
+++ b/front/src/common/Map/Layers/Signals.tsx
@@ -83,6 +83,7 @@ function Signals(props: PlatformProps) {
       />
       <OrderedLayer
         {...configKPLabelLayer({
+          bottomOffset: 6.5,
           colors,
           fieldName: 'extensions_sncf_kp',
           minzoom: 12,

--- a/front/src/common/Map/Layers/Signals.tsx
+++ b/front/src/common/Map/Layers/Signals.tsx
@@ -90,6 +90,7 @@ function Signals(props: PlatformProps) {
           sourceLayer: sourceTable,
         })}
         id="chartis/signal/kp"
+        filter={['in', 'extensions_sncf_installation_type', ...signalsList]}
         layerOrder={layerOrder}
       />
 

--- a/front/src/common/Map/Layers/Signals.tsx
+++ b/front/src/common/Map/Layers/Signals.tsx
@@ -22,6 +22,7 @@ import {
   getSignalMatLayerProps,
   SignalContext,
 } from './geoSignalsLayers';
+import configKPLabelLayer from './configKPLabelLayer';
 
 interface PlatformProps {
   colors: Theme;
@@ -78,6 +79,17 @@ function Signals(props: PlatformProps) {
       <OrderedLayer
         {...getPointLayerProps(context)}
         id="chartis/signal/point"
+        layerOrder={layerOrder}
+      />
+      <OrderedLayer
+        {...configKPLabelLayer({
+          colors,
+          fieldName: 'extensions_sncf_kp',
+          minzoom: 12,
+          isSignalisation: true,
+          sourceLayer: sourceTable,
+        })}
+        id="chartis/signal/kp"
         layerOrder={layerOrder}
       />
 

--- a/front/src/common/Map/Layers/configKPLabelLayer.tsx
+++ b/front/src/common/Map/Layers/configKPLabelLayer.tsx
@@ -1,3 +1,4 @@
+import { ExpressionFilterSpecification } from 'maplibre-gl';
 import { LayerProps } from 'react-map-gl/maplibre';
 
 import { Theme } from 'types';
@@ -5,32 +6,56 @@ import { Theme } from 'types';
 interface PlatformProps {
   colors: Theme;
   fieldName?: string;
-  leftOffset?: number;
   maxzoom?: number;
   minzoom?: number;
-  rotation?: 'map' | 'viewport' | 'auto';
+  isSignalisation?: boolean;
   sourceLayer: string;
 }
-
-/*
-* signals
-OK detectors: seulement ceux sous un signal, ceux qu'on genere en sur les tiv de jonction connait pas leur pk
-OK buffer stops
-OK les panneaux des psl
-OK les operational point parts
-*/
 
 export default function configKPLabelLayer(props: PlatformProps) {
   const {
     colors,
     fieldName = 'kp',
-    leftOffset = -1,
     maxzoom = 24,
     minzoom = 7,
-    rotation = 'viewport',
+    isSignalisation,
     sourceLayer,
   } = props;
-  const rkValue: LayerProps = {
+
+  // Will have to be removed when backend will be updated with consistent fieldnames
+  const testSideExpression = (side: 'LEFT' | 'RIGHT' | 'CENTER') => [
+    'any',
+    ['==', ['get', 'extensions_sncf_side'], side],
+    ['==', ['get', 'side'], side],
+  ];
+
+  const signallingLabeling: LayerProps['layout'] = isSignalisation
+    ? {
+        'text-rotation-alignment': 'map',
+        'text-pitch-alignment': 'map',
+        'text-rotate': ['get', 'angle'],
+        'text-anchor': [
+          'case',
+          testSideExpression('LEFT') as ExpressionFilterSpecification,
+          'right',
+          testSideExpression('RIGHT') as ExpressionFilterSpecification,
+          'left',
+          'center',
+        ],
+        'text-offset': [
+          'case',
+          testSideExpression('LEFT') as ExpressionFilterSpecification,
+          ['literal', [-2.75, 0.2]],
+          testSideExpression('RIGHT') as ExpressionFilterSpecification,
+          ['literal', [2.75, 0.2]],
+          ['literal', [0, 2.5]],
+        ],
+      }
+    : {
+        'text-offset': ['literal', [-1, 0.1]],
+      };
+
+  const kpValue: LayerProps = {
     type: 'symbol',
     'source-layer': sourceLayer,
     filter: ['all', ['!=', ['literal', null], ['get', fieldName]], ['!=', '', ['get', fieldName]]],
@@ -42,11 +67,9 @@ export default function configKPLabelLayer(props: PlatformProps) {
       'text-size': 9,
       'text-anchor': 'right',
       'text-allow-overlap': true,
-      'text-ignore-placement': true,
-      'text-offset': [leftOffset, 0.1],
-      'text-rotation-alignment': rotation,
-      'text-pitch-alignment': rotation,
-      'text-rotate': rotation === 'map' ? ['get', 'angle_geo'] : 0,
+      'text-ignore-placement': false,
+
+      ...signallingLabeling,
     },
     paint: {
       'text-color': colors.kp.text,
@@ -56,5 +79,5 @@ export default function configKPLabelLayer(props: PlatformProps) {
     },
   };
 
-  return rkValue;
+  return kpValue;
 }

--- a/front/src/common/Map/Layers/configKPLabelLayer.tsx
+++ b/front/src/common/Map/Layers/configKPLabelLayer.tsx
@@ -4,6 +4,7 @@ import { LayerProps } from 'react-map-gl/maplibre';
 import { Theme } from 'types';
 
 interface PlatformProps {
+  bottomOffset?: number;
   colors: Theme;
   fieldName?: string;
   maxzoom?: number;
@@ -14,6 +15,7 @@ interface PlatformProps {
 
 export default function configKPLabelLayer(props: PlatformProps) {
   const {
+    bottomOffset = 2.5,
     colors,
     fieldName = 'kp',
     maxzoom = 24,
@@ -48,7 +50,7 @@ export default function configKPLabelLayer(props: PlatformProps) {
           ['literal', [-2.75, 0.2]],
           testSideExpression('RIGHT') as ExpressionFilterSpecification,
           ['literal', [2.75, 0.2]],
-          ['literal', [0, 2.5]],
+          ['literal', [0, bottomOffset]],
         ],
       }
     : {
@@ -62,7 +64,7 @@ export default function configKPLabelLayer(props: PlatformProps) {
     maxzoom,
     minzoom,
     layout: {
-      'text-field': ['concat', 'PK ', ['get', fieldName]],
+      'text-field': ['get', fieldName],
       'text-font': ['Roboto Medium'],
       'text-size': 9,
       'text-anchor': 'right',

--- a/front/src/common/Map/Layers/configKPLabelLayer.tsx
+++ b/front/src/common/Map/Layers/configKPLabelLayer.tsx
@@ -18,15 +18,16 @@ les panneaux des psl
 les operational point parts
 */
 
-export default function configRKLabelLayer(props: PlatformProps) {
-  const { colors, leftOffset = -1, maxzoom = 32, minzoom = 7, sourceLayer } = props;
+export default function configKPLabelLayer(props: PlatformProps) {
+  const { colors, leftOffset = -1, maxzoom = 24, minzoom = 7, sourceLayer } = props;
   const rkValue: LayerProps = {
     type: 'symbol',
     'source-layer': sourceLayer,
+    filter: ['!=', '', ['get', 'extensions_sncf_kp']],
     maxzoom,
     minzoom,
     layout: {
-      'text-field': '{extensions_sncf_rk}',
+      'text-field': ['concat', 'PK ', ['get', 'extensions_sncf_kp']],
       'text-font': ['Roboto Medium'],
       'text-size': 9,
       'text-anchor': 'right',

--- a/front/src/common/Map/Layers/configKPLabelLayer.tsx
+++ b/front/src/common/Map/Layers/configKPLabelLayer.tsx
@@ -4,41 +4,54 @@ import { Theme } from 'types';
 
 interface PlatformProps {
   colors: Theme;
+  fieldName?: string;
+  leftOffset?: number;
   maxzoom?: number;
   minzoom?: number;
-  leftOffset?: number;
+  rotation?: 'map' | 'viewport' | 'auto';
   sourceLayer: string;
 }
 
 /*
 * signals
-detectors: seulement ceux sous un signal, ceux qu'on genere en sur les tiv de jonction connait pas leur pk
-buffer stops
-les panneaux des psl
-les operational point parts
+OK detectors: seulement ceux sous un signal, ceux qu'on genere en sur les tiv de jonction connait pas leur pk
+OK buffer stops
+OK les panneaux des psl
+OK les operational point parts
 */
 
 export default function configKPLabelLayer(props: PlatformProps) {
-  const { colors, leftOffset = -1, maxzoom = 24, minzoom = 7, sourceLayer } = props;
+  const {
+    colors,
+    fieldName = 'kp',
+    leftOffset = -1,
+    maxzoom = 24,
+    minzoom = 7,
+    rotation = 'viewport',
+    sourceLayer,
+  } = props;
   const rkValue: LayerProps = {
     type: 'symbol',
     'source-layer': sourceLayer,
-    filter: ['!=', '', ['get', 'extensions_sncf_kp']],
+    filter: ['all', ['!=', ['literal', null], ['get', fieldName]], ['!=', '', ['get', fieldName]]],
     maxzoom,
     minzoom,
     layout: {
-      'text-field': ['concat', 'PK ', ['get', 'extensions_sncf_kp']],
+      'text-field': ['concat', 'PK ', ['get', fieldName]],
       'text-font': ['Roboto Medium'],
       'text-size': 9,
       'text-anchor': 'right',
       'text-allow-overlap': true,
       'text-ignore-placement': true,
       'text-offset': [leftOffset, 0.1],
+      'text-rotation-alignment': rotation,
+      'text-pitch-alignment': rotation,
+      'text-rotate': rotation === 'map' ? ['get', 'angle_geo'] : 0,
     },
     paint: {
-      'text-color': colors.rk.text,
+      'text-color': colors.kp.text,
       'text-halo-width': 0,
-      'text-halo-color': colors.rk.halo,
+      'text-halo-color': colors.kp.halo,
       'text-halo-blur': 1,
     },
   };

--- a/front/src/common/Map/Layers/configRKLabelLayer.tsx
+++ b/front/src/common/Map/Layers/configRKLabelLayer.tsx
@@ -1,0 +1,46 @@
+import { LayerProps } from 'react-map-gl/maplibre';
+
+import { Theme } from 'types';
+
+interface PlatformProps {
+  colors: Theme;
+  maxzoom?: number;
+  minzoom?: number;
+  leftOffset?: number;
+  sourceLayer: string;
+}
+
+/*
+* signals
+detectors: seulement ceux sous un signal, ceux qu'on genere en sur les tiv de jonction connait pas leur pk
+buffer stops
+les panneaux des psl
+les operational point parts
+*/
+
+export default function configRKLabelLayer(props: PlatformProps) {
+  const { colors, leftOffset = -1, maxzoom = 32, minzoom = 7, sourceLayer } = props;
+  const rkValue: LayerProps = {
+    type: 'symbol',
+    'source-layer': sourceLayer,
+    maxzoom,
+    minzoom,
+    layout: {
+      'text-field': '{extensions_sncf_rk}',
+      'text-font': ['Roboto Medium'],
+      'text-size': 9,
+      'text-anchor': 'right',
+      'text-allow-overlap': true,
+      'text-ignore-placement': true,
+      'text-offset': [leftOffset, 0.1],
+    },
+    paint: {
+      'text-color': colors.rk.text,
+      'text-halo-width': 0,
+      'text-halo-color': colors.rk.halo,
+      'text-halo-blur': 1,
+    },
+  };
+
+  return rkValue;
+}

--- a/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL.tsx
@@ -212,7 +212,7 @@ export default function SNCF_PSL(props: SNCF_PSLProps) {
             layerOrder={layerOrder}
           />
         </Source>
-        <SNCF_PSL_Signs layerOrder={layerOrder} />
+        <SNCF_PSL_Signs colors={colors} layerOrder={layerOrder} />
       </>
     );
   }

--- a/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL_SIGNS.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL_SIGNS.tsx
@@ -122,8 +122,8 @@ export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
         {...configKPLabelLayer({
           colors,
           minzoom: 9.5,
+          isSignalisation: true,
           sourceLayer: 'psl_signs',
-          rotation: 'map',
         })}
         id="chartis/osrd_psl_signs_kp/geo"
         layerOrder={layerOrder}

--- a/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL_SIGNS.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL_SIGNS.tsx
@@ -3,13 +3,15 @@ import { MAP_URL } from 'common/Map/const';
 import { LayerProps, Source, SymbolLayer } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 import { getInfraID } from 'reducers/osrdconf/selectors';
-import { OmitLayer } from 'types';
+import { Theme, OmitLayer } from 'types';
 import { isNil } from 'lodash';
 import { getMap } from 'reducers/map/selectors';
 import OrderedLayer from '../../OrderedLayer';
 import { LayerContext } from '../../types';
+import configKPLabelLayer from '../../configKPLabelLayer';
 
 interface SNCF_PSL_SignsProps {
+  colors: Theme;
   layerOrder?: number;
 }
 
@@ -94,7 +96,7 @@ export function getPSLSignsMastLayerProps({
 
 export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
   const infraID = useSelector(getInfraID);
-  const { layerOrder } = props;
+  const { colors, layerOrder } = props;
 
   const { mapStyle } = useSelector(getMap);
   const prefix = mapStyle === 'blueprint' ? 'SCHB ' : '';
@@ -116,6 +118,16 @@ export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
     >
       <OrderedLayer {...mastsParams} layerOrder={layerOrder} />
       <OrderedLayer {...signsParams} layerOrder={layerOrder} />
+      <OrderedLayer
+        {...configKPLabelLayer({
+          colors,
+          minzoom: 9.5,
+          sourceLayer: 'psl_signs',
+          rotation: 'map',
+        })}
+        id="chartis/osrd_psl_signs_kp/geo"
+        layerOrder={layerOrder}
+      />
     </Source>
   );
 }

--- a/front/src/common/Map/Settings/MapSettings.tsx
+++ b/front/src/common/Map/Settings/MapSettings.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from 'react';
 import MapSettingsLayers from 'common/Map/Settings/MapSettingsLayers';
 import MapSettingsMapStyle from 'common/Map/Settings/MapSettingsMapStyle';
 import MapSettingsBackgroundSwitches from 'common/Map/Settings/MapSettingsBackgroundSwitches';
-import MapSettingsSignals from 'common/Map/Settings/MapSettingsSignals';
 import MapSettingsSpeedLimits from 'common/Map/Settings/MapSettingsSpeedLimits';
 import { useTranslation } from 'react-i18next';
 import HearderPopUp from '../HeaderPopUp';
@@ -12,7 +11,6 @@ interface MapSettingsProps {
 }
 const MapSettings: FC<MapSettingsProps> = ({ closeMapSettingsPopUp }) => {
   const { t } = useTranslation(['translation', 'map-settings']);
-  const [showSettingsSignals, setShowSettingsSignals] = useState(false);
   const [showSettingsLayers, setShowSettingsLayers] = useState(false);
   const [showSettingsSpeedLimits, setShowSettingsSpeedLimits] = useState(false);
 
@@ -23,19 +21,6 @@ const MapSettings: FC<MapSettingsProps> = ({ closeMapSettingsPopUp }) => {
       <MapSettingsMapStyle />
       <div className="my-1" />
       <MapSettingsBackgroundSwitches />
-      <div
-        className="mb-1 mt-3 border-bottom d-flex align-items-center sub-section-title"
-        onClick={() => setShowSettingsSignals((v) => !v)}
-        role="button"
-        tabIndex={0}
-      >
-        {t('map-settings:signalisation')}
-        <i
-          className={`${showSettingsSignals ? 'open' : ''} icons-arrow-down icons-size-20px`}
-          aria-hidden="true"
-        />
-      </div>
-      {showSettingsSignals && <MapSettingsSignals />}
       <div
         className="mb-1 mt-3 border-bottom d-flex align-items-center sub-section-title"
         onClick={() => setShowSettingsLayers((v) => !v)}

--- a/front/src/common/Map/Settings/MapSettingsLayers.tsx
+++ b/front/src/common/Map/Settings/MapSettingsLayers.tsx
@@ -3,8 +3,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { updateLayersSettings } from 'reducers/map';
 import { GiElectric, GiUnplugged } from 'react-icons/gi';
-import { AiOutlineBlock } from 'react-icons/ai';
-import { MdSpaceBar } from 'react-icons/md';
+
+import MapSettingsSignals from 'common/Map/Settings/MapSettingsSignals';
 
 import BufferStopSVGFile from 'assets/pictures/layersicons/bufferstop.svg';
 import OPsSVGFile from 'assets/pictures/layersicons/ops.svg';
@@ -60,44 +60,41 @@ export const Icon2SVG: FC<{ file: string; altName?: string }> = ({ file, altName
 );
 
 const MapSettingsLayers: FC<unknown> = () => (
-  <div className="row">
-    <div className="col-md-6">
-      <FormatSwitch name="catenaries" icon={<GiElectric />} />
+  <>
+    <MapSettingsSignals />
+    <div className="row mt-2">
+      <div className="col-md-6">
+        <FormatSwitch name="catenaries" icon={<GiElectric />} />
+      </div>
+      <div className="col-md-6">
+        <FormatSwitch name="neutral_sections" icon={<GiUnplugged />} />
+      </div>
+      <div className="col-md-6">
+        <FormatSwitch
+          name="operationalpoints"
+          icon={<Icon2SVG file={OPsSVGFile} altName="Operationnal points svg" />}
+        />
+      </div>
+      <div className="col-md-6">
+        <FormatSwitch
+          name="switches"
+          icon={<Icon2SVG file={SwitchesSVGFile} altName="Switches icon svg" />}
+        />
+      </div>
+      <div className="col-md-6">
+        <FormatSwitch
+          name="bufferstops"
+          icon={<Icon2SVG file={BufferStopSVGFile} altName="Buffer stop svg" />}
+        />
+      </div>
+      <div className="col-md-6">
+        <FormatSwitch
+          name="detectors"
+          icon={<Icon2SVG file={DetectorsSVGFile} altName="Detectors circles svg" />}
+        />
+      </div>
     </div>
-    <div className="col-md-6">
-      <FormatSwitch name="neutral_sections" icon={<GiUnplugged />} />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch name="signalingtype" icon={<AiOutlineBlock />} disabled />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch name="tvds" icon={<MdSpaceBar />} disabled />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch
-        name="operationalpoints"
-        icon={<Icon2SVG file={OPsSVGFile} altName="Operationnal points svg" />}
-      />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch
-        name="switches"
-        icon={<Icon2SVG file={SwitchesSVGFile} altName="Switches icon svg" />}
-      />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch
-        name="bufferstops"
-        icon={<Icon2SVG file={BufferStopSVGFile} altName="Buffer stop svg" />}
-      />
-    </div>
-    <div className="col-md-6">
-      <FormatSwitch
-        name="detectors"
-        icon={<Icon2SVG file={DetectorsSVGFile} altName="Detectors circles svg" />}
-      />
-    </div>
-  </div>
+  </>
 );
 
 export default MapSettingsLayers;

--- a/front/src/common/Map/Settings/MapSettingsSignals.tsx
+++ b/front/src/common/Map/Settings/MapSettingsSignals.tsx
@@ -11,7 +11,7 @@ import { getMap } from 'reducers/map/selectors';
 import { RootState } from 'reducers';
 
 type SettingsSignals = RootState['map']['signalsSettings'];
-const SIGNAL_SETTINGS: Array<keyof SettingsSignals> = ['all', 'stops', 'lights'];
+const SIGNAL_SETTINGS: Array<keyof SettingsSignals> = ['lights']; // 'all', 'stops' temporarely desactivated
 const CONSTS_SVG: Partial<Record<keyof SettingsSignals, string>> = {
   stops: stopsIcon,
   lights: lightsIcon,
@@ -76,10 +76,10 @@ const MapSettingsSignals: FC<unknown> = () => {
             ) : (
               <>
                 <img
-                  className="mx-2"
+                  className="mx-1"
                   src={CONSTS_SVG[setting]}
                   alt={`${setting} Icon`}
-                  height="20"
+                  height="16"
                 />
                 <small>{t(setting)}</small>
               </>


### PR DESCRIPTION
Close #5222 

It should display KP on all maps for: 
- detectors
- bufferstops
- signals
- psl signs (broken on angle)

Operational points kps should be displayed when backend will be updated.