### PR TITLE
Add CI/CH/UIC codes next to station names

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1297,6 +1297,9 @@ components:
       type: object
     PathWaypoint:
       properties:
+        ch:
+          nullable: true
+          type: string
         duration:
           format: double
           type: number
@@ -1317,6 +1320,10 @@ components:
           $ref: '#/components/schemas/GeoJsonPoint'
         suggestion:
           type: boolean
+        uic:
+          format: int64
+          nullable: true
+          type: integer
       required:
       - id
       - name
@@ -1326,6 +1333,8 @@ components:
       - suggestion
       - geo
       - sch
+      - uic
+      - ch
       type: object
     PathfindingPayload:
       description: |-
@@ -1748,6 +1757,9 @@ components:
       type: object
     ResultStops:
       properties:
+        ch:
+          nullable: true
+          type: string
         duration:
           format: double
           type: number
@@ -1761,6 +1773,7 @@ components:
       - time
       - position
       - duration
+      - ch
       type: object
     RjsPowerRestrictionRange:
       description: A range along the train path where a power restriction is applied.

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -478,11 +478,13 @@ pub mod tests {
                     time: 0.0,
                     duration: 0.0,
                     position: 0.0,
+                    ch: None,
                 },
                 ResultStops {
                     time: 110.90135448736316,
                     duration: 1.0,
                     position: 2417.6350658673214,
+                    ch: None,
                 },
             ],
             head_positions: vec![ResultPosition {

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -185,6 +185,10 @@ pub struct PathWaypoint {
     ))]
     #[schema(value_type = GeoJsonPoint)]
     pub sch: geojson::Geometry,
+    #[schema(required)]
+    pub uic: Option<i64>,
+    #[schema(required)]
+    pub ch: Option<String>,
 }
 
 impl Pathfinding {

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -239,6 +239,8 @@ pub struct ResultStops {
     pub time: f64,
     pub position: f64,
     pub duration: f64,
+    #[schema(required)]
+    pub ch: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, ToSchema)]

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -375,12 +375,18 @@ impl Pathfinding {
                 } else {
                     steps_duration.next().unwrap()
                 };
-                let op_name = waypoint
-                    .id
-                    .as_ref()
-                    .map(|op_id| op_map.get(op_id).expect("unexpected OP id"))
-                    .and_then(|op| op.extensions.identifier.as_ref())
-                    .map(|ident| ident.name.as_ref().to_owned());
+                let op_info = waypoint.id.as_ref().map(|op_id| {
+                    let op = op_map.get(op_id).expect("unexpected OP id");
+                    let name = op
+                        .extensions
+                        .identifier
+                        .as_ref()
+                        .map(|ident| ident.name.as_ref().to_owned());
+                    let uic = op.extensions.identifier.as_ref().map(|ident| ident.uic);
+                    let ch = op.extensions.sncf.as_ref().map(|sncf| sncf.ch.to_owned());
+                    (name, uic, ch)
+                });
+                let (name, uic, ch) = op_info.unwrap_or_default();
                 let track = track_map
                     .get(&waypoint.location.track_section.0)
                     .expect("unexpected track id");
@@ -397,13 +403,15 @@ impl Pathfinding {
                 let sch = geos::geojson::Geometry::try_from(sch).unwrap();
                 PathWaypoint {
                     id: waypoint.id.clone(),
-                    name: op_name,
+                    name,
                     location: waypoint.location.clone(),
                     duration,
                     path_offset: waypoint.path_offset,
                     suggestion: waypoint.suggestion,
                     geo,
                     sch,
+                    uic,
+                    ch,
                 }
             })
             .collect();

--- a/editoast/src/views/train_schedule/simulation_report.rs
+++ b/editoast/src/views/train_schedule/simulation_report.rs
@@ -273,6 +273,7 @@ async fn add_stops_additional_information(
                         time: s.time,
                         position: s.position,
                         duration: s.duration,
+                        ch: pw.ch.clone(),
                     },
                     id: pw.id.clone(),
                     name: pw.name.clone(),
@@ -286,6 +287,7 @@ async fn add_stops_additional_information(
                         time: s.time,
                         position: s.position,
                         duration: s.duration,
+                        ch: pw.ch.clone(),
                     },
                     ..Default::default()
                 },

