### PR TITLE
ci: exclude deleted lines from base codecov value

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,31 +7,37 @@ coverage:
       core:
         target: 75%
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - core
       editoast:
         target: 70%
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - editoast
       gateway:
         target: auto
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - gateway
       front:
         target: auto
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - front
       tests:
         target: auto
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - tests
       railjson_generator:
         target: auto
         threshold: 0.5%
+        removed_code_behavior: adjust_base
         flags:
           - railjson_generator
     patch:


### PR DESCRIPTION
https://docs.codecov.com/docs/commit-status#removed_code_behavior

All components are concerned, open to debate:
- improves (prevents) the case of "false alarm" when removing covered code.
- degrades (hides) the case of legitimate alarm when covered code is replaced by uncovered code (new code must be covered as much as the untouched code).