### PR TITLE
nix: remove unused variable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,8 +127,6 @@
               ++ scriptBins;
 
             RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
-            OSRD_DEV = "True";
-            OSRD_BACKEND_URL = "http://localhost:8080";
           };
         }
     );


### PR DESCRIPTION
These variable were causing problems since the default values
are incorrect, and `yarn start` actually use them in priority.