### PR TITLE
core: stdcm: fix linear allowance fallback and occupancy tolerance

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/ConstrainedEnvelopePartBuilder.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/ConstrainedEnvelopePartBuilder.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.envelope.part;
 
+import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areSpeedsEqual;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.EnvelopeAttr;
 import fr.sncf.osrd.envelope.EnvelopePhysics;
@@ -102,7 +104,7 @@ public final class ConstrainedEnvelopePartBuilder implements InteractiveEnvelope
             position = intersection.position;
             speed = intersection.speed;
             if (position == lastPos) {
-                assert Math.abs(speed - lastSpeed) < 1e-8;
+                assert areSpeedsEqual(speed, lastSpeed);
                 speed = lastSpeed;
                 timeDelta = 0;
             } else

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -43,7 +43,7 @@ class STDCMGraph(
     /** Constructor  */
     init {
         this.steps = steps
-        delayManager = DelayManager(minScheduleTimeStart, maxRunTime, blockAvailability, this)
+        delayManager = DelayManager(minScheduleTimeStart, maxRunTime, blockAvailability, this, timeStep)
         allowanceManager = AllowanceManager(this)
         backtrackingManager = BacktrackingManager(this)
         this.tag = tag

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -45,7 +45,6 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         val departureTime = computeDepartureTime(ranges, startTime)
         val stops = makeStops(ranges)
         val withAllowance = applyAllowance(
-            graph,
             mergedEnvelopes,
             ranges,
             standardAllowance,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -423,7 +423,7 @@ class DepartureTimeShiftTests {
             .setEndLocations(setOf(EdgeLocation(lastBlock, Offset(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
-            .setMaxDepartureDelay(1000 + timeStep)
+            .setMaxDepartureDelay(1000 + 2 * timeStep)
             .run()!!
         val res = STDCMPathfindingBuilder()
             .setInfra(infra.fullInfra())
@@ -431,7 +431,7 @@ class DepartureTimeShiftTests {
             .setEndLocations(setOf(EdgeLocation(lastBlock, Offset<Block>(0.meters))))
             .setUnavailableTimes(occupancyGraph)
             .setTimeStep(timeStep)
-            .setMaxDepartureDelay(1000 - timeStep)
+            .setMaxDepartureDelay(1000 - 2 * timeStep)
             .run()
         assertNull(res)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -350,6 +350,6 @@ class EngineeringAllowanceTests {
             .setTimeStep(timeStep)
             .run()!!
         occupancyTest(res, occupancyGraph)
-        Assertions.assertEquals(3600.0, res.departureTime, timeStep)
+        Assertions.assertEquals(3600.0, res.departureTime, 2 * timeStep)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingTests.kt
@@ -311,7 +311,7 @@ class STDCMPathfindingTests {
                     block, OccupancySegment(0.0, 1000.0, 0.meters, 100.meters)
                 )
             )
-            .setMaxDepartureDelay(1000 + timeStep)
+            .setMaxDepartureDelay(1000 + 2 * timeStep)
             .setMaxRunTime(100.0)
             .setTimeStep(timeStep)
             .run()!!

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -208,7 +208,7 @@ class StandardAllowanceTests {
         occupancyTest(res, occupancyGraph, TIME_STEP)
         val thirdBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(10001.0))
-        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 2 * TIME_STEP)
+        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
     }
 
     /** This test checks that we add the right delay while backtracking several times, by adding mrsp drops  */


### PR DESCRIPTION
Fix https://github.com/osrd-project/osrd/issues/6285

* We needed to look for conflicts and split allowance ranges, even when using linear allowance as fallback
* To do this, a margin needs to be added when identifying conflicting times
* The PR also includes some smaller bugfixes, as the new version has a lower tolerance for errors
* Some tests need a higher tolerance to account for the conflict margin
