### PR TITLE
core: allowances: enforce capacity speed limit >= 1

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
@@ -20,6 +20,7 @@ public class MarecoAllowance extends AbstractAllowanceWithRanges {
             List<AllowanceRange> ranges
     ) {
         super(beginPos, endPos, capacitySpeedLimit, ranges);
+        assert capacitySpeedLimit >= 1 : "capacity speed limit can't be lower than 1m/s for mareco allowances";
     }
 
     public static final class MarecoSpeedLimit implements EnvelopeAttr {
@@ -36,7 +37,9 @@ public class MarecoAllowance extends AbstractAllowanceWithRanges {
     private double computeVf(double v1, PhysicsRollingStock rollingStock) {
         // formulas given by MARECO
         var wle = v1 * v1 * rollingStock.getRollingResistanceDeriv(v1);
-        return wle * v1 / (wle + rollingStock.getRollingResistance(v1) * v1);
+        var vf = wle * v1 / (wle + rollingStock.getRollingResistance(v1) * v1);
+
+        return Math.max(vf, capacitySpeedLimit); // Prevents coasting from starting below capacity speed limit
     }
 
     /** Compute the initial low bound for the binary search */

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
@@ -47,9 +47,6 @@ public final class CoastingGenerator {
     ) {
         assert endPos >= 0 && endPos <= context.path.getLength();
 
-        // Lower values can often cause many float-related errors when the speed gets too close to 0
-        lowSpeedLimit = Math.max(1, lowSpeedLimit);
-
         // coast backwards from the end position until the base curve is met
         var backwardPartBuilder = new EnvelopePartBuilder();
         backwardPartBuilder.setAttr(EnvelopeProfile.COASTING);
@@ -61,6 +58,7 @@ public final class CoastingGenerator {
 
         double position = endPos;
         double speed = envelope.interpolateSpeed(position);
+        assert speed >= lowSpeedLimit || areSpeedsEqual(speed, lowSpeedLimit) : "start coasting below min speed";
         var initInter = constrainedBuilder.initEnvelopePart(position, speed, -1);
         assert initInter;
         boolean reachedLowLimit = false;

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -99,7 +99,7 @@ class EnvelopePartTest {
         var testContext = new EnvelopeSimContext(testRollingStock, testPath, 4, testEffortCurveMap);
         var allowanceValue = new AllowanceValue.Percentage(10);
 
-        var marecoAllowance = AllowanceTests.makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = AllowanceTests.makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         var envelopeAllowance = AllowanceTests.makeSimpleAllowanceEnvelope(testContext, marecoAllowance, 44.4, false);
 
         for (var i = 0; i < envelopeAllowance.size(); i++) {

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
@@ -37,7 +37,7 @@ public class AllowanceRangesTests {
                 new AllowanceRange(0, 0.3 * path.getLength(), value1),
                 new AllowanceRange(0.3 * path.getLength(), path.getLength(), value2)
         );
-        var allowance = new MarecoAllowance(0, path.getLength(), 0, ranges);
+        var allowance = new MarecoAllowance(0, path.getLength(), 1, ranges);
         return allowance.apply(maxEffortEnvelope, context);
     }
 
@@ -275,7 +275,7 @@ public class AllowanceRangesTests {
         var ranges = List.of(
                 new AllowanceRange(rangesTransitions[0], rangesTransitions[1], value1)
         );
-        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 0, ranges
+        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 1, ranges
         );
         applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope, testContext);
     }
@@ -295,7 +295,7 @@ public class AllowanceRangesTests {
         var ranges = List.of(
                 new AllowanceRange(rangesTransitions[0], rangesTransitions[1], value1)
         );
-        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 0, ranges);
+        var allowance = new LinearAllowance(rangesTransitions[0], rangesTransitions[1], 1, ranges);
         applyAllowanceIgnoringUserError(allowance, maxEffortEnvelope, testContext);
     }
 

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -106,11 +106,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testBinarySearchContinuity(maxEffortEnvelope, marecoAllowance, testContext, 10, 80);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         testBinarySearchContinuity(maxEffortEnvelope, linearAllowance, testContext, 8, 70);
     }
 
@@ -125,7 +125,7 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(50);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, 50_000, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, 50_000, 1, allowanceValue);
         testBinarySearchContinuity(maxEffortEnvelope, marecoAllowance, testContext, 10, 80);
     }
 
