### PR TITLE
core: reduce binary search tolerance when there are several ranges

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -283,13 +283,16 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             throw new OSRDError(ErrorType.AllowanceConvergenceTooMuchTime);
         }
 
+        // Reduce tolerance when there are several ranges, so that the error doesn't add up to more than a time step
+        var tolerance = context.timeStep / ((float) ranges.size());
+
         Envelope res = null;
         OSRDError lastError = null;
         var search = new DoubleBinarySearch(
                 initialLowBound,
                 initialHighBound,
                 targetTime,
-                context.timeStep,
+                tolerance,
                 true
         );
         logger.debug("  target time = {}", targetTime);


### PR DESCRIPTION
Fix https://github.com/osrd-project/osrd/issues/3482


This is the "lazy" version of the bug fix, where we just trade computing time using a smaller tolerance.

If this cause issues later on, we should revert it and look into adjusting time values to compensate for past errors.