### PR TITLE
front: review map's style

### DIFF
--- a/front/src/applications/editor/tools/pointEdition/components.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components.tsx
@@ -428,6 +428,7 @@ export const BasePointEditionLayers: FC<{
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
+        editor
       />
 
       {/* Edited entity */}

--- a/front/src/applications/editor/tools/rangeEdition/catenary/CatenaryEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/catenary/CatenaryEditionLayers.tsx
@@ -189,6 +189,7 @@ export const CatenaryEditionLayers: FC = () => {
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
         isEmphasized={false}
+        editor
       />
       <Source type="geojson" data={catenariesFeature} key="catenaries">
         {layersProps.map((props, i) => (

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -225,6 +225,7 @@ export const SpeedSectionEditionLayers: FC = () => {
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
         isEmphasized={false}
+        editor
       />
       <Source type="geojson" data={speedSectionsFeature} key={isPSL ? 'psl' : 'speed-section'}>
         {layersProps.map((props, i) => (

--- a/front/src/applications/editor/tools/routeEdition/components.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components.tsx
@@ -60,6 +60,7 @@ export const RouteEditionLayers: FC = () => {
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
+        editor
       />
       {state.type === 'editRoutePath' ? (
         <EditRoutePathEditionLayers key="editRoutePath" state={state} />

--- a/front/src/applications/editor/tools/selection/components.tsx
+++ b/front/src/applications/editor/tools/selection/components.tsx
@@ -67,6 +67,7 @@ export const SelectionLayers: FC = () => {
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
+        editor
       />
       <SelectionZone newZone={selectionZone} />
       {state.mousePosition && state.selectionState.type === 'single' && state.hovered && (

--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -287,6 +287,7 @@ export const SwitchEditionLayers: FC = () => {
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
+        editor
       />
 
       {/* Edited switch */}

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -245,6 +245,7 @@ export const TrackEditionLayers: FC = () => {
         fingerprint={renderingFingerprint}
         layersSettings={layersSettings}
         issuesSettings={issuesSettings}
+        editor
       />
 
       {/* Track path */}

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -7,13 +7,27 @@ import { MAP_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import { getLayersSettings } from 'reducers/map/selectors';
 
-export function getBufferStopsLayerProps(params: { sourceTable?: string }): OmitLayer<SymbolLayer> {
+export function getBufferStopsLayerProps(params: {
+  sourceTable?: string;
+  editor?: boolean;
+}): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
     minzoom: 12,
     layout: {
-      'text-field': '{extensions_sncf_kp}',
+      'text-field': !params.editor
+        ? '{extensions_sncf_kp}'
+        : [
+            'format',
+            ['get', 'id'],
+            { 'font-scale': 1 },
+            '\n',
+            {},
+            ['get', 'extensions_sncf_kp'],
+            { 'font-scale': 0.8 },
+          ],
       'text-font': ['Roboto Condensed'],
+      'text-justify': 'left',
       'text-size': 10,
       'text-offset': [1, 0.2],
       'icon-image': 'HEURTOIR',

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -29,14 +29,26 @@ export function getDetectorsLayerProps(params: {
 export function getDetectorsNameLayerProps(params: {
   colors: Theme;
   sourceTable?: string;
+  editor?: boolean;
 }): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
     minzoom: 8,
     layout: {
-      'text-field': '{extensions_sncf_kp}',
+      'text-field': !params.editor
+        ? '{extensions_sncf_kp}'
+        : [
+            'format',
+            ['get', 'id'],
+            { 'font-scale': 1 },
+            '\n',
+            {},
+            ['get', 'extensions_sncf_kp'],
+            { 'font-scale': 0.8 },
+          ],
       'text-font': ['Roboto Condensed'],
       'text-size': 10,
+      'text-justify': 'left',
       'text-anchor': 'left',
       'text-allow-overlap': false,
       'text-ignore-placement': false,

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -371,6 +371,8 @@ const GeoJSONs: FC<{
   beforeId?: string;
   // When true, all layers are rendered (ie "minZoom" restrictions are ignored)
   renderAll?: boolean;
+  // Is used in the editor ?
+  editor?: boolean;
 }> = ({
   colors,
   layersSettings,
@@ -383,6 +385,7 @@ const GeoJSONs: FC<{
   isEmphasized = true,
   beforeId,
   renderAll,
+  editor,
 }) => {
   const infraID = useSelector(getInfraID);
   const selectedPrefix = `${prefix}selected/`;
@@ -434,7 +437,10 @@ const GeoJSONs: FC<{
                 url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${infraID}`,
                 layerOrder: LAYER_ENTITIES_ORDERS[source.entityType],
                 layers: source
-                  .getLayers({ ...hiddenLayerContext, sourceTable: source.entityType }, prefix)
+                  .getLayers(
+                    { ...hiddenLayerContext, sourceTable: source.entityType, editor },
+                    prefix
+                  )
                   .map((layer) =>
                     adaptFilter(layer, (hidden || []).concat(selection || []), [], renderAll)
                   ),
@@ -444,7 +450,10 @@ const GeoJSONs: FC<{
                 url: `${MAP_URL}/layer/${source.entityType}/mvt/geo/?infra=${infraID}`,
                 layerOrder: LAYER_ENTITIES_ORDERS[source.entityType],
                 layers: source
-                  .getLayers({ ...layerContext, sourceTable: source.entityType }, selectedPrefix)
+                  .getLayers(
+                    { ...layerContext, sourceTable: source.entityType, editor },
+                    selectedPrefix
+                  )
                   .map((layer) => adaptFilter(layer, hidden || [], selection || [], renderAll)),
               },
             ]
@@ -466,6 +475,7 @@ const GeoJSONs: FC<{
   if (skipSources) {
     return null;
   }
+
   return (
     <>
       {sources.map((source) => (

--- a/front/src/common/Map/Layers/Switches.tsx
+++ b/front/src/common/Map/Layers/Switches.tsx
@@ -30,13 +30,25 @@ export function getSwitchesLayerProps(params: {
 export function getSwitchesNameLayerProps(params: {
   colors: Theme;
   sourceTable?: string;
+  editor?: boolean;
 }): OmitLayer<SymbolLayer> {
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
     minzoom: 8,
     layout: {
-      'text-field': '{label}',
+      'text-field': !params.editor
+        ? '{extensions_sncf_label}'
+        : [
+            'format',
+            ['get', 'id'],
+            { 'font-scale': 1 },
+            '\n',
+            {},
+            ['get', 'extensions_sncf_label'],
+            { 'font-scale': 0.8 },
+          ],
       'text-font': ['Roboto Condensed'],
+      'text-justify': 'left',
       'text-size': 12,
       'text-anchor': 'left',
       'text-allow-overlap': false,

--- a/front/src/common/Map/Layers/commonLayers.ts
+++ b/front/src/common/Map/Layers/commonLayers.ts
@@ -7,6 +7,7 @@ export function trackNameLayer(colors: Theme): OmitLayer<SymbolLayer> {
     layout: {
       'text-font': ['Roboto Condensed'],
       'symbol-placement': 'line',
+      'symbol-spacing': 750,
       'text-size': 12,
       // [jacomyal]
       // According to TS types, 'text-allow-overlap' should be a boolean or
@@ -35,6 +36,7 @@ export function lineNameLayer(colors: Theme): OmitLayer<SymbolLayer> {
     layout: {
       'text-font': ['Roboto Condensed'],
       'symbol-placement': 'line-center',
+      'symbol-spacing': 750,
       'text-field': '{line_name}',
       'text-size': 10,
       'text-offset': [0, 0.75],
@@ -55,6 +57,7 @@ export function lineNumberLayer(colors: Theme): OmitLayer<SymbolLayer> {
     layout: {
       'text-font': ['Roboto Condensed'],
       'symbol-placement': 'line',
+      'symbol-spacing': 750,
       'text-size': 10,
       'text-offset': [0, 0.5],
     },

--- a/front/src/common/Map/Layers/types.ts
+++ b/front/src/common/Map/Layers/types.ts
@@ -7,4 +7,5 @@ export interface LayerContext extends SignalContext {
   showIGNBDORTHO: boolean;
   layersSettings: MapState['layersSettings'];
   issuesSettings?: MapState['issuesSettings'];
+  editor?: boolean;
 }


### PR DESCRIPTION
Close #5519

On all maps:
- increase spacing between two track section label
- fix the label for switches

On editor:
- display the id for detectors /  buffer stop & switch
