### PR TITLE
core: stdcm: always extend infra explorers lookahead till end of route

### DIFF
--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -193,7 +193,7 @@ class InfraExplorerTests {
         assertEquals(1, blocks.size)
         val block = blocks[0]
 
-        // block 1->2
+        // block 1->2, lookahead 2->3->bx
         var explorers = initInfraExplorer(infra.rawInfra, infra.blockInfra,
             PathfindingEdgeLocationId(block, Offset(0.meters))).toList()
         assertEquals(4, explorers.size) // There should be one instance per route
@@ -204,8 +204,8 @@ class InfraExplorerTests {
             explorers.map { it.getCurrentBlock() }
         ) }
 
-        // block 2->3
-        explorers = explorers.map { extendAndMove(it) }
+        // block 2->3, lookahead 3->bx
+        explorers.forEach { it.moveForward() }
         assertFalse { allEqual(
             explorers.map { it.getLastEdgeIdentifier() }
         ) }
@@ -214,7 +214,7 @@ class InfraExplorerTests {
         ) }
 
         // block 3->b1 and 3->b2
-        explorers = explorers.map { extendAndMove(it) }
+        explorers.forEach { it.moveForward() }
         assertFalse { allEqual(
             explorers.map { it.getLastEdgeIdentifier() }
         ) }
@@ -248,14 +248,5 @@ class InfraExplorerTests {
                 return false
         }
         return true
-    }
-
-    /** Extend lookahead (assuming a single option) and move forward */
-    private fun extendAndMove(explorer: InfraExplorer): InfraExplorer {
-        val all = explorer.cloneAndExtendLookahead()
-        assert(all.size == 1)
-        val extended = all.first()
-        extended.moveForward()
-        return extended
     }
 }


### PR DESCRIPTION
The reasoning is to reduce the number of `NotEnoughLookahead` exceptions, there's no need to restrict the lookahead when we know the direction