### PR TITLE
front: fix #5659 & #5658 - be able to save a track section geo modification

### DIFF
--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -370,7 +370,7 @@ export const TrackEditionLeftPanel: FC = () => {
                 ? {
                     update: [
                       {
-                        source: injectGeometry(state.initialTrack),
+                        source: state.initialTrack,
                         target: injectGeometry(savedEntity),
                       },
                     ],


### PR DESCRIPTION
See the detail in issue #5659 for the explanation