### PR TITLE
core: pathfinding: filter out routes without blocks

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -78,7 +78,7 @@ fun run(envelope: Envelope, trainPath: PathProperties, chunkPath: ChunkPath, sch
     val simulator = fullInfra.signalingSimulator
 
     // get a new generation route path
-    val routePath = toRouteIdList(chunksToRoutes(rawInfra, toIntList(chunkPath.chunks)))
+    val routePath = toRouteIdList(chunksToRoutes(rawInfra, fullInfra.blockInfra, toIntList(chunkPath.chunks)))
 
     // recover blocks from the route paths
     val detailedBlockPath = recoverBlockPath(simulator, fullInfra, routePath)


### PR DESCRIPTION
Fixes #5434 
Fixes #3746
Fixes #5544

As explained in the comment: this *should* never happen, but poor signaling data may be the cause of routes that have no block. Filtering them out fixes the 500s caused by this case. 