### PR TITLE
provide a undefined/null speed limit when user provide empty field

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedInput.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedInput.tsx
@@ -21,15 +21,16 @@ const SpeedInput: FC<
 
   return (
     <input
-      min={0}
+      min={1}
       step={0.1}
       {...attrs}
       type="number"
       value={kmhSpeed}
       onChange={(e) => {
-        setKmhSpeed(e.target.value);
-        const newKmhSpeed = +e.target.value;
-        const newMsSpeed = isNumber(newKmhSpeed) ? kmhToMs(newKmhSpeed) : undefined;
+        const inputValue = e.target.value;
+        setKmhSpeed(inputValue);
+        const newKmhSpeed = parseFloat(inputValue);
+        const newMsSpeed = Number.isNaN(newKmhSpeed) ? undefined : kmhToMs(newKmhSpeed);
         if (newMsSpeed !== msSpeed) onChange(newMsSpeed);
       }}
     />

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionMetadataForm.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionMetadataForm.tsx
@@ -4,7 +4,7 @@ import { SpeedSectionEntity } from 'types';
 import { AiOutlinePlusCircle } from 'react-icons/ai';
 import { FaTimes } from 'react-icons/fa';
 import { MdSpeed } from 'react-icons/md';
-import { cloneDeep, isEmpty, map, mapKeys, omit } from 'lodash';
+import { cloneDeep, isEmpty, mapKeys, omit } from 'lodash';
 
 import EditorContext from '../../../context';
 import { ExtendedEditorContextType } from '../../editorContextTypes';
@@ -74,8 +74,8 @@ const SpeedSectionMetadataForm: FC = () => {
             {t('Editor.tools.speed-edition.additional-speed-limit')}
           </div>
         )}
-        {map(entity.properties.speed_limit_by_tag || {}, (value, key) => (
-          <div key={key} className="form-group field field-string">
+        {Object.entries(entity.properties.speed_limit_by_tag || {}).map(([key, value], index) => (
+          <div key={index} className="form-group field field-string">
             <div className="d-flex flex-row align-items-center">
               <input
                 required


### PR DESCRIPTION
fix the first problem of [this issue](https://github.com/osrd-project/osrd/issues/6407)

The problem was that the way we converted the values entered in Speed limit field returned 0 when the field was left empty.

How to test ?
- On Infra Editor, load an infra
- Open Speed limit tool (![image](https://github.com/osrd-project/osrd/assets/19575568/0f78ce6f-e964-40bc-9fd8-ad289039c175)
- add some Speed limit with empty key/value
- save and check on network tab of devtools that the payload of the request POST on url http://localhost:4000/api/infra/4/ replace empty speed limit by undefined/null 