### PR TITLE
Speed up editoast errors db insertion

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "strum",
  "strum_macros",
  "tempfile",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -60,6 +60,7 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9.25"
+sha1 = "0.10"
 strum = "0.25.0"
 strum_macros = "0.25.3"
 thiserror = "1.0.50"

--- a/editoast/migrations/2023-11-24-162712_add_errors_hash/down.sql
+++ b/editoast/migrations/2023-11-24-162712_add_errors_hash/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE infra_layer_error DROP COLUMN info_hash;

--- a/editoast/migrations/2023-11-24-162712_add_errors_hash/up.sql
+++ b/editoast/migrations/2023-11-24-162712_add_errors_hash/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE infra_layer_error ADD info_hash varchar(40) NOT NULL DEFAULT 'undefined';
+UPDATE infra_layer_error SET info_hash = id::text;
+ALTER TABLE infra_layer_error ADD CONSTRAINT error_hash_unique UNIQUE (info_hash, infra_id);

--- a/editoast/src/generated_data/error/catenaries.rs
+++ b/editoast/src/generated_data/error/catenaries.rs
@@ -10,7 +10,7 @@ use crate::schema::{InfraError, OSRDIdentified, ObjectRef, ObjectType};
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
-    ObjectErrorGenerator::new(1, check_catenary_track_ranges),
+    ObjectErrorGenerator::new(2, check_catenary_track_ranges),
 ];
 
 pub const GLOBAL_GENERATORS: [GlobalErrorGenerator<NoContext>; 1] =

--- a/editoast/src/generated_data/error/operational_points.rs
+++ b/editoast/src/generated_data/error/operational_points.rs
@@ -6,7 +6,7 @@ use crate::schema::{InfraError, ObjectRef, ObjectType};
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
-    ObjectErrorGenerator::new(1, check_op_parts),
+    ObjectErrorGenerator::new(2, check_op_parts),
 ];
 
 /// Check if operational point is empty

--- a/editoast/src/generated_data/error/speed_sections.rs
+++ b/editoast/src/generated_data/error/speed_sections.rs
@@ -12,7 +12,7 @@ use crate::schema::{
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
-    ObjectErrorGenerator::new(1, check_speed_section_track_ranges),
+    ObjectErrorGenerator::new(2, check_speed_section_track_ranges),
 ];
 pub const GLOBAL_GENERATORS: [GlobalErrorGenerator<NoContext>; 1] =
     [GlobalErrorGenerator::new(check_overlapping)];

--- a/editoast/src/generated_data/error/sql/buffer_stops_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/buffer_stops_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     buffer_stops.geographic,
     buffer_stops.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_buffer_stop AS buffer_stops ON buffer_stops.obj_id = information->>'obj_id'
     AND buffer_stops.infra_id = $1

--- a/editoast/src/generated_data/error/sql/catenaries_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/catenaries_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     catenaries.geographic,
     catenaries.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_catenary AS catenaries ON catenaries.obj_id = information->>'obj_id'
     AND catenaries.infra_id = $1

--- a/editoast/src/generated_data/error/sql/detectors_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/detectors_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     detectors.geographic,
     detectors.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_detector AS detectors ON detectors.obj_id = information->>'obj_id'
     AND detectors.infra_id = $1

--- a/editoast/src/generated_data/error/sql/neutral_sections_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/neutral_sections_insert_errors.sql
@@ -1,14 +1,17 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     NULL,
     NULL,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors

--- a/editoast/src/generated_data/error/sql/routes_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/routes_insert_errors.sql
@@ -1,14 +1,17 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     NULL,
     NULL,
-    errors.information
+    errors.information,
+    error_hash
 FROM errors

--- a/editoast/src/generated_data/error/sql/signals_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/signals_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     signals.geographic,
     signals.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_signal AS signals ON signals.obj_id = information->>'obj_id'
     AND signals.infra_id = $1

--- a/editoast/src/generated_data/error/sql/speed_sections_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/speed_sections_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     speeds.geographic,
     speeds.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_speed_section AS speeds ON speeds.obj_id = information->>'obj_id'
     AND speeds.infra_id = $1

--- a/editoast/src/generated_data/error/sql/switch_types_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/switch_types_insert_errors.sql
@@ -1,14 +1,17 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     NULL,
     NULL,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors

--- a/editoast/src/generated_data/error/sql/switches_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/switches_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     switches.geographic,
     switches.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_switch AS switches ON switches.obj_id = information->>'obj_id'
     AND switches.infra_id = $1

--- a/editoast/src/generated_data/error/sql/track_sections_insert_errors.sql
+++ b/editoast/src/generated_data/error/sql/track_sections_insert_errors.sql
@@ -1,16 +1,19 @@
 WITH errors AS (
-    SELECT unnest($2) AS information
+    SELECT unnest($2) AS information,
+        unnest($3) AS error_hash
 )
 INSERT INTO infra_layer_error (
         infra_id,
         geographic,
         schematic,
-        information
+        information,
+        info_hash
     )
 SELECT $1 AS infra_id,
     tracks.geographic,
     tracks.schematic,
-    errors.information
+    errors.information,
+    errors.error_hash
 FROM errors
     LEFT JOIN infra_layer_track_section AS tracks ON tracks.obj_id = information->>'obj_id'
     AND tracks.infra_id = $1

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -97,6 +97,8 @@ diesel::table! {
         schematic -> Nullable<Geometry>,
         information -> Jsonb,
         infra_id -> Int8,
+        #[max_length = 40]
+        info_hash -> Varchar,
     }
 }
 


### PR DESCRIPTION
## What this PR does

Editing an object takes too much time because we have to refresh the whole error layer each time.
The idea is to identify the new errors and those that have disappeared, once all the new errors have been generated. This avoids deleting everything and inserting all the new errors because in practice there are few changes.
To achieve this, we hash (with sha1) the errors.  

## Benchmark

|                | Ref    | New  |
|----------------|--------|------|
| Move detector  | 4089ms | 11ms |
| Remove a track | 3881ms | 89ms |
| Auto fix       | 4225ms | 30ms |

This benchmark was done using a big infra (France) with ~10,000 errors.
In practice editing a big infra took at least `5s` now it takes `1.5s`.

close #5516