### PR TITLE
core: fix the error condition for Datadog report

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
@@ -25,9 +25,9 @@ class TkDataDog(take: Take) : TkWrap(Take { request: Request -> datadog(take, re
             val statusCode = RsStatus.Base(response).status()
             span.setTag(Tags.HTTP_STATUS, statusCode)
             if (statusCode < 400) {
-                span.setTag(Tags.ERROR, true)
-            } else {
                 span.setTag(Tags.ERROR, false)
+            } else {
+                span.setTag(Tags.ERROR, true)
             }
 
             return response


### PR DESCRIPTION
Ooops, should be `false` below 400, not `true`.