### PR TITLE
Bump core dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -165,6 +165,9 @@ sourceSets {
 
 // region CODE_QUALITY
 
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+
 allprojects {
 
     apply plugin: 'checkstyle'
@@ -194,9 +197,9 @@ allprojects {
         showStackTraces = true
         showProgress = true
         // can also be 'more' or 'default'
-        effort = 'max'
+        effort = Effort.valueOf('MAX')
         // report all diagnosed bugs
-        reportLevel = 'low'
+        reportLevel = Confidence.valueOf('LOW')
         maxHeapSize = '1g'
         excludeFilter = rootProject.file('config/spotbugs/exclude.xml')
     }

--- a/core/config/spotbugs/exclude-railjson.xml
+++ b/core/config/spotbugs/exclude-railjson.xml
@@ -1,6 +1,6 @@
 <FindBugsFilter>
   <Match>
-    <Bug code="EI2,EI,THROWS,UrF,UuF" />
+    <Bug code="EI2,EI,THROWS,PA,UrF,UuF,UwF" />
   </Match>
   <Match>
     <Source name="~.*\.kt"/>

--- a/core/config/spotbugs/exclude.xml
+++ b/core/config/spotbugs/exclude.xml
@@ -1,6 +1,9 @@
 <FindBugsFilter>
   <Match>
-    <Bug code="EI2,EI,THROWS" />
+    <Bug code="EI2,EI,THROWS,PA" />
+  </Match>
+  <Match>
+    <Bug pattern="AA_ASSERTION_OF_ARGUMENTS" />
   </Match>
   <Match>
     <Source name="~.*\.kt"/>

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimContext.java
@@ -2,7 +2,7 @@ package fr.sncf.osrd.envelope_sim;
 
 import com.google.common.collect.RangeMap;
 
-public class EnvelopeSimContext {
+public final class EnvelopeSimContext {
     public final PhysicsRollingStock rollingStock;
     public final PhysicsPath path;
     public final double timeStep;

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EnvelopeSimPath implements PhysicsPath {
+public final class EnvelopeSimPath implements PhysicsPath {
     public final double length;
 
     /**

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -7,6 +7,7 @@ import static java.lang.Double.NaN;
 import static java.lang.Math.abs;
 
 import com.carrotsearch.hppc.DoubleArrayList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.*;
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
+@SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
 public abstract class AbstractAllowanceWithRanges implements Allowance {
     public static final Logger logger = LoggerFactory.getLogger(Allowance.class);
 

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
@@ -13,7 +13,7 @@ import java.util.*;
 /** Applies the allowance while maximizing the energy saved.
  * The algorithm and formulas are described in the MARECO paper, which can be read
  * <a href="https://osrd.fr/pdf/MARECO.pdf">here</a> */
-public class MarecoAllowance extends AbstractAllowanceWithRanges {
+public final class MarecoAllowance extends AbstractAllowanceWithRanges {
 
     /** Constructor */
     public MarecoAllowance(

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Neutral.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/electrification/Neutral.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 /**
  * Neutral electrification conditions at a point in the path
  */
-public non-sealed class Neutral implements Electrification {
+public final class Neutral implements Electrification {
     /** Whether the pantograph should be lowered */
     public boolean lowerPantograph;
 

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -14,18 +14,18 @@
 #  - CC Attribution
 
 [versions]
-kotlin = '1.8.0'
-ksp = '1.8.0-1.0.8'
-kotlinx-coroutines = '1.6.+'
+kotlin = '1.9.21'
+ksp = '1.9.21-1.0.15'
+kotlinx-coroutines = '1.7.+'
 logback = '1.4.+'
-moshi = '1.14.0'
-junit = '5.9.+'
-mockito = '4.11.+'
+moshi = '1.15.0'
+junit = '5.10.+'
+mockito = '5.2.+'
 
 [libraries]
 # kotlin stuff
 kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib', version.ref = 'kotlin' }  # Apache 2.0
-kotlin-logging = { module = 'io.github.microutils:kotlin-logging', version = '3.0.4' }  # Apache 2.0
+kotlin-logging = { module = 'io.github.microutils:kotlin-logging', version = '3.0.5' }  # Apache 2.0
 kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' }  # Apache 2.0
 kotlin-test = { module = 'org.jetbrains.kotlin:kotlin-test', version.ref = 'kotlin' }  # Apache 2.0
 kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' }  # Apache 2.0
@@ -37,7 +37,7 @@ logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback'
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback' }  # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
 
 # java stuff
-guava = { module = 'com.google.guava:guava', version = '31.1-jre' }  # Apache 2.0
+guava = { module = 'com.google.guava:guava', version = '32.1.3-jre' }  # Apache 2.0
 jcommander = { module = 'com.beust:jcommander', version = '1.82' }  # Apache 2.0
 hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' }  # Apache 2.0
 moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' }  # Apache 2.0
@@ -45,21 +45,21 @@ moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = '
 moshi-kotlin = { module = 'com.squareup.moshi:moshi-kotlin', version.ref = 'moshi'} # Apache 2.0
 takes = { module = 'org.takes:takes', version = '1.24.+' }  # MIT
 javax-json-api = { module = 'javax.json:javax.json-api', version = '1.1.4' }  # GPLv2 with classpath exemption
-okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.10.0' }  # Apache 2.0
+okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.12.0' }  # Apache 2.0
 classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' }  # MIT
 jmathplot = { module = 'com.github.yannrichet:JMathPlot', version = '1.0.1' }  # BSD
 slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' }  # MIT
-sentry = { module = 'io.sentry:sentry', version = '6.11.+' }  # MIT
+sentry = { module = 'io.sentry:sentry', version = '7.0.+' }  # MIT
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }  # EPL 2.0
 junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' }  # EPL 2.0
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }  # EPL 2.0
-assertj = { module = 'org.assertj:assertj-core', version = '3.23.1'}  # Apache 2.0
-jqwik = { module = 'net.jqwik:jqwik', version = '1.7.+' }  # EPL 2.0
+assertj = { module = 'org.assertj:assertj-core', version = '3.24.2'}  # Apache 2.0
+jqwik = { module = 'net.jqwik:jqwik', version = '1.8.+' }  # EPL 2.0
 mockito-inline = { module = 'org.mockito:mockito-inline', version.ref = 'mockito' }  # MIT
 mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.ref = 'mockito'  }  # MIT
-junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.9.+' }  # EPL 2.0
+junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.10.+' }  # EPL 2.0
 jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' }  # CC Attribution
-spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.7.+' }  # LGPLv2.1
+spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' }  # LGPLv2.1
 geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' }  # Apache 2.0
 
 
@@ -69,6 +69,6 @@ ksp = { id = 'com.google.devtools.ksp', version.ref = 'ksp' }
 kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
 
 # java
-spotbugs = { id = 'com.github.spotbugs', version = '5.0.+' }
-shadow = { id = 'com.github.johnrengelman.shadow', version = '7.1.2' }
-versions = { id = 'com.github.ben-manes.versions', version = '0.44.0' }
+spotbugs = { id = 'com.github.spotbugs', version = '6.0.+' }
+shadow = { id = 'com.github.johnrengelman.shadow', version = '8.1.1' }
+versions = { id = 'com.github.ben-manes.versions', version = '0.50.0' }

--- a/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/LineString.java
+++ b/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/LineString.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class LineString {
+public final class LineString {
 
     /** A list of N coordinates (X component, longitude) */
     private final double[] bufferX;

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/warnings/DiagnosticRecorderImpl.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/warnings/DiagnosticRecorderImpl.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public class DiagnosticRecorderImpl implements DiagnosticRecorder {
 
-    public final List<Warning> warnings = new ArrayList<>();
-    public final List<OSRDError> errors = new ArrayList<>();
+    public List<Warning> warnings = new ArrayList<>();
+    public List<OSRDError> errors = new ArrayList<>();
     private final boolean strict;
 
     public DiagnosticRecorderImpl(boolean strict) {

--- a/core/src/main/java/fr/sncf/osrd/api/ConflictDetectionEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ConflictDetectionEndpoint.java
@@ -65,6 +65,7 @@ public class ConflictDetectionEndpoint implements Take {
         }
     }
 
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ConflictDetectionResult {
         public static final JsonAdapter<ConflictDetectionResult> adapter = new Moshi
                 .Builder()

--- a/core/src/main/java/fr/sncf/osrd/api/ElectricalProfileSetManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ElectricalProfileSetManager.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.api;
 
 import com.squareup.moshi.JsonDataException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping;
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
@@ -91,6 +92,7 @@ public class ElectricalProfileSetManager extends APIClient {
     }
 
 
+    @SuppressFBWarnings("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
     protected static class CacheEntry {
         protected CacheStatus status;
         private ElectricalProfileMapping mapping;
@@ -106,6 +108,7 @@ public class ElectricalProfileSetManager extends APIClient {
         }
     }
 
+    @SuppressFBWarnings("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
     protected enum CacheStatus {
         INITIALIZING,
         DOWNLOADING,

--- a/core/src/main/java/fr/sncf/osrd/api/InfraCacheStatusEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraCacheStatusEndpoint.java
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.api.InfraManager.InfraCacheEntry;
 import fr.sncf.osrd.api.InfraManager.InfraStatus;
 import org.takes.Request;
@@ -65,6 +66,7 @@ public final class InfraCacheStatusEndpoint implements Take {
         }
     }
 
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static final class SerializedInfraCache {
         public InfraStatus status;
 

--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -66,7 +66,7 @@ public class InfraManager extends APIClient {
         }
 
         public final boolean isStable;
-        private InfraStatus[] transitions;
+        private InfraStatus[] transitions = new InfraStatus[]{};
 
         boolean canTransitionTo(InfraStatus newStatus) {
             for (var status : transitions)

--- a/core/src/main/java/fr/sncf/osrd/api/SignalProjectionEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/SignalProjectionEndpoint.java
@@ -5,6 +5,7 @@ import static fr.sncf.osrd.api.pathfinding.PathPropUtilsKt.makeChunkPath;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.common.ID;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance;
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowance;
@@ -75,6 +76,7 @@ public class SignalProjectionEndpoint implements Take {
 
     }
 
+    @SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
     public static class SignalProjectionRequest {
         /**
          * Infra id
@@ -100,6 +102,7 @@ public class SignalProjectionEndpoint implements Take {
         public List<ResultTrain.ZoneUpdate> zoneUpdates;
     }
 
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class SignalProjectionResult {
         public static final JsonAdapter<SignalProjectionResult> adapter = new Moshi
                 .Builder()

--- a/core/src/main/java/fr/sncf/osrd/infra/api/tracks/undirected/SpeedLimits.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/api/tracks/undirected/SpeedLimits.java
@@ -7,7 +7,7 @@ import fr.sncf.osrd.sim_infra.impl.SpeedSection;
 import fr.sncf.osrd.utils.units.Speed;
 import java.util.HashMap;
 
-public class SpeedLimits {
+public final class SpeedLimits {
 
     public final double defaultSpeedLimit;
     public final ImmutableMap<String, Double> speedLimitByTag;

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/directed/TrackRangeView.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** An oriented view on a track range. Can be used to iterate over its content */
-public class TrackRangeView {
+public final class TrackRangeView {
     /** Start of the range on the original undirected track (begin &lt; end) */
     public final double begin;
     /** End of the range on the original undirected track (begin &lt; end) */

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/result/ResultTrain.java
@@ -67,7 +67,7 @@ public class ResultTrain {
     /** A SpacingRequirement represents a requirement for a zone to be free between
      * the given times in order for the train to process unimpeded.
      */
-    public static class SpacingRequirement {
+    public static final class SpacingRequirement {
         public String zone;
         @Json(name = "begin_time")
         public double beginTime;

--- a/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
+++ b/core/src/main/java/fr/sncf/osrd/train/RollingStock.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * There must be a RollingStock instance per train on the network.
  */
 @SuppressFBWarnings({ "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" })
-public class RollingStock implements PhysicsRollingStock {
+public final class RollingStock implements PhysicsRollingStock {
     private static final TractiveEffortPoint[] COASTING_CURVE =
             { new TractiveEffortPoint(0, 0), new TractiveEffortPoint(1, 0) };
 
@@ -93,7 +93,7 @@ public class RollingStock implements PhysicsRollingStock {
      * Associates a speed to a force.
      * https://en.wikipedia.org/wiki/Tractive_force#Tractive_effort_curves
      */
-    protected final Map<String, ModeEffortCurves> modes;
+    private final Map<String, ModeEffortCurves> modes;
 
     private final String defaultMode;
     public final String basePowerClass;

--- a/core/src/test/java/fr/sncf/osrd/infra/InfraHelpers.java
+++ b/core/src/test/java/fr/sncf/osrd/infra/InfraHelpers.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.*;
-import com.google.common.graph.ImmutableNetwork;
-import com.google.common.graph.Network;
-import com.google.common.graph.NetworkBuilder;
-import com.google.common.graph.Traverser;
+import com.google.common.graph.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.infra.api.Direction;
 import fr.sncf.osrd.infra.api.reservation.DiDetector;
@@ -46,8 +43,10 @@ public class InfraHelpers {
                 .immutable();
         for (var n : g.nodes())
             builder.addNode(n);
-        for (var e : g.edges())
-            builder.addEdge(g.incidentNodes(e), e);
+        for (var e : g.edges()) {
+            var pair = g.incidentNodes(e);
+            builder.addEdge(EndpointPair.unordered(pair.nodeU(), pair.nodeV()), e);
+        }
         return builder.build();
     }
 


### PR DESCRIPTION
- **spotbugs-annotations** from 4.7.+ to 4.8.3 (close #6112)
- **junit-platform-launcher** from 1.9.+ to 1.10.1 (close #6059)
- **mockito** from 4.11.+ to 5.2.0 (close #6058)
- **sentry** from 6.11.+ to 7.0.0 (close #6057)
- **assertj-core** from 3.23.1 to 3.24.2 (close #6056)
- **okhttp** from 4.10.0 to 4.12.0 (close #6055)
- **kotlin-logging** from 3.0.4 to 3.0.5 (close #6054)
- **kotlinx-coroutines** from 1.6.+ to 1.7.3 (close #6052)
- **spotbugs** from 5.0.+ to 6.0.2 (close #6051)
- **junit** from 5.9.+ to 5.10.1 (close #6050)
- **ben-manes.versions** from 0.44.0 to 0.50.0 (close #6049)
- **ksp** from 1.8.0-1.0.8 to 1.9.21-1.0.15 (close #6048)
- **johnrengelman.shadow** from 7.1.2 to 8.1.1 (close #6047)
- **guava** from 31.1-jre to 32.1.3-jre (close #6046)
- **kotlin** from 1.8.0 to 1.9.21 (close #6045)
- **jqwik** from 1.7.+ to 1.8.2 (close #6044)
- **moshi** from 1.14.0 to 1.15.0 (close #6043)
