### PR TITLE
front: sort station list by CH code on Map search component 

### DIFF
--- a/front/public/locales/en/map-search.json
+++ b/front/public/locales/en/map-search.json
@@ -5,6 +5,8 @@
   "placeholderline": "Line name or number",
   "placeholdersignal": "Signal name",
   "placeholdername": "Name, label",
+  "placeholderchcode": "CH code",
+  "labelbvonly": "BV only",
   "pk": "PK",
   "resultsCount_zero": "No results",
   "resultsCount_one": "1 result",

--- a/front/public/locales/fr/map-search.json
+++ b/front/public/locales/fr/map-search.json
@@ -5,6 +5,8 @@
   "placeholderline": "Nom ou numéro de ligne",
   "placeholdersignal": "Nom du signal",
   "placeholdername": "Nom, appelation, libellé",
+  "placeholderchcode": "Code CH",
+  "labelbvonly": "BV uniquement",
   "pk": "PK",
   "resultsCount_zero": "Aucun résultat",
   "resultsCount_one": "1 résultat",

--- a/front/src/common/Map/Search/StationCardList.tsx
+++ b/front/src/common/Map/Search/StationCardList.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { SearchResultItemOperationalPoint } from 'common/api/osrdEditoastApi';
+import StationCard from 'common/StationCard';
+
+type StationCardsListProps = {
+  operationalPoints: SearchResultItemOperationalPoint[];
+  stationCHcodes: string[];
+  onStationClick: (result: SearchResultItemOperationalPoint) => void;
+};
+
+const StationCardsList = ({
+  operationalPoints,
+  stationCHcodes,
+  onStationClick,
+}: StationCardsListProps) => {
+  const sortByCh = (
+    a: SearchResultItemOperationalPoint,
+    b: SearchResultItemOperationalPoint
+  ): number => {
+    const aIndex = stationCHcodes.indexOf(a.ch);
+    const bIndex = stationCHcodes.indexOf(b.ch);
+
+    const aIsStation = aIndex !== -1;
+    const bIsStation = bIndex !== -1;
+
+    const aBeforeB = aIsStation && !bIsStation;
+    const bBeforeA = !aIsStation && bIsStation;
+    const aAndbAreStations = aIsStation && bIsStation;
+
+    if (aBeforeB) return -1;
+    if (bBeforeA) return 1;
+    if (aAndbAreStations) return aIndex - bIndex;
+    return 0; // Otherwise, we maintain the order returned by the backend, as the data is already sorted by name.
+  };
+
+  const sortedStations = [...operationalPoints].sort(sortByCh);
+
+  return (
+    <div className="search-results">
+      {sortedStations.map((station) => (
+        <div className="mb-1" key={`mapSearchStation-${station.obj_id}`}>
+          <StationCard
+            station={{ ...station, yardname: station.ch }}
+            onClick={() => onStationClick(station)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default StationCardsList;


### PR DESCRIPTION
close #5958 

### Updates
- refactore `MapSearchStation` component: extract the html part which handle the results list from the component to a new autonom component `StationCardsList`.
- sort station list based on their 'CH' code, placing those with priority codes ('', '00', 'BV') at the top according to their order in the priority list, and sorting the rest alphabetically by name
- New field to filter by CH code and new checkbox to filter only BV 
![image](https://github.com/osrd-project/osrd/assets/19575568/5cd79c42-ef98-440a-a3f7-81687f50408d)
