### PR TITLE
front: fix-warning-message-display-in-stdcm

### DIFF
--- a/front/src/applications/stdcm/views/OSRDSTDCM.tsx
+++ b/front/src/applications/stdcm/views/OSRDSTDCM.tsx
@@ -30,10 +30,12 @@ export default function OSRDSTDCM() {
         currentStdcmRequestStatus={currentStdcmRequestStatus}
         setCurrentStdcmRequestStatus={setCurrentStdcmRequestStatus}
       />
-      <StdcmRequestModal
-        setCurrentStdcmRequestStatus={setCurrentStdcmRequestStatus}
-        currentStdcmRequestStatus={currentStdcmRequestStatus}
-      />
+      {currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending && (
+        <StdcmRequestModal
+          setCurrentStdcmRequestStatus={setCurrentStdcmRequestStatus}
+          currentStdcmRequestStatus={currentStdcmRequestStatus}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
stdcm : fix warning message that was displayed when the component mount if no rolling stock or destination selected. 

closes #5351 