### PR TITLE
Fix signal angle generation

### DIFF
--- a/editoast/src/generated_data/sql/generate_signal_layer.sql
+++ b/editoast/src/generated_data/sql/generate_signal_layer.sql
@@ -32,18 +32,24 @@ INSERT INTO infra_layer_signal (
     )
 SELECT collect.signal_id,
     $1,
-    degrees(
-        ST_Azimuth(
-            ST_LineInterpolatePoint(track_geo, GREATEST(norm_pos - 0.0001, 0.)),
-            ST_LineInterpolatePoint(track_geo, LEAST(norm_pos + 0.0001, 1.))
-        )
-    ) + angle_direction,
-    degrees(
-        ST_Azimuth(
-            ST_LineInterpolatePoint(track_sch, GREATEST(norm_pos - 0.0001, 0.)),
-            ST_LineInterpolatePoint(track_sch, LEAST(norm_pos + 0.0001, 1.))
-        )
-    ) + angle_direction,
+    COALESCE(
+        degrees(
+            ST_Azimuth(
+                ST_LineInterpolatePoint(track_geo, GREATEST(norm_pos - 0.0001, 0.)),
+                ST_LineInterpolatePoint(track_geo, LEAST(norm_pos + 0.0001, 1.))
+            )
+        ) + angle_direction,
+        0.
+    ),
+    COALESCE(
+        degrees(
+            ST_Azimuth(
+                ST_LineInterpolatePoint(track_sch, GREATEST(norm_pos - 0.0001, 0.)),
+                ST_LineInterpolatePoint(track_sch, LEAST(norm_pos + 0.0001, 1.))
+            )
+        ) + angle_direction,
+        0.
+    ),
     ST_LineInterpolatePoint(track_geo, norm_pos),
     ST_LineInterpolatePoint(track_sch, norm_pos)
 FROM collect

--- a/editoast/src/generated_data/sql/insert_update_signal_layer.sql
+++ b/editoast/src/generated_data/sql/insert_update_signal_layer.sql
@@ -33,18 +33,24 @@ INSERT INTO infra_layer_signal (
     )
 SELECT collect.signal_id,
     $1,
-    degrees(
-        ST_Azimuth(
-            ST_LineInterpolatePoint(track_geo, GREATEST(norm_pos - 0.0001, 0.)),
-            ST_LineInterpolatePoint(track_geo, LEAST(norm_pos + 0.0001, 1.))
-        )
-    ) + angle_direction,
-    degrees(
-        ST_Azimuth(
-            ST_LineInterpolatePoint(track_sch, GREATEST(norm_pos - 0.0001, 0.)),
-            ST_LineInterpolatePoint(track_sch, LEAST(norm_pos + 0.0001, 1.))
-        )
-    ) + angle_direction,
+    COALESCE(
+        degrees(
+            ST_Azimuth(
+                ST_LineInterpolatePoint(track_geo, GREATEST(norm_pos - 0.0001, 0.)),
+                ST_LineInterpolatePoint(track_geo, LEAST(norm_pos + 0.0001, 1.))
+            )
+        ) + angle_direction,
+        0.
+    ),
+    COALESCE(
+        degrees(
+            ST_Azimuth(
+                ST_LineInterpolatePoint(track_sch, GREATEST(norm_pos - 0.0001, 0.)),
+                ST_LineInterpolatePoint(track_sch, LEAST(norm_pos + 0.0001, 1.))
+            )
+        ) + angle_direction,
+        0.
+    ),
     ST_LineInterpolatePoint(track_geo, norm_pos),
     ST_LineInterpolatePoint(track_sch, norm_pos)
 FROM collect


### PR DESCRIPTION
When the track geometry is on a point, we can't deduce the angle. 
To avoid getting a "not null" error, we set a default value (0).