### PR TITLE
core: add instrumentation around HTTP endpoints (OTEL, Datadog)

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -12,6 +12,8 @@ RUN gradle shadowJar --no-daemon && \
 FROM eclipse-temurin:17 AS running_env
 
 COPY --from=build_env /home/gradle/src/build/libs/osrd-all.jar /app/osrd_core.jar
+ADD 'https://dtdg.co/latest-java-tracer' /app/dd-java-agent.jar
+ADD 'https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar' /app/opentelemetry-javaagent.jar
 
 ARG OSRD_GIT_DESCRIBE
 ENV OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,6 +71,14 @@ dependencies {
     // Sentry
     implementation libs.sentry
 
+    // OpenTelemetry
+    implementation libs.opentelemetry.api
+    implementation libs.opentelemetry.instrumentation.annotations
+
+    // DataDog
+    implementation 'io.opentracing:opentracing-util:0.33.0'
+    implementation 'com.datadoghq:dd-trace-api:1.28.0'
+
     // Geographic computations
     implementation libs.geodesy
 

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ logback = '1.4.+'
 moshi = '1.15.1'
 junit = '5.10.+'
 mockito = '5.2.+'
+otel = '1.34.1'
 
 [libraries]
 # kotlin stuff
@@ -62,6 +63,8 @@ jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' }  # 
 spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' }  # LGPLv2.1
 geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' }  # Apache 2.0
 
+opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
+opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.0.0' }
 
 [plugins]
 # kotlin

--- a/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
@@ -1,0 +1,36 @@
+package fr.sncf.osrd.cli
+
+import datadog.trace.api.Trace
+import io.opentracing.tag.Tags
+import io.opentracing.util.GlobalTracer
+import org.takes.Request
+import org.takes.Response
+import org.takes.Take
+import org.takes.rq.RqHref
+import org.takes.rq.RqMethod
+import org.takes.rs.RsStatus
+import org.takes.tk.TkWrap
+
+class TkDataDog(take: Take) : TkWrap(Take { request: Request -> datadog(take, request) }) {
+    companion object {
+        @Trace
+        private fun datadog(take: Take, request: Request): Response {
+            val span = GlobalTracer.get().activeSpan()
+            val method = RqMethod.Base(request).method()
+            span.setTag(Tags.HTTP_METHOD, method)
+            val path = RqHref.Base(request).href().path()
+            span.setTag(Tags.HTTP_URL, path)
+
+            val response = take.act(request)
+            val statusCode = RsStatus.Base(response).status()
+            span.setTag(Tags.HTTP_STATUS, statusCode)
+            if (statusCode < 400) {
+                span.setTag(Tags.ERROR, true)
+            } else {
+                span.setTag(Tags.ERROR, false)
+            }
+
+            return response
+        }
+    }
+}

--- a/core/src/main/java/fr/sncf/osrd/cli/TkOpenTelemetry.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/TkOpenTelemetry.kt
@@ -1,0 +1,39 @@
+package fr.sncf.osrd.cli
+
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import org.takes.Request
+import org.takes.Response
+import org.takes.Take
+import org.takes.rq.RqHref
+import org.takes.rq.RqMethod
+import org.takes.rs.RsStatus
+import org.takes.tk.TkWrap
+
+class TkOpenTelemetry(take: Take) :
+    TkWrap(Take { request: Request -> opentelemetry(take, request) }) {
+    companion object {
+        @WithSpan(value = "endpoint", kind = SpanKind.SERVER)
+        private fun opentelemetry(take: Take, request: Request): Response {
+            val span = Span.current()
+            val method = RqMethod.Base(request).method()
+            span.setAttribute("http.request.method", method)
+            val path = RqHref.Base(request).href().path()
+            span.setAttribute("url.path", path)
+
+            val response = take.act(request)
+
+            val statusCode = RsStatus.Base(response).status()
+            span.setAttribute("http.response.status_code", statusCode.toLong())
+            if (statusCode < 400) {
+                span.setStatus(StatusCode.OK)
+            } else {
+                span.setStatus(StatusCode.ERROR)
+            }
+
+            return response
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,7 @@ services:
     restart: unless-stopped
     ports:
       - "4317:4317"
+      - "4318:4318"
       - "16686:16686"
 
   wait-healthy:


### PR DESCRIPTION
First version, first Kotlin and Java in a while, first time with Takes' framework.

Things to know if you want to test:
- add `export JAVA_TOOL_OPTIONS=-javaagent:opentelemetry-javaagent.jar` (or Datadog Java agent, look at the Dockerfile for where to download)
- add `export OSRD_CORE_MONITOR_TYPE=opentelemetry` (or `datadog`)
- launch `jaeger`

I'm not sure it's the best architectural design to configure and switch between Datadog and OpenTelemetry.
The steps above might need to be documented somewhere, but not sure where? They will end up in our deployment process I believe (https://github.com/osrd-project/osrd-chart).