### PR TITLE
core: add regression test for max effort envelope discontinuity

### DIFF
--- a/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeBuilder.java
+++ b/core/envelope-sim/src/testFixtures/java/fr/sncf/osrd/envelope_sim/MaxEffortEnvelopeBuilder.java
@@ -3,6 +3,9 @@ package fr.sncf.osrd.envelope_sim;
 import static fr.sncf.osrd.envelope_sim.TestMRSPBuilder.makeComplexMRSP;
 import static fr.sncf.osrd.envelope_sim.TestMRSPBuilder.makeSimpleMRSP;
 
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
 import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope;
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope;
@@ -14,9 +17,11 @@ public class MaxEffortEnvelopeBuilder {
             double maxSpeed,
             double[] stops
     ) {
-        var flatMRSP = makeSimpleMRSP(context, maxSpeed);
-        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, flatMRSP);
-        return MaxEffortEnvelope.from(context, 0, maxSpeedEnvelope);
+        return makeMaxEffortEnvelopeFromSpeedRanges(
+                context,
+                ImmutableRangeMap.of(Range.open(0., context.path.getLength()), maxSpeed),
+                stops
+        );
     }
 
     /** Builds max effort envelope with one stop in the middle, one at the end, on a flat MRSP */
@@ -32,6 +37,17 @@ public class MaxEffortEnvelopeBuilder {
     ) {
         var mrsp = makeComplexMRSP(context);
         var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, mrsp);
+        return MaxEffortEnvelope.from(context, 0, maxSpeedEnvelope);
+    }
+
+    /** Builds max effort envelope with the specified stops, on a flat MRSP */
+    public static Envelope makeMaxEffortEnvelopeFromSpeedRanges(
+            EnvelopeSimContext context,
+            RangeMap<Double, Double> speeds,
+            double[] stops
+    ) {
+        var flatMRSP = makeSimpleMRSP(context, speeds);
+        var maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stops, flatMRSP);
         return MaxEffortEnvelope.from(context, 0, maxSpeedEnvelope);
     }
 }


### PR DESCRIPTION
See https://github.com/osrd-project/osrd/issues/3851

The bug itself was fixed (likely by [this commit](https://github.com/osrd-project/osrd/commit/b0d61181ac83a30e46d596d3e7e9c24ede33f0a1)), the test doesn't need to be on a branch anymore.
Plus, it adds some useful functions to write tests for given MRSPs using a range map. 