### PR TITLE
core: implement occupancy tests for notEnoughLookahead

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/OccupancySegment.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/OccupancySegment.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm
 
+import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.utils.units.Distance
 
 /** The given element is unavailable from timeStart until timeEnd,
@@ -10,5 +11,7 @@ data class OccupancySegment(
     val timeStart: Double,
     val timeEnd: Double,
     val distanceStart: Distance,
-    val distanceEnd: Distance
+    val distanceEnd: Distance,
+    val enabledIfBlockInLookahead: BlockId? = null,
+    val disabledIfBlockInLookahead: BlockId? = null
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -2,11 +2,8 @@ package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
-import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface.Availability
@@ -55,7 +52,6 @@ class DelayManager internal constructor(
                 is BlockAvailabilityInterface.Unavailable -> {
                     availability.duration + internalMargin * 2
                 }
-                else -> throw NotEnoughLookaheadError()
             }
         }
         return res
@@ -141,6 +137,4 @@ class DelayManager internal constructor(
             startTime
         )
     }
-
-    class NotEnoughLookaheadError : RuntimeException()
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.*
@@ -112,7 +113,7 @@ data class STDCMEdgeBuilder internal constructor(
                     .map { delayNeeded -> makeSingleEdge(delayNeeded) }
                     .filter { obj -> Objects.nonNull(obj) }
                     .toList() as Collection<STDCMEdge>
-        } catch (_: DelayManager.NotEnoughLookaheadError) {
+        } catch (_: BlockAvailabilityInterface.NotEnoughLookaheadError) {
             // More lookahead required, extend and repeat for each new path
             infraExplorer.cloneAndExtendLookahead()
                 .flatMap { copy(infraExplorer=it).makeAllEdges() }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -72,7 +72,10 @@ class STDCMGraph(
             STDCMEdgeBuilder.fromNode(this, node, node.infraExplorer).makeAllEdges()
         else {
             val res = ArrayList<STDCMEdge>()
-            val extendedPaths = node.infraExplorer.cloneAndExtendLookahead()
+            val extendedPaths = if (node.infraExplorer.getLookahead().size == 0)
+                node.infraExplorer.cloneAndExtendLookahead()
+            else
+                listOf(node.infraExplorer.clone())
             for (newPath in extendedPaths) {
                 newPath.moveForward()
                 newPath.addEnvelope(node.previousEdge.envelope)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMStandardAllowance.kt
@@ -15,12 +15,10 @@ import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.infra_exploration.withEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
-import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface.NotEnoughLookahead
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Offset
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -123,7 +121,6 @@ private fun findConflictOffsets(
         endOffset.cast(),
         departureTime
     )
-    assert(availability.javaClass != NotEnoughLookahead::class.java)
     val offsetDistance = (availability as? BlockAvailabilityInterface.Unavailable)?.firstConflictOffset ?: return null
     return offsetDistance
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -16,7 +16,7 @@ import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
-import java.util.Objects
+import java.util.*
 
 /** Explore the infra, without running simulations.
  * Builds one global path from the start of the train, one block at a time.
@@ -62,8 +62,11 @@ interface InfraExplorer {
     /** Returns the length of all blocks before the current one */
     fun getPredecessorLength(): Length<Path>
 
-    /** Returns the all the blocks before the current one */
+    /** Returns all the blocks before the current one */
     fun getPredecessorBlocks(): StaticIdxList<Block>
+
+    /** Returns all the blocks after the current one */
+    fun getLookahead(): StaticIdxList<Block>
 
     /** Returns a copy of the current instance. */
     fun clone(): InfraExplorer
@@ -197,6 +200,13 @@ private class InfraExplorerImpl(
         return res
     }
 
