### PR TITLE
Refine allowance tolerances

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -17,6 +17,7 @@ public final class TrainPhysicsIntegrator {
     private static final double SPEED_EPSILON = 1E-5;
     // An acceleration lower than this value will be considered zero
     private static final double ACCELERATION_EPSILON = 1E-5;
+    private static final double TIME_EPSILON = 1E-5;
 
     private final PhysicsRollingStock rollingStock;
     private final PhysicsPath path;
@@ -187,6 +188,11 @@ public final class TrainPhysicsIntegrator {
     /** Returns true if the accelerations' difference is lower than an epsilon */
     public static boolean areAccelerationsEqual(double a, double b) {
         return areDoublesEqual(a, b, ACCELERATION_EPSILON);
+    }
+
+    /** Returns true if the times' difference is lower than an epsilon */
+    public static boolean areTimesEqual(double a, double b) {
+        return areDoublesEqual(a, b, TIME_EPSILON);
     }
 
     private static boolean areDoublesEqual(double a, double b, double delta) {

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -190,13 +190,13 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             var envelopeRange = Envelope.make(envelopeRegion.slice(range.beginPos, range.endPos));
             var imposedBeginSpeed = imposedTransitionSpeeds[rangeIndex];
             var imposedEndSpeed = imposedTransitionSpeeds[rangeIndex + 1];
-            var tolerance = context.timeStep * envelopeRange.getTotalTime() / envelopeRegion.getTotalTime();
+            var rangeRatio = envelopeRange.getTotalTime() / envelopeRegion.getTotalTime();
+            var tolerance = context.timeStep * rangeRatio;
             var allowanceRange =
                     computeAllowanceRange(envelopeRange, context, range.value, imposedBeginSpeed, imposedEndSpeed,
                             tolerance);
             // memorize the beginning and end speeds
-            imposedTransitionSpeeds[rangeIndex] =
-                    allowanceRange.getBeginSpeed(); // shouldn't we check if it's the same ?
+            imposedTransitionSpeeds[rangeIndex] = allowanceRange.getBeginSpeed();
             imposedTransitionSpeeds[rangeIndex + 1] = allowanceRange.getEndSpeed();
             res[rangeIndex] = allowanceRange;
         }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -175,7 +175,7 @@ public class AllowanceTests {
         var allowanceEnvelope = allowance.apply(base, context);
         var marginTime = allowanceEnvelope.getTotalTime();
         var targetTime = allowance.getTargetTime(base);
-        assertEquals(marginTime, targetTime, 2 * TIME_STEP);
+        assertEquals(marginTime, targetTime, context.timeStep);
     }
 
     private void testTransitionPoints(
@@ -197,8 +197,8 @@ public class AllowanceTests {
         var expectedTimeEndPoint = timeEndPointBase + allowance.getAddedTime(base);
 
         // make sure begin has the same time before and after margin, and that end is offset by the proper value
-        assertEquals(timeBeginPointBase, timeBeginPoint, 5 * TIME_STEP);
-        assertEquals(expectedTimeEndPoint, timeEndPoint, 5 * TIME_STEP);
+        assertEquals(timeBeginPointBase, timeBeginPoint, context.timeStep);
+        assertEquals(expectedTimeEndPoint, timeEndPoint, context.timeStep);
 
         var speedBeginPointBase = base.interpolateSpeed(beginPos);
         var speedEndPointBase = base.interpolateSpeed(endPos);
@@ -384,10 +384,10 @@ public class AllowanceTests {
         var engineeringAllowanceAddedTime = engineeringAllowance.getAddedTime(standardEnvelope);
         var targetTime = baseTime + standardAllowanceAddedTime + engineeringAllowanceAddedTime;
         var marginTime = engineeringEnvelope.getTotalTime();
-        assertEquals(marginTime, targetTime, 5 * TIME_STEP);
+        assertEquals(marginTime, targetTime, 2 * context.timeStep);
 
         var engineeringAllowanceTargetTime = engineeringAllowance.getTargetTime(standardEnvelope);
-        assertEquals(marginTime, engineeringAllowanceTargetTime, 5 * TIME_STEP);
+        assertEquals(marginTime, engineeringAllowanceTargetTime, context.timeStep);
 
     }
 
@@ -427,7 +427,7 @@ public class AllowanceTests {
                 + allowanceA.getAddedTime(maxEffortEnvelope)
                 + allowanceB.getAddedTime(maxEffortEnvelope);
         var marginTime = engineeringEnvelopeB.getTotalTime();
-        assertEquals(marginTime, targetTime, 2 * TIME_STEP);
+        assertEquals(marginTime, targetTime, 2 * testContext.timeStep);
     }
 
     /** Test several engineering allowances on segments */
@@ -546,7 +546,7 @@ public class AllowanceTests {
         var marecoEnvelope = allowance.apply(maxEffortEnvelope, testContext);
         var targetTime = allowance.getTargetTime(maxEffortEnvelope);
         var marginTime = marecoEnvelope.getTotalTime();
-        assertEquals(marginTime, targetTime, 2 * TIME_STEP);
+        assertEquals(marginTime, targetTime, testContext.timeStep);
 
         // The train space-speed curve is supposed to follow this complicated shape because of the multiple
         // accelerating slopes.

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -330,7 +330,8 @@ class StandardAllowanceTests {
         occupancyTest(res, occupancyGraph, TIME_STEP)
         val thirdBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(11000.0))
-        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP) // Actually 3 allowances are built
+        // 2 allowances + the extra safety TIME_STEP added when avoiding conflicts gives us 3 * TIME_STEP
+        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
     }
 
     /** Tests a simple path with no conflict, with a time per distance allowance and very low value  */

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -330,7 +330,7 @@ class StandardAllowanceTests {
         occupancyTest(res, occupancyGraph, TIME_STEP)
         val thirdBlockEntryTime = (res.departureTime
                 + res.envelope.interpolateTotalTime(11000.0))
-        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 2 * TIME_STEP)
+        Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP) // Actually 3 allowances are built
     }
 
     /** Tests a simple path with no conflict, with a time per distance allowance and very low value  */


### PR DESCRIPTION
In this PR I offer two changes:

* Change the way we distribute tolerance (today, with too many stops, we can exceed the wanted tolerance, I offer to distribute the tolerance between each section, proportionally to their travel time)
* Change the order in which we compute allowance ranges (today it's from less restrictive to more restrictive, I offer to compute from shortest to largest)

The first commit changes two tests that highlights why I offer to change those behaviors (a test with a short allowance range and a very bug value will fail, and a test with many stops on a path, on top of an allowance accumulates approximation errors)
The next two fix those problems 
The last one updates all tests regarding allowances to change the tolerances in `assertEquals` to be more restrictive

All of those are not atomic, so I'll squash them before merging

EDIT: distributing allowance tolerance according to section relative time makes for a more accurate computation but will make some particular allowances fail (since we'll demand high precision on small ranges (thus a small range with very high allowance value and very high imposed speed will fail). If that's not okay, we may distribute tolerance with a function that favors small values)

