### PR TITLE
editoast: migrate /auto_fixes to use utoipa

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1029,9 +1029,36 @@ components:
       type: string
     Operation:
       oneOf:
-      - $ref: '#/components/schemas/RailjsonObject'
-      - $ref: '#/components/schemas/DeleteOperation'
-      - $ref: '#/components/schemas/UpdateOperation'
+      - allOf:
+        - $ref: '#/components/schemas/RailjsonObject'
+        - properties:
+            operation_type:
+              enum:
+              - CREATE
+              type: string
+          required:
+          - operation_type
+          type: object
+      - allOf:
+        - $ref: '#/components/schemas/UpdateOperation'
+        - properties:
+            operation_type:
+              enum:
+              - UPDATE
+              type: string
+          required:
+          - operation_type
+          type: object
+      - allOf:
+        - $ref: '#/components/schemas/DeleteOperation'
+        - properties:
+            operation_type:
+              enum:
+              - DELETE
+              type: string
+          required:
+          - operation_type
+          type: object
     OperationObject:
       properties:
         obj_type:
@@ -3886,27 +3913,6 @@ paths:
                 type: object
           description: All objects attached to the given track (arranged by types)
       summary: Retrieve all objects attached to a given track
-  /infra/{id}/auto_fixes/:
-    get:
-      parameters:
-      - description: infra id
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/Operation'
-                type: array
-          description: A list of operations
-      summary: Retrieve a list of suggested operations to fix issues
-      tags:
-      - infra
   /infra/{id}/clone/:
     post:
       parameters:
@@ -4389,6 +4395,29 @@ paths:
                 type: array
           description: Voltages list
       summary: List all voltages
+      tags:
+      - infra
+  /infra/{infra_id}/auto_fixes/:
+    get:
+      description: Retrieve a list of operations to fix infra issues
+      parameters:
+      - description: The ID of the infra to fix
+        in: path
+        name: infra_id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Operation'
+                type: array
+          description: The list of suggested operations
+      summary: Retrieve a list of operations to fix infra issues
       tags:
       - infra
   /layers/layer/{layer_slug}/mvt/{view_slug}/:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -312,28 +312,6 @@ paths:
                     items:
                       $ref: "#/components/schemas/InfraError"
 
-  /infra/{id}/auto_fixes/:
-    get:
-      tags:
-        - infra
-      summary: Retrieve a list of suggested operations to fix issues
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: infra id
-          required: true
-      responses:
-        200:
-          description: A list of operations
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Operation"
-
   /infra/{id}/switch_types/:
     get:
       tags:
@@ -1115,12 +1093,6 @@ components:
           type: array
         detectors:
           type: array
