### PR TITLE
front: rollingstockeditor: set default mode to thermal when adding this mode to an electric rs

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
@@ -417,7 +417,8 @@ export default function RollingStockEditorCurves({
 
   const updateTractionModesList = (newTractionMode: string) => {
     setCurrentRsEffortCurve((prevState) => ({
-      default_mode: prevState ? prevState.default_mode : newTractionMode,
+      default_mode:
+        prevState && newTractionMode !== 'thermal' ? prevState.default_mode : newTractionMode,
       modes: {
         ...(prevState ? prevState.modes : {}),
         [newTractionMode]: createEmptyCurves(newTractionMode, rollingstockParams.comfortLevels),


### PR DESCRIPTION
close #5300 