### PR TITLE
front: fix trash button in rollingstock editor

### DIFF
--- a/front/src/common/SelectorSNCF.tsx
+++ b/front/src/common/SelectorSNCF.tsx
@@ -98,9 +98,14 @@ export default function SelectorSNCF<
                   </div>
                   {((permanentItems && !permanentItems.includes(item)) || !permanentItems) &&
                     onItemRemoved && (
-                      <div className={`${mainClass}-trash-icon`}>
-                        <FaTrash onClick={() => onItemRemoved(item, title)} />
-                      </div>
+                      <button
+                        type="button"
+                        tabIndex={0}
+                        onClick={() => onItemRemoved(item, title)}
+                        className={`${mainClass}-trash-icon `}
+                      >
+                        <FaTrash />
+                      </button>
                     )}
                 </div>
                 {extraColumn && (

--- a/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
+++ b/front/src/styles/scss/applications/rollingStockEditor/_rollingStockForm.scss
@@ -291,6 +291,7 @@
     }
     &-trash-icon {
       visibility: hidden;
+      padding: 0;
     }
     &-item {
       color: var(--coolgray11);
@@ -317,6 +318,8 @@
           color: var(--red);
           visibility: visible;
           width: 2.5rem;
+          border: none;
+          background-color: transparent;
           border-radius: 0 0.3rem 0.3rem 0;
           text-align: center;
           padding-top: 0.1rem;


### PR DESCRIPTION
delete now works when clicking the button, not only the trash icon.

closes #5337