### PR TITLE
front: fix bug lpv color when selecting a speed section tag

### DIFF
--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -36,13 +36,12 @@ import {
   getPointTextErrorsLayerProps,
 } from 'common/Map/Layers/Errors';
 import {
-  getSpeedSectionsFilter,
+  getFilterBySpeedSectionsTag,
   getSpeedSectionsLineLayerProps,
   getSpeedSectionsPointLayerProps,
   getSpeedSectionsTextLayerProps,
 } from 'common/Map/Layers/SpeedLimits';
 import {
-  getPSLFilter,
   getPSLSpeedLineBGLayerProps,
   getPSLSpeedLineLayerProps,
   getPSLSpeedValueLayerProps,
@@ -288,7 +287,7 @@ function getPSLSignsLayers(context: LayerContext, prefix: string): LayerProps[] 
 }
 
 function getPSLLayers(context: LayerContext, prefix: string): LayerProps[] {
-  const filter = getPSLFilter(context.layersSettings);
+  const filter = getFilterBySpeedSectionsTag(context.layersSettings);
   const bgProps = getPSLSpeedLineBGLayerProps(context);
   const layerProps = getPSLSpeedLineLayerProps(context);
 
@@ -331,7 +330,7 @@ function getSwitchesLayers(context: LayerContext, prefix: string): LayerProps[] 
 }
 
 function getSpeedSectionLayers(context: LayerContext, prefix: string): LayerProps[] {
-  const filter = getSpeedSectionsFilter(context.layersSettings);
+  const filter = getFilterBySpeedSectionsTag(context.layersSettings);
   return [
     {
       ...getSpeedSectionsLineLayerProps(context),

--- a/front/src/common/Map/Layers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/SpeedLimits.tsx
@@ -35,7 +35,7 @@ export function getSpeedSectionsName(
   return ['round', ['*', 3.6, ['case', ['!=', tag, 'null'], ['get', tag], ['get', 'speed_limit']]]];
 }
 
-export function getSpeedSectionsFilter(
+export function getFilterBySpeedSectionsTag(
   layersSettings: MapState['layersSettings']
 ): FilterSpecification {
   return isNil(layersSettings.speedlimittag)
@@ -173,7 +173,7 @@ export function getSpeedSectionsTextLayerProps({
 export default function SpeedLimits({ colors, layerOrder, infraID }: SpeedLimitsProps) {
   const { layersSettings } = useSelector((state: RootState) => state.map);
 
-  const filter = getSpeedSectionsFilter(layersSettings);
+  const filter = getFilterBySpeedSectionsTag(layersSettings);
   const lineProps = {
     ...getSpeedSectionsLineLayerProps({
       colors,

--- a/front/src/common/Map/Layers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/PSL.tsx
@@ -6,14 +6,13 @@ import type { LineLayer, SymbolLayer } from 'react-map-gl/maplibre';
 import { isNil } from 'lodash';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import type { FilterSpecification } from 'maplibre-gl';
 
 import type { Theme, OmitLayer } from 'types';
 
 import { MAP_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import SNCF_PSL_Signs from 'common/Map/Layers/extensions/SNCF/PSLSigns';
-import { getSpeedSectionsTag, getSpeedSectionsName } from 'common/Map/Layers/SpeedLimits';
+import { getSpeedSectionsName, getFilterBySpeedSectionsTag } from 'common/Map/Layers/SpeedLimits';
 
 import type { RootState } from 'reducers';
 import type { MapState } from 'reducers/map';
@@ -22,10 +21,6 @@ interface SNCF_PSLProps {
   colors: Theme;
   layerOrder?: number;
   infraID?: number | undefined;
-}
-
-export function getPSLFilter(layersSettings: MapState['layersSettings']): FilterSpecification {
-  return ['any', ['has', 'speed_limit'], ['has', getSpeedSectionsTag(layersSettings)]];
 }
 
 export function getPSLSpeedValueLayerProps({
@@ -161,7 +156,7 @@ const SNCF_PSL = ({ colors, layerOrder, infraID }: SNCF_PSLProps) => {
   const { t } = useTranslation('map-settings');
   const { layersSettings } = useSelector((state: RootState) => state.map);
 
-  const speedSectionFilter = getPSLFilter(layersSettings);
+  const speedSectionFilter = getFilterBySpeedSectionsTag(layersSettings);
 
   const speedValueParams = {
     ...getPSLSpeedValueLayerProps({


### PR DESCRIPTION
closes #5287 

I fixed the color of the PSL when you select a speedLimitTag, but found a new bug (backend #6623): if you select a speedLimitTag and the PSL does not have it, the PSL disappear but not its signs !

Here with a correct speedLimitTag:
![image](https://github.com/osrd-project/osrd/assets/45000526/50d864de-98a2-4c87-9bec-74189976e3d3)
