### PR TITLE
actions: run CI on the merged commit

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -24,9 +24,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python
@@ -54,9 +51,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          # github runs PR workflows on the result of a merge commit.
-          # tell codecov the sha of the unmerged PR https://github.com/codecov/uploader/issues/525
-          override_commit: "${{ github.event.pull_request.head.sha }}"
           name: codecov
           flags: core
           directory: ./core/build/reports/jacoco/testCodeCoverageReport

--- a/.github/workflows/editoast.yml
+++ b/.github/workflows/editoast.yml
@@ -25,9 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install lib posgresql & geos
         run: |
@@ -80,9 +77,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Init database
         run: psql postgresql://postgres:password@localhost -f ./docker/init_db.sql
@@ -124,9 +118,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          # github runs PR workflows on the result of a merge commit.
-          # tell codecov the sha of the unmerged PR https://github.com/codecov/uploader/issues/525
-          override_commit: "${{ github.event.pull_request.head.sha }}"
           name: codecov
           flags: editoast
           files: cobertura.xml
@@ -140,9 +131,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install lib posgresql & geos
         run: |

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          # github runs PR workflows on the result of a merge commit.
-          # tell codecov the sha of the unmerged PR https://github.com/codecov/uploader/issues/525
-          override_commit: "${{ github.event.pull_request.head.sha }}"
           name: codecov
           flags: front
           directory: ./front/tests/unit/coverage

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,9 +19,6 @@ jobs:
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python

--- a/.github/workflows/integration_tests_quality.yml
+++ b/.github/workflows/integration_tests_quality.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # run the CI on the actual latest commit of the PR, not the attempted merge
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python

--- a/.github/workflows/osrd_schemas.yml
+++ b/.github/workflows/osrd_schemas.yml
@@ -65,9 +65,6 @@ jobs:
     steps:
         - name: Checkout
           uses: actions/checkout@v4
-          with:
-            # run the CI on the actual latest commit of the PR, not the attempted merge
-            ref: ${{ github.event.pull_request.head.sha }}
         - name: Install poetry
           run: pipx install poetry
         - uses: actions/setup-python@v4


### PR DESCRIPTION
The reason why we were running CI on the unmerged commit in the first place was a now fixed codecov issue.

See https://github.com/codecov/uploader/issues/525

Reverts: 6c242e92b083584415e98e0b7747d97784b66cec