### PR TITLE
front: fix running time reset to 12h in stdcm

### DIFF
--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -197,7 +197,7 @@ export interface OsrdConfState {
 }
 
 export interface OsrdStdcmConfState extends OsrdConfState {
-  maximumRunTime?: number;
+  maximumRunTime: number;
   stdcmMode: ValueOf<typeof STDCM_MODES>;
   standardStdcmAllowance?: StandardAllowance; // We wait for auto generated types
 }

--- a/front/src/applications/stdcm/components/RunningTime.tsx
+++ b/front/src/applications/stdcm/components/RunningTime.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { updateMaximumRunTime } from 'reducers/osrdconf';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import { Dispatch } from 'redux';
@@ -8,6 +8,7 @@ import { RxLapTimer } from 'react-icons/rx';
 import { useTranslation } from 'react-i18next';
 import { sec2time, time2sec } from 'utils/timeManipulation';
 import { RUNTIME_CAP } from 'applications/operationalStudies/consts';
+import { getMaximumRunTime } from 'reducers/osrdconf/selectors';
 
 interface RunningTimeProps {
   dispatch?: Dispatch;
@@ -22,16 +23,15 @@ export function withProps<T>(Component: ComponentType<T>) {
 
 function RunningTime({ dispatch = noop }: RunningTimeProps) {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const [maximumRuntime, setMaximumRunTime] = useState<string>(sec2time(RUNTIME_CAP));
+  const maximumRunTime = useSelector(getMaximumRunTime);
   const [isRtBelowCap, setIsRtBelowCap] = useState(true);
 
   function checkRunTime(time: string): number {
     if (time2sec(time) <= RUNTIME_CAP) {
-      setMaximumRunTime(time);
       setIsRtBelowCap(true);
       return time2sec(time);
     }
-    setMaximumRunTime(sec2time(RUNTIME_CAP));
+
     setIsRtBelowCap(false);
     return RUNTIME_CAP;
   }
@@ -49,7 +49,7 @@ function RunningTime({ dispatch = noop }: RunningTimeProps) {
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             dispatch(updateMaximumRunTime(checkRunTime(e.target.value)))
           }
-          value={maximumRuntime}
+          value={sec2time(maximumRunTime)}
           sm
           noMargin
           isInvalid={!isRtBelowCap}


### PR DESCRIPTION
maximum running time now keeps its state after refreshing the page

closes #5431