### PR TITLE
front:sdm: align things in sillons menus

### DIFF
--- a/front/src/applications/stdcm/components/RunningTime.tsx
+++ b/front/src/applications/stdcm/components/RunningTime.tsx
@@ -38,7 +38,7 @@ function RunningTime({ dispatch = noop }: RunningTimeProps) {
 
   return (
     <div className="d-flex mb-2 align-items-center osrd-config-item-container">
-      <div className="text-orange mr-2 ml-1">
+      <div className="text-orange mr-2">
         <RxLapTimer />
       </div>
       <div className="font-weight-bold mr-2 flex-grow-1">{t('maximumRunTime')}</div>

--- a/front/src/common/SpeedLimitByTagSelector/SpeedLimitByTagSelector.tsx
+++ b/front/src/common/SpeedLimitByTagSelector/SpeedLimitByTagSelector.tsx
@@ -86,7 +86,7 @@ export function IsolatedSpeedLimitByTagSelector({
           condensed ? 'd-flex align-items-center gap-10' : ''
         }`}
       >
-        <img width="32px" className="mr-2" src={icon} alt="infraIcon" />
+        <img width="32px" src={icon} alt="speedometer" />
         <span className="text-muted">{t('speedLimitByTag')}</span>
         <SelectImprovedSNCF
           sm

--- a/front/src/modules/stdcmAllowances/components/StdcmAllowances.tsx
+++ b/front/src/modules/stdcmAllowances/components/StdcmAllowances.tsx
@@ -52,7 +52,7 @@ const StdcmAllowances = () => {
   };
 
   return (
-    <div className="d-flex mb-2 osrd-config-item-container">
+    <div className="d-flex mb-2 osrd-config-item-container px-0">
       <div className="col-3">
         <InputSNCF
           id="standardAllowanceTypeGridMarginBefore"

--- a/front/src/styles/scss/common/components/_typeAndPath.scss
+++ b/front/src/styles/scss/common/components/_typeAndPath.scss
@@ -1,5 +1,6 @@
 .type-and-path {
   position: relative;
+
   background-color: var(--white);
   padding: 0.5rem;
   border-radius: var(--border-radius);
@@ -7,7 +8,6 @@
     position: relative;
     display: flex;
     align-items: center;
-    justify-content: center;
     height: 5rem;
     max-width: 21vw;
     overflow: auto;


### PR DESCRIPTION
fixes #4481
https://github.com/osrd-project/osrd/issues/4481

changes some margins and padding in elements of the lateral bar of the sillons reservation page
![Screenshot 2023-12-07 at 16-19-56 OSRD](https://github.com/osrd-project/osrd/assets/3931245/e1c4fb7f-4b1f-4548-8e2b-981b09aacb31)