@@ -145,7 +145,7 @@ public class AllowanceTests {
         var length = 10_000;
         var testContext = makeSimpleContext(length, 0);
         var allowanceValue = new AllowanceValue.Percentage(10);
-        var allowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var allowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testAllowanceShapeFlat(testContext, allowance);
     }
 
@@ -166,7 +166,7 @@ public class AllowanceTests {
         var length = 10_000;
         var testContext = makeSimpleContext(length, 20);
         var allowanceValue = new AllowanceValue.Percentage(10);
-        var allowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var allowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testAllowanceShapeSteep(testContext, allowance);
     }
 
@@ -224,11 +224,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(value);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, marecoAllowance);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, linearAllowance);
     }
 
@@ -245,11 +245,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.TimePerDistance(value);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, marecoAllowance);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, linearAllowance);
     }
 
@@ -507,11 +507,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(40);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, marecoAllowance);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         testAllowanceTime(maxEffortEnvelope, testContext, linearAllowance);
     }
 
@@ -542,7 +542,7 @@ public class AllowanceTests {
         var stops = new double[]{ 50_000, length };
         var maxEffortEnvelope = makeComplexMaxEffortEnvelope(testContext, stops);
         var allowanceValue = new AllowanceValue.Percentage(10);
-        var allowance = makeStandardMarecoAllowance(0, testPath.getLength(), 0, allowanceValue);
+        var allowance = makeStandardMarecoAllowance(0, testPath.getLength(), 1, allowanceValue);
         var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var targetTime = allowance.getTargetTime(maxEffortEnvelope);
         var marginTime = marecoEnvelope.getTotalTime();
@@ -573,11 +573,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         makeSimpleAllowanceEnvelope(testContext, marecoAllowance, 100, false);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         makeSimpleAllowanceEnvelope(testContext, linearAllowance, 100, false);
     }
 
@@ -600,11 +600,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.TimePerDistance(10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         marecoAllowance.apply(maxEffortEnvelope, testContext);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         linearAllowance.apply(maxEffortEnvelope, testContext);
     }
 
@@ -626,11 +626,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.TimePerDistance(10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         marecoAllowance.apply(maxEffortEnvelope, testContext);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         linearAllowance.apply(maxEffortEnvelope, testContext);
     }
 
