### PR TITLE
front: editor: add selection in search params

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -353,8 +353,10 @@
           "unselect-all": "Deselect all"
         },
         "errors": {
+          "invalid-url": "Invalid URL",
           "no-heterogenous-edition": "It's not possible to edit multiple elements of different types at the same time.",
-          "no-multi-edition": "It's not possible yet to edit multiple elements (TODO)."
+          "no-multi-edition": "It's not possible yet to edit multiple elements (TODO).",
+          "unable-to-select": "Selection not possible"
         },
         "focus": "Focus",
         "help": {

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -353,8 +353,10 @@
           "unselect-all": "Tout désélectionner"
         },
         "errors": {
+          "invalid-url": "URL invalide",
           "no-heterogenous-edition": "Il n'est pas possible d'éditer plusieurs éléments de différents types en même temps.",
-          "no-multi-edition": "Il n'est pas encore possible d'éditer plusieurs éléments en même temps (TODO)."
+          "no-multi-edition": "Il n'est pas encore possible d'éditer plusieurs éléments en même temps (TODO).",
+          "unable-to-select": "Sélection impossible"
         },
         "focus": "Focus",
         "help": {

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -3,8 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import cx from 'classnames';
-import { isNil, toInteger, uniq } from 'lodash';
-import turfBbox from '@turf/bbox';
+import { isNil, toInteger } from 'lodash';
 
 import 'applications/editor/Editor.scss';
 import 'common/Map/Map.scss';
@@ -29,13 +28,8 @@ import TOOL_TYPES from 'applications/editor/tools/toolTypes';
 
 import type { CommonToolState } from 'applications/editor/tools/commonToolState';
 import { useInfraID, useOsrdActions } from 'common/osrdContext';
-import {
-  EDITOAST_TO_LAYER_DICT,
-  EditoastType,
-  type EditorState,
-} from 'applications/editor/tools/types';
-import { BBox } from '@turf/helpers';
-import type { LngLatBoundsLike, MapRef } from 'react-map-gl/maplibre';
+import type { EditoastType, EditorState } from 'applications/editor/tools/types';
+import type { MapRef } from 'react-map-gl/maplibre';
 import type {
   EditorContextType,
   ExtendedEditorContextType,

--- a/front/src/applications/editor/components/InfraErrors/InfraErrorMapControl.tsx
+++ b/front/src/applications/editor/components/InfraErrors/InfraErrorMapControl.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { LngLatBoundsLike, MapRef } from 'react-map-gl/maplibre';
+import type { MapRef } from 'react-map-gl/maplibre';
 import { BsExclamationOctagon } from 'react-icons/bs';
 import { useTranslation } from 'react-i18next';
 
@@ -8,11 +8,11 @@ import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { getEditorState } from 'reducers/editor/selectors';
 import useKeyboardShortcuts from 'utils/hooks/useKeyboardShortcuts';
 
-import { EditorContextType } from '../../tools/editorContextTypes';
-import { getEntityBbox, selectEntity } from '../../tools/utils';
+import type { EditorContextType } from '../../tools/editorContextTypes';
+import { centerMapOnObject, selectEntities } from '../../tools/utils';
 import { getEntity } from '../../data/api';
 import InfraErrorsModal from './InfraErrorsModal';
-import { InfraError } from './types';
+import type { InfraError } from './types';
 
 const InfraErrorMapControl: FC<{
   mapRef: MapRef;
@@ -42,19 +42,12 @@ const InfraErrorMapControl: FC<{
           );
 
           // select the entity
-          selectEntity(entity, { switchTool, dispatch, editorState });
+          selectEntities([entity], { switchTool, dispatch, editorState });
 
           // closing the modal
           closeModal();
 
-          // Center the map on the object
-          const bbox = await getEntityBbox(infraID, entity, dispatch);
-          if (bbox) {
-            // zoom to the bbox
-            mapRef.fitBounds(bbox as LngLatBoundsLike, { animate: false });
-            // make a zoom out to have some kind of "margin" around the bbox
-            mapRef.zoomOut();
-          }
+          centerMapOnObject(infraID, [entity], dispatch, mapRef);
         }}
       />,
       'lg'
@@ -64,10 +57,10 @@ const InfraErrorMapControl: FC<{
     dispatch,
     editorState,
     mapRef,
-    getEntityBbox,
     getEntity,
     closeModal,
-    selectEntity,
+    selectEntities,
+    centerMapOnObject,
   ]);
 
   // ctrl+E opens the modal

--- a/front/src/applications/editor/tools/utils.ts
+++ b/front/src/applications/editor/tools/utils.ts
@@ -1,11 +1,14 @@
-import type { MapLayerMouseEvent } from 'maplibre-gl';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type { LngLatBoundsLike, MapLayerMouseEvent } from 'maplibre-gl';
 import type { Dispatch } from 'redux';
 import turfBbox from '@turf/bbox';
 import length from '@turf/length';
 import lineSlice from '@turf/line-slice';
 import { featureCollection } from '@turf/helpers';
 import type { NearestPoint } from '@turf/nearest-point';
+import type { BBox2d } from '@turf/helpers/dist/js/lib/geojson';
 import type { Feature, LineString, Point } from 'geojson';
