### PR TITLE
docker: fix docker-compose-host.yml

### DIFF
--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -22,7 +22,7 @@ services:
     network_mode: host
     environment:
       PSQL_HOST: "localhost"
-      EDITOAST_PORT: 8090
+      EDITOAST_PORT: "8090"
       OSRD_BACKEND_URL: "http://localhost:8080"
       REDIS_URL: "redis://localhost"
       DATABASE_URL: "postgres://osrd:password@localhost:5432/osrd"


### PR DESCRIPTION
Without this, starting the containers with `scripts/osrd-compose.sh` fails with:

osrd-editoast   | error: invalid value '%!s(int=8090)' for '--port <PORT>': invalid digit found in string