### PR TITLE
editoast: timetable-import: add PF and Sim timing to the endpoint's response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -664,6 +664,17 @@ components:
     Identifier:
       description: A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.
       type: string
+    ImportTimings:
+      properties:
+        pathfinding:
+          format: double
+          nullable: true
+          type: number
+        simulation:
+          format: double
+          nullable: true
+          type: number
+      type: object
     Infra:
       properties:
         created:
@@ -3447,15 +3458,6 @@ components:
       required:
       - location
       type: object
-    TimetableImportReport:
-      properties:
-        errors:
-          additionalProperties:
-            $ref: '#/components/schemas/TimetableImportError'
-          type: object
-      required:
-      - errors
-      type: object
     TimetableImportTrain:
       properties:
         departure_time:
@@ -3509,6 +3511,17 @@ components:
       - track
       - begin
       - end
+      type: object
+    TrainImportReport:
+      properties:
+        error:
+          allOf:
+          - $ref: '#/components/schemas/TimetableImportError'
+          nullable: true
+        timings:
+          $ref: '#/components/schemas/ImportTimings'
+      required:
+      - timings
       type: object
     TrainSchedule:
       properties:
@@ -6072,7 +6085,9 @@ paths:
       tags:
       - timetable
     post:
-      description: Import a timetable
+      description: |-
+        Import a timetable
+        Returns data about the import for each train imported
       parameters:
       - description: Timetable id
         in: path
@@ -6096,7 +6111,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimetableImportReport'
+                additionalProperties:
+                  $ref: '#/components/schemas/TrainImportReport'
+                type: object
           description: Import report
       summary: Import a timetable
       tags:

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -433,34 +433,24 @@ async fn call_core_pf_and_save_result(
         .with_waypoints(&mut waypoints)
         .with_rolling_stocks(&mut rolling_stocks);
     let steps_duration = payload.steps.iter().map(|step| step.duration).collect();
-    run_pathfinding(
-        &path_request,
-        core.as_ref(),
-        conn,
-        infra_id,
-        update_id,
-        steps_duration,
-    )
-    .await
+    let path_response = path_request.fetch(&core).await?;
+    save_core_pathfinding(path_response, conn, infra_id, update_id, steps_duration).await
 }
 
-/// Run a pathfinding request and store the result in the DB
+/// Turn a core pathfinding response into a [Pathfinding] model and store it in the DB
 /// If `update_id` is provided then update the corresponding path instead of creating a new one
