### PR TITLE
editoast: add utoipa annotations for /pathfinding and /stdcm endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -144,6 +144,18 @@ components:
       - Spacing
       - Routing
       type: string
+    Curve:
+      properties:
+        position:
+          format: double
+          type: number
+        radius:
+          format: double
+          type: number
+      required:
+      - radius
+      - position
+      type: object
     DeleteOperation:
       properties:
         obj_id:
@@ -611,6 +623,9 @@ components:
       - $ref: '#/components/schemas/MultiLineString'
       - $ref: '#/components/schemas/MultiPolygon'
       type: object
+    Identifier:
+      description: A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.
+      type: string
     Infra:
       properties:
         created:
@@ -1291,35 +1306,46 @@ components:
       - slopes
       - curves
       - steps
-    PathQuery:
+    PathResponse:
       properties:
-        infra:
-          type: number
-        rolling_stocks:
-          description: List of rolling stocks that must be able to use this path
+        created:
+          format: date-time
+          type: string
+        curves:
           items:
-            type: integer
+            $ref: '#/components/schemas/Curve'
+          type: array
+        geographic:
+          $ref: '#/components/schemas/GeoJsonLineString'
+        id:
+          format: int64
+          type: integer
+        length:
+          format: double
+          type: number
+        owner:
+          format: uuid
+          type: string
+        schematic:
+          $ref: '#/components/schemas/GeoJsonLineString'
+        slopes:
+          items:
+            $ref: '#/components/schemas/Slope'
           type: array
         steps:
           items:
-            properties:
-              duration:
-                format: float
-                type: number
-              waypoints:
-                items:
-                  $ref: '#/components/schemas/PathWaypoint'
-                type: array
-            required:
-            - duration
-            - waypoints
-            type: object
-          minItems: 2
+            $ref: '#/components/schemas/PathWaypoint'
           type: array
       required:
-      - infra
+      - id
+      - owner
+      - length
+      - created
+      - slopes
+      - curves
+      - geographic
+      - schematic
       - steps
-      - rolling_stocks
       type: object
     PathStep:
       properties:
@@ -1331,7 +1357,7 @@ components:
         id:
           type: string
         location:
-          $ref: '#/components/schemas/TrackSectionLocation'
+          $ref: '#/components/schemas/TrackLocation'
         name:
           type: string
         path_offset:
@@ -1352,21 +1378,53 @@ components:
       type: object
     PathWaypoint:
       properties:
-        geo_coordinate:
-          items:
-            format: float
-            type: number
-          maxItems: 2
-          minItems: 2
-          type: array
-        offset:
+        duration:
+          format: double
           type: number
-        track_section:
-          description: track section ID of the waypoint
+        geo:
+          $ref: '#/components/schemas/GeoJsonLineString'
+        id:
+          nullable: true
           type: string
+        location:
+          $ref: '#/components/schemas/TrackLocation'
+        name:
+          nullable: true
+          type: string
+        path_offset:
+          format: double
+          type: number
+        sch:
+          $ref: '#/components/schemas/GeoJsonLineString'
+        suggestion:
+          type: boolean
       required:
-      - track_section
-      - geo_cordinate
+      - id
+      - name
+      - location
+      - duration
+      - path_offset
+      - suggestion
+      - geo
+      - sch
+      type: object
+    PathfindingRequest:
+      properties:
+        infra:
+          format: int64
+          type: integer
+        rolling_stocks:
+          items:
+            format: int64
+            type: integer
+          type: array
+        steps:
+          items:
+            $ref: '#/components/schemas/StepPayload'
+          type: array
+      required:
+      - infra
+      - steps
       type: object
     Point:
       description: GeoJSon geometry
@@ -2821,6 +2879,18 @@ components:
       - electrification_ranges
       - power_restriction_ranges
       type: object
+    Slope:
+      properties:
+        gradient:
+          format: double
+          type: number
+        position:
+          format: double
+          type: number
+      required:
+      - gradient
+      - position
+      type: object
     SpaceTimePosition:
       properties:
         position:
@@ -2868,6 +2938,19 @@ components:
       - default_value
       - ranges
       - distribution
+      type: object
+    StepPayload:
+      properties:
+        duration:
+          format: double
+          type: number
+        waypoints:
+          items:
+            $ref: '#/components/schemas/WaypointPayload'
+          type: array
+      required:
+      - duration
+      - waypoints
       type: object
     Study:
       properties:
@@ -3142,17 +3225,17 @@ components:
         - train_schedule_summaries
         type: object
     TrackLocation:
-      description: A track location (track section and offset)
+      description: A track location is a track section and an offset
       properties:
         offset:
-          description: The offset on the track section
-          example: 42.0
-          format: float
+          description: The offset on the track section in meters
+          format: double
           type: number
-        track:
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-          type: string
+        track_section:
+          $ref: '#/components/schemas/Identifier'
+      required:
+      - track_section
+      - offset
       type: object
     TrackRange:
       properties:
@@ -3169,22 +3252,6 @@ components:
       - track
       - begin
       - end
-      type: object
-    TrackSectionLocation:
-      description: A track location (track section and offset)
-      properties:
-        offset:
-          description: The offset on the track section
-          example: 42.0
-          format: float
-          type: number
-        track_section:
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-          type: string
-      required:
-      - track_section
-      - offset
       type: object
     TrainSchedule:
       properties:
@@ -3465,6 +3532,39 @@ components:
             type: string
         type: object
       type: array
+    WaypointLocation:
+      oneOf:
+      - properties:
+          offset:
+            description: Offset in meters from the start of the waypoint's track section
+            format: double
+            type: number
+        required:
+        - offset
+        type: object
+      - properties:
+          geo_coordinate:
+            description: A geographic coordinate (lon, lat) that will be projected onto the waypoint's track section
+            items:
+              allOf:
+              - format: double
+                type: number
+              - format: double
+                type: number
+            type: array
+        required:
+        - geo_coordinate
+        type: object
+    WaypointPayload:
+      allOf:
+      - $ref: '#/components/schemas/WaypointLocation'
+      - properties:
+          track_section:
+            description: A track section UUID
+            type: string
+        required:
+        - track_section
+        type: object
     Zone:
       properties:
         geo:
@@ -4628,86 +4728,93 @@ paths:
       - rolling_stock
   /pathfinding/:
     post:
+      description: Run a pathfinding between waypoints and store the resulting path in the DB
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PathQuery'
-        description: Path information
+              $ref: '#/components/schemas/PathfindingRequest'
+        required: true
       responses:
         '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Path'
-          description: The created Path
-      summary: Create a Path
-  /pathfinding/{id}/:
+                $ref: '#/components/schemas/PathResponse'
+          description: The created path
+      summary: Run a pathfinding between waypoints and store the resulting path in the DB
+      tags:
+      - pathfinding
+  /pathfinding/{pathfinding_id}/:
     delete:
+      description: Deletes a stored path
       parameters:
-      - description: Path ID
+      - description: A stored path ID
         in: path
-        name: id
+        name: pathfinding_id
         required: true
         schema:
+          format: int64
           type: integer
       responses:
         '204':
-          description: No content
-      summary: Delete a path
+          description: The path was deleted
+      summary: Deletes a stored path
       tags:
       - pathfinding
     get:
+      description: Retrieves a stored path
       parameters:
-      - description: Path ID
+      - description: A stored path ID
         in: path
-        name: id
+        name: pathfinding_id
         required: true
         schema:
+          format: int64
           type: integer
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Path'
-          description: The retrieved path
-      summary: Retrieve a Path
+                $ref: '#/components/schemas/PathResponse'
+          description: The requested path
+      summary: Retrieves a stored path
       tags:
       - pathfinding
     put:
+      description: Updates an existing path with the result of a new pathfinding run
       parameters:
-      - description: Path ID
+      - description: A stored path ID
         in: path
-        name: id
+        name: pathfinding_id
         required: true
         schema:
+          format: int64
           type: integer
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PathQuery'
-        description: Updated Path
+              $ref: '#/components/schemas/PathfindingRequest'
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/Path'
-                type: array
+                $ref: '#/components/schemas/PathResponse'
           description: The updated path
-      summary: Update a path
+      summary: Updates an existing path with the result of a new pathfinding run
       tags:
       - pathfinding
-  /pathfinding/{path_id}/catenaries/:
+  /pathfinding/{pathfinding_id}/catenaries/:
     get:
       description: Retrieve the catenary modes along a path, as seen by the rolling stock specified
       parameters:
-      - description: The path's id
+      - description: A stored path ID
         in: path
-        name: path_id
+        name: pathfinding_id
         required: true
         schema:
           format: int64
@@ -4722,13 +4829,13 @@ paths:
       summary: Retrieve the catenary modes along a path, as seen by the rolling stock specified
       tags:
       - infra
-  /pathfinding/{path_id}/electrical_profiles/:
+  /pathfinding/{pathfinding_id}/electrical_profiles/:
     get:
       description: Retrieve the electrical profiles along a path, as seen by the rolling stock specified
       parameters:
-      - description: The path's id
+      - description: A stored path ID
         in: path
-        name: path_id
+        name: pathfinding_id
         required: true
         schema:
           format: int64

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -183,20 +183,17 @@ components:
       - STOP_TO_START
       type: string
     DirectionalTrackRange:
-      description: Track range associated with a direction
       properties:
         begin:
-          format: float
+          format: double
           type: number
         direction:
           $ref: '#/components/schemas/Direction'
         end:
-          example: 100.0
-          format: float
+          format: double
           type: number
         track:
-          example: 01234567-89ab-cdef-0123-456789abcdef
-          type: string
+          $ref: '#/components/schemas/Identifier'
       required:
       - track
       - begin
@@ -306,12 +303,7 @@ components:
     ElectrificationRange:
       properties:
         electrificationUsage:
-          discriminator:
-            propertyName: object_type
-          oneOf:
-          - $ref: '#/components/schemas/Electrified'
-          - $ref: '#/components/schemas/Neutral'
-          - $ref: '#/components/schemas/NonElectrified'
+          $ref: '#/components/schemas/ElectrificationUsage'
         start:
           format: double
           type: number
@@ -321,28 +313,49 @@ components:
       required:
       - start
       - stop
-      - is_electrified
       - electrificationUsage
-    Electrified:
-      properties:
-        mode:
-          type: string
-        mode_handled:
-          type: boolean
-        object_type:
-          enum:
-          - Electrified
-          type: string
-        profile:
-          nullable: true
-          type: string
-        profile_handled:
-          type: boolean
-      required:
-      - mode
-      - mode_handled
-      - object_type
-      - profile_handled
+      type: object
+    ElectrificationUsage:
+      oneOf:
+      - properties:
+          mode:
+            type: string
+          mode_handled:
+            type: boolean
+          object_type:
+            enum:
+            - Electrified
+            type: string
+          profile:
+            nullable: true
+            type: string
+          profile_handled:
+            type: boolean
+        required:
+        - mode
+        - mode_handled
+        - profile_handled
+        - object_type
+        type: object
+      - properties:
+          lower_pantograph:
+            type: boolean
+          object_type:
+            enum:
+            - Neutral
+            type: string
+        required:
+        - lower_pantograph
+        - object_type
+        type: object
+      - properties:
+          object_type:
+            enum:
+            - NonElectrified
+            type: string
+        required:
+        - object_type
+        type: object
     EnergySource:
       description: energy source of a rolling stock
       oneOf:
@@ -459,6 +472,40 @@ components:
         required:
         - distribution
         type: object
+    FullResultStops:
+      allOf:
+      - $ref: '#/components/schemas/ResultStops'
+      - properties:
+          id:
+            description: The id of the operational point, null if not applicable
+            nullable: true
+            type: string
+          line_code:
+            format: int32
+            nullable: true
+            type: integer
+          line_name:
+            nullable: true
+            type: string
+          name:
+            description: The name of the operational point, null if not applicable
+            nullable: true
+            type: string
+          track_name:
+            nullable: true
+            type: string
+          track_number:
+            format: int32
+            nullable: true
+            type: integer
+        required:
+        - id
+        - name
+        - line_code
+        - track_number
+        - line_name
+        - track_name
+        type: object
     Gamma:
       properties:
         type:
@@ -547,22 +594,6 @@ components:
       items:
         $ref: '#/components/schemas/GeoJsonPolygonValue'
       type: array
-    GeoJsonObject:
-      description: GeoJson format
-      properties:
-        coordinates:
-          items:
-            items:
-              format: float
-              type: number
-            type: array
-          type: array
-        type:
-          type: string
-      required:
-      - coordinates
-      - type
-      type: object
     GeoJsonPoint:
       oneOf:
       - properties:
@@ -598,21 +629,6 @@ components:
       items:
         $ref: '#/components/schemas/GeoJsonLineStringValue'
       type: array
