### PR TITLE
dev: add additional needed dependencies for Mac OS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,10 @@
                 # Nix formatter
                 alejandra.defaultPackage.${system}
               ]
+              ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+                CoreFoundation
+                SystemConfiguration
+              ])
               ++ scriptBins;
 
             RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";


### PR DESCRIPTION
Without these additional dependencies on Mac OS, this error pops-up when compiling `editoast` (linking phase fails).

```
  = note: ld: warning: directory not found for option '-L/opt/local/lib'
          ld: framework not found SystemConfiguration
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```