### PR TITLE
core: improve distance typing in STDCM and pathfinding modules

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -17,7 +17,6 @@
 package fr.sncf.osrd.utils.units
 
 import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
-import kotlin.math.abs
 import kotlin.math.absoluteValue
 
 @JvmInline
@@ -89,6 +88,15 @@ value class Offset<T>(val distance: Distance) : Comparable<Offset<T>> {
 
     override fun toString(): String {
         return distance.toString()
+    }
+
+    /** Utility function to convert an offset type to another.
+     * It still needs to be called explicitly, but avoids verbose syntaxes on conversions */
+    fun <U> cast(): Offset<U> = Offset(distance)
+
+    companion object {
+        fun <T> min(a: Offset<T>, b: Offset<T>) = Offset<T>(Distance.min(a.distance, b.distance))
+        fun <T> max(a: Offset<T>, b: Offset<T>) = Offset<T>(Distance.max(a.distance, b.distance))
     }
 }
 

--- a/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
+++ b/core/src/main/java/fr/sncf/osrd/railjson/parser/RJSStopsParser.java
@@ -4,6 +4,7 @@ import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import fr.sncf.osrd.sim_infra.api.PathProperties;
+import fr.sncf.osrd.sim_infra.api.PathPropertiesKt;
 import fr.sncf.osrd.sim_infra.api.RawSignalingInfra;
 import fr.sncf.osrd.train.TrainStop;
 import fr.sncf.osrd.utils.units.Distance;
