### PR TITLE
core: fix time interpolation with an epsilon acceleration

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopePhysics.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.envelope;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areAccelerationsEqual;
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
 import static java.lang.Math.max;
 
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -43,7 +45,7 @@ public class EnvelopePhysics {
             double positionDelta
     ) {
         var acceleration = stepAcceleration(lastPos, nextPos, lastSpeed, nextSpeed);
-        if (acceleration == 0.0)
+        if (areAccelerationsEqual(acceleration, 0.0))
             return Math.abs(positionDelta / lastSpeed);
         var interpolatedSpeed = interpolateStepSpeed(acceleration, lastSpeed, positionDelta);
         return Math.abs((interpolatedSpeed - lastSpeed) / acceleration);

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -15,6 +15,8 @@ public final class TrainPhysicsIntegrator {
     private static final double POSITION_EPSILON = 1E-2;
     // A speed lower than this value will be considered zero
     private static final double SPEED_EPSILON = 1E-5;
+    // An acceleration lower than this value will be considered zero
+    private static final double ACCELERATION_EPSILON = 1E-5;
 
     private final PhysicsRollingStock rollingStock;
     private final PhysicsPath path;
@@ -180,6 +182,11 @@ public final class TrainPhysicsIntegrator {
     /** Returns true if the speeds' difference is lower than an epsilon */
     public static boolean areSpeedsEqual(double a, double b) {
         return areDoublesEqual(a, b, SPEED_EPSILON);
+    }
+
+    /** Returns true if the accelerations' difference is lower than an epsilon */
+    public static boolean areAccelerationsEqual(double a, double b) {
+        return areDoublesEqual(a, b, ACCELERATION_EPSILON);
     }
 
     private static boolean areDoublesEqual(double a, double b, double delta) {

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartSliceTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartSliceTest.java
@@ -106,4 +106,15 @@ public class EnvelopePartSliceTest {
         );
         assertEquals(expectedSlice, slice);
     }
+
+    /** Reproduces a bug where the sliced part would have negative time deltas */
+    @Test
+    void sliceWithEpsilonAcceleration() {
+        var ep = EnvelopePart.generateTimes(
+                List.of(TestAttr.A, EnvelopeProfile.ACCELERATING),
+                new double[] {0, 100},
+                new double[] {10, 10 + 1e-8}
+        );
+        ep.slice(50, 100); // The relevant assertions are made in `EnvelopePart.runSanityChecks`
+    }
 }


### PR DESCRIPTION
Fix #6072 

There are two underlying problems:

1. When slicing an envelope part with constant speed, the speed at the slice point may be different by an epsilon (we compute something akin to `sqrt(x²)`.
2. When interpolating a time step on a part with an epsilon acceleration, the result would be inaccurate (we divide by an epsilon and the error is exponential)


This PR fixes the second problem (with a unit test). The first one could be fixed as well but it adds more complexity, and we *should* be robust to epsilon diffs anyway. 