### PR TITLE
front: Intervals dataviz - fix issue on point value when zooming

### DIFF
--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -349,9 +349,10 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           setHoverAtx(e.clientX - (wrapperObject ? wrapperObject.getBoundingClientRect().x : 0));
 
           if (!draginStartAt && onMouseMove && wrapperObject) {
-            const point = getPositionFromMouseEvent(e, fullLength, wrapperObject);
+            const point =
+              (viewBox ? viewBox[0] : 0) + getPositionFromMouseEvent(e, fullLength, wrapperObject);
             const result = getHoveredItem(data, e.clientX);
-            if (result) {
+            if (point > 0 && result) {
               const { hoveredItem, hoveredItemIndex } = result;
               onMouseMove(e, hoveredItem, hoveredItemIndex, point);
             }
@@ -371,7 +372,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           <SimpleScale className="scale-y" begin={min} end={max} />
         )}
 
-        {!isNil(hoverAtx) && !draginStartAt && (
+        {!isNil(hoverAtx) && hoverAtx > 0 && !draginStartAt && (
           <div
             className="hover-x"
             style={{


### PR DESCRIPTION
Close #5710

I just added the viewbox start value to the point position on the `onMouseMove` of the container (Items already handle it).

Moreover, I saw that the hovered point can be negative (due to some margins on HTML elements), so I also added some checks for that