-    GeoJsonPosition:
-      properties:
-        coordinates:
-          items:
-            format: float
-            type: number
-          maxItems: 2
-          minItems: 2
-          type: array
-        type:
-          type: string
-      required:
-      - coordinates
-      - type
-      type: object
     Geometry:
       description: Definition of a GeoJSON geometry
       oneOf:
@@ -622,6 +638,18 @@ components:
       - $ref: '#/components/schemas/MultiPoint'
       - $ref: '#/components/schemas/MultiLineString'
       - $ref: '#/components/schemas/MultiPolygon'
+      type: object
+    GetCurvePoint:
+      properties:
+        position:
+          format: double
+          type: number
+        time:
+          format: double
+          type: number
+      required:
+      - time
+      - position
       type: object
     Identifier:
       description: A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.
@@ -950,6 +978,26 @@ components:
       - default_curve
       - is_electric
       type: object
+    Mrsp:
+      description: A MRSP computation result (Most Restrictive Speed Profile)
+      items:
+        $ref: '#/components/schemas/MrspPoint'
+      type: array
+    MrspPoint:
+      description: An MRSP point
+      properties:
+        position:
+          description: Relative position of the point on its track section (in meters)
+          format: double
+          type: number
+        speed:
+          description: Speed limit at this point (in m/s)
+          format: double
+          type: number
+      required:
+      - position
+      - speed
+      type: object
     MultiLineString:
       description: GeoJSon geometry
       properties:
@@ -1001,17 +1049,6 @@ components:
       - type
       - coordinates
       type: object
-    Neutral:
-      properties:
-        lower_pantograph:
-          type: boolean
-        object_type:
-          enum:
-          - Neutral
-          type: string
-      required:
-      - lower_pantograph
-      - object_type
     NewDocumentResponse:
       properties:
         document_key:
@@ -1020,14 +1057,6 @@ components:
       required:
       - document_key
       type: object
-    NonElectrified:
-      properties:
-        object_type:
-          enum:
-          - NonElectrified
-          type: string
-      required:
-      - object_type
     ObjectType:
       description: Type of the object
       enum:
@@ -1244,68 +1273,6 @@ components:
       items:
         $ref: '#/components/schemas/Patch'
       type: array
-    Path:
-      properties:
-        created:
-          format: date-time
-          type: string
-        curves:
-          description: Curves on the path
-          items:
-            properties:
-              position:
-                format: float
-                type: number
-              radius:
-                format: float
-                type: number
-            required:
-            - radius
-            - position
-            type: object
-          type: array
-        geographic:
-          $ref: '#/components/schemas/GeoJsonObject'
-        id:
-          type: integer
-        length:
-          description: Length of the path
-          format: float
-          type: number
-        owner:
-          format: uuid
-          type: string
-        schematic:
-          $ref: '#/components/schemas/GeoJsonObject'
-        slopes:
-          description: Slopes on the path
-          items:
-            properties:
-              gradient:
-                format: float
-                type: number
-              position:
-                format: float
-                type: number
-            required:
-            - gradient
-            - position
-            type: object
-          type: array
-        steps:
-          items:
-            $ref: '#/components/schemas/PathStep'
-          type: array
-      required:
-      - id
-      - owner
-      - created
-      - length
-      - geographic
-      - schematic
-      - slopes
-      - curves
-      - steps
     PathResponse:
       properties:
         created:
@@ -1347,42 +1314,13 @@ components:
       - schematic
       - steps
       type: object
-    PathStep:
-      properties:
-        duration:
-          format: float
-          type: number
-        geo:
-          $ref: '#/components/schemas/GeoJsonPosition'
-        id:
-          type: string
-        location:
-          $ref: '#/components/schemas/TrackLocation'
-        name:
-          type: string
-        path_offset:
-          description: Offset of the step in the path
-          format: float
-          type: number
-        sch:
-          $ref: '#/components/schemas/GeoJsonPosition'
-        suggestion:
-          type: boolean
-      required:
-      - suggestion
-      - duration
-      - path_offset
-      - location
-      - sch
-      - geo
-      type: object
     PathWaypoint:
       properties:
         duration:
           format: double
           type: number
         geo:
-          $ref: '#/components/schemas/GeoJsonLineString'
+          $ref: '#/components/schemas/GeoJsonPoint'
         id:
           nullable: true
           type: string
@@ -1395,7 +1333,7 @@ components:
           format: double
           type: number
         sch:
-          $ref: '#/components/schemas/GeoJsonLineString'
+          $ref: '#/components/schemas/GeoJsonPoint'
         suggestion:
           type: boolean
       required:
@@ -1407,6 +1345,27 @@ components:
       - suggestion
       - geo
       - sch
+      type: object
+    PathfindingPayload:
+      description: |-
+        The "payload" of a path
+
+        It contains the route paths and the path waypoints that the simulation returned,
+        but enhanced using data from the infra. Notably, path waypoints are reprojected
+        onto their track section to obtain their geographic and schematic representations
+        back.
+      properties:
+        path_waypoints:
+          items:
+            $ref: '#/components/schemas/PathWaypoint'
+          type: array
+        route_paths:
+          items:
+            $ref: '#/components/schemas/RoutePath'
+          type: array
+      required:
+      - route_paths
+      - path_waypoints
       type: object
     PathfindingRequest:
       properties:
@@ -1420,11 +1379,24 @@ components:
           type: array
         steps:
           items:
-            $ref: '#/components/schemas/StepPayload'
+            $ref: '#/components/schemas/PathfindingStep'
           type: array
       required:
       - infra
       - steps
+      type: object
+    PathfindingStep:
+      properties:
+        duration:
+          format: double
+          type: number
+        waypoints:
+          items:
+            $ref: '#/components/schemas/Waypoint'
+          type: array
+      required:
+      - duration
+      - waypoints
       type: object
     Point:
       description: GeoJSon geometry
@@ -1469,29 +1441,6 @@ components:
           type: string
       required:
       - power_restriction
-      type: object
-    PowerRestrictionRange:
-      description: A range along the train path where a power restriction is applied.
-      example:
-        begin_position: 0.0
-        end_position: 1000.0
-        power_restriction_code: C1US
-      properties:
-        begin_position:
-          description: Offset from the start of the path, in meters.
-          format: float
-          type: number
-        end_position:
-          description: Offset from the start of the path, in meters.
-          format: float
-          type: number
-        power_restriction_code:
-          description: The power restriction code to apply.
-          type: string
-      required:
-      - begin_position
-      - end_position
-      - power_restriction_code
       type: object
     PowerRestrictionRangeItem:
       properties:
@@ -1767,6 +1716,98 @@ components:
       required:
       - tau
       - soc_ref
+      type: object
+    ReportTrain:
+      properties:
+        head_positions:
+          items:
+            items:
+              $ref: '#/components/schemas/GetCurvePoint'
+            type: array
+          type: array
+        mechanical_energy_consumed:
+          format: double
+          type: number
+        route_aspects:
+          items:
+            $ref: '#/components/schemas/SignalUpdate'
+          type: array
+        speeds:
+          items:
+            $ref: '#/components/schemas/ResultSpeed'
+          type: array
+        stops:
+          items:
+            $ref: '#/components/schemas/FullResultStops'
+          type: array
+        tail_positions:
+          items:
+            items:
+              $ref: '#/components/schemas/GetCurvePoint'
+            type: array
+          type: array
+      required:
+      - head_positions
+      - tail_positions
+      - speeds
+      - stops
+      - route_aspects
+      - mechanical_energy_consumed
+      type: object
+    ResultSpeed:
+      properties:
+        position:
+          format: double
+          type: number
+        speed:
+          format: double
+          type: number
+        time:
+          format: double
+          type: number
+      required:
+      - time
+      - position
+      - speed
+      type: object
+    ResultStops:
+      properties:
+        duration:
+          format: double
+          type: number
+        position:
+          format: double
+          type: number
+        time:
+          format: double
+          type: number
+      required:
+      - time
+      - position
+      - duration
+      type: object
+    RjsPowerRestrictionRange:
+      description: A range along the train path where a power restriction is applied.
+      example:
+        begin_position: 0.0
+        end_position: 1000.0
+        power_restriction_code: C1US
+      properties:
+        begin_position:
+          description: Offset from the start of the path, in meters.
+          format: float
+          type: number
+        end_position:
+          description: Offset from the start of the path, in meters.
+          format: float
+          type: number
+        power_restriction_code:
+          description: The power restriction code to apply.
+          type: string
+      required:
+      - begin_position
+      - end_position
+      - power_restriction_code
       type: object
     RollingResistance:
       properties:
@@ -2064,6 +2105,21 @@ components:
         required:
         - liveries
         type: object
+    RoutePath:
+      properties:
+        route:
+          type: string
+        signaling_type:
+          type: string
+        track_sections:
+          items:
+            $ref: '#/components/schemas/DirectionalTrackRange'
+          type: array
+      required:
+      - route
+      - signaling_type
+      - track_sections
+      type: object
     RouteTrackRangesCantComputePathError:
       description: Error when the route path couldn't be computed
       properties:
@@ -2098,6 +2154,44 @@ components:
           type: string
       required:
       - type
+      type: object
+    RoutingRequirement:
+      properties:
+        begin_time:
+          format: double
+          type: number
+        route:
+          type: string
+        zones:
+          items:
+            $ref: '#/components/schemas/RoutingZoneRequirement'
+          type: array
+      required:
+      - route
+      - begin_time
+      - zones
+      type: object
+    RoutingZoneRequirement:
+      properties:
+        end_time:
+          format: double
+          type: number
+        entry_detector:
+          type: string
+        exit_detector:
+          type: string
+        switches:
+          additionalProperties:
+            type: string
+          type: object
+        zone:
+          type: string
+      required:
+      - zone
+      - entry_detector
+      - exit_detector
+      - switches
+      - end_time
       type: object
     Scenario:
       properties:
@@ -2531,32 +2625,114 @@ components:
       - line_name
       - line_code
       type: object
+    SignalSighting:
+      properties:
+        offset:
+          format: double
+          type: number
+        signal:
+          type: string
+        state:
+          type: string
+        time:
+          format: double
+          type: number
+      required:
+      - signal
+      - time
+      - offset
+      - state
+      type: object
+    SignalUpdate:
+      properties:
+        aspect_label:
+          description: The labels of the new aspect
+          type: string
+        blinking:
+          description: Whether the signal is blinking
+          type: boolean
+        color:
+          description: |-
+            The color of the aspect
+
+            (Bits 24-31 are alpha, 16-23 are red, 8-15 are green, 0-7 are blue)
+          format: int32
+          type: integer
+        position_end:
+          description: The route ends at this position on the train path
+          format: double
+          nullable: true
+          type: number
+        position_start:
+          description: The route starts at this position on the train path
+          format: double
+          type: number
+        signal_id:
+          description: The id of the updated signal
+          type: string
+        time_end:
+          description: The aspects stop being displayed at this time (number of seconds since 1970-01-01T00:00:00)
+          format: double
+          nullable: true
+          type: number
+        time_start:
+          description: The aspects start being displayed at this time (number of seconds since 1970-01-01T00:00:00)
+          format: double
+          type: number
+        track:
+          type: string
+        track_offset:
+          format: double
+          nullable: true
+          type: number
+      required:
+      - signal_id
+      - time_start
+      - position_start
+      - color
+      - blinking
+      - aspect_label
+      - track
+      type: object
+    SimulationPowerRestrictionRange:
+      properties:
+        code:
+          type: string
+        handled:
+          type: boolean
+        start:
+          format: double
+          type: number
+        stop:
+          format: double
+          type: number
+      required:
+      - start
+      - stop
+      - code
+      - handled
+      type: object
     SimulationReport:
       properties:
         base:
-          $ref: '#/components/schemas/SimulationReportByTrain'
+          $ref: '#/components/schemas/ReportTrain'
         curves:
           items:
-            properties:
-              position:
-                type: number
-              radius:
-                type: number
-            required:
-            - position
-            - radius
-            type: object
-          minItems: 2
+            $ref: '#/components/schemas/Curve'
           type: array
         eco:
-          $ref: '#/components/schemas/SimulationReportByTrain'
+          allOf:
+          - $ref: '#/components/schemas/ReportTrain'
+          nullable: true
         electrification_ranges:
-          description: A list of ranges which should be contiguous and which describe the electrification on the path and if it is handled by the train
+          description: |-
+            A list of ranges which should be contiguous and which describe the
+            electrification on the path and if it is handled by the train
           items:
             $ref: '#/components/schemas/ElectrificationRange'
-          minItems: 1
           type: array
         id:
+          format: int64
           type: integer
         labels:
           items:
@@ -2565,52 +2741,36 @@ components:
         name:
           type: string
         path:
-          description: id of the path used for projection
+          description: The id of the path used for projection
+          format: int64
           type: integer
         power_restriction_ranges:
           description: The list of ranges where power restrictions are applied
           items:
