### PR TITLE
front: d3 performances

### DIFF
--- a/front/src/applications/operationalStudies/components/Scenario/getSimulationResults.ts
+++ b/front/src/applications/operationalStudies/components/Scenario/getSimulationResults.ts
@@ -6,7 +6,7 @@ import {
   updateSimulation,
 } from 'reducers/osrdsimulation/actions';
 import { setFailure } from 'reducers/main';
-import { store } from 'Store';
+import { store } from 'store';
 import i18n from 'i18next';
 import {
   SimulationReport,

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -12,7 +12,6 @@ import {
 import {
   getDisplaySimulation,
   getIsUpdating,
-  getOsrdSimulation,
   getPresentSimulation,
   getSelectedTrain,
 } from 'reducers/osrdsimulation/selectors';
@@ -50,7 +49,6 @@ export default function SimulationResults({
   // TIMELINE DISABLED // const { chart } = useSelector(getOsrdSimulation);
   const displaySimulation = useSelector(getDisplaySimulation);
   const selectedTrain = useSelector(getSelectedTrain);
-  const { positionValues, timePosition } = useSelector(getOsrdSimulation);
   const simulation = useSelector(getPresentSimulation);
   const isUpdating = useSelector(getIsUpdating);
 
@@ -139,12 +137,7 @@ export default function SimulationResults({
       >
         <div className="row">
           <div className="col-xl-4">
-            {selectedTrain && (
-              <TimeButtons
-                selectedTrain={selectedTrain as SimulationReport}
-                timePosition={timePosition}
-              />
-            )}
+            {selectedTrain && <TimeButtons selectedTrain={selectedTrain as SimulationReport} />}
           </div>
           <div className="col-xl-8 d-flex justify-content-end mt-2 mt-xl-0">
             <TrainDetails />
@@ -158,7 +151,6 @@ export default function SimulationResults({
           chart={chart}
           selectedTrainId={selectedTrain?.id || simulation.trains[0].id}
           trains={simulation.trains as SimulationReport[]}
-          timePosition={timePosition}
         />
       )} */}
 
@@ -193,9 +185,7 @@ export default function SimulationResults({
             <SpeedSpaceChart
               initialHeight={heightOfSpeedSpaceChart}
               onSetChartBaseHeight={setHeightOfSpeedSpaceChart}
-              positionValues={positionValues}
               selectedTrain={selectedTrain}
-              timePosition={timePosition}
               trainRollingStock={selectedTrainRollingStock}
               sharedXScaleDomain={positionScaleDomain}
               setSharedXScaleDomain={setPositionScaleDomain}
@@ -231,8 +221,6 @@ export default function SimulationResults({
               <SpaceCurvesSlopes
                 initialHeight={heightOfSpaceCurvesSlopesChart}
                 selectedTrain={selectedTrain as Train} // TODO: remove Train interface
-                timePosition={timePosition}
-                positionValues={positionValues}
                 sharedXScaleDomain={positionScaleDomain}
                 setSharedXScaleDomain={setPositionScaleDomain}
               />

--- a/front/src/applications/stdcm/views/OSRDStdcmResults.tsx
+++ b/front/src/applications/stdcm/views/OSRDStdcmResults.tsx
@@ -3,18 +3,13 @@ import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/w
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import {
-  getOsrdSimulation,
-  getPresentSimulation,
-  getSelectedTrain,
-} from 'reducers/osrdsimulation/selectors';
+import { getPresentSimulation, getSelectedTrain } from 'reducers/osrdsimulation/selectors';
 import { AllowancesSettings } from 'reducers/osrdsimulation/types';
 import { SimulationReport } from 'common/api/osrdEditoastApi';
 
 const OSRDStcdmResults = () => {
   const { t } = useTranslation(['translation', 'operationalStudies/manageTrainSchedule']);
 
-  const { positionValues, timePosition } = useSelector(getOsrdSimulation);
   const selectedTrain = useSelector(getSelectedTrain);
   const simulation = useSelector(getPresentSimulation);
 
@@ -83,8 +78,6 @@ const OSRDStcdmResults = () => {
                   initialHeight={450}
                   onSetChartBaseHeight={setSpeedSpaceChartHeight}
                   selectedTrain={selectedTrain}
-                  positionValues={positionValues}
-                  timePosition={timePosition}
                 />
               </div>
             )}

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -10,7 +10,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import 'styles/styles.scss';
 
 import { SENTRY_CONFIG } from 'config/config';
-import { persistor, store } from 'Store';
+import { persistor, store } from 'store';
 
 // Components
 import App from 'main/app';

--- a/front/src/modules/simulationResult/components/ChartHelpers/ChartSynchronizer.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/ChartSynchronizer.ts
@@ -62,9 +62,8 @@ export class ChartSynchronizer {
     this.positionValues = interpolateOnTime(
       currentTrainSimulation,
       CHART_AXES.SPACE_TIME,
-      LIST_VALUES.SPACE_TIME,
-      this.timePosition
-    );
+      LIST_VALUES.SPACE_TIME
+    )(this.timePosition) as PositionValues;
   }
 
   notifyAll(timePosition: Date) {

--- a/front/src/modules/simulationResult/components/ChartHelpers/ChartSynchronizer.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/ChartSynchronizer.ts
@@ -1,0 +1,106 @@
+import { useRef, useEffect } from 'react';
+
+import type { PositionsSpeedTimes, SimulationTrain } from 'reducers/osrdsimulation/types';
+import type { Store } from 'store';
+import { CHART_AXES, LIST_VALUES } from '../simulationResultsConsts';
+import { interpolateOnTime } from './ChartHelpers';
+
+type PositionValues = PositionsSpeedTimes<Date>;
+type Subscriber = (timePosition: Date, positionValues: PositionValues) => void;
+
+/**
+ * This singleton class allows components to subscribe to d3 data updates.
+ * When notifyAll is called with new data, each subscriber will be called.
+ * each function passed to @method subscribe will receive the new data.
+ * subscriber functions can be used to refresh d3 graphes, or rehydrate react component with this data, now isolated from react life cycle.
+ */
+export class ChartSynchronizer {
+  private static instance: ChartSynchronizer;
+
+  private subscribers: Map<string, Subscriber>;
+
+  private reduxStore: Store | undefined;
+
+  timePosition: Date;
+
+  positionValues: PositionValues;
+
+  private constructor() {
+    this.subscribers = new Map();
+    this.timePosition = new Date();
+    this.positionValues = {} as PositionValues;
+  }
+
+  static getInstance() {
+    if (!ChartSynchronizer.instance) {
+      ChartSynchronizer.instance = new ChartSynchronizer();
+    }
+    return ChartSynchronizer.instance;
+  }
+
+  setReduxStore(reduxStore: Store) {
+    this.reduxStore = reduxStore;
+  }
+
+  subscribe(key: string, newSubscriber: Subscriber) {
+    this.subscribers.set(key, newSubscriber);
+  }
+
+  unsubscribe(key: string) {
+    this.subscribers.delete(key);
+  }
+
+  computePositionValues(newTrainId?: number) {
+    if (!this.reduxStore) {
+      throw new Error('Redux store reference was not set in Chart synchronizer');
+    }
+    const osrdSimulation = this.reduxStore.getState().osrdsimulation;
+    const trainId = newTrainId || osrdSimulation.selectedTrainId;
+    const currentTrainSimulation = osrdSimulation.consolidatedSimulation.find(
+      (consolidatedSimulation: SimulationTrain) => consolidatedSimulation.id === trainId
+    );
+    this.positionValues = interpolateOnTime(
+      currentTrainSimulation,
+      CHART_AXES.SPACE_TIME,
+      LIST_VALUES.SPACE_TIME,
+      this.timePosition
+    );
+  }
+
+  notifyAll(timePosition: Date) {
+    this.timePosition = timePosition;
+    this.computePositionValues();
+    this.subscribers.forEach((sub) => {
+      sub(timePosition, this.positionValues);
+    });
+  }
+}
+
+/**
+ * @param subscriber – The function that is called to notify of the change
+ * @param key – Each subscriber is identified by this key. useful to remove subscriber individually when component unmounts
+ * @param dependencies – When a dependency changes, update the subscriber.
+ * @returns
+ */
+export function useChartSynchronizer(
+  subscriber?: Subscriber,
+  key?: string,
+  dependencies?: unknown[]
+) {
+  const synchronizer = useRef(ChartSynchronizer.getInstance());
+  // create or update subscription
+  useEffect(() => {
+    if (subscriber && key && dependencies) {
+      synchronizer.current.subscribe(key, subscriber);
+      return () => {
+        synchronizer.current.unsubscribe(key);
+      };
+    }
+    return undefined;
+  }, dependencies);
+  return {
+    timePosition: synchronizer.current.timePosition,
+    positionValues: synchronizer.current.positionValues,
+    updateTimePosition: synchronizer.current.notifyAll.bind(synchronizer.current),
+  };
+}

--- a/front/src/modules/simulationResult/components/ChartHelpers/__tests__/ChartHelpers.spec.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/__tests__/ChartHelpers.spec.ts
@@ -27,9 +27,8 @@ describe('interpolateOnTime', () => {
       const result = interpolateOnTime(
         dataSimulation,
         CHART_AXES.SPACE_TIME,
-        LIST_VALUES.REGIME,
-        time
-      );
+        LIST_VALUES.REGIME
+      )(time);
       expect(result).toStrictEqual({
         head_positions: { position: 1870.9890488984856, speed: NaN, time },
         tail_positions: { position: 1471.3290488984856, speed: NaN, time },
@@ -48,9 +47,8 @@ describe('interpolateOnTime', () => {
       const result = interpolateOnTime(
         dataSimulation,
         CHART_AXES.SPACE_TIME,
-        LIST_VALUES.SPACE_TIME,
-        time
-      );
+        LIST_VALUES.SPACE_TIME
+      )(time);
       expect(result).toStrictEqual({
         headPosition: {
           position: 16662.376939865702,

--- a/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
+++ b/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
@@ -264,7 +264,7 @@ export const enableInteractivity = <
   rotate: boolean,
   setChart: React.Dispatch<React.SetStateAction<T | undefined>>,
   simulationIsPlaying: boolean,
-  dispatchUpdateTimePositionValues: (newTimePositionValues: Date) => void,
+  updateTimePosition: (newTimePositionValues: Date) => void,
   chartDimensions: [Date, Date],
   setSharedXScaleDomain?: React.Dispatch<React.SetStateAction<PositionScaleDomain>>,
   additionalValues: ChartAxes[] = [] // more values to display on the same chart
@@ -292,15 +292,6 @@ export const enableInteractivity = <
     .filter(
       (event) => (event.button === 0 || event.button === 1) && (event.ctrlKey || event.shiftKey)
     );
-
-  // TODO: actually a number as we’re not in node.js
-  let debounceTimeoutId: NodeJS.Timeout;
-  function debounceUpdateTimePositionValues(timePositionLocal: Date, interval: number) {
-    clearTimeout(debounceTimeoutId);
-    debounceTimeoutId = setTimeout(() => {
-      dispatchUpdateTimePositionValues(timePositionLocal);
-    }, interval);
-  }
 
   const mousemove = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (!simulationIsPlaying) {
@@ -355,7 +346,7 @@ export const enableInteractivity = <
         });
       }
 
-      debounceUpdateTimePositionValues(timePositionLocal, 15);
+      updateTimePosition(timePositionLocal);
       if (chart.svg && dateIsInRange(timePositionLocal, chartDimensions)) {
         const verticalMark = pointer(event, event.currentTarget)[0];
         const horizontalMark = pointer(event, event.currentTarget)[1];

--- a/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
+++ b/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
@@ -295,7 +295,7 @@ export const enableInteractivity = <
 
   const mousemove = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (!simulationIsPlaying) {
-      let immediatePositionsValuesForPointer: ReturnType<typeof interpolateOnTime>;
+      let immediatePositionsValuesForPointer: ReturnType<ReturnType<typeof interpolateOnTime>>;
       let timePositionLocal: Date | null;
       if (isSpaceTimeChart(keyValues)) {
         // SpaceTimeChart
@@ -308,9 +308,8 @@ export const enableInteractivity = <
         immediatePositionsValuesForPointer = interpolateOnTime(
           selectedTrainData,
           keyValues,
-          LIST_VALUES.SPACE_TIME,
-          timePositionLocal
-        );
+          LIST_VALUES.SPACE_TIME
+        )(timePositionLocal);
       } else {
         // SpeedSpaceChart or SpaceCurvesSlopesChart
         const positionLocal = (
@@ -331,9 +330,8 @@ export const enableInteractivity = <
         immediatePositionsValuesForPointer = interpolateOnTime(
           selectedTrainData,
           keyValues,
-          LIST_VALUES.SPACE_SPEED,
-          timePositionLocal
-        );
+          LIST_VALUES.SPACE_SPEED
+        )(timePositionLocal);
 
         // GEV prepareData func multiply speeds by 3.6. We need to normalize that to make a convenitn pointer update
         LIST_VALUES.SPACE_SPEED.forEach((name) => {

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/helpers.ts
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/helpers.ts
@@ -108,9 +108,8 @@ export function getSimulationHoverPositions(
         const interpolation = interpolateOnTime(
           trainRegime,
           CHART_AXES.SPACE_TIME,
-          LIST_VALUES.REGIME,
-          timePosition
-        ) as Record<string, PositionSpeedTime<Date>>;
+          LIST_VALUES.REGIME
+        )(timePosition) as Record<string, PositionSpeedTime<Date>>;
         if (interpolation.head_positions && interpolation.speeds) {
           concernedTrains.push({
             ...interpolation,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/sampleData.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/sampleData.ts
@@ -1,4 +1,4 @@
-import { OsrdSimulationState, PositionsSpeedTimes } from 'reducers/osrdsimulation/types';
+import { OsrdSimulationState } from 'reducers/osrdsimulation/types';
 
 const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
   chart: {
@@ -100,7 +100,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
     },
   },
   mustRedraw: false,
-  positionValues: {} as PositionsSpeedTimes<Date>,
   selectedProjection: {
     id: 10,
     path: 4,
@@ -115,7 +114,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
     powerRestriction: false,
   },
   signalBase: 'BAL3',
-  timePosition: new Date(),
   consolidatedSimulation: [
     {
       id: 10,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/setPointIti.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/setPointIti.ts
@@ -1,4 +1,4 @@
-import { store } from 'Store';
+import { store } from 'store';
 import { updateFeatureInfoClick } from 'reducers/map';
 import {
   updateOrigin,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { store } from 'Store';
+import { store } from 'store';
 import { FaPlus } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import formatConf from 'modules/trainschedule/components/ManageTrainSchedule/helpers/formatConf';
 import { setFailure, setSuccess } from 'reducers/main';
-import { store } from 'Store';
+import { store } from 'store';
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
 import { updateTrainScheduleIDsToModify } from 'reducers/osrdconf';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
@@ -17,7 +17,7 @@ import {
 } from 'reducers/osrdconf';
 import { sec2time } from 'utils/timeManipulation';
 import { Dispatch } from 'redux';
-import { store } from 'Store';
+import { store } from 'store';
 import { Allowance, PathResponse, TrainSchedule } from 'common/api/osrdEditoastApi';
 import { ArrayElement } from 'utils/types';
 import { PointOnMap } from 'applications/operationalStudies/consts';

--- a/front/src/reducers/__tests__/osrdconf.spec.ts
+++ b/front/src/reducers/__tests__/osrdconf.spec.ts
@@ -1,5 +1,5 @@
 import { MODES, OsrdConfState } from 'applications/operationalStudies/consts';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 import {
   initialState,
   updateOriginTime,

--- a/front/src/reducers/editor/__tests__/editorReducer.spec.ts
+++ b/front/src/reducers/editor/__tests__/editorReducer.spec.ts
@@ -1,5 +1,5 @@
 import { EditorState } from 'applications/editor/tools/types';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 import editorTestDataBuilder from './editorTestDataBuilder';
 import {
   editorInitialState,

--- a/front/src/reducers/main/mainReducer.spec.ts
+++ b/front/src/reducers/main/mainReducer.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 import {
   mainInitialState,
   setLoading,

--- a/front/src/reducers/map/mapReducer.spec.ts
+++ b/front/src/reducers/map/mapReducer.spec.ts
@@ -15,7 +15,7 @@ import {
   updateLayersSettings,
   updateTerrain3DExaggeration,
 } from 'reducers/map';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 
 import { describe, expect } from 'vitest';
 

--- a/front/src/reducers/osrdconf2/common/tests/utils.ts
+++ b/front/src/reducers/osrdconf2/common/tests/utils.ts
@@ -1,7 +1,7 @@
 import { OsrdConfState, PointOnMap } from 'applications/operationalStudies/consts';
 import { Allowance } from 'common/api/osrdEditoastApi';
 import { omit } from 'lodash';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 import { defaultCommonConf } from '..';
 import { simulationConfSliceType } from '../../simulationConf';
 import { stdcmConfSliceType } from '../../stdcmConf';

--- a/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/simulationConf/simulationConfReducers.spec.ts
@@ -1,5 +1,5 @@
 import { OsrdConfState } from 'applications/operationalStudies/consts';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 
 import { describe, expect } from 'vitest';
 import { simulationConfInitialState, simulationConfSlice } from '.';

--- a/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf2/stdcmConf/stdcmConfReducers.spec.ts
@@ -1,5 +1,5 @@
 import { OsrdStdcmConfState, StandardAllowance } from 'applications/operationalStudies/consts';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 
 import { describe, expect } from 'vitest';
 import { stdcmConfInitialState, stdcmConfSlice, stdcmConfSliceActions } from '.';

--- a/front/src/reducers/osrdsimulation/actions.ts
+++ b/front/src/reducers/osrdsimulation/actions.ts
@@ -1,4 +1,7 @@
 import { Dispatch } from 'redux';
+
+import type { GetState } from 'store';
+import type { ChartSynchronizer } from 'modules/simulationResult/components/ChartHelpers/ChartSynchronizer';
 import { SimulationSnapshot, OsrdSimulationState, Chart } from './types';
 
 // Action Types
@@ -74,14 +77,6 @@ export function updateMustRedraw(mustRedraw: OsrdSimulationState['mustRedraw']) 
     });
   };
 }
-export function updatePositionValues(positionValues: OsrdSimulationState['positionValues']) {
-  return (dispatch: Dispatch) => {
-    dispatch({
-      type: UPDATE_POSITION_VALUES,
-      positionValues,
-    });
-  };
-}
 export function updateSelectedProjection(
   selectedProjection: OsrdSimulationState['selectedProjection']
 ) {
@@ -92,14 +87,17 @@ export function updateSelectedProjection(
     });
   };
 }
+
 export function updateSelectedTrainId(selectedTrainId: OsrdSimulationState['selectedTrainId']) {
-  return (dispatch: Dispatch) => {
+  return (dispatch: Dispatch, _: GetState, chartSynchronizer: ChartSynchronizer) => {
+    chartSynchronizer.computePositionValues(selectedTrainId);
     dispatch({
       type: UPDATE_SELECTED_TRAIN_ID,
       selectedTrainId,
     });
   };
 }
+
 export function updateSimulation(simulation: SimulationSnapshot) {
   return (dispatch: Dispatch) => {
     dispatch({
@@ -126,14 +124,7 @@ export function updateSignalBase(signalBase: OsrdSimulationState['signalBase']) 
     });
   };
 }
-export function updateTimePosition(timePosition: OsrdSimulationState['timePosition']) {
-  return (dispatch: Dispatch) => {
-    dispatch({
-      type: UPDATE_TIME_POSITION,
-      timePosition,
-    });
-  };
-}
+
 export function updateDepartureArrivalTimes(
   newDepartureArrivalTimes: OsrdSimulationState['departureArrivalTimes']
 ) {
@@ -151,18 +142,6 @@ export function updateConsolidatedSimulation(
     dispatch({
       type: UPDATE_CONSOLIDATED_SIMULATION,
       consolidatedSimulation,
-    });
-  };
-}
-
-/**
- * Update timePosition in the store and interpolate positionValue from timePosition
- */
-export function updateTimePositionValues(timePosition: OsrdSimulationState['timePosition']) {
-  return (dispatch: Dispatch) => {
-    dispatch({
-      type: UPDATE_TIME_POSITION_VALUES,
-      timePosition,
     });
   };
 }

--- a/front/src/reducers/osrdsimulation/index.ts
+++ b/front/src/reducers/osrdsimulation/index.ts
@@ -4,18 +4,13 @@ import { noop } from 'lodash';
 
 import createTrain from 'modules/simulationResult/components/SpaceTimeChart/createTrain';
 import {
-  LIST_VALUES,
   SIGNAL_BASE_DEFAULT,
   CHART_AXES,
 } from 'modules/simulationResult/components/simulationResultsConsts';
-import {
-  interpolateOnTime,
-  makeTrainListWithAllTrainsOffset,
-} from 'modules/simulationResult/components/ChartHelpers/ChartHelpers';
+import { makeTrainListWithAllTrainsOffset } from 'modules/simulationResult/components/ChartHelpers/ChartHelpers';
 import {
   SPEED_SPACE_SETTINGS_KEYS,
   OsrdSimulationState,
-  SimulationTrain,
   Train,
 } from 'reducers/osrdsimulation/types';
 import { SimulationReport } from 'common/api/osrdEditoastApi';
@@ -30,16 +25,13 @@ import {
   UPDATE_IS_UPDATING,
   UPDATE_ALLOWANCES_SETTINGS,
   UPDATE_MUST_REDRAW,
-  UPDATE_POSITION_VALUES,
   UPDATE_SELECTED_PROJECTION,
   UPDATE_SELECTED_TRAIN_ID,
   UPDATE_SIMULATION,
   UPDATE_SPEEDSPACE_SETTINGS,
   UPDATE_SIGNAL_BASE,
-  UPDATE_TIME_POSITION,
   UPDATE_DEPARTURE_ARRIVAL_TIMES,
   UPDATE_CONSOLIDATED_SIMULATION,
-  UPDATE_TIME_POSITION_VALUES,
   REDO_SIMULATION,
   UNDO_SIMULATION,
 } from './actions';
@@ -52,7 +44,6 @@ export const initialState: OsrdSimulationState = {
   isUpdating: false,
   allowancesSettings: undefined,
   mustRedraw: true,
-  positionValues: {} as OsrdSimulationState['positionValues'],
   selectedProjection: undefined,
   selectedTrainId: undefined,
   speedSpaceSettings: {
@@ -64,7 +55,6 @@ export const initialState: OsrdSimulationState = {
     [SPEED_SPACE_SETTINGS_KEYS.POWER_RESTRICTION]: false,
   },
   signalBase: SIGNAL_BASE_DEFAULT,
-  timePosition: new Date(),
   consolidatedSimulation: [],
   departureArrivalTimes: [],
   displaySimulation: false,
@@ -78,7 +68,6 @@ export const initialState: OsrdSimulationState = {
 // eslint-disable-next-line default-param-last
 export default function reducer(inputState: OsrdSimulationState | undefined, action: AnyAction) {
   const state = inputState || initialState;
-  let currentTrainSimulation;
   return produce(state, (draft) => {
     if (!state.simulation) draft.simulation = undoableSimulation(state.simulation, action);
     switch (action.type) {
@@ -100,24 +89,11 @@ export default function reducer(inputState: OsrdSimulationState | undefined, act
       case UPDATE_MUST_REDRAW:
         draft.mustRedraw = action.mustRedraw;
         break;
-      case UPDATE_POSITION_VALUES:
-        draft.positionValues = action.positionValues;
-        break;
       case UPDATE_SELECTED_PROJECTION:
         draft.selectedProjection = action.selectedProjection;
         break;
       case UPDATE_SELECTED_TRAIN_ID:
         draft.selectedTrainId = action.selectedTrainId;
-        currentTrainSimulation = state.consolidatedSimulation.find(
-          (consolidatedSimulation: SimulationTrain) =>
-            consolidatedSimulation.id === draft.selectedTrainId
-        );
-        draft.positionValues = interpolateOnTime(
-          currentTrainSimulation,
-          CHART_AXES.SPACE_TIME,
-          LIST_VALUES.SPACE_TIME,
-          state.timePosition
-        );
         break;
       case UPDATE_DEPARTURE_ARRIVAL_TIMES:
         draft.departureArrivalTimes = action.departureArrivalTimes;
@@ -152,27 +128,9 @@ export default function reducer(inputState: OsrdSimulationState | undefined, act
       case UPDATE_SIGNAL_BASE:
         draft.signalBase = action.signalBase;
         break;
-      case UPDATE_TIME_POSITION:
-        draft.timePosition = action.timePosition;
-        break;
       case UPDATE_CONSOLIDATED_SIMULATION:
         draft.consolidatedSimulation = action.consolidatedSimulation;
         break;
-      case UPDATE_TIME_POSITION_VALUES: {
-        draft.timePosition = action.timePosition;
-        // position value will be computed depending on current data simulation
-        currentTrainSimulation = state.consolidatedSimulation.find(
-          (consolidatedSimulation: SimulationTrain) =>
-            consolidatedSimulation.id === state.selectedTrainId
-        );
-        draft.positionValues = interpolateOnTime(
-          currentTrainSimulation,
-          CHART_AXES.SPACE_TIME,
-          LIST_VALUES.SPACE_TIME,
-          action.timePosition
-        );
-        break;
-      }
       default:
         break;
     }

--- a/front/src/reducers/osrdsimulation/selectors.ts
+++ b/front/src/reducers/osrdsimulation/selectors.ts
@@ -11,11 +11,9 @@ export const getIsPlaying = makeOsrdSimulationSelector('isPlaying');
 export const getIsUpdating = makeOsrdSimulationSelector('isUpdating');
 export const getAllowancesSettings = makeOsrdSimulationSelector('allowancesSettings');
 export const getMustRedraw = makeOsrdSimulationSelector('mustRedraw');
-export const getPositionValues = makeOsrdSimulationSelector('positionValues');
 export const getSelectedProjection = makeOsrdSimulationSelector('selectedProjection');
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
 export const getSpeedSpaceSettings = makeOsrdSimulationSelector('speedSpaceSettings');
-export const getTimePosition = makeOsrdSimulationSelector('timePosition');
 export const getConsolidatedSimulation = makeOsrdSimulationSelector('consolidatedSimulation');
 export const getDisplaySimulation = makeOsrdSimulationSelector('displaySimulation');
 

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -244,14 +244,12 @@ export interface OsrdSimulationState {
   isUpdating: boolean;
   allowancesSettings?: AllowancesSettings;
   mustRedraw: boolean;
-  positionValues: PositionsSpeedTimes<Date>;
   selectedProjection?: Projection;
   selectedTrainId?: number;
   speedSpaceSettings: {
     [key in SpeedSpaceSettingKey]: boolean;
   };
   signalBase: typeof SIGNAL_BASE_DEFAULT;
-  timePosition: Date;
   consolidatedSimulation: SimulationTrain[];
   departureArrivalTimes: TrainsWithArrivalAndDepartureTimes[];
   simulation: {

--- a/front/src/reducers/user/listener.ts
+++ b/front/src/reducers/user/listener.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { osrdGatewayApi } from 'common/api/osrdGatewayApi';
-import type { AppStartListening } from 'listenerMiddleware';
+import type { AppStartListening } from 'store/listenerMiddleware';
 import { loginSuccess, loginError, logoutSuccess } from '.';
 
 export default function addUserListeners(startListening: AppStartListening) {

--- a/front/src/reducers/user/userReducer.spec.ts
+++ b/front/src/reducers/user/userReducer.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { createStoreWithoutMiddleware } from 'Store';
+import { createStoreWithoutMiddleware } from 'store';
 import {
   userInitialState,
   loginSuccess,

--- a/front/src/store/listenerMiddleware.ts
+++ b/front/src/store/listenerMiddleware.ts
@@ -2,7 +2,7 @@ import { createListenerMiddleware, addListener } from '@reduxjs/toolkit';
 import type { TypedStartListening, TypedAddListener, ListenerEffectAPI } from '@reduxjs/toolkit';
 
 import type { RootState } from 'reducers';
-import type { AppDispatch } from 'Store';
+import type { AppDispatch } from 'store';
 import addUserListeners from 'reducers/user/listener';
 
 export const listenerMiddleware = createListenerMiddleware();

--- a/front/src/stories/SpaceTimeChart.stories.tsx
+++ b/front/src/stories/SpaceTimeChart.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ComponentStory } from '@storybook/react';
 import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import 'stories/storybook.css';
-import ORSD_GEV_SAMPLE_DATA from 'modules/simulationResult/components/SpeedSpaceChart/sampleData';
 
 export default {
   /* 👇 The title prop is optional.
@@ -23,6 +22,4 @@ const Template: ComponentStory<typeof SpaceTimeChart> = (args) => (
 
 export const Standard = Template.bind({});
 
-Standard.args = {
-  timePosition: ORSD_GEV_SAMPLE_DATA.timePosition,
-};
+Standard.args = {};

--- a/front/src/stories/SpeedSpaceChart.stories.tsx
+++ b/front/src/stories/SpeedSpaceChart.stories.tsx
@@ -6,7 +6,7 @@ import SpeedSpaceChart, {
 } from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
 import 'stories/storybook.css';
 import { Provider } from 'react-redux';
-import { store } from 'Store';
+import { store } from 'store';
 import ORSD_GRAPH_SAMPLE_DATA from 'modules/simulationResult/components/SpeedSpaceChart/sampleData';
 
 export default {


### PR DESCRIPTION
Improving d3 general performance during interactions with the main charts and map.

`timePosition` and `positionValues` are now removed from the store and now handled in a separate class `ChartSynchronizer`. These two values are now completely seperate from redux and react life cycle, which alleviates quite some unnecessary workload and re-renders.

Second source of improvement: memoization of the function `interpolateOnTime`, which is called on every mouse move on the charts.

closes #6105 