### PR TITLE
editoast: update args for train_schedule/results

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3734,6 +3734,23 @@ components:
       - NewerRollingStock
       - NewerInfra
       type: string
+    TrainSimulationResponse:
+      properties:
+        invalid_trains:
+          description: Requested trains that are invalid and thus not simulated
+          items:
+            format: int64
+            type: integer
+          type: array
+        simulations:
+          description: The simulation results
+          items:
+            $ref: '#/components/schemas/SimulationReport'
+          type: array
+      required:
+      - simulations
+      - invalid_trains
+      type: object
     UpdateOperation:
       properties:
         obj_id:
@@ -6136,33 +6153,35 @@ paths:
       - train_schedule
       - timetable
   /train_schedule/results/:
-    get:
+    post:
       description: Retrieve the simulation result of multiple train schedules
-      parameters:
-      - description: The ID of the path that was used to project the train path
-        in: query
-        name: path_id
-        required: false
-        schema:
-          format: int64
-          nullable: true
-          type: integer
-      - description: The timetable ID
-        in: query
-        name: timetable_id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                path_id:
+                  description: A path ID to project the simulation results onto. If not provided, the path of the first train will be used.
+                  format: int64
+                  nullable: true
+                  type: integer
+                train_ids:
+                  description: The IDs of the trains to simulate
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+              required:
+              - train_ids
+              type: object
         required: true
