### PR TITLE
editoast: /auto_fixes endpoint for invalid-ref (track) on BufferStop, Signal & Detector

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3886,6 +3886,27 @@ paths:
                 type: object
           description: All objects attached to the given track (arranged by types)
       summary: Retrieve all objects attached to a given track
+  /infra/{id}/auto_fixes/:
+    get:
+      parameters:
+      - description: infra id
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Operation'
+                type: array
+          description: A list of operations
+      summary: Retrieve a list of suggested operations to fix issues
+      tags:
+      - infra
   /infra/{id}/clone/:
     post:
       parameters:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -312,6 +312,28 @@ paths:
                     items:
                       $ref: "#/components/schemas/InfraError"
 
+  /infra/{id}/auto_fixes/:
+    get:
+      tags:
+        - infra
+      summary: Retrieve a list of suggested operations to fix issues
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: infra id
+          required: true
+      responses:
+        200:
+          description: A list of operations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Operation"
+
   /infra/{id}/switch_types/:
     get:
       tags:

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -143,6 +143,92 @@ fn generate_errors<Ctx: Default>(
     errors
 }
 
+pub fn generate_infra_errors(infra_cache: &InfraCache) -> Vec<InfraError> {
+    // Create a graph for topological errors
+    let graph = Graph::load(infra_cache);
+
+    // Generate the errors
+    let mut infra_errors = generate_errors(
+        ObjectType::TrackSection,
+        infra_cache,
+        &graph,
+        &track_sections::OBJECT_GENERATORS,
+        &[],
+    );
+    infra_errors.extend(generate_errors(
+        ObjectType::Signal,
+        infra_cache,
+        &graph,
+        &signals::OBJECT_GENERATORS,
+        &[],
+    ));
+    infra_errors.extend(generate_errors(
+        ObjectType::SpeedSection,
+        infra_cache,
+        &graph,
+        &speed_sections::OBJECT_GENERATORS,
+        &speed_sections::GLOBAL_GENERATORS,
+    ));
+
+    infra_errors.extend(generate_errors(
+        ObjectType::SwitchType,
+        infra_cache,
+        &graph,
+        &switch_types::OBJECT_GENERATORS,
+        &[],
+    ));
+
+    infra_errors.extend(generate_errors(
+        ObjectType::Detector,
+        infra_cache,
+        &graph,
+        &detectors::OBJECT_GENERATORS,
+        &[],
+    ));
+    infra_errors.extend(generate_errors(
+        ObjectType::BufferStop,
+        infra_cache,
+        &graph,
+        &buffer_stops::OBJECT_GENERATORS,
+        &buffer_stops::GLOBAL_GENERATORS,
+    ));
+
+    infra_errors.extend(generate_errors(
+        ObjectType::OperationalPoint,
+        infra_cache,
+        &graph,
+        &operational_points::OBJECT_GENERATORS,
+        &[],
+    ));
+
+    infra_errors.extend(generate_errors(
+        ObjectType::Route,
+        infra_cache,
+        &graph,
+        &routes::OBJECT_GENERATORS,
+        &routes::GLOBAL_GENERATORS,
+    ));
+
+    infra_errors.extend(generate_errors(
+        ObjectType::Switch,
+        infra_cache,
+        &graph,
+        &switches::OBJECT_GENERATORS,
+        &[],
+    ));
+    infra_errors.extend(generate_errors(
+        ObjectType::Catenary,
+        infra_cache,
+        &graph,
+        &catenaries::OBJECT_GENERATORS,
+        &catenaries::GLOBAL_GENERATORS,
+    ));
+
+    // TODO: generate neutralSections errors
+
+    infra_errors
+}
+
 /// Get sql query that insert errors given an object type
 fn get_insert_errors_query(obj_type: ObjectType) -> &'static str {
     match obj_type {
@@ -198,87 +284,7 @@ impl GeneratedData for ErrorLayer {
         infra_id: i64,
         infra_cache: &InfraCache,
     ) -> Result<()> {
-        // Create a graph for topological errors
-        let graph = Graph::load(infra_cache);
-
-        // Generate the errors
-        let mut infra_errors = generate_errors(
-            ObjectType::TrackSection,
-            infra_cache,
-            &graph,
-            &track_sections::OBJECT_GENERATORS,
-            &[],
-        );
-        infra_errors.extend(generate_errors(
-            ObjectType::Signal,
-            infra_cache,
-            &graph,
-            &signals::OBJECT_GENERATORS,
-            &[],
-        ));
-        infra_errors.extend(generate_errors(
-            ObjectType::SpeedSection,
-            infra_cache,
-            &graph,
-            &speed_sections::OBJECT_GENERATORS,
-            &speed_sections::GLOBAL_GENERATORS,
-        ));
-
-        infra_errors.extend(generate_errors(
-            ObjectType::SwitchType,
-            infra_cache,
-            &graph,
-            &switch_types::OBJECT_GENERATORS,
-            &[],
-        ));
-
-        infra_errors.extend(generate_errors(
-            ObjectType::Detector,
-            infra_cache,
-            &graph,
-            &detectors::OBJECT_GENERATORS,
-            &[],
-        ));
-        infra_errors.extend(generate_errors(
-            ObjectType::BufferStop,
-            infra_cache,
-            &graph,
-            &buffer_stops::OBJECT_GENERATORS,
-            &buffer_stops::GLOBAL_GENERATORS,
-        ));
-
-        infra_errors.extend(generate_errors(
-            ObjectType::OperationalPoint,
-            infra_cache,
-            &graph,
-            &operational_points::OBJECT_GENERATORS,
-            &[],
-        ));
-
-        infra_errors.extend(generate_errors(
-            ObjectType::Route,
-            infra_cache,
-            &graph,
-            &routes::OBJECT_GENERATORS,
-            &routes::GLOBAL_GENERATORS,
-        ));
-
-        infra_errors.extend(generate_errors(
-            ObjectType::Switch,
-            infra_cache,
-            &graph,
-            &switches::OBJECT_GENERATORS,
-            &[],
-        ));
-        infra_errors.extend(generate_errors(
-            ObjectType::Catenary,
-            infra_cache,
-            &graph,
-            &catenaries::OBJECT_GENERATORS,
-            &catenaries::GLOBAL_GENERATORS,
-        ));
-
-        // TODO: generer les erreurs pour les neutralSections
+        let infra_errors = generate_infra_errors(infra_cache);
 
         // Insert errors in DB
         insert_errors(conn, infra_id, infra_errors).await?;

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -12,6 +12,8 @@ mod speed_section;
 mod switch;
 mod track_section;
 
+pub use error::generate_infra_errors;
+
 use async_trait::async_trait;
 use buffer_stop::BufferStopLayer;
 use catenary::CatenaryLayer;

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 pub use graph::Graph;
 
 /// Contains infra cached data used to generate layers and errors
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct InfraCache {
     /// Map track section id to the list of objects that depend on it
     /// Contains all referenced track sections (not only existing ones)

--- a/editoast/src/schema/errors.rs
+++ b/editoast/src/schema/errors.rs
@@ -277,6 +277,10 @@ impl InfraError {
             sub_type: InfraErrorType::OverlappingSwitches { reference },
         }
     }
+
+    pub fn get_sub_type(&self) -> &InfraErrorType {
+        &self.sub_type
+    }
 }
 
 impl OSRDIdentified for InfraError {

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -62,7 +62,7 @@ pub trait OSRDIdentified {
 }
 
 /// This trait is used for all object that can be typed and identified.
-/// It allows to get an `ObjectRef` fromt it.
+/// It allows to get an `ObjectRef` from it.
 pub trait OSRDObject: OSRDIdentified {
     fn get_type(&self) -> ObjectType;
     fn get_ref(&self) -> ObjectRef {

--- a/editoast/src/schema/operation/create.rs
+++ b/editoast/src/schema/operation/create.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use super::OperationError;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "obj_type", deny_unknown_fields)]
 pub enum RailjsonObject {
     TrackSection { railjson: TrackSection },

--- a/editoast/src/schema/operation/delete.rs
+++ b/editoast/src/schema/operation/delete.rs
@@ -7,7 +7,7 @@ use diesel::sql_types::{BigInt, Text};
 use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
 /// A delete operation. Contains same information as a object ref but has another serialization.
 pub struct DeleteOperation {

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -13,7 +13,7 @@ pub use self::delete::DeleteOperation;
 pub use create::RailjsonObject;
 pub use update::UpdateOperation;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "operation_type", deny_unknown_fields)]
 pub enum Operation {
     #[serde(rename = "CREATE")]
@@ -67,4 +67,14 @@ enum OperationError {
     ModifyId,
     #[error("A Json Patch error occurred: '{}'", .0)]
     InvalidPatch(String),
+}
+
+impl From<&Operation> for OperationResult {
+    fn from(op: &Operation) -> Self {
+        match op {
+            Operation::Delete(deletion) => OperationResult::Delete(deletion.clone().into()),
+            Operation::Create(railjson_object) => OperationResult::Create(*railjson_object.clone()),
+            Operation::Update(_update) => todo!(),
+        }
+    }
 }

--- a/editoast/src/schema/operation/update.rs
+++ b/editoast/src/schema/operation/update.rs
@@ -11,7 +11,7 @@ use serde_json::{from_value, json, Value};
 
 use super::OperationError;
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct UpdateOperation {
     pub obj_id: String,

--- a/editoast/src/views/infra/auto_fixes.rs
+++ b/editoast/src/views/infra/auto_fixes.rs
@@ -1,0 +1,218 @@
+use std::collections::HashSet;
+
+use crate::error::Result;
+use crate::generated_data::generate_infra_errors;
+use crate::infra_cache::InfraCache;
+use crate::models::{self, Infra, Retrieve};
+use crate::schema::operation::{DeleteOperation, Operation};
+use crate::schema::{
+    InfraError, InfraErrorType, OSRDIdentified, OSRDObject, ObjectRef, ObjectType,
+};
+use crate::DbPool;
+use actix_web::dev::HttpServiceFactory;
+use actix_web::get;
+use actix_web::web::{Data, Json as WebJson, Path};
+use chashmap::CHashMap;
+use editoast_derive::EditoastError;
+use itertools::Itertools;
+use thiserror::Error;
+
+const MAX_AUTO_FIXES_ITERATIONS: u8 = 5;
+
+/// Return `/infra/<infra_id>/auto_fixes` routes
+pub fn routes() -> impl HttpServiceFactory {
+    list_auto_fixes
+}
+
+/// Return the list of suggestions to fix infra errors
+#[get("/auto_fixes")]
+async fn list_auto_fixes(
+    infra: Path<i64>,
+    infra_caches: Data<CHashMap<i64, InfraCache>>,
+    db_pool: Data<DbPool>,
+) -> Result<WebJson<Vec<Operation>>> {
+    let infra_id = infra.into_inner();
+    let infra = Infra::retrieve(db_pool.clone(), infra_id)
+        .await?
+        .ok_or(models::infra::InfraError::NotFound(infra_id))?;
+    let mut conn = db_pool.get().await?;
+
+    // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)
+    let mut infra_cache_clone = InfraCache::get_or_load(&mut conn, &infra_caches, &infra)
+        .await?
+        .clone();
+
+    let mut fixes = vec![];
+    for _ in 0..MAX_AUTO_FIXES_ITERATIONS {
+        let new_fixes = fix_infra(&mut infra_cache_clone)?;
+        if new_fixes.is_empty() {
+            // Every possible error is fixed
+            return Ok(WebJson(fixes));
+        }
+        fixes.extend(new_fixes);
+    }
+
+    // Reapplying an auto-fix should do nothing.
+    // And few iterations are supposed to provide every possible fix.
+    // Yet after reaching the maximum number of iterations, there are still fixes available.
+    Err(AutoFixesEditoastError::MaximumIterationReached().into())
+}
+
+fn fix_infra(infra_cache: &mut InfraCache) -> Result<Vec<Operation>> {
+    let infra_errors = generate_infra_errors(infra_cache);
+
+    let mut delete_fixes_already_retained = HashSet::new();
+    let mut all_fixes = vec![];
+
+    for error in infra_errors {
+        for operation in get_operations_fixing_error(&error)? {
+            let mut must_retain = true;
+            if let Operation::Delete(ref delete_operation) = operation {
+                must_retain = delete_fixes_already_retained.insert(delete_operation.to_owned());
+            }
+            if must_retain {
+                all_fixes.push(operation);
+            }
+        }
+    }
+
+    let operation_results = all_fixes.iter().map_into().collect();
+    infra_cache.apply_operations(&operation_results);
+
+    Ok(all_fixes)
+}
+
+fn get_operations_fixing_error(error: &InfraError) -> Result<Vec<Operation>> {
+    match error.get_sub_type() {
+        InfraErrorType::InvalidReference { reference } => {
+            get_operations_fixing_invalid_reference(error, reference)
+        }
+        _ => Ok(vec![]), // Default: nothing is done to fix error
+    }
+}
+
+fn get_operations_fixing_invalid_reference(
+    error: &InfraError,
+    reference: &ObjectRef,
+) -> Result<Vec<Operation>> {
+    // BufferStop or Signal invalid-reference on track
+    if [
+        ObjectType::BufferStop,
+        ObjectType::Signal,
+        ObjectType::Detector,
+    ]
+    .contains(&error.get_type())
+        && reference.obj_type == ObjectType::TrackSection
+    {
+        return Ok([Operation::Delete(DeleteOperation {
+            obj_id: error.get_id().to_string(),
+            obj_type: error.get_type(),
+        })]
+        .to_vec());
+    }
+
+    Ok(vec![])
+}
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "auto_fixes")]
+pub enum AutoFixesEditoastError {
+    #[error(
+        "Reached maximum number of iterations to fix infra without providing every possible fixe"
+    )]
+    #[editoast_error(status = 500)]
+    MaximumIterationReached(),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::fixtures::tests::{db_pool, small_infra};
+    use crate::schema::operation::{DeleteOperation, Operation};
+    use crate::schema::{ObjectRef, ObjectType, SignalCache};
+    use crate::views::tests::create_test_service;
+    use actix_http::StatusCode;
+    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use serde_json::json;
+
+    #[rstest::rstest]
+    async fn test_no_fix() {
+        let app = create_test_service().await;
+        let small_infra = small_infra(db_pool()).await;
+        let small_infra_id = small_infra.id();
+
+        let req_fix = TestRequest::get()
+            .uri(format!("/infra/{small_infra_id}/auto_fixes").as_str())
+            .to_request();
+        let response = call_service(&app, req_fix).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let operations: Vec<Operation> = read_body_json(response).await;
+        assert!(operations.is_empty());
+    }
+
+    #[rstest::rstest]
+    async fn test_fix_invalid_ref_signal_buffer_stop() {
+        let app = create_test_service().await;
+        let small_infra = small_infra(db_pool()).await;
+        let small_infra_id = small_infra.id();
+        // Remove a track
+        let deletion = Operation::Delete(DeleteOperation {
+            obj_id: "TA1".to_string(),
+            obj_type: ObjectType::TrackSection,
+        });
+        let req_del = TestRequest::post()
+            .uri(format!("/infra/{small_infra_id}/").as_str())
+            .set_json(json!([deletion]))
+            .to_request();
+        assert_eq!(call_service(&app, req_del).await.status(), StatusCode::OK);
+
+        let req_fix = TestRequest::get()
+            .uri(format!("/infra/{small_infra_id}/auto_fixes").as_str())
+            .to_request();
+        let response = call_service(&app, req_fix).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let operations: Vec<Operation> = read_body_json(response).await;
+        assert!(operations.contains(&Operation::Delete(DeleteOperation {
+            obj_id: "SA0".to_string(),
+            obj_type: ObjectType::Signal,
+        })));
+        assert!(operations.contains(&Operation::Delete(DeleteOperation {
+            obj_id: "buffer_stop.1".to_string(),
+            obj_type: ObjectType::BufferStop,
+        })));
+        assert!(operations.contains(&Operation::Delete(DeleteOperation {
+            obj_id: "DA0".to_string(),
+            obj_type: ObjectType::Detector,
+        })));
+    }
+
+    #[test]
+    fn test_invalid_ref_signal_fix() {
+        let error = InfraError::new_invalid_reference(
+            &SignalCache::new("SA0".to_string(), "TA1".to_string(), 0.0, vec![]),
+            "track",
+            ObjectRef::new(ObjectType::TrackSection, "TA1"),
+        );
+
+        assert_eq!(
+            get_operations_fixing_error(&error).unwrap(),
+            vec![Operation::Delete(DeleteOperation {
+                obj_id: "SA0".to_string(),
+                obj_type: ObjectType::Signal,
+            })]
+        );
+    }
+
+    #[test]
+    fn test_wrong_invalid_ref_signal_fix() {
+        let error = InfraError::new_invalid_reference(
+            &SignalCache::new("SA0".to_string(), "TA1".to_string(), 0.0, vec![]),
+            "track",
+            ObjectRef::new(ObjectType::Detector, "TA1"),
+        );
+
+        assert!(get_operations_fixing_error(&error).unwrap().is_empty());
+    }
+}

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1,4 +1,5 @@
 mod attached;
