### PR TITLE
front: fixes speed sections edition

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -105,6 +105,10 @@ const MapUnplugged = ({
     () => (activeTool.getInteractiveLayers ? activeTool.getInteractiveLayers(extendedContext) : []),
     [activeTool, extendedContext]
   );
+  const eventsLayerIDs = useMemo(
+    () => (activeTool.getEventsLayers ? activeTool.getEventsLayers(extendedContext) : null),
+    [activeTool, extendedContext]
+  );
 
   const cursor = useMemo(
     () => (activeTool.getCursor ? activeTool.getCursor(extendedContext, mapState) : 'default'),
@@ -138,7 +142,15 @@ const MapUnplugged = ({
             setToolState({ hovered: null });
           }}
           onMouseMove={(e) => {
-            const nearestResult = getMapMouseEventNearestFeature(e);
+            const nearestResult = getMapMouseEventNearestFeature(
+              e,
+              eventsLayerIDs
+                ? {
+                    layersId: eventsLayerIDs,
+                  }
+                : undefined
+            );
+
             const partialToolState: Partial<CommonToolState> = {
               mousePosition: [e.lngLat.lng, e.lngLat.lat],
             };
@@ -229,7 +241,15 @@ const MapUnplugged = ({
           cursor={cursor}
           interactiveLayerIds={interactiveLayerIDs}
           onClick={(e) => {
-            const nearestResult = getMapMouseEventNearestFeature(e);
+            const nearestResult = getMapMouseEventNearestFeature(
+              e,
+              eventsLayerIDs
+                ? {
+                    layersId: eventsLayerIDs,
+                  }
+                : undefined
+            );
+
             const eventWithFeature = nearestResult
               ? {
                   ...e,

--- a/front/src/applications/editor/tools/editorContextTypes.ts
+++ b/front/src/applications/editor/tools/editorContextTypes.ts
@@ -106,6 +106,7 @@ export interface Tool<S> {
 
   // Display:
   getInteractiveLayers?: (context: ReadOnlyEditorContextType<S>) => string[];
+  getEventsLayers?: (context: ReadOnlyEditorContextType<S>) => string[];
   layersComponent?: ComponentType<{ map: Map }>;
   leftPanelComponent?: ComponentType;
   messagesComponent?: ComponentType;

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -56,13 +56,6 @@ export const SpeedSectionEditionLayers = () => {
     else if (hoveredItem?.itemType) {
       res.push(hoveredItem.track.properties.id);
     }
-    // EditorEntity hovered element:
-    else if (
-      hoveredItem?.type === 'TrackSection' &&
-      !(entity.properties.track_ranges || []).find((range) => range.track === hoveredItem.id)
-    ) {
-      res.push(hoveredItem.id);
-    }
 
     return res;
   }, [interactionState, hoveredItem, entity]);
@@ -251,7 +244,17 @@ export const SpeedSectionEditionLayers = () => {
           <Layer {...props} key={i} />
         ))}
         <Layer
+          type="line"
+          id="speed-section/track-sections"
+          paint={{
+            'line-dasharray': [3, 3],
+            'line-color': '#000000',
+            'line-width': 1,
+          }}
+        />
+        <Layer
           type="circle"
+          id="speed-section/extremities"
           paint={{
             'circle-radius': 4,
             'circle-color': '#fff',
@@ -267,6 +270,7 @@ export const SpeedSectionEditionLayers = () => {
         ))}
         <Layer
           type="circle"
+          id="speed-section/psl/extremities"
           paint={{
             'circle-radius': 4,
             'circle-color': '#fff',

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -375,6 +375,14 @@ function getRangeEditionTool<T extends EditorRange>({
     getInteractiveLayers() {
       return ['editor/geo/track-main'];
     },
+    getEventsLayers() {
+      return [
+        'editor/geo/track-main',
+        'speed-section/extremities',
+        'speed-section/track-sections',
+        'speed-section/psl/extremities',
+      ];
+    },
   };
 }
 

--- a/front/src/utils/mapHelper.ts
+++ b/front/src/utils/mapHelper.ts
@@ -354,7 +354,7 @@ export function getMapMouseEventNearestFeature(
             const layer = feature.sourceLayer as LayerType;
             const multiplier = POINT_FEATURES_DISTANCE_MULTIPLIERS[layer] || DEFAULT_MULTIPLIER;
             nearestFeaturePoint = feature as Feature<Point>;
-            // we boost point, otherwise when a point is on line, it's too hard to find it
+            // we boost point, otherwise when a point is on some line, it's too hard to find it
             distance = fnDistance(coord, nearestFeaturePoint.geometry.coordinates) * multiplier;
             break;
           }
@@ -413,8 +413,7 @@ export function getMapMouseEventNearestFeature(
     )
   );
 
-  if (!result) return null;
-  return result;
+  return result || null;
 }
 
 /**


### PR DESCRIPTION
This commit fixes #6368.

### Details
- Adds a layer to display selected track ranges when editing a "non-PSL" speed section
- Adds a new "getEventsLayers" abstraction, to allow specifying explicitely on which layer the getMapMouseEventNearestFeature calls should be ran

### Note
Adding the new "getEventsLayers" to the tools abstraction brings a bit of debt, but it allows solving this urgent issue without altering the other existing tools. And since the infra editor will be rebooted soon, I think it's worth it.