### PR TITLE
front: editor - compute track section length on creation

### DIFF
--- a/front/src/applications/editor/components/LinearMetadata/FormLineStringLength.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormLineStringLength.tsx
@@ -23,14 +23,10 @@ export const FormLineStringLength: React.FC<WidgetProps> = (props) => {
    */
   useEffect(() => {
     const distance = getLineStringDistance(formContext.geometry);
-    if (formContext.isCreation) {
-      setTimeout(() => onChange(distance), 0);
-    } else {
-      setMin(Math.round(distance - distance * DISTANCE_ERROR_RANGE));
-      setMax(Math.round(distance + distance * DISTANCE_ERROR_RANGE));
-      setGeoLength(distance);
-    }
-  }, [formContext.geometry, formContext.isCreation, onChange]);
+    setMin(Math.round(distance - distance * DISTANCE_ERROR_RANGE));
+    setMax(Math.round(distance + distance * DISTANCE_ERROR_RANGE));
+    setGeoLength(distance);
+  }, [formContext.geometry, formContext.isCreation]);
 
   return (
     <div>
@@ -49,7 +45,7 @@ export const FormLineStringLength: React.FC<WidgetProps> = (props) => {
           }}
         />
       )}
-      {geoLength && (length < min || length > max) && (
+      {geoLength > 0 && (length < min || length > max) && (
         <p className="text-warning">
           {t('Editor.errors.length-out-of-sync-with-geometry', { min, max })}.{' '}
           <button

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -12,7 +12,7 @@ import { featureCollection } from '@turf/helpers';
 import nearestPointOnLine, { NearestPointOnLine } from '@turf/nearest-point-on-line';
 
 import { save } from 'reducers/editor';
-import { entityDoUpdate } from 'common/IntervalsDataViz/data';
+import { entityDoUpdate, getLineStringDistance } from 'common/IntervalsDataViz/data';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { getMapMouseEventNearestFeature } from 'utils/mapHelper';
 import { NEW_ENTITY_ID } from 'applications/editor/data/utils';
@@ -195,7 +195,6 @@ const TrackEditionTool: Tool<TrackEditionState> = {
   // Interactions:
   onClickMap(e, { setState, state }) {
     const { editionState, anchorLinePoints, track, nearestPoint } = state;
-
     if (editionState.type === 'addPoint') {
       // Adding a point on an existing section:
       if (
@@ -230,6 +229,11 @@ const TrackEditionTool: Tool<TrackEditionState> = {
           }
 
           newState.nearestPoint = null;
+
+          // compute new length if it's newly tracksection
+          if (newState.track.properties.id === NEW_ENTITY_ID) {
+            newState.track.properties.length = getLineStringDistance(newState.track.geometry);
+          }
           setState(newState);
         } else {
           setState({


### PR DESCRIPTION
Close #3974

I also fixed an other `0` displayed on the editor form (related to #5709) on the length field