### PR TITLE
core: fix gauge loading from railjson

### DIFF
--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/RJSTrackSection.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.railjson.schema.infra;
 
+import com.squareup.moshi.Json;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.common.Identified;
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString;
@@ -15,6 +16,8 @@ public class RJSTrackSection implements Identified {
 
     public List<RJSSlope> slopes;
     public List<RJSCurve> curves;
+
+    @Json(name = "loading_gauge_limits")
     public List<RJSLoadingGaugeLimit> loadingGaugeLimits;
 
     public RJSLineString geo;

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSLoadingGaugeLimit.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSLoadingGaugeLimit.java
@@ -5,11 +5,11 @@ import java.util.Objects;
 
 public class RJSLoadingGaugeLimit extends RJSRange {
 
-    public RJSLoadingGaugeType type;
+    public RJSLoadingGaugeType category;
 
-    public RJSLoadingGaugeLimit(double begin, double end, RJSLoadingGaugeType type) {
+    public RJSLoadingGaugeLimit(double begin, double end, RJSLoadingGaugeType category) {
         super(begin, end);
-        this.type = type;
+        this.category = category;
     }
 
     @Override
@@ -17,11 +17,11 @@ public class RJSLoadingGaugeLimit extends RJSRange {
         if (this == o) return true;
         if (!(o instanceof RJSLoadingGaugeLimit that)) return false;
         if (!super.equals(o)) return false;
-        return Objects.equals(type, that.type);
+        return Objects.equals(category, that.category);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type);
+        return Objects.hash(super.hashCode(), category);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -341,7 +341,7 @@ public class UndirectedInfraBuilder {
             var allowedTypes = new HashSet<RJSLoadingGaugeType>();
             for (var range : limits)
                 if (range.begin <= begin && range.end >= end)
-                    allowedTypes.addAll(getCompatibleGaugeTypes(range.type));
+                    allowedTypes.addAll(getCompatibleGaugeTypes(range.category));
             var blockedTypes = Sets.difference(
                     Sets.newHashSet(RJSLoadingGaugeType.values()),
                     allowedTypes

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -363,9 +363,6 @@ private fun makeChunk(
         }
         return res
     }
-    for (entry in DistanceRangeMapImpl.from(rangeViewForward.blockedGaugeTypes)) {
-        entry.value!!.isCompatibleWith(LoadingGaugeTypeId(RJSLoadingGaugeType.G1.ordinal.toUInt()))
-    }
 
     val chunkId = builder.trackChunk(
         rangeViewForward.geo,

--- a/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/range_elements.py
@@ -47,6 +47,17 @@ class Curve(RangeElement):
         return infra.Curve(radius=self.radius, begin=self.begin, end=self.end)
 
 
+class LoadingGaugeLimit(RangeElement):
+    category: infra.LoadingGaugeType
+
+    def __init__(self, begin, end, category):
+        super().__init__(begin, end)
+        self.category = category
+
+    def to_rjs(self):
+        return infra.LoadingGaugeLimit(category=self.category, begin=self.begin, end=self.end)
+
+
 @dataclass
 class TrackRange(RangeElement):
     track: "TrackSection"

--- a/python/railjson_generator/railjson_generator/schema/infra/track_section.py
+++ b/python/railjson_generator/railjson_generator/schema/infra/track_section.py
@@ -8,7 +8,11 @@ from railjson_generator.schema.infra.direction import Direction
 from railjson_generator.schema.infra.endpoint import Endpoint, TrackEndpoint
 from railjson_generator.schema.infra.make_geo_data import make_geo_lines
 from railjson_generator.schema.infra.operational_point import OperationalPointPart
-from railjson_generator.schema.infra.range_elements import Curve, Slope
+from railjson_generator.schema.infra.range_elements import (
+    Curve,
+    LoadingGaugeLimit,
+    Slope,
+)
 from railjson_generator.schema.infra.signal import Signal
 from railjson_generator.schema.infra.switch import SwitchGroup
 from railjson_generator.schema.infra.waypoint import BufferStop, Detector, Waypoint
@@ -43,6 +47,7 @@ class TrackSection:
     end_links: List[Tuple[TrackEndpoint, Optional[SwitchGroup]]] = field(default_factory=list, repr=False)
     slopes: List[Slope] = field(default_factory=list)
     curves: List[Curve] = field(default_factory=list)
+    loading_gauge_limits: List[LoadingGaugeLimit] = field(default_factory=list)
 
     def begin(self):
         return TrackEndpoint(self, Endpoint.BEGIN)
@@ -70,6 +75,9 @@ class TrackSection:
 
     def add_curve(self, begin, end, curve):
         self.curves.append(Curve(begin, end, curve))
+
+    def add_loading_gauge_limit(self, begin, end, category):
+        self.loading_gauge_limits.append(LoadingGaugeLimit(begin, end, category))
 
     def sort_waypoints(self):
         self.waypoints.sort(key=lambda w: w.position)
@@ -111,6 +119,7 @@ class TrackSection:
             length=self.length,
             slopes=[slope.to_rjs() for slope in self.slopes],
             curves=[curve.to_rjs() for curve in self.curves],
+            loading_gauge_limits=[loading_gauge_limit.to_rjs() for loading_gauge_limit in self.loading_gauge_limits],
             **geo_data,
             extensions={
                 "sncf": {

--- a/tests/data/infras/circle_infra/infra.json
+++ b/tests/data/infras/circle_infra/infra.json
@@ -105,6 +105,7 @@
             "length": 200.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -145,6 +146,7 @@
             "length": 200.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -185,6 +187,7 @@
             "length": 200.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -225,6 +228,7 @@
             "length": 200.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,

--- a/tests/data/infras/example_script/infra.json
+++ b/tests/data/infras/example_script/infra.json
@@ -525,6 +525,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -565,6 +566,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -605,6 +607,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -645,6 +648,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -685,6 +689,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -725,6 +730,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -765,6 +771,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,

--- a/tests/data/infras/one_line/infra.json
+++ b/tests/data/infras/one_line/infra.json
@@ -562,6 +562,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -602,6 +603,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -642,6 +644,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -682,6 +685,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -722,6 +726,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -762,6 +767,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -802,6 +808,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -842,6 +849,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -882,6 +890,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -922,6 +931,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -1783,6 +1783,23 @@
             "length": 2000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [
+                {
+                    "category": "GB1",
+                    "begin": 0.0,
+                    "end": 200.0
+                },
+                {
+                    "category": "G1",
+                    "begin": 200.0,
+                    "end": 1900.0
+                },
+                {
+                    "category": "FR3.3",
+                    "begin": 100.0,
+                    "end": 1500.0
+                }
+            ],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -1823,6 +1840,7 @@
             "length": 1950.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -1863,6 +1881,7 @@
             "length": 1950.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -1903,6 +1922,7 @@
             "length": 50.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -1943,6 +1963,7 @@
             "length": 50.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -1983,6 +2004,7 @@
             "length": 50.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 424242,
@@ -2054,6 +2076,7 @@
                 }
             ],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2125,6 +2148,7 @@
                 }
             ],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2181,6 +2205,7 @@
             "length": 3000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 414141,
@@ -2237,6 +2262,7 @@
             "length": 1050.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2277,6 +2303,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2317,6 +2344,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2373,6 +2401,7 @@
             "length": 1050.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2444,6 +2473,7 @@
                 }
             ],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2515,6 +2545,7 @@
                 }
             ],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2555,6 +2586,7 @@
             "length": 2000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2603,6 +2635,7 @@
             "length": 3000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -2662,6 +2695,7 @@
                     "end": 1000.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2702,6 +2736,7 @@
             "length": 3.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2764,6 +2799,7 @@
                     "end": 4400.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2831,6 +2867,7 @@
                     "end": 2000.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2871,6 +2908,7 @@
             "length": 2050.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2948,6 +2986,7 @@
                     "end": 2000.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 444444,
