### PR TITLE
front: searchrollingstock: fix rollingstock list showing loader when empty

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
@@ -171,9 +171,7 @@ const SearchRollingStock = ({
   }, [isSuccess]);
 
   useEffect(() => {
-    if (rollingStocks && rollingStocks.length !== 0) {
-      updateSearch();
-    }
+    updateSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, rollingStocks]);
 


### PR DESCRIPTION
- remove condition verifying if rollingstock list length is true
- the loader is still well displayed while searching

to try it you can drop rolling_stock table and test it in a scenario or stop editoast and open the rollingstock editor

close #6013 