### PR TITLE
front: fix psl saving

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -375,6 +375,7 @@
         "sign-angle-geo": "Angle Geo",
         "sign-angle-sch": "Angle Sch",
         "sign-category": "Sign(s) {{signType}}",
+        "sign-kp": "Kilometric point of the sign",
         "sign-select": "Select",
         "sign-remove": "Remove sign",
         "sign-position": "Position",
@@ -387,7 +388,8 @@
         "save-existing-speed-section": "Save modifications",
         "save-new-speed-section": "Save the new speed limit",
         "speed-limits": "Speed limits",
-        "toggle-psl": "Permanent speed limit"
+        "toggle-psl": "Permanent speed limit",
+        "toggle-psl-help": "Click on a track section first to be able to activate this option"
       },
       "switch-edition": {
         "actions": {

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -375,6 +375,7 @@
         "sign-angle-geo": "Angle Geo",
         "sign-angle-sch": "Angle Sch",
         "sign-category": "Panneau(x) {{signType}}",
+        "sign-kp": "Point kilométrique",
         "sign-select": "Sélectionner",
         "sign-remove": "Supprimer le panneau",
         "sign-position": "Position",
@@ -387,7 +388,8 @@
         "save-existing-speed-section": "Sauvegarder les modifications",
         "save-new-speed-section": "Sauvegarder la nouvelle limite de vitesse",
         "speed-limits": "Limitations de vitesses",
-        "toggle-psl": "Limite permanente de vitesse"
+        "toggle-psl": "Limite permanente de vitesse",
+        "toggle-psl-help": "Cliquez d'abord sur un tronçon d'itinéraire pour pouvoir activer cette option"
       },
       "switch-edition": {
         "actions": {

--- a/front/src/applications/editor/tools/rangeEdition/components.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components.tsx
@@ -313,6 +313,7 @@ export const RangeEditionLeftPanel: FC = () => {
                 id="is-psl-checkbox"
                 name="is-psl-checkbox"
                 checked={isPSL}
+                disabled={entity.properties.track_ranges?.length === 0}
                 label={t('Editor.tools.speed-edition.toggle-psl')}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   let newExtension: SpeedSectionEntity['properties']['extensions'] = {
@@ -332,7 +333,8 @@ export const RangeEditionLeftPanel: FC = () => {
                           side: 'LEFT',
                           track: firstRange.track,
                           type: 'Z',
-                          value: null,
+                          value: '',
+                          kp: '',
                         },
                       },
                     };
@@ -341,6 +343,9 @@ export const RangeEditionLeftPanel: FC = () => {
                 }}
               />
             </div>
+            {entity.properties.track_ranges?.length === 0 && (
+              <p className="mt-3 font-size-1">{t('Editor.tools.speed-edition.toggle-psl-help')}</p>
+            )}
             {isPSL && (
               <EditPSLSection
                 entity={entity as SpeedSectionPslEntity}

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/EditPSLSection.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/EditPSLSection.tsx
@@ -23,6 +23,7 @@ const getNewAnnouncementSign = (
     track: firstRange.track,
     type: 'TIV_D',
     value: `${speedMultipleOfFive}`,
+    kp: '',
   } as PSLSign;
 };
 
@@ -37,7 +38,8 @@ const getNewRSign = (
     side: 'LEFT',
     track: lastRange.track,
     type: 'R',
-    value: null,
+    value: '',
+    kp: '',
   } as PSLSign;
 };
 

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/PslSignCard.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/PslSignCard.tsx
@@ -80,6 +80,21 @@ const PslSignCard = ({
         </div>
         <div className="my-2">
           <InputSNCF
+            type="text"
+            id="psl-kp"
+            label={t('Editor.tools.speed-edition.sign-kp')}
+            value={sign.kp ?? ''}
+            onChange={(e) => {
+              updateSign(signInfo, {
+                ...sign,
+                kp: String(e.target.value),
+              });
+            }}
+            sm
+          />
+        </div>
+        <div className="my-2">
+          <InputSNCF
             type="number"
             id="psl-position-from-the-beginning"
             label={t('Editor.tools.speed-edition.sign-position')}

--- a/front/src/types/editor.ts
+++ b/front/src/types/editor.ts
@@ -47,7 +47,8 @@ export interface PSLSign {
   side: 'LEFT' | 'RIGHT' | 'CENTER';
   track: string;
   type: string;
-  value: string | null;
+  value: string;
+  kp: string;
 }
 
 export interface PSLExtension {


### PR DESCRIPTION
close #5792 
close #5842 

- Add empty string ("") as default value for value field in psl signs
- Add KP field for PSL signs forms with empty string ("") as default value
- Disabled PSL checkbox if no track section is selected and add message helper for the user