### PR TITLE
Fix layers order on map and map performances

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -206,7 +206,11 @@ const MapUnplugged: FC<PropsWithChildren<MapProps>> = ({
           attributionControl={false}
           touchZoomRotate
           maxPitch={85}
-          terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
+          terrain={
+            terrain3DExaggeration
+              ? { source: 'terrain', exaggeration: terrain3DExaggeration }
+              : undefined
+          }
           doubleClickZoom={false}
           interactive
           cursor={cursor}

--- a/front/src/applications/referenceMap/Map.tsx
+++ b/front/src/applications/referenceMap/Map.tsx
@@ -123,7 +123,11 @@ function Map() {
         interactiveLayerIds={defineInteractiveLayers()}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
+        terrain={
+          terrain3DExaggeration
+            ? { source: 'terrain', exaggeration: terrain3DExaggeration }
+            : undefined
+        }
       >
         <VirtualLayers />
         <AttributionControl customAttribution={CUSTOM_ATTRIBUTION} />
@@ -149,6 +153,7 @@ function Map() {
             />
           </>
         )}
+
         <Platforms
           colors={colors[mapStyle]}
           layerOrder={LAYER_GROUPS_ORDER[LAYERS.PLATFORMS.GROUP]}

--- a/front/src/assets/mapstyles/OSMStyle.json
+++ b/front/src/assets/mapstyles/OSMStyle.json
@@ -1047,10 +1047,10 @@
     "type": "fill-extrusion",
     "minzoom": 0,
     "paint": {
-        "fill-extrusion-color": "#aaa",
-        "fill-extrusion-height": ["get", "render_height"],
-        "fill-extrusion-base": ["get", "render_min_height"],
-        "fill-extrusion-opacity": 0.6
+      "fill-extrusion-color": "#aaa",
+      "fill-extrusion-height": ["get", "render_height"],
+      "fill-extrusion-base": ["get", "render_min_height"],
+      "fill-extrusion-opacity": 0.6
     }
   },
   {

--- a/front/src/common/Map/Consts/colors.ts
+++ b/front/src/common/Map/Consts/colors.ts
@@ -56,7 +56,7 @@ const colors: Record<string, Theme> = {
       halo: '#eee',
     },
     platform: {
-      fill: '#e05206',
+      fill: '#e9b996',
     },
     pn: {
       text: '#712b2b',

--- a/front/src/common/Map/Layers/Platforms.tsx
+++ b/front/src/common/Map/Layers/Platforms.tsx
@@ -16,7 +16,7 @@ function Platforms(props: PlatformsProps) {
 
   const platformsParams: LayerProps = {
     id: 'osm/platforms',
-    type: 'fill-extrusion',
+    type: 'fill',
     source: 'openmaptiles',
     'source-layer': 'transportation',
     filter: [
@@ -26,10 +26,7 @@ function Platforms(props: PlatformsProps) {
       ['==', 'subclass', 'platform'],
     ],
     paint: {
-      'fill-extrusion-color': colors.platform.fill,
-      'fill-extrusion-height': 2,
-      'fill-extrusion-base': 1,
-      'fill-extrusion-opacity': 0.4,
+      'fill-color': colors.platform.fill,
     },
   };
 

--- a/front/src/modules/simulationResult/components/SimulationResultsMap.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap.tsx
@@ -247,7 +247,11 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
         interactiveLayerIds={interactiveLayerIds}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
+        terrain={
+          terrain3DExaggeration
+            ? { source: 'terrain', exaggeration: terrain3DExaggeration }
+            : undefined
+        }
         onLoad={handleLoadFinished}
       >
         <VirtualLayers />

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
@@ -171,7 +171,11 @@ function Map() {
         interactiveLayerIds={defineInteractiveLayers()}
         touchZoomRotate
         maxPitch={85}
-        terrain={{ source: 'terrain', exaggeration: terrain3DExaggeration }}
+        terrain={
+          terrain3DExaggeration
+            ? { source: 'terrain', exaggeration: terrain3DExaggeration }
+            : undefined
+        }
       >
         <VirtualLayers />
         <AttributionControl position="bottom-right" customAttribution={CUSTOM_ATTRIBUTION} />


### PR DESCRIPTION
close #4872 
close #5619 
close #5392 

The fix for 4872 is the one used for this [closed PR](https://github.com/osrd-project/osrd/pull/5461/files).
When 3D relief scale is at 0 (default), the terrain is at undefined and we can see the tracks. 

![image](https://github.com/osrd-project/osrd/assets/113104137/ac9f67a9-239b-42e3-ab84-7d92e2a46e5c)

If the scale is higher than 0, they go back under the relief.

![image](https://github.com/osrd-project/osrd/assets/113104137/b08f5c3b-4318-461c-b387-1d96cee47dd4)