-            $ref: '#/components/schemas/PowerRestrictionRangeItem'
+            $ref: '#/components/schemas/SimulationPowerRestrictionRange'
           type: array
         slopes:
           items:
-            properties:
-              gradient:
-                type: number
-              position:
-                type: number
-            required:
-            - position
-            - gradient
-            type: object
-          minItems: 2
+            $ref: '#/components/schemas/Slope'
           type: array
         speed_limit_tags:
+          nullable: true
           type: string
         vmax:
-          items:
-            properties:
-              position:
-                type: number
-              speed:
-                type: number
-            required:
-            - position
-            - speed
-            type: object
-          minItems: 2
-          type: array
+          $ref: '#/components/schemas/Mrsp'
       required:
       - id
-      - name
       - labels
       - path
+      - name
       - vmax
       - slopes
       - curves
       - base
+      - speed_limit_tags
       - electrification_ranges
       - power_restriction_ranges
+      type: object
     SimulationReportByTrain:
       properties:
         head_positions:
@@ -2793,7 +2953,7 @@ components:
         power_restriction_ranges:
           description: A list of ranges along the train path where power restrictions apply.
           items:
-            $ref: '#/components/schemas/PowerRestrictionRange'
+            $ref: '#/components/schemas/RjsPowerRestrictionRange'
           nullable: true
           type: array
         rolling_stock_id:
@@ -2904,6 +3064,21 @@ components:
       - position
       - speed
       type: object
+    SpacingRequirement:
+      properties:
+        begin_time:
+          format: double
+          type: number
+        end_time:
+          format: double
+          type: number
+        zone:
+          type: string
+      required:
+      - zone
+      - begin_time
+      - end_time
+      type: object
     SpeedDependantPower:
       description: power-speed curve (in an energy source)
       properties:
@@ -2938,19 +3113,6 @@ components:
       - default_value
       - ranges
       - distribution
-      type: object
-    StepPayload:
-      properties:
-        duration:
-          format: double
-          type: number
-        waypoints:
-          items:
-            $ref: '#/components/schemas/WaypointPayload'
-          type: array
-      required:
-      - duration
-      - waypoints
       type: object
     Study:
       properties:
@@ -3283,7 +3445,7 @@ components:
           type: integer
         power_restriction_ranges:
           items:
-            $ref: '#/components/schemas/PowerRestrictionRange'
+            $ref: '#/components/schemas/RjsPowerRestrictionRange'
           nullable: true
           type: array
         rolling_stock_id:
@@ -3341,7 +3503,7 @@ components:
           nullable: true
         power_restriction_ranges:
           items:
-            $ref: '#/components/schemas/PowerRestrictionRange'
+            $ref: '#/components/schemas/RjsPowerRestrictionRange'
           nullable: true
           type: array
         rolling_stock_id:
@@ -3408,7 +3570,7 @@ components:
           type: integer
         power_restriction_ranges:
           items:
-            $ref: '#/components/schemas/PowerRestrictionRange'
+            $ref: '#/components/schemas/RjsPowerRestrictionRange'
           nullable: true
           type: array
         rolling_stock_id:
@@ -3519,19 +3681,15 @@ components:
       - git_describe
       type: object
     Waypoint:
-      items:
-        properties:
-          geo_coordinate:
-            items:
-              format: float
-              type: number
-            maxItems: 2
-            minItems: 2
-            type: array
+      allOf:
+      - $ref: '#/components/schemas/WaypointLocation'
+      - properties:
           track_section:
+            description: A track section UUID
             type: string
+        required:
+        - track_section
         type: object
-      type: array
     WaypointLocation:
       oneOf:
       - properties:
@@ -3544,7 +3702,7 @@ components:
         type: object
       - properties:
           geo_coordinate:
-            description: A geographic coordinate (lon, lat) that will be projected onto the waypoint's track section
+            description: A geographic coordinate (lon, lat)/WGS84 that will be projected onto the waypoint's track section
             items:
               allOf:
               - format: double
@@ -3555,22 +3713,30 @@ components:
         required:
         - geo_coordinate
         type: object
-    WaypointPayload:
-      allOf:
-      - $ref: '#/components/schemas/WaypointLocation'
-      - properties:
-          track_section:
-            description: A track section UUID
-            type: string
-        required:
-        - track_section
-        type: object
     Zone:
       properties:
         geo:
           $ref: '#/components/schemas/BoundingBox'
         sch:
           $ref: '#/components/schemas/BoundingBox'
+      type: object
+    ZoneUpdate:
+      properties:
+        isEntry:
+          type: boolean
+        offset:
+          format: double
+          type: number
+        time:
+          format: double
+          type: number
+        zone:
+          type: string
+      required:
+      - zone
+      - time
+      - offset
+      - isEntry
       type: object
 info:
   description: OSRD Edition service description
@@ -5673,106 +5839,98 @@ paths:
       - sprites
   /stdcm/:
     post:
+      description: Compute a STDCM and return the simulation result
       requestBody:
         content:
           application/json:
             schema:
+              description: An STDCM request
               properties:
                 comfort:
-                  $ref: '#/components/schemas/Comfort'
+                  $ref: '#/components/schemas/RollingStockComfortType'
                 end_time:
                   format: double
+                  nullable: true
                   type: number
                 infra_id:
+                  format: int64
                   type: integer
                 margin_after:
-                  default: 0
-                  description: |
-                    Margin of y seconds after the train passage, which means that the path used by the train should
-                    be free and available at least y seconds after its passage.
+                  description: |-
+                    Margin after the train passage in seconds
+
+                    Enforces that the path used by the train should be free and
+                    available at least that many seconds after its passage.
                   format: double
                   type: number
                 margin_before:
-                  default: 0
-                  description: |
-                    Margin of x seconds before the train passage, which means that the path used by the train should
-                    be free and available at least x seconds before its passage.
+                  description: |-
+                    Margin before the train passage in seconds
+
+                    Enforces that the path used by the train should be free and
+                    available at least that many seconds before its passage.
                   format: double
                   type: number
                 maximum_departure_delay:
-                  description: By how long we can shift the departure time (s). Defaults to 2h if unspecified.
+                  default: 7200.0
+                  description: By how long we can shift the departure time in seconds
                   format: double
                   type: number
                 maximum_run_time:
-                  description: |
-                    Specifies how long the total run time can be in seconds.
-                    Defaults to 43200s if unspecified, meaning that the result can't exceed 12h.
+                  default: 43200.0
+                  description: Specifies how long the total run time can be in seconds
                   format: double
                   type: number
                 rolling_stock_id:
+                  format: int64
                   type: integer
-                rolling_stocks:
-                  items:
-                    type: integer
-                  type: array
                 speed_limit_tags:
-                  description: Train category for speed limits
+                  description: Train categories for speed limits
+                  nullable: true
                   type: string
                 standard_allowance:
-                  $ref: '#/components/schemas/AllowanceValue'
+                  allOf:
+                  - $ref: '#/components/schemas/AllowanceValue'
+                  nullable: true
                 start_time:
                   format: double
+                  nullable: true
                   type: number
                 steps:
                   items:
-                    properties:
-                      duration:
-                        format: float
-                        type: number
-                      waypoints:
-                        $ref: '#/components/schemas/Waypoint'
-                    required:
-                    - duration
-                    - waypoints
-                    type: object
-                  minItems: 2
+                    $ref: '#/components/schemas/PathfindingStep'
                   type: array
                 timetable_id:
-                  description: timetable ID
+                  format: int64
                   type: integer
               required:
               - infra_id
               - timetable_id
               - steps
-              - rolling_stocks
               - rolling_stock_id
               - comfort
-              - maximum_departure_delay
               type: object
+        required: true
       responses:
-        '200':
+        '201':
           content:
             application/json:
               schema:
-                oneOf:
-                - properties:
-                    path:
-                      $ref: '#/components/schemas/Path'
-                    simulation:
-                      $ref: '#/components/schemas/SimulationReport'
-                  required:
-                  - simulation
-                  - path
-                - properties:
-                    error:
-                      description: Error message
-                      example: No path could be found
-                      type: string
-                  type: object
-          description: Simulation result
-        '400':
-          description: The request body is invalid
-      summary: Find a stdcm and return a simulation result
+                description: The response issued after an STDCM calculation
+                properties:
+                  path:
+                    $ref: '#/components/schemas/PathResponse'
+                  path_payload:
+                    $ref: '#/components/schemas/PathfindingPayload'
+                  simulation:
+                    $ref: '#/components/schemas/SimulationReport'
+                required:
+                - path
+                - path_payload
+                - simulation
+                type: object
+          description: The simulation result
+      summary: Compute a STDCM and return the simulation result
       tags:
       - stdcm
   /timetable/{id}/:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -751,81 +751,6 @@ paths:
                 properties:
                   id: { type: integer }
 
-  /pathfinding/:
-    post:
-      summary: Create a Path
-      requestBody:
-        description: Path information
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PathQuery"
-      responses:
-        201:
-          description: The created Path
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Path"
-
-  /pathfinding/{id}/:
-    get:
-      tags:
-        - pathfinding
-      summary: Retrieve a Path
-      parameters:
-        - in: path
-          name: id
-          schema: { type: integer }
-          description: Path ID
-          required: true
-      responses:
-        200:
-          description: The retrieved path
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Path"
-    put:
-      tags:
-        - pathfinding
-      summary: Update a path
-      parameters:
-        - in: path
-          name: id
-          schema: { type: integer }
-          description: Path ID
-          required: true
-      requestBody:
-        description: Updated Path
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PathQuery"
-      responses:
-        200:
-          description: The updated path
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Path"
-    delete:
-      tags:
-        - pathfinding
-      summary: Delete a path
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: Path ID
-          required: true
-      responses:
-        204:
-          description: No content
-
   /stdcm/:
     post:
       tags:
@@ -1285,35 +1210,6 @@ components:
             is_warning:
               type: boolean
 
-    TrackSectionLocation:
-      type: object
-      description: A track location (track section and offset)
-      properties:
-        track_section:
-          type: string
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-        offset:
-          type: number
-          format: float
-          description: The offset on the track section
-          example: 42.
-      required: [track_section, offset]
-
-    TrackLocation:
-      type: object
-      description: A track location (track section and offset)
-      properties:
-        track:
-          type: string
-          description: The track section ID
-          example: 61205924-6667-11e3-81ff-01f464e0362d
-        offset:
-          type: number
-          format: float
-          description: The offset on the track section
-          example: 42.
-
     Direction:
       type: string
       enum: [START_TO_STOP, STOP_TO_START]
@@ -1392,29 +1288,6 @@ components:
           steps,
         ]
 
-    PathQuery:
-      type: object
-      properties:
-        infra:
-          type: number
-        steps:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              duration: { type: number, format: float }
-              waypoints:
-                type: array
-                items:
-                  $ref: "#/components/schemas/PathWaypoint"
-            required: [duration, waypoints]
-        rolling_stocks:
-          description: List of rolling stocks that must be able to use this path
-          type: array
-          items: { type: integer }
-      required: [infra, steps, rolling_stocks]
-
     PathStep:
       type: object
       properties:
@@ -1427,28 +1300,12 @@ components:
           format: float
           description: Offset of the step in the path
         location:
-          $ref: "#/components/schemas/TrackSectionLocation"
+          $ref: "#/components/schemas/TrackLocation"
         sch:
           $ref: "#/components/schemas/GeoJsonPosition"
         geo:
           $ref: "#/components/schemas/GeoJsonPosition"
       required: [suggestion, duration, path_offset, location, sch, geo]
-
-    PathWaypoint:
-      type: object
-      properties:
-        track_section:
-          description: track section ID of the waypoint
-          type: string
-        geo_coordinate:
-          type: array
-          items: { type: number, format: float }
-          minItems: 2
-          maxItems: 2
-        offset:
-          type: number
-      required: [track_section, geo_cordinate]
-
 
     RouteTrackRangesComputed:
       type: object

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -751,109 +751,6 @@ paths:
                 properties:
                   id: { type: integer }
 
