### PR TITLE
ci: add editoast openapi sync test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,6 +427,26 @@ jobs:
           
           exit $(docker wait editoast-format)
 
+  check_editoast_openapi:
+    # for the same reason as check_editoast_lints, we run this in a separate job
+    runs-on: ubuntu-latest
+
+    needs:
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate OpenAPI
+        run: |
+          docker run --name=editoast-test --net=host -v $PWD/output:/output \
+            ${{ fromJSON(needs.build.outputs.stable_tags).editoast }} \
+            /bin/bash -c 'editoast openapi > /output/openapi.yaml'
+
+      - name: Check for unexpected changes
+        run: |
+          diff $PWD/editoast/openapi.yaml $PWD/output/openapi.yaml
+
   check_gateway:
     runs-on: ubuntu-latest
     needs:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2121,6 +2121,33 @@ components:
           nullable: true
           type: array
       type: object
+    ScenarioResponse:
+      allOf:
+      - $ref: '#/components/schemas/Scenario'
+      - properties:
+          electrical_profile_set_name:
+            nullable: true
+            type: string
+          infra_name:
+            type: string
+          project:
+            $ref: '#/components/schemas/Project'
+          study:
+            $ref: '#/components/schemas/Study'
+          train_schedules:
+            items:
+              $ref: '#/components/schemas/LightTrainSchedule'
+            type: array
+          trains_count:
+            format: int64
+            type: integer
+        required:
+        - infra_name
+        - train_schedules
+        - trains_count
+        - project
+        - study
+        type: object
     ScenarioWithCountTrains:
       allOf:
       - $ref: '#/components/schemas/Scenario'
@@ -2982,6 +3009,19 @@ components:
           nullable: true
           type: array
       type: object
+    StudyResponse:
+      allOf:
+      - $ref: '#/components/schemas/Study'
+      - properties:
+          project:
+            $ref: '#/components/schemas/Project'
+          scenarios_count:
+            format: int64
+            type: integer
+        required:
+        - scenarios_count
+        - project
+        type: object
     StudyWithScenarios:
       allOf:
       - $ref: '#/components/schemas/Study'
@@ -4914,7 +4954,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StudyWithScenarios'
+                $ref: '#/components/schemas/StudyResponse'
           description: The created study
       tags:
       - studies
@@ -4968,7 +5008,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StudyWithScenarios'
+                $ref: '#/components/schemas/StudyResponse'
           description: The requested study
         '404':
           content:
@@ -5007,7 +5047,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StudyWithScenarios'
+                $ref: '#/components/schemas/StudyResponse'
           description: The updated study
         '404':
           content:
@@ -5094,7 +5134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScenarioWithDetails'
+                $ref: '#/components/schemas/ScenarioResponse'
           description: The created scenario
       summary: Create a scenario
       tags:
@@ -5161,7 +5201,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScenarioWithDetails'
+                $ref: '#/components/schemas/ScenarioResponse'
           description: The requested scenario
         '404':
           content:
@@ -5202,6 +5242,10 @@ paths:
         required: true
       responses:
         '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScenarioResponse'
           description: The scenario was updated successfully
         '404':
           content:

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -159,7 +159,7 @@ async fn check_project_study_conn(
     params(ProjectIdParam, StudyIdParam),
     request_body = ScenarioCreateForm,
     responses(
-        (status = 201, body = ScenarioWithDetails, description = "The created scenario"),
+        (status = 201, body = ScenarioResponse, description = "The created scenario"),
     )
 )]
 #[post("")]
@@ -279,7 +279,7 @@ impl From<ScenarioPatchForm> for Scenario {
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     request_body = ScenarioPatchForm,
     responses(
-        (status = 204, description = "The scenario was updated successfully"),
+        (status = 204, body = ScenarioResponse, description = "The scenario was updated successfully"),
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]
@@ -333,7 +333,7 @@ async fn patch(
     tag = "scenarios",
     params(ProjectIdParam, StudyIdParam, ScenarioIdParam),
     responses(
-        (status = 200, body = ScenarioWithDetails, description = "The requested scenario"),
+        (status = 200, body = ScenarioResponse, description = "The requested scenario"),
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
     )
 )]

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -135,7 +135,7 @@ impl StudyResponse {
     params(ProjectIdParam),
     request_body = StudyCreateForm,
     responses(
-        (status = 201, body = StudyWithScenarios, description = "The created study"),
+        (status = 201, body = StudyResponse, description = "The created study"),
     )
 )]
 #[post("")]
