### PR TITLE
editoast: magic wand - remove catenary and speed section

### DIFF
--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -198,3 +198,23 @@ impl EditoastError for reqwest::Error {
         "editoast:ReqwestError"
     }
 }
+
+impl EditoastError for serde_json::Error {
+    fn get_status(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn get_type(&self) -> &str {
+        "editoast:SerdeJsonError"
+    }
+}
+
+impl EditoastError for json_patch::PatchError {
+    fn get_status(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn get_type(&self) -> &str {
+        "editoast:JsonPatchError"
+    }
+}

--- a/editoast/src/schema/operation/create.rs
+++ b/editoast/src/schema/operation/create.rs
@@ -98,27 +98,24 @@ impl RailjsonObject {
     pub fn patch(self, json_patch: &Patch) -> Result<Self> {
         // `json_patch::patch()` operates on `serde_json::Value`.
         // Therefore, we have to:
-        // (1) serialize `RailjsonObject`,
-        // (2) deserialize it into `serde_json::Value`,
-        // (3) patch the object,
-        // (4) serialize patched `serde_json::Value`, and
-        // (5) deserialize it back into a `RailjsonObject`.
+        // (1) transform `RailjsonObject` into `serde_json::Value`,
+        // (2) patch the object,
+        // (3) transform `serde_json::Value` back into a `RailjsonObject`.
         // The code below is explicitely typed (even if not needed) to help understand this dance.
         let object_type = self.get_type();
-        let json = match &self {
-            RailjsonObject::TrackSection { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::Signal { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::NeutralSection { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::SpeedSection { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::Switch { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::SwitchType { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::Detector { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::BufferStop { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::Route { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::OperationalPoint { railjson } => serde_json::to_string(railjson)?,
-            RailjsonObject::Electrification { railjson } => serde_json::to_string(railjson)?,
+        let mut value: serde_json::Value = match &self {
+            RailjsonObject::TrackSection { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::Signal { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::NeutralSection { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::SpeedSection { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::Switch { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::SwitchType { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::Detector { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::BufferStop { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::Route { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::OperationalPoint { railjson } => serde_json::to_value(railjson)?,
+            RailjsonObject::Electrification { railjson } => serde_json::to_value(railjson)?,
         };
-        let mut value: serde_json::Value = serde_json::from_str(&json)?;
         json_patch::patch(&mut value, json_patch)?;
         let railjson_object = match object_type {
             ObjectType::TrackSection => RailjsonObject::TrackSection {

--- a/editoast/src/schema/operation/create.rs
+++ b/editoast/src/schema/operation/create.rs
@@ -6,6 +6,7 @@ use crate::schema::{
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Json, Text};
 use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use json_patch::Patch;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -92,6 +93,69 @@ impl RailjsonObject {
             RailjsonObject::Electrification { railjson: obj } => serde_json::to_value(obj),
         }
         .unwrap()
+    }
+
+    pub fn patch(self, json_patch: &Patch) -> Result<Self> {
+        // `json_patch::patch()` operates on `serde_json::Value`.
+        // Therefore, we have to:
+        // (1) serialize `RailjsonObject`,
+        // (2) deserialize it into `serde_json::Value`,
+        // (3) patch the object,
+        // (4) serialize patched `serde_json::Value`, and
+        // (5) deserialize it back into a `RailjsonObject`.
+        // The code below is explicitely typed (even if not needed) to help understand this dance.
+        let object_type = self.get_type();
+        let json = match &self {
+            RailjsonObject::TrackSection { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::Signal { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::NeutralSection { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::SpeedSection { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::Switch { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::SwitchType { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::Detector { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::BufferStop { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::Route { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::OperationalPoint { railjson } => serde_json::to_string(railjson)?,
+            RailjsonObject::Electrification { railjson } => serde_json::to_string(railjson)?,
+        };
+        let mut value: serde_json::Value = serde_json::from_str(&json)?;
+        json_patch::patch(&mut value, json_patch)?;
+        let railjson_object = match object_type {
+            ObjectType::TrackSection => RailjsonObject::TrackSection {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::Signal => RailjsonObject::Signal {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::SpeedSection => RailjsonObject::SpeedSection {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::Detector => RailjsonObject::Detector {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::NeutralSection => RailjsonObject::NeutralSection {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::Switch => RailjsonObject::Switch {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::SwitchType => RailjsonObject::SwitchType {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::BufferStop => RailjsonObject::BufferStop {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::Route => RailjsonObject::Route {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::OperationalPoint => RailjsonObject::OperationalPoint {
+                railjson: serde_json::from_value(value)?,
+            },
+            ObjectType::Electrification => RailjsonObject::Electrification {
+                railjson: serde_json::from_value(value)?,
+            },
+        };
+        Ok(railjson_object)
     }
 }
 

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -42,14 +42,19 @@ impl CacheOperation {
         railjson_object: RailjsonObject,
     ) -> Result<Self> {
         let cache_operation = match operation {
-            Operation::Create(railjson_object) => {
-                CacheOperation::Create(ObjectCache::from(railjson_object.deref().clone()))
+            Operation::Create(new_railjson_object) => {
+                debug_assert_eq!(new_railjson_object.get_ref(), railjson_object.get_ref());
+                CacheOperation::Create(ObjectCache::from(new_railjson_object.deref().clone()))
             }
             Operation::Update(UpdateOperation { railjson_patch, .. }) => {
                 let railjson_object = railjson_object.patch(railjson_patch)?;
                 CacheOperation::Update(ObjectCache::from(railjson_object))
             }
-            Operation::Delete(_) => CacheOperation::Delete(railjson_object.get_ref()),
+            Operation::Delete(delete_operation) => {
+                let object_ref = ObjectRef::from(delete_operation.clone());
+                debug_assert_eq!(object_ref, railjson_object.get_ref());
+                CacheOperation::Delete(object_ref)
+            }
         };
         Ok(cache_operation)
     }

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -2,7 +2,7 @@ pub mod create;
 mod delete;
 mod update;
 
-use super::ObjectRef;
+use super::{OSRDObject as _, ObjectRef};
 use crate::{error::Result, infra_cache::ObjectCache};
 use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
@@ -34,6 +34,25 @@ pub enum CacheOperation {
     Create(ObjectCache),
     Update(ObjectCache),
     Delete(ObjectRef),
+}
+
+impl CacheOperation {
+    pub fn try_from_operation(
+        operation: &Operation,
+        railjson_object: RailjsonObject,
+    ) -> Result<Self> {
+        let cache_operation = match operation {
+            Operation::Create(railjson_object) => {
+                CacheOperation::Create(ObjectCache::from(railjson_object.deref().clone()))
+            }
+            Operation::Update(UpdateOperation { railjson_patch, .. }) => {
+                let railjson_object = railjson_object.patch(railjson_patch)?;
+                CacheOperation::Update(ObjectCache::from(railjson_object))
+            }
+            Operation::Delete(_) => CacheOperation::Delete(railjson_object.get_ref()),
+        };
+        Ok(cache_operation)
+    }
 }
 
 impl Operation {

--- a/editoast/src/schema/operation/update.rs
+++ b/editoast/src/schema/operation/update.rs
@@ -16,7 +16,7 @@ use super::OperationError;
 pub struct UpdateOperation {
     pub obj_id: String,
     pub obj_type: ObjectType,
-    railjson_patch: Patch,
+    pub railjson_patch: Patch,
 }
 
 impl UpdateOperation {

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -127,12 +127,16 @@ mod tests {
 
         assert_eq!(operations.len(), 1);
 
-        let (operation, cache_operation) = operations.get(&electrification_cache.get_ref()).unwrap();
+        let (operation, cache_operation) =
+            operations.get(&electrification_cache.get_ref()).unwrap();
         let Operation::Update(update_operation) = operation else {
             panic!("not an `Operation::Update`");
         };
         assert_eq!(update_operation.obj_id, "electrification_id");
-        assert!(matches!(update_operation.obj_type, ObjectType::Electrification));
+        assert!(matches!(
+            update_operation.obj_type,
+            ObjectType::Electrification
+        ));
         assert_eq!(
             update_operation.railjson_patch,
             serde_json::from_str::<Patch>(
@@ -143,7 +147,8 @@ mod tests {
             )
             .unwrap()
         );
-        let CacheOperation::Update(ObjectCache::Electrification(electrification)) = cache_operation else {
+        let CacheOperation::Update(ObjectCache::Electrification(electrification)) = cache_operation
+        else {
             panic!("not a `CacheOperation::Update(ObjectCache::Electrification())`");
         };
         assert_eq!(electrification.track_ranges.len(), 1);
@@ -175,7 +180,8 @@ mod tests {
             "electrification",
             ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_1"),
         );
-        let error_electrification_2 = InfraError::new_empty_object(&electrification_cache, "track_ranges");
+        let error_electrification_2 =
+            InfraError::new_empty_object(&electrification_cache, "track_ranges");
 
         let operations = super::fix_electrification(
             &electrification_cache,
@@ -184,12 +190,16 @@ mod tests {
 
         assert_eq!(operations.len(), 1);
 
-        let (operation, cache_operation) = operations.get(&electrification_cache.get_ref()).unwrap();
+        let (operation, cache_operation) =
+            operations.get(&electrification_cache.get_ref()).unwrap();
         let Operation::Delete(delete_operation) = operation else {
             panic!("not an `Operation::Delete`");
         };
         assert_eq!(delete_operation.obj_id, "electrification_id");
-        assert!(matches!(delete_operation.obj_type, ObjectType::Electrification));
+        assert!(matches!(
+            delete_operation.obj_type,
+            ObjectType::Electrification
+        ));
         let CacheOperation::Delete(object_ref) = cache_operation else {
             panic!("not a `CacheOperation::Delete()`");
         };

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -5,7 +5,7 @@ use crate::schema::{
 };
 use itertools::Itertools as _;
 use json_patch::{Patch, PatchOperation, RemoveOperation};
-use log::debug;
+use log::{debug, error};
 use std::collections::HashMap;
 
 fn invalid_reference_to_ordered_operation(
@@ -56,13 +56,18 @@ pub fn fix_electrification(
         .flatten();
     operation
         .and_then(|operation| {
-            let cache_operation = CacheOperation::try_from_operation(
+            let cache_operation = match CacheOperation::try_from_operation(
                 &operation,
                 RailjsonObject::Electrification {
                     railjson: electrification.clone(),
                 },
-            )
-            .ok()?;
+            ) {
+                Ok(cache_operation) => cache_operation,
+                Err(e) => {
+                    error!("failed to convert `Operation` on electrification into a `CacheOperation`: {e}");
+                    return None;
+                }
+            };
             Some((electrification.get_ref(), (operation, cache_operation)))
         })
         .into_iter()

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -1,19 +1,199 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{Electrification, InfraError, InfraErrorType, OSRDObject as _, ObjectRef};
+use super::{Fix, OrderedOperation};
+use crate::schema::{
+    operation::{CacheOperation, DeleteOperation, Operation, RailjsonObject, UpdateOperation},
+    Electrification, InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef,
+};
+use itertools::Itertools as _;
+use json_patch::{Patch, PatchOperation, RemoveOperation};
 use log::debug;
 use std::collections::HashMap;
+
+fn invalid_reference_to_ordered_operation(
+    electrification: &Electrification,
+    object_ref: &ObjectRef,
+) -> Option<OrderedOperation> {
+    let (track_range_idx, _) = electrification
+        .track_ranges
+        .iter()
+        .enumerate()
+        .find(|(_idx, track_range)| track_range.track.as_str() == object_ref.obj_id)?;
+    Some(OrderedOperation::RemoveTrackRange { track_range_idx })
+}
 
 pub fn fix_electrification(
     electrification: &Electrification,
     errors: impl Iterator<Item = InfraError>,
 ) -> HashMap<ObjectRef, Fix> {
-    errors
+    let operation = errors
         .filter_map(|infra_error| match infra_error.get_sub_type() {
-            InfraErrorType::EmptyObject => Some(new_ref_fix_delete_pair(electrification)),
+            InfraErrorType::EmptyObject => Some(OrderedOperation::Delete),
+            InfraErrorType::InvalidReference { reference } => {
+                invalid_reference_to_ordered_operation(electrification, reference)
+            }
             _ => {
                 debug!("error not (yet) fixable for '{}'", infra_error.get_type());
                 None
             }
         })
+        // Need to invert the ordering because removing from the front would invalidate other indexes
+        .sorted_by_key(|ordered_operation| std::cmp::Reverse(ordered_operation.clone()))
+        .map(|ordered_operation| match ordered_operation {
+            OrderedOperation::RemoveTrackRange { track_range_idx } => {
+                Operation::Update(UpdateOperation {
+                    obj_id: electrification.get_id().clone(),
+                    obj_type: electrification.get_type(),
+                    railjson_patch: Patch(vec![PatchOperation::Remove(RemoveOperation {
+                        path: format!("/track_ranges/{track_range_idx}"),
+                    })]),
+                })
+            }
+            OrderedOperation::Delete => {
+                Operation::Delete(DeleteOperation::from(electrification.get_ref()))
+            }
+        })
+        .map(Some)
+        .reduce(super::reduce_operation)
+        .flatten();
+    operation
+        .and_then(|operation| {
+            let cache_operation = CacheOperation::try_from_operation(
+                &operation,
+                RailjsonObject::Electrification {
+                    railjson: electrification.clone(),
+                },
+            )
+            .ok()?;
+            Some((electrification.get_ref(), (operation, cache_operation)))
+        })
+        .into_iter()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use json_patch::Patch;
+
+    use crate::{
+        infra_cache::ObjectCache,
+        schema::{
+            operation::{CacheOperation, Operation},
+            utils::Identifier,
+            ApplicableDirections, ApplicableDirectionsTrackRange, Electrification, InfraError,
+            OSRDObject as _, ObjectRef, ObjectType,
+        },
+    };
+
+    #[test]
+    fn invalid_refs_ordered_electrification() {
+        let electrification_cache = Electrification {
+            id: Identifier::from("electrification_id"),
+            track_ranges: vec![
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_1"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("track_section_id"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_2"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+            ],
+            ..Default::default()
+        };
+        let error_electrification_1 = InfraError::new_invalid_reference(
+            &electrification_cache,
+            "electrification",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_1"),
+        );
+        let error_electrification_2 = InfraError::new_invalid_reference(
+            &electrification_cache,
+            "electrification",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_2"),
+        );
+
+        let operations = super::fix_electrification(
+            &electrification_cache,
+            vec![error_electrification_1, error_electrification_2].into_iter(),
+        );
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&electrification_cache.get_ref()).unwrap();
+        let Operation::Update(update_operation) = operation else {
+            panic!("not an `Operation::Update`");
+        };
+        assert_eq!(update_operation.obj_id, "electrification_id");
+        assert!(matches!(update_operation.obj_type, ObjectType::Electrification));
+        assert_eq!(
+            update_operation.railjson_patch,
+            serde_json::from_str::<Patch>(
+                r#"[
+                        {"op":"remove","path":"/track_ranges/2"},
+                        {"op":"remove","path":"/track_ranges/0"}
+                    ]"#
+            )
+            .unwrap()
+        );
+        let CacheOperation::Update(ObjectCache::Electrification(electrification)) = cache_operation else {
+            panic!("not a `CacheOperation::Update(ObjectCache::Electrification())`");
+        };
+        assert_eq!(electrification.track_ranges.len(), 1);
+        assert_eq!(electrification.track_ranges[0].track.0, "track_section_id");
+    }
+
+    #[test]
+    fn empty_object_and_invalid_ref_electrification() {
+        let electrification_cache = Electrification {
+            id: Identifier::from("electrification_id"),
+            track_ranges: vec![
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_1"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("track_section_id"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+            ],
+            ..Default::default()
+        };
+        let error_electrification_1 = InfraError::new_invalid_reference(
+            &electrification_cache,
+            "electrification",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_1"),
+        );
+        let error_electrification_2 = InfraError::new_empty_object(&electrification_cache, "track_ranges");
+
+        let operations = super::fix_electrification(
+            &electrification_cache,
+            vec![error_electrification_1, error_electrification_2].into_iter(),
+        );
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&electrification_cache.get_ref()).unwrap();
+        let Operation::Delete(delete_operation) = operation else {
+            panic!("not an `Operation::Delete`");
+        };
+        assert_eq!(delete_operation.obj_id, "electrification_id");
+        assert!(matches!(delete_operation.obj_type, ObjectType::Electrification));
+        let CacheOperation::Delete(object_ref) = cache_operation else {
+            panic!("not a `CacheOperation::Delete()`");
+        };
+        assert_eq!(object_ref.obj_id, "electrification_id");
+        assert_eq!(object_ref.obj_type, ObjectType::Electrification);
+    }
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -306,8 +306,8 @@ mod tests {
     use crate::schema::operation::{DeleteOperation, Operation, RailjsonObject};
     use crate::schema::utils::Identifier;
     use crate::schema::{
-        ApplicableDirectionsTrackRange, BufferStop, BufferStopCache, BufferStopExtension, Electrification,
-        Detector, DetectorCache, Endpoint, ObjectRef, ObjectType, OperationalPoint,
+        ApplicableDirectionsTrackRange, BufferStop, BufferStopCache, BufferStopExtension, Detector,
+        DetectorCache, Electrification, Endpoint, ObjectRef, ObjectType, OperationalPoint,
         OperationalPointPart, Route, Signal, SignalCache, Slope, SpeedSection, Switch,
         TrackEndpoint, TrackSection, Waypoint,
     };

--- a/editoast/src/views/infra/auto_fixes/speed_section.rs
+++ b/editoast/src/views/infra/auto_fixes/speed_section.rs
@@ -1,19 +1,207 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{InfraError, InfraErrorType, OSRDObject as _, ObjectRef, SpeedSection};
+use super::{Fix, OrderedOperation};
+use crate::schema::{
+    operation::{CacheOperation, DeleteOperation, Operation, RailjsonObject, UpdateOperation},
+    InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef, SpeedSection,
+};
+use itertools::Itertools as _;
+use json_patch::{Patch, PatchOperation, RemoveOperation};
 use log::debug;
 use std::collections::HashMap;
+
+fn invalid_reference_to_ordered_operation(
+    speed_section: &SpeedSection,
+    object_ref: &ObjectRef,
+) -> Option<OrderedOperation> {
+    let (track_range_idx, _) = speed_section
+        .track_ranges
+        .iter()
+        .enumerate()
+        .find(|(_idx, track_range)| track_range.track.as_str() == object_ref.obj_id)?;
+    Some(OrderedOperation::RemoveTrackRange { track_range_idx })
+}
 
 pub fn fix_speed_section(
     speed_section: &SpeedSection,
     errors: impl Iterator<Item = InfraError>,
 ) -> HashMap<ObjectRef, Fix> {
-    errors
+    let operation = errors
         .filter_map(|infra_error| match infra_error.get_sub_type() {
-            InfraErrorType::EmptyObject => Some(new_ref_fix_delete_pair(speed_section)),
+            InfraErrorType::EmptyObject => Some(OrderedOperation::Delete),
+            InfraErrorType::InvalidReference { reference } => {
+                invalid_reference_to_ordered_operation(speed_section, reference)
+            }
             _ => {
                 debug!("error not (yet) fixable for '{}'", infra_error.get_type());
                 None
             }
         })
+        // Need to invert the ordering because removing from the front would invalidate other indexes
+        .sorted_by_key(|ordered_operation| std::cmp::Reverse(ordered_operation.clone()))
+        .map(|ordered_operation| match ordered_operation {
+            OrderedOperation::RemoveTrackRange { track_range_idx } => {
+                Operation::Update(UpdateOperation {
+                    obj_id: speed_section.get_id().clone(),
+                    obj_type: speed_section.get_type(),
+                    railjson_patch: Patch(vec![PatchOperation::Remove(RemoveOperation {
+                        path: format!("/track_ranges/{track_range_idx}"),
+                    })]),
+                })
+            }
+            OrderedOperation::Delete => {
+                Operation::Delete(DeleteOperation::from(speed_section.get_ref()))
+            }
+        })
+        .map(Some)
+        .reduce(super::reduce_operation)
+        .flatten();
+    operation
+        .and_then(|operation| {
+            let cache_operation = CacheOperation::try_from_operation(
+                &operation,
+                RailjsonObject::SpeedSection {
+                    railjson: speed_section.clone(),
+                },
+            )
+            .ok()?;
+            Some((speed_section.get_ref(), (operation, cache_operation)))
+        })
+        .into_iter()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use json_patch::Patch;
+
+    use crate::{
+        infra_cache::ObjectCache,
+        schema::{
+            operation::{CacheOperation, Operation},
+            utils::Identifier,
+            ApplicableDirections, ApplicableDirectionsTrackRange, InfraError, OSRDObject as _,
+            ObjectRef, ObjectType, SpeedSection,
+        },
+    };
+
+    #[test]
+    fn invalid_refs_ordered_speed_section() {
+        let speed_section_cache = SpeedSection {
+            id: Identifier::from("speed_section_id"),
+            track_ranges: vec![
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_1"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("track_section_id"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_2"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+            ],
+            ..Default::default()
+        };
+        let error_speed_section_1 = InfraError::new_invalid_reference(
+            &speed_section_cache,
+            "speed_section",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_1"),
+        );
+        let error_speed_section_2 = InfraError::new_invalid_reference(
+            &speed_section_cache,
+            "speed_section",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_2"),
+        );
+
+        let operations = super::fix_speed_section(
+            &speed_section_cache,
+            vec![error_speed_section_1, error_speed_section_2].into_iter(),
+        );
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&speed_section_cache.get_ref()).unwrap();
+        let Operation::Update(update_operation) = operation else {
+            panic!("not an `Operation::Update`");
+        };
+        assert_eq!(update_operation.obj_id, "speed_section_id");
+        assert!(matches!(
+            update_operation.obj_type,
+            ObjectType::SpeedSection
+        ));
+        assert_eq!(
+            update_operation.railjson_patch,
+            serde_json::from_str::<Patch>(
+                r#"[
+                        {"op":"remove","path":"/track_ranges/2"},
+                        {"op":"remove","path":"/track_ranges/0"}
+                    ]"#
+            )
+            .unwrap()
+        );
+        let CacheOperation::Update(ObjectCache::SpeedSection(speed_section)) = cache_operation
+        else {
+            panic!("not a `CacheOperation::Update(ObjectCache::SpeedSection())`");
+        };
+        assert_eq!(speed_section.track_ranges.len(), 1);
+        assert_eq!(speed_section.track_ranges[0].track.0, "track_section_id");
+    }
+
+    #[test]
+    fn empty_object_and_invalid_ref_speed_section() {
+        let speed_section_cache = SpeedSection {
+            id: Identifier::from("speed_section_id"),
+            track_ranges: vec![
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("unknown_track_section_1"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+                ApplicableDirectionsTrackRange {
+                    track: Identifier::from("track_section_id"),
+                    begin: 0.,
+                    end: 100.,
+                    applicable_directions: ApplicableDirections::StartToStop,
+                },
+            ],
+            ..Default::default()
+        };
+        let error_speed_section_1 = InfraError::new_invalid_reference(
+            &speed_section_cache,
+            "speed_section",
+            ObjectRef::new(ObjectType::TrackSection, "unknown_track_section_1"),
+        );
+        let error_speed_section_2 =
+            InfraError::new_empty_object(&speed_section_cache, "track_ranges");
+
+        let operations = super::fix_speed_section(
+            &speed_section_cache,
+            vec![error_speed_section_1, error_speed_section_2].into_iter(),
+        );
+
+        assert_eq!(operations.len(), 1);
+
+        let (operation, cache_operation) = operations.get(&speed_section_cache.get_ref()).unwrap();
+        let Operation::Delete(delete_operation) = operation else {
+            panic!("not an `Operation::Delete`");
+        };
+        assert_eq!(delete_operation.obj_id, "speed_section_id");
+        assert!(matches!(
+            delete_operation.obj_type,
+            ObjectType::SpeedSection
+        ));
+        let CacheOperation::Delete(object_ref) = cache_operation else {
+            panic!("not a `CacheOperation::Delete()`");
+        };
+        assert_eq!(object_ref.obj_id, "speed_section_id");
+        assert_eq!(object_ref.obj_type, ObjectType::SpeedSection);
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
           nodejs = fixedNode;
         };
 
-        rustChan = pkgs.rust-bin.stable."1.73.0".rust.override {
+        rustChan = pkgs.rust-bin.stable."1.74.0".rust.override {
           targets = [];
           extensions = [
             "clippy"

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
           nodejs = fixedNode;
         };
 
-        rustChan = pkgs.rust-bin.stable."1.74.0".rust.override {
+        rustChan = pkgs.rust-bin.stable."1.73.0".rust.override {
           targets = [];
           extensions = [
             "clippy"


### PR DESCRIPTION
fixes #5856

I introduced an intermediate representation (IR) `OrderedOperation` that can be... well... ordered. It's necessary since patching an object needs to happen in a well-defined order. Take for example a Catenary whose track range 0 and 2 needs to be removed. If we removed at index 0, then index 2 is not correct anymore and needs to be 1. We ordered in decreasing order to avoid that problem.

`OrderedOperation` is introduced because we can't order before the IR (`InfraError` don't have information about the index to be removed), and we can't order after IR (`Operation` contains a whole `json_patch::Patch` and ordering based on a JSON `String` seems really brittle). Here's the reason for introducing this IR.