### PR TITLE
Adding an error inventory to editoast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,6 +486,13 @@ jobs:
         run: |
           diff $PWD/editoast/openapi.yaml $PWD/output/openapi.yaml
 
+      - name: Check for i18n API errors
+        run: |
+          docker run --name=front-error-i18n --net=host -v $PWD/output/openapi.yaml:/editoast/openapi.yaml \
+              ${{ fromJSON(needs.build.outputs.stable_tags).front-build }} \
+              yarn api-errors-i18n
+          exit $(docker wait front-error-i18n)
+
   check_gateway:
     runs-on: ubuntu-latest
     needs:

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1174,7 +1174,9 @@ dependencies = [
  "futures 0.3.30",
  "futures-util",
  "geos",
+ "heck",
  "image",
+ "inventory",
  "itertools",
  "json-patch",
  "mvt",
@@ -1222,6 +1224,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.48",
 ]
 
@@ -1930,6 +1933,12 @@ checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8573b2b1fb643a372c73b23f4da5f888677feef3305146d68a539250a9bccc7"
 
 [[package]]
 name = "io-lifetimes"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -81,6 +81,8 @@ paste = "1.0.14"
 url = "2.5.0"
 cfg-if = "1.0.0"
 validator = { version = "0.16.1", features = ["derive"] }
+inventory = "0.3"
+heck = "0.4.1"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -10,6 +10,7 @@ syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 darling = "0.20"
+serde_json.workspace = true
 
 [lib]
 proc-macro = true

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -188,6 +188,2262 @@ components:
       - end
       - direction
       type: object
