### PR TITLE
front: fix overlapping names

### DIFF
--- a/front/src/applications/operationalStudies/components/BreadCrumbs.tsx
+++ b/front/src/applications/operationalStudies/components/BreadCrumbs.tsx
@@ -17,28 +17,40 @@ export default function BreadCrumbs({ project, study, scenario }: Props) {
         t('projectsList')
       ) : (
         <>
-          <Link to="/operational-studies/projects">{t('projectsList')}</Link>
+          <div>
+            <Link to="/operational-studies/projects">{t('projectsList')}</Link>{' '}
+          </div>
           <i className="icons-arrow-next icons-size-x75 text-muted" />
         </>
       )}
 
-      {project && !study && !scenario && project.name}
+      {project && !study && !scenario && <div className="text-truncate">{project.name}</div>}
 
       {project && study && (
         <>
-          <Link to={`/operational-studies/projects/${project.id}`}>{project.name}</Link>
+          <div className="text-truncate" title={project.name}>
+            <Link to={`/operational-studies/projects/${project.id}`}> {project.name}</Link>
+          </div>
           <i className="icons-arrow-next icons-size-x75 text-muted" />
         </>
       )}
-      {project && study && !scenario && study.name}
+      {project && study && !scenario && (
+        <div className="text-truncate" title={study.name}>
+          {study.name}
+        </div>
+      )}
 
       {project && study && scenario && (
         <>
-          <Link to={`/operational-studies/projects/${project.id}/studies/${study.id}`}>
-            {study.name}
-          </Link>
+          <div className="text-truncate" title={study.name}>
+            <Link to={`/operational-studies/projects/${project.id}/studies/${study.id}`}>
+              {study.name}
+            </Link>
+          </div>
           <i className="icons-arrow-next icons-size-x75 text-muted" />
-          {scenario.name}
+          <div className="text-truncate" title={scenario.name}>
+            {scenario.name}
+          </div>
         </>
       )}
     </div>

--- a/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
@@ -44,7 +44,9 @@ export const ProjectMiniCard = ({ project, setSelectedID, isSelected }: MiniCard
     <div className="minicard-img">
       <Project2Image project={project} />
     </div>
-    <div>{project.name}</div>
+    <div className="text-truncate" title={project.name}>
+      {project.name}
+    </div>
   </div>
 );
 
@@ -58,7 +60,9 @@ export const StudyMiniCard = ({ study, setSelectedID, isSelected }: MiniCardStud
     tabIndex={0}
     onClick={() => setSelectedID(study.id)}
   >
-    <div>{study.name}</div>
+    <div className="text-truncate" title={study.name}>
+      {study.name}
+    </div>
   </div>
 );
 

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -120,12 +120,20 @@ const ScenarioExplorer = ({
             <div className="scenario-explorator-card-head-content-item">
               <img src={projectIcon} alt="project icon" />
               <span className="scenario-explorator-card-head-legend">{t('projectLegend')}</span>
-              <div className="scenario-explorator-card-head-project">{projectDetails.name}</div>
+              <div className="scenario-explorator-card-head-project">
+                <span className="text-truncate" title={projectDetails.name}>
+                  {projectDetails.name}
+                </span>
+              </div>
             </div>
             <div className="scenario-explorator-card-head-content-item">
               <img src={studyIcon} alt="study icon" />
               <span className="scenario-explorator-card-head-legend">{t('studyLegend')}</span>
-              <div className="scenario-explorator-card-head-study">{studyDetails.name}</div>
+              <div className="scenario-explorator-card-head-study">
+                <span className="text-truncate" title={studyDetails.name}>
+                  {studyDetails.name}
+                </span>
+              </div>
             </div>
             <div className="scenario-explorator-card-head-content-item">
               <img src={scenarioIcon} alt="scenario icon" />

--- a/front/src/modules/scenario/styles/_scenarioExplorer.scss
+++ b/front/src/modules/scenario/styles/_scenarioExplorer.scss
@@ -73,9 +73,11 @@
           border-radius: 0 4px 4px 0;
           background-color: var(--purple);
           width: 100%;
+          overflow: hidden;
         }
         .scenario-explorator-card-head-study {
           background-color: var(--primary);
+          overflow: hidden;
         }
         .scenario-explorator-card-head-scenario {
           display: flex;

--- a/front/src/styles/scss/_body.scss
+++ b/front/src/styles/scss/_body.scss
@@ -94,7 +94,7 @@ body {
   align-items: center;
   gap: 0.5rem;
   font-size: 1.25rem;
-  line-height: 1rem;
+  max-width: 84vw;
   a {
     color: var(--coolgray7);
     &:hover {


### PR DESCRIPTION
closes #6444 

<img width="1470" alt="Capture d’écran 2024-01-29 à 15 48 44" src="https://github.com/osrd-project/osrd/assets/80635161/5cf8a429-beec-4efd-b894-6546d655e9ef">

<img width="794" alt="Capture d’écran 2024-01-29 à 15 44 46" src="https://github.com/osrd-project/osrd/assets/80635161/f2724df2-a131-4c92-aad9-e427d662443a">

<img width="485" alt="Capture d’écran 2024-01-29 à 15 44 23" src="https://github.com/osrd-project/osrd/assets/80635161/5ecd7e2d-a307-41fa-b7de-e061ef7846dd">
