### PR TITLE
Adding `OperationalPointIdLocation` as location for POST `/timetable/{id}`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3340,6 +3340,10 @@ components:
       - properties:
           OperationalPointNotFound:
             properties:
+              missing_ids:
+                items:
+                  type: string
+                type: array
               missing_uics:
                 items:
                   format: int64
@@ -3347,6 +3351,7 @@ components:
                 type: array
             required:
             - missing_uics
+            - missing_ids
             type: object
         required:
         - OperationalPointNotFound
@@ -3418,6 +3423,17 @@ components:
             type: integer
         required:
         - uic
+        - type
+        type: object
+      - properties:
+          id:
+            type: string
+          type:
+            enum:
+            - operational_point_id
+            type: string
+        required:
+        - id
         - type
         type: object
     TimetableImportPathSchedule:

--- a/editoast/src/models/infra_objects/operational_point.rs
+++ b/editoast/src/models/infra_objects/operational_point.rs
@@ -3,7 +3,7 @@
 use crate::error::Result;
 use crate::{schema::OperationalPoint, tables::infra_object_operational_point};
 use derivative::Derivative;
-use diesel::sql_types::{Array, BigInt};
+use diesel::sql_types::{Array, BigInt, Text};
 use diesel::{result::Error as DieselError, sql_query};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
@@ -35,6 +35,21 @@ impl OperationalPointModel {
         Ok(sql_query(query)
             .bind::<BigInt, _>(infra_id)
             .bind::<Array<BigInt>, _>(uic)
+            .load(conn)
+            .await?)
+    }
+
+    /// Retrieve a list of operational points from the database
+    pub async fn retrieve_from_obj_ids(
+        conn: &mut PgConnection,
+        infra_id: i64,
+        ids: &[String],
+    ) -> Result<Vec<Self>> {
+        let query = "SELECT * FROM infra_object_operational_point
+                                WHERE infra_id = $1 AND infra_object_operational_point.obj_id = ANY($2)".to_string();
+        Ok(sql_query(query)
+            .bind::<BigInt, _>(infra_id)
+            .bind::<Array<Text>, _>(ids)
             .load(conn)
             .await?)
     }

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -2308,6 +2308,7 @@ export type TimetableImportError =
     }
   | {
       OperationalPointNotFound: {
+        missing_ids: string[];
         missing_uics: number[];
       };
     }
@@ -2335,6 +2336,10 @@ export type TimetableImportPathLocation =
   | {
       type: 'operational_point';
       uic: number;
+    }
+  | {
+      id: string;
+      type: 'operational_point_id';
     };
 export type TimetableImportPathSchedule = {
   arrival_time: string;


### PR DESCRIPTION
close https://github.com/osrd-project/osrd/issues/6182

I propose this solution since it doesn't make the backend use a SNCF extension and we doesn't have to do extra computation to extract the parts of an operational point corresponding to the uic/ch

It is improving the import when we try to respect commercial stops `+7.8%`:
New stats:
<img width="498" alt="image" src="https://github.com/osrd-project/osrd/assets/32448554/29528a5a-c096-4e0c-8c53-2c41ec8dd4e1">
Previous stats:
<img width="498" alt="image" src="https://github.com/osrd-project/osrd/assets/32448554/586e6bd8-4d7d-4b7f-a902-b7c77f12ebc5">

When we try to respect all-waypoints stats are improving too `+8.7%`:
New stats:
<img width="498" alt="image" src="https://github.com/osrd-project/osrd/assets/32448554/fd115d1a-084c-4484-a1f9-2beb443ee533">
Previous stats:
<img width="498" alt="image" src="https://github.com/osrd-project/osrd/assets/32448554/223bb75a-83aa-4286-9e80-af35b07bac32">

Proposal when we have TrainSchedule V2: `obj_id`is equivalent to `uic + ch`
