### PR TITLE
front: fix double hovering in rollingstock editor

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
@@ -101,6 +101,9 @@ export default function RollingStockEditorCurves({
     is_electric: tractionMode !== THERMAL_TRACTION_IDENTIFIER,
   });
   const [hoveredRollingstockParam, setHoveredRollingstockParam] = useState<string | null>();
+  const [hoveredRollingstockTractionParam, setHoveredRollingstockTractionParam] = useState<
+    string | null
+  >();
   const [selectedCurves, setSelectedCurves] = useState(EmptySelectedCurves);
 
   const dispatchComfortLvl = (value: string) => {
@@ -540,9 +543,9 @@ export default function RollingStockEditorCurves({
               title="tractionModes"
               itemsList={rollingstockParams.tractionModes}
               selectedItem={selectedTractionMode || undefined}
-              hoveredItem={hoveredRollingstockParam}
+              hoveredItem={hoveredRollingstockTractionParam}
               onItemSelected={dispatchTractionMode}
-              onItemHovered={setHoveredRollingstockParam}
+              onItemHovered={setHoveredRollingstockTractionParam}
               onItemRemoved={confirmRsParamRemoval}
               translationFile="rollingstock"
             />


### PR DESCRIPTION
closes #5336 
rollingstock editor : fix double hovering happening when elements have the same value.