### PR TITLE
front: create/update API is now correctly defined in OpenAPI

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1638,14 +1638,9 @@ components:
       properties:
         obj_type:
           $ref: '#/components/schemas/ObjectType'
-        operation_type:
-          enum:
-          - CREATE
-          type: string
         railjson:
           $ref: '#/components/schemas/Railjson'
       required:
-      - operation_type
       - obj_type
       - railjson
     RangeAllowance:
@@ -4133,7 +4128,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/Railjson'
+                  $ref: '#/components/schemas/RailjsonObject'
                 type: array
           description: An array containing infos about the operations processed
       summary: Update/Create/Delete an object of the infra

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -141,7 +141,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Railjson"
+                  $ref: "#/components/schemas/RailjsonObject"
 
     put:
       tags:
@@ -890,14 +890,9 @@ components:
 
     RailjsonObject:
       required:
-        - operation_type
         - obj_type
         - railjson
       properties:
-        operation_type:
-          type: string
-          enum:
-            - CREATE
         obj_type:
           $ref: "#/components/schemas/ObjectType"
         railjson:

--- a/front/src/applications/editor/data/utils.ts
+++ b/front/src/applications/editor/data/utils.ts
@@ -14,7 +14,7 @@ import {
 import {
   DeleteOperation,
   UpdateOperation,
-  RailjsonObject,
+  Operation,
   PostInfraByIdObjectsAndObjectTypeApiResponse,
 } from 'common/api/osrdEditoastApi';
 import { EditoastType } from '../tools/types';
@@ -149,7 +149,7 @@ export function nestEntity(entity: EditorEntity, type: EditoastType): EditorEnti
   };
 }
 
-export function entityToCreateOperation(entity: EditorEntity): RailjsonObject {
+export function entityToCreateOperation(entity: EditorEntity): Operation {
   return {
     operation_type: 'CREATE',
     obj_type: entity.objType,

--- a/front/src/applications/editor/tools/pointEdition/components.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components.tsx
@@ -299,7 +299,7 @@ export const PointEditionLeftPanel: FC<{ type: EditoastType }> = <Entity extends
                 : { create: [savedEntity] }
             )
           );
-          const railjson = res[0];
+          const { railjson } = res[0];
           const { id } = railjson;
           if (id && id !== savedEntity.properties.id) {
             const saveEntity = {

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -113,7 +113,8 @@ function getRangeEditionTool<T extends EditorRange>({
                     : { create: [entity] }
                 )
               );
-              const { entityId } = res[0];
+              const { railjson } = res[0];
+              const { entityId } = railjson;
 
               const savedEntity =
                 entityId && entityId !== entity.properties.id

--- a/front/src/applications/editor/tools/switchEdition/components.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components.tsx
@@ -107,7 +107,8 @@ export const SwitchEditionLeftPanel: FC = () => {
                 : { create: [entityToSave] }
             )
           );
-          const { id } = res[0];
+          const { railjson } = res[0];
+          const { id } = railjson;
 
           if (id && id !== entityToSave.properties.id) {
             const savedEntity = {

--- a/front/src/applications/editor/tools/trackEdition/components.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components.tsx
@@ -25,11 +25,7 @@ import colors from 'common/Map/Consts/colors';
 import { save } from 'reducers/editor';
 import { getMap } from 'reducers/map/selectors';
 import { getInfraID } from 'reducers/osrdconf/selectors';
-import {
-  CatenaryEntity,
-  SpeedSectionEntity,
-  TrackSectionEntity,
-} from 'types';
+import { CatenaryEntity, SpeedSectionEntity, TrackSectionEntity } from 'types';
 
 import { TrackEditionState } from './types';
 import { injectGeometry } from './utils';
@@ -392,7 +388,7 @@ export const TrackEditionLeftPanel: FC = () => {
                 : { create: [injectGeometry(savedEntity)] }
             )
           );
-          const railjson = res[0];
+          const { railjson } = res[0];
           const savedTrack = {
             objType: 'TrackSection',
             type: 'Feature',

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -814,7 +814,7 @@ export type GetInfraByIdApiArg = {
   id: number;
 };
 export type PostInfraByIdApiResponse =
-  /** status 200 An array containing infos about the operations processed */ Railjson[];
+  /** status 200 An array containing infos about the operations processed */ RailjsonObject[];
 export type PostInfraByIdApiArg = {
   /** infra id */
   id: number;
@@ -1381,10 +1381,6 @@ export type RailjsonFile = {
   track_sections?: any;
   version?: string;
 };
-export type Railjson = {
-  id: string;
-  [key: string]: any;
-};
 export type ObjectType =
   | 'TrackSection'
   | 'Signal'
@@ -1396,9 +1392,12 @@ export type ObjectType =
   | 'Route'
   | 'OperationalPoint'
   | 'Catenary';
+export type Railjson = {
+  id: string;
+  [key: string]: any;
+};
 export type RailjsonObject = {
   obj_type: ObjectType;
-  operation_type: 'CREATE';
   railjson: Railjson;
 };
 export type Patch = {


### PR DESCRIPTION
The edition (create or update) of objects is now broken because the OpenAPI was incorrectly updated in #5924.

The serialized object on `editoast` is `RailjsonObject` (something like `{"id": "..."}`) which ends up being serialized with a wrapper because of `#[serde(tag = "obj_type")]` (so more like `{"obj_type": "Catenary", "railjson": { "id": "...", ... }}`).