### PR TITLE
front: operationalstudies: fix conflicts not displayed with two trains same departure

### DIFF
--- a/front/src/applications/operationalStudies/views/Scenario.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario.tsx
@@ -173,6 +173,12 @@ export default function Scenario() {
       }
     );
 
+  const { data: conflicts = [], refetch: refetchConflicts } =
+    osrdEditoastApi.endpoints.getTimetableByIdConflicts.useQuery(
+      { id: timetable?.id as number },
+      { skip: !timetable }
+    );
+
   useEffect(() => {
     if (timetable && infra?.state === 'CACHED' && timetable.train_schedule_summaries.length > 0) {
       selectProjection(timetable.train_schedule_summaries, selectedProjection, selectedTrainId);
@@ -290,6 +296,7 @@ export default function Scenario() {
                     setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
                     infraState={infra.state}
                     refetchTimetable={refetchTimetable}
+                    refetchConflicts={refetchConflicts}
                   />
                 )}
                 {infra && (
@@ -300,6 +307,7 @@ export default function Scenario() {
                     timetable={timetable}
                     selectedTrainId={selectedTrainId}
                     refetchTimetable={refetchTimetable}
+                    conflicts={conflicts}
                   />
                 )}
               </div>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
@@ -12,6 +12,7 @@ import { Infra, TrainScheduleBatchItem, osrdEditoastApi } from 'common/api/osrdE
 type Props = {
   infraState?: Infra['state'];
   refetchTimetable: () => void;
+  refetchConflicts: () => void;
   setIsWorking: (isWorking: boolean) => void;
 };
 
@@ -29,6 +30,7 @@ type error400 = {
 export default function SubmitConfAddTrainSchedule({
   infraState,
   refetchTimetable,
+  refetchConflicts,
   setIsWorking,
 }: Props) {
   const [postTrainSchedule] =
@@ -93,6 +95,7 @@ export default function SubmitConfAddTrainSchedule({
         );
         setIsWorking(false);
         refetchTimetable();
+        refetchConflicts();
       } catch (e: unknown) {
         setIsWorking(false);
         if (e instanceof Error) {

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -15,7 +15,12 @@ import { getTrainScheduleIDsToModify } from 'reducers/osrdconf/selectors';
 import { ScheduledTrain } from 'reducers/osrdsimulation/types';
 import { updateTrainScheduleIDsToModify } from 'reducers/osrdconf';
 import { valueToInterval } from 'utils/numbers';
-import { Infra, TimetableWithSchedulesDetails, osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import {
+  Conflict,
+  Infra,
+  TimetableWithSchedulesDetails,
+  osrdEditoastApi,
+} from 'common/api/osrdEditoastApi';
 import { durationInSeconds } from 'utils/timeManipulation';
 import { getSelectedProjection } from 'reducers/osrdsimulation/selectors';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
@@ -32,6 +37,7 @@ type Props = {
   timetable: TimetableWithSchedulesDetails | undefined;
   selectedTrainId?: number;
   refetchTimetable: () => void;
+  conflicts?: Conflict[];
 };
 
 export default function Timetable({
@@ -41,6 +47,7 @@ export default function Timetable({
   timetable,
   selectedTrainId,
   refetchTimetable,
+  conflicts,
 }: Props) {
   const selectedProjection = useSelector(getSelectedProjection);
   const trainScheduleIDsToModify = useSelector(getTrainScheduleIDsToModify);
@@ -57,11 +64,6 @@ export default function Timetable({
   const debouncedTerm = useDebounce(filter, 500) as string;
 
   const [deleteTrainSchedules] = osrdEditoastApi.endpoints.deleteTrainSchedule.useMutation();
-
-  const { data: conflicts = [] } = osrdEditoastApi.endpoints.getTimetableByIdConflicts.useQuery(
-    { id: timetable?.id as number },
-    { skip: !timetable }
-  );
 
   useEffect(() => {
     setMultiselectOn(false);
@@ -300,11 +302,13 @@ export default function Timetable({
             <span className="flex-grow-1">{t('timetable.invalidTrains')}</span>
           </div>
         )}
-        <ConflictsList
-          conflicts={conflicts}
-          expanded={conflictsListExpanded}
-          toggleConflictsList={toggleConflictsListExpanded}
-        />
+        {conflicts && (
+          <ConflictsList
+            conflicts={conflicts}
+            expanded={conflictsListExpanded}
+            toggleConflictsList={toggleConflictsListExpanded}
+          />
+        )}
       </div>
     </div>
   );

--- a/front/src/modules/trainschedule/components/Timetable/TimetableManageTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableManageTrainSchedule.tsx
@@ -16,6 +16,7 @@ type Props = {
   setDisplayTrainScheduleManagement: (type: string) => void;
   infraState?: Infra['state'];
   refetchTimetable: () => void;
+  refetchConflicts: () => void;
 };
 
 export default function TimetableManageTrainSchedule({
@@ -23,6 +24,7 @@ export default function TimetableManageTrainSchedule({
   setDisplayTrainScheduleManagement,
   infraState,
   refetchTimetable,
+  refetchConflicts,
 }: Props) {
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');
   const dispatch = useDispatch();
@@ -54,6 +56,7 @@ export default function TimetableManageTrainSchedule({
                 infraState={infraState}
                 refetchTimetable={refetchTimetable}
                 setIsWorking={setIsWorking}
+                refetchConflicts={refetchConflicts}
               />
             )}
             <TrainAddingSettings />


### PR DESCRIPTION
- add getTimetableByIdConflicts
- set it in a useEffect with timetable in dependencies

close #5832 