### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # --- CI - CODEOWNERS - Dependabot - Template ---
-/.github                                                 @flomonster @multun
+/.github                                                 @osrd-project/devops
+/.github/CODEOWNERS                                      @flomonster @bloussou @nicolaswurtz
 
 # --- FRONT ---
 /front                                                   @osrd-project/front-maintainers
@@ -14,7 +15,7 @@
 /python                                                  @osrd-project/editoast-maintainers
 
 # --- INTEGRATION TESTS  ---
-/tests                                                   @eckter
+/tests                                                   @eckter @bloussou @shenriotpro
 
 # --- CORE ---
 /core                                                    @osrd-project/core-maintainers


### PR DESCRIPTION
- Add DevOps group owner of `.github` (except for `CODEOWNERS`)
- Add @bloussou and @shenriotpro owners of `tests`