### PR TITLE
editoast: improve /auto_fixes tests

### DIFF
--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -556,6 +556,17 @@ impl InfraCache {
         }
         Ok(())
     }
+
+    pub fn get_route(&self, route_id: &str) -> Result<&Route> {
+        Ok(self
+            .routes()
+            .get(route_id)
+            .ok_or_else(|| InfraCacheEditoastError::ObjectNotFound {
+                obj_type: ObjectType::Route.to_string(),
+                obj_id: route_id.to_string(),
+            })?
+            .unwrap_route())
+    }
 }
 
 #[derive(Debug, Error, EditoastError)]
@@ -567,6 +578,14 @@ pub enum OperationResultError {
     #[error("{obj_type} '{obj_id}', a duplicate already exists")]
     #[editoast_error(status = 404)]
     DuplicateIdsProvided { obj_type: String, obj_id: String },
+}
+
+#[derive(Debug, Error, EditoastError)]
+#[editoast_error(base_id = "infra_cache")]
+pub enum InfraCacheEditoastError {
+    #[error("{obj_type} '{obj_id}', could not be found in the infrastructure cache")]
+    #[editoast_error(status = 404)]
+    ObjectNotFound { obj_type: String, obj_id: String },
 }
 
 #[cfg(test)]

--- a/editoast/src/tests/small_infra/small_infra.json
+++ b/editoast/src/tests/small_infra/small_infra.json
@@ -238,7 +238,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA2": "RIGHT"
+                "PA2": "A_B2"
             }
         },
         {
@@ -268,8 +268,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA0": "LEFT",
-                "PA2": "LEFT"
+                "PA0": "A_B1",
+                "PA2": "A_B1"
             }
         },
         {
@@ -285,8 +285,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA0": "RIGHT",
-                "PA3": "RIGHT"
+                "PA0": "A_B2",
+                "PA3": "A_B2"
             }
         },
         {
@@ -316,8 +316,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA1": "RIGHT",
-                "PA3": "LEFT"
+                "PA1": "A_B2",
+                "PA3": "A_B1"
             }
         },
         {
@@ -333,8 +333,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA2": "LEFT",
-                "PA0": "LEFT"
+                "PA2": "A_B1",
+                "PA0": "A_B1"
             }
         },
         {
@@ -350,7 +350,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA2": "RIGHT"
+                "PA2": "A_B2"
             }
         },
         {
@@ -366,7 +366,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC0": "LEFT"
+                "PC0": "A_B1"
             }
         },
         {
@@ -382,7 +382,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC0": "RIGHT"
+                "PC0": "A_B2"
             }
         },
         {
@@ -398,8 +398,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA3": "LEFT",
-                "PA1": "RIGHT"
+                "PA3": "A_B1",
+                "PA1": "A_B2"
             }
         },
         {
@@ -415,8 +415,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA3": "LEFT",
-                "PA1": "LEFT"
+                "PA3": "A_B1",
+                "PA1": "A_B1"
             }
         },
         {
@@ -432,8 +432,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA3": "RIGHT",
-                "PA0": "RIGHT"
+                "PA3": "A_B2",
+                "PA0": "A_B2"
             }
         },
         {
@@ -449,7 +449,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC1": "LEFT"
+                "PC1": "A_B1"
             }
         },
         {
@@ -465,7 +465,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC1": "RIGHT"
+                "PC1": "A_B2"
             }
         },
         {
@@ -495,8 +495,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PA1": "LEFT",
-                "PA3": "LEFT"
+                "PA1": "A_B1",
+                "PA3": "A_B1"
             }
         },
         {
@@ -512,7 +512,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC0": "LEFT"
+                "PC0": "A_B1"
             }
         },
         {
@@ -528,7 +528,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC2": "RIGHT"
+                "PC2": "A_B2"
             }
         },
         {
@@ -544,7 +544,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC0": "RIGHT"
+                "PC0": "A_B2"
             }
         },
         {
@@ -560,7 +560,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC2": "LEFT"
+                "PC2": "A_B1"
             }
         },
         {
@@ -576,7 +576,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC1": "LEFT"
+                "PC1": "A_B1"
             }
         },
         {
@@ -592,7 +592,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC3": "RIGHT"
+                "PC3": "A_B2"
             }
         },
         {
@@ -608,7 +608,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC1": "RIGHT"
+                "PC1": "A_B2"
             }
         },
         {
@@ -624,7 +624,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC3": "LEFT"
+                "PC3": "A_B1"
             }
         },
         {
@@ -640,7 +640,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC2": "LEFT"
+                "PC2": "A_B1"
             }
         },
         {
@@ -656,7 +656,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC2": "RIGHT"
+                "PC2": "A_B2"
             }
         },
         {
@@ -672,7 +672,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD0": "static"
+                "PD0": "STATIC"
             }
         },
         {
@@ -688,7 +688,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC3": "LEFT"
+                "PC3": "A_B1"
             }
         },
         {
@@ -704,7 +704,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PC3": "RIGHT"
+                "PC3": "A_B2"
             }
         },
         {
@@ -720,7 +720,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD1": "static"
+                "PD1": "STATIC"
             }
         },
         {
@@ -736,7 +736,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD0": "static"
+                "PD0": "STATIC"
             }
         },
         {
@@ -752,7 +752,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE2": "LEFT"
+                "PE2": "A_B1"
             }
         },
         {
@@ -768,14 +768,14 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE2": "RIGHT"
+                "PE2": "A_B2"
             }
         },
         {
-            "id": "rt.DD5->DD1",
+            "id": "rt.DF0->DD1",
             "entry_point": {
                 "type": "Detector",
-                "id": "DD5"
+                "id": "DF0"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
@@ -784,7 +784,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD1": "static"
+                "PD1": "STATIC"
             }
         },
         {
@@ -800,7 +800,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N1_S2"
+                "PH0": "A1_B2"
             }
         },
         {
@@ -816,7 +816,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N2_S2"
+                "PH0": "A2_B2"
             }
         },
         {
@@ -832,7 +832,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE0": "LEFT"
+                "PE0": "A_B1"
             }
         },
         {
@@ -848,7 +848,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE0": "RIGHT"
+                "PE0": "A_B2"
             }
         },
         {
@@ -864,12 +864,12 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD1": "static",
-                "PD0": "static"
+                "PD1": "STATIC",
+                "PD0": "STATIC"
             }
         },
         {
-            "id": "rt.buffer_stop.4->DF0",
+            "id": "rt.buffer_stop.4->DD5",
             "entry_point": {
                 "type": "BufferStop",
                 "id": "buffer_stop.4"
@@ -877,16 +877,16 @@
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
                 "type": "Detector",
-                "id": "DF0"
+                "id": "DD5"
             },
             "release_detectors": [],
             "switches_directions": {}
         },
         {
-            "id": "rt.DF0->DE1",
+            "id": "rt.DD5->DE1",
             "entry_point": {
                 "type": "Detector",
-                "id": "DF0"
+                "id": "DD5"
             },
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
@@ -895,8 +895,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PD0": "static",
-                "PD1": "static"
+                "PD0": "STATIC",
+                "PD1": "STATIC"
             }
         },
         {
@@ -912,7 +912,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE1": "RIGHT"
+                "PE1": "A_B2"
             }
         },
         {
@@ -928,7 +928,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE0": "LEFT"
+                "PE0": "A_B1"
             }
         },
         {
@@ -944,7 +944,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE1": "LEFT"
+                "PE1": "A_B1"
             }
         },
         {
@@ -960,7 +960,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE0": "RIGHT"
+                "PE0": "A_B2"
             }
         },
         {
@@ -976,7 +976,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE2": "LEFT"
+                "PE2": "A_B1"
             }
         },
         {
@@ -992,7 +992,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE1": "LEFT"
+                "PE1": "A_B1"
             }
         },
         {
@@ -1008,7 +1008,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE1": "RIGHT"
+                "PE1": "A_B2"
             }
         },
         {
@@ -1024,7 +1024,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PE2": "RIGHT"
+                "PE2": "A_B2"
             }
         },
         {
@@ -1040,7 +1040,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N1_S1"
+                "PH0": "A1_B1"
             }
         },
         {
@@ -1056,7 +1056,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N2_S1"
+                "PH0": "A2_B1"
             }
         },
         {
@@ -1072,11 +1072,11 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N1_S1"
+                "PH0": "A1_B1"
             }
         },
         {
-            "id": "rt.DG1->DD5",
+            "id": "rt.DG1->DF0",
             "entry_point": {
                 "type": "Detector",
                 "id": "DG1"
@@ -1084,11 +1084,11 @@
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
                 "type": "Detector",
-                "id": "DD5"
+                "id": "DF0"
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N1_S2"
+                "PH0": "A1_B2"
             }
         },
         {
@@ -1104,7 +1104,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG0": "LEFT"
+                "PG0": "A_B1"
             }
         },
         {
@@ -1120,8 +1120,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG0": "RIGHT",
-                "PG1": "RIGHT"
+                "PG0": "A_B2",
+                "PG1": "A_B2"
             }
         },
         {
@@ -1137,7 +1137,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH1": "LEFT"
+                "PH1": "A_B1"
             }
         },
         {
@@ -1153,7 +1153,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG1": "LEFT"
+                "PG1": "A_B1"
             }
         },
         {
@@ -1183,7 +1183,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG0": "LEFT"
+                "PG0": "A_B1"
             }
         },
         {
@@ -1213,7 +1213,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG1": "LEFT"
+                "PG1": "A_B1"
             }
         },
         {
@@ -1229,8 +1229,8 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PG1": "RIGHT",
-                "PG0": "RIGHT"
+                "PG1": "A_B2",
+                "PG0": "A_B2"
             }
         },
         {
@@ -1246,11 +1246,11 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N2_S1"
+                "PH0": "A2_B1"
             }
         },
         {
-            "id": "rt.DH1->DD5",
+            "id": "rt.DH1->DF0",
             "entry_point": {
                 "type": "Detector",
                 "id": "DH1"
@@ -1258,11 +1258,11 @@
             "entry_point_direction": "STOP_TO_START",
             "exit_point": {
                 "type": "Detector",
-                "id": "DD5"
+                "id": "DF0"
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH0": "N2_S2"
+                "PH0": "A2_B2"
             }
         },
         {
@@ -1278,7 +1278,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH1": "LEFT"
+                "PH1": "A_B1"
             }
         },
         {
@@ -1294,7 +1294,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH1": "RIGHT"
+                "PH1": "A_B2"
             }
         },
         {
@@ -1324,7 +1324,7 @@
             },
             "release_detectors": [],
             "switches_directions": {
-                "PH1": "RIGHT"
+                "PH1": "A_B2"
             }
         }
     ],
