### PR TITLE
core: add reverse neutral-section to small_infra for test

### DIFF
--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/EnvelopeTrainPathTest.kt
@@ -310,6 +310,30 @@ class EnvelopeTrainPathTest {
         putInElectrificationMapByPowerClass(
             expectedElectrificationPowerClass1,
             2_600.0,
+            2_900.0,
+            Electrified("1500V"),
+            "B",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            2_900.0,
+            2_910.0,
+            Neutral(false, Electrified("1500V"), true),
+            "B",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            2_910.0,
+            3_050.0,
+            Neutral(false, Electrified("1500V"), false),
+            "B",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass1,
+            3_050.0,
             3_300.0,
             Electrified("1500V"),
             "B",
@@ -348,14 +372,38 @@ class EnvelopeTrainPathTest {
         putInElectrificationMapByPowerClass(
             expectedElectrificationPowerClass2,
             2_700.0,
-            3_000.0,
+            2_900.0,
             Electrified("1500V"),
             "C",
             false
         )
         putInElectrificationMapByPowerClass(
             expectedElectrificationPowerClass2,
+            2_900.0,
+            2_910.0,
+            Neutral(false, Electrified("1500V"), true),
+            "C",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            2_910.0,
             3_000.0,
+            Neutral(false, Electrified("1500V"), false),
+            "C",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            3_000.0,
+            3_050.0,
+            Neutral(false, Electrified("1500V"), false),
+            "D",
+            false
+        )
+        putInElectrificationMapByPowerClass(
+            expectedElectrificationPowerClass2,
+            3_050.0,
             4_000.0,
             Electrified("1500V"),
             "D",
@@ -374,18 +422,18 @@ class EnvelopeTrainPathTest {
                     Direction.INCREASING,
                     ImmutableRangeMap.Builder<Double, Electrification>()
                         .put(Range.closedOpen(0.0, 300.0), NonElectrified())
-                        .put(Range.closedOpen(300.0, 1350.0), Electrified("1500V"))
+                        .put(Range.closedOpen(300.0, 1_350.0), Electrified("1500V"))
                         .put(
-                            Range.closedOpen(1350.0, 1460.0),
+                            Range.closedOpen(1_350.0, 1_460.0),
                             Neutral(true, Electrified("1500V"), true)
                         )
                         .put(
-                            Range.closedOpen(1460.0, 1500.0),
+                            Range.closedOpen(1_460.0, 1_500.0),
                             Neutral(true, Electrified("1500V"), false)
                         )
-                        .put(Range.closedOpen(1500.0, 2500.0), Electrified("1500V"))
-                        .put(Range.closedOpen(2500.0, 2600.0), NonElectrified())
-                        .put(Range.closed(2600.0, 3100.0), Electrified("25000V"))
+                        .put(Range.closedOpen(1_500.0, 2_500.0), Electrified("1500V"))
+                        .put(Range.closedOpen(2_500.0, 2_600.0), NonElectrified())
+                        .put(Range.closed(2_600.0, 3_100.0), Electrified("25000V"))
                         .build()
                 ),
                 Arguments.of(
@@ -394,8 +442,17 @@ class EnvelopeTrainPathTest {
                     ImmutableRangeMap.Builder<Double, Electrification>()
                         .put(Range.closedOpen(0.0, 350.0), Electrified("25000V"))
                         .put(Range.closedOpen(350.0, 450.0), NonElectrified())
-                        .put(Range.closedOpen(450.0, 2650.0), Electrified("1500V"))
-                        .put(Range.closed(2650.0, 3100.0), NonElectrified())
+                        .put(Range.closedOpen(450.0, 1_450.0), Electrified("1500V"))
+                        .put(
+                            Range.closedOpen(1_450.0, 1_460.0),
+                            Neutral(false, Electrified("1500V"), true)
+                        )
+                        .put(
+                            Range.closedOpen(1_460.0, 1_600.0),
+                            Neutral(false, Electrified("1500V"), false)
+                        )
+                        .put(Range.closedOpen(1_600.0, 2_650.0), Electrified("1500V"))
+                        .put(Range.closed(2_650.0, 3_100.0), NonElectrified())
                         .build()
                 ),
             )

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -6867,6 +6867,26 @@
                 }
             ],
             "lower_pantograph": false
+        },
+        {
+            "id": "neutral_section.3",
+            "announcement_track_ranges": [
+                {
+                    "track": "TA0",
+                    "begin": 1990.0,
+                    "end": 2000.0,
+                    "direction": "STOP_TO_START"
+                }
+            ],
+            "track_ranges": [
+                {
+                    "track": "TA0",
+                    "begin": 1850.0,
+                    "end": 1990.0,
+                    "direction": "STOP_TO_START"
+                }
+            ],
+            "lower_pantograph": false
         }
     ]
 }

--- a/tests/infra-scripts/small_infra.py
+++ b/tests/infra-scripts/small_infra.py
@@ -600,15 +600,18 @@ builder.infra.electrifications.append(Electrification("electrification_1.5k", "1
 lower_pantograph_section_1 = builder.add_neutral_section(lower_pantograph=True)
 lower_pantograph_section_1.add_announcement_track_range(tg1, 3500, tg1.length, Direction.START_TO_STOP)
 lower_pantograph_section_1.add_track_range(tg4, 0, 500, Direction.START_TO_STOP)
-
+lower_pantograph_section_1.add_track_range(ta6, 0, 10, Direction.START_TO_STOP)
 
 lower_pantograph_section_2 = builder.add_neutral_section(lower_pantograph=True)
 lower_pantograph_section_2.add_announcement_track_range(ta0, 1850, 1960, Direction.START_TO_STOP)
 lower_pantograph_section_2.add_track_range(ta0, 1960, 2000, Direction.START_TO_STOP)
-lower_pantograph_section_1.add_track_range(ta6, 0, 10, Direction.START_TO_STOP)
 
-lower_pantograph_section_3 = builder.add_neutral_section(lower_pantograph=False)
-lower_pantograph_section_3.add_track_range(ta6, 8500, 8600, Direction.START_TO_STOP)
+keep_pantograph_section_3 = builder.add_neutral_section(lower_pantograph=False)
+keep_pantograph_section_3.add_track_range(ta6, 8500, 8600, Direction.START_TO_STOP)
+
+keep_pantograph_section_4 = builder.add_neutral_section(lower_pantograph=False)
+keep_pantograph_section_4.add_announcement_track_range(ta0, 1990, 2000, Direction.STOP_TO_START)
+keep_pantograph_section_4.add_track_range(ta0, 1850, 1990, Direction.STOP_TO_START)
 
 
 # ================================


### PR DESCRIPTION
The main goal is to read neutral-sections oriented from stop to start on a track section (later test on refactor of railjson reading)

Also: update neutral section tests accordingly