### PR TITLE
front: small fix for the search by ci code

### DIFF
--- a/front/src/common/Map/Search/MapSearchStation.tsx
+++ b/front/src/common/Map/Search/MapSearchStation.tsx
@@ -73,8 +73,7 @@ const MapSearchStation = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchS
         if (isSearchingByTrigram) {
           setNameResults([]);
           setTrigramResults(results as SearchResultItemOperationalPoint[]);
-        }
-        if (isSearchingByName) {
+        } else {
           setTrigramResults([]);
           setNameResults(orderResults(results as SearchResultItemOperationalPoint[]));
         }


### PR DESCRIPTION
The results are not displayed when you search an OP by its CI code due to a wrongful condition after the api call.