### PR TITLE
core: stdcm: fix block availability legacy adapter

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
@@ -58,7 +58,7 @@ public class EnvelopeConcat implements EnvelopeTimeInterpolate {
     public double interpolateTotalTime(double position) {
         var envelope = findEnvelopeAt(position);
         assert envelope != null : "Trying to interpolate time outside of the envelope";
-        return envelope.startTime + envelope.envelope.interpolateTotalTime(position - envelope.startOffset);
+        return envelope.startTime + envelope.envelope.interpolateTotalTimeClamp(position - envelope.startOffset);
     }
 
     @Override

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -132,10 +132,12 @@ class DelayManager internal constructor(
         val explorerWithNewEnvelope = infraExplorer
             .clone()
             .addEnvelope(envelopeWithStop)
+        val startOffsetOnPath = startOffset + explorerWithNewEnvelope.getPredecessorLength().distance
+        val endOffsetOnPath = startOffsetOnPath + (endOffset - startOffset)
         return blockAvailability.getAvailability(
             explorerWithNewEnvelope,
-            startOffset.distance,
-            endOffset.distance,
+            startOffsetOnPath.distance,
+            endOffsetOnPath.distance,
             startTime
         )
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -59,6 +59,12 @@ interface InfraExplorer {
     /** Returns the length of the current block. */
     fun getCurrentBlockLength(): Length<Block>
 
+    /** Returns the length of all blocks before the current one */
+    fun getPredecessorLength(): Length<Path>
+
+    /** Returns the all the blocks before the current one */
+    fun getPredecessorBlocks(): StaticIdxList<Block>
+
     /** Returns a copy of the current instance. */
     fun clone(): InfraExplorer
 }
@@ -160,12 +166,26 @@ private class InfraExplorerImpl(
     }
 
     override fun getCurrentBlock(): BlockId {
-        assert(currentIndex < blocks.size) { "InfraExplorer: currentBlockIndex is out of bounds."}
+        assert(currentIndex < blocks.size) { "InfraExplorer: currentBlockIndex is out of bounds." }
         return blocks[currentIndex]
     }
 
     override fun getCurrentBlockLength(): Length<Block> {
         return blockInfra.getBlockLength(getCurrentBlock())
+    }
+
+    override fun getPredecessorLength(): Length<Path> {
+        return Length(Distance(millimeters =
+        getPredecessorBlocks()
+            .sumOf { blockInfra.getBlockLength(it).distance.millimeters }
+        ))
+    }
+
+    override fun getPredecessorBlocks(): StaticIdxList<Block> {
+        val res = mutableStaticIdxArrayListOf<Block>()
+        for (i in 0..<currentIndex)
+            res.add(blocks[i])
+        return res
     }
 
     override fun clone(): InfraExplorer {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.kt
@@ -2,10 +2,10 @@ package fr.sncf.osrd.stdcm.preprocessing.implementation
 
 import com.google.common.collect.Multimap
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
-import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
 import fr.sncf.osrd.stdcm.OccupancySegment
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface.Availability
@@ -16,35 +16,52 @@ import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 
 /** This class implements the BlockAvailabilityInterface using the legacy block occupancy data.
- * It's meant to be removed once STDCM is fully integrated with the conflict detection module.  */
+ * It's meant to be moved to test modules once STDCM is fully integrated with the conflict detection module. */
 class BlockAvailabilityLegacyAdapter
-/** Constructor  */(
+    (
     private val blockInfra: BlockInfra,
     private val unavailableSpace: Multimap<BlockId, OccupancySegment>
 ) : BlockAvailabilityInterface {
+    /** Simple record used to group together a block and the offset of its start on the given path  */
+    @JvmRecord
+    private data class BlockWithOffset(val blockId: BlockId, val pathOffset: Distance)
+
     override fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
         startOffset: Distance,
         endOffset: Distance,
         startTime: Double
     ): Availability {
-        val envelope = infraExplorer.getLastEnvelope()
-        val block = infraExplorer.getCurrentBlock()
-        assert(TrainPhysicsIntegrator.arePositionsEqual((endOffset - startOffset).meters, envelope.endPos))
-        val unavailability = findMinimumDelay(block, startOffset, endOffset, envelope, startTime)
+        val envelope = infraExplorer.getFullEnvelope()
+        val blocksWithOffsets = makeBlocksWithOffsets(infraExplorer)
+        val unavailability = findMinimumDelay(blocksWithOffsets, startOffset, endOffset, envelope, startTime)
         return unavailability
             ?: findMaximumDelay(
-                block,
+                blocksWithOffsets,
                 startOffset,
+                endOffset,
                 envelope,
                 startTime
             )
     }
 
+    /** Create pairs of (block, offset)  */
+    private fun makeBlocksWithOffsets(infraExplorer: InfraExplorer): List<BlockWithOffset> {
+        var offset = 0.meters
+        val res = ArrayList<BlockWithOffset>()
+        for (block in infraExplorer.getPredecessorBlocks()) {
+            val length = blockInfra.getBlockLength(block)
+            res.add(BlockWithOffset(block, offset))
+            offset += length.distance
+        }
+        res.add(BlockWithOffset(infraExplorer.getCurrentBlock(), offset))
+        return res
+    }
+
     /** Find the minimum delay needed to avoid any conflict.
      * Returns 0 if the train isn't currently causing any conflict.  */
     private fun findMinimumDelay(
-        block: BlockId,
+        blocks: List<BlockWithOffset>,
         startOffset: Distance,
         endOffset: Distance,
         envelope: EnvelopeTimeInterpolate,
@@ -52,25 +69,29 @@ class BlockAvailabilityLegacyAdapter
     ): BlockAvailabilityInterface.Unavailable? {
         var minimumDelay = 0.0
         var conflictOffset = 0.meters
-        for (unavailableSegment in unavailableSpace[block]) {
-            val trainInBlock = getTimeTrainInBlock(
-                unavailableSegment,
-                startOffset,
-                envelope,
-                startTime
-            ) ?: continue
-            if (trainInBlock.start < unavailableSegment.timeEnd
-                && trainInBlock.end > unavailableSegment.timeStart
-            ) {
-                val blockMinimumDelay = unavailableSegment.timeEnd - trainInBlock.start
-                if (blockMinimumDelay > minimumDelay) {
-                    minimumDelay = blockMinimumDelay
-                    conflictOffset = if (trainInBlock.start <= unavailableSegment.timeStart) {
-                        // The train enters the block before it's unavailable: conflict at end location
-                        unavailableSegment.distanceEnd
-                    } else {
-                        // The train enters the block when it's already unavailable: conflict at start location
-                        unavailableSegment.distanceStart
+        for (blockWithOffset in getBlocksInRange(blocks, startOffset, endOffset)) {
+            for (unavailableSegment in unavailableSpace[blockWithOffset.blockId]) {
+                val trainInBlock = getTimeTrainInBlock(
+                    unavailableSegment,
+                    blockWithOffset,
+                    envelope,
+                    startTime,
+                    startOffset,
+                    endOffset
+                ) ?: continue
+                if (trainInBlock.start < unavailableSegment.timeEnd
+                    && trainInBlock.end > unavailableSegment.timeStart
+                ) {
+                    val blockMinimumDelay = unavailableSegment.timeEnd - trainInBlock.start
+                    if (blockMinimumDelay > minimumDelay) {
+                        minimumDelay = blockMinimumDelay
+                        conflictOffset = if (trainInBlock.start <= unavailableSegment.timeStart) {
+                            // The train enters the block before it's unavailable: conflict at end location
+                            blockWithOffset.pathOffset + unavailableSegment.distanceEnd
+                        } else {
+                            // The train enters the block when it's already unavailable: conflict at start location
+                            blockWithOffset.pathOffset + unavailableSegment.distanceStart
+                        }
                     }
                 }
             }
@@ -80,42 +101,60 @@ class BlockAvailabilityLegacyAdapter
         if (isFinite(minimumDelay)) {
             // We need to add delay, a recursive call is needed to detect new conflicts
             // that may appear with the added delay
-            val recursiveDelay = findMinimumDelay(block, startOffset, endOffset, envelope, startTime + minimumDelay)
+            val recursiveDelay = findMinimumDelay(blocks, startOffset, endOffset, envelope, startTime + minimumDelay)
             if (recursiveDelay != null) // The recursive call returns null if there is no new conflict
                 minimumDelay += recursiveDelay.duration
         }
-        val pathLength = blockInfra.getBlockLength(block)
-        conflictOffset = max(0.meters, min(pathLength.distance, conflictOffset))
+        conflictOffset = max(startOffset, min(endOffset, conflictOffset))
         return BlockAvailabilityInterface.Unavailable(minimumDelay, conflictOffset)
     }
 
     /** Find the maximum amount of delay that can be added to the train without causing conflict.
      * Cannot be called if the train is currently causing a conflict.  */
     private fun findMaximumDelay(
-        block: BlockId,
+        blocks: List<BlockWithOffset>,
         startOffset: Distance,
+        endOffset: Distance,
         envelope: EnvelopeTimeInterpolate,
         startTime: Double
     ): BlockAvailabilityInterface.Available {
         var maximumDelay = Double.POSITIVE_INFINITY
         var timeOfNextOccupancy = Double.POSITIVE_INFINITY
-        for (segment in unavailableSpace[block]) {
-            val timeTrainInBlock = getTimeTrainInBlock(
-                segment,
-                startOffset,
-                envelope,
-                startTime
-            )
-            if (timeTrainInBlock == null || timeTrainInBlock.start >= segment.timeEnd)
-                continue // The block is occupied before we enter it
-            assert(timeTrainInBlock.start <= segment.timeStart)
-            val maxDelayForBlock = segment.timeStart - timeTrainInBlock.end
-            if (maxDelayForBlock < maximumDelay) {
-                maximumDelay = maxDelayForBlock
-                timeOfNextOccupancy = segment.timeStart
+        for (blockWithOffset in getBlocksInRange(blocks, startOffset, endOffset)) {
+            for (block in unavailableSpace[blockWithOffset.blockId]) {
+                val timeTrainInBlock = getTimeTrainInBlock(
+                    block,
+                    blockWithOffset,
+                    envelope,
+                    startTime,
+                    startOffset,
+                    endOffset
+                )
+                if (timeTrainInBlock == null || timeTrainInBlock.start >= block.timeEnd)
+                    continue // The block is occupied before we enter it
+                assert(timeTrainInBlock.start <= block.timeStart)
+                val maxDelayForBlock = block.timeStart - timeTrainInBlock.end
+                if (maxDelayForBlock < maximumDelay) {
+                    maximumDelay = maxDelayForBlock
+                    timeOfNextOccupancy = block.timeStart
+                }
             }
         }
         return BlockAvailabilityInterface.Available(maximumDelay, timeOfNextOccupancy)
+    }
+
+    /** Returns the list of blocks in the given interval on the path  */
+    private fun getBlocksInRange(
+        blocks: List<BlockWithOffset>,
+        start: Distance,
+        end: Distance
+    ): List<BlockWithOffset> {
+        return blocks.stream()
+            .filter { (_, pathOffset): BlockWithOffset -> pathOffset < end }
+            .filter { (blockId, pathOffset): BlockWithOffset ->
+                pathOffset + blockInfra.getBlockLength(blockId).distance > start
+            }
+            .toList()
     }
 
     private class TimeInterval(val start: Double, val end: Double)
@@ -123,18 +162,22 @@ class BlockAvailabilityLegacyAdapter
     /** Returns the time interval during which the train is on the given blocK.  */
     private fun getTimeTrainInBlock(
         unavailableSegment: OccupancySegment,
-        startOffset: Distance,
+        block: BlockWithOffset,
         envelope: EnvelopeTimeInterpolate,
-        startTime: Double
+        startTime: Double,
+        startOffset: Distance,
+        endOffset: Distance
     ): TimeInterval? {
-        val startBlockOffsetOnEnvelope = -startOffset
-        // Offsets on the envelope
-        val blockEnterOffset = (startBlockOffsetOnEnvelope + unavailableSegment.distanceStart).meters
-        val blockExitOffset = (startBlockOffsetOnEnvelope + unavailableSegment.distanceEnd).meters
-        if (blockEnterOffset > envelope.endPos || blockExitOffset < 0)
+        val blockEnterOffset = (block.pathOffset + unavailableSegment.distanceStart)
+        val blockExitOffset = (block.pathOffset + unavailableSegment.distanceEnd)
+        if (startOffset > blockExitOffset || endOffset < blockEnterOffset)
             return null
-        val enterTime = startTime + envelope.interpolateTotalTimeClamp(blockEnterOffset)
-        val exitTime = startTime + envelope.interpolateTotalTimeClamp(blockExitOffset)
+
+        // startTime refers to the time at startOffset, we need to offset it when interpolating on the envelope
+        val envelopeStartTime = startTime - envelope.interpolateTotalTimeClamp(startOffset.meters)
+
+        val enterTime = envelopeStartTime + envelope.interpolateTotalTimeClamp(blockEnterOffset.meters)
+        val exitTime = envelopeStartTime + envelope.interpolateTotalTimeClamp(blockExitOffset.meters)
         return TimeInterval(enterTime, exitTime)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -123,7 +123,7 @@ class StandardAllowanceTests {
         Assertions.assertNotNull(res.withAllowance!!)
         val timeEnterOccupiedSection = (res.withAllowance.departureTime
                 + res.withAllowance.envelope.interpolateTotalTime(5000.0))
-        Assertions.assertEquals(3600.0, timeEnterOccupiedSection, 2 * TIME_STEP)
+        Assertions.assertEquals(3600.0, timeEnterOccupiedSection, 3 * TIME_STEP)
         occupancyTest(res.withAllowance, occupancyGraph, 2 * TIME_STEP)
         checkAllowanceResult(res, allowance)
     }
@@ -330,7 +330,7 @@ class StandardAllowanceTests {
         occupancyTest(res, occupancyGraph, TIME_STEP)
         val thirdBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(11000.0))
-        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 2 * TIME_STEP)
+        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
     }
 
     /** Tests a simple path with no conflict, with a time per distance allowance and very low value  */


### PR DESCRIPTION
The rewrite of `BlockInfraAvailabilityLegacyAdapter` was too simple and missed a few cases. I reverted the whole file back to its state on `dev` and then adapted it to the `InfraExplorer` input.

There's also some bug fixes to stabilize the branch