-
-    Operation:
-      oneOf:
-        - $ref: "#/components/schemas/RailjsonObject"
-        - $ref: "#/components/schemas/DeleteOperation"
-        - $ref: "#/components/schemas/UpdateOperation"
 
     OperationResult:
       oneOf:

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -49,6 +49,7 @@ use self::utils::{Identifier, NonBlankString};
 
 crate::schemas! {
     rolling_stock::schemas(),
+    operation::schemas(),
 }
 
 /// This trait should be implemented by all struct that represents an OSRD type.

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -8,15 +8,19 @@ use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use utoipa::ToSchema;
 
 pub use self::delete::DeleteOperation;
 pub use create::RailjsonObject;
 pub use update::UpdateOperation;
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+crate::schemas! { Operation, }
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(tag = "operation_type", deny_unknown_fields)]
 pub enum Operation {
     #[serde(rename = "CREATE")]
+    #[schema(value_type = RailjsonObject)]
     Create(Box<RailjsonObject>),
     #[serde(rename = "UPDATE")]
     Update(UpdateOperation),

--- a/editoast/src/views/infra/auto_fixes.rs
+++ b/editoast/src/views/infra/auto_fixes.rs
@@ -8,8 +8,8 @@ use crate::schema::operation::{DeleteOperation, Operation};
 use crate::schema::{
     InfraError, InfraErrorType, OSRDIdentified, OSRDObject, ObjectRef, ObjectType,
 };
+use crate::views::infra::InfraIdParam;
 use crate::DbPool;
-use actix_web::dev::HttpServiceFactory;
 use actix_web::get;
 use actix_web::web::{Data, Json as WebJson, Path};
 use chashmap::CHashMap;
@@ -19,13 +19,18 @@ use thiserror::Error;
 
 const MAX_AUTO_FIXES_ITERATIONS: u8 = 5;
 
-/// Return `/infra/<infra_id>/auto_fixes` routes
-pub fn routes() -> impl HttpServiceFactory {
-    list_auto_fixes
-}
+// Return `/infra/<infra_id>/auto_fixes` routes
+crate::routes! {"/infra/{infra_id}/auto_fixes" => { list_auto_fixes, } } // TODO:  move it to infra when migrated (and un-pub module)
 
-/// Return the list of suggestions to fix infra errors
-#[get("/auto_fixes")]
+/// Retrieve a list of operations to fix infra issues
+#[utoipa::path(
+    tag = "infra",
+    params(InfraIdParam),
+    responses(
+        (status = 200, description = "The list of suggested operations", body = Vec<Operation>)
+    )
+)]
+#[get("")]
 async fn list_auto_fixes(
     infra: Path<i64>,
     infra_caches: Data<CHashMap<i64, InfraCache>>,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -1,5 +1,5 @@
 mod attached;
-mod auto_fixes;
+pub mod auto_fixes;
 mod edition;
 mod errors;
 mod lines;
@@ -38,6 +38,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use thiserror::Error;
+use utoipa::IntoParams;
 use uuid::Uuid;
 
 /// Return `/infra` routes
@@ -68,7 +69,6 @@ pub fn routes() -> impl HttpServiceFactory {
                 ))
                 .service((
                     errors::routes(),
-                    auto_fixes::routes(),
                     objects::routes(),
                     lines::routes(),
                     routes::routes(),
@@ -238,6 +238,13 @@ struct InfraWithState {
     #[serde(flatten)]
     pub infra: Infra,
     pub state: InfraState,
+}
+
+#[derive(IntoParams)]
+#[allow(unused)]
+struct InfraIdParam {
+    /// The ID of the infra to fix
+    infra_id: i64,
 }
 
 /// Return a specific infra

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -31,6 +31,7 @@ use actix_web::dev::HttpServiceFactory;
 use actix_web::web::{Data, Json};
 use actix_web::{get, services};
 use diesel::sql_query;
+use infra::auto_fixes;
 use redis::cmd;
 use serde_derive::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
@@ -41,7 +42,7 @@ use utoipa::{OpenApi, ToSchema};
 fn routes_v2() -> Routes<impl HttpServiceFactory> {
     crate::routes! {
         (health, version, core_version),
-        timetable::routes(),
+        (timetable::routes(),
         documents::routes(),
         sprites::routes(),
         pathfinding::routes(),
@@ -52,6 +53,7 @@ fn routes_v2() -> Routes<impl HttpServiceFactory> {
         light_rolling_stocks::routes(),
         electrical_profiles::routes(),
         layers::routes(),
+        auto_fixes::routes()),
     }
     routes()
 }

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -159,13 +159,6 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({ url: `/infra/${queryArg.id}/attached/${queryArg.trackId}/` }),
       }),
-      getInfraByIdAutoFixes: build.query<
-        GetInfraByIdAutoFixesApiResponse,
-        GetInfraByIdAutoFixesApiArg
-      >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.id}/auto_fixes/` }),
-        providesTags: ['infra'],
-      }),
       postInfraByIdClone: build.mutation<PostInfraByIdCloneApiResponse, PostInfraByIdCloneApiArg>({
         query: (queryArg) => ({
           url: `/infra/${queryArg.id}/clone/`,
@@ -280,6 +273,13 @@ const injectedRtkApi = api
           url: `/infra/${queryArg.id}/voltages/`,
           params: { include_rolling_stock_modes: queryArg.includeRollingStockModes },
         }),
+        providesTags: ['infra'],
+      }),
+      getInfraByInfraIdAutoFixes: build.query<
+        GetInfraByInfraIdAutoFixesApiResponse,
+        GetInfraByInfraIdAutoFixesApiArg
+      >({
+        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/auto_fixes/` }),
         providesTags: ['infra'],
       }),
       getLayersLayerByLayerSlugMvtAndViewSlug: build.query<
@@ -829,11 +829,6 @@ export type GetInfraByIdAttachedAndTrackIdApiArg = {
   /** Track ID */
   trackId: string;
 };
-export type GetInfraByIdAutoFixesApiResponse = /** status 200 A list of operations */ Operation[];
-export type GetInfraByIdAutoFixesApiArg = {
-  /** infra id */
-  id: number;
-};
 export type PostInfraByIdCloneApiResponse = /** status 201 The duplicated infra id */ {
   id?: number;
 };
@@ -966,6 +961,12 @@ export type GetInfraByIdVoltagesApiArg = {
   id: number;
   /** include rolling stocks modes or not */
   includeRollingStockModes?: boolean;
+};
+export type GetInfraByInfraIdAutoFixesApiResponse =
+  /** status 200 The list of suggested operations */ Operation[];
+export type GetInfraByInfraIdAutoFixesApiArg = {
+  /** The ID of the infra to fix */
+  infraId: number;
 };
 export type GetLayersLayerByLayerSlugMvtAndViewSlugApiResponse =
   /** status 200 Successful Response */ {
@@ -1423,7 +1424,16 @@ export type UpdateOperation = {
   operation_type: 'UPDATE';
   railjson_patch: Patches;
 };
-export type Operation = RailjsonObject | DeleteOperation | UpdateOperation;
+export type Operation =
+  | (RailjsonObject & {
+      operation_type: 'CREATE';
+    })
+  | (UpdateOperation & {
+      operation_type: 'UPDATE';
+    })
+  | (DeleteOperation & {
+      operation_type: 'DELETE';
+    });
 export type Point3D = number[];
 export type Point = {
   coordinates: Point3D;


### PR DESCRIPTION
Only partial migration (especially not all the /infra endpoints and RailjsonObjects)

After https://github.com/osrd-project/osrd/pull/5673#discussion_r1392765489 (TODO 2. of the main comment)