### PR TITLE
front: remove signalAspects as they aren’t used

### DIFF
--- a/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
@@ -10,7 +10,6 @@ import {
   PositionSpeedTime,
   RouteAspect,
   ConsolidatedRouteAspect,
-  SignalAspect,
   MergedDataPoint,
   Train,
   Stop,
@@ -73,22 +72,6 @@ export const formatStepsWithTimeMulti = (data: Position[][]): Position<Date | nu
   );
 
 export const formatRouteAspects = (data: RouteAspect[] = []): ConsolidatedRouteAspect[] =>
-  data.map((step) => ({
-    ...step,
-    time_start: sec2d3datetime(step.time_start),
-    time_end: sec2d3datetime(step.time_end),
-    color: colorModelToHex(step.color),
-  }));
-
-/**
- * Signal Aspects (state of signals in the simulation depending on time)
- * need some formatting before inclusion in consolidatedSimulation
- * @param {Array} data
- * @returns
- */
-export const formatSignalAspects = (
-  data: SignalAspect[] = []
-): SignalAspect<Date | null, string>[] =>
   data.map((step) => ({
     ...step,
     time_start: sec2d3datetime(step.time_start),

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/createTrain.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/createTrain.ts
@@ -3,7 +3,6 @@ import { TFunction, Namespace } from 'react-i18next';
 
 import {
   formatRouteAspects,
-  formatSignalAspects,
   formatStepsWithTime,
   formatStepsWithTimeMulti,
   mergeDatasArea,
@@ -38,7 +37,6 @@ export default function createTrain(
       headPosition: formatStepsWithTimeMulti(train.base.head_positions),
       tailPosition: formatStepsWithTimeMulti(train.base.tail_positions),
       routeAspects: formatRouteAspects(train.base.route_aspects),
-      signalAspects: formatSignalAspects(train.base.signal_aspects),
       speed: formatStepsWithTime(train.base.speeds),
     };
 
@@ -49,7 +47,6 @@ export default function createTrain(
         eco_headPosition: formatStepsWithTimeMulti(train.eco.head_positions),
         eco_tailPosition: formatStepsWithTimeMulti(train.eco.tail_positions),
         eco_routeAspects: formatRouteAspects(train.eco.route_aspects),
-        eco_signalAspects: formatSignalAspects(train.eco.signal_aspects),
         eco_areaBlock: mergeDatasArea<Date | null>(
           dataSimulationTrain.eco_tailPosition,
           dataSimulationTrain.eco_headPosition,
@@ -86,7 +83,6 @@ export function isolatedCreateTrain(keyValues: ChartAxes, train: Train): Simulat
     headPosition: formatStepsWithTimeMulti(train.base.head_positions),
     tailPosition: formatStepsWithTimeMulti(train.base.tail_positions),
     routeAspects: formatRouteAspects(train.base.route_aspects),
-    signalAspects: formatSignalAspects(train.base.signal_aspects),
     speed: formatStepsWithTime(train.base.speeds),
   };
 
@@ -97,7 +93,6 @@ export function isolatedCreateTrain(keyValues: ChartAxes, train: Train): Simulat
         eco_headPosition: formatStepsWithTimeMulti(train.eco.head_positions),
         eco_tailPosition: formatStepsWithTimeMulti(train.eco.tail_positions),
         eco_routeAspects: formatRouteAspects(train.eco.route_aspects),
-        eco_signalAspects: formatSignalAspects(train.eco.signal_aspects),
         eco_areaBlock: mergeDatasArea<Date | null>(
           dataSimulationTrain.eco_tailPosition,
           dataSimulationTrain.eco_headPosition,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/sampleData.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/sampleData.ts
@@ -1670,7 +1670,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
           track_offset: 705,
         },
       ],
-      signalAspects: [],
       speed: [
         {
           time: new Date('1900-01-01T13:50:39.000Z'),
@@ -3777,7 +3776,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
           track_offset: 705,
         },
       ],
-      signalAspects: [],
       speed: [
         {
           time: new Date('1900-01-01T14:05:39.000Z'),
@@ -5884,7 +5882,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
           track_offset: 705,
         },
       ],
-      signalAspects: [],
       speed: [
         {
           time: new Date('1900-01-01T14:20:39.000Z'),

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -97,23 +97,12 @@ export interface RouteAspect<Time = number, Color = number> {
 }
 export type ConsolidatedRouteAspect<DateType = Date> = RouteAspect<DateType | null, string>;
 
-export interface SignalAspect<Time = number, Color = number> {
-  signal_id: string;
-  time_start: Time;
-  time_end: Time;
-  color: Color;
-  blinking: boolean;
-  aspect_label: string;
-}
-export type ConsolidatedSignalAspect<DateType = Date> = SignalAspect<DateType | null, string>;
-
 export interface Regime {
   head_positions: Position[][];
   tail_positions: Position[][];
   speeds: PositionSpeedTime[];
   stops: Stop[];
   route_aspects: RouteAspect[];
-  signal_aspects?: SignalAspect[];
   error?: string;
   mechanical_energy_consumed: number;
 }
@@ -189,13 +178,11 @@ export interface SimulationTrain<DateType = Date> {
   headPosition: ConsolidatedPosition<DateType>[][];
   tailPosition: ConsolidatedPosition<DateType>[][];
   routeAspects: ConsolidatedRouteAspect<DateType>[];
-  signalAspects: ConsolidatedSignalAspect[];
   areaBlock?: ConsolidatedMergeDataPoint[][];
   speed: ConsolidatedPositionSpeedTime[];
   eco_headPosition?: ConsolidatedPosition<DateType>[][];
   eco_tailPosition?: ConsolidatedPosition<DateType>[][];
   eco_routeAspects?: ConsolidatedRouteAspect<DateType>[];
-  eco_signalAspects?: ConsolidatedSignalAspect[];
   eco_areaBlock?: ConsolidatedMergeDataPoint[][];
   eco_speed?: ConsolidatedPositionSpeedTime[];
 }

--- a/front/tests/assets/operationStudies/simulationTrain.js
+++ b/front/tests/assets/operationStudies/simulationTrain.js
@@ -680,7 +680,6 @@ export default {
         blinking: false,
       },
     ],
-    signalAspects: [],
     speed: [
       {
         time: new Date('1900-01-01T11:50:39.000Z'),


### PR DESCRIPTION
To my understanding, signal_aspects are never used. They are optional from simulation results, but editoast never returns such things: https://github.com/osrd-project/osrd/blob/dev/front/src/common/api/osrdEditoastApi.ts#L2033-L2068