### PR TITLE
Fix track section length when editing geometry

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -450,8 +450,9 @@
           "mode-add-point": "Add a point",
           "mode-delete-point": "Delete points",
           "mode-move-point": "Move points",
-          "toggle-anchoring": "Toggle anchoring on/off",
-          "save-line": "Save the line"
+          "reset-line": "Reset data",
+          "save-line": "Save the line",
+          "toggle-anchoring": "Toggle anchoring on/off"
         },
         "help": {
           "add-anchor-point": "Click to add a point at the end of the track section. Click on the track to add an intermediate point.",

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -450,8 +450,9 @@
           "mode-add-point": "Ajouter un point",
           "mode-delete-point": "Supprimer des points",
           "mode-move-point": "Déplacer les points",
-          "toggle-anchoring": "Activer / désactiver l'ancrage automatique",
-          "save-line": "Sauvegarder la ligne"
+          "reset-line": "Réinitialiser les données",
+          "save-line": "Sauvegarder la ligne",
+          "toggle-anchoring": "Activer / désactiver l'ancrage automatique"
         },
         "help": {
           "add-anchor-point": "Cliquez pour ajouter un point au bout de la section de ligne. Cliquez sur la ligne pour ajouter un point intermédiaire.",

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cloneDeep, isEmpty, isEqual } from 'lodash';
 import { MdShowChart } from 'react-icons/md';
 import { RiDragMoveLine } from 'react-icons/ri';
-import { BiAnchor, BiArrowFromLeft, BiArrowToRight } from 'react-icons/bi';
+import { BiAnchor, BiArrowFromLeft, BiArrowToRight, BiReset } from 'react-icons/bi';
 import { Feature, LineString } from 'geojson';
 import getNearestPoint from '@turf/nearest-point';
 import { featureCollection } from '@turf/helpers';
@@ -63,6 +63,19 @@ const TrackEditionTool: Tool<TrackEditionState> = {
           if (setIsFormSubmited) {
             setIsFormSubmited(true);
           }
+        },
+      },
+      {
+        id: 'reset-entity',
+        icon: BiReset,
+        labelTranslationKey: `Editor.tools.track-edition.actions.reset-line`,
+        isDisabled({ state: { track, initialTrack } }) {
+          return isEqual(track, initialTrack);
+        },
+        onClick({ setState, state: { initialTrack } }) {
+          setState({
+            track: cloneDeep(initialTrack),
+          });
         },
       },
     ],
@@ -219,7 +232,6 @@ const TrackEditionTool: Tool<TrackEditionState> = {
         const position = nearestPoint.geometry.coordinates as [number, number];
         const index = nearestPoint.properties.sectionIndex;
         const newState = cloneDeep(state);
-
         newState.track.geometry.coordinates.splice(index + 1, 0, position);
         newState.track = entityDoUpdate(newState.track, state.track.geometry);
         newState.nearestPoint = null;

--- a/front/src/applications/editor/tools/trackEdition/utils.ts
+++ b/front/src/applications/editor/tools/trackEdition/utils.ts
@@ -1,7 +1,7 @@
 import { EditorEntity, TrackSectionEntity } from 'types';
+import { LinearMetadataItem } from 'common/IntervalsDataViz/types';
 import { NEW_ENTITY_ID } from '../../data/utils';
 
-// eslint-disable-next-line import/prefer-default-export
 export function getNewLine(points: [number, number][]): TrackSectionEntity {
   return {
     type: 'Feature',
@@ -15,6 +15,7 @@ export function getNewLine(points: [number, number][]): TrackSectionEntity {
       length: 0,
       slopes: [],
       curves: [],
+      loading_gauge_limits: [],
     },
   };
 }
@@ -28,4 +29,16 @@ export function injectGeometry(track: EditorEntity): EditorEntity {
       sch: track.geometry,
     },
   };
+}
+
+/**
+ * Remove the invalid ranges when the length of the track section has been modified
+ * - keep ranges if begin is undefined in case we just added a new one or if we deleted the begin input value
+ * - remove ranges which start after the new end
+ * - cut the ranges which start before the new end but end after it
+ */
+export function removeInvalidRanges<T>(values: LinearMetadataItem<T>[], newLength: number) {
+  return values
+    .filter((item) => item.begin < newLength || item.begin === undefined)
+    .map((item) => (item.end >= newLength ? { ...item, end: newLength } : item));
 }