-  /stdcm/:
-    post:
-      tags:
-        - stdcm
-      summary: Find a stdcm and return a simulation result
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                [
-                  infra_id,
-                  timetable_id,
-                  steps,
-                  rolling_stocks,
-                  rolling_stock_id,
-                  comfort,
-                  maximum_departure_delay,
-                ]
-              properties:
-                infra_id:
-                  type: integer
-                timetable_id:
-                  type: integer
-                  description: timetable ID
-                start_time:
-                  type: number
-                  format: double
-                end_time:
-                  type: number
-                  format: double
-                steps:
-                  type: array
-                  minItems: 2
-                  items:
-                    type: object
-                    properties:
-                      duration:
-                        type: number
-                        format: float
-                      waypoints:
-                        $ref: "#/components/schemas/Waypoint"
-                    required: [duration, waypoints]
-                rolling_stocks:
-                  type: array
-                  items:
-                    type: integer
-                rolling_stock_id:
-                  type: integer
-                comfort:
-                  $ref: "#/components/schemas/Comfort"
-                maximum_departure_delay:
-                  type: number
-                  format: double
-                  description: By how long we can shift the departure time (s). Defaults to 2h if unspecified.
-                maximum_run_time:
-                  type: number
-                  format: double
-                  description: |
-                    Specifies how long the total run time can be in seconds.
-                    Defaults to 43200s if unspecified, meaning that the result can't exceed 12h.
-                speed_limit_tags:
-                  type: string
-                  description: Train category for speed limits
-                margin_before:
-                  type: number
-                  format: double
-                  description: |
-                    Margin of x seconds before the train passage, which means that the path used by the train should
-                    be free and available at least x seconds before its passage.
-                  default: 0
-                margin_after:
-                  type: number
-                  format: double
-                  description: |
-                    Margin of y seconds after the train passage, which means that the path used by the train should
-                    be free and available at least y seconds after its passage.
-                  default: 0
-                standard_allowance:
-                  $ref: "#/components/schemas/AllowanceValue"
-      responses:
-        200:
-          description: Simulation result
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - properties:
-                      simulation:
-                        $ref: "#/components/schemas/SimulationReport"
-                      path:
-                        $ref: "#/components/schemas/Path"
-                    required: [simulation, path]
-                  - type: object
-                    properties:
-                      error:
-                        type: string
-                        description: Error message
-                        example: No path could be found
-        400:
-          description: The request body is invalid
-
   /single_simulation/:
     post:
       summary: Runs a simulation with a single train, does not write anything to the database
@@ -891,29 +788,6 @@ components:
       type: string
       enum: ["AC", "HEATING", "STANDARD"]
       default: "STANDARD"
-
-    GeoJsonObject:
-      type: object
-      description: GeoJson format
-      properties:
-        coordinates:
-          type: array
-          items:
-            type: array
-            items: { type: number, format: float }
-        type: { type: string }
-      required: [coordinates, type]
-
-    GeoJsonPosition:
-      type: object
-      properties:
-        coordinates:
-          type: array
-          items: { type: number, format: float }
-          minItems: 2
-          maxItems: 2
-        type: { type: string }
-      required: [coordinates, type]
 
     Infra:
       properties:
@@ -1209,103 +1083,6 @@ components:
               type: string
             is_warning:
               type: boolean
-
-    Direction:
-      type: string
-      enum: [START_TO_STOP, STOP_TO_START]
-
-    DirectionalTrackRange:
-      type: object
-      description: Track range associated with a direction
-      required:
-        - track
-        - begin
-        - end
-        - direction
-      properties:
-        track:
-          type: string
-          example: 01234567-89ab-cdef-0123-456789abcdef
-        begin:
-          type: number
-          format: float
-        end:
-          type: number
-          format: float
-          example: 100.
-        direction:
-          $ref: "#/components/schemas/Direction"
-
-    Path:
-      properties:
-        id: { type: integer }
-        owner:
-          type: string
-          format: uuid
-        created:
-          type: string
-          format: date-time
-        length:
-          type: number
-          format: float
-          description: Length of the path
-        geographic:
-          $ref: "#/components/schemas/GeoJsonObject"
-        schematic:
-          $ref: "#/components/schemas/GeoJsonObject"
-        slopes:
-          description: Slopes on the path
-          type: array
-          items:
-            type: object
-            properties:
-              gradient: { type: number, format: float }
-              position: { type: number, format: float }
-            required: [gradient, position]
-        curves:
-          description: Curves on the path
-          type: array
-          items:
-            type: object
-            properties:
-              radius: { type: number, format: float }
-              position: { type: number, format: float }
-            required: [radius, position]
-        steps:
-          type: array
-          items:
-            $ref: "#/components/schemas/PathStep"
-      required:
-        [
-          id,
-          owner,
-          created,
-          length,
-          geographic,
-          schematic,
-          slopes,
-          curves,
-          steps,
-        ]
-
-    PathStep:
-      type: object
-      properties:
-        id: { type: string }
-        name: { type: string }
-        suggestion: { type: boolean }
-        duration: { type: number, format: float }
-        path_offset:
-          type: number
-          format: float
-          description: Offset of the step in the path
-        location:
-          $ref: "#/components/schemas/TrackLocation"
-        sch:
-          $ref: "#/components/schemas/GeoJsonPosition"
-        geo:
-          $ref: "#/components/schemas/GeoJsonPosition"
-      required: [suggestion, duration, path_offset, location, sch, geo]
 
     RouteTrackRangesComputed:
       type: object
@@ -1615,76 +1392,6 @@ components:
         position: { type: number, format: float }
       required: [time, position, speed]
 
-    SimulationReport:
-      properties:
-        id:
-          type: integer
-        name:
-          type: string
-        labels:
-          type: array
-          items:
-            type: string
-        path:
-          type: integer
-          description: id of the path used for projection
-        vmax:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              speed: { type: number }
-            required: [position, speed]
-        slopes:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              gradient: { type: number }
-            required: [position, gradient]
-        curves:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              position: { type: number }
-              radius: { type: number }
-            required: [position, radius]
-        base:
-          $ref: "#/components/schemas/SimulationReportByTrain"
-        eco:
-          $ref: "#/components/schemas/SimulationReportByTrain"
-        speed_limit_tags:
-          type: string
-        electrification_ranges:
-          description: A list of ranges which should be contiguous and which describe the electrification on the path and if it is handled by the train
-          type: array
-          items:
-            $ref: "#/components/schemas/ElectrificationRange"
-          minItems: 1
-        power_restriction_ranges:
-          description: The list of ranges where power restrictions are applied
-          type: array
-          items:
-            $ref: "#/components/schemas/PowerRestrictionRangeItem"
-
-      required:
-        - id
-        - name
-        - labels
-        - path
-        - vmax
-        - slopes
-        - curves
-        - base
-        - electrification_ranges
-        - power_restriction_ranges
-
     PowerRestrictionRangeItem:
       properties:
         start:
@@ -1698,66 +1405,6 @@ components:
         handled:
           type: boolean
       required: [start, stop, code, handled]
-
-    ElectrificationRange:
-      properties:
-        start:
-          type: number
-          format: double
-        stop:
-          type: number
-          format: double
-        electrificationUsage:
-          oneOf:
-            - $ref: "#/components/schemas/Electrified"
-            - $ref: "#/components/schemas/Neutral"
-            - $ref: "#/components/schemas/NonElectrified"
-          discriminator:
-            propertyName: object_type
-      required: [start, stop, is_electrified, electrificationUsage]
-
-    Electrified:
-      properties:
-        mode:
-          type: string
-        mode_handled:
-          type: boolean
-        object_type:
-          type: string
-          enum: ["Electrified"]
-        profile:
-          type: string
-          nullable: true
-        profile_handled:
-          type: boolean
-      required: [mode, mode_handled, object_type, profile_handled]
-    Neutral:
-      properties:
-        lower_pantograph:
-          type: boolean
-        object_type:
-          type: string
-          enum: ["Neutral"]
-      required: [lower_pantograph, object_type]
-    NonElectrified:
-      properties:
-        object_type:
-          type: string
-          enum: ["NonElectrified"]
-      required: [object_type]
-
-    Waypoint:
-      type: array
-      items:
-        type: object
-        properties:
-          track_section:
-            type: string
-          geo_coordinate:
-            type: array
-            items: { type: number, format: float }
-            minItems: 2
-            maxItems: 2
 
     SingleSimulationRequest:
       type: object
@@ -1815,7 +1462,7 @@ components:
           description: A list of ranges along the train path where power restrictions apply.
           type: array
           items:
-            $ref: "#/components/schemas/PowerRestrictionRange"
+            $ref: "#/components/schemas/RjsPowerRestrictionRange"
           nullable: true
         options:
           allOf:

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -27,6 +27,10 @@ use thiserror::Error;
 #[cfg(test)]
 use crate::core::mocking::MockingError;
 
+crate::schemas! {
+    simulation::schemas(),
+}
+
 const MAX_RETRIES: u8 = 5;
 
 fn colored_method(method: &reqwest::Method) -> ColoredString {

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -3,6 +3,7 @@ pub mod tests {
     use std::io::Cursor;
 
     use crate::client::PostgresConfig;
+    use crate::models::train_schedule::Mrsp;
     use crate::models::{
         Create, Delete, Document, ElectricalProfileSet, Identifiable, Infra, Pathfinding,
         PathfindingChangeset, Project, ResultPosition, ResultStops, ResultTrain,
@@ -21,7 +22,6 @@ pub mod tests {
     use futures::executor;
     use postgis_diesel::types::LineString;
     use rstest::*;
-    use serde_json::json;
     use std::fmt;
 
     pub struct TestFixture<T: Delete + Identifiable + Send> {
@@ -452,11 +452,11 @@ pub mod tests {
         };
 
         let simulation_output = SimulationOutputChangeset {
-            mrsp: Some(json!({})),
+            mrsp: Some(diesel_json::Json(Mrsp::default())),
             base_simulation: Some(diesel_json::Json(result_train)),
             eco_simulation: Some(None),
-            electrification_ranges: Some(json!({})),
-            power_restriction_ranges: Some(json!({})),
+            electrification_ranges: Some(diesel_json::Json(Vec::default())),
+            power_restriction_ranges: Some(diesel_json::Json(Vec::default())),
             train_schedule_id: Some(train_schedule.id),
             ..Default::default()
         };

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -43,6 +43,7 @@ crate::schemas! {
     train_schedule::schemas(),
     timetable::schemas(),
     rolling_stock::schemas(),
+    pathfinding::schemas(),
 }
 
 pub trait Identifiable<T = i64>

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -15,6 +15,13 @@ use editoast_derive::Model;
 use geos::geojson;
 use postgis_diesel::types::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+crate::schemas! {
+    Slope,
+    Curve,
+    PathWaypoint,
+}
 
 /// Describes a pathfinding that resulted from a simulation and stored in the DB
 ///
@@ -122,13 +129,13 @@ impl From<PathfindingChangeset> for Pathfinding {
 pub type SlopeGraph = Vec<Slope>;
 pub type CurveGraph = Vec<Curve>;
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct Slope {
     pub gradient: f64,
     pub position: f64,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct Curve {
     radius: f64,
     position: f64,
@@ -149,10 +156,12 @@ pub struct RoutePath {
     pub track_ranges: Vec<DirectionalTrackRange>,
 }
 
-#[derive(Debug, Clone, PartialEq, Derivative, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Derivative, Deserialize, Serialize, ToSchema)]
 #[derivative(Default)]
 pub struct PathWaypoint {
+    #[schema(required)]
     pub id: Option<String>,
+    #[schema(required)]
     pub name: Option<String>,
     pub location: TrackLocation,
     pub duration: f64,
@@ -161,10 +170,12 @@ pub struct PathWaypoint {
     #[derivative(Default(
         value = "geojson::Geometry::new(geojson::Value::LineString(Default::default()))"
     ))]
+    #[schema(value_type = GeoJsonLineString)]
     pub geo: geojson::Geometry,
     #[derivative(Default(
         value = "geojson::Geometry::new(geojson::Value::LineString(Default::default()))"
     ))]
+    #[schema(value_type = GeoJsonLineString)]
     pub sch: geojson::Geometry,
 }
 

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -20,6 +20,8 @@ use utoipa::ToSchema;
 crate::schemas! {
     Slope,
     Curve,
+    PathfindingPayload,
+    RoutePath,
     PathWaypoint,
 }
 
@@ -141,14 +143,20 @@ pub struct Curve {
     position: f64,
 }
 
-#[derive(Debug, Clone, PartialEq, Derivative, Deserialize, Serialize)]
+/// The "payload" of a path
+///
+/// It contains the route paths and the path waypoints that the simulation returned,
+/// but enhanced using data from the infra. Notably, path waypoints are reprojected
+/// onto their track section to obtain their geographic and schematic representations
+/// back.
+#[derive(Debug, Clone, PartialEq, Derivative, Deserialize, Serialize, ToSchema)]
 #[derivative(Default)]
 pub struct PathfindingPayload {
     pub route_paths: Vec<RoutePath>,
     pub path_waypoints: Vec<PathWaypoint>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct RoutePath {
     pub route: String,
     pub signaling_type: String,
@@ -168,14 +176,14 @@ pub struct PathWaypoint {
     pub path_offset: f64,
     pub suggestion: bool,
     #[derivative(Default(
-        value = "geojson::Geometry::new(geojson::Value::LineString(Default::default()))"
+        value = "geojson::Geometry::new(geojson::Value::Point(Default::default()))"
     ))]
-    #[schema(value_type = GeoJsonLineString)]
+    #[schema(value_type = GeoJsonPoint)]
     pub geo: geojson::Geometry,
     #[derivative(Default(
-        value = "geojson::Geometry::new(geojson::Value::LineString(Default::default()))"
+        value = "geojson::Geometry::new(geojson::Value::Point(Default::default()))"
     ))]
