### PR TITLE
editor: fixes saving a new speed section

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -118,7 +118,7 @@ function getRangeEditionTool<T extends EditorRange>({
                 )
               );
               const { railjson } = res[0];
-              const { entityId } = railjson;
+              const { id: entityId } = railjson;
 
               const savedEntity =
                 entityId && entityId !== entity.properties.id


### PR DESCRIPTION
Fixes #6413. When saving an entity in Editoast, the returned railjson stores the entity id as `id` and not `entityId`, as the code suggested.