### PR TITLE
core: fix pathfinding validation

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -366,6 +366,11 @@ public enum ErrorType {
             "Electrical profile set had invalid status after loading",
             ErrorCause.INTERNAL
     ),
+    PathWithRepeatedTracks(
+            "path_with_repeated_tracks",
+            "the path goes over the same track multiple times",
+            ErrorCause.USER
+    ),
     ;
 
     public final String type;

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
@@ -301,6 +301,8 @@ public class PathfindingBlocksEndpoint implements Take {
             for (var dirTrack : getRouteDirTracks(rawInfra, rawInfra.getRouteFromName(routePath.route)))
                 if (routeTracks.isEmpty() || !routeTracks.get(routeTracks.size() - 1).equals(dirTrack))
                     routeTracks.add(dirTrack);
+        if (new HashSet<>(routeTracks).size() < routeTracks.size())
+            throw new OSRDError(ErrorType.PathWithRepeatedTracks);
         assertPathRoutesAreAdjacent(routeTracks, rawInfra);
 
         var tracksOnPath = res.routePaths.stream()

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
@@ -296,11 +296,11 @@ public class PathfindingBlocksEndpoint implements Take {
 
     private void validatePathfindingResult(PathfindingResult res, PathfindingWaypoint[][] reqWaypoints,
                                            RawSignalingInfra rawInfra) {
-        var routeTracks = res.routePaths.stream()
-                .flatMap(rjsRoutePath ->
-                        getRouteDirTracks(rawInfra, rawInfra.getRouteFromName(rjsRoutePath.route)).stream())
-                .distinct()
-                .toList();
+        var routeTracks = new ArrayList<Integer>();
+        for (var routePath : res.routePaths)
+            for (var dirTrack : getRouteDirTracks(rawInfra, rawInfra.getRouteFromName(routePath.route)))
+                if (routeTracks.isEmpty() || !routeTracks.get(routeTracks.size() - 1).equals(dirTrack))
+                    routeTracks.add(dirTrack);
         assertPathRoutesAreAdjacent(routeTracks, rawInfra);
 
         var tracksOnPath = res.routePaths.stream()


### PR DESCRIPTION
The previous version didn't handle paths that would go over the same tracks more than once

Fix #5536 