@@ -652,11 +652,11 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.FixedTime(10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(begin, end, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(begin, end, 1, allowanceValue);
         marecoAllowance.apply(maxEffortEnvelope, testContext);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(begin, end, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(begin, end, 1, allowanceValue);
         linearAllowance.apply(maxEffortEnvelope, testContext);
     }
 
@@ -686,7 +686,7 @@ public class AllowanceTests {
         var allowanceValue = new AllowanceValue.Percentage(1e10);
 
         // test mareco distribution
-        var marecoAllowance = makeStandardMarecoAllowance(0, length, 0, allowanceValue);
+        var marecoAllowance = makeStandardMarecoAllowance(0, length, 1, allowanceValue);
         var marecoException = assertThrows(
                 OSRDError.class, 
                 () -> makeSimpleAllowanceEnvelope(testContext, marecoAllowance, 44.4, true)
@@ -694,7 +694,7 @@ public class AllowanceTests {
         assertEquals(marecoException.osrdErrorType, ErrorType.AllowanceConvergenceTooMuchTime);
 
         // test linear distribution
-        var linearAllowance = makeStandardLinearAllowance(0, length, 0, allowanceValue);
+        var linearAllowance = makeStandardLinearAllowance(0, length, 1, allowanceValue);
         var linearException = assertThrows(OSRDError.class, () ->
                 makeSimpleAllowanceEnvelope(testContext, linearAllowance, 44.4, true)
         );

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MarecoDecelerationTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/MarecoDecelerationTests.java
@@ -42,7 +42,7 @@ public class MarecoDecelerationTests {
         EnvelopeDeceleration.decelerate(context, 100_000, 0, overlayBuilder, -1);
         var envelope = builder.build();
 
-        var allowance = new MarecoAllowance(startOffset, endOffset, 0,
+        var allowance = new MarecoAllowance(startOffset, endOffset, 1,
                 List.of(new AllowanceRange(startOffset, endOffset, new AllowanceValue.Percentage(50))));
         try {
             allowance.apply(envelope, context);

--- a/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/StandaloneSimulationTest.java
@@ -340,7 +340,7 @@ public class StandaloneSimulationTest extends ApiTest {
         // build the simulation request
         var stops = new RJSTrainStop[]{RJSTrainStop.lastStop(0.1)};
         var allowance = new RJSAllowance[]{new RJSAllowance.EngineeringAllowance(
-                RJSAllowanceDistribution.MARECO, 0, 1000, new RJSAllowanceValue.Time(30), 0.01
+                RJSAllowanceDistribution.MARECO, 0, 1000, new RJSAllowanceValue.Time(5), 1
         )
         };
         var trains = new ArrayList<RJSStandaloneTrainSchedule>();
@@ -365,7 +365,7 @@ public class StandaloneSimulationTest extends ApiTest {
         var noAllowanceTime = noAllowanceResult.headPositions.get(noAllowanceResult.headPositions.size() - 1).time;
         var allowanceResult = simResult.ecoSimulations.get(1);
         var allowanceTime = allowanceResult.headPositions.get(allowanceResult.headPositions.size() - 1).time;
-        assertEquals(noAllowanceTime + 30, allowanceTime, noAllowanceTime * 0.01);
+        assertEquals(noAllowanceTime + 5, allowanceTime, noAllowanceTime * 0.01);
     }
 
     @Test

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -572,7 +572,7 @@ def make_random_allowances(path_length: float) -> List[Dict]:
                 "allowance_type": "standard",
                 "default_value": make_random_allowance_value(path_length),
                 "ranges": list(make_random_ranges(path_length)),
-                "capacity_speed_limit": random.random() * 10,
+                "capacity_speed_limit": 1 + random.random() * 30,
                 "distribution": "MARECO" if random.randint(0, 1) == 0 else "LINEAR",
             }
         )
@@ -586,7 +586,7 @@ def make_random_allowances(path_length: float) -> List[Dict]:
                 "begin_position": min(positions),
                 "end_position": max(positions),
                 "value": make_random_allowance_value(max(positions) - min(positions)),
-                "capacity_speed_limit": random.random() * 10,
+                "capacity_speed_limit": 1 + random.random() * 30,
                 "distribution": "MARECO" if random.randint(0, 1) == 0 else "LINEAR",
             }
         )

--- a/tests/tests/regression_tests_data/acceleration_assert.json
+++ b/tests/tests/regression_tests_data/acceleration_assert.json
@@ -1,1 +1,56 @@
-{"error_type": "SCHEDULE", "code": 500, "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"stackTrace\":[\"EnvelopePhysics.java:14\",\"EnvelopePhysics.java:54\",\"ConstrainedEnvelopePartBuilder.java:102\",\"EnvelopeAcceleration.java:25\",\"AbstractAllowanceWithRanges.java:397\",\"AbstractAllowanceWithRanges.java:315\",\"AbstractAllowanceWithRanges.java:280\",\"AbstractAllowanceWithRanges.java:257\",\"AbstractAllowanceWithRanges.java:187\",\"AbstractAllowanceWithRanges.java:129\",\"StandaloneSim.java:95\",\"StandaloneSim.java:58\",\"StandaloneSimulationEndpoint.java:85\",\"FkRegex.java:157\",\"FkRegex.java:228\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:89\",\"TkFallback.java:57\",\"TkFallback.java:69\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:127\",\"BkBasic.java:102\",\"BkSafe.java:49\",\"BkWrap.java:51\",\"BkParallel.java:87\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}", "infra_name": "small_infra", "path_payload": {"infra": 94, "name": "foo", "steps": [{"duration": 0, "waypoints": [{"track_section": "TA1", "offset": 1856.6077154118593}]}, {"duration": 1, "waypoints": [{"track_section": "TA4", "offset": 25.049733930557206}]}]}, "schedule_payload": {"timetable": 74, "path": 16446, "schedules": [{"train_name": "foo", "labels": [], "departure_time": 0, "allowances": [{"allowance_type": "engineering", "begin_position": 86.71793651828453, "end_position": 92.01725738112799, "value": {"value_type": "percentage", "percentage": 19.78715063935094}, "capacity_speed_limit": 0.12096469825170542, "distribution": "LINEAR"}], "initial_speed": 0, "rolling_stock": "253"}]}}
+{
+  "error_type": "SCHEDULE",
+  "code": 500,
+  "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"stackTrace\":[\"EnvelopePhysics.java:14\",\"EnvelopePhysics.java:54\",\"ConstrainedEnvelopePartBuilder.java:102\",\"EnvelopeAcceleration.java:25\",\"AbstractAllowanceWithRanges.java:397\",\"AbstractAllowanceWithRanges.java:315\",\"AbstractAllowanceWithRanges.java:280\",\"AbstractAllowanceWithRanges.java:257\",\"AbstractAllowanceWithRanges.java:187\",\"AbstractAllowanceWithRanges.java:129\",\"StandaloneSim.java:95\",\"StandaloneSim.java:58\",\"StandaloneSimulationEndpoint.java:85\",\"FkRegex.java:157\",\"FkRegex.java:228\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:89\",\"TkFallback.java:57\",\"TkFallback.java:69\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:127\",\"BkBasic.java:102\",\"BkSafe.java:49\",\"BkWrap.java:51\",\"BkParallel.java:87\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}",
+  "infra_name": "small_infra",
+  "path_payload": {
+    "infra": 94,
+    "name": "foo",
+    "steps": [
+      {
+        "duration": 0,
+        "waypoints": [
+          {
+            "track_section": "TA1",
+            "offset": 1856.6077154118593
+          }
+        ]
+      },
+      {
+        "duration": 1,
+        "waypoints": [
+          {
+            "track_section": "TA4",
+            "offset": 25.049733930557206
+          }
+        ]
+      }
+    ]
+  },
+  "schedule_payload": {
+    "timetable": 74,
+    "path": 16446,
+    "schedules": [
+      {
+        "train_name": "foo",
+        "labels": [],
+        "departure_time": 0,
+        "allowances": [
+          {
+            "allowance_type": "engineering",
+            "begin_position": 86.71793651828453,
+            "end_position": 92.01725738112799,
+            "value": {
+              "value_type": "percentage",
+              "percentage": 19.78715063935094
+            },
+            "capacity_speed_limit": 1,
+            "distribution": "LINEAR"
+          }
+        ],
+        "initial_speed": 0,
+        "rolling_stock": "253"
+      }
+    ]
+  }
+}

--- a/tests/tests/regression_tests_data/allowance_speed_discontinuity_assert.json
+++ b/tests/tests/regression_tests_data/allowance_speed_discontinuity_assert.json
@@ -72,7 +72,7 @@
               "value_type": "percentage",
               "percentage": 10.071188593833375
             },
-            "capacity_speed_limit": 0.6513002857517136,
+            "capacity_speed_limit": 1,
             "distribution": "MARECO"
           }
         ],

--- a/tests/tests/regression_tests_data/discontinuity_allowance_section.json
+++ b/tests/tests/regression_tests_data/discontinuity_allowance_section.json
@@ -1,1 +1,67 @@
-{"error_type": "SCHEDULE", "code": 500, "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"message\":\"Discontinuity in allowance section\",\"stackTrace\":[\"AbstractAllowanceWithRanges.java:333\",\"AbstractAllowanceWithRanges.java:280\",\"AbstractAllowanceWithRanges.java:257\",\"AbstractAllowanceWithRanges.java:187\",\"AbstractAllowanceWithRanges.java:129\",\"StandaloneSim.java:95\",\"StandaloneSim.java:58\",\"StandaloneSimulationEndpoint.java:85\",\"FkRegex.java:157\",\"FkRegex.java:228\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:89\",\"TkFallback.java:57\",\"TkFallback.java:69\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:127\",\"BkBasic.java:102\",\"BkSafe.java:49\",\"BkWrap.java:51\",\"BkParallel.java:87\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}", "infra_name": "small_infra", "path_payload": {"infra": 94, "name": "foo", "steps": [{"duration": 943.0266885370196, "waypoints": [{"track_section": "TD1", "offset": 24886.39300078958}]}, {"duration": 1, "waypoints": [{"track_section": "TD3", "offset": 1492.7819321527872}]}]}, "schedule_payload": {"timetable": 74, "path": 15644, "schedules": [{"train_name": "foo", "labels": [], "departure_time": 0, "allowances": [{"allowance_type": "engineering", "begin_position": 89.04813196643823, "end_position": 1499.2257604804738, "value": {"value_type": "percentage", "percentage": 9.39492183155911}, "capacity_speed_limit": 1.5588659163562057, "distribution": "LINEAR"}, {"allowance_type": "engineering", "begin_position": 1186.9863734998637, "end_position": 1329.551340448644, "value": {"value_type": "percentage", "percentage": 17.832255901956753}, "capacity_speed_limit": 5.082651972765994, "distribution": "MARECO"}], "initial_speed": 0, "rolling_stock": "253"}]}}
+{
+  "error_type": "SCHEDULE",
+  "code": 500,
+  "error": "{\"type\":\"core:assert_error\",\"cause\":\"INTERNAL\",\"message\":\"Discontinuity in allowance section\",\"stackTrace\":[\"AbstractAllowanceWithRanges.java:333\",\"AbstractAllowanceWithRanges.java:280\",\"AbstractAllowanceWithRanges.java:257\",\"AbstractAllowanceWithRanges.java:187\",\"AbstractAllowanceWithRanges.java:129\",\"StandaloneSim.java:95\",\"StandaloneSim.java:58\",\"StandaloneSimulationEndpoint.java:85\",\"FkRegex.java:157\",\"FkRegex.java:228\",\"FkChain.java:72\",\"TkFork.java:98\",\"TkFallback.java:89\",\"TkFallback.java:57\",\"TkFallback.java:69\",\"TkWrap.java:58\",\"TkSlf4j.java:110\",\"BkBasic.java:127\",\"BkBasic.java:102\",\"BkSafe.java:49\",\"BkWrap.java:51\",\"BkParallel.java:87\",\"ThreadPoolExecutor.java:1136\",\"ThreadPoolExecutor.java:635\",\"Thread.java:833\"],\"trace\":[]}",
+  "infra_name": "small_infra",
+  "path_payload": {
+    "infra": 94,
+    "name": "foo",
+    "steps": [
+      {
+        "duration": 943.0266885370196,
+        "waypoints": [
+          {
+            "track_section": "TD1",
+            "offset": 24886.39300078958
+          }
+        ]
+      },
+      {
+        "duration": 1,
+        "waypoints": [
+          {
+            "track_section": "TD3",
+            "offset": 1492.7819321527872
+          }
+        ]
+      }
+    ]
+  },
+  "schedule_payload": {
+    "timetable": 74,
+    "path": 15644,
+    "schedules": [
+      {
+        "train_name": "foo",
+        "labels": [],
+        "departure_time": 0,
+        "allowances": [
+          {
+            "allowance_type": "engineering",
+            "begin_position": 89.04813196643823,
+            "end_position": 1499.2257604804738,
+            "value": {
+              "value_type": "percentage",
+              "percentage": 9.39492183155911
+            },
+            "capacity_speed_limit": 1.5588659163562057,
+            "distribution": "LINEAR"
+          },
+          {
+            "allowance_type": "engineering",
+            "begin_position": 1186.9863734998637,
+            "end_position": 1329.551340448644,
+            "value": {
+              "value_type": "percentage",
+              "percentage": 17.832255901956753
+            },
+            "capacity_speed_limit": 5.082651972765994,
+            "distribution": "MARECO"
+          }
+        ],
+        "initial_speed": 0,
+        "rolling_stock": "253"
+      }
+    ]
+  }
+}

--- a/tests/tests/regression_tests_data/envelope_part_builder_assert.json
+++ b/tests/tests/regression_tests_data/envelope_part_builder_assert.json
@@ -62,7 +62,7 @@
                             "value_type": "percentage",
                             "percentage": 16.6967933672574
                         },
-                        "capacity_speed_limit": 0.4692768695585636,
+                        "capacity_speed_limit": 1,
                         "distribution": "MARECO"
                     }
                 ],

