### PR TITLE
editoast: rename assert_editoast_error_type macro

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -287,7 +287,7 @@ mod tests {
     ///
     /// The other error fields (message, status_code and context) are ignored.
     #[macro_export]
-    macro_rules! assert_editoast_error_type {
+    macro_rules! assert_response_error_type_match {
         ($response: ident, $error: expr) => {{
             let expected_error: $crate::error::InternalError = $error.into();
             let payload: serde_json::Value = actix_web::test::try_read_body_json($response)

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -539,7 +539,7 @@ mod test {
     use crate::views::pathfinding::{PathfindingError, Response};
     use crate::views::tests::create_test_service;
     use crate::views::tests::create_test_service_with_core_client;
-    use crate::{assert_editoast_error_type, assert_status_and_read};
+    use crate::{assert_response_error_type_match, assert_status_and_read};
 
     #[rstest::rstest]
     async fn test_get_pf(#[future] pathfinding: TestFixture<Pathfinding>) {
@@ -676,7 +676,10 @@ mod test {
             .to_request();
         let response = call_service(&app, req).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert_editoast_error_type!(response, PathfindingError::InfraNotFound { infra_id: 0 });
+        assert_response_error_type_match!(
+            response,
+            PathfindingError::InfraNotFound { infra_id: 0 }
+        );
     }
 
     #[rstest::rstest]
@@ -694,7 +697,7 @@ mod test {
             .to_request();
         let response = call_service(&app, req).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             response,
             PathfindingError::RollingStockNotFound {
                 rolling_stock_id: 0
@@ -717,7 +720,7 @@ mod test {
             .to_request();
         let response = call_service(&app, req).await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             response,
             PathfindingError::TrackSectionsNotFound {
                 track_sections: Default::default()

--- a/editoast/src/views/rolling_stocks/mod.rs
+++ b/editoast/src/views/rolling_stocks/mod.rs
@@ -470,7 +470,7 @@ pub mod tests {
     use crate::models::rolling_stock::tests::get_invalid_effort_curves;
     use crate::models::{Delete, RollingStockModel};
     use crate::views::tests::create_test_service;
-    use crate::{assert_editoast_error_type, assert_status_and_read, DbPool};
+    use crate::{assert_response_error_type_match, assert_status_and_read, DbPool};
     use actix_http::{Request, StatusCode};
     use actix_web::dev::ServiceResponse;
     use actix_web::http::header::ContentType;
@@ -640,7 +640,7 @@ pub mod tests {
         )
         .await;
         assert_eq!(patch_response.status(), StatusCode::BAD_REQUEST);
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             patch_response,
             RollingStockError::RollingStockIsLocked { rolling_stock_id }
         );
@@ -649,7 +649,7 @@ pub mod tests {
         let delete_request = rolling_stock_delete_request(rolling_stock_id);
         let delete_response = call_service(&app, delete_request).await;
         assert_eq!(delete_response.status(), StatusCode::BAD_REQUEST);
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             delete_response,
             RollingStockError::RollingStockIsLocked { rolling_stock_id }
         );
@@ -777,7 +777,7 @@ pub mod tests {
 
         // THEN
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             response,
             RollingStockError::NameAlreadyUsed {
                 name: String::from(other_rs_name),
@@ -872,7 +872,7 @@ pub mod tests {
                 .clone()
                 .unwrap(),
         }];
-        assert_editoast_error_type!(
+        assert_response_error_type_match!(
             response,
             RollingStockError::RollingStockIsUsed {
                 rolling_stock_id,

--- a/editoast/src/views/single_simulation.rs
+++ b/editoast/src/views/single_simulation.rs
@@ -184,7 +184,7 @@ mod tests {
         db_pool, electrical_profile_set, named_fast_rolling_stock, pathfinding,
     };
     use crate::views::tests::create_test_service_with_core_client;
-    use crate::{assert_editoast_error_type, assert_status_and_read};
+    use crate::{assert_response_error_type_match, assert_status_and_read};
     use actix_web::test::{call_service, TestRequest};
     use pretty_assertions::assert_eq;
     use reqwest::{Method, StatusCode};
@@ -282,7 +282,7 @@ mod tests {
 
         // THEN
         if let Some(expected_error) = expected_error {
-            assert_editoast_error_type!(response, expected_error);
+            assert_response_error_type_match!(response, expected_error);
         } else {
             let response_body: SingleSimulationResponse =
                 assert_status_and_read!(response, StatusCode::OK);


### PR DESCRIPTION
I changed the name of the `assert_editoast_error_type` macro to `assert_response_error_type_match` to make it clearer. This macro checks if the **type** field in the response matches the **type** field in the provided `InternalError`.