@@ -1332,18 +1332,18 @@
     "switches": [
         {
             "id": "PA0",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TA1"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TA3"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TA4"
                 }
@@ -1356,18 +1356,18 @@
         },
         {
             "id": "PA1",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TA5"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TB0"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TA2"
                 }
@@ -1380,18 +1380,18 @@
         },
         {
             "id": "PA2",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TA6"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TA3"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TA0"
                 }
@@ -1404,18 +1404,18 @@
         },
         {
             "id": "PA3",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TA7"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TA5"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TA4"
                 }
@@ -1428,18 +1428,18 @@
         },
         {
             "id": "PC0",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TA6"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TC0"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TC1"
                 }
@@ -1452,18 +1452,18 @@
         },
         {
             "id": "PC1",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TA7"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TC2"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TC3"
                 }
@@ -1476,18 +1476,18 @@
         },
         {
             "id": "PC2",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TD0"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TC1"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TC0"
                 }
@@ -1500,18 +1500,18 @@
         },
         {
             "id": "PC3",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TD1"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TC3"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TC2"
                 }
@@ -1524,24 +1524,24 @@
         },
         {
             "id": "PD0",
-            "switch_type": "cross",
+            "switch_type": "crossing",
             "group_change_delay": 0.0,
             "ports": {
-                "north": {
+                "A1": {
                     "endpoint": "END",
                     "track": "TE0"
                 },
-                "south": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TF0"
                 },
-                "east": {
-                    "endpoint": "BEGIN",
-                    "track": "TD2"
-                },
-                "west": {
+                "A2": {
                     "endpoint": "END",
                     "track": "TD0"
+                },
+                "B2": {
+                    "endpoint": "BEGIN",
+                    "track": "TD2"
                 }
             },
             "extensions": {
@@ -1552,24 +1552,24 @@
         },
         {
             "id": "PD1",
-            "switch_type": "cross",
+            "switch_type": "crossing",
             "group_change_delay": 0.0,
             "ports": {
-                "north": {
+                "A1": {
                     "endpoint": "END",
                     "track": "TF0"
                 },
-                "south": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TF1"
                 },
-                "east": {
-                    "endpoint": "BEGIN",
-                    "track": "TD3"
-                },
-                "west": {
+                "A2": {
                     "endpoint": "END",
                     "track": "TD1"
+                },
+                "B2": {
+                    "endpoint": "BEGIN",
+                    "track": "TD3"
                 }
             },
             "extensions": {
@@ -1580,18 +1580,18 @@
         },
         {
             "id": "PE0",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TE0"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TE1"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TE2"
                 }
@@ -1604,18 +1604,18 @@
         },
         {
             "id": "PE1",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TE3"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TE2"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TE1"
                 }
@@ -1628,18 +1628,18 @@
         },
         {
             "id": "PE2",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TD2"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TE3"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TG0"
                 }
@@ -1652,18 +1652,18 @@
         },
         {
             "id": "PG0",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TG1"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TG4"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TG3"
                 }
@@ -1676,18 +1676,18 @@
         },
         {
             "id": "PG1",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "BEGIN",
                     "track": "TG5"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TG2"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "END",
                     "track": "TG3"
                 }
