### PR TITLE
editoast: infra/{id}/pathfinding starts in both directions

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4144,12 +4144,7 @@ paths:
                 ending:
                   $ref: '#/components/schemas/TrackLocation'
                 starting:
-                  allOf:
-                  - $ref: '#/components/schemas/TrackLocation'
-                  - properties:
-                      direction:
-                        $ref: '#/components/schemas/Direction'
-                    type: object
+                  $ref: '#/components/schemas/TrackLocation'
               type: object
         description: Starting and ending track location
       responses:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -642,12 +642,7 @@ paths:
               type: object
               properties:
                 starting:
-                  allOf:
-                    - $ref: "#/components/schemas/TrackLocation"
-                    - type: object
-                      properties:
-                        direction:
-                          $ref: "#/components/schemas/Direction"
+                  $ref: "#/components/schemas/TrackLocation"
                 ending:
                   $ref: "#/components/schemas/TrackLocation"
       responses:

--- a/editoast/src/map/bounding_box.rs
+++ b/editoast/src/map/bounding_box.rs
@@ -54,6 +54,20 @@ impl BoundingBox {
     pub fn from_geometry(value: Geometry) -> Result<Self> {
         Self::from_geojson(value.value)
     }
+
+    /// Computes the length (in meters) of the diagonal
+    /// It represents the longest distance as the crow flies between two points in the box
+    pub fn diagonal_length(&self) -> f64 {
+        let a = osm4routing::Coord {
+            lon: self.0 .0,
+            lat: self.0 .1,
+        };
+        let b = osm4routing::Coord {
+            lon: self.1 .0,
+            lat: self.1 .1,
+        };
+        a.distance_to(b)
+    }
 }
 
 #[derive(Debug, Error, EditoastError)]

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -184,7 +184,19 @@ fn compute_path(
     let into_cost = |length: f64| (length * 100.).round() as u64;
     let get_length = |track: &String| track_sections[track].unwrap_track_section().length;
     let success = |step: &PathfindingStep| step.found;
-    let mut best_distance = u64::MAX;
+
+    let starting_track = track_sections[&input.starting.track.0].unwrap_track_section();
+    let ending_track = track_sections[&input.ending.track.0].unwrap_track_section();
+    let best_distance = starting_track
+        .bbox_geo
+        .clone()
+        .union(&ending_track.bbox_geo)
+        .diagonal_length();
+    // We build an upper bound that is the diagonal of the bounding box covering start and end
+    // During the path search, we prune any route that is twice that distance
+    // We set an upper bound of at least 10 km to avoid problems on very short distances
+    let mut best_distance = into_cost(best_distance.max(10_000.0));
+
     let successors = |step: &PathfindingStep| {
         // We initially don’t know in which direction start searching the path
         // So the first step as two successors, at the same track-position, but in opposite directions

--- a/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
@@ -214,6 +214,7 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
                         properties: {
                           id: '', // will be replaced by entityToCreateOperation
                           entry_point: omit(entryPoint, 'position'),
+                          entry_point_direction: candidate.data.track_ranges[0].direction,
                           exit_point: omit(exitPoint, 'position'),
                           switches_directions: candidate.data.switches_directions,
                           release_detectors: includeReleaseDetectors

--- a/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/EditRoutePath.tsx
@@ -42,13 +42,12 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
   const infraID = useSelector(getInfraID);
   const [isSaving, setIsSaving] = useState(false);
   const [includeReleaseDetectors, setIncludeReleaseDetectors] = useState(true);
-  const { entryPoint, exitPoint, entryPointDirection } = state.routeState;
+  const { entryPoint, exitPoint } = state.routeState;
 
   const [postPathfinding] = osrdEditoastApi.endpoints.postInfraByIdPathfinding.useMutation();
 
   const searchCandidates = useCallback(async () => {
-    if (!entryPoint || !exitPoint || !entryPointDirection || state.optionsState.type === 'loading')
-      return;
+    if (!entryPoint || !exitPoint || state.optionsState.type === 'loading') return;
 
     setState({
       optionsState: { type: 'loading' },
@@ -57,7 +56,6 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
     const payload = await getCompatibleRoutesPayload(
       infraID as number,
       entryPoint,
-      entryPointDirection,
       exitPoint,
       dispatch
     );
@@ -87,7 +85,7 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
         })),
       },
     });
-  }, [entryPoint, entryPointDirection, exitPoint, infraID, setState, state.optionsState.type]);
+  }, [entryPoint, exitPoint, infraID, setState, state.optionsState.type]);
 
   const focusedOptionIndex =
     state.optionsState.type === 'options' ? state.optionsState.focusedOptionIndex : null;
@@ -108,12 +106,7 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
         <button
           className="btn btn-primary btn-sm mr-2 d-block w-100 text-center"
           type="submit"
