### PR TITLE
front: fix punctual object position calculation

### DIFF
--- a/front/src/applications/editor/tools/pointEdition/CustomPosition.tsx
+++ b/front/src/applications/editor/tools/pointEdition/CustomPosition.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { WidgetProps } from '@rjsf/core';
+import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
+
+export const CustomPosition: React.FC<WidgetProps> = (props) => {
+  const { schema, onChange, title, value } = props;
+  const POINT_NAME = 'point-parameter';
+
+  return (
+    <div key={`${POINT_NAME}-${schema.description}`}>
+      <p>{title}</p>
+      <InputSNCF
+        name={POINT_NAME}
+        id={`${POINT_NAME}-${schema.description}`}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        type="number"
+        min={0}
+      />
+    </div>
+  );
+};
+
+export default CustomPosition;

--- a/front/src/applications/editor/tools/utils.ts
+++ b/front/src/applications/editor/tools/utils.ts
@@ -30,13 +30,19 @@ import { getEntity } from '../data/api';
  * Since Turf and Editoast do not compute the lengths the same way (see #1751)
  * we can have data "end" being larger than Turf's computed length, which
  * throws an error. Until we find a way to get similar computations, we can
- * approximate this way:
+ * approximate it with a rule of Three.
+ *
+ * This approximation is not good if the track is long.
  */
 export function approximateDistanceWithEditoastData(track: TrackSectionEntity, point: Point) {
-  const distanceAlongTrack =
-    (length(lineSlice(track.geometry.coordinates[0], point, track)) * track.properties.length) /
-    length(track);
-  return distanceAlongTrack;
+  const wrongDistanceAlongTrack = length(lineSlice(track.geometry.coordinates[0], point, track));
+  const wrongTrackLength = length(track);
+  const realTrackLength = track.properties.length;
+
+  const distanceAlongTrack = (wrongDistanceAlongTrack * realTrackLength) / wrongTrackLength;
+
+  if (Math.abs(distanceAlongTrack - realTrackLength) < 0.1) return realTrackLength;
+  return Math.round(distanceAlongTrack * 100) / 100;
 }
 
 /** return the trackRanges near the mouse thanks to the hover event */


### PR DESCRIPTION
closes #4246 

- [x] Add the approximateDistanceWithEditoastData function to the PointEditionToolFactory when moving/clicking on the map
- [x] Add a custom field in the PointEditionLeftPanel schema for the 3 entities (bufferStop, detector and signal)
