### PR TITLE
codeowners: use a group for integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /python                                                  @osrd-project/editoast-maintainers
 
 # --- INTEGRATION TESTS  ---
-/tests                                                   @eckter @bloussou @shenriotpro
+/tests                                                   @osrd-project/test-maintainers
 
 # --- CORE ---
 /core                                                    @osrd-project/core-maintainers


### PR DESCRIPTION
The previous setup required approval of all explicitly listed members.