+    override fun getLookahead(): StaticIdxList<Block> {
+        val res = mutableStaticIdxArrayListOf<Block>()
+        for (i in currentIndex + 1..<blocks.size)
+            res.add(blocks[i])
+        return res
+    }
+
     override fun clone(): InfraExplorer {
         return InfraExplorerImpl(
             this.rawInfra,
@@ -231,6 +241,10 @@ private class InfraExplorerImpl(
             travelledPathBegin = Distance.ZERO,
             travelledPathEnd = Distance.ZERO
         ))
+    }
+
+    override fun toString(): String {
+        return String.format("currentBlock=%s, lookahead=%s", getCurrentBlock(), getLookahead())
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
-import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 
 /** Abstract interface used to request the availability of path sections  */
@@ -35,7 +34,7 @@ interface BlockAvailabilityInterface {
     ): Availability
 
     /** Represents the availability of the requested section  */
-    abstract class Availability
+    sealed class Availability
 
     /** The requested section is available.
      *
@@ -64,8 +63,8 @@ interface BlockAvailabilityInterface {
         val firstConflictOffset: Offset<Path>
     ) : Availability()
 
-    /** The availability of the requested section can't be determined,
+    /** This is thrown when the availability of the requested section can't be determined,
      * the path needs to extend further. The availability depends
      * on the block taken by the train after the end of the given path.  */
-    class NotEnoughLookahead : Availability()
+    class NotEnoughLookaheadError : RuntimeException()
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/ConditionalOccupancyTests.kt
@@ -1,0 +1,178 @@
+package fr.sncf.osrd.stdcm
+
+import com.google.common.collect.ImmutableMultimap
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class ConditionalOccupancyTests {
+
+    @Test
+    fun straightPathSimpleConditionalOccupancyTest() {
+        /*
+                 #     x
+        a --> b --> c --> d
+
+        #: conditional occupancy
+        x: occupancy
+         */
+
+        val infra = DummyInfra()
+        val block1 = infra.addBlock("a", "b")
+        val block2 = infra.addBlock("b", "c")
+        val unavailableBlock = infra.addBlock("c", "d")
+        val occupancyGraph = ImmutableMultimap.of(
+            block2, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock),
+        )
+
+        //No conflicts
+        val res1 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+            .run()
+        assertNotNull(res1)
+
+        //Conflict
+        val res2 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters))))
+            .run()
+        assertNull(res2)
+    }
+
+    @Test
+    fun simpleConditionalOccupancyTest() {
+        /*
+
+                 x
+                --> d
+           #   /
+        a --> b --> c
+
+        #: conditional occupancy
+        x: occupancy
+         */
+
+        val infra = DummyInfra()
+        val block1 = infra.addBlock("a", "b")
+        val block2 = infra.addBlock("b", "c")
+        val unavailableBlock = infra.addBlock("b", "d")
+        val occupancyGraph = ImmutableMultimap.of(
+            block1, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block2),
+        )
+
+        //No conflicts
+        val res1 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+            .run()
+        assertNotNull(res1)
+
+        //Conflict
+        val res2 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters))))
+            .run()
+        assertNull(res2)
+    }
+
+    @Test
+    fun recursiveConditionalOccupanciesTest() {
+        /*
+                                         x
+                                        --> i
+                 #     #     #     #   /
+                --> d --> e --> f --> g --> h
+           #   /
+        a --> b --> c
+
+        #: conditional occupancy
+        x: occupancy
+         */
+        val infra = DummyInfra()
+        val block1 = infra.addBlock("a", "b")
+        val block2 = infra.addBlock("b", "c")
+        val block3 = infra.addBlock("b", "d")
+        val block4 = infra.addBlock("d", "e")
+        val block5 = infra.addBlock("e", "f")
+        val block6 = infra.addBlock("f", "g")
+        val block7 = infra.addBlock("g", "h")
+        val unavailableBlock = infra.addBlock("g", "i")
+        val occupancyGraph = ImmutableMultimap.of(
+            block1, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block2),
+            block3, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block7),
+            block4, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block7),
+            block5, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block7),
+            block6, OccupancySegment(0.0, Double.POSITIVE_INFINITY, 0.meters, 100.meters, unavailableBlock, block7),
+        )
+
+        //End location on b --> c: no conflict
+        val res1 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(block2, Offset(50.meters))))
+            .run()
+        assertNotNull(res1)
+
+        //End location on d --> e: no conflict
+        val res2 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(block4, Offset(50.meters))))
+            .run()
+        assertNotNull(res2)
+
+        //End location on g --> h: no conflict
+        val res3 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(block7, Offset(50.meters))))
+            .run()
+        assertNotNull(res3)
+
+        //End location on g --> i: conflict
+        val res4 = initBuilder(infra.fullInfra(), occupancyGraph, block1)
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(unavailableBlock, Offset(50.meters))))
+            .run()
+        assertNull(res4)
+    }
+
+    @Test
+    fun avoidConditionalOccupancy() {
+        /*
+                 #     x
+        a --> b --> c --> d
+
+        #: conditional occupancy
+        x: occupancy
+
+        Test that we can avoid the occupancy by adding delay
+         */
+
+        val infra = DummyInfra()
+        val blocks = listOf(
+            infra.addBlock("a", "b"),
+            infra.addBlock("b", "c"),
+            infra.addBlock("c", "d")
+        )
+        val occupancyGraph = ImmutableMultimap.of(
+            blocks[0], OccupancySegment(0.0, 3600.0, 0.meters, 100.meters, blocks[2]),
+        )
+
+        val res = STDCMPathfindingBuilder()
+            .setInfra(infra.fullInfra())
+            .setUnavailableTimes(occupancyGraph)
+            .setStartLocations(setOf(Pathfinding.EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(Pathfinding.EdgeLocation(blocks[2], Offset(50.meters))))
+            .run()!!
+        assertTrue { res.departureTime + res.envelope.totalTime >= 3600 }
+    }
+
+    private fun initBuilder(
+        fullInfra: FullInfra,
+        occupancyGraph: ImmutableMultimap<BlockId, OccupancySegment>,
+        startBlock: BlockId
+    ): STDCMPathfindingBuilder {
+        return STDCMPathfindingBuilder()
+            .setInfra(fullInfra)
+            .setUnavailableTimes(occupancyGraph)
+            .setStartLocations(setOf(Pathfinding.EdgeLocation(startBlock, Offset(0.meters))))
+    }
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -5,7 +5,6 @@ import com.google.common.collect.Multimap
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.graph.Pathfinding
-import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId


### PR DESCRIPTION
Fixes #6275 & #6274.
Modify `BlockAvailabilityLegacyAdapter` to handle conditional `OccupancySegment` objects, so as to use them in tests for `NotEnoughLookahead`.