### PR TITLE
front: improves PSLs highlighting in editor

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -40,21 +40,27 @@ export const SpeedSectionEditionLayers: FC = () => {
   const { mapStyle, layersSettings, issuesSettings, showIGNBDORTHO } = useSelector(getMap);
   const infraId = useSelector(getInfraID);
   const selection = useMemo(() => {
+    const res: string[] = [entity.properties.id];
+
     // Dragging an extremity:
-    if (interactionState.type === 'moveRangeExtremity')
-      return [(entity.properties.track_ranges || [])[interactionState.rangeIndex].track];
+    if (interactionState.type === 'moveRangeExtremity') {
+      res.push((entity.properties.track_ranges || [])[interactionState.rangeIndex].track);
+    }
 
     // Custom hovered element:
-    if (hoveredItem?.speedSectionItemType) return [hoveredItem.track.properties.id];
+    else if (hoveredItem?.speedSectionItemType) {
+      res.push(hoveredItem.track.properties.id);
+    }
 
     // EditorEntity hovered element:
-    if (
+    else if (
       hoveredItem?.type === 'TrackSection' &&
       !(entity.properties.track_ranges || []).find((range) => range.track === hoveredItem.id)
-    )
-      return [hoveredItem.id];
+    ) {
+      res.push(hoveredItem.id);
+    }
 
-    return undefined;
+    return res;
   }, [interactionState, hoveredItem, entity]);
 
   const speedSectionsFeature: FeatureCollection = useMemo(() => {

--- a/front/src/common/Map/Consts/colors.ts
+++ b/front/src/common/Map/Consts/colors.ts
@@ -3,6 +3,14 @@ import { Theme } from '../../../types';
 const bpBg = '#405cb1';
 const bpMedium = '#98aedd';
 const bpLight = '#e4eaf6';
+const speedNone = '#b9b9b9';
+const speed30 = '#ef5151';
+const speed60 = '#fbb286';
+const speed100 = '#fdf479';
+const speed140 = '#e0fe64';
+const speed160 = '#9eff77';
+const speed220 = '#89f7d8';
+const speedOver220 = '#91d3ff';
 
 const colors: Record<string, Theme> = {
   normal: {
@@ -81,6 +89,7 @@ const colors: Record<string, Theme> = {
       detailhalo: '#ffffff',
       text: '#4d4f53',
       halo: '#ffffff',
+      color: '#747678',
     },
     radio: {
       text: '#5596c8',
@@ -116,6 +125,14 @@ const colors: Record<string, Theme> = {
       detailhalo: '#ffffff',
       text: '#4d4f53',
       halo: '#ffffff',
+      speedNone,
+      speed30,
+      speed60,
+      speed100,
+      speed140,
+      speed160,
+      speed220,
+      speedOver220,
     },
     station: {
       circle: '#555555',
@@ -233,6 +250,7 @@ const colors: Record<string, Theme> = {
       detailhalo: '#0b011d',
       text: '#3a86ff',
       halo: '#000000',
+      color: '#747678',
     },
     radio: {
       text: '#5596c8',
@@ -268,6 +286,14 @@ const colors: Record<string, Theme> = {
       detailhalo: '#0b011d',
       text: '#3a86ff',
       halo: '#000000',
+      speedNone,
+      speed30,
+      speed60,
+      speed100,
+      speed140,
+      speed160,
+      speed220,
+      speedOver220,
     },
     station: {
       circle: '#3a86ff',
@@ -377,6 +403,7 @@ const colors: Record<string, Theme> = {
       detailhalo: bpBg,
       text: bpLight,
       halo: bpBg,
+      color: '#747678',
     },
     radio: {
       text: bpMedium,
@@ -412,6 +439,14 @@ const colors: Record<string, Theme> = {
       detailhalo: bpBg,
       text: bpLight,
       halo: bpBg,
+      speedNone,
+      speed30,
+      speed60,
+      speed100,
+      speed140,
+      speed160,
+      speed220,
+      speedOver220,
     },
     station: {
       circle: bpLight,
@@ -521,6 +556,7 @@ const colors: Record<string, Theme> = {
       detailhalo: '#ffffff',
       text: '#4d4f53',
       halo: '#ffffff',
+      color: '#747678',
     },
     radio: {
       text: '#5596c8',
@@ -556,6 +592,14 @@ const colors: Record<string, Theme> = {
       detailhalo: '#ffffff',
       text: '#4d4f53',
       halo: '#ffffff',
+      speedNone,
+      speed30,
+      speed60,
+      speed100,
+      speed140,
+      speed160,
+      speed220,
+      speedOver220,
     },
     station: {
       circle: '#555555',

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -242,6 +242,9 @@ function getPSLSignsLayers(context: LayerContext, prefix: string): LayerProps[] 
 
 function getPSLLayers(context: LayerContext, prefix: string): LayerProps[] {
   const filter = getPSLFilter(context.layersSettings);
+  const bgProps = getPSLSpeedLineBGLayerProps(context);
+  const layerProps = getPSLSpeedLineLayerProps(context);
+
   return [
     {
       ...getPSLSpeedValueLayerProps(context),
@@ -249,13 +252,17 @@ function getPSLLayers(context: LayerContext, prefix: string): LayerProps[] {
       filter,
     },
     {
-      ...getPSLSpeedLineBGLayerProps(context),
+      ...bgProps,
       id: `${prefix}geo/psl-line-bg`,
+      paint: context.isEmphasized ? bgProps.paint : { ...bgProps.paint, 'line-width': 1 },
       filter,
     },
     {
-      ...getPSLSpeedLineLayerProps(context),
+      ...layerProps,
       id: `${prefix}geo/psl-line`,
+      paint: context.isEmphasized
+        ? layerProps.paint
+        : { ...layerProps.paint, 'line-width': 1, 'line-opacity': 0.2 },
       filter,
     },
   ];
@@ -387,7 +394,10 @@ const GeoJSONs: FC<{
   const infraID = useSelector(getInfraID);
   const selectedPrefix = `${prefix}selected/`;
   const hiddenColors = useMemo(
-    () => transformTheme(colors, (color) => chroma(color).desaturate(50).brighten(1).hex()),
+    () =>
+      transformTheme(colors, (color) =>
+        chroma.average([color, colors.background.color], 'lab', [1.5, 1]).hex()
+      ),
     [colors]
   );
 

--- a/front/src/common/Map/Layers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/SpeedLimits.tsx
@@ -44,10 +44,11 @@ export function getSpeedSectionsFilter(
 }
 
 export function getSpeedSectionsLineLayerProps({
+  colors,
   sourceTable,
   layersSettings,
 }: {
-  colors?: Theme;
+  colors: Theme;
   sourceTable?: string;
   layersSettings: MapState['layersSettings'];
 }): OmitLayer<LineLayer> {
@@ -68,20 +69,20 @@ export function getSpeedSectionsLineLayerProps({
         [
           'case',
           ['all', ['>', ['var', 'speed_limit'], 220]],
-          'rgba(145, 211, 255, 1)',
+          colors.speed.speedOver220,
           ['all', ['>', ['var', 'speed_limit'], 160], ['<=', ['var', 'speed_limit'], 220]],
-          'rgba(137, 247, 216, 1)',
+          colors.speed.speed220,
           ['all', ['>=', ['var', 'speed_limit'], 140], ['<=', ['var', 'speed_limit'], 160]],
-          'rgba(158, 255, 119, 1)',
+          colors.speed.speed160,
           ['all', ['>=', ['var', 'speed_limit'], 100], ['<', ['var', 'speed_limit'], 140]],
-          'rgba(224, 254, 100, 1)',
+          colors.speed.speed140,
           ['all', ['>', ['var', 'speed_limit'], 60], ['<', ['var', 'speed_limit'], 100]],
-          'rgba(253, 244, 121, 1)',
+          colors.speed.speed100,
           ['all', ['<=', ['var', 'speed_limit'], 60], ['>', ['var', 'speed_limit'], 30]],
-          'rgba(251, 178, 134, 1)',
+          colors.speed.speed60,
           ['all', ['<=', ['var', 'speed_limit'], 30]],
-          'rgba(239, 81, 81, 1)',
-          'rgba(185, 185, 185, 1)',
+          colors.speed.speed30,
+          colors.speed.speedNone,
         ],
       ],
       'line-width': 4,

--- a/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/SNCF_PSL.tsx
@@ -71,9 +71,10 @@ export function getPSLSpeedValueLayerProps({
 }
 
 export function getPSLSpeedLineBGLayerProps({
+  colors,
   sourceTable,
 }: {
-  colors?: Theme;
+  colors: Theme;
   sourceTable?: string;
   layersSettings?: MapState['layersSettings'];
 }): OmitLayer<LineLayer> {
@@ -86,7 +87,7 @@ export function getPSLSpeedLineBGLayerProps({
       'line-cap': ['step', ['zoom'], 'round', 15, 'square'],
     },
     paint: {
-      'line-color': '#747678',
+      'line-color': colors.psl.color,
       'line-width': 3,
       'line-offset': 0,
       'line-opacity': 1,
@@ -100,10 +101,11 @@ export function getPSLSpeedLineBGLayerProps({
 }
 
 export function getPSLSpeedLineLayerProps({
+  colors,
   sourceTable,
   layersSettings,
 }: {
-  colors?: Theme;
+  colors: Theme;
   sourceTable?: string;
   layersSettings: MapState['layersSettings'];
 }): OmitLayer<LineLayer> {
@@ -123,20 +125,20 @@ export function getPSLSpeedLineLayerProps({
         [
           'case',
           ['all', ['>', ['var', 'speed_limit'], 220]],
-          'rgba(145, 211, 255, 1)',
+          colors.speed.speedOver220,
           ['all', ['>', ['var', 'speed_limit'], 160], ['<=', ['var', 'speed_limit'], 220]],
-          'rgba(137, 247, 216, 1)',
+          colors.speed.speed220,
           ['all', ['>=', ['var', 'speed_limit'], 140], ['<=', ['var', 'speed_limit'], 160]],
-          'rgba(158, 255, 119, 1)',
+          colors.speed.speed160,
           ['all', ['>=', ['var', 'speed_limit'], 100], ['<', ['var', 'speed_limit'], 140]],
-          'rgba(224, 254, 100, 1)',
+          colors.speed.speed140,
           ['all', ['>', ['var', 'speed_limit'], 60], ['<', ['var', 'speed_limit'], 100]],
-          'rgba(253, 244, 121, 1)',
+          colors.speed.speed100,
           ['all', ['<=', ['var', 'speed_limit'], 60], ['>', ['var', 'speed_limit'], 30]],
-          'rgba(251, 178, 134, 1)',
+          colors.speed.speed60,
           ['all', ['<=', ['var', 'speed_limit'], 30]],
-          'rgba(239, 81, 81, 1)',
-          'rgba(185, 185, 185, 1)',
+          colors.speed.speed30,
+          colors.speed.speedNone,
         ],
       ],
       'line-width': 3,


### PR DESCRIPTION
Fix #5799.

Details:
- Moves hardcoded speed colors from SpeedLimits.tsx and SNCF_PSL.tsx to colors.ts (so that they are transformed by transformTheme in GeoJSONs.tsx)
- Always adds edited entity ID to selection in SpeedSectionEditionLayers so that GeoJSONs always draws everything else as unemphasized
- Improves the transformTheme call in GeoJSONs.tsx, so that bright colors are not always turned to white (the old formula was not working well with the speed colors)