### PR TITLE
editoast: enhance editoast error context

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -621,7 +621,7 @@ components:
       - $ref: '#/components/schemas/EditoastSearchUndefinedFunction'
       - $ref: '#/components/schemas/EditoastSearchUndefinedOverload'
       - $ref: '#/components/schemas/EditoastSearchUnexpectedArg'
-      - $ref: '#/components/schemas/EditoastSearchUnexpectedColummn'
+      - $ref: '#/components/schemas/EditoastSearchUnexpectedColumn'
       - $ref: '#/components/schemas/EditoastSearchUnexpectedErsatz'
       - $ref: '#/components/schemas/EditoastSearchVariadicArgTypeMismatch'
       - $ref: '#/components/schemas/EditoastSingleSimulationElectricalProfileSetNotFound'
@@ -702,6 +702,11 @@ components:
     EditoastInfraEditionInfraIsLocked:
       properties:
         context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
           type: object
         message:
           type: string
@@ -764,6 +769,11 @@ components:
     EditoastInfraNotFound:
       properties:
         context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
           type: object
         message:
           type: string
@@ -802,6 +812,11 @@ components:
     EditoastInfraObjectsObjectIdNotFound:
       properties:
         context:
+          properties:
+            object_id:
+              type: string
+          required:
+          - object_id
           type: object
         message:
           type: string
@@ -840,6 +855,14 @@ components:
     EditoastInfraPathfindingInvalidNumberOfPaths:
       properties:
         context:
+          properties:
+            max_number:
+              type: integer
+            path_number:
+              type: integer
+          required:
+          - max_number
+          - path_number
           type: object
         message:
           type: string
@@ -970,6 +993,11 @@ components:
     EditoastOperationInvalidPatch:
       properties:
         context:
+          properties:
+            error:
+              type: string
+          required:
+          - error
           type: object
         message:
           type: string
@@ -1343,6 +1371,11 @@ components:
     EditoastProjectImageError:
       properties:
         context:
+          properties:
+            error:
+              type: string
+          required:
+          - error
           type: object
         message:
           type: string
@@ -1410,6 +1443,14 @@ components:
     EditoastRailjsonUnsupportedVersion:
       properties:
         context:
+          properties:
+            actual:
+              type: string
+            expected:
+              type: string
+          required:
+          - actual
+          - expected
           type: object
         message:
           type: string
@@ -1709,6 +1750,11 @@ components:
     EditoastSearchIntegerConversion:
       properties:
         context:
+          properties:
+            value:
+              type: integer
+          required:
+          - value
           type: object
         message:
           type: string
@@ -1728,6 +1774,11 @@ components:
     EditoastSearchInvalidColumnName:
       properties:
         context:
+          properties:
+            value:
+              type: object
+          required:
+          - value
           type: object
         message:
           type: string
@@ -1747,6 +1798,11 @@ components:
     EditoastSearchInvalidFunctionIdentifier:
       properties:
         context:
+          properties:
+            value:
+              type: object
+          required:
+          - value
           type: object
         message:
           type: string
@@ -1766,6 +1822,11 @@ components:
     EditoastSearchInvalidSyntax:
       properties:
         context:
+          properties:
+            value:
+              type: object
+          required:
+          - value
           type: object
         message:
           type: string
@@ -1785,6 +1846,11 @@ components:
     EditoastSearchObjectType:
       properties:
         context:
+          properties:
+            object_type:
+              type: string
+          required:
+          - object_type
           type: object
         message:
           type: string
@@ -1804,6 +1870,11 @@ components:
     EditoastSearchQueryAst:
       properties:
         context:
+          properties:
+            query_type:
+              type: string
+          required:
+          - query_type
           type: object
         message:
           type: string
@@ -1853,6 +1924,11 @@ components:
     EditoastSearchUndefinedFunction:
       properties:
         context:
+          properties:
+            function:
+              type: string
+          required:
+          - function
           type: object
         message:
           type: string
@@ -1891,6 +1967,11 @@ components:
     EditoastSearchUnexpectedArg:
       properties:
         context:
+          properties:
+            arg_type:
+              type: object
+          required:
+          - arg_type
           type: object
         message:
           type: string