-pub async fn run_pathfinding(
-    path_request: &CorePathfindingRequest,
-    core: &CoreClient,
+pub async fn save_core_pathfinding(
+    core_response: PathfindingResponse,
     conn: &mut PgConnection,
     infra_id: i64,
     update_id: Option<i64>,
     steps_duration: Vec<f64>,
 ) -> Result<Pathfinding> {
-    assert_eq!(steps_duration.len(), path_request.nb_waypoints());
-    let response = path_request.fetch(core).await?;
-    let response_track_map = response.fetch_track_map(infra_id, conn).await?;
-    let response_op_map = response.fetch_op_map(infra_id, conn).await?;
+    let response_track_map = core_response.fetch_track_map(infra_id, conn).await?;
+    let response_op_map = core_response.fetch_op_map(infra_id, conn).await?;
     let pathfinding = Pathfinding::from_core_response(
         steps_duration,
-        response,
+        core_response,
         &response_track_map,
         &response_op_map,
     )?;

--- a/editoast/src/views/timetable/import.rs
+++ b/editoast/src/views/timetable/import.rs
@@ -19,7 +19,7 @@ use crate::models::{
 };
 use crate::schema::rolling_stock::{RollingStock, RollingStockComfortType};
 use crate::views::infra::{call_core_infra_state, InfraState};
-use crate::views::pathfinding::run_pathfinding;
+use crate::views::pathfinding::save_core_pathfinding;
 use crate::views::train_schedule::process_simulation_response;
 use actix_web::web::Json;
 use chrono::Timelike;
@@ -36,7 +36,8 @@ crate::schemas! {
     TimetableImportPathSchedule,
     TimetableImportPathLocation,
     TimetableImportTrain,
-    TimetableImportReport,
+    TrainImportReport,
+    ImportTimings,
     TimetableImportError,
 }
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -51,10 +52,34 @@ impl TimetableImportItem {
     pub fn report_error(
         &self,
         error: TimetableImportError,
-    ) -> HashMap<String, TimetableImportError> {
+        timings: ImportTimings,
+    ) -> HashMap<String, TrainImportReport> {
         self.trains
             .iter()
-            .map(|train| (train.name.clone(), TrainImportReport::new(error.clone())))
+            .map(|train| {
+                (
+                    train.name.clone(),
+                    TrainImportReport {
+                        error: Some(error.clone()),
+                        timings: timings.clone(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    pub fn report_success(&self, timings: ImportTimings) -> HashMap<String, TrainImportReport> {
+        self.trains
+            .iter()
+            .map(|train| {
+                (
+                    train.name.clone(),
+                    TrainImportReport {
+                        error: None,
+                        timings: timings.clone(),
+                    },
+                )
+            })
             .collect()
     }
 }
@@ -85,8 +110,15 @@ pub enum TimetableImportPathLocation {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-struct TimetableImportReport {
-    errors: HashMap<String, TimetableImportError>,
+pub struct TrainImportReport {
+    error: Option<TimetableImportError>,
+    timings: ImportTimings,
+}
+
+#[derive(Debug, Serialize, ToSchema, Default, Clone)]
+pub struct ImportTimings {
+    pub pathfinding: Option<f64>,
+    pub simulation: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -120,13 +152,14 @@ struct OperationalPointsToParts {
 }
 
 /// Import a timetable
+/// Returns data about the import for each train imported
 #[utoipa::path(
     tag = "timetable",
     params(
         ("id" = u64, Path, description = "Timetable id"),
     ),
     responses(
-        (status = 200, description = "Import report", body = TimetableImportReport),
+        (status = 200, description = "Import report", body = HashMap<String, TrainImportReport>),
     ),
 )]
 #[post("")]
@@ -135,7 +168,7 @@ pub async fn post_timetable(
     timetable_id: Path<i64>,
     core_client: Data<CoreClient>,
     data: Json<Vec<TimetableImportItem>>,
-) -> Result<Json<TimetableImportReport>> {
+) -> Result<Json<HashMap<String, TrainImportReport>>> {
     let timetable_id = timetable_id.into_inner();
     let mut conn = db_pool.get().await?;
 
@@ -160,10 +193,10 @@ pub async fn post_timetable(
         return Err(TimetableError::InfraNotLoaded { infra_id }.into());
     }
 
-    let mut errors = HashMap::new();
+    let mut reports = HashMap::new();
 
     for item in data.into_inner() {
-        errors.extend(
+        reports.extend(
             import_item(
                 infra_id,
                 &infra_version,
@@ -176,7 +209,15 @@ pub async fn post_timetable(
         );
     }
 
-    Ok(Json(TimetableImportReport { errors }))
+    Ok(Json(reports))
+}
+
+macro_rules! time_execution {
+    ($s:expr) => {{
+        let timer = std::time::Instant::now();
+        let res = $s;
+        (res, timer.elapsed().as_secs_f64())
+    }};
 }
 
 async fn import_item(
@@ -186,15 +227,17 @@ async fn import_item(
     import_item: TimetableImportItem,
     timetable_id: i64,
     core_client: &CoreClient,
-) -> Result<HashMap<String, TimetableImportError>> {
+) -> Result<HashMap<String, TrainImportReport>> {
+    let mut timings = ImportTimings::default();
     let Some(rolling_stock_model) =
         RollingStockModel::retrieve_by_name(conn, import_item.rolling_stock.clone()).await?
     else {
-        return Ok(
-            import_item.report_error(TimetableImportError::RollingStockNotFound {
+        return Ok(import_item.report_error(
+            TimetableImportError::RollingStockNotFound {
                 name: import_item.rolling_stock.clone(),
-            }),
-        );
+            },
+            timings.clone(),
+        ));
     };
     let rolling_stock_id = rolling_stock_model.id.unwrap();
     let rollingstock_version = rolling_stock_model.version;
@@ -209,7 +252,7 @@ async fn import_item(
     let op_to_parts = match find_operation_points(&ops_uic, &ops_id, infra_id, conn).await? {
         Ok(op_to_parts) => op_to_parts,
         Err(err) => {
-            return Ok(import_item.report_error(err.clone()));
+            return Ok(import_item.report_error(err.clone(), timings.clone()));
         }
     };
     // Create waypoints
@@ -219,28 +262,24 @@ async fn import_item(
     // Run pathfinding
     // TODO: Stops duration should be associated to trains not path
     let steps_duration = vec![0.; pf_request.nb_waypoints()];
-    let path_response = match run_pathfinding(
-        &pf_request,
-        core_client,
-        conn,
-        infra_id,
-        None,
-        steps_duration,
-    )
-    .await
-    {
-        Ok(path_response) => path_response,
+    let (raw_path_response, elapsed) = time_execution!(pf_request.fetch(core_client).await);
+    timings.pathfinding = Some(elapsed);
+    let pathfinding_result = match raw_path_response {
         Err(error) => {
-            return Ok(
-                import_item.report_error(TimetableImportError::PathfindingError {
+            return Ok(import_item.report_error(
+                TimetableImportError::PathfindingError {
                     cause: error.clone(),
-                }),
-            );
+                },
+                timings.clone(),
+            ));
+        }
+        Ok(raw_path_response) => {
+            save_core_pathfinding(raw_path_response, conn, infra_id, None, steps_duration).await?
         }
     };
-    let path_id = path_response.id;
+    let path_id = pathfinding_result.id;
 
-    let waypoint_offsets: Vec<_> = path_response
+    let waypoint_offsets: Vec<_> = pathfinding_result
         .payload
         .path_waypoints
         .iter()
@@ -248,7 +287,7 @@ async fn import_item(
         .map(|pw| pw.path_offset)
         .collect();
 
-    let mut fake_stops: Vec<_> = path_response
+    let mut fake_stops: Vec<_> = pathfinding_result
         .payload
         .path_waypoints
         .clone()
@@ -269,17 +308,20 @@ async fn import_item(
         &mut fake_stops,
         &rolling_stock,
         infra_id,
-        path_response,
+        pathfinding_result,
     );
     // Run the simulation
-    let response_payload = match request.fetch(core_client).await {
+    let (response_payload, elapsed) = time_execution!(request.fetch(core_client).await);
+    timings.simulation = Some(elapsed);
+    let response_payload = match response_payload {
         Ok(response_payload) => response_payload,
         Err(error) => {
-            return Ok(
-                import_item.report_error(TimetableImportError::SimulationError {
+            return Ok(import_item.report_error(
+                TimetableImportError::SimulationError {
                     cause: error.clone(),
-                }),
-            );
+                },
+                timings.clone(),
+            ));
         }
     };
 
@@ -308,7 +350,7 @@ async fn import_item(
         sim_output.create_conn(conn).await?;
     }
 
-    Ok(HashMap::new())
+    Ok(import_item.report_success(timings))
 }
 
 async fn find_operation_points(

--- a/editoast/src/views/timetable/import.rs
+++ b/editoast/src/views/timetable/import.rs
@@ -47,6 +47,18 @@ pub struct TimetableImportItem {
     trains: Vec<TimetableImportTrain>,
 }
 
+impl TimetableImportItem {
+    pub fn report_error(
+        &self,
+        error: TimetableImportError,
+    ) -> HashMap<String, TimetableImportError> {
+        self.trains
+            .iter()
+            .map(|train| (train.name.clone(), TrainImportReport::new(error.clone())))
+            .collect()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct TimetableImportPathStep {
     location: TimetableImportPathLocation,
@@ -78,7 +90,7 @@ struct TimetableImportReport {
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
-enum TimetableImportError {
+pub enum TimetableImportError {
     RollingStockNotFound {
         name: String,
     },
@@ -178,18 +190,11 @@ async fn import_item(
     let Some(rolling_stock_model) =
         RollingStockModel::retrieve_by_name(conn, import_item.rolling_stock.clone()).await?
     else {
-        return Ok(import_item
-            .trains
-            .into_iter()
-            .map(|train| {
-                (
-                    train.name,
-                    TimetableImportError::RollingStockNotFound {
-                        name: import_item.rolling_stock.clone(),
-                    },
-                )
-            })
-            .collect());
+        return Ok(
+            import_item.report_error(TimetableImportError::RollingStockNotFound {
+                name: import_item.rolling_stock.clone(),
+            }),
+        );
     };
     let rolling_stock_id = rolling_stock_model.id.unwrap();
     let rollingstock_version = rolling_stock_model.version;
@@ -204,11 +209,7 @@ async fn import_item(
     let op_to_parts = match find_operation_points(&ops_uic, &ops_id, infra_id, conn).await? {
         Ok(op_to_parts) => op_to_parts,
         Err(err) => {
-            return Ok(import_item
-                .trains
-                .into_iter()
-                .map(|train: TimetableImportTrain| (train.name, err.clone()))
-                .collect());
+            return Ok(import_item.report_error(err.clone()));
         }
     };
     // Create waypoints
@@ -230,18 +231,11 @@ async fn import_item(
     {
         Ok(path_response) => path_response,
         Err(error) => {
-            return Ok(import_item
-                .trains
-                .into_iter()
-                .map(|train: TimetableImportTrain| {
-                    (
-                        train.name,
-                        TimetableImportError::PathfindingError {
-                            cause: error.clone(),
-                        },
-                    )
-                })
-                .collect());
+            return Ok(
+                import_item.report_error(TimetableImportError::PathfindingError {
+                    cause: error.clone(),
+                }),
+            );
         }
     };
     let path_id = path_response.id;
@@ -281,18 +275,11 @@ async fn import_item(
     let response_payload = match request.fetch(core_client).await {
         Ok(response_payload) => response_payload,
         Err(error) => {
-            return Ok(import_item
-                .trains
-                .into_iter()
-                .map(|train: TimetableImportTrain| {
-                    (
-                        train.name,
-                        TimetableImportError::SimulationError {
-                            cause: error.clone(),
-                        },
-                    )
-                })
-                .collect());
+            return Ok(
+                import_item.report_error(TimetableImportError::SimulationError {
+                    cause: error.clone(),
+                }),
+            );
         }
     };
 

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1253,7 +1253,9 @@ export type GetTimetableByIdApiArg = {
   /** Timetable id */
   id: number;
 };
-export type PostTimetableByIdApiResponse = /** status 200 Import report */ TimetableImportReport;
+export type PostTimetableByIdApiResponse = /** status 200 Import report */ {
+  [key: string]: TrainImportReport;
+};
 export type PostTimetableByIdApiArg = {
   /** Timetable id */
   id: number;
@@ -2319,10 +2321,13 @@ export type TimetableImportError =
         cause: InternalError;
       };
     };
-export type TimetableImportReport = {
-  errors: {
-    [key: string]: TimetableImportError;
-  };
+export type ImportTimings = {
+  pathfinding?: number | null;
+  simulation?: number | null;
+};
+export type TrainImportReport = {
+  error?: TimetableImportError | null;
+  timings: ImportTimings;
 };
 export type TimetableImportPathLocation =
   | {

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -245,10 +245,10 @@ def test_timetable_import(small_scenario: Scenario, fast_rolling_stock: int):
         json=payload,
     )
     r.raise_for_status()
-    errors = r.json()["errors"]
+    results = r.json()
 
-    assert "PathfindingError" in errors["TRAIN1"]
-    assert "RollingStockNotFound" in errors["TRAIN2"]
-    assert "OperationalPointNotFound" in errors["TRAIN3"]
-    assert errors["TRAIN3"]["OperationalPointNotFound"]["missing_uics"] == [32867]
-    assert "TRAIN4" not in errors
+    assert "PathfindingError" in results["TRAIN1"]["error"]
+    assert "RollingStockNotFound" in results["TRAIN2"]["error"]
+    assert "OperationalPointNotFound" in results["TRAIN3"]["error"]
+    assert results["TRAIN3"]["error"]["OperationalPointNotFound"]["missing_uics"] == [32867]
+    assert results["TRAIN4"]["error"] is None


### PR DESCRIPTION
Some things I'm not sure are good enough:
* naming of variables
* the macro for timing

linked to #6558 