-        schema:
-          format: int64
-          type: integer
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/SimulationReport'
-                type: array
-          description: The train schedule results
+                $ref: '#/components/schemas/TrainSimulationResponse'
+          description: The train schedule simulations results and a list of invalid train_ids
       summary: Retrieve the simulation result of multiple train schedules
       tags:
       - train_schedule

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -24,9 +24,7 @@ pub use rolling_stock::{LightRollingStockModel, RollingStockLiveryModel, Rolling
 pub use scenario::{Scenario, ScenarioWithCountTrains, ScenarioWithDetails};
 pub use study::{Study, StudyWithScenarios};
 pub use text_array::TextArray;
-pub use timetable::{
-    check_train_validity, get_timetable_train_schedules, Timetable, TimetableWithSchedulesDetails,
-};
+pub use timetable::{check_train_validity, Timetable, TimetableWithSchedulesDetails};
 pub use train_schedule::{
     Allowance, FullResultStops, ResultPosition, ResultSpeed, ResultStops, ResultTrain,
     RoutingRequirement, ScheduledPoint, SignalSighting, SimulationOutput,

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -9,7 +9,7 @@ import {
   persistentRedoSimulation,
   persistentUndoSimulation,
 } from 'reducers/osrdsimulation/simulation';
-import { getDisplaySimulation, getIsUpdating } from 'reducers/osrdsimulation/selectors';
+import { getIsUpdating } from 'reducers/osrdsimulation/selectors';
 import { updateSelectedProjection, updateSimulation } from 'reducers/osrdsimulation/actions';
 
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
@@ -22,10 +22,10 @@ import TrainDetails from 'modules/simulationResult/components/TrainDetails';
 import DriverTrainSchedule from 'modules/trainschedule/components/DriverTrainSchedule/DriverTrainSchedule';
 import getScaleDomainFromValues from 'modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues';
 import SpaceCurvesSlopes from 'modules/simulationResult/components/SpaceCurvesSlopes';
+import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import SpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChart';
 import type { PositionScaleDomain } from 'modules/simulationResult/consts';
 import { Train } from 'reducers/osrdsimulation/types';
-import SpaceTimeChart from 'modules/simulationResult/components/SpaceTimeChart/SpaceTimeChart';
 import { useStoreDataForSpaceTimeChart } from 'modules/simulationResult/components/SpaceTimeChart/useStoreDataForSpaceTimeChart';
 
 const MAP_MIN_HEIGHT = 450;
@@ -33,17 +33,18 @@ const MAP_MIN_HEIGHT = 450;
 type SimulationResultsProps = {
   isDisplayed: boolean;
   collapsedTimetable: boolean;
+  setTrainResultsToFetch: (trainSchedulesIDs?: number[]) => void;
 };
 
 export default function SimulationResults({
   isDisplayed,
   collapsedTimetable,
+  setTrainResultsToFetch,
 }: SimulationResultsProps) {
   const { t } = useTranslation('simulation');
   const dispatch = useDispatch();
 
   // TIMELINE DISABLED // const { chart } = useSelector(getOsrdSimulation);
-  const displaySimulation = useSelector(getDisplaySimulation);
   const isUpdating = useSelector(getIsUpdating);
 
   const timeTableRef = useRef<HTMLDivElement | null>(null);
@@ -171,7 +172,7 @@ export default function SimulationResults({
 
         <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
           <div className="chart-container" style={{ height: `${heightOfSpaceTimeChart}px` }}>
-            {displaySimulation && (
+            {simulation.trains.length > 0 && (
               <SpaceTimeChart
                 allowancesSettings={allowancesSettings}
                 inputSelectedTrain={selectedTrain}
@@ -183,6 +184,7 @@ export default function SimulationResults({
                 isDisplayed={isDisplayed}
                 dispatchUpdateSelectedTrainId={dispatchUpdateSelectedTrainId}
                 dispatchPersistentUpdateSimulation={dispatchPersistentUpdateSimulation}
+                setTrainResultsToFetch={setTrainResultsToFetch}
               />
             )}
           </div>

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -665,15 +665,16 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/train_schedule/`, method: 'PATCH', body: queryArg.body }),
         invalidatesTags: ['train_schedule', 'timetable'],
       }),
-      getTrainScheduleResults: build.query<
-        GetTrainScheduleResultsApiResponse,
-        GetTrainScheduleResultsApiArg
+      postTrainScheduleResults: build.mutation<
+        PostTrainScheduleResultsApiResponse,
+        PostTrainScheduleResultsApiArg
       >({
         query: (queryArg) => ({
           url: `/train_schedule/results/`,
-          params: { path_id: queryArg.pathId, timetable_id: queryArg.timetableId },
+          method: 'POST',
+          body: queryArg.body,
         }),
-        providesTags: ['train_schedule'],
+        invalidatesTags: ['train_schedule'],
       }),
       postTrainScheduleStandaloneSimulation: build.mutation<
         PostTrainScheduleStandaloneSimulationApiResponse,
@@ -1273,13 +1274,13 @@ export type PatchTrainScheduleApiResponse = unknown;
 export type PatchTrainScheduleApiArg = {
   body: TrainSchedulePatch[];
 };
-export type GetTrainScheduleResultsApiResponse =
-  /** status 200 The train schedule results */ SimulationReport[];
-export type GetTrainScheduleResultsApiArg = {
-  /** The ID of the path that was used to project the train path */
-  pathId?: number | null;
-  /** The timetable ID */
-  timetableId: number;
+export type PostTrainScheduleResultsApiResponse =
+  /** status 200 The train schedule simulations results and a list of invalid train_ids */ TrainSimulationResponse;
+export type PostTrainScheduleResultsApiArg = {
+  body: {
+    path_id?: number | null;
+    train_ids: number[];
+  };
 };
 export type PostTrainScheduleStandaloneSimulationApiResponse =
   /** status 200 The ids of the train_schedules created */ number[];
@@ -2373,6 +2374,10 @@ export type TrainSchedulePatch = {
   scheduled_points?: ScheduledPoint[] | null;
   speed_limit_tags?: string | null;
   train_name?: string | null;
+};
+export type TrainSimulationResponse = {
+  invalid_trains: number[];
+  simulations: SimulationReport[];
 };
 export type TrainScheduleBatchItem = {
   allowances?: Allowance[];

--- a/front/src/modules/simulationResult/components/sampleData.ts
+++ b/front/src/modules/simulationResult/components/sampleData.ts
@@ -6446,7 +6446,6 @@ const ORSD_GRAPH_SAMPLE_DATA: OsrdSimulationState = {
       ],
     },
   ],
-  displaySimulation: true,
   simulation: {
     past: [
       {

--- a/front/src/modules/simulationResult/components/simulationResultsHelpers.ts
+++ b/front/src/modules/simulationResult/components/simulationResultsHelpers.ts
@@ -41,7 +41,6 @@ export const changeTrain =
       error: getTrainDetailsError,
       isSuccess: isGetTrainDetailsSuccess,
     } = await dispatch(osrdEditoastApi.endpoints.getTrainScheduleById.initiate({ id }));
-
     if (isGetTrainDetailsSuccess) {
       // TODO: add the other information of the trainSchedule (allowances...)
       const trainSchedule: TrainSchedulePatch = {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
@@ -19,6 +19,7 @@ type SubmitConfAddTrainScheduleProps = {
   refetchTimetable: () => void;
   refetchConflicts: () => void;
   setIsWorking: (isWorking: boolean) => void;
+  setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
 };
 
 type error400 = {
@@ -37,6 +38,7 @@ export default function SubmitConfAddTrainSchedule({
   refetchTimetable,
   refetchConflicts,
   setIsWorking,
+  setTrainResultsToFetch,
 }: SubmitConfAddTrainScheduleProps) {
   const [postTrainSchedule] =
     osrdEditoastApi.endpoints.postTrainScheduleStandaloneSimulation.useMutation();
@@ -87,7 +89,7 @@ export default function SubmitConfAddTrainSchedule({
       }
 
       try {
-        await postTrainSchedule({
+        const newTrainIds = await postTrainSchedule({
           body: {
             path: pathfindingID,
             schedules,
@@ -102,6 +104,7 @@ export default function SubmitConfAddTrainSchedule({
           })
         );
         setIsWorking(false);
+        setTrainResultsToFetch(newTrainIds);
         refetchTimetable();
         refetchConflicts();
       } catch (e: unknown) {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
@@ -18,6 +18,7 @@ import { updateSelectedProjection, updateSelectedTrainId } from 'reducers/osrdsi
 type SubmitConfUpdateTrainSchedulesProps = {
   setIsWorking: (isWorking: boolean) => void;
   setDisplayTrainScheduleManagement: (arg0: string) => void;
+  setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
 };
 
 // Refacto in a component to prepare the migration of the patch in editoast (need to be a React component to use hooks inside like rtk's)
@@ -25,6 +26,7 @@ type SubmitConfUpdateTrainSchedulesProps = {
 export default function SubmitConfUpdateTrainSchedules({
   setIsWorking,
   setDisplayTrainScheduleManagement,
+  setTrainResultsToFetch,
 }: SubmitConfUpdateTrainSchedulesProps) {
   const { getTrainScheduleIDsToModify, getConf, getPathfindingID, getName, getDepartureTime } =
     useOsrdConfSelectors();
@@ -79,6 +81,7 @@ export default function SubmitConfUpdateTrainSchedules({
           })
         );
         if (callSuccess) {
+          setTrainResultsToFetch(trainScheduleIDsToModify);
           dispatch(
             setSuccess({
               title: t('trainUpdated'),

--- a/front/src/modules/trainschedule/components/Timetable/TimetableManageTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableManageTrainSchedule.tsx
@@ -17,6 +17,7 @@ import type { Infra } from 'common/api/osrdEditoastApi';
 type TimetableManageTrainScheduleProps = {
   displayTrainScheduleManagement: string;
   setDisplayTrainScheduleManagement: (type: string) => void;
+  setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
   infraState?: Infra['state'];
   refetchTimetable: () => void;
   refetchConflicts: () => void;
@@ -25,6 +26,7 @@ type TimetableManageTrainScheduleProps = {
 export default function TimetableManageTrainSchedule({
   displayTrainScheduleManagement,
   setDisplayTrainScheduleManagement,
+  setTrainResultsToFetch,
   infraState,
   refetchTimetable,
   refetchConflicts,
@@ -46,6 +48,7 @@ export default function TimetableManageTrainSchedule({
           <SubmitConfUpdateTrainSchedules
             setIsWorking={setIsWorking}
             setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
+            setTrainResultsToFetch={setTrainResultsToFetch}
           />
         )}
 
@@ -61,6 +64,7 @@ export default function TimetableManageTrainSchedule({
                 refetchTimetable={refetchTimetable}
                 setIsWorking={setIsWorking}
                 refetchConflicts={refetchConflicts}
+                setTrainResultsToFetch={setTrainResultsToFetch}
               />
             )}
             <TrainAddingSettings />

--- a/front/src/reducers/osrdsimulation/index.ts
+++ b/front/src/reducers/osrdsimulation/index.ts
@@ -2,7 +2,6 @@ import produce from 'immer';
 import { noop } from 'lodash';
 import { AnyAction } from 'redux';
 
-import { SimulationReport } from 'common/api/osrdEditoastApi';
 import { SIGNAL_BASE_DEFAULT, CHART_AXES } from 'modules/simulationResult/consts';
 import createTrain from 'modules/simulationResult/components/SpaceTimeChart/createTrain';
 import {
@@ -51,7 +50,6 @@ export const initialState: OsrdSimulationState = {
   },
   signalBase: SIGNAL_BASE_DEFAULT,
   consolidatedSimulation: [],
-  displaySimulation: false,
   simulation: {
     past: [],
     present: { trains: [] },
@@ -100,12 +98,6 @@ export default function reducer(inputState: OsrdSimulationState | undefined, act
           draft.simulation.present.trains as Train[], // TODO: remove Train interface
           noop
         );
-        draft.displaySimulation =
-          draft.simulation.present?.trains.length > 0 &&
-          // TODO: delete this cast when we have chosen the appropriate type for the simulation
-          (draft.simulation.present.trains as SimulationReport[]).find(
-            (train) => train.id === state.selectedTrainId
-          ) !== undefined;
 
         break;
       case UPDATE_SPEEDSPACE_SETTINGS:

--- a/front/src/reducers/osrdsimulation/selectors.ts
+++ b/front/src/reducers/osrdsimulation/selectors.ts
@@ -15,7 +15,6 @@ export const getSelectedProjection = makeOsrdSimulationSelector('selectedProject
 export const getSelectedTrainId = makeOsrdSimulationSelector('selectedTrainId');
 export const getSpeedSpaceSettings = makeOsrdSimulationSelector('speedSpaceSettings');
 export const getConsolidatedSimulation = makeOsrdSimulationSelector('consolidatedSimulation');
-export const getDisplaySimulation = makeOsrdSimulationSelector('displaySimulation');
 
 export const getPresentSimulation = (state: RootState) => state.osrdsimulation.simulation.present;
 

--- a/front/src/reducers/osrdsimulation/types.ts
+++ b/front/src/reducers/osrdsimulation/types.ts
@@ -242,5 +242,4 @@ export interface OsrdSimulationState {
     present: SimulationSnapshot;
     future: SimulationHistory;
   };
-  displaySimulation: boolean;
 }

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -64,23 +64,18 @@ def test_editoast_get_and_update_schedule_result(west_to_south_east_simulation: 
     assert "eco" in simulation_report
 
 
-def test_api_bulk_delete(small_scenario, west_to_south_east_simulations: Sequence[int]):
+def test_editoast_bulk_delete(west_to_south_east_simulations: Sequence[int]):
     ids = west_to_south_east_simulations[0:2]
-    schedules = requests.get(f"{EDITOAST_URL}train_schedule/results/?timetable_id={small_scenario.timetable}").json()
-    old_len = len(schedules)
     r = requests.delete(f"{EDITOAST_URL}train_schedule/", json={"ids": ids})
     if r.status_code // 100 != 2:
         raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(ids)}")
-    schedules = requests.get(f"{EDITOAST_URL}train_schedule/results/?timetable_id={small_scenario.timetable}").json()
-    assert len(schedules) == old_len - 2
-
-
-def test_editoast_bulk_delete(small_scenario, west_to_south_east_simulations: Sequence[int]):
-    ids = west_to_south_east_simulations[0:2]
-    schedules = requests.get(f"{EDITOAST_URL}train_schedule/results/?timetable_id={small_scenario.timetable}").json()
-    old_len = len(schedules)
-    r = requests.delete(f"{EDITOAST_URL}train_schedule/", json={"ids": ids})
-    if r.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(ids)}")
-    schedules = requests.get(f"{EDITOAST_URL}train_schedule/results/?timetable_id={small_scenario.timetable}").json()
-    assert len(schedules) == old_len - 2
+    r = requests.post(
+        f"{EDITOAST_URL}train_schedule/results/",
+        json={"path_id": None, "train_ids": west_to_south_east_simulations[0]},
+    )
+    assert r.status_code == 400
+    r = requests.post(
+        f"{EDITOAST_URL}train_schedule/results/",
+        json={"path_id": None, "train_ids": west_to_south_east_simulations[1]},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
Close #6095 

Front part : 
- remove displaySimulation from the store (wasn't relevant on the only spot where it was used)
- add a state in Scenario.tsx to control which trains we want the results for
- optimize the fetching of train results when adding/updating/deleting train(s)

⚠️ There is still one non optimize case when deleting the last projected train of its path on a large timetable, the (long) fetching of train results is launched 2 times but that should be fixed with https://github.com/osrd-project/osrd/issues/6385