+import { uniq } from 'lodash';
 
 import type {
   Bbox,
@@ -81,8 +84,15 @@ export function getTrackSectionEntityFromNearestPoint(
   return track;
 }
 
-export function selectEntity(
-  entity: EditorEntity,
+function getNeededLayers(entities: EditorEntity[]) {
+  const objectTypes = uniq(entities.map((entity) => entity.objType));
+  return uniq(
+    objectTypes.flatMap((objectType) => EDITOAST_TO_LAYER_DICT[objectType as EditoastType])
+  );
+}
+
+export function selectEntities(
+  entities: EditorEntity[],
   context: {
     switchTool: EditorContextType['switchTool'];
     dispatch: Dispatch;
@@ -93,7 +103,7 @@ export function selectEntity(
   // call the switch tool
   switchTool({
     toolType: TOOL_TYPES.SELECTION,
-    toolState: { selection: [entity] },
+    toolState: { selection: entities },
   });
 
   // enable the needed layer
@@ -102,9 +112,10 @@ export function selectEntity(
   // create the next list of layer
   const nextLayers = new Set(actualLayers);
 
+  const neededLayers = getNeededLayers(entities);
+
   // iterate over needed layer
-  const neededLayers = EDITOAST_TO_LAYER_DICT[entity.objType as EditoastType];
-  (neededLayers || []).forEach((l) => {
+  neededLayers.forEach((l) => {
     if (!nextLayers.has(l)) nextLayers.add(l);
   });
 
@@ -203,26 +214,47 @@ export function openEntityEditionPanel(
 }
 
 /**
- * Given an editor entity, return the bbox that contains its geo element if possible.
+ * Given an array of editor entities, return the bbox which fits all of their geo elements.
  */
-export async function getEntityBbox(
+function getLargestBbox(entities: EditorEntity[]): BBox2d {
+  const bboxList = entities.map((entity) => turfBbox(entity.geometry));
+
+  let [minLeft, minBottom, minRight, minTop] = bboxList[0];
+
+  bboxList.forEach(([left, bottom, right, top]) => {
+    if (left < minLeft) minLeft = left;
+    if (bottom < minBottom) minBottom = bottom;
+    if (right > minRight) minRight = right;
+    if (top > minTop) minTop = top;
+  });
+  return [minLeft, minBottom, minRight, minTop] as BBox2d;
+}
+
+/**
+ * Given an array of editor entities, return the bbox that contains its geo element if possible depending the entities type.
+ */
+export async function getEntitiesBbox(
   infraId: number,
-  entity: EditorEntity,
+  entities: EditorEntity[],
   dispatch: Dispatch
 ): Promise<Bbox | null> {
-  if (entity.geometry) {
-    const bbox = turfBbox(entity.geometry);
+  const hasRouteEntity = entities.some((entity) => entity.objType === 'Route');
+
+  if (!hasRouteEntity) {
+    let bbox = turfBbox(entities[0].geometry);
+    if (entities.length > 1) bbox = getLargestBbox(entities);
     return [
       [bbox[0], bbox[1]],
       [bbox[2], bbox[3]],
     ];
   }
-  if (entity.objType === 'Route') {
+
+  if (entities.length === 1 && entities[0].objType === 'Route') {
     // get start point
-    const { id: startPointId, type: startPointIdType } = entity.properties.entry_point;
+    const { id: startPointId, type: startPointIdType } = entities[0].properties.entry_point;
     const startPoint = await getEntity(infraId, startPointId, startPointIdType, dispatch);
     // get end point
-    const { id: endPointId, type: endPointIdType } = entity.properties.exit_point;
+    const { id: endPointId, type: endPointIdType } = entities[0].properties.exit_point;
     const endPoint = await getEntity(infraId, endPointId, endPointIdType, dispatch);
 
     const fc = featureCollection([startPoint, endPoint]);
@@ -233,4 +265,20 @@ export async function getEntityBbox(
     ];
   }
   return null;
+}
+
+export async function centerMapOnObject(
+  infraId: number,
+  entities: EditorEntity[],
+  dispatch: Dispatch,
+  mapRef: MapRef
+): Promise<void> {
+  // Center the map on the object
+  const bbox = await getEntitiesBbox(infraId, entities, dispatch);
+  if (bbox) {
+    // zoom to the bbox
+    mapRef.fitBounds(bbox as LngLatBoundsLike, { animate: false });
+    // make a zoom out to have some kind of "margin" around the bbox
+    mapRef.zoomOut();
+  }
 }

--- a/front/src/common/BootstrapSNCF/ModalSNCF/ModalProvider.tsx
+++ b/front/src/common/BootstrapSNCF/ModalSNCF/ModalProvider.tsx
@@ -147,11 +147,11 @@ export const ModalProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
 
   /**
    * When route change
-   * => close modal on route change
+   * => close modal on route change (not for search params change)
    */
   useEffect(() => {
     closeModal();
-  }, [location]);
+  }, [location.pathname]);
 
   return (
     <ModalContext.Provider value={modalContext}>


### PR DESCRIPTION
close #5956 

- When selecting an object or many objects, the url gets updated with the objtype and its id
- if we share an url containing selection of objects, these get selected
- if the url is invalid, display error message to the user and redirect to the editor home page