### PR TITLE
core: infra: ignore 0-length ranges when building zones

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
@@ -30,6 +30,7 @@ data class ChunkViewer(
 data class ZonePathViewer(
     val chunks: List<DirectedViewer<ChunkViewer>>,
     val id: ZonePathId,
+    val length: Length<ZonePath>,
 )
 
 data class BlockViewer(
@@ -71,6 +72,7 @@ fun makeZonePath(infra: RawInfra, id: StaticIdx<ZonePath>): ZonePathViewer {
         infra.getZonePathChunks(id)
             .map { dirChunk -> makeDirViewer(dirChunk, makeChunk(infra, dirChunk.value)) },
         id,
+        infra.getZonePathLength(id),
     )
 }
 

--- a/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.java
@@ -235,6 +235,7 @@ public class PathfindingBlocksEndpoint implements Take {
         blocksOnWaypoint.forEach(block -> {
             var offset = getBlockOffset(block, trackChunkOnWaypoint, trackSectionId, waypoint.offset,
                     waypoint.direction, infra);
+            assert offset <= infra.blockInfra().getBlockLength(block);
             res.add(new Pathfinding.EdgeLocation<>(block, offset));
         });
         return res;

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -506,14 +506,14 @@ private fun buildZonePath(
     // Build chunk list
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
     for (range in zoneTrackPath) {
-        val chunk = trackChunkMap[range.track]!![range.begin]
-        if (chunk != null)
-            chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))
-        else {
-            // This can happen with 0-length range at track transition, which can be ignored.
-            // We assert that we are in that scenario and move on
-            assert(range.begin == range.end)
+        if (range.begin == range.end) {
+            // 0-length ranges can happen at track transition.
+            // They can and should be ignored, adding the chunk starting there would add an extra chunk.
+            // We assert that we are at a track transition, and move on
             assert(range.end == Distance.fromMeters(range.track.length) || range.end == 0.meters)
+        } else {
+            val chunk = trackChunkMap[range.track]!![range.begin]!!
+            chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))
         }
     }
 


### PR DESCRIPTION
In the previous version, when the end detector was placed precisely at a transition between two tracks, we would add the chunk that starts there. 

Fixes #5535 