-    #[schema(value_type = GeoJsonLineString)]
+    #[schema(value_type = GeoJsonPoint)]
     pub sch: geojson::Geometry,
 }
 

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -56,6 +56,8 @@ use strum_macros::{Display, EnumIter};
 use utoipa::ToSchema;
 
 crate::schemas! {
+    TrackLocation,
+    utils::schemas(),
     rolling_stock::schemas(),
     operation::schemas(),
 }
@@ -393,8 +395,11 @@ pub struct Sign {
     pub kp: String,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+/// A track location is a track section and an offset
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, ToSchema)]
 pub struct TrackLocation {
+    /// The track section UUID
     pub track_section: Identifier,
+    /// The offset on the track section in meters
     pub offset: f64,
 }

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -57,6 +57,8 @@ use utoipa::ToSchema;
 
 crate::schemas! {
     TrackLocation,
+    DirectionalTrackRange,
+    Direction,
     utils::schemas(),
     rolling_stock::schemas(),
     operation::schemas(),
@@ -238,7 +240,7 @@ impl TrackRange {
     }
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[derivative(Default)]
 pub struct DirectionalTrackRange {
@@ -313,7 +315,7 @@ impl ApplicableDirectionsTrackRange {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Direction {
     StartToStop,

--- a/editoast/src/schema/utils/identifier.rs
+++ b/editoast/src/schema/utils/identifier.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 /// A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, utoipa::ToSchema)]
-pub struct Identifier(pub String);
+pub struct Identifier(#[schema(max_length = 255)] pub String);
 
 impl<'de> Deserialize<'de> for Identifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/editoast/src/schema/utils/identifier.rs
+++ b/editoast/src/schema/utils/identifier.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 /// A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, utoipa::ToSchema)]
 pub struct Identifier(pub String);
 
 impl<'de> Deserialize<'de> for Identifier {

--- a/editoast/src/schema/utils/mod.rs
+++ b/editoast/src/schema/utils/mod.rs
@@ -4,3 +4,8 @@ mod non_blank_string;
 
 pub use identifier::Identifier;
 pub use non_blank_string::NonBlankString;
+
+crate::schemas! {
+    geometry::schemas(),
+    Identifier,
+}

--- a/editoast/src/tests/small_infra/stdcm/test_1/stdcm_post_expected_response.json
+++ b/editoast/src/tests/small_infra/stdcm/test_1/stdcm_post_expected_response.json
@@ -325,7 +325,7 @@
         },
         "eco": null,
         "speed_limit_tags": null,
-        "electrification_ranges": null,
-        "power_restriction_ranges": null
+        "electrification_ranges": [],
+        "power_restriction_ranges": []
     }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -62,8 +62,6 @@ pub fn routes() -> impl HttpServiceFactory {
     services![
         routes_v2(),
         infra::routes(),
-        pathfinding::routes_v1(),
-        train_schedule::routes(),
         stdcm::routes(),
         single_simulation::routes(),
     ]
@@ -79,7 +77,7 @@ schemas! {
     pathfinding::schemas(),
     projects::schemas(),
     search::schemas(),
-    crate::schema::utils::geometry::schemas(),
+    crate::schema::schemas(),
     train_schedule::schemas(),
     rolling_stocks::schemas(),
     light_rolling_stocks::schemas(),

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -21,7 +21,7 @@ pub mod train_schedule;
 use self::openapi::{merge_path_items, remove_discriminator, OpenApiMerger, Routes};
 use crate::client::get_app_version;
 use crate::core::version::CoreVersionRequest;
-use crate::core::{AsCoreRequest, CoreClient};
+use crate::core::{self, AsCoreRequest, CoreClient};
 use crate::error::{self, Result};
 use crate::map::redis_utils::RedisClient;
 use crate::models;
@@ -42,35 +42,29 @@ use utoipa::{OpenApi, ToSchema};
 fn routes_v2() -> Routes<impl HttpServiceFactory> {
     crate::routes! {
         (health, version, core_version),
-        (timetable::routes(),
+        (rolling_stocks::routes(), light_rolling_stocks::routes()),
+        (pathfinding::routes(), stdcm::routes(), train_schedule::routes()),
+        timetable::routes(),
         documents::routes(),
         sprites::routes(),
-        pathfinding::routes(),
         projects::routes(),
         search::routes(),
-        train_schedule::routes(),
-        rolling_stocks::routes(),
-        light_rolling_stocks::routes(),
         electrical_profiles::routes(),
         layers::routes(),
-        auto_fixes::routes()),
+        auto_fixes::routes(),
     }
     routes()
 }
 
 pub fn routes() -> impl HttpServiceFactory {
-    services![
-        routes_v2(),
-        infra::routes(),
-        stdcm::routes(),
-        single_simulation::routes(),
-    ]
+    services![routes_v2(), infra::routes(), single_simulation::routes(),]
 }
 
 schemas! {
     error::schemas(),
     models::schemas(),
     schema::schemas(),
+    core::schemas(),
     Version,
     timetable::schemas(),
     documents::schemas(),

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -64,7 +64,7 @@ pub struct PaginationQueryParam {
     pub page_size: Option<i64>,
 }
 
-fn default_page() -> i64 {
+const fn default_page() -> i64 {
     1
 }
 

--- a/editoast/src/views/pathfinding/catenaries.rs
+++ b/editoast/src/views/pathfinding/catenaries.rs
@@ -3,7 +3,7 @@ use crate::infra_cache::InfraCache;
 use crate::models::{pathfinding::Pathfinding, Infra, Retrieve};
 use crate::schema::ObjectType;
 use crate::views::pathfinding::path_rangemap::{make_path_range_map, TrackMap};
-use crate::views::pathfinding::PathfindingError;
+use crate::views::pathfinding::{PathfindingError, PathfindingIdParam};
 use crate::DbPool;
 use actix_web::{
     get,
@@ -85,21 +85,19 @@ struct CatenariesOnPathResponse {
 
 #[utoipa::path(
     tag = "infra",
-    params(
-        ("path_id" = i64, Path, description = "The path's id"),
-    ),
+    params(PathfindingIdParam),
     responses(
         (status = 200, body = CatenariesOnPathResponse),
     )
 )]
-#[get("/pathfinding/{path_id}/catenaries")]
+#[get("/catenaries")]
 /// Retrieve the catenary modes along a path, as seen by the rolling stock specified
 async fn catenaries_on_path(
-    pathfinding_id: Path<i64>,
+    params: Path<PathfindingIdParam>,
     db_pool: Data<DbPool>,
     infra_caches: Data<CHashMap<i64, InfraCache>>,
 ) -> Result<Json<CatenariesOnPathResponse>> {
-    let pathfinding_id = *pathfinding_id;
+    let pathfinding_id = params.pathfinding_id;
     let pathfinding = match Pathfinding::retrieve(db_pool.clone(), pathfinding_id).await? {
         Some(pf) => pf,
         None => return Err(PathfindingError::NotFound { pathfinding_id }.into()),

--- a/editoast/src/views/pathfinding/electrical_profiles.rs
+++ b/editoast/src/views/pathfinding/electrical_profiles.rs
@@ -4,6 +4,7 @@ use crate::models::{
 };
 use crate::schema::electrical_profiles::ElectricalProfileSetData;
 use crate::views::electrical_profiles::ElectricalProfilesError;
+use crate::views::pathfinding::PathfindingIdParam;
 use crate::views::pathfinding::{
     path_rangemap::{make_path_range_map, TrackMap},
     PathfindingError,
@@ -79,22 +80,19 @@ struct ProfilesOnPathResponse {
 
 #[utoipa::path(
     tag = "electrical_profiles",
-    params(
-        ("path_id" = i64, Path, description = "The path's id"),
-        ProfilesOnPathQuery,
-    ),
+    params(PathfindingIdParam, ProfilesOnPathQuery),
     responses(
         (status = 200, body = ProfilesOnPathResponse),
     )
 )]
-#[get("/pathfinding/{path_id}/electrical_profiles")]
+#[get("/electrical_profiles")]
 /// Retrieve the electrical profiles along a path, as seen by the rolling stock specified
 async fn electrical_profiles_on_path(
-    pathfinding_id: Path<i64>,
+    params: Path<PathfindingIdParam>,
     request: Query<ProfilesOnPathQuery>,
     db_pool: Data<DbPool>,
 ) -> Result<Json<ProfilesOnPathResponse>> {
-    let pathfinding_id = *pathfinding_id;
+    let pathfinding_id = params.pathfinding_id;
     let pathfinding = match Pathfinding::retrieve(db_pool.clone(), pathfinding_id).await? {
         Some(pf) => pf,
         None => return Err(PathfindingError::NotFound { pathfinding_id }.into()),

--- a/editoast/src/views/single_simulation.rs
+++ b/editoast/src/views/single_simulation.rs
@@ -5,7 +5,8 @@ use crate::core::{AsCoreRequest, CoreClient};
 use crate::error::{InternalError, Result};
 use crate::models::electrical_profiles::ElectricalProfileSet;
 use crate::models::train_schedule::{
-    Allowance, PowerRestrictionRange, ResultTrain, ScheduledPoint, TrainScheduleOptions,
+    Allowance, ElectrificationRange, Mrsp, ResultTrain, RjsPowerRestrictionRange, ScheduledPoint,
+    SimulationPowerRestrictionRange, TrainScheduleOptions,
 };
 use crate::models::{Pathfinding, Retrieve, RollingStockModel};
 use crate::schema::rolling_stock::RollingStockComfortType;
@@ -15,7 +16,6 @@ use actix_web::post;
 use actix_web::web::{scope, Data, Json};
 use editoast_derive::EditoastError;
 use serde_derive::{Deserialize, Serialize};
-use serde_json::Value;
 use thiserror::Error;
 
 #[derive(Debug, Error, EditoastError)]
@@ -54,7 +54,7 @@ struct ScheduleArgs {
     #[serde(default)]
     pub comfort: RollingStockComfortType,
     #[serde(default)]
-    pub power_restriction_ranges: Option<Vec<PowerRestrictionRange>>,
+    pub power_restriction_ranges: Option<Vec<RjsPowerRestrictionRange>>,
     #[serde(default)]
     pub options: Option<TrainScheduleOptions>,
 }
@@ -90,10 +90,10 @@ struct SingleSimulationRequest {
 struct SingleSimulationResponse {
     pub base_simulation: ResultTrain,
     pub eco_simulation: Option<ResultTrain>,
-    pub speed_limits: Vec<Value>,
+    pub speed_limits: Mrsp,
     pub warnings: Vec<String>,
-    pub electrification_ranges: Vec<Value>,
-    pub power_restriction_ranges: Vec<Value>,
+    pub electrification_ranges: Vec<ElectrificationRange>,
+    pub power_restriction_ranges: Vec<SimulationPowerRestrictionRange>,
 }
 
 fn get_first_from_core_vec<T>(core_vec: Vec<T>) -> Result<T> {
@@ -303,7 +303,7 @@ mod tests {
         )
         .await;
 
-        let request_body: Value = json!({
+        let request_body: serde_json::Value = json!({
             "rolling_stock_id": rs.id(),
             "path_id": pf.id(),
         });

--- a/front/src/applications/editor/tools/routeEdition/utils.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.ts
@@ -236,12 +236,12 @@ export async function getCompatibleRoutesPayload(
 
   return {
     starting: {
-      track: entryPointEntity.properties.track as string,
-      position: entryPointEntity.properties.position as number,
+      track_section: entryPointEntity.properties.track as string,
+      offset: entryPointEntity.properties.position as number,
     },
     ending: {
-      track: exitPointEntity.properties.track as string,
-      position: exitPointEntity.properties.position as number,
+      track_section: exitPointEntity.properties.track as string,
+      offset: exitPointEntity.properties.position as number,
     },
   };
 }

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -6,10 +6,8 @@ import {
   AllowanceValue,
   RollingStockComfortType,
   ElectrificationRange,
-  Electrified,
-  Neutral,
-  NonElectrified,
-  Path,
+  ElectrificationUsage,
+  PathResponse,
   PowerRestrictionRangeItem,
 } from 'common/api/osrdEditoastApi';
 import { LinearMetadataItem } from 'common/IntervalsDataViz/types';
@@ -174,9 +172,9 @@ export interface OsrdConfState {
   departureTime: string;
   destination?: PointOnMap;
   vias: PointOnMap[];
-  suggeredVias: Path['steps'] | PointOnMap[];
+  suggeredVias: PathResponse['steps'] | PointOnMap[];
   trainCompo: undefined;
-  geojson?: Path;
+  geojson?: PathResponse;
   originDate?: string;
   originTime?: string;
   originUpperBoundDate?: string;
@@ -223,7 +221,7 @@ export interface ElectricalConditionSegment {
   height_start: number;
   height_end: number;
   height_middle: number;
-  electrification: Electrified | Neutral | NonElectrified;
+  electrification: ElectrificationUsage;
   seenRestriction?: string;
   usedRestriction?: string;
   color: string;

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -1,4 +1,4 @@
-import { Path } from 'common/api/osrdEditoastApi';
+import { PathResponse } from 'common/api/osrdEditoastApi';
 
 export interface Destination {
   uic: number;
@@ -36,7 +36,7 @@ export interface TrainScheduleWithPathRef extends TrainSchedule {
 export interface TrainScheduleWithPath extends TrainScheduleWithPathRef {
   pathId: number;
   rollingStockId: number;
-  pathFinding: Path;
+  pathFinding: PathResponse;
 }
 
 export type ImportedTrainSchedule = {

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -33,11 +33,13 @@ export default function ManageTrainSchedule() {
   const pathFindingID = useSelector(getPathfindingID);
   const trainScheduleIDsToModify = useSelector(getTrainScheduleIDsToModify);
   const [getTrainScheduleById] = osrdEditoastApi.endpoints.getTrainScheduleById.useLazyQuery({});
-  const [getPathfindingById] = osrdEditoastApi.endpoints.getPathfindingById.useLazyQuery({});
+  const [getPathfindingById] = osrdEditoastApi.endpoints.getPathfindingByPathfindingId.useLazyQuery(
+    {}
+  );
 
   // Details for tabs
-  const { data: pathFinding } = osrdEditoastApi.useGetPathfindingByIdQuery(
-    { id: pathFindingID as number },
+  const { data: pathFinding } = osrdEditoastApi.useGetPathfindingByPathfindingIdQuery(
+    { pathfindingId: pathFindingID as number },
     {
       skip: !pathFindingID,
     }
@@ -53,8 +55,8 @@ export default function ManageTrainSchedule() {
   );
 
   const { data: pathWithCatenaries = { catenary_ranges: [] as RangedValue[] } } =
-    osrdEditoastApi.endpoints.getPathfindingByPathIdCatenaries.useQuery(
-      { pathId: pathFindingID as number },
+    osrdEditoastApi.endpoints.getPathfindingByPathfindingIdCatenaries.useQuery(
+      { pathfindingId: pathFindingID as number },
       { skip: !pathFindingID }
     );
 
@@ -154,7 +156,7 @@ export default function ManageTrainSchedule() {
         .unwrap()
         .then((trainSchedule) => {
           if (trainSchedule.path_id) {
-            getPathfindingById({ id: trainSchedule.path_id })
+            getPathfindingById({ pathfindingId: trainSchedule.path_id })
               .unwrap()
               .then((path) => {
                 adjustConfWithTrainToModify(trainSchedule, path, dispatch);

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -31,6 +31,7 @@ import SpaceCurvesSlopes from 'modules/simulationResult/components/SpaceCurvesSl
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
 import SpaceTimeChartIsolated from 'modules/simulationResult/components/SpaceTimeChart/withOSRDData';
 import type { PositionScaleDomain } from 'modules/simulationResult/components/simulationResultsConsts';
+import { Train } from 'reducers/osrdsimulation/types';
 
 const MAP_MIN_HEIGHT = 450;
 
@@ -229,7 +230,7 @@ export default function SimulationResults({
             >
               <SpaceCurvesSlopes
                 initialHeight={heightOfSpaceCurvesSlopesChart}
-                selectedTrain={selectedTrain}
+                selectedTrain={selectedTrain as Train} // TODO: remove Train interface
                 timePosition={timePosition}
                 positionValues={positionValues}
                 sharedXScaleDomain={positionScaleDomain}
@@ -243,7 +244,10 @@ export default function SimulationResults({
       {/* TRAIN : DRIVER TRAIN SCHEDULE */}
       {selectedTrain && selectedTrainRollingStock && (
         <div className="osrd-simulation-container mb-2">
-          <DriverTrainSchedule train={selectedTrain} rollingStock={selectedTrainRollingStock} />
+          <DriverTrainSchedule
+            train={selectedTrain as Train} // TODO: remove Train interface
+            rollingStock={selectedTrainRollingStock}
+          />
         </div>
       )}
 

--- a/front/src/applications/stdcm/formatStcmConf.ts
+++ b/front/src/applications/stdcm/formatStcmConf.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from 'redux';
 import { TFunction } from 'i18next';
-import { PathQuery, PostStdcmApiArg } from 'common/api/osrdEditoastApi';
+import { PathfindingRequest, PostStdcmApiArg } from 'common/api/osrdEditoastApi';
 
 import { createAllowanceValue } from 'applications/stdcm/components/allowancesConsts';
 import { OsrdStdcmConfState } from 'applications/operationalStudies/consts';
@@ -84,7 +84,7 @@ export default function formatStdcmConf(
     );
 
     // we already checked that everything is defined
-    const pathfindingQuery = getPathfindingQuery(osrdconf) as PathQuery;
+    const pathfindingQuery = getPathfindingQuery(osrdconf) as PathfindingRequest;
     const osrdConfStdcm = {
       body: {
         steps: pathfindingQuery.steps,

--- a/front/src/applications/stdcm/views/StdcmRequestModal.tsx
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.tsx
@@ -28,6 +28,7 @@ import { Spinner } from 'common/Loader';
 import { osrdEditoastApi, SimulationReport } from 'common/api/osrdEditoastApi';
 import { StdcmRequestStatus } from 'applications/stdcm/types';
 import { extractMessageFromError, extractStatusFromError } from 'utils/error';
+import { Train } from 'reducers/osrdsimulation/types';
 
 type StdcmRequestModalProps = {
   setCurrentStdcmRequestStatus: (currentStdcmRequestStatus: StdcmRequestStatus) => void;
@@ -82,7 +83,7 @@ export default function StdcmRequestModal(props: StdcmRequestModalProps) {
                 const consolidatedSimulation = createTrain(
                   dispatch,
                   CHART_AXES.SPACE_TIME,
-                  trains,
+                  trains as Train[], // TODO: remove Train interface
                   t
                 );
                 dispatch(updateConsolidatedSimulation(consolidatedSimulation));

--- a/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
+++ b/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
@@ -77,7 +77,7 @@ const SimulationWarpedMap: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
         DataStatePayload)
   >({ type: 'idle' });
   const pathfindingID = useSelector(getSelectedProjection)?.path as number;
-  const [getPath] = osrdEditoastApi.endpoints.getPathfindingById.useLazyQuery();
+  const [getPath] = osrdEditoastApi.endpoints.getPathfindingByPathfindingId.useLazyQuery();
   const layers = useMemo(() => new Set<LayerType>(['track_sections']), []);
   const [mode, setMode] = useState<'manual' | 'auto'>('auto');
   const {
@@ -169,7 +169,7 @@ const SimulationWarpedMap: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
   const itineraryState: AsyncMemoState<Feature<LineString> | null> = useAsyncMemo(async () => {
     if (!selectedTrain || state.type !== 'dataLoaded') return null;
 
-    const { data: path } = await getPath({ id: selectedTrain.path });
+    const { data: path } = await getPath({ pathfindingId: selectedTrain.path });
     if (!path) return null;
 
     return lineString(path.geographic.coordinates);
@@ -235,7 +235,7 @@ const SimulationWarpedMap: FC<{ collapsed?: boolean }> = ({ collapsed }) => {
    */
   useEffect(() => {
     setState({ type: 'loading' });
-    getPath({ id: pathfindingID })
+    getPath({ pathfindingId: pathfindingID })
       .then(({ data, isError, error }) => {
         if (isError) {
           setState({ type: 'error', message: error as string });

--- a/front/src/common/Pathfinding/TypeAndPath.tsx
+++ b/front/src/common/Pathfinding/TypeAndPath.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import {
-  Path,
+  PathResponse,
   PostSearchApiArg,
   SearchResultItemOperationalPoint,
   osrdEditoastApi,
@@ -118,9 +118,9 @@ export default function TypeAndPath({ zoomToFeature }: PathfindingProps) {
             })),
           })),
       };
-      postPathfinding({ pathQuery: params })
+      postPathfinding({ pathfindingRequest: params })
         .unwrap()
-        .then((itineraryCreated: Path) => {
+        .then((itineraryCreated: PathResponse) => {
           zoomToFeature(bbox(itineraryCreated.geographic));
           loadPathFinding(itineraryCreated, dispatch);
         })

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -320,40 +320,51 @@ const injectedRtkApi = api
         providesTags: ['rolling_stock'],
       }),
       postPathfinding: build.mutation<PostPathfindingApiResponse, PostPathfindingApiArg>({
-        query: (queryArg) => ({ url: `/pathfinding/`, method: 'POST', body: queryArg.pathQuery }),
-      }),
-      deletePathfindingById: build.mutation<
-        DeletePathfindingByIdApiResponse,
-        DeletePathfindingByIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.id}/`, method: 'DELETE' }),
-        invalidatesTags: ['pathfinding'],
-      }),
-      getPathfindingById: build.query<GetPathfindingByIdApiResponse, GetPathfindingByIdApiArg>({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.id}/` }),
-        providesTags: ['pathfinding'],
-      }),
-      putPathfindingById: build.mutation<PutPathfindingByIdApiResponse, PutPathfindingByIdApiArg>({
         query: (queryArg) => ({
-          url: `/pathfinding/${queryArg.id}/`,
-          method: 'PUT',
-          body: queryArg.pathQuery,
+          url: `/pathfinding/`,
+          method: 'POST',
+          body: queryArg.pathfindingRequest,
         }),
         invalidatesTags: ['pathfinding'],
       }),
-      getPathfindingByPathIdCatenaries: build.query<
-        GetPathfindingByPathIdCatenariesApiResponse,
-        GetPathfindingByPathIdCatenariesApiArg
+      deletePathfindingByPathfindingId: build.mutation<
+        DeletePathfindingByPathfindingIdApiResponse,
+        DeletePathfindingByPathfindingIdApiArg
       >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathId}/catenaries/` }),
-        providesTags: ['infra'],
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}/`, method: 'DELETE' }),
+        invalidatesTags: ['pathfinding'],
       }),
-      getPathfindingByPathIdElectricalProfiles: build.query<
-        GetPathfindingByPathIdElectricalProfilesApiResponse,
-        GetPathfindingByPathIdElectricalProfilesApiArg
+      getPathfindingByPathfindingId: build.query<
+        GetPathfindingByPathfindingIdApiResponse,
+        GetPathfindingByPathfindingIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}/` }),
+        providesTags: ['pathfinding'],
+      }),
+      putPathfindingByPathfindingId: build.mutation<
+        PutPathfindingByPathfindingIdApiResponse,
+        PutPathfindingByPathfindingIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/pathfinding/${queryArg.pathId}/electrical_profiles/`,
+          url: `/pathfinding/${queryArg.pathfindingId}/`,
+          method: 'PUT',
+          body: queryArg.pathfindingRequest,
+        }),
+        invalidatesTags: ['pathfinding'],
+      }),
+      getPathfindingByPathfindingIdCatenaries: build.query<
+        GetPathfindingByPathfindingIdCatenariesApiResponse,
+        GetPathfindingByPathfindingIdCatenariesApiArg
+      >({
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}/catenaries/` }),
+        providesTags: ['infra'],
+      }),
+      getPathfindingByPathfindingIdElectricalProfiles: build.query<
+        GetPathfindingByPathfindingIdElectricalProfilesApiResponse,
+        GetPathfindingByPathfindingIdElectricalProfilesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/pathfinding/${queryArg.pathfindingId}/electrical_profiles/`,
           params: {
             rolling_stock_id: queryArg.rollingStockId,
             electrical_profile_set_id: queryArg.electricalProfileSetId,
@@ -1002,39 +1013,39 @@ export type GetLightRollingStockByRollingStockIdApiResponse =
 export type GetLightRollingStockByRollingStockIdApiArg = {
   rollingStockId: number;
 };
-export type PostPathfindingApiResponse = /** status 201 The created Path */ Path;
+export type PostPathfindingApiResponse = /** status 201 The created path */ PathResponse;
 export type PostPathfindingApiArg = {
-  /** Path information */
-  pathQuery: PathQuery;
+  pathfindingRequest: PathfindingRequest;
 };
-export type DeletePathfindingByIdApiResponse = unknown;
-export type DeletePathfindingByIdApiArg = {
-  /** Path ID */
-  id: number;
+export type DeletePathfindingByPathfindingIdApiResponse = unknown;
+export type DeletePathfindingByPathfindingIdApiArg = {
+  /** A stored path ID */
+  pathfindingId: number;
 };
-export type GetPathfindingByIdApiResponse = /** status 200 The retrieved path */ Path;
-export type GetPathfindingByIdApiArg = {
-  /** Path ID */
-  id: number;
+export type GetPathfindingByPathfindingIdApiResponse =
+  /** status 200 The requested path */ PathResponse;
+export type GetPathfindingByPathfindingIdApiArg = {
+  /** A stored path ID */
+  pathfindingId: number;
 };
-export type PutPathfindingByIdApiResponse = /** status 200 The updated path */ Path[];
-export type PutPathfindingByIdApiArg = {
-  /** Path ID */
-  id: number;
-  /** Updated Path */
-  pathQuery: PathQuery;
+export type PutPathfindingByPathfindingIdApiResponse =
+  /** status 200 The updated path */ PathResponse;
+export type PutPathfindingByPathfindingIdApiArg = {
+  /** A stored path ID */
+  pathfindingId: number;
+  pathfindingRequest: PathfindingRequest;
 };
-export type GetPathfindingByPathIdCatenariesApiResponse =
+export type GetPathfindingByPathfindingIdCatenariesApiResponse =
   /** status 200  */ CatenariesOnPathResponse;
-export type GetPathfindingByPathIdCatenariesApiArg = {
-  /** The path's id */
-  pathId: number;
+export type GetPathfindingByPathfindingIdCatenariesApiArg = {
+  /** A stored path ID */
+  pathfindingId: number;
 };
-export type GetPathfindingByPathIdElectricalProfilesApiResponse =
+export type GetPathfindingByPathfindingIdElectricalProfilesApiResponse =
   /** status 200  */ ProfilesOnPathResponse;
-export type GetPathfindingByPathIdElectricalProfilesApiArg = {
-  /** The path's id */
-  pathId: number;
+export type GetPathfindingByPathfindingIdElectricalProfilesApiArg = {
+  /** A stored path ID */
+  pathfindingId: number;
   rollingStockId: number;
   electricalProfileSetId: number;
 };
@@ -1498,9 +1509,10 @@ export type DirectionalTrackRange = {
   end: number;
   track: string;
 };
+export type Identifier = string;
 export type TrackLocation = {
-  offset?: number;
-  track?: string;
+  offset: number;
+  track_section: Identifier;
 };
 export type RouteTrackRangesNotFoundError = {
   type: 'NotFound';
@@ -1626,57 +1638,59 @@ export type PaginatedResponseOfLightRollingStockWithLiveries = {
   previous: number | null;
   results: LightRollingStockWithLiveries[];
 };
-export type GeoJsonObject = {
-  coordinates: number[][];
-  type: string;
+export type Curve = {
+  position: number;
+  radius: number;
 };
-export type GeoJsonPosition = {
-  coordinates: number[];
-  type: string;
+export type GeoJsonPointValue = number[];
+export type GeoJsonLineStringValue = GeoJsonPointValue[];
+export type GeoJsonLineString = {
+  coordinates: GeoJsonLineStringValue;
+  type: 'LineString';
 };
-export type TrackSectionLocation = {
-  offset: number;
-  track_section: string;
+export type Slope = {
+  gradient: number;
+  position: number;
 };
-export type PathStep = {
+export type PathWaypoint = {
   duration: number;
-  geo: GeoJsonPosition;
-  id?: string;
-  location: TrackSectionLocation;
-  name?: string;
+  geo: GeoJsonLineString;
+  id: string | null;
+  location: TrackLocation;
+  name: string | null;
   path_offset: number;
-  sch: GeoJsonPosition;
+  sch: GeoJsonLineString;
   suggestion: boolean;
 };
-export type Path = {
+export type PathResponse = {
   created: string;
-  curves: {
-    position: number;
-    radius: number;
-  }[];
-  geographic: GeoJsonObject;
+  curves: Curve[];
+  geographic: GeoJsonLineString;
   id: number;
   length: number;
   owner: string;
-  schematic: GeoJsonObject;
-  slopes: {
-    gradient: number;
-    position: number;
-  }[];
-  steps: PathStep[];
+  schematic: GeoJsonLineString;
+  slopes: Slope[];
+  steps: PathWaypoint[];
 };
-export type PathWaypoint = {
-  geo_coordinate?: number[];
-  offset?: number;
+export type WaypointLocation =
+  | {
+      offset: number;
+    }
+  | {
+      geo_coordinate: (number & number)[];
+    };
+export type WaypointPayload = WaypointLocation & {
   track_section: string;
 };
-export type PathQuery = {
+export type StepPayload = {
+  duration: number;
+  waypoints: WaypointPayload[];
+};
+export type PathfindingRequest = {
   infra: number;
-  rolling_stocks: number[];
-  steps: {
-    duration: number;
-    waypoints: PathWaypoint[];
-  }[];
+  rolling_stocks?: number[];
+  steps: StepPayload[];
 };
 export type RangedValue = {
   begin: number;
@@ -1954,7 +1968,6 @@ export type SearchResultItemTrack = {
   line_code: number;
   line_name: string;
 };
-export type GeoJsonPointValue = number[];
 export type GeoJsonPoint = {
   coordinates: GeoJsonPointValue;
   type: 'Point';
@@ -2177,6 +2190,41 @@ export type SingleSimulationRequest = {
     position?: number;
   }[];
   tag?: string;
+};
+export type GeoJsonObject = {
+  coordinates: number[][];
+  type: string;
+};
+export type GeoJsonPosition = {
+  coordinates: number[];
+  type: string;
+};
+export type PathStep = {
+  duration: number;
+  geo: GeoJsonPosition;
+  id?: string;
+  location: TrackLocation;
+  name?: string;
+  path_offset: number;
+  sch: GeoJsonPosition;
+  suggestion: boolean;
+};
+export type Path = {
+  created: string;
+  curves: {
+    position: number;
+    radius: number;
+  }[];
+  geographic: GeoJsonObject;
+  id: number;
+  length: number;
+  owner: string;
+  schematic: GeoJsonObject;
+  slopes: {
+    gradient: number;
+    position: number;
+  }[];
+  steps: PathStep[];
 };
 export type SimulationReport = {
   base: SimulationReportByTrain;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -2211,12 +2211,12 @@ export type ResultStops = {
   time: number;
 };
 export type FullResultStops = ResultStops & {
-  id?: string | null;
-  line_code?: number | null;
-  line_name?: string | null;
-  name?: string | null;
-  track_name?: string | null;
-  track_number?: number | null;
+  id: string | null;
+  line_code: number | null;
+  line_name: string | null;
+  name: string | null;
+  track_name: string | null;
+  track_number: number | null;
 };
 export type ReportTrain = {
   head_positions: GetCurvePoint[][];

--- a/front/src/modules/simulationResult/components/SimulationResultsMap.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap.tsx
@@ -84,7 +84,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
   const [selectedTrainHoverPosition, setTrainHoverPosition] = useState<TrainPosition>();
   const [otherTrainsHoverPosition, setOtherTrainsHoverPosition] = useState<TrainPosition[]>([]);
   const { urlLat = '', urlLon = '', urlZoom = '', urlBearing = '', urlPitch = '' } = useParams();
-  const [getPath] = osrdEditoastApi.useLazyGetPathfindingByIdQuery();
+  const [getPath] = osrdEditoastApi.useLazyGetPathfindingByPathfindingIdQuery();
   const dispatch = useDispatch();
 
   const updateViewportChange = useCallback(
@@ -112,7 +112,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
   };
 
   const getGeoJSONPath = async (pathID: number) => {
-    const { data: path, isError, error } = await getPath({ id: pathID });
+    const { data: path, isError, error } = await getPath({ pathfindingId: pathID });
     if (path && !isError) {
       const features = lineString(path.geographic.coordinates);
       setGeojsonPath(features);
@@ -354,7 +354,7 @@ const Map: FC<MapProps> = ({ setExtViewport }) => {
             geojsonPath={geojsonPath}
             layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRAIN.GROUP]}
             viewport={viewport}
-            train={selectedTrain}
+            train={selectedTrain as Train} // TODO: remove Train interface
             allowancesSettings={allowancesSettings}
           />
         )}

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart.tsx
@@ -112,9 +112,9 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
     (offset: number) => {
       if (trainSimulations) {
         const trains = trainSimulations.map((train) =>
-          train.id === selectedTrain.id ? timeShiftTrain(train, offset) : train
+          train.id === selectedTrain.id ? timeShiftTrain(train as Train, offset) : train
         );
-        setTrainSimulations(trains);
+        setTrainSimulations(trains as Train[]);
         onOffsetTimeByDragging(trains, offset);
       }
     },
@@ -161,7 +161,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
   const redrawChart = () => {
     if (trainSimulations) {
       const trainsToDraw = trainSimulations.map((train) =>
-        createTrain(CHART_AXES.SPACE_TIME, train)
+        createTrain(CHART_AXES.SPACE_TIME, train as Train)
       );
       drawAllTrains(
         allowancesSettings,
@@ -176,10 +176,10 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
         resetChart,
         rotate,
         selectedProjection,
-        selectedTrain,
+        selectedTrain as Train,
         setChart,
         setDragOffset,
-        trainSimulations,
+        trainSimulations as Train[],
         trainsToDraw
       );
       setResetChart(false);
@@ -198,7 +198,7 @@ export default function SpaceTimeChart(props: SpaceTimeChartProps) {
   /* add behaviour on zoom and mousemove/mouseover/wheel on the new chart each time the chart changes */
   useEffect(() => {
     if (trainSimulations) {
-      const dataSimulation = createTrain(CHART_AXES.SPACE_TIME, selectedTrain);
+      const dataSimulation = createTrain(CHART_AXES.SPACE_TIME, selectedTrain as Train);
       enableInteractivity(
         chart,
         dataSimulation,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart.tsx
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart.tsx
@@ -103,7 +103,7 @@ export default function SpeedSpaceChart({
     toggleSetting(settings);
   };
 
-  const trainSimulation = useMemo(() => prepareData(selectedTrain), [selectedTrain]);
+  const trainSimulation = useMemo(() => prepareData(selectedTrain as Train), [selectedTrain]);
 
   const timeScaleRange: [Date, Date] = useMemo(() => {
     if (chart) {

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleModal.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleModal.tsx
@@ -15,7 +15,7 @@ import {
 import { refactorUniquePaths } from 'modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleHelpers';
 import {
   LightRollingStock,
-  Path,
+  PathResponse,
   TrainScheduleBatchItem,
   osrdEditoastApi,
 } from 'common/api/osrdEditoastApi';
@@ -199,7 +199,7 @@ const ImportTrainScheduleModal = ({
    */
   async function generatePaths(autocomplete = false) {
     const pathErrors: string[] = [];
-    const pathFindings: Record<string, { rollingStockId: number; pathFinding: Path }> = {};
+    const pathFindings: Record<string, { rollingStockId: number; pathFinding: PathResponse }> = {};
     const pathFindingsCount = pathsDictionnary.length;
     let pathFindingsDoneCount = 0;
 
@@ -225,7 +225,7 @@ const ImportTrainScheduleModal = ({
         })
       );
 
-      await postPathFinding({ pathQuery: payload })
+      await postPathFinding({ pathfindingRequest: payload })
         .unwrap()
         .then((pathFinding) => {
           pathFindings[pathRef] = { rollingStockId, pathFinding };

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayload.ts
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayload.ts
@@ -1,16 +1,16 @@
 import { Step, TrainScheduleWithPath } from 'applications/operationalStudies/types';
-import { PathStep, TrainScheduleBatchItem } from 'common/api/osrdEditoastApi';
+import { PathWaypoint, TrainScheduleBatchItem } from 'common/api/osrdEditoastApi';
 import { time2sec } from 'utils/timeManipulation';
 
 // Hope for indexes are the same !
 // Synchronisation is done with indexes between pathfinding not suggered positions, and required steps from importation
-function mixPathPositionsAndTimes(requiredSteps: Step[], pathFindingSteps: PathStep[]) {
+function mixPathPositionsAndTimes(requiredSteps: Step[], pathFindingWaypoints: PathWaypoint[]) {
   const startTime = new Date(requiredSteps[0].departureTime);
-  const pathFindingStepsFiltered = pathFindingSteps.filter((step) => !step.suggestion);
+  const pathFindingStepsFiltered = pathFindingWaypoints.filter((waypoint) => !waypoint.suggestion);
   const scheduledPoints: { path_offset: number; time: number }[] = [];
-  requiredSteps.forEach((step, idx) => {
+  requiredSteps.forEach((waypoint, idx) => {
     if (idx !== 0) {
-      const arrivalTime = new Date(step.arrivalTime);
+      const arrivalTime = new Date(waypoint.arrivalTime);
       scheduledPoints.push({
         path_offset: pathFindingStepsFiltered[idx].path_offset,
         time: Math.round((arrivalTime.getTime() - startTime.getTime()) / 1000),

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/Allowances.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/Allowances.tsx
@@ -39,8 +39,8 @@ export default function Allowances() {
   const { t } = useTranslation('operationalStudies/allowances');
   const dispatch = useDispatch();
   const pathFindingID = useSelector(getPathfindingID);
-  const { data: pathFinding } = osrdEditoastApi.useGetPathfindingByIdQuery(
-    { id: pathFindingID as number },
+  const { data: pathFinding } = osrdEditoastApi.useGetPathfindingByPathfindingIdQuery(
+    { pathfindingId: pathFindingID as number },
     { skip: !pathFindingID }
   );
 
@@ -177,7 +177,7 @@ export default function Allowances() {
                   allowanceSelectedIndex={standardAllowanceSelectedIndex}
                   setAllowanceSelectedIndex={setStandardAllowanceSelectedIndex}
                   setOverlapAllowancesIndexes={setOverlapAllowancesIndexes}
-                  pathFindingSteps={pathFinding?.steps}
+                  pathFindingWaypoints={pathFinding?.steps}
                   updateAllowances={updateStandardAllowances}
                   defaultAllowance={standardAllowance.default_value}
                   overlapAllowancesIndexes={overlapAllowancesIndexes}
@@ -222,7 +222,7 @@ export default function Allowances() {
               type={AllowancesTypes.engineering}
               allowanceSelectedIndex={EngineeringAllowanceSelectedIndex}
               setAllowanceSelectedIndex={setEngineeringAllowanceSelectedIndex}
-              pathFindingSteps={pathFinding?.steps}
+              pathFindingWaypoints={pathFinding?.steps}
               overlapAllowancesIndexes={engineeringOverlapAllowancesIndexes}
               setOverlapAllowancesIndexes={setEngineeringOverlapAllowancesIndexes}
             />

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesActions.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesActions.tsx
@@ -7,7 +7,7 @@ import { GoTrash } from 'react-icons/go';
 import { FaPlus, FaSearch } from 'react-icons/fa';
 import { CgArrowsShrinkH } from 'react-icons/cg';
 import { BiArrowFromLeft, BiArrowFromRight } from 'react-icons/bi';
-import { EngineeringAllowance, PathStep } from 'common/api/osrdEditoastApi';
+import { EngineeringAllowance, PathWaypoint } from 'common/api/osrdEditoastApi';
 import { BsCheckLg } from 'react-icons/bs';
 import { MdCancel } from 'react-icons/md';
 import cx from 'classnames';
@@ -37,7 +37,7 @@ interface Props<T extends RangeAllowanceForm | EngineeringAllowanceForm> {
   allowances: T[];
   defaultAllowance?: AllowanceValueForm;
   pathLength: number;
-  pathFindingSteps?: PathStep[];
+  pathFindingWaypoints?: PathWaypoint[];
   allowanceSelectedIndex?: number;
   updateAllowances: (allowances: T[]) => void;
   setAllowanceSelectedIndex: SetAllowanceSelectedIndexType;
@@ -49,7 +49,7 @@ interface Props<T extends RangeAllowanceForm | EngineeringAllowanceForm> {
 const AllowancesActions = <T extends RangeAllowanceForm | EngineeringAllowanceForm>({
   allowances,
   pathLength,
-  pathFindingSteps,
+  pathFindingWaypoints,
   allowanceSelectedIndex,
   setAllowanceSelectedIndex,
   setOverlapAllowancesIndexes,
@@ -273,14 +273,14 @@ const AllowancesActions = <T extends RangeAllowanceForm | EngineeringAllowanceFo
             value={beginPosition}
             onChange={(e) => handleInputFrom(+e.target.value)}
             appendOptions={
-              pathFindingSteps && {
+              pathFindingWaypoints && {
                 label: <FaSearch />,
                 name: 'op-begin-position',
                 onClick: () =>
                   openModal(
                     <AllowancesModalOP
                       setPosition={setBeginPosition}
-                      pathFindingSteps={pathFindingSteps}
+                      pathFindingWaypoints={pathFindingWaypoints}
                     />
                   ),
               }
@@ -312,14 +312,14 @@ const AllowancesActions = <T extends RangeAllowanceForm | EngineeringAllowanceFo
             value={endPosition}
             onChange={(e) => handleInputTo(+e.target.value)}
             appendOptions={
-              pathFindingSteps && {
+              pathFindingWaypoints && {
                 label: <FaSearch />,
                 name: 'op-end-position',
                 onClick: () =>
                   openModal(
                     <AllowancesModalOP
                       setPosition={setEndPosition}
-                      pathFindingSteps={pathFindingSteps}
+                      pathFindingWaypoints={pathFindingWaypoints}
                     />
                   ),
               }

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesModalOP.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesModalOP.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import { PathStep } from 'common/api/osrdEditoastApi';
+import { PathWaypoint } from 'common/api/osrdEditoastApi';
 import { ModalBodySNCF, ModalHeaderSNCF } from 'common/BootstrapSNCF/ModalSNCF';
 
 export default function AllowancesModalOP({
   setPosition,
-  pathFindingSteps,
+  pathFindingWaypoints,
 }: {
   setPosition: (position: number) => void;
-  pathFindingSteps: PathStep[];
+  pathFindingWaypoints: PathWaypoint[];
 }) {
   const { closeModal } = useContext(ModalContext);
   return (
@@ -16,18 +16,18 @@ export default function AllowancesModalOP({
       <ModalHeaderSNCF withCloseButton />
       <ModalBodySNCF>
         <div className="allowances-op-list">
-          {pathFindingSteps.map((step) => (
+          {pathFindingWaypoints.map((waypoint) => (
             <button
               className="row allowances-op"
               type="button"
               onClick={() => {
-                setPosition(step.path_offset);
+                setPosition(waypoint.path_offset);
                 closeModal();
               }}
-              key={step.path_offset}
+              key={waypoint.path_offset}
             >
-              <div className="col-6">{step.path_offset}</div>
-              <div className="col-6">{step.name}</div>
+              <div className="col-6">{waypoint.path_offset}</div>
+              <div className="col-6">{waypoint.name}</div>
             </button>
           ))}
         </div>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/Itinerary.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/Itinerary.tsx
@@ -17,15 +17,15 @@ import ModalSuggerredVias from 'modules/trainschedule/components/ManageTrainSche
 import { getOrigin, getDestination, getVias, getGeojson } from 'reducers/osrdconf/selectors';
 import { getMap } from 'reducers/map/selectors';
 import Pathfinding from 'common/Pathfinding/Pathfinding';
-import { Path } from 'common/api/osrdEditoastApi';
 import { useTranslation } from 'react-i18next';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { GoArrowSwitch, GoPlus, GoRocket, GoTrash } from 'react-icons/go';
 import Tipped from 'applications/editor/components/Tipped';
 import TypeAndPath from 'common/Pathfinding/TypeAndPath';
+import { PathResponse } from 'common/api/osrdEditoastApi';
 
 type ItineraryProps = {
-  path?: Path;
+  path?: PathResponse;
 };
 
 function Itinerary({ path }: ItineraryProps) {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
@@ -18,23 +18,26 @@ import {
 import { sec2time } from 'utils/timeManipulation';
 import { Dispatch } from 'redux';
 import { store } from 'Store';
-import { Allowance, Path, TrainSchedule } from 'common/api/osrdEditoastApi';
+import { Allowance, PathResponse, TrainSchedule } from 'common/api/osrdEditoastApi';
 import { ArrayElement } from 'utils/types';
 import { PointOnMap } from 'applications/operationalStudies/consts';
 import { compact } from 'lodash';
 import { ms2kmh } from 'utils/physics';
 
-function convertStepToPointOnMap(step?: ArrayElement<Path['steps']>): PointOnMap | undefined {
+function convertStepToPointOnMap(
+  step?: ArrayElement<PathResponse['steps']>
+): PointOnMap | undefined {
   return step
     ? {
         ...step,
         id: step.location.track_section,
+        name: step.name || undefined,
         coordinates: step.geo?.coordinates,
       }
     : undefined;
 }
 
-export function loadPathFinding(path: Path, dispatch: Dispatch) {
+export function loadPathFinding(path: PathResponse, dispatch: Dispatch) {
   if (path.steps && path.steps.length > 1) {
     dispatch(updatePathfindingID(path.id));
     dispatch(updateItinerary(path));
@@ -56,7 +59,7 @@ export function loadPathFinding(path: Path, dispatch: Dispatch) {
 
 export default function adjustConfWithTrainToModify(
   trainSchedule: TrainSchedule,
-  path: Path,
+  path: PathResponse,
   dispatch: Dispatch
 ) {
   const { osrdconf } = store.getState();

--- a/front/src/reducers/osrdconf/index.ts
+++ b/front/src/reducers/osrdconf/index.ts
@@ -12,8 +12,8 @@ import {
   PowerRestrictionRange,
 } from 'applications/operationalStudies/consts';
 import { formatIsoDate } from 'utils/date';
-import { Allowance, Path, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { SwitchType, ThunkAction } from 'types';
+import { Allowance, PathResponse, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { computeLinkedOriginTimes } from './helpers';
 
 /* eslint-disable default-case */
@@ -631,7 +631,7 @@ export function updateDestinationDate(destinationDate: string) {
     });
   };
 }
-export function updateItinerary(geojson?: Path) {
+export function updateItinerary(geojson?: PathResponse) {
   return (dispatch: Dispatch) => {
     dispatch({
       type: UPDATE_ITINERARY,

--- a/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
@@ -3,7 +3,7 @@ import {
   PointOnMap,
   PowerRestrictionRange,
 } from 'applications/operationalStudies/consts';
-import { Allowance, Path } from 'common/api/osrdEditoastApi';
+import { Allowance, PathResponse } from 'common/api/osrdEditoastApi';
 import { Feature } from 'geojson';
 import { SwitchType } from 'types';
 
@@ -62,7 +62,7 @@ export default function commonConfBuilder() {
       name: 'point',
       ...fields,
     }),
-    buildGeoJson: (): Path => ({
+    buildGeoJson: (): PathResponse => ({
       created: '10/10/2023',
       curves: [{ position: 10, radius: 2 }],
       geographic: {
@@ -70,7 +70,7 @@ export default function commonConfBuilder() {
           [1, 2],
           [3, 4],
         ],
-        type: 'type-test',
+        type: 'LineString',
       },
       id: 1,
       length: 10,
@@ -80,7 +80,7 @@ export default function commonConfBuilder() {
           [1, 2],
           [3, 4],
         ],
-        type: 'type-test',
+        type: 'LineString',
       },
       slopes: [
         {
@@ -93,7 +93,7 @@ export default function commonConfBuilder() {
           duration: 2,
           geo: {
             coordinates: [1, 2],
-            type: 'type-test',
+            type: 'Point',
           },
           id: 'toto',
           location: {
@@ -104,7 +104,7 @@ export default function commonConfBuilder() {
           path_offset: 42,
           sch: {
             coordinates: [1, 2],
-            type: 'type-test',
+            type: 'Point',
           },
           suggestion: true,
         },

--- a/front/src/reducers/osrdsimulation/index.ts
+++ b/front/src/reducers/osrdsimulation/index.ts
@@ -16,6 +16,7 @@ import {
   SPEED_SPACE_SETTINGS_KEYS,
   OsrdSimulationState,
   SimulationTrain,
+  Train,
 } from 'reducers/osrdsimulation/types';
 import { SimulationReport } from 'common/api/osrdEditoastApi';
 // TODO: Dependency cycle will be removed during the refactoring of store
@@ -127,14 +128,14 @@ export default function reducer(inputState: OsrdSimulationState | undefined, act
         // get only the present, thanks
         draft.simulation = undoableSimulation(state.simulation, action);
         draft.departureArrivalTimes = makeTrainListWithAllTrainsOffset(
-          draft.simulation.present.trains,
+          draft.simulation.present.trains as Train[], // TODO: remove Train interface
           0
         );
 
         draft.consolidatedSimulation = createTrain(
           noop,
           CHART_AXES.SPACE_TIME,
-          draft.simulation.present.trains,
+          draft.simulation.present.trains as Train[], // TODO: remove Train interface
           noop
         );
         draft.displaySimulation =

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -76,10 +76,10 @@ export interface Stop {
   time: number;
   duration: number;
   position: number;
-  line_code: number;
-  track_number: number;
-  line_name: string;
-  track_name: string;
+  line_code: number | null;
+  track_number: number | null;
+  line_name: string | null;
+  track_name: string | null;
 }
 
 export interface RouteAspect<Time = number, Color = number> {


### PR DESCRIPTION
refs #4580 

Adds utoipa annotations to /pathfinding and /stdcm endpoints.

__Breaking change__: to improve reusability, the STDCMResponse got an additional `payload` field, which was
previously embedded within the `PathResponse`.

@osrd-project/front-maintainers POST /pathfinding was not tagged `"pathfinding"`, is it ok to add it?

@osrd-project/front-maintainers I tried to remove the `Train` interface at first, but that would have resulted in waaaaay too much diff. So I gave up and added a bunch of `as Train` everywhere (sorry 😓).