+    EditoastAttachedTrackNotFound:
+      properties:
+        context:
+          properties:
+            track_id:
+              type: string
+          required:
+          - track_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:attached:TrackNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastAutoFixesConflictingFixesOnSameObject:
+      properties:
+        context:
+          properties:
+            fixes:
+              type: array
+            object:
+              type: object
+          required:
+          - fixes
+          - object
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:auto_fixes:ConflictingFixesOnSameObject
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastAutoFixesFixTrialFailure:
+      properties:
+        context:
+          properties:
+            source:
+              type: object
+          required:
+          - source
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:auto_fixes:FixTrialFailure
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastAutoFixesMaximumIterationReached:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:auto_fixes:MaximumIterationReached
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastAutoFixesMissingErrorObject:
+      properties:
+        context:
+          properties:
+            source:
+              type: object
+          required:
+          - source
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:auto_fixes:MissingErrorObject
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCacheOperationDuplicateIdsProvided:
+      properties:
+        context:
+          properties:
+            obj_id:
+              type: string
+            obj_type:
+              type: string
+          required:
+          - obj_id
+          - obj_type
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:cache_operation:DuplicateIdsProvided
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCacheOperationObjectNotFound:
+      properties:
+        context:
+          properties:
+            obj_id:
+              type: string
+            obj_type:
+              type: string
+          required:
+          - obj_id
+          - obj_type
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:cache_operation:ObjectNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientCannotExtractResponseBody:
+      properties:
+        context:
+          properties:
+            msg:
+              type: string
+          required:
+          - msg
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:CannotExtractResponseBody
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientConnectionClosedBeforeMessageCompleted:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:ConnectionClosedBeforeMessageCompleted
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientConnectionResetByPeer:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:ConnectionResetByPeer
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientCoreResponseFormatError:
+      properties:
+        context:
+          properties:
+            msg:
+              type: string
+          required:
+          - msg
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:CoreResponseFormatError
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientGenericCoreError:
+      properties:
+        context:
+          properties:
+            raw_error:
+              type: string
+            status:
+              type: object
+            url:
+              type: string
+          required:
+          - raw_error
+          - status
+          - url
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:GenericCoreError
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastCoreclientUnparsableErrorOutput:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:coreclient:UnparsableErrorOutput
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastDocumentNotFound:
+      properties:
+        context:
+          properties:
+            document_key:
+              type: integer
+          required:
+          - document_key
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:document:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastElectricalProfilesNotFound:
+      properties:
+        context:
+          properties:
+            electrical_profile_set_id:
+              type: integer
+          required:
+          - electrical_profile_set_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:electrical_profiles:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastError:
+      description: Generated error type for Editoast
+      discriminator:
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/EditoastAttachedTrackNotFound'
+      - $ref: '#/components/schemas/EditoastAutoFixesConflictingFixesOnSameObject'
+      - $ref: '#/components/schemas/EditoastAutoFixesFixTrialFailure'
+      - $ref: '#/components/schemas/EditoastAutoFixesMaximumIterationReached'
+      - $ref: '#/components/schemas/EditoastAutoFixesMissingErrorObject'
+      - $ref: '#/components/schemas/EditoastCacheOperationDuplicateIdsProvided'
+      - $ref: '#/components/schemas/EditoastCacheOperationObjectNotFound'
+      - $ref: '#/components/schemas/EditoastCoreclientCannotExtractResponseBody'
+      - $ref: '#/components/schemas/EditoastCoreclientConnectionClosedBeforeMessageCompleted'
+      - $ref: '#/components/schemas/EditoastCoreclientConnectionResetByPeer'
+      - $ref: '#/components/schemas/EditoastCoreclientCoreResponseFormatError'
+      - $ref: '#/components/schemas/EditoastCoreclientGenericCoreError'
+      - $ref: '#/components/schemas/EditoastCoreclientUnparsableErrorOutput'
+      - $ref: '#/components/schemas/EditoastDocumentNotFound'
+      - $ref: '#/components/schemas/EditoastElectricalProfilesNotFound'
+      - $ref: '#/components/schemas/EditoastGeometryUnexpectedGeometry'
+      - $ref: '#/components/schemas/EditoastInfraNotFound'
+      - $ref: '#/components/schemas/EditoastInfraNotFound'
+      - $ref: '#/components/schemas/EditoastInfraEditionInfraIsLocked'
+      - $ref: '#/components/schemas/EditoastInfraErrorsWrongErrorTypeProvided'
+      - $ref: '#/components/schemas/EditoastInfraLinesLineNotFound'
+      - $ref: '#/components/schemas/EditoastInfraObjectsDuplicateIdsProvided'
+      - $ref: '#/components/schemas/EditoastInfraObjectsObjectIdNotFound'
+      - $ref: '#/components/schemas/EditoastInfraPathfindingEndingTrackLocationNotFound'
+      - $ref: '#/components/schemas/EditoastInfraPathfindingInvalidNumberOfPaths'
+      - $ref: '#/components/schemas/EditoastInfraPathfindingStartingTrackLocationNotFound'
+      - $ref: '#/components/schemas/EditoastInfraRailjsonWrongRailjsonVersionProvided'
+      - $ref: '#/components/schemas/EditoastInfraCacheObjectNotFound'
+      - $ref: '#/components/schemas/EditoastLayersLayerNotFound'
+      - $ref: '#/components/schemas/EditoastLayersViewNotFound'
+      - $ref: '#/components/schemas/EditoastOperationEmptyId'
+      - $ref: '#/components/schemas/EditoastOperationInvalidPatch'
+      - $ref: '#/components/schemas/EditoastOperationModifyId'
+      - $ref: '#/components/schemas/EditoastOperationObjectNotFound'
+      - $ref: '#/components/schemas/EditoastPaginationInvalidPage'
+      - $ref: '#/components/schemas/EditoastPaginationInvalidPageSize'
+      - $ref: '#/components/schemas/EditoastPathfindingElectricalProfilesOverlap'
+      - $ref: '#/components/schemas/EditoastPathfindingElectrificationOverlap'
+      - $ref: '#/components/schemas/EditoastPathfindingInfraNotFound'
+      - $ref: '#/components/schemas/EditoastPathfindingNotFound'
+      - $ref: '#/components/schemas/EditoastPathfindingOperationalPointsNotFound'
+      - $ref: '#/components/schemas/EditoastPathfindingRollingStockNotFound'
+      - $ref: '#/components/schemas/EditoastPathfindingTrackSectionsNotFound'
+      - $ref: '#/components/schemas/EditoastPostgresHost'
+      - $ref: '#/components/schemas/EditoastPostgresPassword'
+      - $ref: '#/components/schemas/EditoastPostgresPort'
+      - $ref: '#/components/schemas/EditoastPostgresUsername'
+      - $ref: '#/components/schemas/EditoastProjectImageError'
+      - $ref: '#/components/schemas/EditoastProjectImageNotFound'
+      - $ref: '#/components/schemas/EditoastProjectNotFound'
+      - $ref: '#/components/schemas/EditoastRailjsonUnsupportedVersion'
+      - $ref: '#/components/schemas/EditoastRedisUrl'
+      - $ref: '#/components/schemas/EditoastRollingstocksBasePowerClassEmpty'
+      - $ref: '#/components/schemas/EditoastRollingstocksCannotCreateCompoundImage'
+      - $ref: '#/components/schemas/EditoastRollingstocksCannotReadImage'
+      - $ref: '#/components/schemas/EditoastRollingstocksNameAlreadyUsed'
+      - $ref: '#/components/schemas/EditoastRollingstocksNotFound'
+      - $ref: '#/components/schemas/EditoastRollingstocksRollingStockIsLocked'
+      - $ref: '#/components/schemas/EditoastRollingstocksRollingStockIsUsed'
+      - $ref: '#/components/schemas/EditoastScenarioNotFound'
+      - $ref: '#/components/schemas/EditoastSearchArgMissing'
+      - $ref: '#/components/schemas/EditoastSearchArgTypeMismatch'
+      - $ref: '#/components/schemas/EditoastSearchEmptyArray'
+      - $ref: '#/components/schemas/EditoastSearchIntegerConversion'
+      - $ref: '#/components/schemas/EditoastSearchInvalidColumnName'
+      - $ref: '#/components/schemas/EditoastSearchInvalidFunctionIdentifier'
+      - $ref: '#/components/schemas/EditoastSearchInvalidSyntax'
+      - $ref: '#/components/schemas/EditoastSearchObjectType'
+      - $ref: '#/components/schemas/EditoastSearchQueryAst'
+      - $ref: '#/components/schemas/EditoastSearchRuntimeTypeCheckFail'
+      - $ref: '#/components/schemas/EditoastSearchUndefinedFunction'
+      - $ref: '#/components/schemas/EditoastSearchUndefinedOverload'
+      - $ref: '#/components/schemas/EditoastSearchUnexpectedArg'
+      - $ref: '#/components/schemas/EditoastSearchUnexpectedColummn'
+      - $ref: '#/components/schemas/EditoastSearchUnexpectedErsatz'
+      - $ref: '#/components/schemas/EditoastSearchVariadicArgTypeMismatch'
+      - $ref: '#/components/schemas/EditoastSingleSimulationElectricalProfileSetNotFound'
+      - $ref: '#/components/schemas/EditoastSingleSimulationPathNotFound'
+      - $ref: '#/components/schemas/EditoastSingleSimulationRollingStockNotFound'
+      - $ref: '#/components/schemas/EditoastSingleSimulationWrongCoreResponseFormat'
+      - $ref: '#/components/schemas/EditoastSpritesFileNotFound'
+      - $ref: '#/components/schemas/EditoastSpritesUnknownSignalingSystem'
+      - $ref: '#/components/schemas/EditoastStdcmInfraNotFound'
+      - $ref: '#/components/schemas/EditoastStudyNotFound'
+      - $ref: '#/components/schemas/EditoastStudyStartDateAfterEndDate'
+      - $ref: '#/components/schemas/EditoastTimetableInfraNotLoaded'
+      - $ref: '#/components/schemas/EditoastTimetableNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleBatchShouldHaveSameTimetable'
+      - $ref: '#/components/schemas/EditoastTrainScheduleBatchTrainScheduleNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleNoSimulation'
+      - $ref: '#/components/schemas/EditoastTrainScheduleNoTrainSchedules'
+      - $ref: '#/components/schemas/EditoastTrainScheduleNotFound'
+      - $ref: '#/components/schemas/EditoastTrainSchedulePathNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleRollingStockNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleTimetableNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleUnsimulatedTrainSchedule'
+      - $ref: '#/components/schemas/EditoastUrlInvalidUrl'
+    EditoastGeometryUnexpectedGeometry:
+      properties:
+        context:
+          properties:
+            actual:
+              type: string
+            expected:
+              type: string
+          required:
+          - actual
+          - expected
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:geometry:UnexpectedGeometry
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraCacheObjectNotFound:
+      properties:
+        context:
+          properties:
+            obj_id:
+              type: string
+            obj_type:
+              type: string
+          required:
+          - obj_id
+          - obj_type
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:infra_cache:ObjectNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraEditionInfraIsLocked:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:edition:InfraIsLocked
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraErrorsWrongErrorTypeProvided:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:errors:WrongErrorTypeProvided
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraLinesLineNotFound:
+      properties:
+        context:
+          properties:
+            line_code:
+              type: integer
+          required:
+          - line_code
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:lines:LineNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraObjectsDuplicateIdsProvided:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:objects:DuplicateIdsProvided
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraObjectsObjectIdNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:objects:ObjectIdNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraPathfindingEndingTrackLocationNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:pathfinding:EndingTrackLocationNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraPathfindingInvalidNumberOfPaths:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:pathfinding:InvalidNumberOfPaths
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraPathfindingStartingTrackLocationNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:pathfinding:StartingTrackLocationNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastInfraRailjsonWrongRailjsonVersionProvided:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:infra:railjson:WrongRailjsonVersionProvided
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastLayersLayerNotFound:
+      properties:
+        context:
+          properties:
+            expected_names:
+              type: array
+            layer_name:
+              type: string
+          required:
+          - expected_names
+          - layer_name
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:layers:LayerNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastLayersViewNotFound:
+      properties:
+        context:
+          properties:
+            expected_names:
+              type: array
+            view_name:
+              type: string
+          required:
+          - expected_names
+          - view_name
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:layers:ViewNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastOperationEmptyId:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:operation:EmptyId
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastOperationInvalidPatch:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:operation:InvalidPatch
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastOperationModifyId:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:operation:ModifyId
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastOperationObjectNotFound:
+      properties:
+        context:
+          properties:
+            infra_id:
+              type: integer
+            obj_id:
+              type: string
+          required:
+          - infra_id
+          - obj_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:operation:ObjectNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPaginationInvalidPage:
+      properties:
+        context:
+          properties:
+            page:
+              type: integer
+          required:
+          - page
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pagination:InvalidPage
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPaginationInvalidPageSize:
+      properties:
+        context:
+          properties:
+            max_page_size:
+              type: integer
+            provided_page_size:
+              type: integer
+          required:
+          - max_page_size
+          - provided_page_size
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:pagination:InvalidPageSize
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingElectricalProfilesOverlap:
+      properties:
+        context:
+          properties:
+            overlapping_ranges:
+              type: array
+          required:
+          - overlapping_ranges
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:ElectricalProfilesOverlap
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingElectrificationOverlap:
+      properties:
+        context:
+          properties:
+            electrification_id:
+              type: string
+            overlapping_ranges:
+              type: array
+          required:
+          - electrification_id
+          - overlapping_ranges
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:ElectrificationOverlap
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingInfraNotFound:
+      properties:
+        context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:InfraNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingNotFound:
+      properties:
+        context:
+          properties:
+            pathfinding_id:
+              type: integer
+          required:
+          - pathfinding_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingOperationalPointsNotFound:
+      properties:
+        context:
+          properties:
+            operational_points:
+              type: object
+          required:
+          - operational_points
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:OperationalPointsNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingRollingStockNotFound:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+          required:
+          - rolling_stock_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:RollingStockNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPathfindingTrackSectionsNotFound:
+      properties:
+        context:
+          properties:
+            track_sections:
+              type: object
+          required:
+          - track_sections
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:pathfinding:TrackSectionsNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPostgresHost:
+      properties:
+        context:
+          properties:
+            hostname:
+              type: string
+          required:
+          - hostname
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:postgres:Host
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPostgresPassword:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:postgres:Password
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPostgresPort:
+      properties:
+        context:
+          properties:
+            port:
+              type: integer
+          required:
+          - port
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:postgres:Port
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastPostgresUsername:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:postgres:Username
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastProjectImageError:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:project:ImageError
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastProjectImageNotFound:
+      properties:
+        context:
+          properties:
+            document_key:
+              type: integer
+          required:
+          - document_key
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:project:ImageNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastProjectNotFound:
+      properties:
+        context:
+          properties:
+            project_id:
+              type: integer
+          required:
+          - project_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:project:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRailjsonUnsupportedVersion:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:railjson:UnsupportedVersion
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRedisUrl:
+      properties:
+        context:
+          properties:
+            url:
+              type: string
+          required:
+          - url
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:redis:Url
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksBasePowerClassEmpty:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:BasePowerClassEmpty
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksCannotCreateCompoundImage:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:CannotCreateCompoundImage
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksCannotReadImage:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:CannotReadImage
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksNameAlreadyUsed:
+      properties:
+        context:
+          properties:
+            name:
+              type: string
+          required:
+          - name
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:NameAlreadyUsed
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksNotFound:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+          required:
+          - rolling_stock_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksRollingStockIsLocked:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+          required:
+          - rolling_stock_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:RollingStockIsLocked
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastRollingstocksRollingStockIsUsed:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+            usage:
+              type: array
+          required:
+          - rolling_stock_id
+          - usage
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 409
+          type: integer
+        type:
+          enum:
+          - editoast:rollingstocks:RollingStockIsUsed
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastScenarioNotFound:
+      properties:
+        context:
+          properties:
+            scenario_id:
+              type: integer
+          required:
+          - scenario_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:scenario:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchArgMissing:
+      properties:
+        context:
+          properties:
+            arg_pos:
+              type: integer
+            expected:
+              type: object
+          required:
+          - arg_pos
+          - expected
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:ArgMissing
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchArgTypeMismatch:
+      properties:
+        context:
+          properties:
+            actual:
+              type: object
+            arg_pos:
+              type: integer
+            expected:
+              type: object
+          required:
+          - actual
+          - arg_pos
+          - expected
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:ArgTypeMismatch
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchEmptyArray:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:EmptyArray
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchIntegerConversion:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:IntegerConversion
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchInvalidColumnName:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:InvalidColumnName
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchInvalidFunctionIdentifier:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:InvalidFunctionIdentifier
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchInvalidSyntax:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:InvalidSyntax
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchObjectType:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:ObjectType
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchQueryAst:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:QueryAst
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchRuntimeTypeCheckFail:
+      properties:
+        context:
+          properties:
+            actual:
+              type: object
+            expected:
+              type: object
+            value:
+              type: string
+          required:
+          - actual
+          - expected
+          - value
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:RuntimeTypeCheckFail
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchUndefinedFunction:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:UndefinedFunction
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchUndefinedOverload:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:UndefinedOverload
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchUnexpectedArg:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:UnexpectedArg
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchUnexpectedColummn:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:UnexpectedColummn
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchUnexpectedErsatz:
+      properties:
+        context:
+          properties:
+            expected:
+              type: object
+            value:
+              type: string
+          required:
+          - expected
+          - value
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:UnexpectedErsatz
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSearchVariadicArgTypeMismatch:
+      properties:
+        context:
+          properties:
+            actual:
+              type: object
+            expected:
+              type: object
+          required:
+          - actual
+          - expected
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:search:VariadicArgTypeMismatch
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSingleSimulationElectricalProfileSetNotFound:
+      properties:
+        context:
+          properties:
+            electrical_profile_set_id:
+              type: integer
+          required:
+          - electrical_profile_set_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:single_simulation:ElectricalProfileSetNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSingleSimulationPathNotFound:
+      properties:
+        context:
+          properties:
+            path_id:
+              type: integer
+          required:
+          - path_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:single_simulation:PathNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSingleSimulationRollingStockNotFound:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+          required:
+          - rolling_stock_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:single_simulation:RollingStockNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSingleSimulationWrongCoreResponseFormat:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:single_simulation:WrongCoreResponseFormat
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSpritesFileNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:sprites:FileNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastSpritesUnknownSignalingSystem:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:sprites:UnknownSignalingSystem
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastStdcmInfraNotFound:
+      properties:
+        context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:stdcm:InfraNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastStudyNotFound:
+      properties:
+        context:
+          properties:
+            study_id:
+              type: integer
+          required:
+          - study_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:study:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastStudyStartDateAfterEndDate:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:study:StartDateAfterEndDate
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTimetableInfraNotLoaded:
+      properties:
+        context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:timetable:InfraNotLoaded
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTimetableNotFound:
+      properties:
+        context:
+          properties:
+            timetable_id:
+              type: integer
+          required:
+          - timetable_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:timetable:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleBatchShouldHaveSameTimetable:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:BatchShouldHaveSameTimetable
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleBatchTrainScheduleNotFound:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:BatchTrainScheduleNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleNoSimulation:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:NoSimulation
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleNoTrainSchedules:
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:NoTrainSchedules
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleNotFound:
+      properties:
+        context:
+          properties:
+            train_schedule_id:
+              type: integer
+          required:
+          - train_schedule_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:NotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainSchedulePathNotFound:
+      properties:
+        context:
+          properties:
+            path_id:
+              type: integer
+          required:
+          - path_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:PathNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleRollingStockNotFound:
+      properties:
+        context:
+          properties:
+            rolling_stock_id:
+              type: integer
+          required:
+          - rolling_stock_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:RollingStockNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleTimetableNotFound:
+      properties:
+        context:
+          properties:
+            timetable_id:
+              type: integer
+          required:
+          - timetable_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:TimetableNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleUnsimulatedTrainSchedule:
+      properties:
+        context:
+          properties:
+            train_schedule_id:
+              type: integer
+          required:
+          - train_schedule_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule:UnsimulatedTrainSchedule
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastUrlInvalidUrl:
+      properties:
+        context:
+          properties:
+            url:
+              type: string
+          required:
+          - url
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 500
+          type: integer
+        type:
+          enum:
+          - editoast:url:InvalidUrl
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
     EffortCurve:
       additionalProperties: false
       properties:

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -219,3 +219,31 @@ impl EditoastError for json_patch::PatchError {
         "editoast:JsonPatchError"
     }
 }