--- a/front/src/applications/operationalStudies/consts.ts
+++ b/front/src/applications/operationalStudies/consts.ts
@@ -113,6 +113,8 @@ export interface PointOnMap {
   track?: string;
   position?: number;
   path_offset?: number;
+  uic?: number | null;
+  ch?: string | null;
   location?: {
     track_section?: string;
     offset?: number;

--- a/front/src/common/StationCard.tsx
+++ b/front/src/common/StationCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatUicToCi } from 'utils/strings';
 
 export interface ImportStation {
   trigram?: string;
@@ -33,17 +34,15 @@ export default function StationCard({ station, onClick, fixedHeight = false }: P
     >
       <div className="station-card-head">
         <span className="station-card-code">{trigram}</span>
-        <span className="station-card-name">{name}</span>
-        {yardname && !yardNamesToExclude.includes(yardname) && (
-          <span className="station-card-ch">{yardname}</span>
-        )}
+        <span className="station-card-name">{name}&nbsp;</span>
+        {yardname && !yardNamesToExclude.includes(yardname) && <small>{yardname}</small>}
+        {uic && <span className="station-card-uic ml-3">{formatUicToCi(uic)}</span>}
       </div>
       <div className="station-card-localization">
         <span className="station-card-city">{town}</span>
         <span className="station-card-department">{department}</span>
         {department && region && <div className="station-card-separator">/</div>}
         <span className="station-card-region">{region}</span>
-        <span className="station-card-uic">{uic}</span>
       </div>
       {linename && (
         <div className="station-card-footer">

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1642,6 +1642,7 @@ export type GeoJsonPoint = {
   type: 'Point';
 };
 export type PathWaypoint = {
+  ch: string | null;
   duration: number;
   geo: GeoJsonPoint;
   id: string | null;
@@ -1650,6 +1651,7 @@ export type PathWaypoint = {
   path_offset: number;
   sch: GeoJsonPoint;
   suggestion: boolean;
+  uic: number | null;
 };
 export type PathResponse = {
   created: string;
@@ -2200,6 +2202,7 @@ export type ResultSpeed = {
   time: number;
 };
 export type ResultStops = {
+  ch: string | null;
   duration: number;
   position: number;
   time: number;

--- a/front/src/modules/trainschedule/components/DriverTrainSchedule/DriverTrainScheduleStop.tsx
+++ b/front/src/modules/trainschedule/components/DriverTrainSchedule/DriverTrainScheduleStop.tsx
@@ -52,7 +52,10 @@ export default function DriverTrainScheduleStop({ stop, idx, train }: Props) {
       <td className="d-flex justify-content-center">
         <div>{Number.isInteger(pk) ? `${pk}.0` : pk}</div>
       </td>
-      <td>{stop.name || 'Unknown'}</td>
+      <td>
+        {stop.name || 'Unknown'}&nbsp;
+        <small>{stop.ch}</small>
+      </td>
       <td className="stoptime-container">
         <div className="box">
           <div className="box-row">

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayload.ts
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayload.ts
@@ -3,7 +3,7 @@ import { PathWaypoint, TrainScheduleBatchItem } from 'common/api/osrdEditoastApi
 import { time2sec } from 'utils/timeManipulation';
 
 // Hope for indexes are the same !
-// Synchronisation is done with indexes between pathfinding not suggered positions, and required steps from importation
+// Synchronisation is done with indexes between pathfinding not suggested positions, and required steps from importation
 function mixPathPositionsAndTimes(requiredSteps: Step[], pathFindingWaypoints: PathWaypoint[]) {
   const startTime = new Date(requiredSteps[0].departureTime);
   const pathFindingStepsFiltered = pathFindingWaypoints.filter((waypoint) => !waypoint.suggestion);

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesModalOP.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Allowances/AllowancesModalOP.tsx
@@ -27,7 +27,10 @@ export default function AllowancesModalOP({
               key={waypoint.path_offset}
             >
               <div className="col-6">{waypoint.path_offset}</div>
-              <div className="col-6">{waypoint.name}</div>
+              <div className="col-6">
+                {waypoint.name}&nbsp;
+                {waypoint.ch === '00' || !waypoint.ch ? 'BV' : `${waypoint.ch}`}
+              </div>
             </button>
           ))}
         </div>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayVias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayVias.tsx
@@ -9,6 +9,7 @@ import cx from 'classnames';
 import { AnyAction, ThunkAction } from '@reduxjs/toolkit';
 import { Position } from 'geojson';
 import { RootState } from 'reducers';
+import { formatUicToCi } from 'utils/strings';
 
 type InputStopTimeProps = {
   index: number;
@@ -99,6 +100,10 @@ export default function DisplayVias({ zoomToFeaturePoint }: DisplayViasProps) {
                             `KM ${place.position && Math.round(place.position) / 1000}`
                           }`}
                         </small>
+                        <small className="">{place.ch}</small>
+                        {place.uic && (
+                          <small className="text-muted ml-3">{formatUicToCi(place.uic)}</small>
+                        )}
                       </div>
                       {index !== indexSelected && (
                         <div className="default-durations-button mr-1">

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/ModalSuggeredVias.tsx
@@ -11,6 +11,8 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { Spinner } from 'common/Loader';
 import type { ArrayElement } from 'utils/types';
 import type { PathResponse, PathWaypoint } from 'common/api/osrdEditoastApi';
+import { formatUicToCi } from 'utils/strings';
+import cx from 'classnames';
 
 type Props = {
   removeAllVias: () => void;
@@ -65,32 +67,37 @@ export default function ModalSugerredVias({ removeAllVias, pathfindingInProgress
 
   const formatVia = (via: ArrayElement<PathResponse['steps']>, idx: number, idxTrueVia: number) => (
     <div
-      key={`suggered-via-modal-${via.id}-${idx}`}
-      className={`d-flex align-items-center p-1 ${via.suggestion && 'suggerred-via-clickable'}`}
+      key={`suggested-via-modal-${via.id}-${idx}`}
+      className={cx('d-flex align-items-center p-1', via.suggestion && 'suggested-via-clickable')}
+      title={via.name!}
     >
       {!via.suggestion && <small className="pr-2">{idxTrueVia}</small>}
       <i className={`${via.suggestion ? 'text-muted' : 'text-info'} icons-itinerary-bullet mr-2`} />
-      {via.name || ''}
-      <small className="ml-2">
-        {via.path_offset && `KM ${Math.round(via.path_offset) / 1000}`}
-      </small>
-      {via.suggestion && via.id && !selectedViasTracks.includes(via.id) ? (
-        <button
-          className="btn btn-sm btn-only-icon ml-auto"
-          type="button"
-          onClick={() => convertPathfindingVias(suggeredVias, idx - 1)}
-        >
-          <GoPlus />
-        </button>
-      ) : (
-        <button
-          className="btn btn-sm btn-only-icon ml-auto bg-dark"
-          type="button"
-          onClick={() => removeViaFromPath(via)}
-        >
-          <GoDash color="white" />
-        </button>
-      )}
+      <span className="suggested-via-name">{via.name || ''}</span>&nbsp;
+      <span>{via.ch}</span>
+      {via.uic && <small className="text-muted ml-3">{formatUicToCi(via.uic)}</small>}
+      <div className="ml-auto">
+        {via.path_offset && (
+          <small className="mr-2">{`KM ${Math.round(via.path_offset) / 1000}`}</small>
+        )}
+        {via.suggestion && via.id && !selectedViasTracks.includes(via.id) ? (
+          <button
+            className="btn btn-sm btn-only-icon"
+            type="button"
+            onClick={() => convertPathfindingVias(suggeredVias, idx - 1)}
+          >
+            <GoPlus />
+          </button>
+        ) : (
+          <button
+            className="btn btn-sm btn-only-icon bg-dark"
+            type="button"
+            onClick={() => removeViaFromPath(via)}
+          >
+            <GoDash color="white" />
+          </button>
+        )}
+      </div>
     </div>
   );
 
@@ -104,7 +111,7 @@ export default function ModalSugerredVias({ removeAllVias, pathfindingInProgress
         </button>
       </ModalHeaderSNCF>
       <ModalBodySNCF>
-        <div className="suggered-vias">
+        <div className="suggested-vias">
           {pathfindingInProgress && <LoaderPathfindingInProgress />}
           {suggeredVias &&
             suggeredVias.map((via, idx) => {

--- a/front/src/modules/trainschedule/styles/ManageTrainSchedule/_itinerary.scss
+++ b/front/src/modules/trainschedule/styles/ManageTrainSchedule/_itinerary.scss
@@ -34,7 +34,7 @@
 }
 
 .manage-vias-modal {
-  .suggered-vias {
+  .suggested-vias {
     max-height: 30vh;
     overflow-y: auto;
     .loaderPathfindingInProgress {
@@ -48,11 +48,20 @@
       border-radius: 0 0 4px 4px;
       background-color: rgba(242, 242, 242, 0.75);
     }
-    .suggerred-via-clickable {
-      cursor: pointer;
-      border-radius: 4px;
-      &:hover {
-        background-color: var(--coolgray1);
+    .suggested-via {
+      &-clickable {
+        cursor: pointer;
+        border-radius: 4px;
+        &:hover {
+          background-color: var(--coolgray1);
+        }
+      }
+
+      &-name {
+        max-width: 47%;
+        white-space: nowrap;
+        overflow: hidden;
+       text-overflow: ellipsis;
       }
     }
   }

--- a/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf2/common/tests/commonConfBuilder.ts
@@ -107,6 +107,8 @@ export default function commonConfBuilder() {
             type: 'Point',
           },
           suggestion: true,
+          ch: null,
+          uic: null,
         },
       ],
     }),

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -80,6 +80,7 @@ export interface Stop {
   track_number: number | null;
   line_name: string | null;
   track_name: string | null;
+  ch?: string | null;
 }
 
 export interface RouteAspect<Time = number, Color = number> {

--- a/front/src/styles/scss/common/components/_stationCard.scss
+++ b/front/src/styles/scss/common/components/_stationCard.scss
@@ -34,6 +34,11 @@
       font-weight: 500;
       font-size: .8rem;
     }
+    .station-card-uic {
+      margin-left: auto;
+      font-size: .6rem;
+      color: var(--primary);    
+    }
   }
   .station-card-localization {
     display: flex;
@@ -57,11 +62,6 @@
     .station-card-region {
       text-transform: uppercase;
       font-size: .6rem;   
-    }
-    .station-card-uic {
-      margin-left: auto;
-      font-size: .6rem;
-      color: var(--primary);    
     }
   }
   .station-card-footer {

--- a/front/src/utils/strings.ts
+++ b/front/src/utils/strings.ts
@@ -55,3 +55,13 @@ export function onlyDigit(str: string): string {
 export function convertInputStringToNumber(str: string) {
   return str !== '' && !Number.isNaN(str) ? +str : undefined;
 }
+
+/**
+ * Given an UIC number, check if it begins with 87,
+ * if true return the UIC without the 87,
+ * if false return the full UIC
+ * @param uic full UIC and CI code (8 digits)
+ */
+export function formatUicToCi(uic: number) {
+  return uic.toString().replace(/^87/, '');
+}

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -60,6 +60,8 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
                 "suggestion": False,
                 "geo": {"coordinates": [-0.387122554630656, 49.49979999999999], "type": "Point"},
                 "sch": {"coordinates": [-0.387122554630656, 49.49979999999999], "type": "Point"},
+                "ch": None,
+                "uic": None,
             },
             {
                 "id": "Mid_West_station",
@@ -70,6 +72,8 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
                 "suggestion": True,
                 "geo": {"coordinates": [-0.30369999999999997, 49.4999], "type": "Point"},
                 "sch": {"coordinates": [-0.30369999999999997, 49.4999], "type": "Point"},
+                "ch": "aa",
+                "uic": 0,
             },
             {
                 "id": "Mid_East_station",
@@ -80,6 +84,8 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
                 "suggestion": True,
                 "geo": {"coordinates": [-0.22656, 49.4999], "type": "Point"},
                 "sch": {"coordinates": [-0.22656, 49.4999], "type": "Point"},
+                "ch": "aa",
+                "uic": 0,
             },
             {
                 "id": None,
@@ -90,6 +96,8 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
                 "suggestion": False,
                 "geo": {"coordinates": [-0.095104854807785, 49.484], "type": "Point"},
                 "sch": {"coordinates": [-0.095104854807785, 49.484], "type": "Point"},
+                "ch": None,
+                "uic": None,
             },
         ],
         "geographic": {


### PR DESCRIPTION
editoast:
- add uic and ch to PathfindingResponse and PathWaypoint struct
- get them from waypoint in Pathfinding impl
- add ch to ResultStops struct, add_stops_additional_information fn and train_with_simulation_output_fixture_set fn
- update openapi.yaml

front:
- create formatUicToCi in utils/strings.ts
- add CI/CH codes in ModalSugerredVias, StationCard and DisplayVias
- add CH code in AllowancesModalOP and DriverTrainScheduleStop
- add elipsis to vias name in modal
- replace suggered by suggested