### PR TITLE
editoast: magic wand revamp

### DIFF
--- a/editoast/src/views/infra/auto_fixes/buffer_stop.rs
+++ b/editoast/src/views/infra/auto_fixes/buffer_stop.rs
@@ -1,0 +1,28 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    BufferStopCache, InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_buffer_stop(
+    buffer_stop: &BufferStopCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::OddBufferStopLocation | InfraErrorType::OutOfRange { .. } => {
+                Some(new_ref_fix_delete_pair(buffer_stop))
+            }
+            InfraErrorType::InvalidReference { reference }
+                if reference.obj_type == ObjectType::TrackSection =>
+            {
+                Some(new_ref_fix_delete_pair(buffer_stop))
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/catenary.rs
+++ b/editoast/src/views/infra/auto_fixes/catenary.rs
@@ -1,0 +1,19 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{Catenary, InfraError, InfraErrorType, OSRDObject as _, ObjectRef};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_catenary(
+    catenary: &Catenary,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::EmptyObject => Some(new_ref_fix_delete_pair(catenary)),
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/detector.rs
+++ b/editoast/src/views/infra/auto_fixes/detector.rs
@@ -1,0 +1,26 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    DetectorCache, InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_detector(
+    detector: &DetectorCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::OutOfRange { .. } => Some(new_ref_fix_delete_pair(detector)),
+            InfraErrorType::InvalidReference { reference }
+                if reference.obj_type == ObjectType::TrackSection =>
+            {
+                Some(new_ref_fix_delete_pair(detector))
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/operational_point.rs
+++ b/editoast/src/views/infra/auto_fixes/operational_point.rs
@@ -1,0 +1,21 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, OperationalPointCache,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_operational_point(
+    operational_point: &OperationalPointCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::EmptyObject => Some(new_ref_fix_delete_pair(operational_point)),
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/route.rs
+++ b/editoast/src/views/infra/auto_fixes/route.rs
@@ -1,0 +1,34 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef, ObjectType, Route,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_route(
+    route: &Route,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::InvalidReference { reference }
+                if matches!(
+                    reference.obj_type,
+                    ObjectType::BufferStop | ObjectType::Detector
+                ) =>
+            {
+                if reference.obj_id.eq(route.entry_point.get_id())
+                    || reference.obj_id.eq(route.exit_point.get_id())
+                {
+                    Some(new_ref_fix_delete_pair(route))
+                } else {
+                    None
+                }
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/signal.rs
+++ b/editoast/src/views/infra/auto_fixes/signal.rs
@@ -1,0 +1,26 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType, SignalCache,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_signal(
+    signal: &SignalCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::OutOfRange { .. } => Some(new_ref_fix_delete_pair(signal)),
+            InfraErrorType::InvalidReference { reference }
+                if reference.obj_type == ObjectType::TrackSection =>
+            {
+                Some(new_ref_fix_delete_pair(signal))
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/speed_section.rs
+++ b/editoast/src/views/infra/auto_fixes/speed_section.rs
@@ -1,0 +1,19 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{InfraError, InfraErrorType, OSRDObject as _, ObjectRef, SpeedSection};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_speed_section(
+    speed_section: &SpeedSection,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::EmptyObject => Some(new_ref_fix_delete_pair(speed_section)),
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/switch.rs
+++ b/editoast/src/views/infra/auto_fixes/switch.rs
@@ -1,0 +1,26 @@
+use super::{new_ref_fix_delete_pair, Fix};
+use crate::schema::{
+    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType, SwitchCache,
+};
+use log::debug;
+use std::collections::HashMap;
+
+pub fn fix_switch(
+    switch: &SwitchCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::InvalidSwitchPorts => Some(new_ref_fix_delete_pair(switch)),
+            InfraErrorType::InvalidReference { reference }
+                if reference.obj_type == ObjectType::TrackSection =>
+            {
+                Some(new_ref_fix_delete_pair(switch))
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}

--- a/editoast/src/views/infra/auto_fixes/track_section.rs
+++ b/editoast/src/views/infra/auto_fixes/track_section.rs
@@ -1,0 +1,94 @@
+use super::{new_ref_fix_create_pair, Fix};
+use crate::schema::{
+    operation::RailjsonObject, utils::Identifier, BufferStop, Endpoint, InfraError, InfraErrorType,
+    OSRDIdentified as _, OSRDObject as _, ObjectRef, TrackSectionCache,
+};
+use log::debug;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+pub fn fix_track_section(
+    track_section: &TrackSectionCache,
+    errors: impl Iterator<Item = InfraError>,
+) -> HashMap<ObjectRef, Fix> {
+    errors
+        .filter_map(|infra_error| match infra_error.get_sub_type() {
+            InfraErrorType::MissingBufferStop { endpoint } => {
+                let track_id = infra_error.get_id();
+                let position = match endpoint {
+                    Endpoint::Begin => 0.0,
+                    Endpoint::End => track_section.length,
+                };
+                let buffer_stop = RailjsonObject::BufferStop {
+                    railjson: (BufferStop {
+                        id: Identifier::from(Uuid::new_v4()),
+                        track: track_id.to_string().into(),
+                        position,
+                        ..Default::default()
+                    }),
+                };
+                Some(new_ref_fix_create_pair(buffer_stop))
+            }
+            _ => {
+                debug!("error not (yet) fixable for '{}'", infra_error.get_type());
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+
+    use super::*;
+    use crate::{
+        infra_cache::ObjectCache,
+        schema::{
+            operation::{CacheOperation, Operation},
+            TrackSection,
+        },
+    };
+
+    #[test]
+    fn missing_buffer_stop() {
+        let track_section = TrackSection {
+            id: Identifier::from("track_section_id"),
+            length: 42.0,
+            ..Default::default()
+        };
+        let errors = vec![InfraError::new_missing_buffer_stop(
+            &track_section,
+            Endpoint::End,
+        )];
+        let operations = fix_track_section(
+            &TrackSectionCache::from(track_section.clone()),
+            errors.into_iter(),
+        );
+
+        assert_eq!(operations.len(), 1);
+        let (operation, cache_operation) = operations.into_values().next().unwrap();
+        let Operation::Create(railjson) = operation else {
+            panic!("expecting an `Operation::Create(_)`");
+        };
+        let railjson = railjson.deref().clone();
+        let RailjsonObject::BufferStop {
+            railjson: buffer_stop,
+        } = railjson
+        else {
+            panic!("expecting a `RailjsonObject::BufferStop {{ .. }}`")
+        };
+        assert_eq!(buffer_stop.track, track_section.id);
+        assert_eq!(buffer_stop.position, 42.0);
+
+        let CacheOperation::Create(object_cache) = cache_operation else {
+            panic!("expecting an `CacheOperation::Create(_)`");
+        };
+        let ObjectCache::BufferStop(buffer_stop_cache) = object_cache else {
+            panic!("expecting a `ObjectCache::BufferStop(_)`");
+        };
+        assert_eq!(buffer_stop_cache.obj_id, buffer_stop.id.as_str());
+        assert_eq!(buffer_stop_cache.track, track_section.id.as_str());
+        assert_eq!(buffer_stop_cache.position, 42.0);
+    }
+}


### PR DESCRIPTION
If we want to keep opportunities to parallelize this code, all the errors related to the same object should be addressed together. It will become important when some `Operation::Update` will happen and need to be ordered correctly.

Still missing some tests on (can take inspiration on `fn fix_track_section()`):
- [ ] `fn fix_catenary()`
- [ ] `fn fix_detector()`
- [ ] `fn fix_operational_point()`
- [ ] `fn fix_route()`
- [ ] `fn fix_signal()`
- [ ] `fn fix_speed_section()`
- [ ] `fn fix_switch()`