@@ -2996,6 +3035,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -3076,6 +3116,7 @@
             "length": 4000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 454545,
@@ -3148,6 +3189,7 @@
             "length": 3000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 454545,
@@ -3188,6 +3230,7 @@
             "length": 50.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
@@ -3228,6 +3271,7 @@
             "length": 2000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
@@ -3268,6 +3312,7 @@
             "length": 2000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 464646,
@@ -3316,6 +3361,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 434343,
@@ -3380,6 +3426,7 @@
             "length": 5000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 474647,

--- a/tests/data/infras/three_trains/infra.json
+++ b/tests/data/infras/three_trains/infra.json
@@ -398,6 +398,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -438,6 +439,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -478,6 +480,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -518,6 +521,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -558,6 +562,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -598,6 +603,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -638,6 +644,7 @@
             "length": 1000.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,

--- a/tests/data/infras/tiny_infra/infra.json
+++ b/tests/data/infras/tiny_infra/infra.json
@@ -271,6 +271,7 @@
                     "end": 200.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -323,6 +324,7 @@
                     "end": 200.0
                 }
             ],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -363,6 +365,7 @@
             "length": 200.0,
             "slopes": [],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,
@@ -414,6 +417,7 @@
                 }
             ],
             "curves": [],
+            "loading_gauge_limits": [],
             "extensions": {
                 "sncf": {
                     "line_code": 0,

--- a/tests/infra-scripts/small_infra.py
+++ b/tests/infra-scripts/small_infra.py
@@ -6,6 +6,7 @@ For more information, and a diagram of this infrastructure, see: https://osrd.fr
 """
 from typing import Mapping, Optional, Tuple
 
+from osrd_schemas.infra import LoadingGaugeType
 from railjson_generator import (
     ApplicableDirection,
     ExternalGeneratedInputs,
@@ -196,6 +197,11 @@ ta6.add_slope(begin=7700, end=8000, slope=3)
 ta7.add_slope(begin=7000, end=7300, slope=3)
 ta7.add_slope(begin=7300, end=7700, slope=6)
 ta7.add_slope(begin=7700, end=8000, slope=3)
+
+# Loading Gauge Limits
+ta0.add_loading_gauge_limit(begin=0, end=200, category=LoadingGaugeType.GB1)
+ta0.add_loading_gauge_limit(begin=200, end=1900, category=LoadingGaugeType.G1)
+ta0.add_loading_gauge_limit(begin=100, end=1500, category=LoadingGaugeType.FR3_3)
 
 # ================================
 #  Around station B: South-West


### PR DESCRIPTION
Add corresponding tests: adapt existing tests to read railjson instead of modifying gauge constraints after read (add gauge in railjson generator).
⚠️ this will add gauge constraints to `TA0` in small_infra.

Also:
* remove useless code in RawInfraAdapter.kt