### PR TITLE
front: editor: improves speed sections form

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/tools.ts
+++ b/front/src/applications/editor/tools/rangeEdition/tools.ts
@@ -28,8 +28,7 @@ export const SpeedEditionTool = getRangeEditionTool<SpeedSectionEntity | SpeedSe
   leftPanelComponent: RangeEditionLeftPanel,
   canSave(state) {
     const records = state.entity.properties.speed_limit_by_tag || {};
-    const compositionCodes = Object.keys(records);
-    return compositionCodes.every((code) => !!code);
+    return !state.error && Object.keys(records).every((code) => !!code);
   },
   getEventsLayers() {
     return [

--- a/front/src/applications/editor/tools/rangeEdition/types.ts
+++ b/front/src/applications/editor/tools/rangeEdition/types.ts
@@ -144,6 +144,7 @@ export type PslSignInformation =
   | { signType: PSL_SIGN_TYPES.Z };
 
 export type RangeEditionState<E extends EditorEntity> = CommonToolState & {
+  error?: string;
   initialEntity: E;
   entity: E;
   hoveredItem:


### PR DESCRIPTION
Fixes #6442.

Details:
- "Add new limit" button is no more disabled
- Save button is disabled instead when speed limits are not valid
- Speed limits by tags in the form are now handled as an array, separated from the collection in entity.properties.speed_limit_by_tag
- Uses "required" and "pattern" attributes to get a red border when tag or speed inputs are not valid