### PR TITLE
core: implement new version of `BlockAvailabilityInterface`

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
@@ -38,9 +38,6 @@ class PathFragment(
         }
 }
 
-/** A marker type for Offset<Path> */
-sealed interface Path
-
 /** A marker type for Offset<TravelledPath> */
 sealed interface TravelledPath
 
@@ -91,6 +88,7 @@ interface IncrementalPath {
     val travelledPathEnd: Offset<Path> //
 
     fun toTravelledPath(offset: Offset<Path>): Offset<TravelledPath>
+    fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<Path>
 }
 
 fun incrementalPathOf(rawInfra: RawInfra, blockInfra: BlockInfra): IncrementalPath {
@@ -289,5 +287,9 @@ private class IncrementalPathImpl(
 
     override fun toTravelledPath(offset: Offset<Path>): Offset<TravelledPath> {
         return Offset(offset.distance - travelledPathBegin.distance)
+    }
+
+    override fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<Path> {
+        return Offset(offset.distance + travelledPathBegin.distance)
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.conflicts
 
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.units.Offset
 import kotlin.math.max

--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -1,16 +1,15 @@
 package fr.sncf.osrd.conflicts
 
-import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.units.Offset
-import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.math.min
 
 class IncrementalRequirementEnvelopeAdapter(
     private val incrementalPath: IncrementalPath,
     private val rollingStock: RollingStock,
-    private val envelopeWithStops: EnvelopeStopWrapper
+    private val envelopeWithStops: EnvelopeTimeInterpolate
 )  : IncrementalRequirementCallbacks {
     override fun arrivalTimeInRange(pathBeginOff: Offset<Path>, pathEndOff: Offset<Path>): Double {
         // if the head of the train enters the zone at some point, use that

--- a/core/src/main/java/fr/sncf/osrd/conflicts/Resources.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/Resources.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.conflicts
 
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.utils.units.Offset
 
 interface IncrementalRequirementCallbacks {

--- a/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -74,7 +74,7 @@ enum class SpacingRequirementPhase {
 
 class SpacingRequirementAutomaton(
     // context
-    val rawInfra: SimInfraAdapter,
+    val rawInfra: RawInfra,
     val loadedSignalInfra: LoadedSignalInfra,
     val blockInfra: BlockInfra,
     val simulator: SignalingSimulator,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -136,8 +136,8 @@ class DelayManager internal constructor(
         val endOffsetOnPath = startOffsetOnPath + (endOffset - startOffset)
         return blockAvailability.getAvailability(
             explorerWithNewEnvelope,
-            startOffsetOnPath.distance,
-            endOffsetOnPath.distance,
+            startOffsetOnPath.cast(),
+            endOffsetOnPath.cast(),
             startTime
         )
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.kt
@@ -119,13 +119,13 @@ private fun findConflictOffsets(
     assert(TrainPhysicsIntegrator.arePositionsEqual(envelopeWithStops.endPos, (endOffset - startOffset).meters))
     val availability = blockAvailability.getAvailability(
         explorer,
-        startOffset.distance,
-        endOffset.distance,
+        startOffset.cast(),
+        endOffset.cast(),
         departureTime
     )
     assert(availability.javaClass != NotEnoughLookahead::class.java)
     val offsetDistance = (availability as? BlockAvailabilityInterface.Unavailable)?.firstConflictOffset ?: return null
-    return Offset(offsetDistance)
+    return offsetDistance
 }
 
 /** Applies the allowance to the final envelope, with range transitions at the given offsets  */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -4,7 +4,9 @@ import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.utils.units.Offset
 
 /** Explore the infra while running simulations. Builds one global envelope and path from the start of the train.
  * The path can extend further than the part that has been simulated
@@ -19,6 +21,9 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
 
     /** Adds an envelope. */
     fun addEnvelope(envelope: EnvelopeTimeInterpolate): InfraExplorerWithEnvelope
+
+    /** Calls `InterpolateTotalTimeClamp` on the underlying envelope, taking the travelled path offset into account. */
+    fun interpolateTimeClamp(pathOffset: Offset<Path>): Double
 
     /** Only shallow copies are made.
      * Used to enable backtracking by cloning explorers at each step. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -2,6 +2,8 @@ package fr.sncf.osrd.stdcm.infra_exploration
 
 import fr.sncf.osrd.envelope.EnvelopeConcat
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.utils.units.Offset
 
 data class InfraExplorerWithEnvelopeImpl(
     private val infraExplorer: InfraExplorer,
@@ -24,6 +26,12 @@ data class InfraExplorerWithEnvelopeImpl(
     override fun addEnvelope(envelope: EnvelopeTimeInterpolate): InfraExplorerWithEnvelope {
         envelopes.add(envelope)
         return this
+    }
+
+    override fun interpolateTimeClamp(pathOffset: Offset<Path>): Double {
+        return getFullEnvelope().interpolateTotalTimeClamp(
+            getIncrementalPath().toTravelledPath(pathOffset).distance.meters
+        )
     }
 
     override fun clone(): InfraExplorerWithEnvelope {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -1,0 +1,111 @@
+package fr.sncf.osrd.stdcm.preprocessing.implementation
+
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.conflicts.IncrementalRequirementEnvelopeAdapter
+import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
+import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
+import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.train.RollingStock
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+
+data class BlockAvailability(
+    val fullInfra: FullInfra,
+    val rollingStock: RollingStock,
+    val requirements: Map<ZoneId, List<SpacingRequirement>>
+) : GenericBlockAvailability() {
+
+    private data class ZoneResourceUse(
+        override val startOffset: Offset<Path>,
+        override val endOffset: Offset<Path>,
+        override val startTime: Double,
+        override val endTime: Double,
+        val zoneId: ZoneId,
+    ) : ResourceUse
+
+    override fun generateResourcesForPath(
+        infraExplorer: InfraExplorerWithEnvelope,
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>
+    ): List<ResourceUse> {
+        // TODO: discuss things here
+        // We're supposed to return null at some point (when more lookahead is required)
+        // Instantiating an automaton each time is probably wrong
+        val incrementalPath = infraExplorer.getIncrementalPath()
+        val envelopeAdapter = IncrementalRequirementEnvelopeAdapter(
+            incrementalPath, rollingStock, infraExplorer.getFullEnvelope()
+        )
+        val spacingGenerator = SpacingRequirementAutomaton(
+            fullInfra.rawInfra, fullInfra.loadedSignalInfra, fullInfra.blockInfra,
+            fullInfra.signalingSimulator, envelopeAdapter, incrementalPath
+        )
+        val res = mutableListOf<ResourceUse>()
+        val resources = spacingGenerator.processPathUpdate()
+        for (resource in resources) {
+            val resourceStartOffset = getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), resource.beginTime)
+            val resourceEndOffset = getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), resource.endTime)
+            if (resourceStartOffset > endOffset || resourceEndOffset < startOffset)
+                continue // The resource use is outside the considered range
+            res.add(
+                ZoneResourceUse(
+                    resourceStartOffset,
+                    resourceEndOffset,
+                    resource.beginTime,
+                    resource.endTime,
+                    fullInfra.rawInfra.getZoneFromName(resource.zone)
+                )
+            )
+        }
+        return res
+    }
+
+    override fun getScheduledResources(
+        infraExplorer: InfraExplorerWithEnvelope,
+        resource: ResourceUse
+    ): List<ResourceUse> {
+        val res = mutableListOf<ResourceUse>()
+        val zoneResourceUse = resource as ZoneResourceUse
+        for (scheduledRequirement in requirements[zoneResourceUse.zoneId] ?: listOf()) {
+            val resourceStartOffset =
+                getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), scheduledRequirement.beginTime)
+            val resourceEndOffset =
+                getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), scheduledRequirement.endTime)
+            res.add(
+                ZoneResourceUse(
+                    resourceStartOffset,
+                    resourceEndOffset,
+                    scheduledRequirement.beginTime,
+                    scheduledRequirement.endTime,
+                    zoneResourceUse.zoneId
+                )
+            )
+        }
+        return res
+    }
+
+    /** Turns a time into an offset on an envelope with a binary search. Can be optimized if needed. */
+    private fun getEnvelopeOffsetFromTime(envelope: EnvelopeTimeInterpolate, time: Double): Offset<Path> {
+        val search = DoubleBinarySearch(envelope.beginPos, envelope.endPos, time, 2.0, false)
+        while (!search.complete())
+            search.feedback(envelope.interpolateTotalTimeClamp(search.input))
+        return Offset(Distance.fromMeters(search.result))
+    }
+}
+
+fun buildBlockAvailability(
+    infra: FullInfra,
+    rollingStock: RollingStock,
+    rawRequirements: Collection<SpacingRequirement>
+): BlockAvailability {
+    val requirements = mutableMapOf<ZoneId, MutableList<SpacingRequirement>>()
+    for (requirement in rawRequirements) {
+        val zone = infra.rawInfra.getZoneFromName(requirement.zone)
+        requirements.putIfAbsent(zone, mutableListOf())
+        requirements[zone]!!.add(requirement)
+    }
+    return BlockAvailability(infra, rollingStock, requirements)
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -3,7 +3,6 @@ package fr.sncf.osrd.stdcm.preprocessing.implementation
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.conflicts.IncrementalRequirementEnvelopeAdapter
 import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
-import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.ZoneId
@@ -46,8 +45,8 @@ data class BlockAvailability(
         val res = mutableListOf<ResourceUse>()
         val resources = spacingGenerator.processPathUpdate()
         for (resource in resources) {
-            val resourceStartOffset = getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), resource.beginTime)
-            val resourceEndOffset = getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), resource.endTime)
+            val resourceStartOffset = getEnvelopeOffsetFromTime(infraExplorer, resource.beginTime)
+            val resourceEndOffset = getEnvelopeOffsetFromTime(infraExplorer, resource.endTime)
             if (resourceStartOffset > endOffset || resourceEndOffset < startOffset)
                 continue // The resource use is outside the considered range
             res.add(
@@ -71,9 +70,9 @@ data class BlockAvailability(
         val zoneResourceUse = resource as ZoneResourceUse
         for (scheduledRequirement in requirements[zoneResourceUse.zoneId] ?: listOf()) {
             val resourceStartOffset =
-                getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), scheduledRequirement.beginTime)
+                getEnvelopeOffsetFromTime(infraExplorer, scheduledRequirement.beginTime)
             val resourceEndOffset =
-                getEnvelopeOffsetFromTime(infraExplorer.getFullEnvelope(), scheduledRequirement.endTime)
+                getEnvelopeOffsetFromTime(infraExplorer, scheduledRequirement.endTime)
             res.add(
                 ZoneResourceUse(
                     resourceStartOffset,
@@ -88,11 +87,12 @@ data class BlockAvailability(
     }
 
     /** Turns a time into an offset on an envelope with a binary search. Can be optimized if needed. */
-    private fun getEnvelopeOffsetFromTime(envelope: EnvelopeTimeInterpolate, time: Double): Offset<Path> {
+    private fun getEnvelopeOffsetFromTime(explorer: InfraExplorerWithEnvelope, time: Double): Offset<Path> {
+        val envelope = explorer.getFullEnvelope()
         val search = DoubleBinarySearch(envelope.beginPos, envelope.endPos, time, 2.0, false)
         while (!search.complete())
             search.feedback(envelope.interpolateTotalTimeClamp(search.input))
-        return Offset(Distance.fromMeters(search.result))
+        return explorer.getIncrementalPath().fromTravelledPath(Offset(Distance.fromMeters(search.result)))
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailabilityLegacyAdapter.kt
@@ -4,45 +4,81 @@ import com.google.common.collect.Multimap
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.stdcm.OccupancySegment
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
-import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
-import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface.Availability
 import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Distance.Companion.max
-import fr.sncf.osrd.utils.units.Distance.Companion.min
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import java.lang.Double.isFinite
 
 /** This class implements the BlockAvailabilityInterface using the legacy block occupancy data.
  * It's meant to be moved to test modules once STDCM is fully integrated with the conflict detection module. */
-class BlockAvailabilityLegacyAdapter
-    (
+class BlockAvailabilityLegacyAdapter(
     private val blockInfra: BlockInfra,
     private val unavailableSpace: Multimap<BlockId, OccupancySegment>
-) : BlockAvailabilityInterface {
+) : GenericBlockAvailability() {
     /** Simple record used to group together a block and the offset of its start on the given path  */
-    @JvmRecord
     private data class BlockWithOffset(val blockId: BlockId, val pathOffset: Distance)
 
-    override fun getAvailability(
+    private data class BlockResourceUse(
+        override val startOffset: Offset<Path>,
+        override val endOffset: Offset<Path>,
+        override val startTime: Double,
+        override val endTime: Double,
+        val blockId: BlockId,
+    ): ResourceUse
+
+
+    /** Returns all resource usage for the given path */
+    override fun generateResourcesForPath(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Distance,
-        endOffset: Distance,
-        startTime: Double
-    ): Availability {
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>,
+    ): List<ResourceUse> {
         val envelope = infraExplorer.getFullEnvelope()
-        val blocksWithOffsets = makeBlocksWithOffsets(infraExplorer)
-        val unavailability = findMinimumDelay(blocksWithOffsets, startOffset, endOffset, envelope, startTime)
-        return unavailability
-            ?: findMaximumDelay(
-                blocksWithOffsets,
-                startOffset,
-                endOffset,
-                envelope,
-                startTime
-            )
+        val blocks = makeBlocksWithOffsets(infraExplorer)
+        val res = mutableListOf<ResourceUse>()
+        for (blockWithOffset in getBlocksInRange(blocks, startOffset, endOffset)) {
+            for (unavailableSegment in unavailableSpace[blockWithOffset.blockId]) {
+                val trainInBlock = getTimeTrainInBlock(
+                    unavailableSegment,
+                    blockWithOffset,
+                    envelope,
+                    startOffset,
+                    endOffset
+                ) ?: continue
+                val segmentStartOffset = Offset<Path>(blockWithOffset.pathOffset + unavailableSegment.distanceStart)
+                val segmentEndOffset = Offset<Path>(blockWithOffset.pathOffset + unavailableSegment.distanceStart)
+                res.add(BlockResourceUse(
+                    segmentStartOffset,
+                    segmentEndOffset,
+                    trainInBlock.start,
+                    trainInBlock.end,
+                    blockWithOffset.blockId
+                ))
+            }
+        }
+        return res
+    }
+
+    /** Returns all the scheduled resource use that use the same resource as the one given as parameter */
+    override fun getScheduledResources(infraExplorer: InfraExplorerWithEnvelope, resource: ResourceUse): List<ResourceUse> {
+        val blocks = makeBlocksWithOffsets(infraExplorer)
+        val blockUse = resource as BlockResourceUse
+        val res = mutableListOf<ResourceUse>()
+        for (segment in unavailableSpace[blockUse.blockId]) {
+            // Can be optimized
+            val blockOffset = Offset<Path>(blocks.first { it.blockId == blockUse.blockId }.pathOffset)
+            res.add(BlockResourceUse(
+                blockOffset + segment.distanceStart,
+                blockOffset + segment.distanceEnd,
+                segment.timeStart,
+                segment.timeEnd,
+                blockUse.blockId
+            ))
+        }
+        return res
     }
 
     /** Create pairs of (block, offset)  */
@@ -58,105 +94,6 @@ class BlockAvailabilityLegacyAdapter
         return res
     }
 
-    /** Find the minimum delay needed to avoid any conflict.
-     * Returns 0 if the train isn't currently causing any conflict.  */
-    private fun findMinimumDelay(
-        blocks: List<BlockWithOffset>,
-        startOffset: Distance,
-        endOffset: Distance,
-        envelope: EnvelopeTimeInterpolate,
-        startTime: Double
-    ): BlockAvailabilityInterface.Unavailable? {
-        var minimumDelay = 0.0
-        var conflictOffset = 0.meters
-        for (blockWithOffset in getBlocksInRange(blocks, startOffset, endOffset)) {
-            for (unavailableSegment in unavailableSpace[blockWithOffset.blockId]) {
-                val trainInBlock = getTimeTrainInBlock(
-                    unavailableSegment,
-                    blockWithOffset,
-                    envelope,
-                    startTime,
-                    startOffset,
-                    endOffset
-                ) ?: continue
-                if (trainInBlock.start < unavailableSegment.timeEnd
-                    && trainInBlock.end > unavailableSegment.timeStart
-                ) {
-                    val blockMinimumDelay = unavailableSegment.timeEnd - trainInBlock.start
-                    if (blockMinimumDelay > minimumDelay) {
-                        minimumDelay = blockMinimumDelay
-                        conflictOffset = if (trainInBlock.start <= unavailableSegment.timeStart) {
-                            // The train enters the block before it's unavailable: conflict at end location
-                            blockWithOffset.pathOffset + unavailableSegment.distanceEnd
-                        } else {
-                            // The train enters the block when it's already unavailable: conflict at start location
-                            blockWithOffset.pathOffset + unavailableSegment.distanceStart
-                        }
-                    }
-                }
-            }
-        }
-        if (minimumDelay == 0.0)
-            return null
-        if (isFinite(minimumDelay)) {
-            // We need to add delay, a recursive call is needed to detect new conflicts
-            // that may appear with the added delay
-            val recursiveDelay = findMinimumDelay(blocks, startOffset, endOffset, envelope, startTime + minimumDelay)
-            if (recursiveDelay != null) // The recursive call returns null if there is no new conflict
-                minimumDelay += recursiveDelay.duration
-        }
-        conflictOffset = max(startOffset, min(endOffset, conflictOffset))
-        return BlockAvailabilityInterface.Unavailable(minimumDelay, conflictOffset)
-    }
-
-    /** Find the maximum amount of delay that can be added to the train without causing conflict.
-     * Cannot be called if the train is currently causing a conflict.  */
-    private fun findMaximumDelay(
-        blocks: List<BlockWithOffset>,
-        startOffset: Distance,
-        endOffset: Distance,
-        envelope: EnvelopeTimeInterpolate,
-        startTime: Double
-    ): BlockAvailabilityInterface.Available {
-        var maximumDelay = Double.POSITIVE_INFINITY
-        var timeOfNextOccupancy = Double.POSITIVE_INFINITY
-        for (blockWithOffset in getBlocksInRange(blocks, startOffset, endOffset)) {
-            for (block in unavailableSpace[blockWithOffset.blockId]) {
-                val timeTrainInBlock = getTimeTrainInBlock(
-                    block,
-                    blockWithOffset,
-                    envelope,
-                    startTime,
-                    startOffset,
-                    endOffset
-                )
-                if (timeTrainInBlock == null || timeTrainInBlock.start >= block.timeEnd)
-                    continue // The block is occupied before we enter it
-                assert(timeTrainInBlock.start <= block.timeStart)
-                val maxDelayForBlock = block.timeStart - timeTrainInBlock.end
-                if (maxDelayForBlock < maximumDelay) {
-                    maximumDelay = maxDelayForBlock
-                    timeOfNextOccupancy = block.timeStart
-                }
-            }
-        }
-        return BlockAvailabilityInterface.Available(maximumDelay, timeOfNextOccupancy)
-    }
-
-    /** Returns the list of blocks in the given interval on the path  */
-    private fun getBlocksInRange(
-        blocks: List<BlockWithOffset>,
-        start: Distance,
-        end: Distance
-    ): List<BlockWithOffset> {
-        return blocks.stream()
-            .filter { (_, pathOffset): BlockWithOffset -> pathOffset < end }
-            .filter { (blockId, pathOffset): BlockWithOffset ->
-                pathOffset + blockInfra.getBlockLength(blockId).distance > start
-            }
-            .toList()
-    }
-
     private class TimeInterval(val start: Double, val end: Double)
 
     /** Returns the time interval during which the train is on the given blocK.  */
@@ -164,20 +101,33 @@ class BlockAvailabilityLegacyAdapter
         unavailableSegment: OccupancySegment,
         block: BlockWithOffset,
         envelope: EnvelopeTimeInterpolate,
-        startTime: Double,
-        startOffset: Distance,
-        endOffset: Distance
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>
     ): TimeInterval? {
         val blockEnterOffset = (block.pathOffset + unavailableSegment.distanceStart)
         val blockExitOffset = (block.pathOffset + unavailableSegment.distanceEnd)
-        if (startOffset > blockExitOffset || endOffset < blockEnterOffset)
+        if (startOffset.distance > blockExitOffset || endOffset.distance < blockEnterOffset)
             return null
 
         // startTime refers to the time at startOffset, we need to offset it when interpolating on the envelope
-        val envelopeStartTime = startTime - envelope.interpolateTotalTimeClamp(startOffset.meters)
+        // val envelopeStartTime = startTime - envelope.interpolateTotalTimeClamp(startOffset.meters)
 
-        val enterTime = envelopeStartTime + envelope.interpolateTotalTimeClamp(blockEnterOffset.meters)
-        val exitTime = envelopeStartTime + envelope.interpolateTotalTimeClamp(blockExitOffset.meters)
+        val enterTime = envelope.interpolateTotalTimeClamp(blockEnterOffset.meters)
+        val exitTime = envelope.interpolateTotalTimeClamp(blockExitOffset.meters)
         return TimeInterval(enterTime, exitTime)
+    }
+
+    /** Returns the list of blocks in the given interval on the path  */
+    private fun getBlocksInRange(
+        blocks: List<BlockWithOffset>,
+        start: Offset<Path>,
+        end: Offset<Path>
+    ): List<BlockWithOffset> {
+        return blocks.stream()
+            .filter { (_, pathOffset): BlockWithOffset -> pathOffset < end.distance }
+            .filter { (blockId, pathOffset): BlockWithOffset ->
+                pathOffset + blockInfra.getBlockLength(blockId).distance > start.distance
+            }
+            .toList()
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/GenericBlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/GenericBlockAvailability.kt
@@ -1,0 +1,111 @@
+package fr.sncf.osrd.stdcm.preprocessing.implementation
+
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+
+/** This class is used to share as much code as possible between
+ * BlockAvailability and the legacy / test version  */
+abstract class GenericBlockAvailability : BlockAvailabilityInterface {
+
+    interface ResourceUse {
+        val startOffset: Offset<Path>
+        val endOffset: Offset<Path>
+        val startTime: Double
+        val endTime: Double
+    }
+
+    /** Returns all resource usage for the given path, or null if more lookahead is needed */
+    abstract fun generateResourcesForPath(
+        infraExplorer: InfraExplorerWithEnvelope,
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>,
+    ): List<ResourceUse>?
+
+    /** Returns all the scheduled resource use that use the same resource as the one given as parameter */
+    abstract fun getScheduledResources(infraExplorer: InfraExplorerWithEnvelope, resource: ResourceUse): List<ResourceUse>
+
+    override fun getAvailability(
+        infraExplorer: InfraExplorerWithEnvelope,
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>,
+        startTime: Double
+    ): BlockAvailabilityInterface.Availability {
+        val resourceUses = generateResourcesForPath(infraExplorer, startOffset, endOffset)
+            ?: return BlockAvailabilityInterface.NotEnoughLookahead()
+        // startTime refers to the time at startOffset, we need to offset it
+        val pathStartTime = startTime - infraExplorer.getFullEnvelope().interpolateTotalTimeClamp(startOffset.distance.meters)
+        val unavailability = findMinimumDelay(infraExplorer, resourceUses, pathStartTime)
+        return unavailability ?: findMaximumDelay(infraExplorer, resourceUses, pathStartTime)
+    }
+
+    /** Find the minimum delay needed to avoid any conflict.
+     * Returns 0 if the train isn't currently causing any conflict.  */
+    private fun findMinimumDelay(
+        infraExplorer: InfraExplorerWithEnvelope,
+        resourceUses: List<ResourceUse>,
+        pathStartTime: Double
+    ): BlockAvailabilityInterface.Unavailable? {
+        var minimumDelay = 0.0
+        var conflictOffset = Offset<Path>(0.meters)
+        for (resourceUse in resourceUses) {
+            val resourceStartTime = resourceUse.startTime + pathStartTime
+            val resourceEndTime = resourceUse.endTime + pathStartTime
+            for (scheduledResourceUse in getScheduledResources(infraExplorer, resourceUse)) {
+                if (resourceStartTime > scheduledResourceUse.endTime
+                    || resourceEndTime < scheduledResourceUse.startTime)
+                    continue
+                val resourceMinimumDelay = scheduledResourceUse.endTime - resourceStartTime
+                if (resourceMinimumDelay > minimumDelay) {
+                    minimumDelay = resourceMinimumDelay
+                    conflictOffset = if (resourceStartTime <= scheduledResourceUse.startTime) {
+                        // The train enters the block before it's unavailable: conflict at end location
+                        resourceUse.endOffset
+                    } else {
+                        // The train enters the block when it's already unavailable: conflict at start location
+                        resourceUse.startOffset
+                    }
+                }
+            }
+        }
+        if (minimumDelay == 0.0)
+            return null
+        if (java.lang.Double.isFinite(minimumDelay)) {
+            // We need to add delay, a recursive call is needed to detect new conflicts
+            // that may appear with the added delay
+            val recursiveDelay = findMinimumDelay(infraExplorer, resourceUses, pathStartTime + minimumDelay)
+            if (recursiveDelay != null) // The recursive call returns null if there is no new conflict
+                minimumDelay += recursiveDelay.duration
+        }
+        return BlockAvailabilityInterface.Unavailable(minimumDelay, conflictOffset)
+    }
+
+    /** Find the maximum amount of delay that can be added to the train without causing conflict.
+     * Cannot be called if the train is currently causing a conflict.  */
+    private fun findMaximumDelay(
+        infraExplorer: InfraExplorerWithEnvelope,
+        resourceUses: List<ResourceUse>,
+        pathStartTime: Double,
+    ): BlockAvailabilityInterface.Available {
+        var maximumDelay = Double.POSITIVE_INFINITY
+        var timeOfNextOccupancy = Double.POSITIVE_INFINITY
+        for (resourceUse in resourceUses) {
+            val resourceStartTime = resourceUse.startTime + pathStartTime
+            val resourceEndTime = resourceUse.endTime + pathStartTime
+            for (scheduledResourceUse in getScheduledResources(infraExplorer, resourceUse)) {
+                if (resourceStartTime >= scheduledResourceUse.endTime)
+                    continue // The block is occupied before we enter it
+                assert(resourceStartTime <= scheduledResourceUse.startTime)
+                val maxDelayForBlock = scheduledResourceUse.startTime - resourceEndTime
+                if (maxDelayForBlock < maximumDelay) {
+                    maximumDelay = maxDelayForBlock
+                    timeOfNextOccupancy = scheduledResourceUse.startTime
+                }
+            }
+        }
+        return BlockAvailabilityInterface.Available(maximumDelay, timeOfNextOccupancy)
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/GenericBlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/GenericBlockAvailability.kt
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.stdcm.preprocessing.implementation
 
 import fr.sncf.osrd.sim_infra.api.Path
-import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.utils.units.Offset
@@ -37,7 +36,7 @@ abstract class GenericBlockAvailability : BlockAvailabilityInterface {
         val resourceUses = generateResourcesForPath(infraExplorer, startOffset, endOffset)
             ?: return BlockAvailabilityInterface.NotEnoughLookahead()
         // startTime refers to the time at startOffset, we need to offset it
-        val pathStartTime = startTime - infraExplorer.getFullEnvelope().interpolateTotalTimeClamp(startOffset.distance.meters)
+        val pathStartTime = startTime - infraExplorer.interpolateTimeClamp(startOffset)
         val unavailability = findMinimumDelay(infraExplorer, resourceUses, pathStartTime)
         return unavailability ?: findMaximumDelay(infraExplorer, resourceUses, pathStartTime)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,7 +1,9 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
+import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 
 /** Abstract interface used to request the availability of path sections  */
 interface BlockAvailabilityInterface {
@@ -27,8 +29,8 @@ interface BlockAvailabilityInterface {
      */
     fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Distance,
-        endOffset: Distance,
+        startOffset: Offset<Path>,
+        endOffset: Offset<Path>,
         startTime: Double
     ): Availability
 
@@ -57,9 +59,9 @@ interface BlockAvailabilityInterface {
         val duration: Double,
         /** Exact offset of the first conflict encountered. It's always an offset that delimits an unavailable section.
          *
-         * It's either the offset where we start using a ressource before it's available,
-         * or the offset where the train would have released a ressource it has kept for too long.  */
-        val firstConflictOffset: Distance
+         * It's either the offset where we start using a resource before it's available,
+         * or the offset where the train would have released a resource it has kept for too long.  */
+        val firstConflictOffset: Offset<Path>
     ) : Availability()
 
     /** The availability of the requested section can't be determined,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,16 +1,12 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
-import com.google.common.base.Objects
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
-import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Distance
 
 /** Abstract interface used to request the availability of path sections  */
 interface BlockAvailabilityInterface {
     /** Request availability information about a section of the path.
-     * <br></br>
+     *
      * Can return either an instance of either type:
      *
      *  * Available: the section is available
@@ -18,7 +14,7 @@ interface BlockAvailabilityInterface {
      *  * NotEnoughLookahead: the train path needs to extend further, it depends on a directional choice
      *
      * More details are given in the instances.
-     * <br></br>
+     *
      * Note: every position refers to the position of the head of the train.
      * The implementation of BlockAvailabilityInterface must account for train length, sight distance,
      * and similar factors.
@@ -40,7 +36,7 @@ interface BlockAvailabilityInterface {
     abstract class Availability
 
     /** The requested section is available.
-     * <br></br>
+     *
      * For example: a train enter the section at t=10, sees a signal 42s after entering the section,
      * and the signal is green until t=100. The result would be:
      *
@@ -48,52 +44,23 @@ interface BlockAvailabilityInterface {
      *  * timeOfNextConflict = 100
      *
      */
-    class Available(
+    data class Available(
         /** The train can use the section now and up to `maximumDelay` later without conflict  */
         val maximumDelay: Double,
         /** Earliest time any resource used by the train is reused by another one  */
         val timeOfNextConflict: Double
-    ) : Availability() {
-        override fun equals(other: Any?): Boolean {
-            if (this === other)
-                return true
-            if (other == null || javaClass != other.javaClass)
-                return false
-            val available = other as Available
-            return (available.maximumDelay.compareTo(maximumDelay) == 0
-                    && available.timeOfNextConflict.compareTo(timeOfNextConflict) == 0)
-        }
-
-        override fun hashCode(): Int {
-            return Objects.hashCode(maximumDelay, timeOfNextConflict)
-        }
-    }
+    ) : Availability()
 
     /** The requested section isn't available yet  */
-    class Unavailable(
+    data class Unavailable(
         /** Minimum delay to add to the departure time to avoid any conflict  */
         val duration: Double,
-        /** Exact offset of the first conflict encountered. It's always the offset that marks either the border of an
-         * unavailable section.
-         * <br></br>
+        /** Exact offset of the first conflict encountered. It's always an offset that delimits an unavailable section.
+         *
          * It's either the offset where we start using a ressource before it's available,
          * or the offset where the train would have released a ressource it has kept for too long.  */
         val firstConflictOffset: Distance
-    ) : Availability() {
-        override fun equals(other: Any?): Boolean {
-            if (this === other)
-                return true
-            if (other == null || javaClass != other.javaClass)
-                return false
-            val that = other as Unavailable
-            return (that.duration.compareTo(duration) == 0
-                    && that.firstConflictOffset.millimeters.compareTo(firstConflictOffset.millimeters) == 0)
-        }
-
-        override fun hashCode(): Int {
-            return Objects.hashCode(duration, firstConflictOffset)
-        }
-    }
+    ) : Availability()
 
     /** The availability of the requested section can't be determined,
      * the path needs to extend further. The availability depends

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityLegacyAdapterTests.kt
@@ -56,11 +56,11 @@ class BlockAvailabilityLegacyAdapterTests {
             )
         val res = adapter.getAvailability(
             explorer,
-            0.meters,
-            1.meters,
+            Offset(0.meters),
+            Offset(1.meters),
             42.0
         )
-        val expected = BlockAvailabilityInterface.Unavailable((42 + 20).toDouble(), 0.meters)
+        val expected = BlockAvailabilityInterface.Unavailable((42 + 20).toDouble(), Offset(0.meters))
         Assertions.assertEquals(expected, res)
     }
 }


### PR DESCRIPTION
Fix #6266 

1. Split the current version into an abstract class with a partial implementation, and a class that inherits from it
2. Add a new class using the same parent, using the new incremental resource generation

There are several steps that are not optimized at all, the goal is to have everything working with the new version and then optimize what's needed. 

The new version requires a few extra steps (described [here](https://github.com/osrd-project/osrd/issues/6370)) to be fully operational, so we still call the legacy version for now. 