### PR TITLE
Sba/front/fix pathfinding error after inversion

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -1,5 +1,5 @@
 {
-  "addVias": "Add stops or waypoints",
+  "addVias": "Add waypoints",
   "addTrainSchedule": "Add one or several trains",
   "apply": "Apply",
   "blocktype": "Signalling block type",
@@ -11,6 +11,7 @@
   "chooseOnMap": "Choose on the map",
   "composition": "Composition",
   "deleteVias": "Delete steps",
+  "deleteRoute": "Delete the route",
   "destination": "Destination",
   "errorMessages": {
     "allowance_convergence": "We could not go slow enough in this setting to match the given allowance time",
@@ -54,7 +55,7 @@
   "infraLoading": "Infrastructure is loading…",
   "inputOPTrigrams": "Enter the trigrams of operational points you want to the path to go through, separated by a space.",
   "inputOPTrigramsExample": "Ex: LSN CIG CCS",
-  "inverseOD": "Reverse origin/destination",
+  "inverseOD": "Reverse itinerary",
   "launchSimulation": "Start",
   "manageVias": "Steps management",
   "maximumRunTime": "Maximum running time",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -1,5 +1,5 @@
 {
-  "addVias": "Ajouter d'arrêts ou points de passage",
+  "addVias": "Ajout de vias",
   "addTrainSchedule": "Ajouter un ou plusieurs trains",
   "apply": "Appliquer",
   "blocktype": "Type de block",
@@ -10,6 +10,7 @@
   "cancelRequest": "Annuler la requête",
   "chooseOnMap": "Choisir sur la carte",
   "composition": "Composition",
+  "deleteRoute": "Supprimer l'itinéraire",
   "deleteVias": "Supprimer les étapes",
   "destination": "Destination",
   "errorMessages": {
@@ -54,7 +55,7 @@
   "infraLoading": "Infra en cours de chargement…",
   "inputOPTrigrams": "Entrez les trigrammes des points remarquables par lesquels vous voulez que l'itinéraire se fasse, séparés par un espace.",
   "inputOPTrigramsExample": "Ex : LSN CIG CCS",
-  "inverseOD": "Inverser origine/destination",
+  "inverseOD": "Inverser l'itinéraire",
   "launchSimulation": "Démarrer",
   "manageVias": "Gestion des étapes",
   "maximumRunTime": "Temps de parcours maximum",

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -102,9 +102,9 @@ export default function ManageTrainSchedule() {
     label: t('tabs.pathFinding'),
     content: (
       <div className="osrd-config-item-container-map" data-testid="map">
-        <span className="floating-itinerary">
+        <div className="floating-itinerary">
           <Itinerary path={pathFinding} />
-        </span>
+        </div>
         <Map />
       </div>
     ),

--- a/front/src/common/Pathfinding/Pathfinding.tsx
+++ b/front/src/common/Pathfinding/Pathfinding.tsx
@@ -124,7 +124,7 @@ export function reducer(state: PathfindingState, action: Action): PathfindingSta
         state.running ||
         (action.type === 'INFRA_CHANGED' && action.params.pathfindingId)
       ) {
-        return state;
+        return { ...state };
       }
       const { origin, destination, rollingStockID } = action.params;
       if (!origin || !destination || !Number.isInteger(rollingStockID)) {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayItinerary/Vias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayItinerary/Vias.tsx
@@ -2,37 +2,21 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
-
 import DisplayVias from 'modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayVias';
-import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
-import { getGeojson, getVias } from 'reducers/osrdconf/selectors';
-import { FaPlus } from 'react-icons/fa';
+import { getVias } from 'reducers/osrdconf/selectors';
 
 interface ViasProps {
   zoomToFeaturePoint: (lngLat?: Position, id?: string) => void;
-  viaModalContent: JSX.Element;
 }
 
 function Vias(props: ViasProps) {
-  const { zoomToFeaturePoint, viaModalContent } = props;
+  const { zoomToFeaturePoint } = props;
   const vias = useSelector(getVias);
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const geojson = useSelector(getGeojson);
-  const { openModal } = useModal();
 
   return (
     <div data-testid="itinerary-vias">
-      {geojson && (
-        <button
-          className="btn btn-link text-cyan w-100 justify-content-center btn-sm"
-          type="button"
-          onClick={() => openModal(viaModalContent)}
-        >
-          <span className="mr-2">{t('addVias')}</span>
-          <FaPlus />
-        </button>
-      )}
-      <div className="vias-list">
+      <div className="vias-list mb-2">
         {vias && vias.length > 0 ? (
           <DisplayVias zoomToFeaturePoint={zoomToFeaturePoint} />
         ) : (

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayItinerary/index.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayItinerary/index.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
 import { Position } from 'geojson';
-
 import Origin from './Origin';
 import Vias from './Vias';
 import Destination from './Destination';
 
 interface DisplayItineraryProps {
   zoomToFeaturePoint: (lngLat?: Position, id?: string) => void;
-  viaModalContent: JSX.Element;
 }
 
 export default function DisplayItinerary(props: DisplayItineraryProps) {
-  const { zoomToFeaturePoint, viaModalContent } = props;
+  const { zoomToFeaturePoint } = props;
 
   return (
     <div data-testid="display-itinerary">
       <Origin zoomToFeaturePoint={zoomToFeaturePoint} />
-      <Vias zoomToFeaturePoint={zoomToFeaturePoint} viaModalContent={viaModalContent} />
+      <Vias zoomToFeaturePoint={zoomToFeaturePoint} />
       <Destination zoomToFeaturePoint={zoomToFeaturePoint} />
     </div>
   );

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
@@ -1,8 +1,6 @@
 import React, { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { GoTrash } from 'react-icons/go';
-import { FaLongArrowAltUp, FaLongArrowAltDown, FaMinus } from 'react-icons/fa';
 
 import { replaceVias } from 'reducers/osrdconf';
 import { getSuggeredVias, getVias } from 'reducers/osrdconf/selectors';
@@ -14,9 +12,9 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { Spinner } from 'common/Loader';
 import { ArrayElement } from 'utils/types';
 import { Path, PathStep } from 'common/api/osrdEditoastApi';
+import { GoDash, GoPlus, GoTrash } from 'react-icons/go';
 
 type Props = {
-  inverseOD: () => void;
   removeAllVias: () => void;
   pathfindingInProgress?: boolean;
 };
@@ -25,11 +23,7 @@ function LoaderPathfindingInProgress() {
   return <Spinner className="loaderPathfindingInProgress" />;
 }
 
-export default function ModalSugerredVias({
-  inverseOD,
-  removeAllVias,
-  pathfindingInProgress,
-}: Props) {
+export default function ModalSugerredVias({ removeAllVias, pathfindingInProgress }: Props) {
   const dispatch = useDispatch();
   const suggeredVias = useSelector(getSuggeredVias) as PathStep[];
   const vias = useSelector(getVias);
@@ -81,7 +75,7 @@ export default function ModalSugerredVias({
           type="button"
           onClick={() => convertPathfindingVias(suggeredVias, idx - 1)}
         >
-          <i className="icons-add" />
+          <GoPlus />
         </button>
       ) : (
         <button
@@ -89,7 +83,7 @@ export default function ModalSugerredVias({
           type="button"
           onClick={() => removeViaFromPath(via)}
         >
-          <FaMinus color="white" />
+          <GoDash color="white" />
         </button>
       )}
     </div>
@@ -118,24 +112,15 @@ export default function ModalSugerredVias({
         </div>
       </ModalBodySNCF>
       <ModalFooterSNCF>
-        <div className="row">
-          <div className="col-12">
-            <button
-              className="btn btn-danger btn-sm btn-block mb-1"
-              type="button"
-              onClick={removeAllVias}
-            >
-              <GoTrash />
-              <span className="ml-2">{t('deleteVias')}</span>
-            </button>
-          </div>
-          <div className="col-12">
-            <button className="btn btn-warning btn-sm btn-block" type="button" onClick={inverseOD}>
-              <FaLongArrowAltUp />
-              <FaLongArrowAltDown />
-              <span className="ml-2">{t('inverseOD')}</span>
-            </button>
-          </div>
+        <div className="w-100 mt-2 mb-n2">
+          <button
+            className="btn btn-danger btn-sm btn-block mb-1"
+            type="button"
+            onClick={removeAllVias}
+          >
+            <GoTrash />
+            <span className="ml-2">{t('deleteVias')}</span>
+          </button>
         </div>
       </ModalFooterSNCF>
     </div>

--- a/front/src/reducers/osrdconf/index.ts
+++ b/front/src/reducers/osrdconf/index.ts
@@ -55,6 +55,7 @@ export const UPDATE_VIA_STOPTIME = 'osrdconf/UPDATE_VIA_STOPTIME';
 export const PERMUTE_VIAS = 'osrdconf/PERMUTE_VIAS';
 export const UPDATE_SUGGERED_VIAS = 'osrdconf/UPDATE_SUGGERED_VIAS';
 export const DELETE_VIAS = 'osrdconf/DELETE_VIAS';
+export const CLEAR_VIAS = 'osrdconf/CLEAR_VIAS';
 export const DELETE_ITINERARY = 'osrdconfDELETE_ITINERARY';
 export const UPDATE_DESTINATION = 'osrdconf/UPDATE_DESTINATION';
 export const UPDATE_DESTINATION_TIME = 'osrdconf/UPDATE_UPDATE_DESTINATION_TIME';
@@ -278,6 +279,9 @@ export default function reducer(inputState: OsrdMultiConfState | undefined, acti
         break;
       case DELETE_VIAS:
         draft[section].vias.splice(action.index, 1);
+        break;
+      case CLEAR_VIAS:
+        draft[section].vias = action.vias;
         break;
       case DELETE_ITINERARY:
         draft[section].origin = undefined;
@@ -607,6 +611,14 @@ export function deleteVias(index: number) {
     dispatch({
       type: DELETE_VIAS,
       index,
+    });
+  };
+}
+export function clearVias() {
+  return (dispatch: Dispatch) => {
+    dispatch({
+      type: CLEAR_VIAS,
+      vias: [],
     });
   };
 }

--- a/front/src/styles/scss/common/_common.scss
+++ b/front/src/styles/scss/common/_common.scss
@@ -29,13 +29,12 @@
   padding: 0.5rem;
   height: 100%;
 
-  .floating-itinerary  {
+  .floating-itinerary {
     position: absolute;
     z-index: 1;
     top: 1rem;
     left: 1rem;
     max-height: calc(100% - 2rem);
-    overflow: auto;
   }
 
   // à creuser
@@ -157,7 +156,7 @@
 }
 
 .shadow {
-  box-shadow:  0 .5rem 1rem rgba(#000, .15);
+  box-shadow: 0 0.5rem 1rem rgba(#000, 0.15);
 }
 
 svg text {

--- a/front/src/styles/scss/common/components/_pathfinding.scss
+++ b/front/src/styles/scss/common/components/_pathfinding.scss
@@ -22,13 +22,13 @@
       border: none;
       background-color: transparent;
     }
-
     &.via {
       display: flex;
       align-items: center;
       margin-bottom: 0rem;
-      border-radius: 4px;
-      padding-left: 0.25rem;
+      padding: 0 0 0 0.65rem;
+      margin: 0 0.9rem 0 0.75rem;
+      border-right: 1px solid #30338375;
       .ring {
         position: relative;
         display: block;


### PR DESCRIPTION
Closes #5719 

In this PR ⬇️ 

- The button to invert an itinerary has been moved out of the ModalSuggeredVias component.
- I added a function to clear the vias list in the store when we remove the origin / destination points to avoid an error after relaunching the pathfinding.

Actual behavior :

https://github.com/osrd-project/osrd/assets/103027832/40301127-c73b-45ef-abba-69fc81e5f6b4

New behavior : 

https://github.com/osrd-project/osrd/assets/103027832/5345bd85-8815-4089-bc34-b9d871608918