-          disabled={
-            !entryPoint ||
-            !entryPointDirection ||
-            !exitPoint ||
-            state.optionsState.type === 'loading'
-          }
+          disabled={!entryPoint || !exitPoint || state.optionsState.type === 'loading'}
         >
           <FiSearch /> {t('Editor.tools.routes-edition.search-routes')}
         </button>
@@ -222,7 +215,6 @@ export const EditRoutePathLeftPanel: FC<{ state: EditRoutePathState }> = ({ stat
                           id: '', // will be replaced by entityToCreateOperation
                           entry_point: omit(entryPoint, 'position'),
                           exit_point: omit(exitPoint, 'position'),
-                          entry_point_direction: entryPointDirection,
                           switches_directions: candidate.data.switches_directions,
                           release_detectors: includeReleaseDetectors
                             ? candidate.data.detectors

--- a/front/src/applications/editor/tools/routeEdition/components/Endpoints.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/Endpoints.tsx
@@ -1,5 +1,4 @@
-import Select from 'react-select';
-import React, { FC, useContext, useMemo } from 'react';
+import React, { FC, useContext } from 'react';
 import { BsArrowBarRight, BsBoxArrowInRight } from 'react-icons/bs';
 import { HiSwitchVertical } from 'react-icons/hi';
 import { FaFlagCheckered } from 'react-icons/fa';
@@ -7,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getInfraID } from 'reducers/osrdconf/selectors';
-import { BufferStopEntity, DetectorEntity, DIRECTIONS, WayPoint, WayPointEntity } from 'types';
+import { BufferStopEntity, DetectorEntity, WayPoint, WayPointEntity } from 'types';
 import EditorContext from 'applications/editor/context';
 import { getEntity } from 'applications/editor/data/api';
 import EntitySumUp from 'applications/editor/components/EntitySumUp';
@@ -20,20 +19,7 @@ export const EditEndpoints: FC<{ state: RouteState; onChange: (newState: RouteSt
   onChange,
 }) => {
   const { t } = useTranslation();
-  const { entryPoint, exitPoint, entryPointDirection } = state;
-
-  const options = useMemo(
-    () =>
-      DIRECTIONS.map((s) => ({
-        value: s,
-        label: t(`Editor.tools.routes-edition.directions.${s}`),
-      })),
-    [t]
-  );
-  const option = useMemo(
-    () => options.find((o) => o.value === entryPointDirection) || options[0],
-    [options, entryPointDirection]
-  );
+  const { entryPoint, exitPoint } = state;
 
   return (
     <>
@@ -45,22 +31,6 @@ export const EditEndpoints: FC<{ state: RouteState; onChange: (newState: RouteSt
         wayPoint={entryPoint}
         onChange={(wayPoint) => onChange({ ...state, entryPoint: wayPoint })}
       />
-      {entryPoint && (
-        <div className="d-flex flex-row align-items-baseline justify-content-center mb-2">
-          <span className="mr-2">{t('Editor.tools.routes-edition.start_direction')}</span>
-          <Select
-            value={option}
-            options={options}
-            onChange={(o) => {
-              if (o)
-                onChange({
-                  ...state,
-                  entryPointDirection: o.value,
-                });
-            }}
-          />
-        </div>
-      )}
       <div className="text-center">
         <button
           type="button"

--- a/front/src/applications/editor/tools/routeEdition/utils.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.ts
@@ -9,7 +9,6 @@ import { getEntities, getEntity, getMixedEntities } from 'applications/editor/da
 import { DEFAULT_COMMON_TOOL_STATE } from 'applications/editor/tools/commonToolState';
 import { RouteCandidate, RouteEditionState } from 'applications/editor/tools/routeEdition/types';
 import {
-  Direction,
   PartialButFor,
   RouteEntity,
   TrackRange,
@@ -220,7 +219,6 @@ export async function getRouteGeometries(
 export async function getCompatibleRoutesPayload(
   infra: number,
   entryPoint: WayPoint,
-  entryPointDirection: Direction,
   exitPoint: WayPoint,
   dispatch: Dispatch
 ) {
@@ -240,7 +238,6 @@ export async function getCompatibleRoutesPayload(
     starting: {
       track: entryPointEntity.properties.track as string,
       position: entryPointEntity.properties.position as number,
-      direction: entryPointDirection,
     },
     ending: {
       track: exitPointEntity.properties.track as string,

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -905,9 +905,7 @@ export type PostInfraByIdPathfindingApiArg = {
   /** Starting and ending track location */
   body: {
     ending?: TrackLocation;
-    starting?: TrackLocation & {
-      direction?: Direction;
-    };
+    starting?: TrackLocation;
   };
 };
 export type GetInfraByIdRailjsonApiResponse =


### PR DESCRIPTION
Closes #5543

- The first commit searches in both directions and fixes the functional aspects
- The second commit adds a bound to avoid searching routes for too long (this endpoint searches k-shortest path, and the second shortest could be significantly longer)
- The last commit is removing the parameter