### PR TITLE
display jaune cli on GET

### DIFF
--- a/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/ChartHelpers.ts
@@ -18,6 +18,7 @@ import {
   PositionsSpeedTimes,
 } from 'reducers/osrdsimulation/types';
 import { ChartAxes, ListValues, XAxis, Y2Axis, YAxis } from 'modules/simulationResult/consts';
+import { BaseType } from 'd3';
 
 export function sec2d3datetime(time: number) {
   return d3.timeParse('%H:%M:%S')(sec2time(time));
@@ -429,4 +430,26 @@ export function getAxis(keyValues: ChartAxes, axis: 'x' | 'y' | 'y2', rotate: bo
     return (!rotate ? keyValues[0] : keyValues[1]) as XAxis;
   }
   return (!rotate ? keyValues[1] : keyValues[0]) as YAxis | Y2Axis;
+}
+
+export function buildStripe(
+  stripSelection: d3.Selection<BaseType, unknown, null, undefined>,
+  {
+    id,
+    color,
+    width = 8,
+    height = 8,
+    strokeWidth = 2.5,
+  }: { id: string; color: string; width?: number; height?: number; strokeWidth?: number }
+) {
+  stripSelection
+    .append('pattern')
+    .attr('id', id)
+    .attr('patternUnits', 'userSpaceOnUse')
+    .attr('width', width)
+    .attr('height', height)
+    .append('path')
+    .attr('d', 'M-2,2 l4,-4 M0,8 l8,-8 M6,10 l4,-4')
+    .attr('stroke', color)
+    .attr('stroke-width', strokeWidth);
 }

--- a/front/src/modules/simulationResult/components/ChartHelpers/drawElectricalProfile.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/drawElectricalProfile.ts
@@ -3,7 +3,7 @@ import i18n from 'i18n';
 import { Chart } from 'reducers/osrdsimulation/types';
 import { ElectricalConditionSegment, DrawingKeys } from 'applications/operationalStudies/consts';
 import getAxisValues from 'modules/simulationResult/components/ChartHelpers/drawHelpers';
-import { getElementWidth } from './ChartHelpers';
+import { getElementWidth, buildStripe } from './ChartHelpers';
 
 const ELECTRIFIED = 'Electrified';
 const NEUTRAL = 'Neutral';
