### PR TITLE
front: remove beta from rs editor card title

### DIFF
--- a/front/public/locales/de/home/home.json
+++ b/front/public/locales/de/home/home.json
@@ -2,6 +2,6 @@
   "editor": "Infrastrukturverlag",
   "map": "Kartografie",
   "operationalStudies": "Eisenbahnbetriebsstudien",
-  "rollingStockEditor": "Éditeur de matériel roulant (Bêta)",
+  "rollingStockEditor": "Schienenfahrzeugbearbeiter",
   "stdcm": "Click'n ride"
 }

--- a/front/public/locales/en/home/home.json
+++ b/front/public/locales/en/home/home.json
@@ -2,6 +2,6 @@
   "editor": "Infrastructure editor",
   "map": "Map viewer",
   "operationalStudies": "Operational studies",
-  "rollingStockEditor": "Rolling stock editor (Beta)",
+  "rollingStockEditor": "Rolling stock editor",
   "stdcm": "Short term path request"
 }

--- a/front/public/locales/fr/home/home.json
+++ b/front/public/locales/fr/home/home.json
@@ -2,6 +2,6 @@
   "editor": "Éditeur d'infrastructure",
   "map": "Cartographie",
   "operationalStudies": "Études d'exploitation",
-  "rollingStockEditor": "Éditeur de matériel roulant (Bêta)",
+  "rollingStockEditor": "Éditeur de matériel roulant",
   "stdcm": "Sillons de dernière minute"
 }


### PR DESCRIPTION
closes #5473 

"Editeur de matériel roulant" -> "Schienenfahrzeugbearbeiter" in Deutsch (according to Tristram)

![image](https://github.com/osrd-project/osrd/assets/45000526/c5bd55fe-6189-4659-96f6-08964f39508e)

