### PR TITLE
front: fix modal zindex #5395

### DIFF
--- a/front/src/styles/scss/_body.scss
+++ b/front/src/styles/scss/_body.scss
@@ -172,6 +172,11 @@ body {
   }
 }
 
+.modal.show {
+  // mastheader is at 1056 
+  z-index:1057;
+}
+
 @media (min-width: 576px) {
   .modal-dialog.modal-lg,
   .modal-dialog.modal-xl {


### PR DESCRIPTION
See issue #5395

Modal should be on top of everything, even on top of the app header