@@ -27,10 +28,8 @@ public class RJSStopsParser {
             if (stop.position != null)
                 positionMM = Distance.fromMeters(stop.position);
             else {
-                var offset = path.getTrackLocationOffset(RJSTrackLocationParser.parse(infra, stop.location));
-                if (offset == null)
-                    throw new OSRDError(ErrorType.InvalidScheduleTrackLocationNotIncludedInPath);
-                positionMM = offset.getMillimeters();
+                positionMM = PathPropertiesKt.getTrackLocationOffsetOrThrow(path,
+                        RJSTrackLocationParser.parse(infra, stop.location));
             }
 
             if (positionMM > path.getLength())

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -478,7 +478,7 @@ fun trainPathBlockOffset(infra: RawInfra, blockInfra: BlockInfra,
         for (zonePath in blockInfra.getBlockPath(block)) {
             for (dirChunk in infra.getZonePathChunks(zonePath)) {
                 if (dirChunk == firstChunk)
-                    return prevChunksLength + chunkPath.beginOffset
+                    return prevChunksLength + chunkPath.beginOffset.distance
                 prevChunksLength += infra.getTrackChunkLength(dirChunk.value).distance
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
@@ -3,11 +3,11 @@ package fr.sncf.osrd.api.pathfinding.constraints
 import fr.sncf.osrd.graph.EdgeToRanges
 import fr.sncf.osrd.graph.Pathfinding
 
-class ConstraintCombiner<EdgeT> : EdgeToRanges<EdgeT> {
+class ConstraintCombiner<EdgeT, OffsetType> : EdgeToRanges<EdgeT, OffsetType> {
     @JvmField
-    val functions: MutableList<EdgeToRanges<EdgeT>> = ArrayList()
-    override fun apply(edge: EdgeT): Collection<Pathfinding.Range> {
-        val res = HashSet<Pathfinding.Range>()
+    val functions: MutableList<EdgeToRanges<EdgeT, OffsetType>> = ArrayList()
+    override fun apply(edge: EdgeT): Collection<Pathfinding.Range<OffsetType>> {
+        val res = HashSet<Pathfinding.Range<OffsetType>>()
         for (f in functions)
             res.addAll(f.apply(edge))
         return res

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Graph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Graph.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.graph
 
 /** This is the minimal interface we need to run pathfindings.  */
-interface Graph<NodeT, EdgeT> {
+interface Graph<NodeT, EdgeT, OffsetT> {
     /** Returns the node placed at the end of the given edge  */
     fun getEdgeEnd(edge: EdgeT & Any): NodeT
 

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/GraphAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/GraphAdapter.kt
@@ -1,9 +1,6 @@
 package fr.sncf.osrd.graph
 
-import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.sim_infra.api.BlockInfra
-import fr.sncf.osrd.sim_infra.api.DirDetectorId
-import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
+import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.getBlockExit
 
 /**
@@ -11,7 +8,7 @@ import fr.sncf.osrd.sim_infra.impl.getBlockExit
  * where node = detector and edge = block
  */
 class GraphAdapter(private val blockInfra: BlockInfra, private val rawSignalingInfra: RawSignalingInfra) :
-    Graph<DirDetectorId, BlockId> {
+    Graph<DirDetectorId, BlockId, Block> {
     override fun getEdgeEnd(edge: BlockId): DirDetectorId {
         return blockInfra.getBlockExit(rawSignalingInfra, edge)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
@@ -1,35 +1,45 @@
 package fr.sncf.osrd.graph
 
-import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
 
 /** This interface defines a function that can be used as a heuristic for an A* pathfinding.
  * It takes an edge and an offset on this edge as inputs, and returns an estimation of the remaining distance.  */
-fun interface AStarHeuristic<EdgeT> {
-    fun apply(edge: EdgeT, offset: Distance): Double
+fun interface AStarHeuristic<EdgeT, OffsetType> {
+    fun apply(edge: EdgeT, offset: Offset<OffsetType>): Double
 }
 
 /** Defines the cost of an edge range */
-fun interface EdgeRangeCost<EdgeT> {
-    fun apply(range: Pathfinding.EdgeRange<EdgeT>): Double
+fun interface EdgeRangeCost<EdgeT, OffsetType> {
+    fun apply(range: Pathfinding.EdgeRange<EdgeT, OffsetType>): Double
 }
 
 /** Defines a function that takes an edge and returns its length  */
-fun interface EdgeToLength<EdgeT> {
-    fun apply(edge: EdgeT): Distance
+fun interface EdgeToLength<EdgeT, OffsetType> {
+    fun apply(edge: EdgeT): Length<OffsetType>
 }
 
 /** Function that takes an edge and returns a collection of ranges,
  * used to define blocked ranges on an edge  */
-fun interface EdgeToRanges<EdgeT> {
-    fun apply(edge: EdgeT): Collection<Pathfinding.Range>
+fun interface EdgeToRanges<EdgeT, OffsetType> {
+    fun apply(edge: EdgeT): Collection<Pathfinding.Range<OffsetType>>
 }
 
 /** Functions that takes an edge and returns the offset of any target for the current step on the edge */
-fun interface TargetsOnEdge<EdgeT> {
-    fun apply(edge: EdgeT): Collection<Pathfinding.EdgeLocation<EdgeT>>
+fun interface TargetsOnEdge<EdgeT, OffsetType> {
+    fun apply(edge: EdgeT): Collection<Pathfinding.EdgeLocation<EdgeT, OffsetType>>
 }
 
 /** Alternate way to define the cost: returns the absolute cost of a location on an edge */
-fun interface TotalCostUntilEdgeLocation<EdgeT> {
-    fun apply(edgeLocation: Pathfinding.EdgeLocation<EdgeT>): Double
+fun interface TotalCostUntilEdgeLocation<EdgeT, OffsetType> {
+    fun apply(edgeLocation: Pathfinding.EdgeLocation<EdgeT, OffsetType>): Double
 }
+
+// Type aliases to avoid repeating `StaticIdx<T>, T` when edge types are static idx
+typealias AStarHeuristicId<T> = AStarHeuristic<StaticIdx<T>, T>
+typealias EdgeRangeCostId<T> = EdgeRangeCost<StaticIdx<T>, T>
+typealias EdgeToLengthId<T> = EdgeToLength<StaticIdx<T>, T>
+typealias EdgeToRangesId<T> = EdgeToRanges<StaticIdx<T>, T>
+typealias TargetsOnEdgeId<T> = TargetsOnEdge<StaticIdx<T>, T>
+typealias TotalCostUntilEdgeLocationId<T> = TotalCostUntilEdgeLocation<StaticIdx<T>, T>

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/NetworkGraphAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/NetworkGraphAdapter.kt
@@ -3,7 +3,8 @@ package fr.sncf.osrd.graph
 import com.google.common.graph.ImmutableNetwork
 
 /** Implements our custom Graph interface using an ImmutableNetwork  */
-class NetworkGraphAdapter<NodeT, EdgeT>(private val g: ImmutableNetwork<NodeT, EdgeT>) : Graph<NodeT, EdgeT> {
+class NetworkGraphAdapter<NodeT, EdgeT, OffsetT>(private val g: ImmutableNetwork<NodeT, EdgeT>)
+    : Graph<NodeT, EdgeT, OffsetT> {
     override fun getEdgeEnd(edge: EdgeT & Any): NodeT {
         return g.incidentNodes(edge).nodeV()
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Pathfinding.kt
@@ -4,7 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import fr.sncf.osrd.api.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.time.Duration
 import java.time.Instant
@@ -15,18 +16,18 @@ import java.util.stream.Collectors
     value = ["FE_FLOATING_POINT_EQUALITY"],
     justification = "No arithmetic is done on values where we test for equality, only copies"
 )
-class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, EdgeT>) {
+class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(private val graph: Graph<NodeT, EdgeT, OffsetType>) {
     /** Pathfinding step  */
     @JvmRecord
-    private data class Step<EdgeT>(
-        val range: EdgeRange<EdgeT>,  // Range covered by this step
-        val prev: Step<EdgeT>?,  // Previous step (to construct the result)
+    private data class Step<EdgeT, OffsetType>(
+        val range: EdgeRange<EdgeT, OffsetType>,  // Range covered by this step
+        val prev: Step<EdgeT, OffsetType>?,  // Previous step (to construct the result)
         val totalDistance: Double,  // Total distance from the start
         val weight: Double,  // Priority queue weight (could be different from totalDistance to allow for A*)
         val nReachedTargets: Int,  // How many targets we found by this path
-        val targets: List<EdgeLocation<EdgeT>>
-    ) : Comparable<Step<EdgeT>> {
-        override fun compareTo(other: Step<EdgeT>): Int {
+        val targets: List<EdgeLocation<EdgeT, OffsetType>>
+    ) : Comparable<Step<EdgeT, OffsetType>> {
+        override fun compareTo(other: Step<EdgeT, OffsetType>): Int {
             return if (weight != other.weight)
                 weight.compareTo(other.weight)
             else {
@@ -37,45 +38,45 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
     }
 
     /** Contains all the results of a pathfinding  */
-    data class Result<EdgeT>(
-        val ranges: List<EdgeRange<EdgeT>>,  // Full path as edge ranges
-        val waypoints: List<EdgeLocation<EdgeT>>
+    data class Result<EdgeT, OffsetType>(
+        val ranges: List<EdgeRange<EdgeT, OffsetType>>,  // Full path as edge ranges
+        val waypoints: List<EdgeLocation<EdgeT, OffsetType>>
     )
 
     /** A location on a range, made of edge + offset. Used for the input of the pathfinding  */
-    data class EdgeLocation<EdgeT>(val edge: EdgeT, val offset: Distance)
+    data class EdgeLocation<EdgeT, OffsetType>(val edge: EdgeT, val offset: Offset<OffsetType>)
 
     /** A range, made of edge + start and end offsets on the edge. Used for the output of the pathfinding  */
-    data class EdgeRange<EdgeT>(val edge: EdgeT, val start: Distance, val end: Distance)
+    data class EdgeRange<EdgeT, OffsetType>(val edge: EdgeT, val start: Offset<OffsetType>, val end: Offset<OffsetType>)
 
     /** A simple range with no edge attached  */
-    data class Range(val start: Distance, val end: Distance)
+    data class Range<OffsetType>(val start: Offset<OffsetType>, val end: Offset<OffsetType>)
 
     /** Step priority queue  */
-    private val queue = PriorityQueue<Step<EdgeT>>()
+    private val queue = PriorityQueue<Step<EdgeT, OffsetType>>()
 
     /** Function to call to get edge length  */
-    private var edgeToLength: EdgeToLength<EdgeT>? = null
+    private var edgeToLength: EdgeToLength<EdgeT, OffsetType>? = null
 
     /** Function to call to get the blocked ranges on an edge  */
-    private val blockedRangesOnEdge = ConstraintCombiner<EdgeT>()
+    private val blockedRangesOnEdge = ConstraintCombiner<EdgeT, OffsetType>()
 
     /** Keeps track of visited location. For each visited range, keeps the max number of passed targets at that point  */
-    private val seen = HashMap<EdgeRange<EdgeT>, Int>()
+    private val seen = HashMap<EdgeRange<EdgeT, OffsetType>, Int>()
 
     /** Functions to call to get estimate of the remaining distance.
      * We have a list of function for each step.
      * These functions take the edge and the offset and returns a distance.  */
-    private var estimateRemainingDistance: List<AStarHeuristic<EdgeT>>? = ArrayList()
+    private var estimateRemainingDistance: List<AStarHeuristic<EdgeT, OffsetType>>? = ArrayList()
 
     /** Function to call to know the cost of the range.  */
-    private var edgeRangeCost: EdgeRangeCost<EdgeT>? = null
+    private var edgeRangeCost: EdgeRangeCost<EdgeT, OffsetType>? = null
 
     /**
      * Function to call to know the cost of the path from the departure point to the edge location .
      * Used in STDCM. Either totalDistanceUntilEdgeLocation or edgeRangeCost must be defined.
      */
-    private var totalCostUntilEdgeLocation: TotalCostUntilEdgeLocation<EdgeT>? = null
+    private var totalCostUntilEdgeLocation: TotalCostUntilEdgeLocation<EdgeT, OffsetType>? = null
 
     /**
      * Timeout, in seconds, to avoid infinite loop when no path can be found.
@@ -83,43 +84,43 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
     private var timeout = TIMEOUT
 
     /** Sets the functor used to estimate the remaining distance for A*  */
-    fun setEdgeToLength(f: EdgeToLength<EdgeT>?): Pathfinding<NodeT, EdgeT> {
+    fun setEdgeToLength(f: EdgeToLength<EdgeT, OffsetType>?): Pathfinding<NodeT, EdgeT, OffsetType> {
         edgeToLength = f
         return this
     }
 
     /** Sets functors used to estimate the remaining distance for A*  */
-    fun setRemainingDistanceEstimator(f: List<AStarHeuristic<EdgeT>>?): Pathfinding<NodeT, EdgeT> {
+    fun setRemainingDistanceEstimator(f: List<AStarHeuristic<EdgeT, OffsetType>>?): Pathfinding<NodeT, EdgeT, OffsetType> {
         estimateRemainingDistance = f
         return this
     }
 
     /** Sets the functor used to estimate the cost for a range  */
-    fun setEdgeRangeCost(f: EdgeRangeCost<EdgeT>?): Pathfinding<NodeT, EdgeT> {
+    fun setEdgeRangeCost(f: EdgeRangeCost<EdgeT, OffsetType>?): Pathfinding<NodeT, EdgeT, OffsetType> {
         edgeRangeCost = f
         return this
     }
 
     /** Sets the functor used to estimate the cost for a range  */
-    fun setTotalCostUntilEdgeLocation(f: TotalCostUntilEdgeLocation<EdgeT>?): Pathfinding<NodeT, EdgeT> {
+    fun setTotalCostUntilEdgeLocation(f: TotalCostUntilEdgeLocation<EdgeT, OffsetType>?): Pathfinding<NodeT, EdgeT, OffsetType> {
         totalCostUntilEdgeLocation = f
         return this
     }
 
     /** Sets the functor used to determine which ranges are blocked on an edge  */
-    fun addBlockedRangeOnEdges(f: EdgeToRanges<EdgeT>): Pathfinding<NodeT, EdgeT> {
+    fun addBlockedRangeOnEdges(f: EdgeToRanges<EdgeT, OffsetType>): Pathfinding<NodeT, EdgeT, OffsetType> {
         blockedRangesOnEdge.functions.add(f)
         return this
     }
 
     /** Sets the functor used to determine which ranges are blocked on an edge  */
-    fun addBlockedRangeOnEdges(f: Collection<EdgeToRanges<EdgeT>>): Pathfinding<NodeT, EdgeT> {
+    fun addBlockedRangeOnEdges(f: Collection<EdgeToRanges<EdgeT, OffsetType>>): Pathfinding<NodeT, EdgeT, OffsetType> {
         blockedRangesOnEdge.functions.addAll(f)
         return this
     }
 
     /** Sets the pathfinding's timeout  */
-    fun setTimeout(timeout: Double): Pathfinding<NodeT, EdgeT> {
+    fun setTimeout(timeout: Double): Pathfinding<NodeT, EdgeT, OffsetType> {
         this.timeout = timeout
         return this
     }
@@ -131,14 +132,14 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
      * It uses Dijkstra algorithm by default, but can be changed to an A* by
      * specifying a function to estimate the remaining distance, using `setRemainingDistanceEstimator`  */
     fun runPathfinding(
-        targets: List<Collection<EdgeLocation<EdgeT>>>
-    ): Result<EdgeT>? {
+        targets: List<Collection<EdgeLocation<EdgeT, OffsetType>>>
+    ): Result<EdgeT, OffsetType>? {
         // We convert the targets of each step into functions, to call the more generic overload of this method below
         val starts = targets[0]
-        val targetsOnEdges = ArrayList<TargetsOnEdge<EdgeT>>()
+        val targetsOnEdges = ArrayList<TargetsOnEdge<EdgeT, OffsetType>>()
         for (i in 1 until targets.size) {
             targetsOnEdges.add { edge: EdgeT ->
-                val res = HashSet<EdgeLocation<EdgeT>>()
+                val res = HashSet<EdgeLocation<EdgeT, OffsetType>>()
                 for (target in targets[i]) {
                     if (target.edge == edge)
                         res.add(EdgeLocation(edge, target.offset))
@@ -157,9 +158,9 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
      * It uses Dijkstra algorithm by default, but can be changed to an A* by
      * specifying a function to estimate the remaining distance, using `setRemainingDistanceEstimator`  */
     fun runPathfinding(
-        starts: Collection<EdgeLocation<EdgeT>>,
-        targetsOnEdges: List<TargetsOnEdge<EdgeT>>
-    ): Result<EdgeT>? {
+        starts: Collection<EdgeLocation<EdgeT, OffsetType>>,
+        targetsOnEdges: List<TargetsOnEdge<EdgeT, OffsetType>>
+    ): Result<EdgeT, OffsetType>? {
         checkParameters()
         for (location in starts) {
             val startRange = EdgeRange(location.edge, location.offset, location.offset)
@@ -206,7 +207,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
                 val neighbors = graph.getAdjacentEdges(endNode)
                 for (edge in neighbors) {
                     registerStep(
-                        EdgeRange(edge, 0.meters, edgeToLength!!.apply(edge)),
+                        EdgeRange(edge, Offset(0.meters), edgeToLength!!.apply(edge)),
                         step,
                         step.totalDistance,
                         step.nReachedTargets
@@ -222,12 +223,12 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
 
     /** Runs the pathfinding, returning a path as a list of edge.  */
     fun runPathfindingEdgesOnly(
-        targets: List<Collection<EdgeLocation<EdgeT>>>
+        targets: List<Collection<EdgeLocation<EdgeT, OffsetType>>>
     ): List<EdgeT>? {
         val res = runPathfinding(targets)
             ?: return null
         return res.ranges.stream()
-            .map { step: EdgeRange<EdgeT> -> step.edge }
+            .map { step: EdgeRange<EdgeT, OffsetType> -> step.edge }
             .collect(Collectors.toList())
     }
 
@@ -242,21 +243,21 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
     /** Returns true if the step has reached the end of the path (last target)  */
     private fun hasReachedEnd(
         nTargets: Int,
-        step: Step<EdgeT>
+        step: Step<EdgeT, OffsetType>
     ): Boolean {
         return step.nReachedTargets >= nTargets
     }
 
     /** Builds the result, iterating over the previous steps and merging ranges  */
-    private fun buildResult(lastStep: Step<EdgeT>): Result<EdgeT> {
-        var mutLastStep: Step<EdgeT>? = lastStep
-        val orderedSteps = ArrayDeque<Step<EdgeT>>()
+    private fun buildResult(lastStep: Step<EdgeT, OffsetType>): Result<EdgeT, OffsetType> {
+        var mutLastStep: Step<EdgeT, OffsetType>? = lastStep
+        val orderedSteps = ArrayDeque<Step<EdgeT, OffsetType>>()
         while (mutLastStep != null) {
             orderedSteps.addFirst(mutLastStep)
             mutLastStep = mutLastStep.prev
         }
-        val ranges = ArrayList<EdgeRange<EdgeT>>()
-        val waypoints = ArrayList<EdgeLocation<EdgeT>>()
+        val ranges = ArrayList<EdgeRange<EdgeT, OffsetType>>()
+        val waypoints = ArrayList<EdgeLocation<EdgeT, OffsetType>>()
         for (step in orderedSteps) {
             val range = step.range
             val lastIndex = ranges.size - 1
@@ -274,7 +275,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
     }
 
     /** Filter the range to keep only the parts that can be reached  */
-    private fun filterRange(range: EdgeRange<EdgeT>): EdgeRange<EdgeT>? {
+    private fun filterRange(range: EdgeRange<EdgeT, OffsetType>): EdgeRange<EdgeT, OffsetType>? {
         var end = range.end
         for (blockedRange in blockedRangesOnEdge.apply(range.edge)) {
             if (blockedRange.end < range.start) {
@@ -285,18 +286,18 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
                 // The start of the range is blocked: we don't visit this range
                 return null
             }
-            end = Distance.min(end, blockedRange.start)
+            end = Offset.min(end, blockedRange.start)
         }
         return EdgeRange(range.edge, range.start, end)
     }
 
     /** Registers one step, adding the edge to the queue if not already seen  */
     private fun registerStep(
-        range: EdgeRange<EdgeT>,
-        prev: Step<EdgeT>?,
+        range: EdgeRange<EdgeT, OffsetType>,
+        prev: Step<EdgeT, OffsetType>?,
         prevDistance: Double,
         nPassedTargets: Int,
-        targets: List<EdgeLocation<EdgeT>> = listOf()
+        targets: List<EdgeLocation<EdgeT, OffsetType>> = listOf()
     ) {
         val filteredRange = filterRange(range)
             ?: return
@@ -329,3 +330,9 @@ class Pathfinding<NodeT : Any, EdgeT : Any>(private val graph: Graph<NodeT, Edge
         const val TIMEOUT = 120.0
     }
 }
+
+// Type aliases to avoid repeating `StaticIdx<T>, T` when edge types are static idx
+typealias PathfindingId<NodeT, T> = Pathfinding<NodeT, StaticIdx<T>, T>
+typealias PathfindingResultId<T> = Pathfinding.Result<StaticIdx<T>, T>
+typealias PathfindingEdgeLocationId<T> = Pathfinding.EdgeLocation<StaticIdx<T>, T>
+typealias PathfindingEdgeRangeId<T> = Pathfinding.EdgeRange<StaticIdx<T>, T>

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -2,8 +2,8 @@ package fr.sncf.osrd.stdcm
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.PhysicsPath
-import fr.sncf.osrd.graph.Pathfinding
-import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.graph.PathfindingResultId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.PathProperties
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.train.TrainStop
@@ -12,7 +12,7 @@ import fr.sncf.osrd.train.TrainStop
  * It is made of a physical path part and envelope, as well as different representations
  * of the same data that can be reused in later steps.  */
 data class STDCMResult(
-    val blocks: Pathfinding.Result<BlockId>,
+    val blocks: PathfindingResultId<Block>,
     val envelope: Envelope,
     val trainPath: PathProperties,
     val chunkPath: ChunkPath,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
@@ -1,10 +1,10 @@
 package fr.sncf.osrd.stdcm
 
-import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
-import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
 
 data class STDCMStep(
-    val locations: Collection<EdgeLocation<BlockId>>,
+    val locations: Collection<PathfindingEdgeLocationId<Block>>,
     val duration: Double?,
     val stop: Boolean
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -75,7 +75,7 @@ data class STDCMEdge(
                 maximumAddedDelayAfter,
                 this,
                 newWaypointIndex,
-                EdgeLocation(block, envelopeStartOffset.distance + length.distance),
+                EdgeLocation(block, envelopeStartOffset + length.distance),
                 stopDuration
             )
         }
@@ -84,7 +84,7 @@ data class STDCMEdge(
     val totalTime: Double
         /** Returns how long it takes to go from the start to the end of the block, accounting standard allowance.  */
         get() = envelope.totalTime / standardAllowanceSpeedFactor
-    val length: Length<Block>
+    val length: Length<STDCMEdge>
         /** Returns the length of the edge  */
         get() = Length(fromMeters(envelope.endPos))
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -228,7 +228,7 @@ internal constructor(
             val builder = STDCMEdgeBuilder(blockId, graph)
             if (node.locationOnBlock != null) {
                 assert(blockId == node.locationOnBlock.edge)
-                builder.startOffset = Offset(node.locationOnBlock.offset)
+                builder.startOffset = node.locationOnBlock.offset
             } else assert(graph.blockInfra.getBlockEntry(graph.rawInfra, blockId) == node.detector)
             builder.startTime = node.time
             builder.startSpeed = node.speed

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -31,7 +31,7 @@ class STDCMGraph(
     steps: List<STDCMStep>,
     tag: String?,
     standardAllowance: AllowanceValue?
-) : Graph<STDCMNode, STDCMEdge> {
+) : Graph<STDCMNode, STDCMEdge, STDCMEdge> {
     var stdcmSimulations: STDCMSimulations = STDCMSimulations()
     val steps: List<STDCMStep>
     val delayManager: DelayManager

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm.graph
 
-import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
-import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 
 data class STDCMNode(
@@ -12,6 +12,6 @@ data class STDCMNode(
     val maximumAddedDelay: Double,  // Maximum delay we can add by delaying the start time without causing conflicts
     val previousEdge: STDCMEdge,  // Edge that lead to this node
     val waypointIndex: Int,  // Index of the last waypoint passed by the train
-    val locationOnBlock: EdgeLocation<BlockId>?,  // Position on a block, if this node isn't on the transition between blocks (stop)
+    val locationOnBlock: PathfindingEdgeLocationId<Block>?,  // Position on a block, if this node isn't on the transition between blocks (stop)
     val stopDuration: Double?  // When the node is a stop, how long the train remains here
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -8,11 +8,13 @@ import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
 import fr.sncf.osrd.graph.Pathfinding.EdgeRange
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TrackChunk
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.sim_infra.impl.buildChunkPath
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.*
@@ -20,7 +22,7 @@ import kotlin.math.min
 
 /** Combines all the envelopes in the given edge ranges  */
 fun mergeEnvelopeRanges(
-    edges: List<EdgeRange<STDCMEdge>>,
+    edges: List<EdgeRange<STDCMEdge, STDCMEdge>>,
     path: PhysicsPath
 ): Envelope {
     val parts = ArrayList<EnvelopePart>()
@@ -49,8 +51,8 @@ fun mergeEnvelopes(
     context: EnvelopeSimContext
 ): Envelope {
     return mergeEnvelopeRanges(
-        edges
-            .map { e: STDCMEdge -> EdgeRange(e, 0.meters, graph.blockInfra.getBlockLength(e.block).distance) }
+        edges.stream()
+            .map { e: STDCMEdge -> EdgeRange(e, Offset(0.meters), e.length) }
             .toList(),
         context.path
     )
@@ -74,7 +76,7 @@ fun getStopOnBlock(
         return null
     for (endLocation in nextStep.locations) {
         if (endLocation.edge == block) {
-            val offset = Offset<Block>(endLocation.offset - startOffset.distance)
+            val offset = endLocation.offset - startOffset.distance
             if (offset >= Offset(0.meters))
                 res.add(offset)
         }
@@ -86,19 +88,29 @@ fun getStopOnBlock(
 }
 
 /** Create a TrainPath instance from a list of edge ranges  */
-fun makeChunkPathFromRanges(graph: STDCMGraph, ranges: List<EdgeRange<STDCMEdge>>): ChunkPath {
+fun makeChunkPathFromRanges(graph: STDCMGraph, ranges: List<EdgeRange<STDCMEdge, STDCMEdge>>): ChunkPath {
     val blocks = ranges.stream()
         .map { range -> range.edge.block }
         .distinct()
         .toList()
-    val totalPathLength = Distance(millimeters = ranges.stream()
+    val totalPathLength = Length<Path>(Distance(millimeters = ranges.stream()
         .mapToLong { range -> (range.end - range.start).millimeters }
-        .sum())
-    val firstOffset = ranges[0].edge.envelopeStartOffset + ranges[0].start
-    val lastOffset = firstOffset + totalPathLength
+        .sum()))
+    val firstOffset = Offset<Path>(ranges[0].edge.envelopeStartOffset.distance + ranges[0].start.distance)
+    val lastOffset = totalPathLength + firstOffset.distance
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
     for (block in blocks)
         for (chunk in graph.blockInfra.getTrackChunksFromBlock(block))
             chunks.add(chunk)
     return buildChunkPath(graph.rawInfra, chunks, firstOffset, lastOffset)
+}
+
+/** Converts an offset on an STDCM edge into an offset on its underlying block */
+fun convertOffsetToBlock(edgeOffset: Offset<STDCMEdge>, envelopeStartOffset: Offset<Block>): Offset<Block> {
+    return Offset(edgeOffset.distance + envelopeStartOffset.distance)
+}
+
+/** Converts an offset on a block into an offset on its STDCM edge */
+fun convertOffsetToEdge(blockOffset: Offset<Block>, envelopeStartOffset: Offset<Block>): Offset<STDCMEdge> {
+    return Offset(blockOffset.distance - envelopeStartOffset.distance)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
@@ -14,7 +14,7 @@ import fr.sncf.osrd.utils.units.Distance
  */
 fun buildElectrificationMap(path: PathProperties): DistanceRangeMap<Electrification> {
     val res: DistanceRangeMap<Electrification> = DistanceRangeMapImpl()
-    res.put(Distance.ZERO, path.getLength(), NonElectrified())
+    res.put(Distance.ZERO, path.getLength().distance, NonElectrified())
     res.updateMap(
         path.getCatenary()
     ) { _: Electrification?, catenaryMode: String ->

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
@@ -4,13 +4,13 @@ import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator
 import fr.sncf.osrd.graph.AStarHeuristic
 import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.graph.Pathfinding
-import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.Helpers.convertRouteLocation
 import fr.sncf.osrd.utils.Helpers.fullInfraFromRJS
 import fr.sncf.osrd.utils.Helpers.getExampleInfra
-import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -24,8 +24,8 @@ class AStarTests {
     @Throws(Exception::class)
     fun lessBlocksVisitedWithHeuristic() {
         val infra = fullInfraFromRJS(getExampleInfra("small_infra/infra.json"))
-        val origin = mutableSetOf(convertRouteLocation(infra, "rt.DA2->DA5", 0.meters))
-        val destination = mutableSetOf(convertRouteLocation(infra, "rt.DH2->buffer_stop.7", 0.meters))
+        val origin = mutableSetOf(convertRouteLocation(infra, "rt.DA2->DA5", Offset(0.meters)))
+        val destination = mutableSetOf(convertRouteLocation(infra, "rt.DH2->buffer_stop.7", Offset(0.meters)))
         val remainingDistanceEstimator = RemainingDistanceEstimator(
             infra.blockInfra, infra.rawInfra,
             destination, 0.0
@@ -36,7 +36,7 @@ class AStarTests {
             .setEdgeToLength { blockId ->
                 infra.blockInfra.getBlockLength(
                     blockId
-                ).distance
+                )
             }
             .setRemainingDistanceEstimator(
                 listOf(
@@ -45,12 +45,12 @@ class AStarTests {
                         remainingDistanceEstimator.apply(block, offset)
                     })
             )
-            .runPathfinding(listOf<Set<EdgeLocation<StaticIdx<Block>>>>(origin, destination))
+            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
         Pathfinding(GraphAdapter(infra.blockInfra, infra.rawInfra))
             .setEdgeToLength { blockId ->
                 infra.blockInfra.getBlockLength(
                     blockId
-                ).distance
+                )
             }
             .setRemainingDistanceEstimator(
                 listOf(
@@ -59,7 +59,7 @@ class AStarTests {
                         0.0
                     })
             )
-            .runPathfinding(listOf<Set<EdgeLocation<StaticIdx<Block>>>>(origin, destination))
+            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
         Assertions.assertTrue(seenWithHeuristic.size < seenWithoutHeuristic.size)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
@@ -6,7 +6,10 @@ import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes
@@ -31,7 +34,7 @@ class PathfindingBlocksEndpointTest {
     @MethodSource("testFindWaypointBlocksArgs")
     fun testFindWaypointBlocks(
         pathfindingWaypoint: PathfindingWaypoint,
-        expectedEdgeLocations: Set<EdgeLocation<BlockId>>
+        expectedEdgeLocations: Set<PathfindingEdgeLocationId<Block>>
     ) {
         val blocks = findWaypointBlocks(smallInfra!!, pathfindingWaypoint)
         Assertions.assertThat(blocks).containsExactlyInAnyOrderElementsOf(expectedEdgeLocations)
@@ -51,13 +54,13 @@ class PathfindingBlocksEndpointTest {
             return Stream.of(
                 Arguments.of(
                     PathfindingWaypoint("TA3", 10.0, EdgeDirection.START_TO_STOP),
-                    mutableSetOf(EdgeLocation(BlockId(8U), 190.meters))
+                    mutableSetOf(EdgeLocation(BlockId(8U), Offset<Block>(190.meters)))
                 ),
                 Arguments.of(
                     PathfindingWaypoint("TA5", 20.0, EdgeDirection.STOP_TO_START),
                     mutableSetOf(
-                        EdgeLocation(BlockId(19U), 210.meters),
-                        EdgeLocation(BlockId(18U), 210.meters)
+                        EdgeLocation(BlockId(19U), Offset<Block>(210.meters)),
+                        EdgeLocation(BlockId(18U), Offset<Block>(210.meters))
                     )
                 )
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingResultConverterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingResultConverterTest.kt
@@ -7,11 +7,15 @@ import fr.sncf.osrd.api.pathfinding.makePathWaypoint
 import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.graph.Pathfinding.EdgeRange
+import fr.sncf.osrd.graph.PathfindingEdgeRangeId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -27,19 +31,19 @@ class PathfindingResultConverterTest {
                 "rt.DA5->DC5"
             )
         )
-        val ranges = ArrayList<EdgeRange<BlockId>>()
+        val ranges = ArrayList<PathfindingEdgeRangeId<Block>>()
         for (block in blocks) {
             ranges.add(
                 EdgeRange(
-                    block, 0.meters,
-                    infra.blockInfra.getBlockLength(block).distance
+                    block, Offset(0.meters),
+                    infra.blockInfra.getBlockLength(block)
                 )
             )
         }
         val chunkPath = makeChunkPath(infra.rawInfra, infra.blockInfra, ranges)
         val expectedLength = 10000.meters + 1000.meters // length of route 1 + 2
-        Assertions.assertEquals(0.meters, chunkPath.beginOffset)
-        Assertions.assertEquals(expectedLength, chunkPath.endOffset)
+        Assertions.assertEquals(Offset<Path>(0.meters), chunkPath.beginOffset)
+        Assertions.assertEquals(expectedLength, chunkPath.endOffset.distance)
         checkBlocks(infra, chunkPath, setOf("TA0", "TA6", "TC1"), Direction.INCREASING, expectedLength)
     }
 
@@ -56,26 +60,27 @@ class PathfindingResultConverterTest {
         assert(blocks.size == 4)
         val ranges = listOf(
             EdgeRange(
-                blocks[0], 10.meters,
-                infra.blockInfra.getBlockLength(blocks[0]).distance
+                blocks[0], Offset(10.meters),
+                infra.blockInfra.getBlockLength(blocks[0])
             ),
             EdgeRange(
-                blocks[1], 0.meters,
-                infra.blockInfra.getBlockLength(blocks[1]).distance
+                blocks[1], Offset(0.meters),
+                infra.blockInfra.getBlockLength(blocks[1])
             ),
             EdgeRange(
-                blocks[2], 0.meters,
-                infra.blockInfra.getBlockLength(blocks[2]).distance
+                blocks[2], Offset(0.meters),
+                infra.blockInfra.getBlockLength(blocks[2])
             ),
             EdgeRange(
-                blocks[3], 0.meters,
-                infra.blockInfra.getBlockLength(blocks[3]).distance - 10.meters
+                blocks[3], Offset(0.meters),
+                infra.blockInfra.getBlockLength(blocks[3]) - 10.meters
             )
         )
         val chunkPath = makeChunkPath(infra.rawInfra, infra.blockInfra, ranges)
         val expectedBlockLength = 1050.meters + 10000.meters // length of route 1 + 2
-        Assertions.assertEquals(10.meters, chunkPath.beginOffset)
-        Assertions.assertEquals((expectedBlockLength - 10.meters), chunkPath.endOffset)
+        Assertions.assertEquals(
+            Offset<Path>(10.meters), chunkPath.beginOffset)
+        Assertions.assertEquals((expectedBlockLength - 10.meters), chunkPath.endOffset.distance)
         checkBlocks(infra, chunkPath, setOf("TC0", "TD0", "TA6"), Direction.DECREASING, expectedBlockLength)
     }
 
@@ -89,11 +94,11 @@ class PathfindingResultConverterTest {
             )
         )
         assert(blocks.size == 1)
-        val ranges = listOf(EdgeRange(blocks[0], 600.meters, 800.meters))
+        val ranges = listOf(EdgeRange(blocks[0], Offset<Block>(600.meters), Offset(800.meters)))
         val path = makePathProps(infra.rawInfra, infra.blockInfra, ranges)
         val rawResult = Pathfinding.Result(
             ranges, listOf(
-                EdgeLocation(ranges[0].edge, 650.meters)
+                EdgeLocation(ranges[0].edge, Offset(650.meters))
             )
         )
         val waypoints = makePathWaypoint(
@@ -122,15 +127,15 @@ class PathfindingResultConverterTest {
         )
         assert(blocks.size == 1)
         val blockId = blocks[0]
-        val blockLength = infra.blockInfra.getBlockLength(blockId).distance
+        val blockLength = infra.blockInfra.getBlockLength(blockId)
         val ranges = listOf(
-            EdgeRange(blockId, 600.meters, blockLength),
-            EdgeRange(blockId, 0.meters, 200.meters)
+            EdgeRange(blockId, Offset(600.meters), blockLength),
+            EdgeRange(blockId, Offset(0.meters), Offset(200.meters))
         )
         val rawResult = Pathfinding.Result(
             ranges, listOf(
-                EdgeLocation(ranges[0].edge, 600.meters),
-                EdgeLocation(ranges[0].edge, 200.meters)
+                EdgeLocation(ranges[0].edge, Offset(600.meters)),
+                EdgeLocation(ranges[0].edge, Offset(200.meters))
             )
         )
         val path = makePathProps(infra.rawInfra, infra.blockInfra, ranges)

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -6,11 +6,14 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator
 import fr.sncf.osrd.api.pathfinding.makePathProps
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.PathProperties
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -40,10 +43,10 @@ class RemainingDistanceEstimatorTest {
     @ParameterizedTest
     @MethodSource("testRemainingDistanceEstimatorArgs")
     fun testRemainingDistanceEstimator(
-        edgeLocations: Collection<EdgeLocation<BlockId>>,
+        edgeLocations: Collection<PathfindingEdgeLocationId<Block>>,
         remainingDistance: Double,
         expectedDistance: Double,
-        blockOffset: Distance
+        blockOffset: Offset<Block>
     ) {
         val estimator = RemainingDistanceEstimator(
             smallInfra!!.blockInfra, smallInfra!!.rawInfra, edgeLocations,
@@ -57,13 +60,13 @@ class RemainingDistanceEstimatorTest {
         val points = path!!.getGeo().points
         return Stream.of( // Test same point
             Arguments.of(
-                listOf(EdgeLocation(block, 0.meters)),
+                listOf(EdgeLocation(block, Offset<Block>(0.meters))),
                 0,
                 0,
                 0
             ),  // Test same point with non-null remaining distance
             Arguments.of(
-                listOf(EdgeLocation(block, 0.meters)),
+                listOf(EdgeLocation(block, Offset<Block>(0.meters))),
                 10,
                 10,
                 0
@@ -76,7 +79,7 @@ class RemainingDistanceEstimatorTest {
             ),  // Test multiple targets
             Arguments.of(
                 listOf(
-                    EdgeLocation(block, 0.meters),
+                    EdgeLocation(block, Offset(0.meters)),
                     EdgeLocation(block, path!!.getLength())
                 ),
                 0,
@@ -89,7 +92,7 @@ class RemainingDistanceEstimatorTest {
                 ),
                 0,
                 0,
-                path!!.getLength().millimeters
+                path!!.getLength().distance.millimeters
             )
         )
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraintsTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/constraints/LoadingGaugeConstraintsTest.kt
@@ -5,12 +5,14 @@ import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.TrackChunk
 import fr.sncf.osrd.sim_infra.api.TrackChunkId
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -50,7 +52,7 @@ class LoadingGaugeConstraintsTest {
 
     @ParameterizedTest
     @MethodSource("testLoadingGaugeArgs")
-    fun testLoadingGaugeBlockedRanges(blockId: BlockId, expectedBlockedRanges: Collection<Pathfinding.Range>) {
+    fun testLoadingGaugeBlockedRanges(blockId: BlockId, expectedBlockedRanges: Collection<Pathfinding.Range<Block>>) {
         val blockedRanges = loadingGaugeConstraints!!.apply(blockId)
         Assertions.assertThat(blockedRanges).isEqualTo(expectedBlockedRanges)
     }
@@ -59,9 +61,9 @@ class LoadingGaugeConstraintsTest {
         return Stream.of( // Loading gauge constraints partially applied to block
             Arguments.of(
                 0,
-                setOf(Pathfinding.Range(0.meters, chunk0Length.distance))
+                setOf(Pathfinding.Range(Offset(0.meters), chunk0Length))
             ),  // Loading gauge constraints fully applied to block
-            Arguments.of(1, setOf(Pathfinding.Range(0.meters, chunk1Length.distance))),  // No loading gauge constraints
+            Arguments.of(1, setOf(Pathfinding.Range(Offset(0.meters), chunk1Length))),  // No loading gauge constraints
             Arguments.of(2, HashSet<Any>())
         )
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -9,12 +9,14 @@ import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPoint
 import fr.sncf.osrd.railjson.schema.infra.trackranges.*
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.train.TestTrains.MAX_SPEED
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.pathFromTracks
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed.Companion.fromMetersPerSecond
 import fr.sncf.osrd.utils.units.meters
 import org.assertj.core.api.Assertions.assertThat
@@ -106,9 +108,9 @@ class PathPropertiesTests {
             .map { op -> Pair(infra.getOperationalPointPartName(op.value), op.offset) }
         assertEquals(
             listOf(
-                Pair("point1", 500.meters),
-                Pair("point1", 1_000.meters),
-                Pair("point2", 1_500.meters),
+                Pair("point1", Offset(500.meters)),
+                Pair("point1", Offset(1_000.meters)),
+                Pair("point2", Offset(1_500.meters)),
             ), opIdsIdxWithOffset
         )
 
@@ -117,10 +119,10 @@ class PathPropertiesTests {
             .map { op -> Pair(infra.getOperationalPointPartName(op.value), op.offset) }
         assertEquals(
             listOf(
-                Pair("point2", 0.meters),
-                Pair("point2", 1_950.meters),
-                Pair("point1", 2_450.meters),
-                Pair("point1", 2_950.meters),
+                Pair("point2", Offset(0.meters)),
+                Pair("point2", Offset(1_950.meters)),
+                Pair("point1", Offset(2_450.meters)),
+                Pair("point1", Offset(2_950.meters)),
             ), opIdsIdxWithOffsetBackward
         )
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -2,10 +2,12 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -23,7 +25,8 @@ class BacktrackingTests {
         val block = infra.addBlock("a", "b", 1000.meters)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            block, 0.0, 0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            block, 0.0, Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD,
+            2.0, null, null
         )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph = ImmutableMultimap.of(
@@ -31,8 +34,8 @@ class BacktrackingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(block, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(block, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(block, Offset<Block>(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -51,7 +54,8 @@ class BacktrackingTests {
         val lastBlock = infra.addBlock("d", "e", 10.meters)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            firstBlock, 0.0, Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN,
+            RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph = ImmutableMultimap.of(
@@ -59,8 +63,8 @@ class BacktrackingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 5.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(5.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -77,7 +81,8 @@ class BacktrackingTests {
         val secondBlock = infra.addBlock("b", "c", 100.meters, 5.0)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            firstBlock, 0.0, Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN,
+            RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val runTime = firstBlockEnvelope.totalTime
         val occupancyGraph = ImmutableMultimap.of(
@@ -85,8 +90,8 @@ class BacktrackingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 5.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(5.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run() ?: return
         occupancyTest(res, occupancyGraph)
@@ -108,8 +113,8 @@ class BacktrackingTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 5.0)
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(1000.meters))))
             .run()!!
         Assertions.assertTrue(res.envelope.continuous)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -4,8 +4,10 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -29,8 +31,8 @@ class DepartureTimeShiftTests {
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(50.meters))))
             .run()!!
         val secondBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(infra.getBlockLength(firstBlock).distance.meters))
@@ -56,8 +58,8 @@ class DepartureTimeShiftTests {
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(50.meters))))
             .run()!!
         val secondBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(infra.getBlockLength(firstBlock).distance.meters))
@@ -91,8 +93,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(1000.meters))))
             .run()!!
         val blocks = res.blocks.ranges.stream()
             .map { edgeRange -> infra.blockPool[edgeRange.edge.index.toInt()].name }
@@ -139,8 +141,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         val blocks = res.blocks.ranges.stream()
@@ -163,7 +165,7 @@ class DepartureTimeShiftTests {
         val secondBlock = infra.addBlock("b", "c")
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters,
+            firstBlock, 0.0, Offset(0.meters),
             TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val occupancyGraph = ImmutableMultimap.of(
@@ -177,8 +179,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 100.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(100.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()
         Assertions.assertNull(res)
@@ -213,8 +215,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(thirdBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset<Block>(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -245,8 +247,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -276,8 +278,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset<Block>(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -314,8 +316,8 @@ class DepartureTimeShiftTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(forthBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(forthBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()
         Assertions.assertNull(res)
@@ -356,8 +358,8 @@ class DepartureTimeShiftTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(forthBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(forthBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()
         Assertions.assertNull(res)
@@ -395,8 +397,8 @@ class DepartureTimeShiftTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(thirdBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -417,16 +419,16 @@ class DepartureTimeShiftTests {
         val timeStep = 2.0
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .setMaxDepartureDelay(1000 + timeStep)
             .run()!!
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .setMaxDepartureDelay(1000 - timeStep)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -2,10 +2,12 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -34,13 +36,14 @@ class EngineeringAllowanceTests {
         val thirdBlock = infra.addBlock("c", "d", 100.meters, 30.0)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters,
+            firstBlock, 0.0, Offset(0.meters),
             TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val secondBlockEnvelope = simulateBlock(
             infra, infra,
             secondBlock, firstBlockEnvelope.endSpeed,
-            0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0,
+            null, null
         )!!
         val timeThirdBlockFree = firstBlockEnvelope.totalTime + secondBlockEnvelope.totalTime
         val occupancyGraph = ImmutableMultimap.of(
@@ -53,8 +56,8 @@ class EngineeringAllowanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(thirdBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -91,13 +94,14 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters,
+            firstBlock, 0.0, Offset(0.meters),
             TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val secondBlockEnvelope = simulateBlock(
             infra, infra,
             secondBlock, firstBlockEnvelope.endSpeed,
-            0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0,
+            null, null
         )!!
         val timeLastBlockFree = firstBlockEnvelope.totalTime + 120 + secondBlockEnvelope.totalTime * 3
         val occupancyGraph = ImmutableMultimap.of(
@@ -109,8 +113,8 @@ class EngineeringAllowanceTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -153,13 +157,13 @@ class EngineeringAllowanceTests {
         val lastBlock = infra.addBlock("e", "f", 1000.meters, 20.0)
         val firstBlockEnvelope = simulateBlock(
             infra, infra,
-            firstBlock, 0.0, 0.meters,
+            firstBlock, 0.0, Offset(0.meters),
             TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val secondBlockEnvelope = simulateBlock(
             infra, infra,
             secondBlock, firstBlockEnvelope.endSpeed,
-            0.meters, TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
+            Offset(0.meters), TestTrains.REALISTIC_FAST_TRAIN, RollingStock.Comfort.STANDARD, 2.0, null, null
         )!!
         val timeLastBlockFree = firstBlockEnvelope.totalTime + 120 + secondBlockEnvelope.totalTime * 3
         val timeThirdBlockOccupied = firstBlockEnvelope.totalTime + 5 + secondBlockEnvelope.totalTime * 2
@@ -176,8 +180,8 @@ class EngineeringAllowanceTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -220,8 +224,8 @@ class EngineeringAllowanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(thirdBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -264,8 +268,8 @@ class EngineeringAllowanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(forthBlock, 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(forthBlock, Offset<Block>(1.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -303,8 +307,8 @@ class EngineeringAllowanceTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset<Block>(1000.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setMaxDepartureDelay(Double.POSITIVE_INFINITY)
             .run()
@@ -340,8 +344,8 @@ class EngineeringAllowanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 100.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset<Block>(100.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.standalone_sim.run
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.Helpers
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -31,7 +32,7 @@ class FullSTDCMTests {
                 setOf(
                     Helpers.convertRouteLocation(
                         infra,
-                        "rt.buffer_stop_b->tde.foo_b-switch_foo", 100.meters
+                        "rt.buffer_stop_b->tde.foo_b-switch_foo", Offset(100.meters)
                     )
                 )
             )
@@ -39,7 +40,7 @@ class FullSTDCMTests {
                 setOf(
                     Helpers.convertRouteLocation(
                         infra,
-                        "rt.tde.foo_b-switch_foo->buffer_stop_c", 10125.meters
+                        "rt.tde.foo_b-switch_foo->buffer_stop_c", Offset(10125.meters)
                     )
                 )
             )
@@ -56,13 +57,13 @@ class FullSTDCMTests {
         val start = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.buffer_stop_b->tde.foo_b-switch_foo", 100.meters
+                "rt.buffer_stop_b->tde.foo_b-switch_foo", Offset(100.meters)
             )
         )
         val end = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.tde.foo_b-switch_foo->buffer_stop_c", 10125.meters
+                "rt.tde.foo_b-switch_foo->buffer_stop_c", Offset(10125.meters)
             )
         )
         val requirements = makeRequirementsFromPath(infra, start, end, 0.0)
@@ -93,13 +94,13 @@ class FullSTDCMTests {
         val start = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.buffer_stop.3->DB0", 1590.meters
+                "rt.buffer_stop.3->DB0", Offset(1590.meters)
             )
         )
         val end = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.DH2->buffer_stop.7", 5000.meters
+                "rt.DH2->buffer_stop.7", Offset(5000.meters)
             )
         )
         val requirements = makeRequirementsFromPath(infra, start, end, 0.0).toMutableList()
@@ -124,13 +125,13 @@ class FullSTDCMTests {
         val start = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.buffer_stop.3->DB0", 1590.meters
+                "rt.buffer_stop.3->DB0", Offset(1590.meters)
             )
         )
         val end = setOf(
             Helpers.convertRouteLocation(
                 infra,
-                "rt.DH2->buffer_stop.7", 5000.meters
+                "rt.DH2->buffer_stop.7", Offset(5000.meters)
             )
         )
         val requirements = makeRequirementsFromPath(infra, start, end, 0.0)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/PerformanceTests.kt
@@ -4,9 +4,11 @@ import com.google.common.collect.ImmutableMultimap
 import com.google.common.collect.Iterables
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Disabled
@@ -53,8 +55,8 @@ class PerformanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(Iterables.getLast(blocks), 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(Iterables.getLast(blocks), Offset<Block>(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()!!
@@ -102,8 +104,8 @@ class PerformanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(unreachable, 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(unreachable, Offset<Block>(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
             .run()
@@ -156,8 +158,8 @@ class PerformanceTests {
         val timeStep = 2.0
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(Iterables.getLast(blocks), 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset<Block>(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(Iterables.getLast(blocks), Offset<Block>(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep) //TODO: remove this once the test runs in less than Pathfinding.TIMEOUT
             .setPathfindingTimeout(Double.POSITIVE_INFINITY)
@@ -225,7 +227,7 @@ class PerformanceTests {
                 setOf(
                     EdgeLocation(
                         BlockId(infra.getRouteFromName("25,25->25,26").index),
-                        0.meters
+                        Offset<Block>(0.meters)
                     )
                 )
             )
@@ -233,7 +235,7 @@ class PerformanceTests {
                 setOf(
                     EdgeLocation(
                         BlockId(infra.getRouteFromName("75,75->75,76").index),
-                        0.meters
+                        Offset<Block>(0.meters)
                     )
                 )
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -6,6 +6,8 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.graph.findPath
 import fr.sncf.osrd.stdcm.preprocessing.implementation.BlockAvailabilityLegacyAdapter
@@ -52,13 +54,13 @@ class STDCMPathfindingBuilder {
     }
 
     /** Sets the locations at which the train can start. Meant to be used for simple tests with no intermediate steps  */
-    fun setStartLocations(startLocations: Set<EdgeLocation<BlockId>>): STDCMPathfindingBuilder {
+    fun setStartLocations(startLocations: Set<PathfindingEdgeLocationId<Block>>): STDCMPathfindingBuilder {
         steps.add(0, STDCMStep(startLocations, 0.0, true))
         return this
     }
 
     /** Sets the locations the train must reach. Meant to be used for simple tests with no intermediate steps  */
-    fun setEndLocations(endLocations: Set<EdgeLocation<BlockId>>): STDCMPathfindingBuilder {
+    fun setEndLocations(endLocations: Set<PathfindingEdgeLocationId<Block>>): STDCMPathfindingBuilder {
         steps.add(STDCMStep(endLocations, 0.0, true))
         return this
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -2,8 +2,12 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -22,8 +26,8 @@ class STDCMPathfindingTests {
         val secondBlock = infra.addBlock("b", "c")
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(50.meters))))
             .run()!!
     }
 
@@ -38,10 +42,10 @@ class STDCMPathfindingTests {
         val secondBlock = infra.addBlock("b", "c")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 30.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 30.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(30.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(30.meters))))
             .run()!!
-        Assertions.assertEquals(100.meters, res.trainPath.getLength())
+        Assertions.assertEquals(Length<Path>(100.meters), res.trainPath.getLength())
     }
 
     /** Look for a path where the blocks are occupied before and after  */
@@ -62,8 +66,8 @@ class STDCMPathfindingTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -83,8 +87,8 @@ class STDCMPathfindingTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(0.meters))))
             .run()
         Assertions.assertNull(res)
     }
@@ -107,8 +111,8 @@ class STDCMPathfindingTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()
         Assertions.assertNull(res)
@@ -128,8 +132,8 @@ class STDCMPathfindingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(50.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -164,14 +168,14 @@ class STDCMPathfindingTests {
         )
         val res1 = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(50.meters))))
             .setUnavailableTimes(occupancyGraph1)
             .run()!!
         val res2 = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(50.meters))))
             .setUnavailableTimes(occupancyGraph2)
             .run()!!
         val blocks1 = res1.blocks.ranges.stream()
@@ -200,8 +204,8 @@ class STDCMPathfindingTests {
         val lastBlock = infra.addBlock("c", "d", 10000.meters)
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 9000.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(9000.meters))))
             .run()!!
     }
 
@@ -227,8 +231,8 @@ class STDCMPathfindingTests {
         infra.blockPool[blockTop.index.toInt()].gradient = 1000.0
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(lastBlock, 50.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(50.meters))))
             .run()!!
     }
 
@@ -247,8 +251,8 @@ class STDCMPathfindingTests {
         val disconnectedBlock = infra.addBlock("x", "y")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(firstLoop, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(disconnectedBlock, 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(firstLoop, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(disconnectedBlock, Offset(0.meters))))
             .run()
         Assertions.assertNull(res)
     }
@@ -263,8 +267,8 @@ class STDCMPathfindingTests {
         val block = infra.addBlock("a", "b", 10000.meters)
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(block, 10000.meters)))
+            .setStartLocations(setOf(EdgeLocation(block, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(block, Offset(10000.meters))))
             .setMaxRunTime(100.0)
             .run()
         Assertions.assertNull(res)
@@ -282,8 +286,8 @@ class STDCMPathfindingTests {
             blocks.add(infra.addBlock((i + 1).toString(), (i + 2).toString(), 1000.meters))
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[9], 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[9], Offset(1000.meters))))
             .setMaxRunTime(100.0)
             .run()
         Assertions.assertNull(res)
@@ -300,8 +304,8 @@ class STDCMPathfindingTests {
         val block = infra.addBlock("a", "b")
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(block, 100.meters)))
+            .setStartLocations(setOf(EdgeLocation(block, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(block, Offset(100.meters))))
             .setUnavailableTimes(
                 ImmutableMultimap.of(
                     block, OccupancySegment(0.0, 1000.0, 0.meters, 100.meters)
@@ -325,8 +329,8 @@ class STDCMPathfindingTests {
         val block = infra.addBlock("a", "b", 100000.meters)
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(block, 10.meters)))
+            .setStartLocations(setOf(EdgeLocation(block, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(block, Offset(10.meters))))
             .setUnavailableTimes(
                 ImmutableMultimap.of(
                     block, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 99000.meters, 100000.meters)
@@ -347,8 +351,8 @@ class STDCMPathfindingTests {
         val block = infra.addBlock("a", "b", 100000.meters)
         STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(block, 10.meters)))
+            .setStartLocations(setOf(EdgeLocation(block, Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(block, Offset(10.meters))))
             .setUnavailableTimes(
                 ImmutableMultimap.of(
                     block, OccupancySegment(300.0, Double.POSITIVE_INFINITY, 0.meters, 100000.meters)
@@ -389,8 +393,8 @@ class STDCMPathfindingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 100.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(100.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setMaxRunTime(runTime + 60) // We add a margin for the stop time
             .run()!!
@@ -417,8 +421,8 @@ class STDCMPathfindingTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[0], 100.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[0], Offset(100.meters))))
             .setUnavailableTimes(occupancyGraph)
             .run()!!
         occupancyTest(res, occupancyGraph)
@@ -443,8 +447,8 @@ class STDCMPathfindingTests {
         infra.addBlock("x", "y")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .setStartLocations(setOf(EdgeLocation(BlockId(infra.getRouteFromName("a->b").index), 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(BlockId(infra.getRouteFromName("x->y").index), 0.meters)))
+            .setStartLocations(setOf(EdgeLocation(BlockId(infra.getRouteFromName("a->b").index), Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(BlockId(infra.getRouteFromName("x->y").index), Offset(0.meters))))
             .run()
         Assertions.assertNull(res)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -32,8 +33,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(blocks[2], 1000.meters)))
+                .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1000.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withAllowance)
@@ -57,8 +58,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(blocks[2], 1000.meters)))
+                .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1000.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withAllowance)
@@ -83,8 +84,8 @@ class StandardAllowanceTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
                 .setUnavailableTimes(occupancyGraph)
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(secondBlock, 50.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(secondBlock, Offset(50.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withoutAllowance!!)
@@ -114,8 +115,8 @@ class StandardAllowanceTests {
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
                 .setUnavailableTimes(occupancyGraph)
-                .setStartLocations(setOf(EdgeLocation(block, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(block, 10000.meters)))
+                .setStartLocations(setOf(EdgeLocation(block, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(block, Offset(10000.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withoutAllowance!!)
@@ -159,8 +160,8 @@ class StandardAllowanceTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1000.meters))))
             .setStandardAllowance(allowance)
             .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
@@ -200,8 +201,8 @@ class StandardAllowanceTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 1.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1.meters))))
             .setStandardAllowance(allowance)
             .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
@@ -236,8 +237,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(blocks[blocks.size - 1], 0.meters)))
+                .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(blocks[blocks.size - 1], Offset(0.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withAllowance)
@@ -279,8 +280,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(forthBlock, 1.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(1.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setStandardAllowance(allowance)
         )
@@ -322,8 +323,8 @@ class StandardAllowanceTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setUnavailableTimes(occupancyGraph)
-            .setStartLocations(setOf(EdgeLocation(blocks[0], 0.meters)))
-            .setEndLocations(setOf(EdgeLocation(blocks[2], 1000.meters)))
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[2], Offset(1000.meters))))
             .setStandardAllowance(allowance)
             .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
@@ -347,8 +348,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(forthBlock, 100.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(100.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withoutAllowance)
@@ -373,8 +374,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(forthBlock, 100.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(100.meters))))
                 .setStandardAllowance(allowance)
         )
         Assertions.assertNotNull(res.withoutAllowance)
@@ -418,8 +419,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(forthBlock, 100.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(forthBlock, Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setStandardAllowance(allowance)
         )
@@ -463,8 +464,8 @@ class StandardAllowanceTests {
         val res = runWithAndWithoutAllowance(
             STDCMPathfindingBuilder()
                 .setInfra(infra.fullInfra())
-                .setStartLocations(setOf(EdgeLocation(firstBlock, 0.meters)))
-                .setEndLocations(setOf(EdgeLocation(thirdBlock, 100.meters)))
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset(100.meters))))
                 .setUnavailableTimes(occupancyGraph)
                 .setStandardAllowance(allowance)
         )

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.stdcm.StandardAllowanceTests.Companion.runWithAndWithoutAllo
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -26,9 +27,9 @@ class StopTests {
         val secondBlock = infra.addBlock("b", "c")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 50.meters)), 10000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 100.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(50.meters))), 10000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(100.meters))), 0.0, true))
             .run()!!
         val expectedOffset = 150.0
 
@@ -60,9 +61,9 @@ class StopTests {
         val secondBlock = infra.addBlock("b", "c")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 0.meters)), 10000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 100.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(0.meters))), 10000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(100.meters))), 0.0, true))
             .run()!!
         checkStop(
             res, listOf(
@@ -82,9 +83,9 @@ class StopTests {
         val secondBlock = infra.addBlock("b", "c")
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 100.meters)), 10000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 100.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(100.meters))), 10000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(100.meters))), 0.0, true))
             .run()!!
         checkStop(
             res, listOf(
@@ -120,9 +121,9 @@ class StopTests {
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
             .setStartTime(100.0)
-            .addStep(STDCMStep(setOf(EdgeLocation(blocksDirectPath[0], 0.meters)), 0.0, false))
-            .addStep(STDCMStep(setOf(EdgeLocation(detour[1], 1000.meters)), 0.0, stop))
-            .addStep(STDCMStep(setOf(EdgeLocation(blocksDirectPath[3], 0.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocksDirectPath[0], Offset(0.meters))), 0.0, false))
+            .addStep(STDCMStep(setOf(EdgeLocation(detour[1], Offset(1000.meters))), 0.0, stop))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocksDirectPath[3], Offset(0.meters))), 0.0, true))
             .run()!!
         val blocks = res.blocks.ranges.stream()
             .map { edgeRange -> infra.blockPool[edgeRange.edge.index.toInt()].name }
@@ -153,9 +154,9 @@ class StopTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, 10.meters)), 100000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, 100.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(firstBlock, Offset(10.meters))), 100000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(secondBlock, Offset(100.meters))), 0.0, true))
             .setUnavailableTimes(unavailableTimes)
             .run()
         Assertions.assertNull(res)
@@ -179,9 +180,9 @@ class StopTests {
         )
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], 50.meters)), 10000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[2], 1.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], Offset(50.meters))), 10000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[2], Offset(1.meters))), 0.0, true))
             .setUnavailableTimes(occupancy)
             .run()!!
         checkStop(
@@ -230,9 +231,9 @@ class StopTests {
             .setInfra(infra.fullInfra())
             .setUnavailableTimes(occupancy)
             .setTimeStep(timeStep)
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], 0.meters)), 0.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], 50.meters)), 1000.0, true))
-            .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], 1.meters)), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], Offset(0.meters))), 0.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], Offset(50.meters))), 1000.0, true))
+            .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], Offset(1.meters))), 0.0, true))
             .run()!!
         checkStop(
             res, listOf(
@@ -280,9 +281,9 @@ class StopTests {
                 .setUnavailableTimes(occupancy)
                 .setTimeStep(timeStep)
                 .setStandardAllowance(allowance)
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], 0.meters)), 0.0, true))
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], 50.meters)), 1000.0, true))
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], 1.meters)), 0.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], Offset(0.meters))), 0.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], Offset(50.meters))), 1000.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], Offset(1.meters))), 0.0, true))
         )
         val expectedStops = listOf(
             TrainStop(51.0, 1000.0)
@@ -335,9 +336,9 @@ class StopTests {
                 .setUnavailableTimes(occupancy)
                 .setTimeStep(timeStep)
                 .setStandardAllowance(allowance)
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], 0.meters)), 0.0, true))
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], 50.meters)), 1000.0, true))
-                .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], 1.meters)), 0.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[0], Offset(0.meters))), 0.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[1], Offset(50.meters))), 1000.0, true))
+                .addStep(STDCMStep(setOf(EdgeLocation(blocks[3], Offset(1.meters))), 0.0, true))
         )
         val expectedStops = listOf(
             TrainStop(51.0, 1000.0)

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.JsonAdapter
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra
 import fr.sncf.osrd.infra.api.signaling.SignalingModule
 import fr.sncf.osrd.infra.implementation.signaling.SignalingInfraBuilder
@@ -25,7 +26,6 @@ import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.moshi.MoshiUtils
-import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import java.io.File
 import java.io.IOException
@@ -158,14 +158,14 @@ object Helpers {
     fun convertRouteLocation(
         infra: FullInfra,
         routeName: String?,
-        offset: Distance
-    ): EdgeLocation<BlockId> {
+        offset: Offset<Route>
+    ): PathfindingEdgeLocationId<Block> {
         var mutOffset = offset
         val blocks = getBlocksOnRoutes(infra, listOf(routeName))
         for (block in blocks) {
             val blockLength = infra.blockInfra.getBlockLength(block)
-            if (mutOffset <= blockLength.distance)
-                return EdgeLocation(block, mutOffset)
+            if (mutOffset <= blockLength.cast())
+                return EdgeLocation(block, mutOffset.cast())
             mutOffset -= blockLength.distance
         }
         throw RuntimeException("Couldn't find route location")
@@ -188,6 +188,6 @@ object Helpers {
         }
         val startOffset = getOffsetOfTrackLocationOnChunks(infra, start, chunks)
         val endOffset = getOffsetOfTrackLocationOnChunks(infra, end, chunks)
-        return buildChunkPath(infra, chunks, Offset(startOffset!!), Offset(endOffset!!))
+        return buildChunkPath(infra, chunks, startOffset!!, endOffset!!)
     }
 }


### PR DESCRIPTION
Summary of the largest changes: 

1. The generic `Pathfinding` class has an extra type parameters for its offsets, with type aliases to avoid `StaticIdx<T>, T` repetitions
2. Typing in STDCM modules have been significantly improved, `Offset<STDCMEdge>` has been introduced with conversion to/from `Offset<Block>`
3. `Offset<Path>` has been introduced

These changes need many changes in call sites to compile, hence the large amount of diff.

A few bugs have been highlighted by mismatched typing, and fixed.