@@ -1907,9 +1988,14 @@ components:
       - status
       - message
       type: object
-    EditoastSearchUnexpectedColummn:
+    EditoastSearchUnexpectedColumn:
       properties:
         context:
+          properties:
+            column:
+              type: string
+          required:
+          - column
           type: object
         message:
           type: string
@@ -1919,7 +2005,7 @@ components:
           type: integer
         type:
           enum:
-          - editoast:search:UnexpectedColummn
+          - editoast:search:UnexpectedColumn
           type: string
       required:
       - type
@@ -2074,6 +2160,11 @@ components:
     EditoastSpritesFileNotFound:
       properties:
         context:
+          properties:
+            file:
+              type: string
+          required:
+          - file
           type: object
         message:
           type: string
@@ -2093,6 +2184,11 @@ components:
     EditoastSpritesUnknownSignalingSystem:
       properties:
         context:
+          properties:
+            signaling_system:
+              type: string
+          required:
+          - signaling_system
           type: object
         message:
           type: string

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -448,7 +448,11 @@ async fn clone_infra(
             cloned_infra.id.unwrap()
         ),
         Err(e) => {
-            if e == InfraError::NotFound(infra_args.id as i64).into() {
+            if e == (InfraError::NotFound {
+                infra_id: infra_args.id as i64,
+            })
+            .into()
+            {
                 let error = CliError::new(
                     1,
                     format!("❌ Infrastructure not found, ID: {}", infra_args.id),

--- a/editoast/src/modelsv2/railjson.rs
+++ b/editoast/src/modelsv2/railjson.rs
@@ -12,8 +12,8 @@ use crate::{
 #[derive(Debug, thiserror::Error, EditoastError)]
 #[editoast_error(base_id = "railjson")]
 pub enum RailJsonError {
-    #[error("Unsupported railjson version '{0}'. Should be {}.", RAILJSON_VERSION)]
-    UnsupportedVersion(String),
+    #[error("Unsupported railjson version '{actual}'. Should be {expected}.")]
+    UnsupportedVersion { actual: String, expected: String },
 }
 
 /// Inserts the content of a RailJson object into the database
@@ -55,7 +55,11 @@ pub async fn persist_railjson(
         neutral_sections,
     } = railjson;
     if version != RAILJSON_VERSION {
-        return Err(RailJsonError::UnsupportedVersion(version).into());
+        return Err(RailJsonError::UnsupportedVersion {
+            actual: version,
+            expected: RAILJSON_VERSION.to_string(),
+        }
+        .into());
     }
     futures::try_join!(
         persist!(TrackSectionModel, track_sections),

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -94,6 +94,6 @@ enum OperationError {
     EmptyId,
     #[error("Update operation try to modify object id, which is forbidden")]
     ModifyId,
-    #[error("A Json Patch error occurred: '{}'", .0)]
-    InvalidPatch(String),
+    #[error("A Json Patch error occurred: '{error}'")]
+    InvalidPatch { error: String },
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -74,7 +74,7 @@ async fn list_auto_fixes(
     let infra_id = infra.into_inner();
     let infra = Infra::retrieve(db_pool.clone(), infra_id)
         .await?
-        .ok_or(models::infra::InfraError::NotFound(infra_id))?;
+        .ok_or(models::infra::InfraError::NotFound { infra_id })?;
     let mut conn = db_pool.get().await?;
 
     // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -53,7 +53,10 @@ async fn apply_edit(
     let infra_id = infra.id.unwrap();
     // Check if the infra is locked
     if infra.locked.unwrap() {
-        return Err(EditionError::InfraIsLocked(infra.id.unwrap()).into());
+        return Err(EditionError::InfraIsLocked {
+            infra_id: infra.id.unwrap(),
+        }
+        .into());
     }
 
     // Apply modifications
@@ -104,6 +107,6 @@ async fn apply_edit(
 #[derive(Debug, Clone, Error, EditoastError)]
 #[editoast_error(base_id = "infra:edition")]
 enum EditionError {
-    #[error("Infra {0} is locked")]
-    InfraIsLocked(i64),
+    #[error("Infra {infra_id} is locked")]
+    InfraIsLocked { infra_id: i64 },
 }

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -27,8 +27,8 @@ pub fn routes() -> impl HttpServiceFactory {
 enum GetObjectsErrors {
     #[error("Duplicate object ids provided")]
     DuplicateIdsProvided,
-    #[error("Object id '{0}' not found")]
-    ObjectIdNotFound(String),
+    #[error("Object id '{object_id}' not found")]
+    ObjectIdNotFound { object_id: String },
 }
 
 /// Return whether the list of ids contains unique values or has duplicate
@@ -104,7 +104,10 @@ async fn get_objects(
             .iter()
             .find(|obj_id| !objects.contains_key(*obj_id))
             .unwrap();
-        return Err(GetObjectsErrors::ObjectIdNotFound(not_found_id.clone()).into());
+        return Err(GetObjectsErrors::ObjectIdNotFound {
+            object_id: not_found_id.clone(),
+        }
+        .into());
     }
 
     // Reorder the result to match the order of the input

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -41,11 +41,8 @@ enum PathfindingViewErrors {
     StartingTrackLocationNotFound,
     #[error("Ending track location was not found")]
     EndingTrackLocationNotFound,
-    #[error(
-        "The pathfinding cannot return {0} paths (expected: [1-{}])",
-        MAX_NUMBER_OF_PATHS
-    )]
-    InvalidNumberOfPaths(u8),
+    #[error("The pathfinding cannot return {path_number} paths (expected: [1-{max_number}])")]
+    InvalidNumberOfPaths { path_number: u8, max_number: u8 },
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -94,7 +91,11 @@ async fn pathfinding_view(
     let infra_id = infra.into_inner().infra_id;
     let number = params.number.unwrap_or(DEFAULT_NUMBER_OF_PATHS);
     if !(1..=MAX_NUMBER_OF_PATHS).contains(&number) {
-        return Err(PathfindingViewErrors::InvalidNumberOfPaths(number).into());
+        return Err(PathfindingViewErrors::InvalidNumberOfPaths {
+            path_number: number,
+            max_number: MAX_NUMBER_OF_PATHS,
+        }
+        .into());
     }
 
     let mut conn = db_pool.get().await?;

--- a/editoast/src/views/search/context.rs
+++ b/editoast/src/views/search/context.rs
@@ -88,12 +88,12 @@ where
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "search")]
 pub enum ProcessingError {
-    #[error("undefined function '{0}'")]
-    UndefinedFunction(String),
+    #[error("undefined function '{function}'")]
+    UndefinedFunction { function: String },
     #[error("no suitable overload of '{0}' found for {1}")]
     UndefinedOverload(String, String),
-    #[error("unexpected column '{0}'")]
-    UnexpectedColummn(String),
+    #[error("unexpected column '{column}'")]
+    UnexpectedColumn { column: String },
     #[error("expected type {expected}, got value '{value}' of type {actual} instead")]
     #[editoast_error(no_context)]
     RuntimeTypeCheckFail {
@@ -155,12 +155,15 @@ impl QueryContext {
         function_name: &String,
         arglist_types: &[TypeSpec],
     ) -> Result<&QueryFunction> {
-        let functions = self
-            .functions
-            .get(function_name)
-            .ok_or_else(|| ProcessingError::UndefinedFunction(function_name.to_owned()))?;
+        let functions = self.functions.get(function_name).ok_or_else(|| {
+            ProcessingError::UndefinedFunction {
+                function: function_name.to_owned(),
+            }
+        })?;
         let function = match functions.len() {
-            0 => Err(ProcessingError::UndefinedFunction(function_name.to_owned())),
+            0 => Err(ProcessingError::UndefinedFunction {
+                function: function_name.to_owned(),
+            }),
             1 => {
                 let function = functions.first().unwrap();
                 function

--- a/editoast/src/views/search/process.rs
+++ b/editoast/src/views/search/process.rs
@@ -24,7 +24,9 @@ impl QueryContext {
             SearchAst::Column(column) => self
                 .columns_type
                 .get(column)
-                .ok_or_else(|| ProcessingError::UnexpectedColummn(column.to_owned()))?
+                .ok_or_else(|| ProcessingError::UnexpectedColumn {
+                    column: column.to_owned(),
+                })?
                 .clone(),
             SearchAst::Call(function_name, args) => {
                 let arglist_types = args

--- a/editoast/src/views/search/typing.rs
+++ b/editoast/src/views/search/typing.rs
@@ -30,8 +30,9 @@ enum TypeCheckError {
     #[error("expected argument of type {expected} at position {arg_pos} is missing")]
     #[editoast_error(no_context)]
     ArgMissing { expected: TypeSpec, arg_pos: usize },
-    #[error("unexpected argument of type {0} found")]
-    UnexpectedArg(TypeSpec),
+    #[error("unexpected argument of type {arg_type} found")]
+    #[editoast_error(no_context)]
+    UnexpectedArg { arg_type: TypeSpec },
 }
 
 /// Defines all the atomic types that are expressible by the search query language
@@ -249,7 +250,10 @@ impl TypeSpec {
             }
         }
         match args_iter.next() {
-            Some(arg) => Err(TypeCheckError::UnexpectedArg((*arg).clone()).into()),
+            Some(arg) => Err(TypeCheckError::UnexpectedArg {
+                arg_type: (*arg).clone(),
+            }
+            .into()),
             None => Ok(()),
         }
     }

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -17,12 +17,12 @@ crate::routes! {
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "sprites")]
 enum SpriteErrors {
-    #[error("Unknown signaling system '{0}'")]
+    #[error("Unknown signaling system '{signaling_system}'")]
     #[editoast_error(status = 404)]
-    UnknownSignalingSystem(String),
-    #[error("File '{0}' not found")]
+    UnknownSignalingSystem { signaling_system: String },
+    #[error("File '{file}' not found")]
     #[editoast_error(status = 404)]
-    FileNotFound(String),
+    FileNotFound { file: String },
 }
 
 /// This endpoint returns the list of supported signaling systems
@@ -56,11 +56,11 @@ async fn sprites(path: Path<(String, String)>) -> Result<NamedFile> {
     let (signaling_system, file_name) = path.into_inner();
     let sprite_configs = SpriteConfig::load();
     if !sprite_configs.contains_key(&signaling_system) {
-        return Err(SpriteErrors::UnknownSignalingSystem(signaling_system).into());
+        return Err(SpriteErrors::UnknownSignalingSystem { signaling_system }.into());
     }
     let path = get_assets_path().join(format!("signal_sprites/{signaling_system}/{file_name}"));
     if !path.is_file() {
-        return Err(SpriteErrors::FileNotFound(file_name).into());
+        return Err(SpriteErrors::FileNotFound { file: file_name }.into());
     }
     Ok(NamedFile::open(path).unwrap().use_last_modified(false))
 }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -132,7 +132,7 @@
       "UndefinedFunction": "Undefined function",
       "UndefinedOverload": "No suitable overload",
       "UnexpectedArg": "Unexpected argument of type found",
-      "UnexpectedColummn": "Unexpected column",
+      "UnexpectedColumn": "Unexpected column",
       "UnexpectedErsatz": "Expected value of type {{expected}}, but got ersatz '{{value}}'",
       "VariadicArgTypeMismatch": "Expected variadic argument of type {{expected}}, but got {{actual}}"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -132,7 +132,7 @@
       "UndefinedFunction": "Fonction non définie",
       "UndefinedOverload": "Aucune surcharge appropriée",
       "UnexpectedArg": "Argument inattendu trouvé",
-      "UnexpectedColummn": "Colonne inattendue",
+      "UnexpectedColumn": "Colonne inattendue",
       "UnexpectedErsatz": "Une valeur de type {{expected}} était attendue, mais '{{value}}' trouvé",
       "VariadicArgTypeMismatch": "Un argument variadique de type {{expected}} était attendu, mais {{actual}} trouvé"
     },


### PR DESCRIPTION
See https://github.com/osrd-project/osrd-confidential/issues/281#issuecomment-1948412084 for more details.

This PR contains : 
- context should be an object with parameter to be well displayed in the UI
- adding needed parameters in some error (like `InfraNotFound` for example)