### PR TITLE
Add batch operation support for ModelV2

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -230,6 +230,10 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// * `impl Update<T, Model> for ModelChangeset`: if `Model: Identifiable<T>`
 /// * `impl Delete for Model`
 /// * `impl DeleteStatic<T> for Model`: if `Model: Identifiable<T>`
+/// * `impl RetrieveBatchUnchecked<T> for Model`: if `Model: Identifiable<T>`
+/// * `impl UpdateBatchUnchecked<T, Model> for ModelChangeset`: if `Model: Identifiable<T>`
+/// * `impl CreateBatch<T, ModelChangeset> for Model`: if `Model: Identifiable<T>`
+/// * `impl DeleteBatch<T> for Model`: if `Model: Identifiable<T>`
 ///
 /// ## Options
 /// ### Struct-level options

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -221,8 +221,6 @@ pub trait Create<Row: Send>: Sized {
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-// NOTE: I'd argue that taking an &self is better than a borrow here
-// as one might want to access the values of the model after deletion
 #[async_trait]
 pub trait Delete: Sized {
     /// Deletes the row corresponding to this model instance
@@ -278,5 +276,673 @@ where
             Ok(false) => Err(fail().into()),
             Err(e) => Err(e),
         }
+    }
+}
+
+/// Splits a query into chunks to accommodate libpq's maximum number of parameters
+///
+/// This is a hack around a libpq limitation (cf. <https://github.com/diesel-rs/diesel/issues/2414>).
+/// The rows to process are split into chunks for which at most `2^16 - 1` parameters are sent to libpq.
+/// Hence the macro needs to know how many parameters are sent per row.
+/// The result of the chunked query is then concatenated into `result`, which must
+/// implement `std::iter::Extend<RowType>`.
+/// The chunked query is defined using a closure-like syntax. The argument of the "closure"
+/// is a variable of type `&[ParameterType]`, and it must "return" a `Result<impl IntoIterator<Item = RowType>, E>`.
+/// The values can be any type that implements `IntoIterator<Item = ParameterType>`.
+///
+/// # Example
+///
+/// ```
+/// chunked_for_libpq! {
+///     3, // 3 parameters are binded per row
+///     values, // an iterator of parameters
+///     Vec::new(), // the collection to extend with the result
+///     chunk => { // chunk is a variable of type `&[ParameterType]`
+///         diesel::insert_into(dsl::document)
+///             .values(chunk)
+///             .load_stream::<<Self as Model>::Row>(conn)
+///             .await
+///             .map(|s| s.map_ok(<Document as Model>::from_row).try_collect::<Vec<_>>())?
+///             .await?
+///         // returns a Result<Vec<RowType>, impl EditoastError>
+///     } // (this is not a real closure)
+/// }
+/// ```
+///
+/// # On concurrency
+///
+/// There seem to be a problem with concurrent queries using deadpool, panicking with
+/// 'Cannot access shared transaction state'. So this macro do not run each chunk's query concurrently.
+/// While AsyncPgConnection supports pipelining, each query will be sent one after the other.
+/// (But hey, it's still better than just making one query per row :p)
+#[macro_export]
+macro_rules! chunked_for_libpq {
+    // Collects every chunk result into a vec
+    ($parameters_per_row:expr, $values:expr, $chunk:ident => $query:tt) => {{
+        const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
+        // We need to divide further because of AsyncPgConnection, maybe it is related to connection pipelining
+        const ASYNC_SUBDIVISION: usize = 2_usize;
+        const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
+        let mut result = Vec::new();
+        let values = $values.into_iter().collect::<Vec<_>>();
+        let chunks = values.chunks(CHUNK_SIZE);
+        for $chunk in chunks.into_iter() {
+            let chunk_result = $query;
+            result.push(chunk_result);
+        }
+        result
+    }};
+    // Extends the result structure with every chunked query result
+    ($parameters_per_row:expr, $values:expr, $result:expr, $chunk:ident => $query:tt) => {{
+        const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
+        // We need to divide further because of AsyncPgConnection, maybe it is related to connection pipelining
+        const ASYNC_SUBDIVISION: usize = 2_usize;
+        const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
+        let mut result = $result;
+        let values = $values.into_iter().collect::<Vec<_>>();
+        let chunks = values.chunks(CHUNK_SIZE);
+        for $chunk in chunks.into_iter() {
+            let chunk_result = $query;
+            result.extend(chunk_result);
+        }
+        result
+    }};
+}
+
+/// Describes how a [Model] can be created in the database given a batch of its changesets
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait::async_trait]
+pub trait CreateBatch<Cs, K>: Sized
+where
+    Cs: Send,
+    K: Send + Clone,
+{
+    /// Creates a batch of rows in the database given an iterator of changesets
+    ///
+    /// Returns a collection of the created rows.
+    /// ```
+    /// let changesets = (0..5).map(|i| {
+    ///     Document::changeset()
+    ///         .content_type(String::from("text/plain"))
+    ///         .data(vec![i])
+    /// });
+    /// let docs: Vec<Document> = Document::create_batch(&mut conn, changesets).await?;
+    /// assert_eq!(docs.len(), 5);
+    /// ```
+    async fn create_batch<
+        I: IntoIterator<Item = Cs> + Send + 'async_trait,
+        C: Default + std::iter::Extend<Self> + Send,
+    >(
+        conn: &mut diesel_async::AsyncPgConnection,
+        values: I,
+    ) -> Result<C>;
+
+    /// Just like [CreateBatch::create_batch] but the returned models are paired with their key
+    async fn create_batch_with_key<
+        I: IntoIterator<Item = Cs> + Send + 'async_trait,
+        C: Default + std::iter::Extend<(K, Self)> + Send,
+    >(
+        conn: &mut diesel_async::AsyncPgConnection,
+        values: I,
+    ) -> Result<C>;
+}
+
+/// Unchecked batch retrieval of a [Model] from the database
+///
+/// Any [Model] that implement this trait also implement [RetrieveBatch].
+/// Unless you know what you're doing, you should use [RetrieveBatch] instead.
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait::async_trait]
+pub trait RetrieveBatchUnchecked<K>: Sized
+where
+    for<'async_trait> K: Send + 'async_trait,
+{
+    /// Retrieves a batch of rows from the database given an iterator of keys
+    ///
+    /// Returns a collection of the retrieved rows. That collection can contain
+    /// fewer items than the number of provided keys if some rows were not found.
+    /// Use [RetrieveBatch::retrieve_batch] or [RetrieveBatch::retrieve_batch_or_fail]
+    /// if you want to fail if some rows were not found.
+    /// Unless you know what you're doing, you should use these functions instead.
+    async fn retrieve_batch_unchecked<
+        I: IntoIterator<Item = K> + Send + 'async_trait,
+        C: Default + std::iter::Extend<Self> + Send,
+    >(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<C>;
+
+    /// Just like [RetrieveBatchUnchecked::retrieve_batch_unchecked] but the returned models are paired with their key
+    ///
+    /// Returns a collection of the retrieved rows. That collection can contain
+    /// fewer items than the number of provided keys if some rows were not found.
+    /// Use [RetrieveBatch::retrieve_batch_with_key] or [RetrieveBatch::retrieve_batch_with_key_or_fail]
+    /// if you want to fail if some rows were not found.
+    /// Unless you know what you're doing, you should use these functions instead.
+    async fn retrieve_batch_with_key_unchecked<
+        I: IntoIterator<Item = K> + Send + 'async_trait,
+        C: Default + std::iter::Extend<(K, Self)> + Send,
+    >(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<C>;
+}
+
+/// Unchecked batch update of a [Model] in the database
+///
+/// Any [Model] that implement this trait also implement [UpdateBatch].
+/// Unless you know what you're doing, you should use [UpdateBatch] instead.
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait::async_trait]
+pub trait UpdateBatchUnchecked<M, K>: Sized
+where
+    M: Send,
+    K: Send + Clone,
+{
+    /// Updates a batch of rows in the database given an iterator of keys
+    ///
+    /// Returns a collection of the updated rows. That collection can contain
+    /// fewer items than the number of provided keys if some rows were not found.
+    /// Use [UpdateBatch::update_batch] or [UpdateBatch::update_batch_or_fail]
+    /// if you want to fail if some rows were not found.
+    /// Unless you know what you're doing, you should use these functions instead.
+    async fn update_batch_unchecked<
+        I: IntoIterator<Item = K> + Send + 'async_trait,
+        C: Default + std::iter::Extend<M> + Send,
+    >(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<C>;
+
+    /// Just like [UpdateBatchUnchecked::update_batch_unchecked] but the returned models are paired with their key
+    ///
+    /// Returns a collection of the updated rows. That collection can contain
+    /// fewer items than the number of provided keys if some rows were not found.
+    /// Use [UpdateBatch::update_batch_with_key] or [UpdateBatch::update_batch_with_key_or_fail]
+    /// if you want to fail if some rows were not found.
+    /// Unless you know what you're doing, you should use these functions instead.
+    async fn update_batch_with_key_unchecked<
+        I: IntoIterator<Item = K> + Send + 'async_trait,
+        C: Default + std::iter::Extend<(K, M)> + Send,
+    >(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<C>;
+}
+
+/// Describes how a [Model] can be deleted from the database given a batch of keys
+///
+/// You can implement this type manually but its recommended to use the `Model`
+/// derive macro instead.
+#[async_trait::async_trait]
+pub trait DeleteBatch<K>: Sized
+where
+    for<'async_trait> K: Send + 'async_trait,
+{
+    /// Deletes a batch of rows from the database given an iterator of keys
+    ///
+    /// Returns the number of rows deleted.
+    async fn delete_batch<I: IntoIterator<Item = K> + Send + 'async_trait>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<usize>;
+
+    /// Just like [DeleteBatch::delete_batch] but returns `Err(fail(missing))` where `missing`
+    /// is the number of rows that were not deleted
+    async fn delete_batch_or_fail<I, E, F>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<()>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        E: EditoastError,
+        F: FnOnce(usize) -> E + Send + 'async_trait,
+    {
+        let ids = ids.into_iter().collect::<Vec<_>>();
+        let expected_count = ids.len();
+        let count = Self::delete_batch(conn, ids).await?;
+        if count != expected_count {
+            Err(fail(expected_count - count).into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Describes how a [Model] can be retrieved from the database given a batch of keys
+///
+/// This trait is automatically implemented for all models that implement
+/// [RetrieveBatchUnchecked]. [RetrieveBatchUnchecked] is a lower-level trait
+/// which implementation is automatically generated by the `Model` derive macro.
+///
+/// 99% of the time you should use this trait instead of [RetrieveBatchUnchecked].
+/// This won't be possible however if the model's key is not `Eq` or `Hash`.
+#[async_trait::async_trait]
+pub trait RetrieveBatch<K>: RetrieveBatchUnchecked<K>
+where
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+{
+    /// Retrieves a batch of rows from the database given an iterator of keys
+    ///
+    /// Returns a collection of the retrieved rows and a set of the keys
+    /// that were not found.
+    ///
+    /// ```
+    /// let mut ids = (0..5).collect::<Vec<_>>();
+    /// ids.push(123456789);
+    /// let (docs, missing): (HashSet<_>, _) = Document::retrieve_batch(&mut conn, ids).await?;
+    /// assert!(ids.contains(&123456789));
+    /// assert_eq!(docs.len(), 5);
+    /// ```
+    async fn retrieve_batch<I, C>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<(C, std::collections::HashSet<K>)>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<Self>
+            + std::iter::FromIterator<Self>
+            + std::iter::IntoIterator<Item = Self>,
+    {
+        let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
+        let (retrieved_ids, results): (std::collections::HashSet<_>, C) =
+            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(
+                conn,
+                ids.clone().into_iter(),
+            )
+            .await?
+            .into_iter()
+            .unzip();
+        let missing = ids
+            .difference(&retrieved_ids)
+            .collect::<std::collections::HashSet<_>>();
+        Ok((results, missing.into_iter().cloned().collect()))
+    }
+
+    /// Just like [RetrieveBatch::retrieve_batch] but the returned models are paired with their key
+    ///
+    /// ```
+    /// let mut ids = (0..5).collect::<Vec<_>>();
+    /// ids.push(123456789);
+    /// let (docs, missing): (HashMap<_, _>, _) = Document::retrieve_batch_with_key(&mut conn, ids).await?;
+    /// assert!(ids.contains(&123456789));
+    /// assert!(docs.contains(&1));
+    /// ```
+    async fn retrieve_batch_with_key<I, C>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<(C, std::collections::HashSet<K>)>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<(K, Self)>
+            + std::iter::FromIterator<(K, Self)>
+            + std::iter::IntoIterator<Item = (K, Self)>,
+    {
+        let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
+        let (retrieved_ids, results): (std::collections::HashSet<_>, C) =
+            Self::retrieve_batch_with_key_unchecked::<_, Vec<(_, _)>>(
+                conn,
+                ids.clone().into_iter(),
+            )
+            .await?
+            .into_iter()
+            .map(|(k, v)| (k.clone(), (k, v)))
+            .unzip();
+        let missing = ids
+            .difference(&retrieved_ids)
+            .collect::<std::collections::HashSet<_>>();
+        Ok((results, missing.into_iter().cloned().collect()))
+    }
+
+    /// Retrieves a batch of rows from the database given an iterator of keys
+    ///
+    /// Returns a collection of the retrieved rows and fails if some rows were not found.
+    /// On failure, the error returned is the result of calling `fail(missing)` where `missing`
+    /// is the set of ids that were not found.
+    ///
+    /// ```
+    /// let ids = (0..5).collect::<Vec<_>>();
+    /// let docs: HashSet<_> = Document::retrieve_batch_or_fail(&mut conn, ids, |missing| {
+    ///    MyErrorType::DocumentsNotFound(missing)
+    /// }).await?;
+    /// ```
+    async fn retrieve_batch_or_fail<I, C, E, F>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<C>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<Self>
+            + std::iter::FromIterator<Self>
+            + std::iter::IntoIterator<Item = Self>,
+        E: EditoastError,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+    {
+        let (result, missing) = Self::retrieve_batch::<_, C>(conn, ids).await?;
+        if missing.is_empty() {
+            Ok(result)
+        } else {
+            Err(fail(missing).into())
+        }
+    }
+
+    /// Just like [RetrieveBatch::retrieve_batch_or_fail] but the returned models are paired with their key
+    ///
+    /// ```
+    /// let ids = (0..5).collect::<Vec<_>>();
+    /// let docs: HashMap<_, _> = Document::retrieve_batch_with_key_or_fail(&mut conn, ids, |missing| {
+    ///   MyErrorType::DocumentsNotFound(missing)
+    /// }).await?;
+    /// ```
+    async fn retrieve_batch_with_key_or_fail<I, C, E, F>(
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<C>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<(K, Self)>
+            + std::iter::FromIterator<(K, Self)>
+            + std::iter::IntoIterator<Item = (K, Self)>,
+        E: EditoastError,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+    {
+        let (result, missing) = Self::retrieve_batch_with_key::<_, C>(conn, ids).await?;
+        if missing.is_empty() {
+            Ok(result)
+        } else {
+            Err(fail(missing).into())
+        }
+    }
+}
+
+/// Describes how a [Model] can be updated in the database given a batch of its changesets
+///
+/// This trait is automatically implemented for all models that implement
+/// [UpdateBatchUnchecked]. [UpdateBatchUnchecked] is a lower-level trait
+/// which implementation is automatically generated by the `Model` derive macro.
+///
+/// 99% of the time you should use this trait instead of [UpdateBatchUnchecked].
+/// This won't be possible however if the model's key is not `Eq` or `Hash`.
+#[async_trait::async_trait]
+pub trait UpdateBatch<M, K>: UpdateBatchUnchecked<M, K>
+where
+    M: Send,
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+{
+    /// Applies the changeset to a batch of rows in the database given an iterator of keys
+    ///
+    /// Returns a collection of the updated rows and a set of the keys
+    /// that were not found.
+    ///
+    /// ```
+    /// let mut ids = (0..5).collect::<Vec<_>>();
+    /// ids.push(123456789);
+    /// let (docs, missing): (Vec<_>, _) =
+    ///     Document::changeset()
+    ///         .data(vec![])
+    ///         .update_batch(&mut conn, ids)
+    ///         .await?;
+    /// assert!(missing.contains(&123456789));
+    /// assert_eq!(docs.len(), 5);
+    /// assert_eq!(docs[0].data, vec![]);
+    /// ```
+    async fn update_batch<I, C>(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<(C, std::collections::HashSet<K>)>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<M>
+            + std::iter::FromIterator<M>
+            + std::iter::IntoIterator<Item = M>,
+    {
+        let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
+        let (updated_ids, results): (std::collections::HashSet<_>, C) = self
+            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone().into_iter())
+            .await?
+            .into_iter()
+            .unzip();
+        let missing = ids
+            .difference(&updated_ids)
+            .collect::<std::collections::HashSet<_>>();
+        Ok((results, missing.into_iter().cloned().collect()))
+    }
+
+    /// Just like [UpdateBatch::update_batch] but the returned models are paired with their key
+    ///
+    /// ```
+    /// let mut ids = (0..5).collect::<Vec<_>>();
+    /// ids.push(123456789);
+    /// let (docs, missing): (BTreeMap<_, _>, _) =
+    ///    Document::changeset()
+    ///       .data(vec![])
+    ///       .update_batch_with_key(&mut conn, ids)
+    ///       .await?;
+    /// assert!(missing.contains(&123456789));
+    /// ```
+    async fn update_batch_with_key<I, C>(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+    ) -> Result<(C, std::collections::HashSet<K>)>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<(K, M)>
+            + std::iter::FromIterator<(K, M)>
+            + std::iter::IntoIterator<Item = (K, M)>,
+    {
+        let ids = ids.into_iter().collect::<std::collections::HashSet<_>>();
+        let (updated_ids, results): (std::collections::HashSet<_>, C) = self
+            .update_batch_with_key_unchecked::<_, Vec<(_, _)>>(conn, ids.clone().into_iter())
+            .await?
+            .into_iter()
+            .map(|(k, v)| (k.clone(), (k, v)))
+            .unzip();
+        let missing = ids
+            .difference(&updated_ids)
+            .collect::<std::collections::HashSet<_>>();
+        Ok((results, missing.into_iter().cloned().collect()))
+    }
+
+    /// Applies the changeset to a batch of rows in the database given an iterator of keys
+    ///
+    /// Returns a collection of the updated rows and fails if some rows were not found.
+    /// On failure, the error returned is the result of calling `fail(missing)` where `missing`
+    /// is the set of ids that were not found.
+    ///
+    /// ```
+    /// let docs: Vec<_> = Document::changeset()
+    ///     .data(vec![])
+    ///     .update_batch_or_fail(&mut conn, (0..5), |missing| {
+    ///         MyErrorType::DocumentsNotFound(missing)
+    ///     }).await?;
+    /// ```
+    async fn update_batch_or_fail<I, C, E, F>(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<C>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<M>
+            + std::iter::FromIterator<M>
+            + std::iter::IntoIterator<Item = M>,
+        E: EditoastError,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+    {
+        let (result, missing) = self.update_batch::<_, C>(conn, ids).await?;
+        if missing.is_empty() {
+            Ok(result)
+        } else {
+            Err(fail(missing).into())
+        }
+    }
+
+    /// Just like [UpdateBatch::update_batch_or_fail] but the returned models are paired with their key
+    ///
+    /// ```
+    /// let docs: BTreeMap<_, _> = Document::changeset()
+    ///     .data(vec![])
+    ///     .update_batch_with_key_or_fail(&mut conn, (0..5), |missing| {
+    ///         MyErrorType::DocumentsNotFound(missing)
+    ///     }).await?;
+    /// ```
+    async fn update_batch_with_key_or_fail<I, C, E, F>(
+        self,
+        conn: &mut diesel_async::AsyncPgConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<C>
+    where
+        I: Send + IntoIterator<Item = K> + 'async_trait,
+        C: Send
+            + Default
+            + std::iter::Extend<(K, M)>
+            + std::iter::FromIterator<(K, M)>
+            + std::iter::IntoIterator<Item = (K, M)>,
+        E: EditoastError,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+    {
+        let (result, missing) = self.update_batch_with_key::<_, C>(conn, ids).await?;
+        if missing.is_empty() {
+            Ok(result)
+        } else {
+            Err(fail(missing).into())
+        }
+    }
+}
+
+// Auto-impl of RetrieveBatch for all models that implement RetrieveBatchUnchecked
+#[async_trait::async_trait]
+impl<M, K> RetrieveBatch<K> for M
+where
+    M: RetrieveBatchUnchecked<K>,
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+{
+}
+
+// Auto-impl of UpdateBatch for all models that implement UpdateBatchUnchecked
+#[async_trait::async_trait]
+impl<Cs, M, K> UpdateBatch<M, K> for Cs
+where
+    Cs: UpdateBatchUnchecked<M, K>,
+    M: Send,
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fixtures::tests::{db_pool, TestFixture};
+    use editoast_derive::ModelV2;
+    use itertools::Itertools;
+    use std::collections::HashSet;
+
+    #[derive(Debug, Default, Clone, ModelV2)]
+    #[model(table = crate::tables::document)]
+    pub struct Document {
+        pub id: i64,
+        pub content_type: String,
+        pub data: Vec<u8>,
+    }
+
+    #[rstest::rstest]
+    async fn test_batch() {
+        use crate::modelsv2::*;
+        let pool = db_pool();
+        let mut conn = pool.get().await.unwrap();
+        let changesets = (0..5).map(|i| {
+            Document::changeset()
+                .content_type(String::from("text/plain"))
+                .data(vec![i])
+        });
+        let docs = Document::create_batch::<_, Vec<_>>(&mut conn, changesets)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|d| TestFixture::new(d, pool.clone()))
+            .collect::<Vec<_>>();
+        assert_eq!(docs.len(), 5);
+
+        let mut ids = docs.iter().map(|d| d.model.id).collect::<Vec<_>>();
+        ids.push(123456789);
+
+        let (docs, missing): (Vec<_>, _) =
+            Document::retrieve_batch(&mut pool.get().await.unwrap(), ids.clone())
+                .await
+                .unwrap();
+        assert_eq!(missing.into_iter().collect_vec(), vec![123456789]);
+        assert_eq!(docs.len(), 5);
+        assert_eq!(
+            docs.iter()
+                .map(|d| d.content_type.clone())
+                .collect::<HashSet<_>>(),
+            HashSet::from([String::from("text/plain")])
+        );
+        assert_eq!(
+            docs.iter()
+                .flat_map(|d| d.data.clone())
+                .collect::<HashSet<_>>(),
+            HashSet::from_iter(0..5)
+        );
+
+        let new_ct = String::from("I like trains");
+        let (updated_docs, missing): (Vec<_>, _) = Document::changeset()
+            .content_type(new_ct.clone())
+            .update_batch(&mut pool.get().await.unwrap(), ids.iter().cloned().take(2))
+            .await
+            .unwrap();
+        assert!(missing.is_empty());
+        assert!(updated_docs.iter().all(|d| d.content_type == new_ct));
+        assert_eq!(updated_docs.len(), 2);
+
+        let (docs, _): (Vec<_>, _) =
+            Document::retrieve_batch(&mut pool.get().await.unwrap(), ids.clone())
+                .await
+                .unwrap();
+        assert_eq!(
+            docs.iter()
+                .map(|d| d.content_type.clone())
+                .collect::<HashSet<_>>(),
+            HashSet::from([String::from("text/plain"), new_ct])
+        );
+
+        let not_deleted = ids.remove(0);
+        let count = Document::delete_batch(&mut pool.get().await.unwrap(), ids)
+            .await
+            .unwrap();
+        assert_eq!(count, 4);
+
+        let survivor = Document::retrieve(&mut pool.get().await.unwrap(), not_deleted)
+            .await
+            .unwrap();
+        assert!(survivor.is_some());
     }
 }


### PR DESCRIPTION
closes #5055 

Content:

* Batch trait definitions in modelsv2/mod.rs
* Impl generation in ModelV2 macro
* Batch operation test in modelsv2/mod.rs (redefines `Document`)
* Application of retrieve_batch for TrackSectionModel