### PR TITLE
front: editor - implementing ordered layer

### DIFF
--- a/front/src/common/Map/WarpedMap/WarpedMap.tsx
+++ b/front/src/common/Map/WarpedMap/WarpedMap.tsx
@@ -7,7 +7,7 @@ import { Feature, FeatureCollection, LineString } from 'geojson';
 import ReactMapGL, { Layer, MapRef, Source } from 'react-map-gl/maplibre';
 import { LngLatBoundsLike } from 'maplibre-gl';
 
-import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
+import { LAYERS, LAYER_ENTITIES_ORDERS, LAYER_GROUPS_ORDER } from 'config/layerOrder';
 import colors from 'common/Map/Consts/colors';
 import { ALL_SIGNAL_LAYERS } from 'common/Map/Consts/SignalsNames';
 import { LayerType } from 'applications/editor/tools/types';
@@ -16,28 +16,13 @@ import VirtualLayers from 'modules/simulationResult/components/SimulationResults
 import RenderItinerary from 'modules/simulationResult/components/SimulationResultsMap/RenderItinerary';
 import TrainHoverPosition from 'modules/simulationResult/components/SimulationResultsMap/TrainHoverPosition';
 import { LayerContext } from 'common/Map/Layers/types';
-import { EditorSource, SourcesDefinitionsIndex } from 'common/Map/Layers/GeoJSONs';
 import OrderedLayer, { OrderedLayerProps } from 'common/Map/Layers/OrderedLayer';
 import { genOSMLayerProps } from 'common/Map/Layers/OSM';
 import { useMapBlankStyle } from 'common/Map/Layers/blankStyle';
+import { EditorSource, SourcesDefinitionsIndex } from 'common/Map/Layers/GeoJSONs';
 import { Viewport } from 'reducers/map';
 import { getMap } from 'reducers/map/selectors';
 import { AllowancesSettings, Train } from 'reducers/osrdsimulation/types';
-
-const OSRD_LAYER_ORDERS: Record<LayerType, number> = {
-  buffer_stops: LAYER_GROUPS_ORDER[LAYERS.BUFFER_STOPS.GROUP],
-  detectors: LAYER_GROUPS_ORDER[LAYERS.DETECTORS.GROUP],
-  signals: LAYER_GROUPS_ORDER[LAYERS.SIGNALS.GROUP],
-  switches: LAYER_GROUPS_ORDER[LAYERS.SWITCHES.GROUP],
-  track_sections: LAYER_GROUPS_ORDER[LAYERS.TRACKS_GEOGRAPHIC.GROUP],
-  // Unused:
-  catenaries: 0,
-  psl: 0,
-  psl_signs: 0,
-  routes: 0,
-  speed_sections: 0,
-  errors: 0,
-};
 
 /**
  * This component handles displaying warped data. The data must be warped before being given to this component.
@@ -88,7 +73,7 @@ const WarpedMap: FC<{
     () =>
       Array.from(osrdLayers).map((layer) => ({
         source: layer,
-        order: OSRD_LAYER_ORDERS[layer],
+        order: LAYER_ENTITIES_ORDERS[layer],
         id: `${prefix}geo/${layer}`,
         layers: SourcesDefinitionsIndex[layer](layerContext, prefix).map(
           (props) => omit(props, 'source-layer') as typeof props

--- a/front/src/config/layerOrder.ts
+++ b/front/src/config/layerOrder.ts
@@ -1,3 +1,5 @@
+import { LayerType } from 'applications/editor/tools/types';
+
 export const LAYER_GROUPS = Object.freeze({
   MAP_BACKGROUND: Symbol('MAP_BACKGROUND'),
   TOPOGRAPHY: Symbol('TOPOGRAPHY'),
@@ -6,6 +8,7 @@ export const LAYER_GROUPS = Object.freeze({
   SIGNALS: Symbol('SIGNALS'),
   DYN_SIGNALS: Symbol('DYN_SIGNALS'),
   TRAIN: Symbol('TRAIN'),
+  ERRORS: Symbol('ERRORS'),
 });
 
 export const LAYER_GROUPS_ORDER = Object.freeze({
@@ -16,6 +19,7 @@ export const LAYER_GROUPS_ORDER = Object.freeze({
   [LAYER_GROUPS.SIGNALS]: 4,
   [LAYER_GROUPS.DYN_SIGNALS]: 5,
   [LAYER_GROUPS.TRAIN]: 6,
+  [LAYER_GROUPS.ERRORS]: 7,
 });
 
 /**
@@ -49,4 +53,20 @@ export const LAYERS = Object.freeze({
   SIGNALS: { GROUP: LAYER_GROUPS.DYN_SIGNALS },
   // 6
   TRAIN: { GROUP: LAYER_GROUPS.TRAIN },
+  // 7
+  ERRORS: { GROUP: LAYER_GROUPS.ERRORS },
+});
+
+export const LAYER_ENTITIES_ORDERS: Record<LayerType, number> = Object.freeze({
+  buffer_stops: LAYER_GROUPS_ORDER[LAYERS.BUFFER_STOPS.GROUP],
+  detectors: LAYER_GROUPS_ORDER[LAYERS.DETECTORS.GROUP],
+  signals: LAYER_GROUPS_ORDER[LAYERS.SIGNALS.GROUP],
+  switches: LAYER_GROUPS_ORDER[LAYERS.SWITCHES.GROUP],
+  track_sections: LAYER_GROUPS_ORDER[LAYERS.TRACKS_GEOGRAPHIC.GROUP],
+  catenaries: LAYER_GROUPS_ORDER[LAYERS.CATENARIES.GROUP],
+  speed_sections: LAYER_GROUPS_ORDER[LAYERS.SPEED_LIMITS.GROUP],
+  routes: LAYER_GROUPS_ORDER[LAYERS.ROUTES.GROUP],
+  psl: LAYER_GROUPS_ORDER[LAYERS.SIGNALS.GROUP],
+  psl_signs: LAYER_GROUPS_ORDER[LAYERS.SIGNALS.GROUP],
+  errors: LAYER_GROUPS_ORDER[LAYERS.ERRORS.GROUP],
 });


### PR DESCRIPTION
Close #5611 and also the detector issue related to #5650 (now detector layer is always on top the track section one)

- adding in the conf a set by entities type
- refacto wrapped map to use this new config
- refacto GeoJson to use the orderLayer