### PR TITLE
front: operationalstudies: fix scenario and study card names wrong display when too long

### DIFF
--- a/front/src/modules/scenario/components/ScenarioCard.tsx
+++ b/front/src/modules/scenario/components/ScenarioCard.tsx
@@ -35,7 +35,9 @@ export default function StudyCard({ setFilterChips, scenario }: Props) {
         <span className="mr-2">
           <RiFolderChartLine />
         </span>
-        {scenario.name}
+        <span className="scenario-card-name-text" title={scenario.name}>
+          {scenario.name}
+        </span>
         <button
           data-testid="openScenario"
           className="btn btn-sm"

--- a/front/src/modules/scenario/styles/_scenarioCard.scss
+++ b/front/src/modules/scenario/styles/_scenarioCard.scss
@@ -66,6 +66,10 @@
     padding: 0.25rem 0.25rem 0.25rem 0.5rem;
     font-size: 1.1rem;
     transition: 0.4s;
+    &-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   .scenario-card-description {
     padding: 0.5rem;

--- a/front/src/modules/study/components/StudyCard.tsx
+++ b/front/src/modules/study/components/StudyCard.tsx
@@ -34,7 +34,9 @@ export default function StudyCard({ setFilterChips, study }: Props) {
         <span className="mr-2">
           <img src={studyLogo} alt="study logo" height="24" />
         </span>
-        {study.name}
+        <span className="study-card-name-text" title={study.name}>
+          {study.name}
+        </span>
         <button
           data-testid="openStudy"
           className="btn btn-primary btn-sm"

--- a/front/src/modules/study/styles/_studyCard.scss
+++ b/front/src/modules/study/styles/_studyCard.scss
@@ -64,6 +64,10 @@
     padding: 0.5rem 0.5rem 0.5rem;
     background-color: var(--coolgray3);
     color: var(--secondary);
+    &-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   .study-card-type {
     overflow: hidden;


### PR DESCRIPTION
- add names in span then give it "-text" classname suffix
- add elipsis to those classnames

close #5937 