### PR TITLE
.github: ensure editoast tests are not run in parallel (for now)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,7 +340,7 @@ jobs:
           docker run --name=editoast-test --net=host -v $PWD/output:/output \
             -e DATABASE_URL="postgres://osrd:password@localhost:5432/osrd" \
             ${{ fromJSON(needs.build.outputs.stable_tags).editoast-test }} \
-            /bin/bash -c "diesel migration run --locked-schema && cargo test --verbose && grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o /output/lcov.info"
+            /bin/bash -c "diesel migration run --locked-schema && cargo test --verbose -- --test-threads=1 && grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o /output/lcov.info"
           
           exit $(docker wait editoast-test)
 


### PR DESCRIPTION
see https://github.com/osrd-project/osrd/actions/runs/7085605938/job/19282326205?pr=5982, https://github.com/osrd-project/osrd/issues/5441, and https://github.com/osrd-project/osrd/tree/dev/editoast#tests