@@ -39,18 +39,10 @@ const drawElectricalProfile = (
 
   // prepare stripe pattern
   if (isStripe) {
-    const stripe = chart.drawZone.select(`#${groupID}`);
-    stripe
-
-      .append('pattern')
-      .attr('id', `${id}`)
-      .attr('patternUnits', 'userSpaceOnUse')
-      .attr('width', 8)
-      .attr('height', 8)
-      .append('path')
-      .attr('d', 'M-2,2 l4,-4 M0,8 l8,-8 M6,10 l4,-4')
-      .attr('stroke', electricalConditionSegment.color)
-      .attr('stroke-width', 2.5);
+    buildStripe(chart.drawZone.select(`#${groupID}`), {
+      id,
+      color: electricalConditionSegment.color,
+    });
   }
 
   const drawZone = chart.drawZone.select(`#${groupID}`);

--- a/front/src/modules/simulationResult/components/ChartHelpers/drawPowerRestriction.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/drawPowerRestriction.ts
@@ -3,6 +3,7 @@ import { pointer } from 'd3-selection';
 import i18n from 'i18n';
 import { Chart } from 'reducers/osrdsimulation/types';
 import getAxisValues from 'modules/simulationResult/components/ChartHelpers/drawHelpers';
+import { buildStripe } from './ChartHelpers';
 
 const drawPowerRestriction = (
   chart: Chart,
@@ -29,17 +30,7 @@ const drawPowerRestriction = (
 
   // prepare stripe pattern
   if (isStripe) {
-    const stripe = chart.drawZone.select(`#${groupID}`);
-    stripe
-      .append('pattern')
-      .attr('id', `${id}`)
-      .attr('patternUnits', 'userSpaceOnUse')
-      .attr('width', 8)
-      .attr('height', 8)
-      .append('path')
-      .attr('d', 'M-2,2 l4,-4 M0,8 l8,-8 M6,10 l4,-4')
-      .attr('stroke', '#333')
-      .attr('stroke-width', 2.5);
+    buildStripe(chart.drawZone.select(`#${groupID}`), { id, color: '#333' });
   }
 
   const drawZone = chart.drawZone.select(`#${groupID}`);

--- a/front/src/modules/simulationResult/components/ChartHelpers/drawRect.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/drawRect.ts
@@ -1,4 +1,5 @@
 import { Chart, ConsolidatedRouteAspect } from 'reducers/osrdsimulation/types';
+import { buildStripe } from './ChartHelpers';
 
 /**
  * Draw rect for SpaceTimeChart
@@ -22,15 +23,20 @@ const drawRect = (
     ? chart.y(dataSimulation.time_end) - chart.y(dataSimulation.time_start)
     : chart.y(dataSimulation.position_end) - chart.y(dataSimulation.position_start);
 
+  const isStripe = dataSimulation.blinking;
+  if (isStripe) {
+    buildStripe(chart.drawZone.select(`#${groupID}`), { id: id!, color: dataSimulation.color });
+  }
+
   const drawZone = chart.drawZone.select(`#${groupID}`);
   drawZone
     .append('rect')
     .attr('id', id)
     .attr('class', `rect zoomable ${classes}`)
     .datum(dataSimulation)
-    .attr('fill', dataSimulation.color)
+    .attr('fill', isStripe ? `url(#${id})` : dataSimulation.color)
     .attr('stroke-width', 1)
-    .attr('stroke', dataSimulation.color)
+    .attr('stroke', isStripe ? `url(#${id})` : dataSimulation.color)
     .attr('x', chart.x(rotate ? dataSimulation.position_start : dataSimulation.time_start))
     .attr(
       'y',

--- a/front/src/modules/simulationResult/components/ChartHelpers/drawRect.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/drawRect.ts
@@ -10,7 +10,7 @@ const drawRect = (
   dataSimulation: ConsolidatedRouteAspect,
   groupID: string,
   rotate: boolean,
-  id: string | null = null
+  id: string
 ) => {
   if (dataSimulation.time_end === null || dataSimulation.time_start === null) {
     return;
@@ -25,7 +25,7 @@ const drawRect = (
 
   const isStripe = dataSimulation.blinking;
   if (isStripe) {
-    buildStripe(chart.drawZone.select(`#${groupID}`), { id: id!, color: dataSimulation.color });
+    buildStripe(chart.drawZone.select(`#${groupID}`), { id, color: dataSimulation.color });
   }
 
   const drawZone = chart.drawZone.select(`#${groupID}`);

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
@@ -88,14 +88,14 @@ export default function drawTrain(
       });
     } else {
       // Let's draw normal route_aspects
-      trainToDraw.routeAspects.forEach((routeAspect) => {
+      trainToDraw.routeAspects.forEach((routeAspect, index) => {
         drawRect(
           chart,
           `${isSelected && 'selected'} route-aspect`,
           routeAspect,
           groupID,
           rotate,
-          `${groupID}${routeAspect.route_id}${routeAspect.color}`
+          `${groupID}_${routeAspect.signal_id}_${index}`
         );
       });
     }

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
@@ -75,30 +75,17 @@ export default function drawTrain(
     : undefined;
 
   if (direction && currentAllowanceSettings) {
-    if (trainToDraw.eco_routeAspects) {
-      // Let's draw eco_route_aspects
-      trainToDraw.eco_routeAspects.forEach((ecoRouteAspect) => {
-        drawRect(
-          chart,
-          `${isSelected && 'selected'} route-aspect`,
-          ecoRouteAspect,
-          groupID,
-          rotate
-        );
-      });
-    } else {
-      // Let's draw normal route_aspects
-      trainToDraw.routeAspects.forEach((routeAspect, index) => {
-        drawRect(
-          chart,
-          `${isSelected && 'selected'} route-aspect`,
-          routeAspect,
-          groupID,
-          rotate,
-          `${groupID}_${routeAspect.signal_id}_${index}`
-        );
-      });
-    }
+    const routeAspects = trainToDraw.eco_routeAspects ?? trainToDraw.routeAspects;
+    routeAspects.forEach((routeAspect, index) => {
+      drawRect(
+        chart,
+        `${isSelected && 'selected'} route-aspect`,
+        routeAspect,
+        groupID,
+        rotate,
+        `${groupID}_${routeAspect.signal_id}_${index}`
+      );
+    });
   }
 
   if (currentAllowanceSettings?.base) {


### PR DESCRIPTION
closes #6652  
The occupation blocks corresponding to the "jaune cli" are identified by the `blinking` field of `routeAspects` object setted to true. Right now, the backend handle these blocks indifferently from the other blocks. Because of this, the blinking field is always false for now. But, this PR prepares the frontend ready to show stripes on the blocks that have a "jaune cli" in GET

To check this, you need to change one thing in the file `drawRect.ts` at `line 26`. Just add the `!` operator to flip the condition, and you'll see that all the blocks get striped colors.

Now the last parameter of drawRect (id) is mandatory because we need this when we want to hatch color of block.

I've also added d3js code that allows adding stripes to a color in a function. I reused this function wherever it was needed to avoid duplicating the logic.