### PR TITLE
front: quick fix for speed label

### DIFF
--- a/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
@@ -24,24 +24,23 @@ function getFill(isSelectedTrain: boolean, ecoBlocks: boolean) {
   return '#333';
 }
 
-function getSpeedAndTimeLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: TrainPosition) {
+function getSpeedLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: TrainPosition) {
   if (isSelectedTrain) {
     return (
       <>
         <span
-          className={cx('small', 'font-weight-bold', ecoBlocks ? 'text-secondary' : 'text-primary')}
+          className={cx('small', 'train-speed-label', 'font-weight-bold', ecoBlocks ? 'text-secondary' : 'text-primary')}
         >
           {Math.round(point?.speedTime?.speed ?? 0)}
           km/h
         </span>
-        {point.speedTime && <span className="ml-2 small">{`${point.speedTime.time}`}</span>}
       </>
     );
   }
   return (
     <>
       {/* <small>{point.properties.name}</small> */}
-      <span className="small ml-1 font-weight-bold text-muted">
+      <span className="train-speed-label small ml-1 font-weight-bold text-muted">
         {Math.round(point?.speedTime?.speed)}
         km/h
       </span>
@@ -205,7 +204,7 @@ function TrainHoverPosition(props: TrainHoverPositionProps) {
   ) {
     const { ecoBlocks } = get(allowancesSettings, train.id, {} as AllowancesSetting);
     const fill = getFill(isSelectedTrain as boolean, ecoBlocks);
-    const label = getSpeedAndTimeLabel(isSelectedTrain, ecoBlocks, point);
+    const label = getSpeedLabel(isSelectedTrain, ecoBlocks, point);
 
     const zoomLengthFactor = getzoomPowerOf2LengthFactor(viewport);
     const [trainGeoJsonPath, headTriangle, rearTriangle] = getTrainPieces(

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
@@ -24,8 +24,9 @@ function getFill(isSelectedTrain: boolean, ecoBlocks: boolean) {
   return '#333';
 }
 
-function getSpeedLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: TrainPosition) {
+function getSpeedTimeLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: TrainPosition) {
   if (isSelectedTrain) {
+    console.log(point.speedTime);
     return (
       <>
         <span
@@ -34,6 +35,7 @@ function getSpeedLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: Trai
           {Math.round(point?.speedTime?.speed ?? 0)}
           km/h
         </span>
+        {point.speedTime && <span className="ml-2 small">{`${point.speedTime.time}`}</span>}
       </>
     );
   }
@@ -204,7 +206,7 @@ function TrainHoverPosition(props: TrainHoverPositionProps) {
   ) {
     const { ecoBlocks } = get(allowancesSettings, train.id, {} as AllowancesSetting);
     const fill = getFill(isSelectedTrain as boolean, ecoBlocks);
-    const label = getSpeedLabel(isSelectedTrain, ecoBlocks, point);
+    const label = getSpeedTimeLabel(isSelectedTrain, ecoBlocks, point);
 
     const zoomLengthFactor = getzoomPowerOf2LengthFactor(viewport);
     const [trainGeoJsonPath, headTriangle, rearTriangle] = getTrainPieces(

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition.tsx
@@ -15,6 +15,7 @@ import { AllowancesSetting, AllowancesSettings, Train } from 'reducers/osrdsimul
 import { boundedValue } from 'utils/numbers';
 import { getCurrentBearing } from 'utils/geometry';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
+import { datetime2time } from 'utils/timeManipulation';
 import { TrainPosition } from './types';
 
 function getFill(isSelectedTrain: boolean, ecoBlocks: boolean) {
@@ -26,16 +27,24 @@ function getFill(isSelectedTrain: boolean, ecoBlocks: boolean) {
 
 function getSpeedTimeLabel(isSelectedTrain: boolean, ecoBlocks: boolean, point: TrainPosition) {
   if (isSelectedTrain) {
-    console.log(point.speedTime);
     return (
       <>
         <span
-          className={cx('small', 'train-speed-label', 'font-weight-bold', ecoBlocks ? 'text-secondary' : 'text-primary')}
+          className={cx(
+            'small',
+            'train-speed-label',
+            'font-weight-bold',
+            ecoBlocks ? 'text-secondary' : 'text-primary'
+          )}
         >
           {Math.round(point?.speedTime?.speed ?? 0)}
           km/h
         </span>
-        {point.speedTime && <span className="ml-2 small">{`${point.speedTime.time}`}</span>}
+        {point.speedTime?.time && (
+          <span className="ml-2 small train-speed-label">{`${datetime2time(
+            point.speedTime.time
+          )}`}</span>
+        )}
       </>
     );
   }

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -43,4 +43,11 @@
     padding: 1rem;
     border-radius: 4px;
   }
+
+  /* MAP */
+  .train-speed-label {
+    text-shadow : 0 0 3px #FFFFFF;
+    padding-bottom: 1.5rem
+  }
+
 }


### PR DESCRIPTION
#closes #5496

This is a quick fix which will remove badly formatted time and give a shadow to the speed to it will remained visible

Correct behavior correction need a rewrite of train display logic