@@ -1700,22 +1700,22 @@
         },
         {
             "id": "PH0",
-            "switch_type": "double_cross",
+            "switch_type": "double_slip_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "north_1": {
+                "A1": {
                     "endpoint": "BEGIN",
                     "track": "TG1"
                 },
-                "north_2": {
-                    "endpoint": "BEGIN",
-                    "track": "TH0"
-                },
-                "south_1": {
+                "B1": {
                     "endpoint": "END",
                     "track": "TG0"
                 },
-                "south_2": {
+                "A2": {
+                    "endpoint": "BEGIN",
+                    "track": "TH0"
+                },
+                "B2": {
                     "endpoint": "END",
                     "track": "TD3"
                 }
@@ -1728,18 +1728,18 @@
         },
         {
             "id": "PH1",
-            "switch_type": "point",
+            "switch_type": "point_switch",
             "group_change_delay": 0.0,
             "ports": {
-                "base": {
+                "A": {
                     "endpoint": "END",
                     "track": "TH0"
                 },
-                "left": {
+                "B1": {
                     "endpoint": "BEGIN",
                     "track": "TG2"
                 },
-                "right": {
+                "B2": {
                     "endpoint": "BEGIN",
                     "track": "TH1"
                 }
@@ -3629,13 +3629,67 @@
             "voltage": "25000",
             "track_ranges": [
                 {
-                    "track": "TH1",
+                    "track": "TF0",
                     "begin": 0.0,
-                    "end": 5000.0,
+                    "end": 3.0,
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TE3",
+                    "track": "TE2",
+                    "begin": 0.0,
+                    "end": 2050.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TA6",
+                    "begin": 0.0,
+                    "end": 10000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TC2",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TD0",
+                    "begin": 0.0,
+                    "end": 25000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TG0",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TC1",
+                    "begin": 0.0,
+                    "end": 1000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TD2",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TG3",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TA1",
+                    "begin": 0.0,
+                    "end": 1950.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TG4",
                     "begin": 0.0,
                     "end": 2000.0,
                     "applicable_directions": "BOTH"
@@ -3647,57 +3701,9 @@
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TA6",
-                    "begin": 0.0,
-                    "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA5",
-                    "begin": 0.0,
-                    "end": 50.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD2",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
                     "track": "TA7",
                     "begin": 0.0,
                     "end": 10000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF1",
-                    "begin": 0.0,
-                    "end": 6500.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TD0",
-                    "begin": 0.0,
-                    "end": 25000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TA1",
-                    "begin": 0.0,
-                    "end": 1950.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC0",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TF0",
-                    "begin": 0.0,
-                    "end": 3.0,
                     "applicable_directions": "BOTH"
                 },
                 {
@@ -3707,9 +3713,45 @@
                     "applicable_directions": "BOTH"
                 },
                 {
+                    "track": "TF1",
+                    "begin": 0.0,
+                    "end": 6500.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TC0",
+                    "begin": 0.0,
+                    "end": 1050.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TE3",
+                    "begin": 0.0,
+                    "end": 2000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TG1",
+                    "begin": 0.0,
+                    "end": 4000.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
                     "track": "TA3",
                     "begin": 0.0,
                     "end": 50.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TA5",
+                    "begin": 0.0,
+                    "end": 50.0,
+                    "applicable_directions": "BOTH"
+                },
+                {
+                    "track": "TH1",
+                    "begin": 0.0,
+                    "end": 5000.0,
                     "applicable_directions": "BOTH"
                 },
                 {
@@ -3719,7 +3761,7 @@
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TG5",
+                    "track": "TE1",
                     "begin": 0.0,
                     "end": 2000.0,
                     "applicable_directions": "BOTH"
@@ -3731,13 +3773,13 @@
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TA4",
+                    "track": "TC3",
                     "begin": 0.0,
-                    "end": 50.0,
+                    "end": 1050.0,
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TG3",
+                    "track": "TA4",
                     "begin": 0.0,
                     "end": 50.0,
                     "applicable_directions": "BOTH"
@@ -3749,55 +3791,13 @@
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TG1",
-                    "begin": 0.0,
-                    "end": 4000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
                     "track": "TH0",
                     "begin": 0.0,
                     "end": 1000.0,
                     "applicable_directions": "BOTH"
                 },
                 {
-                    "track": "TC2",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG0",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC3",
-                    "begin": 0.0,
-                    "end": 1050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE1",
-                    "begin": 0.0,
-                    "end": 2000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TC1",
-                    "begin": 0.0,
-                    "end": 1000.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TE2",
-                    "begin": 0.0,
-                    "end": 2050.0,
-                    "applicable_directions": "BOTH"
-                },
-                {
-                    "track": "TG4",
+                    "track": "TG5",
                     "begin": 0.0,
                     "end": 2000.0,
                     "applicable_directions": "BOTH"
@@ -5569,7 +5569,7 @@
         {
             "track": "TD3",
             "position": 200.0,
-            "id": "SD5",
+            "id": "SF0",
             "direction": "STOP_TO_START",
             "sight_distance": 400.0,
             "logical_signals": [
@@ -5583,7 +5583,7 @@
             ],
             "extensions": {
                 "sncf": {
-                    "label": "SD5",
+                    "label": "SF0",
                     "side": "LEFT",
                     "kp": ""
                 }
@@ -5661,7 +5661,7 @@
         {
             "track": "TF1",
             "position": 200.0,
-            "id": "SF0",
+            "id": "SD5",
             "direction": "STOP_TO_START",
             "sight_distance": 400.0,
             "logical_signals": [
@@ -5675,7 +5675,7 @@
             ],
             "extensions": {
                 "sncf": {
-                    "label": "SF0",
+                    "label": "SD5",
                     "side": "LEFT",
                     "kp": ""
                 }
@@ -6693,7 +6693,7 @@
         {
             "track": "TD3",
             "position": 180.0,
-            "id": "DD5",
+            "id": "DF0",
             "applicable_directions": "BOTH"
         },
         {
@@ -6717,7 +6717,7 @@
         {
             "track": "TF1",
             "position": 180.0,
-            "id": "DF0",
+            "id": "DD5",
             "applicable_directions": "BOTH"
         },
         {

--- a/editoast/src/views/infra/auto_fixes.rs
+++ b/editoast/src/views/infra/auto_fixes.rs
@@ -283,7 +283,7 @@ mod test {
             obj_type: ObjectType::Route,
         })));
         assert!(operations.contains(&Operation::Delete(DeleteOperation {
-            obj_id: "rt.buffer_stop.4->DF0".to_string(),
+            obj_id: "rt.buffer_stop.4->DD5".to_string(),
             obj_type: ObjectType::Route,
         })));
     }

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -64,9 +64,9 @@ enum ListErrorsErrors {
     WrongErrorTypeProvided,
 }
 
-#[derive(QueryableByName, Debug, Clone, Serialize)]
+#[derive(QueryableByName, Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-struct InfraError {
+pub struct InfraError {
     #[diesel(sql_type = Json)]
     pub information: JsonValue,
 }

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -47,7 +47,7 @@ macro_rules! decl_paginated_response {
 }
 
 /// A paginated response
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PaginatedResponse<T> {
     pub count: i64,
     pub previous: Option<i64>,


### PR DESCRIPTION
While preparing https://github.com/osrd-project/osrd/issues/5859:
* fix small_infra.json (outdated and broken)
* add a test that `/auto_fixes` doesn't alter infra and related errors
* initiate a little interface for object-cache retrieval in infra cache and improve editoast's error on the way

:mag: easier reviewed by commit