### PR TITLE
core: bump kotlin to 1.9.22 and ksp to 1.9.22-1.0.16

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -14,8 +14,8 @@
 #  - CC Attribution
 
 [versions]
-kotlin = '1.9.21'
-ksp = '1.9.21-1.0.15'
+kotlin = '1.9.22'
+ksp = '1.9.22-1.0.16'
 kotlinx-coroutines = '1.7.+'
 logback = '1.4.+'
 moshi = '1.15.0'


### PR DESCRIPTION
Supersede #6195, #6215