--- a/front/src/common/BootstrapSNCF/FormSNCF/DebouncedNumberInputSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/FormSNCF/DebouncedNumberInputSNCF.tsx
@@ -10,6 +10,8 @@ type DebouncedNumberInputSNCFProps = {
   id?: string;
   max?: number;
   min?: number;
+  sm?: boolean;
+  showFlex?: boolean;
 };
 
 const DebouncedNumberInputSNCF = ({
@@ -18,8 +20,10 @@ const DebouncedNumberInputSNCF = ({
   setInput,
   debouncedDelay = 800,
   id = '',
-  max = 100,
+  max,
   min = 0,
+  sm = false,
+  showFlex = false,
 }: DebouncedNumberInputSNCFProps) => {
   const [value, setValue] = useState<number | null>(input);
 
@@ -28,19 +32,27 @@ const DebouncedNumberInputSNCF = ({
   }, [input]);
 
   const checkChangedInput = (newValue: number | null) => {
-    if (newValue !== null && newValue !== input && min <= newValue && newValue <= max)
+    if (
+      newValue !== null &&
+      newValue !== input &&
+      min <= newValue &&
+      (max === undefined || newValue <= max)
+    ) {
       setInput(newValue);
-    else if (value === null && input !== 0) setInput(0);
+    } else if (value === null && input !== 0) {
+      const previousValue = input;
+      setInput(previousValue);
+    }
   };
 
   useDebouncedFunc(value, debouncedDelay, checkChangedInput);
 
   return (
-    <div className="debounced-number-input">
+    <div className={`${showFlex && 'debounced-number-input'}`}>
       <InputSNCF
         type="number"
         id={id}
-        isInvalid={value !== null && (value < min || max < value)}
+        isInvalid={value !== null && (value < min || (max !== undefined && max < value))}
         label={label}
         max={max}
         min={min}
@@ -49,7 +61,7 @@ const DebouncedNumberInputSNCF = ({
           setValue(e.target.value !== '' ? parseFloat(e.target.value) : null);
         }}
         value={value !== null ? value : ''}
-        sm
+        sm={sm}
       />
     </div>
   );

--- a/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
@@ -75,6 +75,8 @@ const IntervalsEditorCommonForm = ({
         label={t('begin')}
         setInput={setBegin}
         max={interval.end}
+        sm
+        showFlex
       />
       <DebouncedNumberInputSNCF
         id="item-end-input"
@@ -83,6 +85,8 @@ const IntervalsEditorCommonForm = ({
         setInput={setEnd}
         min={interval.begin}
         max={Math.round(totalLength)}
+        sm
+        showFlex
       />
     </div>
   );

--- a/front/src/types/editor.ts
+++ b/front/src/types/editor.ts
@@ -1,6 +1,11 @@
 import { JSONSchema7 } from 'json-schema';
 import { Feature, GeoJsonProperties, Geometry, Point, LineString, MultiLineString } from 'geojson';
-import { Direction, DirectionalTrackRange, ObjectType } from 'common/api/osrdEditoastApi';
+import {
+  Direction,
+  DirectionalTrackRange,
+  LoadingGaugeType,
+  ObjectType,
+} from 'common/api/osrdEditoastApi';
 import { LinearMetadataItem } from 'common/IntervalsDataViz/types';
 import { NullGeometry } from './geospatial';
 
@@ -24,6 +29,7 @@ export interface TrackSectionEntity
     {
       length: number;
       slopes: LinearMetadataItem<{ gradient: number }>[];
+      loading_gauge_limits: LinearMetadataItem<{ category: LoadingGaugeType }>[];
       curves: LinearMetadataItem<{ radius: number }>[];
       extensions?: {
         sncf?: {


### PR DESCRIPTION
Closes #5933 

Implementation of a new behavior: when a track section is created, length can be edited directly on the map, but when a length is already entered, the drag must not affect the length.