### PR TITLE
ci: bump setup-buildx-action to v3

### DIFF
--- a/.github/workflows/unstable-build-images.yml
+++ b/.github/workflows/unstable-build-images.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           version: v0.12.0
           driver-opts: image=moby/buildkit:v0.12.3


### PR DESCRIPTION
It isn't supposed to solve the current caching issue, but still better.