### PR TITLE
front: restore miniGET sync by storing scale domain

### DIFF
--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -120,6 +120,17 @@ export default function SimulationResults({
     }
   }, [extViewport]);
 
+  useEffect(() => {
+    if (selectedTrain) {
+      const positions = selectedTrain.base.speeds.map((speed) => speed.position);
+      const newPositionsScaleDomain = getScaleDomainFromValues(positions);
+      setPositionScaleDomain({
+        initial: newPositionsScaleDomain,
+        current: newPositionsScaleDomain,
+      });
+    }
+  }, [selectedTrain]);
+
   return simulation.trains.length === 0 && !isUpdating ? (
     <h1 className="text-center mt-5">{t('noData')}</h1>
   ) : (

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -20,7 +20,6 @@ import TimeButtons from 'modules/simulationResult/components/TimeButtons';
 // TIMELINE DISABLED // import TimeLine from 'modules/simulationResult/components/TimeLine/TimeLine';
 import TrainDetails from 'modules/simulationResult/components/TrainDetails';
 import DriverTrainSchedule from 'modules/trainschedule/components/DriverTrainSchedule/DriverTrainSchedule';
-import getScaleDomainFromValues from 'modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues';
 import SpaceCurvesSlopes from 'modules/simulationResult/components/SpaceCurvesSlopes';
 import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
@@ -57,6 +56,8 @@ export default function SimulationResults({
   const [heightOfSpaceCurvesSlopesChart, setHeightOfSpaceCurvesSlopesChart] = useState(150);
   const [initialHeightOfSpaceCurvesSlopesChart, setInitialHeightOfSpaceCurvesSlopesChart] =
     useState(heightOfSpaceCurvesSlopesChart);
+
+  const [chartXScaleDomain] = useState<number[] | Date[]>([]);
 
   // X scale domain shared between SpeedSpace and SpaceCurvesSlopes charts.
   const [positionScaleDomain, setPositionScaleDomain] = useState<PositionScaleDomain>({
@@ -119,17 +120,6 @@ export default function SimulationResults({
     }
   }, [extViewport]);
 
-  useEffect(() => {
-    if (selectedTrain) {
-      const positions = selectedTrain.base.speeds.map((speed) => speed.position);
-      const newPositionsScaleDomain = getScaleDomainFromValues(positions);
-      setPositionScaleDomain({
-        initial: newPositionsScaleDomain,
-        current: newPositionsScaleDomain,
-      });
-    }
-  }, [selectedTrain]);
-
   return simulation.trains.length === 0 && !isUpdating ? (
     <h1 className="text-center mt-5">{t('noData')}</h1>
   ) : (
@@ -156,6 +146,7 @@ export default function SimulationResults({
           chart={chart}
           selectedTrainId={selectedTrain?.id || simulation.trains[0].id}
           trains={simulation.trains as SimulationReport[]}
+          onChangeXScaleDomain={setChartXScaleDomain}
         />
       )} */}
 
@@ -185,6 +176,7 @@ export default function SimulationResults({
                 dispatchUpdateSelectedTrainId={dispatchUpdateSelectedTrainId}
                 dispatchPersistentUpdateSimulation={dispatchPersistentUpdateSimulation}
                 setTrainResultsToFetch={setTrainResultsToFetch}
+                chartXScaleDomain={chartXScaleDomain}
               />
             )}
           </div>

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -23,7 +23,7 @@ import DriverTrainSchedule from 'modules/trainschedule/components/DriverTrainSch
 import SpaceCurvesSlopes from 'modules/simulationResult/components/SpaceCurvesSlopes';
 import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
-import type { PositionScaleDomain, TimeScaleDomain } from 'modules/simulationResult/consts';
+import type { PositionScaleDomain, TimeScaleDomain } from 'modules/simulationResult/types';
 import { Train } from 'reducers/osrdsimulation/types';
 import { useStoreDataForSpaceTimeChart } from 'modules/simulationResult/components/SpaceTimeChart/useStoreDataForSpaceTimeChart';
 import getScaleDomainFromValues from 'modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues';
@@ -161,7 +161,7 @@ export default function SimulationResults({
           timeScaleDomain={timeScaleDomain}
           selectedTrainId={selectedTrain?.id || simulation.trains[0].id}
           trains={simulation.trains as SimulationReport[]}
-          onChangeTimeScaleDomain={setTimeScaleDomain}
+          onTimeScaleDomainChange={setTimeScaleDomain}
         />
       )}
       */}

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -23,9 +23,10 @@ import DriverTrainSchedule from 'modules/trainschedule/components/DriverTrainSch
 import SpaceCurvesSlopes from 'modules/simulationResult/components/SpaceCurvesSlopes';
 import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
-import type { PositionScaleDomain } from 'modules/simulationResult/consts';
+import type { PositionScaleDomain, TimeScaleDomain } from 'modules/simulationResult/consts';
 import { Train } from 'reducers/osrdsimulation/types';
 import { useStoreDataForSpaceTimeChart } from 'modules/simulationResult/components/SpaceTimeChart/useStoreDataForSpaceTimeChart';
+import getScaleDomainFromValues from 'modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues';
 
 const MAP_MIN_HEIGHT = 450;
 
@@ -57,7 +58,10 @@ export default function SimulationResults({
   const [initialHeightOfSpaceCurvesSlopesChart, setInitialHeightOfSpaceCurvesSlopesChart] =
     useState(heightOfSpaceCurvesSlopesChart);
 
-  const [chartXScaleDomain] = useState<number[] | Date[]>([]);
+  const [timeScaleDomain, setTimeScaleDomain] = useState<TimeScaleDomain>({
+    range: undefined,
+    source: undefined,
+  });
 
   // X scale domain shared between SpeedSpace and SpaceCurvesSlopes charts.
   const [positionScaleDomain, setPositionScaleDomain] = useState<PositionScaleDomain>({
@@ -152,14 +156,15 @@ export default function SimulationResults({
       </div>
 
       {/* SIMULATION: TIMELINE — TEMPORARILY DISABLED
-      {simulation.trains.length && chart && (
+      {simulation.trains.length && (
         <TimeLine
-          chart={chart}
+          timeScaleDomain={timeScaleDomain}
           selectedTrainId={selectedTrain?.id || simulation.trains[0].id}
           trains={simulation.trains as SimulationReport[]}
-          onChangeXScaleDomain={setChartXScaleDomain}
+          onChangeTimeScaleDomain={setTimeScaleDomain}
         />
-      )} */}
+      )}
+      */}
 
       {/* SIMULATION : SPACE TIME CHART */}
       <div className="simulation-warped-map d-flex flex-row align-items-stretch mb-2 bg-white">
@@ -187,7 +192,8 @@ export default function SimulationResults({
                 dispatchUpdateSelectedTrainId={dispatchUpdateSelectedTrainId}
                 dispatchPersistentUpdateSimulation={dispatchPersistentUpdateSimulation}
                 setTrainResultsToFetch={setTrainResultsToFetch}
-                chartXScaleDomain={chartXScaleDomain}
+                timeScaleDomain={timeScaleDomain}
+                setTimeScaleDomain={setTimeScaleDomain}
               />
             )}
           </div>

--- a/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
@@ -17,15 +17,7 @@ import {
   SimulationD3Scale,
   PositionsSpeedTimes,
 } from 'reducers/osrdsimulation/types';
-import {
-  ChartAxes,
-  GRADIENT,
-  ListValues,
-  TIME,
-  XAxis,
-  Y2Axis,
-  YAxis,
-} from 'modules/simulationResult/consts';
+import { ChartAxes, ListValues, XAxis, Y2Axis, YAxis } from 'modules/simulationResult/consts';
 
 export function sec2d3datetime(time: number) {
   return d3.timeParse('%H:%M:%S')(sec2time(time));
@@ -383,9 +375,9 @@ const specificInterpolateOnTime =
     return positionInterpolated;
   };
 
-export const isSpaceTimeChart = (keyValues: ChartAxes) => keyValues[0] === TIME;
+export const isSpaceTimeChart = (keyValues: ChartAxes) => keyValues[0] === 'time';
 
-export const isSpaceSlopesCurves = (keyValues: ChartAxes) => keyValues[1] === GRADIENT;
+export const isSpaceSlopesCurves = (keyValues: ChartAxes) => keyValues[1] === 'gradient';
 
 export function trainWithDepartureAndArrivalTimes(train: Train, dragOffset = 0) {
   const firstStop = train.base.stops[0];

--- a/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
+++ b/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
@@ -12,12 +12,8 @@ import {
   getAxis,
   isSpaceTimeChart,
 } from 'modules/simulationResult/components/ChartHelpers/ChartHelpers';
-import {
-  CHART_AXES,
-  LIST_VALUES,
-  type ChartAxes,
-  type PositionScaleDomain,
-} from 'modules/simulationResult/consts';
+import { CHART_AXES, LIST_VALUES, type ChartAxes } from 'modules/simulationResult/consts';
+import type { PositionScaleDomain } from 'modules/simulationResult/types';
 import drawGuideLines from 'modules/simulationResult/components/ChartHelpers/drawGuideLines';
 import type { SpaceCurvesSlopesData } from 'modules/simulationResult/components/SpaceCurvesSlopes';
 import type {

--- a/front/src/modules/simulationResult/components/SpaceCurvesSlopes.tsx
+++ b/front/src/modules/simulationResult/components/SpaceCurvesSlopes.tsx
@@ -3,7 +3,8 @@ import { useSelector } from 'react-redux';
 import * as d3 from 'd3';
 import { CgLoadbar } from 'react-icons/cg';
 
-import { CHART_AXES, type PositionScaleDomain } from 'modules/simulationResult/consts';
+import { CHART_AXES } from 'modules/simulationResult/consts';
+import type { PositionScaleDomain } from 'modules/simulationResult/types';
 import {
   defineLinear,
   interpolateOnPosition,

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
@@ -56,6 +56,7 @@ export type SpaceTimeChartProps = {
   dispatchUpdateSelectedTrainId: DispatchUpdateSelectedTrainId;
   dispatchPersistentUpdateSimulation: DispatchPersistentUpdateSimulation;
   setTrainResultsToFetch?: (trainSchedulesIDs?: number[]) => void;
+  chartXScaleDomain?: number[] | Date[];
 };
 
 export default function SpaceTimeChart(props: SpaceTimeChartProps) {
@@ -74,6 +75,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
     dispatchUpdateSelectedTrainId,
     dispatchPersistentUpdateSimulation,
     setTrainResultsToFetch = noop,
+    chartXScaleDomain,
   } = props;
 
   const [baseHeight, setBaseHeight] = useState(initialHeight);
@@ -182,6 +184,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
       const trainsToDraw = trainSimulations.map((train) =>
         createTrain(CHART_AXES.SPACE_TIME, train as Train)
       );
+
       drawAllTrains(
         allowancesSettings,
         chart,
@@ -209,7 +212,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
    */
   useEffect(() => {
     redrawChart();
-  }, [resetChart, rotate, selectedTrain, trainSimulations, height]);
+  }, [resetChart, rotate, selectedTrain, trainSimulations, height, chartXScaleDomain]);
 
   /* add behaviour on zoom and mousemove/mouseover/wheel on the new chart each time the chart changes */
   useEffect(() => {

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
@@ -4,7 +4,8 @@ import { CgLoadbar } from 'react-icons/cg';
 import { GiResize } from 'react-icons/gi';
 import { Rnd } from 'react-rnd';
 
-import { CHART_AXES, TimeScaleDomain } from 'modules/simulationResult/consts';
+import { CHART_AXES } from 'modules/simulationResult/consts';
+import type { TimeScaleDomain } from 'modules/simulationResult/types';
 import {
   enableInteractivity,
   traceVerticalLine,
@@ -57,7 +58,7 @@ export type SpaceTimeChartProps = {
   dispatchUpdateSelectedTrainId: DispatchUpdateSelectedTrainId;
   dispatchPersistentUpdateSimulation: DispatchPersistentUpdateSimulation;
   setTrainResultsToFetch?: (trainSchedulesIDs?: number[]) => void;
-  setTimeScaleDomain?: React.Dispatch<React.SetStateAction<TimeScaleDomain>>;
+  setTimeScaleDomain?: (newTimeScaleDomain: TimeScaleDomain) => void;
 };
 
 export default function SpaceTimeChart(props: SpaceTimeChartProps) {
@@ -180,16 +181,15 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
     dragShiftTrain(dragOffset);
   }, [dragOffset]);
 
-  const redrawChart = (newResizedChart?: Chart) => {
+  const redrawChart = () => {
     if (trainSimulations && allowancesSettings) {
       const trainsToDraw = trainSimulations.map((train) =>
         createTrain(CHART_AXES.SPACE_TIME, train as Train)
       );
 
-      const newChart = newResizedChart ?? chart;
       const newDrawnedChart = drawAllTrains(
         allowancesSettings,
-        newChart,
+        chart,
         CHART_ID,
         dispatchUpdateSelectedTrainId,
         height,
@@ -221,8 +221,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
     if (chart && timeScaleDomain && timeScaleDomain.source !== 'SpaceTimeChart') {
       const currentTimeRange = timeScaleDomain.range;
       if (currentTimeRange) {
-        const newChart = { ...chart };
-        newChart.x.domain(currentTimeRange);
+        chart.x.domain(currentTimeRange);
         redrawChart();
       }
     }
@@ -240,19 +239,17 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
         });
       }
 
-      if (trainSimulations && selectedTrain && timeScaleDomain) {
-        const dataSimulation = createTrain(CHART_AXES.SPACE_TIME, selectedTrain as Train);
-        enableInteractivity(
-          chart,
-          dataSimulation,
-          CHART_AXES.SPACE_TIME,
-          rotate,
-          setChart,
-          simulationIsPlaying,
-          updateTimePosition,
-          newTimeScaleRange
-        );
-      }
+      const dataSimulation = createTrain(CHART_AXES.SPACE_TIME, selectedTrain as Train);
+      enableInteractivity(
+        chart,
+        dataSimulation,
+        CHART_AXES.SPACE_TIME,
+        rotate,
+        setChart,
+        simulationIsPlaying,
+        updateTimePosition,
+        newTimeScaleRange
+      );
     }
   }, [chart]);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
@@ -229,7 +229,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
 
   /* add behaviour on zoom and mousemove/mouseover/wheel on the new chart each time the chart changes */
   useEffect(() => {
-    if (chart) {
+    if (chart && selectedTrain) {
       const newTimeScaleRange = (rotate ? chart.y.domain() : chart.x.domain()) as [Date, Date];
 
       if (setTimeScaleDomain) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/d3Helpers.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/d3Helpers.ts
@@ -59,7 +59,6 @@ const drawAllTrains = (
   rotate: boolean,
   selectedProjection: OsrdSimulationState['selectedProjection'],
   selectedTrain: Train,
-  setChart: React.Dispatch<React.SetStateAction<Chart | undefined>>,
   setDragOffset: React.Dispatch<React.SetStateAction<number>>,
   simulationTrains: Train[],
   trainsToDraw: SimulationTrain[]
@@ -96,7 +95,7 @@ const drawAllTrains = (
       train
     );
   });
-  setChart(chartLocal);
+  return chartLocal;
 };
 
 export { drawOPs, drawAllTrains };

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart.tsx
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart.tsx
@@ -5,11 +5,8 @@ import { GiResize } from 'react-icons/gi';
 import { Rnd } from 'react-rnd';
 
 import { LightRollingStock, SimulationReport } from 'common/api/osrdEditoastApi';
-import {
-  CHART_AXES,
-  type PositionScaleDomain,
-  type ChartAxes,
-} from 'modules/simulationResult/consts';
+import { CHART_AXES, type ChartAxes } from 'modules/simulationResult/consts';
+import type { PositionScaleDomain } from 'modules/simulationResult/types';
 import {
   enableInteractivity,
   traceVerticalLine,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/d3Helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/d3Helpers.ts
@@ -6,7 +6,7 @@ import {
   createPowerRestrictionSegment,
   DRAWING_KEYS,
 } from 'applications/operationalStudies/consts';
-import { POSITION, SPEED, HEIGHT, CHART_AXES } from 'modules/simulationResult/consts';
+import { CHART_AXES } from 'modules/simulationResult/consts';
 import drawArea from 'modules/simulationResult/components/ChartHelpers/drawArea';
 import drawCurve from 'modules/simulationResult/components/ChartHelpers/drawCurve';
 import defineChart from 'modules/simulationResult/components/ChartHelpers/defineChart';
@@ -39,19 +39,19 @@ function createChart(
   let scaleY2: d3.ScaleLinear<number, number, never> = defineLinear(0, 0, 0);
 
   if (chart === undefined || resetChart) {
-    const maxX = d3.max(trainSimulation.speed, (speedObject) => speedObject[POSITION]) as number;
+    const maxX = d3.max(trainSimulation.speed, (speedObject) => speedObject.position) as number;
     scaleX = defineLinear(maxX + 100);
 
-    const maxY = d3.max(trainSimulation.speed, (speedObject) => speedObject[SPEED]) as number;
+    const maxY = d3.max(trainSimulation.speed, (speedObject) => speedObject.speed) as number;
     scaleY = defineLinear(maxY);
 
     const minY2 = d3.min(
       trainSimulation.slopesCurve,
-      (speedObject) => speedObject[HEIGHT]
+      (speedObject) => speedObject.height
     ) as number;
     const maxY2 = d3.max(
       trainSimulation.slopesCurve,
-      (speedObject) => speedObject[HEIGHT]
+      (speedObject) => speedObject.height
     ) as number;
     scaleY2 = chart === undefined ? defineLinear(maxY2, 0, minY2) : chart.y2;
   } else {

--- a/front/src/modules/simulationResult/components/TimeLine/TimeLine.tsx
+++ b/front/src/modules/simulationResult/components/TimeLine/TimeLine.tsx
@@ -5,7 +5,7 @@ import { SimulationReport } from 'common/api/osrdEditoastApi';
 import { getDirection, gridX } from 'modules/simulationResult/components/ChartHelpers/ChartHelpers';
 import { useChartSynchronizer } from 'modules/simulationResult/components/ChartHelpers/ChartSynchronizer';
 import { sec2datetime } from 'utils/timeManipulation';
-import { TimeScaleDomain } from 'modules/simulationResult/consts';
+import type { TimeScaleDomain } from 'modules/simulationResult/types';
 
 const drawTrain = (
   train: SimulationReport,
@@ -34,14 +34,14 @@ type TimeLineProps = {
   timeScaleDomain?: TimeScaleDomain;
   selectedTrainId: number;
   trains: SimulationReport[];
-  onChangeTimeScaleDomain: (domain: TimeScaleDomain) => void;
+  onTimeScaleDomainChange: (domain: TimeScaleDomain) => void;
 };
 
 const TimeLine = ({
   timeScaleDomain,
   selectedTrainId,
   trains,
-  onChangeTimeScaleDomain,
+  onTimeScaleDomainChange,
 }: TimeLineProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [svgState, setSvg] = useState<
@@ -171,7 +171,7 @@ const TimeLine = ({
           const delta = xScale.invert(dragValue).getTime() - xScale.domain()[0].getTime();
           const newX0 = new Date(currentTimeScaleRange[0].getTime() + delta);
           const newX1 = new Date(currentTimeScaleRange[1].getTime() + delta);
-          onChangeTimeScaleDomain({
+          onTimeScaleDomainChange({
             range: [newX0, newX1],
             source: 'Timeline',
           });

--- a/front/src/modules/simulationResult/consts.ts
+++ b/front/src/modules/simulationResult/consts.ts
@@ -1,21 +1,15 @@
 import { ArrayElement, ObjectFieldsTypes } from 'utils/types';
 
 // CHARTS
-export const TIME = 'time';
-export const POSITION = 'position';
-export const SPEED = 'speed';
-export const GRADIENT = 'gradient';
-export const RADIUS = 'radius';
-export const HEIGHT = 'height';
 
 export type AxisKey = 'time' | 'position' | 'speed' | 'gradient' | 'radius' | 'height';
 
 export const CHART_AXES = {
-  SPACE_TIME: [TIME, POSITION],
-  SPACE_SPEED: [POSITION, SPEED],
-  SPACE_GRADIENT: [POSITION, GRADIENT],
-  SPACE_RADIUS: [POSITION, RADIUS],
-  SPACE_HEIGHT: [POSITION, HEIGHT],
+  SPACE_TIME: ['time', 'position'],
+  SPACE_SPEED: ['position', 'speed'],
+  SPACE_GRADIENT: ['position', 'gradient'],
+  SPACE_RADIUS: ['position', 'radius'],
+  SPACE_HEIGHT: ['position', 'height'],
 } as const;
 
 export type ChartAxes = ObjectFieldsTypes<typeof CHART_AXES>;
@@ -40,19 +34,8 @@ export const LIST_VALUES = {
 
 export type ListValues = ObjectFieldsTypes<typeof LIST_VALUES>;
 export type AllListValues = ArrayElement<ListValues>;
-// Signal Base is the Signaling system chosen for results display
 
+// Signal Base is the Signaling system chosen for results display
 export const SIGNAL_BASE_DEFAULT = 'BAL3';
 
 export const LIST_VALUES_SIGNAL_BASE = ['BAL3'];
-
-export type PositionScaleDomain = {
-  initial: number[];
-  current: number[];
-  source?: 'SpeedSpaceChart' | 'SpaceCurvesSlopes';
-};
-
-export type TimeScaleDomain = {
-  range?: [Date, Date];
-  source?: 'SpaceTimeChart' | 'Timeline';
-};

--- a/front/src/modules/simulationResult/consts.ts
+++ b/front/src/modules/simulationResult/consts.ts
@@ -2,8 +2,6 @@ import { ArrayElement, ObjectFieldsTypes } from 'utils/types';
 
 // CHARTS
 
-export type AxisKey = 'time' | 'position' | 'speed' | 'gradient' | 'radius' | 'height';
-
 export const CHART_AXES = {
   SPACE_TIME: ['time', 'position'],
   SPACE_SPEED: ['position', 'speed'],

--- a/front/src/modules/simulationResult/consts.ts
+++ b/front/src/modules/simulationResult/consts.ts
@@ -51,3 +51,8 @@ export type PositionScaleDomain = {
   current: number[];
   source?: 'SpeedSpaceChart' | 'SpaceCurvesSlopes';
 };
+
+export type TimeScaleDomain = {
+  range?: [Date, Date];
+  source?: 'SpaceTimeChart' | 'Timeline';
+};

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -1,0 +1,10 @@
+export type PositionScaleDomain = {
+  initial: number[];
+  current: number[];
+  source?: 'SpeedSpaceChart' | 'SpaceCurvesSlopes';
+};
+
+export type TimeScaleDomain = {
+  range?: [Date, Date];
+  source?: 'SpaceTimeChart' | 'Timeline';
+};

--- a/front/src/reducers/osrdsimulation/actions.ts
+++ b/front/src/reducers/osrdsimulation/actions.ts
@@ -6,7 +6,6 @@ import { SimulationSnapshot, OsrdSimulationState } from './types';
 
 // Action Types
 export const UPDATE_CHART = 'osrdsimu/UPDATE_CHART';
-export const UPDATE_CHARTXGEV = 'osrdsimu/UPDATE_CHARTXGEV';
 export const UPDATE_HOVER_POSITION = 'osrdsimu/UPDATE_HOVER_POSITION';
 export const UPDATE_IS_PLAYING = 'osrdsimu/UPDATE_IS_PLAYING';
 export const UPDATE_IS_UPDATING = 'osrdsimu/UPDATE_IS_UPDATING';
@@ -26,14 +25,6 @@ export const UNDO_SIMULATION = 'osrdsimu/UNDO_SIMULATION';
 export const REDO_SIMULATION = 'osrdsimu/REDO_SIMULATION';
 // Functions
 
-export function updateChartXGEV(chartXGEV: OsrdSimulationState['chartXGEV']) {
-  return (dispatch: Dispatch) => {
-    dispatch({
-      type: UPDATE_CHARTXGEV,
-      chartXGEV,
-    });
-  };
-}
 export function updateIsPlaying(isPlaying: OsrdSimulationState['isPlaying']) {
   return (dispatch: Dispatch) => {
     dispatch({

--- a/front/src/reducers/osrdsimulation/index.ts
+++ b/front/src/reducers/osrdsimulation/index.ts
@@ -15,7 +15,6 @@ import undoableSimulation from './simulation';
 
 import {
   UPDATE_CHART,
-  UPDATE_CHARTXGEV,
   UPDATE_IS_PLAYING,
   UPDATE_IS_UPDATING,
   UPDATE_ALLOWANCES_SETTINGS,
@@ -33,7 +32,6 @@ import {
 // Reducer
 export const initialState: OsrdSimulationState = {
   chart: undefined,
-  chartXGEV: undefined,
   isPlaying: false,
   isUpdating: false,
   allowancesSettings: undefined,
@@ -65,9 +63,6 @@ export default function reducer(inputState: OsrdSimulationState | undefined, act
     switch (action.type) {
       case UPDATE_CHART:
         draft.chart = action.chart;
-        break;
-      case UPDATE_CHARTXGEV:
-        draft.chartXGEV = action.chartXGEV;
         break;
       case UPDATE_IS_PLAYING:
         draft.isPlaying = action.isPlaying;

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -225,7 +225,6 @@ export type SpeedSpaceSettingsType = { [key in SpeedSpaceSettingKey]: boolean };
 export interface OsrdSimulationState {
   redirectToGraph?: boolean;
   chart?: Chart;
-  chartXGEV?: Chart['x'];
   isPlaying: boolean;
   isUpdating: boolean;
   allowancesSettings?: AllowancesSettings;


### PR DESCRIPTION
This will restore sunc between Timeline and GET in domain changes by sliders. Cannot pass D3Scale trhough Store, so it is the retrurn of chartXCGEV, in a readable manner (i hope)

Closes #5367 