### PR TITLE
Add new editor error for node endpoints unicity

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -761,6 +761,7 @@ components:
       - overlapping_catenaries
       - unknown_port_name
       - unused_port
+      - node_endpoints_not_unique
       type: string
     InternalError:
       properties:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -1021,6 +1021,7 @@ components:
         - overlapping_catenaries
         - unknown_port_name
         - unused_port
+        - node_endpoints_not_unique
 
     InfraError:
       type: object

--- a/editoast/src/schema/errors.rs
+++ b/editoast/src/schema/errors.rs
@@ -35,6 +35,7 @@ pub enum InfraErrorType {
     MissingBufferStop {
         endpoint: Endpoint,
     },
+    NodeEndpointsNotUnique,
     ObjectOutOfPath {
         reference: ObjectRef,
     },
@@ -134,6 +135,16 @@ impl InfraError {
             field: Default::default(),
             is_warning: true,
             sub_type: InfraErrorType::MissingRoute,
+        }
+    }
+
+    pub fn new_node_endpoint_not_unique<T: AsRef<str>>(switch_id: &T) -> Self {
+        Self {
+            obj_id: switch_id.as_ref().into(),
+            obj_type: ObjectType::Switch,
+            field: Default::default(),
+            is_warning: false,
+            sub_type: InfraErrorType::NodeEndpointsNotUnique,
         }
     }
 

--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -139,6 +139,10 @@
         "unused_port": {
           "name": "Unused branch",
           "description": "Branch « {{port_name}} » of switch type « {{obj_id}} » is nerver used"
+        },
+        "node_endpoints_not_unique": {
+          "name": "Node endpoints not unique",
+          "description": "The « {{obj_id}} » node has a track endpoint used by several ports."
         }
       },
       "list": {

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -139,6 +139,10 @@
         "unused_port": {
           "name": "Branche non utilisée",
           "description": "La branche « {{port_name}} » déclarée dans le type d’aiguille/nœud « {{obj_id}} » n’est pas utilisée dans les configurations de ce type"
+        },
+        "node_endpoints_not_unique": {
+          "name": "Extrémité de voie de nœud non unique",
+          "description": "Une extrémité de voie est utilisée par plusieurs ports du nœud « {{obj_id}} »"
         }
       },
       "list": {

--- a/front/src/applications/editor/components/InfraErrors/types.ts
+++ b/front/src/applications/editor/components/InfraErrors/types.ts
@@ -23,6 +23,7 @@ export const infraErrorTypeList: Record<'errors' | 'warnings', Set<InfraErrorTyp
     'object_out_of_path',
     'out_of_range',
     'unknown_port_name',
+    'node_endpoints_not_unique',
   ]),
   warnings: new Set([
     'duplicated_group',
@@ -96,6 +97,9 @@ type InfraErrorUnusedPort = InfraErrorInformation & {
   error_type: 'unused_port';
   port_name: string;
 };
+type InfraErrorNodeEndpointsNotUnique = InfraErrorInformation & {
+  error_type: 'node_endpoints_not_unique';
+};
 
 // Type of an error
 export type InfraError = Omit<InfraErrorApiType, 'informations'> & {
@@ -116,5 +120,6 @@ export type InfraError = Omit<InfraErrorApiType, 'informations'> & {
     | InfraErrorOverlappingSpeedSections
     | InfraErrorOverlappingSwitches
     | InfraErrorOverlappingCatenaries
-    | InfraErrorUnusedPort;
+    | InfraErrorUnusedPort
+    | InfraErrorNodeEndpointsNotUnique;
 };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1470,7 +1470,8 @@ export type InfraErrorType =
   | 'overlapping_switches'
   | 'overlapping_catenaries'
   | 'unknown_port_name'
-  | 'unused_port';
+  | 'unused_port'
+  | 'node_endpoints_not_unique';
 export type InfraError = {
   geographic?: Geometry | null;
   information: {

--- a/python/osrd_schemas/osrd_schemas/generated.py
+++ b/python/osrd_schemas/osrd_schemas/generated.py
@@ -52,6 +52,10 @@ class InvalidRoute(InfraErrorTrait):
     error_type: Literal["invalid_route"] = Field(default="invalid_route")
 
 
+class NodeEndpointsNotUnique(InfraErrorTrait):
+    error_type: Literal["node_endpoints_not_unique"] = Field(default="node_endpoints_not_unique")
+
+
 class UnknownPortName(InfraErrorTrait):
     error_type: Literal["unknown_port_name"] = Field(default="unknown_port_name")
     port_name: str
@@ -113,6 +117,7 @@ InfraError = Annotated[
         InvalidSwitchPorts,
         MissingRoute,
         MissingBufferStop,
+        NodeEndpointsNotUnique,
         ObjectOutOfPath,
         OddBufferStopLocation,
         OutOfRange,


### PR DESCRIPTION
close #6159

### How to test it?

- Create an empty infra
- Create a new track section
- Create a node (a switch) using multiple times the same track endpoint
- An infra error should be visible