@@ -255,7 +255,7 @@ async fn list(
     tag = "studies",
     params(ProjectIdParam, StudyIdParam),
     responses(
-        (status = 200, body = StudyWithScenarios, description = "The requested study"),
+        (status = 200, body = StudyResponse, description = "The requested study"),
         (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]
@@ -333,7 +333,7 @@ impl TryFrom<StudyPatchForm> for Study {
         description = "The fields to update"
     ),
     responses(
-        (status = 200, body = StudyWithScenarios, description = "The updated study"),
+        (status = 200, body = StudyResponse, description = "The updated study"),
         (status = 404, body = InternalError, description = "The requested study was not found"),
     )
 )]

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1079,7 +1079,7 @@ export type GetProjectsByProjectIdStudiesApiArg = {
   ordering?: Ordering;
 };
 export type PostProjectsByProjectIdStudiesApiResponse =
-  /** status 201 The created study */ StudyWithScenarios;
+  /** status 201 The created study */ StudyResponse;
 export type PostProjectsByProjectIdStudiesApiArg = {
   /** The id of a project */
   projectId: number;
@@ -1093,14 +1093,14 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdApiArg = {
   studyId: number;
 };
 export type GetProjectsByProjectIdStudiesAndStudyIdApiResponse =
-  /** status 200 The requested study */ StudyWithScenarios;
+  /** status 200 The requested study */ StudyResponse;
 export type GetProjectsByProjectIdStudiesAndStudyIdApiArg = {
   /** The id of a project */
   projectId: number;
   studyId: number;
 };
 export type PatchProjectsByProjectIdStudiesAndStudyIdApiResponse =
-  /** status 200 The updated study */ StudyWithScenarios;
+  /** status 200 The updated study */ StudyResponse;
 export type PatchProjectsByProjectIdStudiesAndStudyIdApiArg = {
   /** The id of a project */
   projectId: number;
@@ -1119,7 +1119,7 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
   ordering?: Ordering;
 };
 export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiResponse =
-  /** status 201 The created scenario */ ScenarioWithDetails;
+  /** status 201 The created scenario */ ScenarioResponse;
 export type PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg = {
   /** The id of a project */
   projectId: number;
@@ -1135,7 +1135,7 @@ export type DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg 
   scenarioId: number;
 };
 export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 200 The requested scenario */ ScenarioWithDetails;
+  /** status 200 The requested scenario */ ScenarioResponse;
 export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
   /** The id of a project */
   projectId: number;
@@ -1143,7 +1143,7 @@ export type GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
   scenarioId: number;
 };
 export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiResponse =
-  /** status 204 The scenario was updated successfully */ undefined;
+  /** status 204 The scenario was updated successfully */ ScenarioResponse;
 export type PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg = {
   /** The id of a project */
   projectId: number;
@@ -1763,6 +1763,10 @@ export type PaginatedResponseOfStudyWithScenarios = {
   previous: number | null;
   results: StudyWithScenarios[];
 };
+export type StudyResponse = Study & {
+  project: Project;
+  scenarios_count: number;
+};
 export type StudyCreateForm = {
   actual_end_date?: string | null;
   budget?: number;
@@ -1817,9 +1821,11 @@ export type LightTrainSchedule = {
   train_name: string;
   train_path: number;
 };
-export type ScenarioWithDetails = Scenario & {
+export type ScenarioResponse = Scenario & {
   electrical_profile_set_name?: string | null;
   infra_name: string;
+  project: Project;
+  study: Study;
   train_schedules: LightTrainSchedule[];
   trains_count: number;
 };


### PR DESCRIPTION
We need a CI check to ensure that any modification of the endpoints or the schemas have been documented into openapi.yaml.

Debugged-by: Younes Khoudli <younes.khoudli@epita.fr> 🫡