### PR TITLE
core: improve argument parsing

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/App.java
+++ b/core/src/main/java/fr/sncf/osrd/App.java
@@ -2,10 +2,7 @@ package fr.sncf.osrd;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import fr.sncf.osrd.cli.ApiServerCommand;
-import fr.sncf.osrd.cli.CliCommand;
-import fr.sncf.osrd.cli.StandaloneSimulationCommand;
-import fr.sncf.osrd.cli.ValidateInfra;
+import fr.sncf.osrd.cli.*;
 import java.util.HashMap;
 
 public class App {
@@ -21,6 +18,7 @@ public class App {
 
         // prepare the command line parser
         var argsParserBuilder = JCommander.newBuilder();
+        argsParserBuilder.defaultProvider(new EnvProvider("CORE_"));
         for (var command : commands.entrySet())
             argsParserBuilder.addCommand(command.getKey(), command.getValue());
         var argsParser = argsParserBuilder.build();

--- a/core/src/main/java/fr/sncf/osrd/cli/EnvProvider.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/EnvProvider.java
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.cli;
+
+import com.beust.jcommander.IDefaultProvider;
+import java.util.Locale;
+
+public class EnvProvider implements IDefaultProvider {
+    final String prefix;
+
+    public EnvProvider(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String getDefaultValueFor(String optionName) {
+        // ignore short arguments
+        if (!optionName.startsWith("--"))
+            return null;
+
+        var kebabName = optionName.substring(2);
+        var screamingSnakeName = kebabName.replace('-', '_').toUpperCase(Locale.ENGLISH);
+        return System.getenv(prefix + screamingSnakeName);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     ports: ["8080:8080"]
     command: "java -ea -jar /app/osrd_core.jar api -p 8080"
     environment:
-      MIDDLEWARE_BASE_URL: "http://osrd-editoast"
+      CORE_EDITOAST_URL: "http://osrd-editoast"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       start_period: 4s

--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -15,7 +15,7 @@ services:
     ports: []
     network_mode: host
     environment:
-      MIDDLEWARE_BASE_URL: "http://localhost:8090"
+      CORE_EDITOAST_URL: "http://localhost:8090"
 
   editoast:
     ports: []


### PR DESCRIPTION
- Allow all parameters to be set using environment variables starting with CORE_
- Rename MIDDLEWARE_BASE_URL to CORE_EDITOAST_URL
- Rename FETCH_INFRA_AUTHORIZATION to CORE_EDITOAST_AUTHORIZATION
- Rename SENTRY_DSN to CORE_SENTRY_DSN
- Rename OSRD_API_THREADS to CORE_THREADS