### PR TITLE
front: editor: fixes electrification edition

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
@@ -45,13 +45,6 @@ export const ElectrificationEditionLayers = () => {
     // Custom hovered element:
     if (hoveredItem?.itemType) return [hoveredItem.track.properties.id];
 
-    // EditorEntity hovered element:
-    if (
-      hoveredItem?.type === 'TrackSection' &&
-      !(entity.properties.track_ranges || []).find((range) => range.track === hoveredItem.id)
-    )
-      return [hoveredItem.id];
-
     return undefined;
   }, [interactionState, hoveredItem, entity]);
 
@@ -203,7 +196,17 @@ export const ElectrificationEditionLayers = () => {
           <Layer {...props} key={i} />
         ))}
         <Layer
+          type="line"
+          id="electrification/track-sections"
+          paint={{
+            'line-dasharray': [3, 3],
+            'line-color': '#000000',
+            'line-width': 1,
+          }}
+        />
+        <Layer
           type="circle"
+          id="electrification/extremities"
           paint={{
             'circle-radius': 4,
             'circle-color': '#fff',

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -16,7 +16,7 @@ import {
 } from 'types/editor';
 import { getNearestPoint } from 'utils/mapHelper';
 import { NEW_ENTITY_ID } from 'applications/editor/data/utils';
-import { PartialOrReducer, Tool } from '../editorContextTypes';
+import { PartialOrReducer, ReadOnlyEditorContextType, Tool } from '../editorContextTypes';
 import { DEFAULT_COMMON_TOOL_STATE } from '../commonToolState';
 import { approximateDistanceWithEditoastData } from '../utils';
 import { LAYER_TO_EDITOAST_DICT, LAYERS_SET, LayerType } from '../types';
@@ -49,6 +49,7 @@ interface RangeEditionToolParams<T extends EditorRange> {
   layersComponent: ComponentType<{ map: Map }>;
   leftPanelComponent: ComponentType;
   canSave?: (state: RangeEditionState<T>) => boolean;
+  getEventsLayers?: (context: ReadOnlyEditorContextType<RangeEditionState<T>>) => string[];
 }
 
 function getRangeEditionTool<T extends EditorRange>({
@@ -59,6 +60,7 @@ function getRangeEditionTool<T extends EditorRange>({
   layersComponent,
   leftPanelComponent,
   canSave,
+  getEventsLayers,
 }: RangeEditionToolParams<T>): Tool<RangeEditionState<T>> {
   const layersEntity = getNewEntity();
   function getInitialState(): RangeEditionState<T> {
@@ -379,14 +381,7 @@ function getRangeEditionTool<T extends EditorRange>({
     getInteractiveLayers() {
       return ['editor/geo/track-main'];
     },
-    getEventsLayers() {
-      return [
-        'editor/geo/track-main',
-        'speed-section/extremities',
-        'speed-section/track-sections',
-        'speed-section/psl/extremities',
-      ];
-    },
+    getEventsLayers,
   };
 }
 

--- a/front/src/applications/editor/tools/rangeEdition/tools.ts
+++ b/front/src/applications/editor/tools/rangeEdition/tools.ts
@@ -25,6 +25,14 @@ export const SpeedEditionTool = getRangeEditionTool<SpeedSectionEntity | SpeedSe
     const compositionCodes = Object.keys(records);
     return compositionCodes.every((code) => !!code);
   },
+  getEventsLayers() {
+    return [
+      'editor/geo/track-main',
+      'speed-section/extremities',
+      'speed-section/track-sections',
+      'speed-section/psl/extremities',
+    ];
+  },
 });
 
 export const ElectrificationEditionTool = getRangeEditionTool<ElectrificationEntity>({
@@ -34,4 +42,11 @@ export const ElectrificationEditionTool = getRangeEditionTool<ElectrificationEnt
   messagesComponent: ElectrificationMessages,
   layersComponent: ElectrificationEditionLayers,
   leftPanelComponent: RangeEditionLeftPanel,
+  getEventsLayers() {
+    return [
+      'editor/geo/track-main',
+      'electrification/extremities',
+      'electrification/track-sections',
+    ];
+  },
 });


### PR DESCRIPTION
This commit fixes #6452. It basically ports recent fix for issue #6368 that was related to speed sections, but now for electrification.

Also, it moves the declaration of edition layers from the tool-factory to each tool, since they differ between speed sections and electrification edition.