+mod auto_fixes;
 mod edition;
 mod errors;
 mod lines;
@@ -67,6 +68,7 @@ pub fn routes() -> impl HttpServiceFactory {
                 ))
                 .service((
                     errors::routes(),
+                    auto_fixes::routes(),
                     objects::routes(),
                     lines::routes(),
                     routes::routes(),

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -159,6 +159,13 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({ url: `/infra/${queryArg.id}/attached/${queryArg.trackId}/` }),
       }),
+      getInfraByIdAutoFixes: build.query<
+        GetInfraByIdAutoFixesApiResponse,
+        GetInfraByIdAutoFixesApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.id}/auto_fixes/` }),
+        providesTags: ['infra'],
+      }),
       postInfraByIdClone: build.mutation<PostInfraByIdCloneApiResponse, PostInfraByIdCloneApiArg>({
         query: (queryArg) => ({
           url: `/infra/${queryArg.id}/clone/`,
@@ -821,6 +828,11 @@ export type GetInfraByIdAttachedAndTrackIdApiArg = {
   id: number;
   /** Track ID */
   trackId: string;
+};
+export type GetInfraByIdAutoFixesApiResponse = /** status 200 A list of operations */ Operation[];
+export type GetInfraByIdAutoFixesApiArg = {
+  /** infra id */
+  id: number;
 };
 export type PostInfraByIdCloneApiResponse = /** status 201 The duplicated infra id */ {
   id?: number;


### PR DESCRIPTION
Endpoint `/auto_fixes` suggests Operations to be applied to given infra to correct errors.
Fixes: https://github.com/osrd-project/osrd/issues/5521 (first part)

Current limitations:
* No front

TODO:

1. Clean error when apply attempt fails ( in a [separate PR](https://github.com/osrd-project/osrd/pull/5844))
2. Try to use utoipa openapi generation (in a [separate PR](https://github.com/osrd-project/osrd/pull/5820))

As for perfs (locally):
* ~5s to generate InfraCache
* ~1s for a loop calling fix_infra