### PR TITLE
front:editor: add infra error type overlapping_catenaries

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -72,6 +72,7 @@
         "out_of_range": "Invalid value (out of range)",
         "overlapping_speed_sections": "Speed limit superposition",
         "overlapping_switches": "Overlapping switches",
+        "overlapping_catenaries": "Overlapping catenaries",
         "unknown_port_name": "Unknown port name",
         "unused_port": "Unused port"
       },

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -72,6 +72,7 @@
         "out_of_range": "Valeur invalide (hors intervalle)",
         "overlapping_speed_sections": "Superposition de limites de vitesse",
         "overlapping_switches": "Superposition d'aiguilles",
+        "overlapping_catenaries": "Superposition de caténaires",
         "unknown_port_name": "Nom de port inconnu",
         "unused_port": "Port non utilisé"
       },

--- a/front/src/applications/editor/components/InfraErrors/types.ts
+++ b/front/src/applications/editor/components/InfraErrors/types.ts
@@ -23,6 +23,7 @@ export const InfraErrorTypeList: Array<InfraErrorType> = [
   'out_of_range',
   'overlapping_speed_sections',
   'overlapping_switches',
+  'overlapping_catenaries',
   'unknown_port_name',
   'unused_port',
 ];


### PR DESCRIPTION
follows #5430 