--- a/tests/tests/regression_tests_data/null_pointer_exception.json
+++ b/tests/tests/regression_tests_data/null_pointer_exception.json
@@ -1,1 +1,86 @@
-{"error_type": "SCHEDULE", "code": 500, "error": "{\"detail\":\"java.lang.NullPointerException\"}", "infra_name": "small_infra", "path_payload": {"infra": 94, "name": "foo", "steps": [{"duration": 523.8554716291783, "waypoints": [{"track_section": "TA6", "offset": 9911.760394159366}]}, {"duration": 1, "waypoints": [{"track_section": "TC1", "offset": 53.49288045747232}]}]}, "schedule_payload": {"timetable": 74, "path": 15435, "schedules": [{"train_name": "foo", "labels": [], "departure_time": 0, "allowances": [{"allowance_type": "standard", "default_value": {"value_type": "time", "seconds": 0.6043913143059488}, "ranges": [{"begin_position": 0, "end_position": 7.28731620110872, "value": {"value_type": "time", "seconds": 0.013915865661086595}}], "capacity_speed_limit": 0.012461944170274464, "distribution": "MARECO"}, {"allowance_type": "engineering", "begin_position": 0.37991166582879193, "end_position": 22.966574232067636, "value": {"value_type": "time_per_distance", "minutes": 7.176840177285413}, "capacity_speed_limit": 3.6046936557626443, "distribution": "LINEAR"}, {"allowance_type": "engineering", "begin_position": 33.49088880319503, "end_position": 99.66245935193172, "value": {"value_type": "time", "seconds": 0.23297447038701385}, "capacity_speed_limit": 4.121352224179729, "distribution": "LINEAR"}], "initial_speed": 0, "rolling_stock": "253"}]}}
+{
+  "error_type": "SCHEDULE",
+  "code": 500,
+  "error": "{\"detail\":\"java.lang.NullPointerException\"}",
+  "infra_name": "small_infra",
+  "path_payload": {
+    "infra": 94,
+    "name": "foo",
+    "steps": [
+      {
+        "duration": 523.8554716291783,
+        "waypoints": [
+          {
+            "track_section": "TA6",
+            "offset": 9911.760394159366
+          }
+        ]
+      },
+      {
+        "duration": 1,
+        "waypoints": [
+          {
+            "track_section": "TC1",
+            "offset": 53.49288045747232
+          }
+        ]
+      }
+    ]
+  },
+  "schedule_payload": {
+    "timetable": 74,
+    "path": 15435,
+    "schedules": [
+      {
+        "train_name": "foo",
+        "labels": [],
+        "departure_time": 0,
+        "allowances": [
+          {
+            "allowance_type": "standard",
+            "default_value": {
+              "value_type": "time",
+              "seconds": 0.6043913143059488
+            },
+            "ranges": [
+              {
+                "begin_position": 0,
+                "end_position": 7.28731620110872,
+                "value": {
+                  "value_type": "time",
+                  "seconds": 0.013915865661086595
+                }
+              }
+            ],
+            "capacity_speed_limit": 1,
+            "distribution": "MARECO"
+          },
+          {
+            "allowance_type": "engineering",
+            "begin_position": 0.37991166582879193,
+            "end_position": 22.966574232067636,
+            "value": {
+              "value_type": "time_per_distance",
+              "minutes": 7.176840177285413
+            },
+            "capacity_speed_limit": 3.6046936557626443,
+            "distribution": "LINEAR"
+          },
+          {
+            "allowance_type": "engineering",
+            "begin_position": 33.49088880319503,
+            "end_position": 99.66245935193172,
+            "value": {
+              "value_type": "time",
+              "seconds": 0.23297447038701385
+            },
+            "capacity_speed_limit": 4.121352224179729,
+            "distribution": "LINEAR"
+          }
+        ],
+        "initial_speed": 0,
+        "rolling_stock": "253"
+      }
+    ]
+  }
+}

