### PR TITLE
editoast: set the minimum tile level to 5

### DIFF
--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -95,7 +95,7 @@ async fn layer_view(
         "scheme": "xyz",
         "tiles": [tiles_url_pattern],
         "attribution": layer.attribution.clone().unwrap_or_default(),
-        "minzoom": 0,
+        "minzoom": 5,
         "maxzoom": map_layers_config.max_zoom,
     })))
 }


### PR DESCRIPTION
Currently, editoast has a big performance issue: generating the bigger tiles takes a lot longer than we can afford, which blocks database threads and can cause lockups.

As users open the app and zoom out, huge tiles need to be generated by the back-end. A lot of these tiles aren't even useful, as the front-end will immediately request smaller tiles, which don't cause as many issues.

This value is hard-coded as editoast does not have the performance budget to generate bigger tiles.