### PR TITLE
front: editor - Strange behaviour with the range editor.

### DIFF
--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -26,7 +26,6 @@ import { LinearMetadataDataviz } from 'common/IntervalsDataViz/dataviz';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { tooltipPosition, notEmpty } from 'common/IntervalsDataViz/utils';
 import HelpModal from './HelpModal';
-
 import { LinearMetadataTooltip } from './tooltip';
 import { FormBeginEndWidget } from './FormBeginEndWidget';
 import 'common/IntervalsDataViz/style.scss';

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -386,16 +386,18 @@ export const TrackEditionLeftPanel: FC = () => {
           );
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const operation = res[0] as EntityObjectOperationResult;
-          const { id } = operation.railjson;
+          const savedTrack = {
+            objType: 'TrackSection',
+            type: 'Feature',
+            properties: operation.railjson,
+            geometry: operation.railjson.geo,
+          } as TrackSectionEntity;
 
-          if (id && id !== savedEntity.properties.id) {
-            const savedTrack = { ...track, properties: { ...track.properties, id: `${id}` } };
-            setState({
-              ...state,
-              initialTrack: savedTrack,
-              track: savedTrack,
-            });
-          }
+          setState({
+            ...state,
+            initialTrack: savedTrack,
+            track: savedTrack,
+          });
         }}
         onChange={(newTrack) => {
           setState({ ...state, track: newTrack as TrackSectionEntity });


### PR DESCRIPTION
Close #5708 

Issue was related to a bad state between the data given by the API and the data we use in the form which is called "fixedData" (due to some algo that clean/fix the data given by the API, we have to clean linear metadata).

Previously, when we saved the track section, we sent to the backend the `fixedData` but the record of the data in the state was still the `data` (and not the `fixedData` one). 
So by doing multiple  "change & save" cycles without reload the full track section, we introduced an error.

Now, after every API call, we re-inject in the state the data returned by the API.

This is the scenario I used to reproduce the issue :

- split the track section in two segments. Make the left one with a value of `0`, and the other one with a value of `10` for example. 
- save
- select the right segment
- click on `merge in left`
- save
- click on the select tool
- (re)-select the track section and edit it 

You should still see two segment and not one .