--- a/tests/tests/regression_tests_data/search_space_discontinuity.json
+++ b/tests/tests/regression_tests_data/search_space_discontinuity.json
@@ -1,1 +1,67 @@
-{"error_type": "SCHEDULE", "code": 500, "error": "{\"type\":\"core:allowance_convergence\",\"cause\":\"INTERNAL\",\"errorType\":\"discontinuity\",\"message\":\"Failed to converge when computing allowances because of a discontinuity in the search space\",\"trace\":[{\"type\":\"allowance\",\"index\":\"1\"}]}", "infra_name": "small_infra", "path_payload": {"infra": 94, "name": "foo", "steps": [{"duration": 338.9396149098179, "waypoints": [{"track_section": "TA7", "offset": 144.01694825192175}]}, {"duration": 1, "waypoints": [{"track_section": "TB0", "offset": 669.2927737032946}]}]}, "schedule_payload": {"timetable": 74, "path": 16041, "schedules": [{"train_name": "foo", "labels": [], "departure_time": 0, "allowances": [{"allowance_type": "engineering", "begin_position": 655.7681522126178, "end_position": 2258.43307578361, "value": {"value_type": "percentage", "percentage": 8.101399265042275}, "capacity_speed_limit": 9.183335961543804, "distribution": "LINEAR"}, {"allowance_type": "engineering", "begin_position": 485.9086361515102, "end_position": 2286.516833610721, "value": {"value_type": "percentage", "percentage": 13.02719840932256}, "capacity_speed_limit": 3.4416022635242394, "distribution": "MARECO"}], "initial_speed": 0, "rolling_stock": "253"}]}}
+{
+  "error_type": "SCHEDULE",
+  "code": 500,
+  "error": "{\"type\":\"core:allowance_convergence\",\"cause\":\"INTERNAL\",\"errorType\":\"discontinuity\",\"message\":\"Failed to converge when computing allowances because of a discontinuity in the search space\",\"trace\":[{\"type\":\"allowance\",\"index\":\"1\"}]}",
+  "infra_name": "small_infra",
+  "path_payload": {
+    "infra": 94,
+    "name": "foo",
+    "steps": [
+      {
+        "duration": 338.9396149098179,
+        "waypoints": [
+          {
+            "track_section": "TA7",
+            "offset": 144.01694825192175
+          }
+        ]
+      },
+      {
+        "duration": 1,
+        "waypoints": [
+          {
+            "track_section": "TB0",
+            "offset": 669.2927737032946
+          }
+        ]
+      }
+    ]
+  },
+  "schedule_payload": {
+    "timetable": 74,
+    "path": 16041,
+    "schedules": [
+      {
+        "train_name": "foo",
+        "labels": [],
+        "departure_time": 0,
+        "allowances": [
+          {
+            "allowance_type": "engineering",
+            "begin_position": 655.7681522126178,
+            "end_position": 2258.43307578361,
+            "value": {
+              "value_type": "percentage",
+              "percentage": 8.101399265042275
+            },
+            "capacity_speed_limit": 9.183335961543804,
+            "distribution": "LINEAR"
+          },
+          {
+            "allowance_type": "engineering",
+            "begin_position": 485.9086361515102,
+            "end_position": 2286.516833610721,
+            "value": {
+              "value_type": "percentage",
+              "percentage": 13.02719840932256
+            },
+            "capacity_speed_limit": 3.4416022635242394,
+            "distribution": "MARECO"
+          }
+        ],
+        "initial_speed": 0,
+        "rolling_stock": "253"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fix #5730 

The reasoning is that running complex simulations with speed getting too close to 0 causes many issues, and it's not something we actually want to support.

Most of the changes are test changes to replace capacity speed limits set to 0. 