+
+// error definition : uses by the macro EditoastError to generate
+// the list of error and share it with the openAPI generator
+pub struct ErrorDefinition {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub status: u16,
+    context_serialized: &'static str,
+}
+impl ErrorDefinition {
+    pub const fn new(
+        id: &'static str,
+        name: &'static str,
+        status: u16,
+        context_serialized: &'static str,
+    ) -> Self {
+        ErrorDefinition {
+            id,
+            name,
+            status,
+            context_serialized,
+        }
+    }
+    pub fn get_context(&self) -> HashMap<String, String> {
+        serde_json::from_str(self.context_serialized).expect("Error context should be a valid json")
+    }
+}
+inventory::collect!(ErrorDefinition);

--- a/front/package.json
+++ b/front/package.json
@@ -116,6 +116,7 @@
     "sort-by": "^1.2.0",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",
+    "tsx": "^4.7.1",
     "uuid": "^9.0.1",
     "viewport-mercator-project": "^7.0.4"
   },
@@ -196,7 +197,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "generate-licenses": "license-checker-rseidelsohn --json --production --direct --excludePackagesStartingWith '@types' --excludePrivatePackages --customPath src/common/ReleaseInformations/json/licenseCustomFormat.json > src/common/ReleaseInformations/json/licenses.json",
-    "e2e-tests": "yarn playwright test"
+    "e2e-tests": "yarn playwright test",
+    "api-errors-i18n": "tsx ./scripts/api-errors-i18n.ts"
   },
   "browserslist": {
     "production": [

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -1,11 +1,175 @@
 {
-"401": "Unauthenticated user",
-"403": "Access denied",
-"404": "Resource not found",
-"500": "Server errors",
-"502": "Server errors",
-"503": "Server errors",
-"504": "The server did not respond.",
-"default": "An error has occurred.",
-"pageNotFound": "The page you are looking for does not exist."
+  "401": "Unauthenticated user",
+  "403": "Access denied",
+  "404": "Resource not found",
+  "500": "Server errors",
+  "502": "Server errors",
+  "503": "Server errors",
+  "504": "The server did not respond.",
+  "default": "An error has occurred.",
+  "pageNotFound": "The page you are looking for does not exist.",
+  "editoast": {
+    "attached": {
+      "TrackNotFound": "Track {{track_id}} not found"
+    },
+    "auto_fixes": {
+      "ConflictingFixesOnSameObject": "Conflicting fixes for the same object on the same fix-iteration",
+      "FixTrialFailure": "Failed trying to apply fixes",
+      "MaximumIterationReached": "Reached maximum number of iterations to fix infra without providing every possible fixes",
+      "MissingErrorObject": "Failed to find the error's object"
+    },
+    "cache_operation": {
+      "DuplicateIdsProvided": "{{obj_type}} {{obj_id}} : a duplicate already exists",
+      "ObjectNotFound": "{{obj_type}} {{obj_id}} could not be found everywhere in the infrastructure cache"
+    },
+    "coreclient": {
+      "CannotExtractResponseBody": "Cannot extract Core response body: {{msg}}",
+      "ConnectionClosedBeforeMessageCompleted": "Core connection closed before message completed. Should retry.",
+      "ConnectionResetByPeer": "Core connection reset by peer. Should retry.",
+      "CoreResponseFormatError": "Cannot parse Core response: {{msg}}",
+      "GenericCoreError": "Core error {{raw_error}}",
+      "UnparsableErrorOutput": "Core returned an error in an unknown format"
+    },
+    "document": {
+      "NotFound": "Document '{{document_key}}' not found"
+    },
+    "electrical_profiles": {
+      "NotFound": "Electrical Profile Set '{{electrical_profile_set_id}}', could not be found"
+    },
+    "geometry": {
+      "UnexpectedGeometry": "Expected geometry {{expected}} but got {{actual}}"
+    },
+    "infra_cache": {
+      "ObjectNotFound": "{{obj_type}} '{{obj_id}}', could not be found everywhere in the infrastructure cache"
+    },
+    "infra": {
+      "NotFound": "",
+      "edition": {
+        "InfraIsLocked": "Infra is locked"
+      },
+      "errors": {
+        "WrongErrorTypeProvided": "Wrong Error type provided"
+      },
+      "lines": {
+        "LineNotFound": "No line with code {{line_code}} found"
+      },
+      "objects": {
+        "DuplicateIdsProvided": "Duplicate object ids provided",
+        "ObjectIdNotFound": "Object ID not found"
+      },
+      "pathfinding": {
+        "EndingTrackLocationNotFound": "Ending track location was not found",
+        "InvalidNumberOfPaths": "The pathfinding cannot return 5 paths (expected: [1-5])",
+        "StartingTrackLocationNotFound": "Starting track location was not found"
+      },
+      "railjson": {
+        "WrongRailjsonVersionProvided": "Wrong railjson version provided"
+      }
+    },
+    "layers": {
+      "LayerNotFound": "Layer {{layer_name}} not found.",
+      "ViewNotFound": "View {{view_name}} not found."
+    },
+    "operation": {
+      "EmptyId": "Empty string id is forbidden",
+      "InvalidPatch": "A Json Patch error occurred",
+      "ModifyId": "Update operation try to modify object id, which is forbidden",
+      "ObjectNotFound": "Object '{{obj_id}}', could not be found in the infrastructure '{{infra_id}}'"
+    },
+    "pagination": {
+      "InvalidPage": "Invalid page number ({{page}})",
+      "InvalidPageSize": "Invalid page size ({{provided_page_size}}), expected an integer 0 < page_size <= {{max_page_size}}"
+    },
+    "pathfinding": {
+      "ElectricalProfilesOverlap": "Electrical Profile overlaps with others",
+      "ElectrificationOverlap": "Electrification {{electrification_id}} overlaps with other electrifications",
+      "InfraNotFound": "Infra {{infra_id}} does not exist",
+      "NotFound": "Pathfinding {{pathfinding_id}} does not exist",
+      "OperationalPointsNotFound": "Operational points do not exist: {{operational_points}}",
+      "RollingStockNotFound": "Rolling stock with id {{rolling_stock_id}} does not exist",
+      "TrackSectionsNotFound": "Track sections do not exist: {{track_sections}}"
+    },
+    "postgres": {
+      "Host": "Invalid host '{{hostname}}'",
+      "Password": "Invalid password",
+      "Port": "Invalid port '{{port}}'",
+      "Username": "Invalid username"
+    },
+    "project": {
+      "ImageError": "The provided image is not valid",
+      "ImageNotFound": "Image document '{{document_key}}' not found",
+      "NotFound": "Project '{{project_id}}', could not be found"
+    },
+    "railjson": {
+      "UnsupportedVersion": "Unsupported railjson version"
+    },
+    "redis": {
+      "Url": "Invalid url '{{url}}'"
+    },
+    "rollingstocks": {
+      "BasePowerClassEmpty": "Base power class is an empty string",
+      "CannotCreateCompoundImage": "Impossible to copy the separated image on the compound image",
+      "CannotReadImage": "Impossible to read the separated image",
+      "NameAlreadyUsed": "Name '{{name}}' already used",
+      "NotFound": "Rolling stock '{{rolling_stock_id}}' could not be found",
+      "RollingStockIsLocked": "RollingStock '{{rolling_stock_id}}' is locked",
+      "RollingStockIsUsed": "RollingStock '{{rolling_stock_id}}' is used"
+    },
+    "scenario": {
+      "NotFound": "Scenario not found"
+    },
+    "search": {
+      "ArgMissing": "Expected argument of type {{expected}} at position {{arg_pos}} is missing",
+      "ArgTypeMismatch": "Expected argument of type {{expected}} at position {{arg_pos}}, but got {{actual}}",
+      "EmptyArray": "Empty arrays are invalid syntax",
+      "IntegerConversion": "Could not convert to i64",
+      "InvalidColumnName": "Invalid column name",
+      "InvalidFunctionIdentifier": "Function identifer must be a string",
+      "InvalidSyntax": "Invalid syntax",
+      "ObjectType": "Object type is invalid",
+      "QueryAst": "Query Boolean type is expected",
+      "RuntimeTypeCheckFail": "Expected type {{expected}}, got value '{{value}}' of type {{actual}} instead",
+      "UndefinedFunction": "Undefined function",
+      "UndefinedOverload": "No suitable overload",
+      "UnexpectedArg": "Unexpected argument of type found",
+      "UnexpectedColummn": "Unexpected column",
+      "UnexpectedErsatz": "Expected value of type {{expected}}, but got ersatz '{{value}}'",
+      "VariadicArgTypeMismatch": "Expected variadic argument of type {{expected}}, but got {{actual}}"
+    },
+    "single_simulation": {
+      "ElectricalProfileSetNotFound": "Electrical Profile Set '{{electrical_profile_set_id}}' could not be found",
+      "PathNotFound": "Path '{{path_id}}' could not be found",
+      "RollingStockNotFound": "Rolling Stock '{{rolling_stock_id}}' could not be found",
+      "WrongCoreResponseFormat": "Received wrong response format from core"
+    },
+    "sprites": {
+      "FileNotFound": "File not found",
+      "UnknownSignalingSystem": "Unknown signaling system"
+    },
+    "stdcm": {
+      "InfraNotFound": "Infra {{infra_id}} does not exist"
+    },
+    "study": {
+      "NotFound": "Study '{{study_id}}' could not be found",
+      "StartDateAfterEndDate": "The study start date must be before the end date"
+    },
+    "timetable": {
+      "InfraNotLoaded": "Infra '{{infra_id}}' is not loaded",
+      "NotFound": "Timetable '{{timetable_id}}' could not be found"
+    },
+    "train_schedule": {
+      "BatchShouldHaveSameTimetable": "Batch should have the same timetable",
+      "BatchTrainScheduleNotFound": "Some Train Schedules could not be found",
+      "NoSimulation": "No simulation given",
+      "NoTrainSchedules": "No train schedules given",
+      "NotFound": "Train Schedule '{{train_schedule_id}}' could not be found",
+      "PathNotFound": "Path '{{path_id}}' could not be found",
+      "RollingStockNotFound": "Rolling Stock '{{rolling_stock_id}}' could not be found",
+      "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",
+      "UnsimulatedTrainSchedule": "Train Schedule '{{train_schedule_id}}' is not simulated"
+    },
+    "url": {
+      "InvalidUrl": "Invalid url '{{url}}'"
+    }
+  }
 }

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -1,11 +1,175 @@
 {
-"401" : "Utilisateur non authentifié",
-"403" : "Accès refusé",
-"404" : "Ressource non trouvée",
-"500" : "Erreurs serveur",
-"502" : "Erreurs serveur",
-"503" : "Erreurs serveur",
-"504" : "Le serveur n'a pas répondu.",
-"default" : "Une erreur est survenue.",
-"pageNotFound" : "La page que vous recherchez n'existe pas."    
+  "401": "Utilisateur non authentifié",
+  "403": "Accès refusé",
+  "404": "Ressource non trouvée",
+  "500": "Erreurs serveur",
+  "502": "Erreurs serveur",
+  "503": "Erreurs serveur",
+  "504": "Le serveur n'a pas répondu.",
+  "default": "Une erreur est survenue.",
+  "pageNotFound": "La page que vous recherchez n'existe pas.",
+  "editoast": {
+    "attached": {
+      "TrackNotFound": "Section de ligne {{track_id}} non trouvée"
+    },
+    "auto_fixes": {
+      "ConflictingFixesOnSameObject": "Correctifs conflictuels pour le même objet sur la même itération de correctif",
+      "FixTrialFailure": "Echec de l'application des correctifs",
+      "MaximumIterationReached": "Nombre maximum d'itérations atteint pour corriger l'infra sans fournir tous les correctifs possibles",
+      "MissingErrorObject": "Impossible de trouver l'objet de l'erreur"
+    },
+    "cache_operation": {
+      "DuplicateIdsProvided": "{{obj_type}} {{obj_id}}: un doublon existe déjà",
+      "ObjectNotFound": "{{obj_type}} {{obj_id}} n'a pu être trouvé nulle part dans le cache de l'infrastructure"
+    },
+    "coreclient": {
+      "CannotExtractResponseBody": "Core: Impossible d'extraire le corps de la réponse : {{msg}}",
+      "ConnectionClosedBeforeMessageCompleted": "Core: connexion fermée avant la fin du message. Nouvelle tentative.",
+      "ConnectionResetByPeer": "Core: réinitialisation de la connexion. Nouvelle tentative.",
+      "CoreResponseFormatError": "Core: impossible d'analyser la réponse '{{msg}}'",
+      "GenericCoreError": "Core: erreur {{raw_error}}",
+      "UnparsableErrorOutput": "Core: a renvoyé une erreur dans un format inconnu"
+    },
+    "document": {
+      "NotFound": "Document '{{document_key}}' non trouvé"
+    },
+    "electrical_profiles": {
+      "NotFound": "Profil électrique '{{electrical_profile_set_id}}' non trouvé"
+    },
+    "geometry": {
+      "UnexpectedGeometry": "Géometrie {{expected}} attendue mais {{actual}} reçue"
+    },
+    "infra_cache": {
+      "ObjectNotFound": "{{obj_type}} '{{obj_id}}' introuvable dans le cache de l'infrastructure"
+    },
+    "infra": {
+      "NotFound": "",
+      "edition": {
+        "InfraIsLocked": "Infrastructure verrouillée"
+      },
+      "errors": {
+        "WrongErrorTypeProvided": "Mauvais type d'erreur fourni"
+      },
+      "lines": {
+        "LineNotFound": "Aucune ligne trouvée avec le code {{line_code}}"
+      },
+      "objects": {
+        "DuplicateIdsProvided": "Identifiants d'objet fournis en double",
+        "ObjectIdNotFound": "Objet ID non trouvé"
+      },
+      "pathfinding": {
+        "EndingTrackLocationNotFound": "Localisation de la fin de la section non trouvé",
+        "InvalidNumberOfPaths": "La recherche de chemin ne peut pas renvoyer plus de 5 chemins",
+        "StartingTrackLocationNotFound": "Localisation du début de la section non trouvé"
+      },
+      "railjson": {
+        "WrongRailjsonVersionProvided": "Mauvaise version de railjson fournie"
+      }
+    },
+    "layers": {
+      "LayerNotFound": "Couche de données {{layer_name}} non trouvée.",
+      "ViewNotFound": "View {{view_name}} non trouvé."
+    },
+    "operation": {
+      "EmptyId": "Une chaine de caractères vide est interdit comme identifiant",
+      "InvalidPatch": "Une erreur de correctif JSON est survenue",
+      "ModifyId": "L'opération de mise à jour tente de modifier l'ID de l'objet, ce qui est interdit",
+      "ObjectNotFound": "Objet '{{obj_id}}' non trouvé dans l'infrastructure '{{infra_id}}'"
+    },
+    "pagination": {
+      "InvalidPage": "Le numéro de page '{{page}}' est invalide",
+      "InvalidPageSize": "La taille de la page '{{provided_page_size}}' est invalide, il doit être un entier compris entre 0 et {{max_page_size}}"
+    },
+    "pathfinding": {
+      "ElectricalProfilesOverlap": "Des profils électriques se chevauchent",
+      "ElectrificationOverlap": "Electrification {{electrification_id}} se supperpose avec d'autres",
+      "InfraNotFound": "Infrastructure {{infra_id}} non trouvée",
+      "NotFound": "Itinéraire {{pathfinding_id}} non trouvé",
+      "OperationalPointsNotFound": "Points opérationnels {{operational_points}} non trouvés",
+      "RollingStockNotFound": "Matériel roulant {{rolling_stock_id}} non trouvé",
+      "TrackSectionsNotFound": "Section de ligne {{track_sections}} non trouvée"
+    },
+    "postgres": {
+      "Host": "Url de base de données '{{hostname}} est invalide",
+      "Password": "Mot-de-passe erroné",
+      "Port": "Port '{{port}}' invalide",
+      "Username": "Identifiant invalide"
+    },
+    "project": {
+      "ImageError": "L'image fournie est invalide",
+      "ImageNotFound": "Image '{{document_key}}' non trouvée",
+      "NotFound": "Projet '{{project_id}}' non trouvé"
+    },
+    "railjson": {
+      "UnsupportedVersion": "Version de railjson non supportée"
+    },
+    "redis": {
+      "Url": "Url invalide '{{url}}'"
+    },
+    "rollingstocks": {
+      "BasePowerClassEmpty": "La classe de puissance par défaut ne peut être vide",
+      "CannotCreateCompoundImage": "Impossible de créer l'image composée",
+      "CannotReadImage": "Impossible de lire l'image",
+      "NameAlreadyUsed": "Un matériel roulant avec le nom '{{name}}' existe déjà",
+      "NotFound": "Matériel roulant '{{rolling_stock_id}}' non trouvé",
+      "RollingStockIsLocked": "Matériel roulant '{{rolling_stock_id}}' est verrouillé",
+      "RollingStockIsUsed": "Matériel roulant '{{rolling_stock_id}}' est occupé"
+    },
+    "scenario": {
+      "NotFound": "Scénario non trouvé"
+    },
+    "search": {
+      "ArgMissing": "Argument de type {{expected}} manquant à la position {{arg_pos}}",
+      "ArgTypeMismatch": "Argument de type {{expected}} attendu à la position {{arg_pos}}, mais {{actual}} reçu",
+      "EmptyArray": "Les tableaux vides sont interdits",
+      "IntegerConversion": "Impossible de convertir en 'i64'",
+      "InvalidColumnName": "Nom de colonne invalide",
+      "InvalidFunctionIdentifier": "L'identifiant de la fonction doit être une chaîne de caractères",
+      "InvalidSyntax": "Syntaxe invalide",
+      "ObjectType": "Le type de l'objet est invalide",
+      "QueryAst": "Une requête de type booléen est attendue",
+      "RuntimeTypeCheckFail": "Type attendu {{expected}}, mais reçu '{{value}}' de type {{actual}} à la place",
+      "UndefinedFunction": "Fonction non définie",
+      "UndefinedOverload": "Aucune surcharge appropriée",
+      "UnexpectedArg": "Argument inattendu trouvé",
+      "UnexpectedColummn": "Colonne inattendue",
+      "UnexpectedErsatz": "Une valeur de type {{expected}} était attendue, mais '{{value}}' trouvé",
+      "VariadicArgTypeMismatch": "Un argument variadique de type {{expected}} était attendu, mais {{actual}} trouvé"
+    },
+    "single_simulation": {
+      "ElectricalProfileSetNotFound": "Profil électrique '{{electrical_profile_set_id}}' non trouvé",
+      "PathNotFound": "Chemin '{{path_id}}' non trouvé",
+      "RollingStockNotFound": "Matériel roulant '{{rolling_stock_id}}' non trouvé",
+      "WrongCoreResponseFormat": "Mauvais format de réponse reçu de Core"
+    },
+    "sprites": {
+      "FileNotFound": "Fichier non trouvé",
+      "UnknownSignalingSystem": "Système de signalisation inconnu"
+    },
+    "stdcm": {
+      "InfraNotFound": "Infrastructure {{infra_id}} non trouvée"
+    },
+    "study": {
+      "NotFound": "Etude '{{study_id}}' non trouvée",
+      "StartDateAfterEndDate": "La date de début de l'étude doit commencer avant sa date de fin"
+    },
+    "timetable": {
+      "InfraNotLoaded": "L'infrastructure '{{infra_id}}' n'est pas chargée",
+      "NotFound": "Grille horaire '{{timetable_id}}' non trouvée"
+    },
+    "train_schedule": {
+      "BatchShouldHaveSameTimetable": "Le lot doit avoir une grille horaire identique",
+      "BatchTrainScheduleNotFound": "Certaines circulations sont introuvables",
+      "NoSimulation": "Aucune simulation fournie",
+      "NoTrainSchedules": "Aucune circulation de train fournie",
+      "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
+      "PathNotFound": "Chemin '{{path_id}}' non trouvé",
+      "RollingStockNotFound": "Matériel roulant '{{rolling_stock_id}}' non trouvé",
+      "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
+      "UnsimulatedTrainSchedule": "La circulation '{{train_schedule_id}}' n'est pas simulée"
+    },
+    "url": {
+      "InvalidUrl": "Url invalide '{{url}}'"
+    }
+  }
 }

--- a/front/scripts/api-errors-i18n.ts
+++ b/front/scripts/api-errors-i18n.ts
@@ -1,0 +1,88 @@
+import SwaggerParser from '@apidevtools/swagger-parser';
+import i18next from 'i18next';
+import { noop } from 'lodash';
+
+// relative the project's root
+const openapi_path = '../editoast/openapi.yaml';
+// relative to this file
+const i18n_error_path = '../public/locales/fr/errors.json';
+
+/**
+ * Check if the given error is well filled in the i18n.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function checkI18N(error: any): Promise<string[]> {
+  const result: string[] = [];
+
+  // Error data for i18n
+  const errorName = error.properties.type.enum[0];
+  const errorId = errorName.split(':').join('.');
+  const errorVarExample = Object.keys(error.properties.context.properties || {}).reduce(
+    (acc, curr) => {
+      acc[curr] = '';
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+
+  // Init the i18n system
+  const i18nData = require(i18n_error_path);
+  const i18n = await i18next.createInstance(
+    {
+      lng: 'fr',
+      resources: {
+        fr: {
+          translation: i18nData,
+        },
+      },
+      parseMissingKeyHandler: () => {
+        result.push(
+          `Error "${errorName}" has missing i18n message. Please add the key "${errorId}" to the file "${i18n_error_path}"`
+        );
+      },
+      missingInterpolationHandler: (_text, value) => {
+        result.push(`Message for error "${errorName}" is using an unknown variable ${value[0]}`);
+      },
+    },
+    noop
+  );
+
+  // Generate the error message
+  i18n.t(errorId, errorVarExample);
+
+  return result;
+}
+
+async function run() {
+  try {
+    const api = await SwaggerParser.validate(openapi_path);
+
+    // Do some checks on the generic error
+    if (!api.components.schemas.EditoastError)
+      throw new Error(`"EditoastError" can't be found in "components > schemas"`);
+    if (!api.components.schemas.EditoastError.oneOf)
+      throw new Error(`Expected "EditoastError" to be a "oneOf" object`);
+
+    // Check i18n for all errors
+    const errors = (
+      await Promise.all(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        api.components.schemas.EditoastError.oneOf.map((error: any) => checkI18N(error))
+      )
+    ).flat();
+
+    if (errors.length > 0) {
+      console.log(errors);
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  } finally {
+    process.exit();
+  }
+}
+
+run();

--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -1,8 +1,19 @@
 import { SerializedError } from '@reduxjs/toolkit';
+
 import { ApiError } from 'common/api/baseGeneratedApis';
+import i18n from 'i18n';
 
 // eslint-disable-next-line import/prefer-default-export
-export const extractMessageFromError = (error: ApiError | SerializedError) =>
-  `${(error as ApiError)?.data?.message || (error as SerializedError)?.message}`;
+export const extractMessageFromError = (error: ApiError | SerializedError | Error): string => {
+  let message = i18n.t('default', { ns: ['errors'] });
+  if ('data' in error) {
+    const { type, context } = error.data;
+    const i18nId = type.split(':').join('.');
+    message = i18n.t(i18nId, error.data.message, { context, ns: ['errors'] });
+  } else if (error.message) {
+    message = error.message;
+  }
+  return message;
+};
 
 export const extractStatusFromError = (error: ApiError) => (error as ApiError)?.status;

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -6641,9 +6641,9 @@ ejs@^3.1.8:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.670"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.670.tgz#0fc5ac92ada8371e898ea72d577ffc888167a017"
-  integrity sha512-hcijYOWjOtjKrKPtNA6tuLlA/bTLO3heFG8pQA6mLpq7dRydSWicXova5lyxDzp1iVJaYhK7J2OQlGE52KYn7A==
+  version "1.4.672"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.672.tgz#f8ce803b43898b7e91dcfcf70d6fd656b11a645d"
+  integrity sha512-YYCy+goe3UqZqa3MOQCI5Mx/6HdBLzXL/mkbGCEWL3sP3Z1BP9zqAzeD3YEmLZlespYGFtyM8tRp5i2vfaUGCA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -6880,7 +6880,7 @@ esbuild@^0.18.0:
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
 
-esbuild@^0.19.3:
+esbuild@^0.19.3, esbuild@~0.19.10:
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.12.tgz#dc82ee5dc79e82f5a5c3b4323a2a641827db3e04"
   integrity sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==
@@ -7887,6 +7887,13 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
+
+get-tsconfig@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.2.tgz#0dcd6fb330391d46332f4c6c1bf89a6514c2ddce"
+  integrity sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 get-value@^2.0.2, get-value@^2.0.6:
   version "2.0.6"
@@ -11999,6 +12006,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
@@ -12153,9 +12165,9 @@ sass-loader@^14.1.0:
     neo-async "^2.6.2"
 
 sass@^1.70.0:
-  version "1.70.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.70.0.tgz#761197419d97b5358cb25f9dd38c176a8a270a75"
-  integrity sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==
+  version "1.71.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.71.0.tgz#b3085759b9b2ab503a977aecb7e91153bf941117"
+  integrity sha512-HKKIKf49Vkxlrav3F/w6qRuPcmImGVbIXJ2I3Kg0VMA+3Bav+8yE9G5XmP5lMj6nl4OlqbPftGAscNaNu28b8w==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -13177,6 +13189,16 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tsx@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.7.1.tgz#27af6cbf4e1cdfcb9b5425b1c61bb7e668eb5e84"
+  integrity sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==
+  dependencies:
+    esbuild "~0.19.10"
+    get-tsconfig "^4.7.2"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
See https://github.com/osrd-project/osrd-confidential/issues/281 for more details 
close #6193

What I did is :
- editoast generates API errors definition into `openapi.yaml` by looking at all object that derives from `EditoastError`
- frontend task "api-errors-i18n" reads the `openapi.yml` and i18n `errors.json` file to check if there are some missing or invalid values
- frontend task is run on the CI, within the check of the openapi (see job `check_editoast_openapi`)

Moreover, the function `extractMessageFromError` in `front/src/utils/error.ts`  has been changed, to search the message to display in the I18N.