### PR TITLE
front: warns on using LegacyFilterSpecification

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -18,6 +18,18 @@
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": ["error"],
+
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "LegacyFilterSpecification": {
+            "message": "Use ExpressionFilterSpecification instead",
+            "fixWith": "ExpressionFilterSpecification"
+          }
+        }
+      }
+    ],
     "arrow-body-style": ["error", "as-needed"],
     "global-require": "off",
     "import/extensions": [

--- a/front/src/common/Map/Layers/Errors.ts
+++ b/front/src/common/Map/Layers/Errors.ts
@@ -9,7 +9,11 @@ export function getLineErrorsLayerProps(context: LayerContext): OmitLayer<LineLa
   const enableErrorTypes = context.issuesSettings?.types || INFRA_ERRORS;
   const res: OmitLayer<LineLayer> = {
     type: 'line',
-    filter: ['all', ['in', 'obj_type', ...LINE_OBJECT], ['in', 'error_type', ...enableErrorTypes]],
+    filter: [
+      'all',
+      ['in', ['get', 'obj_type'], ['literal', LINE_OBJECT]],
+      ['in', ['get', 'error_type'], ['literal', enableErrorTypes]],
+    ],
     paint: {
       'line-color': [
         'case',
@@ -30,7 +34,11 @@ export function getLineTextErrorsLayerProps(context: LayerContext): OmitLayer<Sy
   const enableErrorTypes = context.issuesSettings?.types || INFRA_ERRORS;
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
-    filter: ['all', ['in', 'obj_type', ...LINE_OBJECT], ['in', 'error_type', ...enableErrorTypes]],
+    filter: [
+      'all',
+      ['in', ['get', 'obj_type'], ['literal', LINE_OBJECT]],
+      ['in', ['get', 'error_type'], ['literal', enableErrorTypes]],
+    ],
     layout: {
       'symbol-placement': 'line',
       'text-font': ['Roboto Condensed'],
@@ -56,7 +64,11 @@ export function getPointErrorsLayerProps(context: LayerContext): OmitLayer<Circl
   const enableErrorTypes = context.issuesSettings?.types || INFRA_ERRORS;
   const res: OmitLayer<CircleLayer> = {
     type: 'circle',
-    filter: ['all', ['!in', 'obj_type', ...LINE_OBJECT], ['in', 'error_type', ...enableErrorTypes]],
+    filter: [
+      'all',
+      ['!', ['in', ['get', 'obj_type'], ['literal', LINE_OBJECT]]],
+      ['in', ['get', 'error_type'], ['literal', enableErrorTypes]],
+    ],
     paint: {
       'circle-color': [
         'case',
@@ -76,7 +88,11 @@ export function getPointTextErrorsLayerProps(context: LayerContext): OmitLayer<S
   const enableErrorTypes = context.issuesSettings?.types || INFRA_ERRORS;
   const res: OmitLayer<SymbolLayer> = {
     type: 'symbol',
-    filter: ['all', ['!in', 'obj_type', ...LINE_OBJECT], ['in', 'error_type', ...enableErrorTypes]],
+    filter: [
+      'all',
+      ['!', ['in', ['get', 'obj_type'], ['literal', LINE_OBJECT]]],
+      ['in', ['get', 'error_type'], ['literal', enableErrorTypes]],
+    ],
     layout: {
       'symbol-placement': 'point',
       'text-font': ['Roboto Condensed'],

--- a/front/src/common/Map/Layers/LineSearchLayer.tsx
+++ b/front/src/common/Map/Layers/LineSearchLayer.tsx
@@ -32,7 +32,7 @@ const LineSearchLayer = ({ layerOrder, infraID }: TracksGeographicProps) => {
             'line-color': '#ffb612',
             'line-width': 4,
           }}
-          filter={['==', 'extensions_sncf_line_code', lineSearchCode]}
+          filter={['==', ['get', 'extensions_sncf_line_code'], lineSearchCode]}
         />
       )}
     </Source>

--- a/front/src/common/Map/Layers/Platforms.tsx
+++ b/front/src/common/Map/Layers/Platforms.tsx
@@ -23,9 +23,9 @@ export function Platforms(props: PlatformsProps) {
     'source-layer': 'transportation',
     filter: [
       'all',
-      ['==', '$type', 'Polygon'],
-      ['==', 'class', 'path'],
-      ['==', 'subclass', 'platform'],
+      ['==', ['get', '$type'], 'Polygon'],
+      ['==', ['get', 'class'], 'path'],
+      ['==', ['get', 'subclass'], 'platform'],
     ],
     paint: {
       'fill-color': colors.platform.fill,

--- a/front/src/common/Map/Layers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/SpeedLimits.tsx
@@ -39,8 +39,8 @@ export function getFilterBySpeedSectionsTag(
   layersSettings: MapState['layersSettings']
 ): FilterSpecification {
   return isNil(layersSettings.speedlimittag)
-    ? ['all', ['has', 'speed_limit']]
-    : ['all', ['has', getSpeedSectionsTag(layersSettings)]];
+    ? ['has', 'speed_limit']
+    : ['has', getSpeedSectionsTag(layersSettings)];
 }
 
 export function getSpeedSectionsLineLayerProps({

--- a/front/src/common/Map/Layers/TracksOSM.tsx
+++ b/front/src/common/Map/Layers/TracksOSM.tsx
@@ -22,7 +22,7 @@ function TracksOSM(props: TracksOSMProps) {
     type: 'line',
     source: 'openmaptiles',
     'source-layer': 'transportation',
-    filter: ['all', ['==', 'class', 'rail'], ['==', 'service', 'yard']],
+    filter: ['all', ['==', ['get', 'class'], 'rail'], ['==', ['get', 'service'], 'yard']],
     layout: {
       visibility: 'visible',
     },
@@ -36,7 +36,7 @@ function TracksOSM(props: TracksOSMProps) {
     type: 'line',
     source: 'openmaptiles',
     'source-layer': 'transportation',
-    filter: ['all', ['==', 'class', 'rail'], ['!=', 'service', 'yard']],
+    filter: ['all', ['==', ['get', 'class'], 'rail'], ['!=', ['get', 'service'], 'yard']],
     layout: {
       visibility: 'visible',
     },


### PR DESCRIPTION
Fix #5850.

Details:
- Adds a "ban-types" rule for `LegacyFilterSpecification`
- Adds warnings at runtime when detecting `LegacyFilterSpecification`
- Removes (hopefully) all occurrences of `LegacyFilterSpecification` from the current codebase, and replaces them by `ExpressionFilterSpecification`

---

@nicolaswurtz I did not find a good way to prevent "at compilation" (using TypeScript, tslint or eslint) the usage of a specific type. I discovered the ["ban-types"](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-types.md) eslint rule, but it does not cover types inferences.

So, instead, I chose to `console.warn` "at runtime" those instances from the `adaptFilter` function. Since in editor all layer filters go through this function at some point, it should be enough to make us find future instances of LegacyFilterSpecification when they occur.