### PR TITLE
front: refacto of error management 

### DIFF
--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -55,7 +55,7 @@
       },
       "objects": {
         "DuplicateIdsProvided": "Duplicate object ids provided",
-        "ObjectIdNotFound": "Object ID not found"
+        "ObjectIdNotFound": "Object '{{object_id}}' not found"
       },
       "pathfinding": {
         "EndingTrackLocationNotFound": "Ending track location was not found",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -55,7 +55,7 @@
       },
       "objects": {
         "DuplicateIdsProvided": "Identifiants d'objet fournis en double",
-        "ObjectIdNotFound": "Objet ID non trouvé"
+        "ObjectIdNotFound": "Objet '{{object_id}}' non trouvé"
       },
       "pathfinding": {
         "EndingTrackLocationNotFound": "Localisation de la fin de la section non trouvé",

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -1,4 +1,3 @@
-import { SerializedError } from '@reduxjs/toolkit';
 import cx from 'classnames';
 import { isNil, toInteger } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -7,10 +6,8 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
-import { ApiError } from 'common/api/baseGeneratedApis';
 import type { ObjectType } from 'common/api/osrdEditoastApi';
 import { useInfraID, useOsrdActions } from 'common/osrdContext';
-
 import type { EditorSliceActions } from 'reducers/editor';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import MapButtons from 'common/Map/Buttons/MapButtons';
@@ -23,8 +20,7 @@ import { getEditorState, getInfraLockStatus } from 'reducers/editor/selectors';
 import { loadDataModel, updateTotalsIssue } from 'reducers/editor/thunkActions';
 import { updateViewport, type Viewport } from 'reducers/map';
 import { setFailure } from 'reducers/main';
-import { extractMessageFromError } from 'utils/error';
-
+import { castErrorToFailure } from 'utils/error';
 import { getEntity, getMixedEntities } from 'applications/editor/data/api';
 import { NEW_ENTITY_ID } from 'applications/editor/data/utils';
 import { useSwitchTypes } from 'applications/editor/tools/switchEdition/types';
@@ -37,7 +33,6 @@ import type { switchProps } from 'applications/editor/tools/switchProps';
 import { centerMapOnObject, selectEntities } from 'applications/editor/tools/utils';
 import TOOLS from 'applications/editor/tools/constsTools';
 import TOOL_NAMES from 'applications/editor/tools/constsToolNames';
-
 import type { EditoastType } from './consts';
 import type { EditorContextType, ExtendedEditorContextType, FullTool, Reducer } from './types';
 import type { EditorEntity } from './typesEditorEntity';
@@ -244,13 +239,12 @@ const Editor = () => {
             if (mapRef.current) centerMapOnObject(+urlInfra, entities, dispatch, mapRef.current);
           } catch (e) {
             dispatch(
-              setFailure({
-                name: t('translation:Editor.tools.select-items.errors.unable-to-select'),
-                message:
-                  extractMessageFromError(e as ApiError | SerializedError) !== 'undefined'
-                    ? extractMessageFromError(e as ApiError | SerializedError)
-                    : t('translation:Editor.tools.select-items.errors.invalid-url'),
-              })
+              setFailure(
+                castErrorToFailure(e, {
+                  name: t('translation:Editor.tools.select-items.errors.unable-to-select'),
+                  message: t('translation:Editor.tools.select-items.errors.invalid-url'),
+                })
+              )
             );
           }
         };

--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -17,7 +17,7 @@ import {
 import { translateSchema } from 'applications/editor/tools/translationTools';
 import { getEditorState } from 'reducers/editor/selectors';
 import type { EditorEntity } from 'applications/editor/typesEditorEntity';
-
+import { getErrorMessage } from 'utils/error';
 import { FormComponent, FormLineStringLength } from './LinearMetadata';
 
 const fields = {
@@ -119,8 +119,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
             setError(null);
             await onSubmit({ ...data, properties: { ...data.properties, ...formData } });
           } catch (e) {
-            if (e instanceof Error) setError(e.message);
-            else setError(JSON.stringify(e));
+            setError(getErrorMessage(e));
           } finally {
             setSubmited(true);
           }

--- a/front/src/applications/operationalStudies/components/Scenario/getSimulationResults.ts
+++ b/front/src/applications/operationalStudies/components/Scenario/getSimulationResults.ts
@@ -13,10 +13,8 @@ import {
   TrainScheduleSummary,
   osrdEditoastApi,
 } from 'common/api/osrdEditoastApi';
-import { extractMessageFromError } from 'utils/error';
+import { castErrorToFailure } from 'utils/error';
 import { AllowancesSettings, Projection } from 'reducers/osrdsimulation/types';
-import { ApiError } from 'common/api/baseGeneratedApis';
-import { SerializedError } from '@reduxjs/toolkit';
 import { differenceBy } from 'lodash';
 
 export function selectProjection(
@@ -132,12 +130,12 @@ export default async function getSimulationResults(
       store.dispatch(updateAllowancesSettings(newAllowancesSettings));
     } catch (e) {
       store.dispatch(
-        setFailure({
-          name: i18n.t('simulation:errorMessages.unableToRetrieveTrainSchedule'),
-          message: extractMessageFromError(e as ApiError | SerializedError),
-        })
+        setFailure(
+          castErrorToFailure(e, {
+            name: i18n.t('simulation:errorMessages.unableToRetrieveTrainSchedule'),
+          })
+        )
       );
-      console.error('trainScheduleResults error : ', e);
     } finally {
       store.dispatch(updateIsUpdating(false));
     }

--- a/front/src/applications/stdcm/views/StdcmRequestModal.tsx
+++ b/front/src/applications/stdcm/views/StdcmRequestModal.tsx
@@ -25,7 +25,7 @@ import { Spinner } from 'common/Loaders';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { SimulationReport } from 'common/api/osrdEditoastApi';
 import type { StdcmRequestStatus } from 'applications/stdcm/types';
-import { extractMessageFromError, extractStatusFromError } from 'utils/error';
+import { castErrorToFailure } from 'utils/error';
 import { Train } from 'reducers/osrdsimulation/types';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
 import { useAppDispatch } from 'store';
@@ -104,29 +104,22 @@ export default function StdcmRequestModal(props: StdcmRequestModalProps) {
                     })
                   );
                 })
-                .catch(() => {
+                .catch((e) => {
                   dispatch(
-                    setFailure({
-                      name: t('stdcm:stdcmError'),
-                      message: t('translation:common.error'),
-                    })
+                    setFailure(
+                      castErrorToFailure(e, {
+                        name: t('stdcm:stdcmError'),
+                        message: t('translation:common.error'),
+                      })
+                    )
                   );
                 });
             });
           }
         })
         .catch((e) => {
-          const errorMessage = extractMessageFromError(e);
           setCurrentStdcmRequestStatus(STDCM_REQUEST_STATUS.rejected);
-          dispatch(
-            setFailure({
-              name: t('stdcm:stdcmError'),
-              message:
-                extractStatusFromError(e) === 400 && errorMessage === 'No path could be found'
-                  ? t('stdcm:stdcmErrorNoPaths')
-                  : errorMessage,
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(e, { name: t('stdcm:stdcmError') })));
         });
     }
   }, [currentStdcmRequestStatus]);

--- a/front/src/common/ErrorBoundary.tsx
+++ b/front/src/common/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useNavigate, useRouteError } from 'react-router-dom';
 import { SerializedError } from '@reduxjs/toolkit';
 import { useTranslation } from 'react-i18next';
-import { extractMessageFromError } from 'utils/error';
+import { getErrorMessage } from 'utils/error';
 import { ApiError } from 'common/api/baseGeneratedApis';
 import NavBarSNCF from 'common/BootstrapSNCF/NavBarSNCF';
 import { ModalProvider } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
@@ -21,7 +21,7 @@ export default function ErrorBoundary() {
               <h1>
                 {t(`errors:${(error as ApiError).status ? (error as ApiError).status : 'default'}`)}
               </h1>
-              <p>{extractMessageFromError(error)}</p>
+              <p>{getErrorMessage(error)}</p>
             </>
           ) : (
             <h1>{t('errors:pageNotFound')}</h1>

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -5,6 +5,7 @@ import { getMap } from 'reducers/map/selectors';
 import { setFailure } from 'reducers/main';
 import { sortBy } from 'lodash';
 import { useDebounce } from 'utils/helpers';
+import { castErrorToFailure } from 'utils/error';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
@@ -14,7 +15,6 @@ import MultiSelectSNCF from 'common/BootstrapSNCF/MultiSelectSNCF';
 import nextId from 'react-id-generator';
 import SelectImproved from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import SignalCard from 'common/Map/Search/SignalCard';
-
 import type { SearchResultItemSignal, SearchPayload } from 'common/api/osrdEditoastApi';
 import { useAppDispatch } from 'store';
 import type { Viewport } from 'reducers/map';
@@ -137,13 +137,11 @@ const MapSearchSignal = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchSi
         setSearchResults([...results] as SearchResultItemSignal[]);
       })
       .catch((e) => {
-        console.error(e);
         setSearchResults([]);
         dispatch(
-          setFailure({
-            name: t('map-search:errorMessages.unableToSearchSignal'),
-            message: `${e.message}`,
-          })
+          setFailure(
+            castErrorToFailure(e, { name: t('map-search:errorMessages.unableToSearchSignal') })
+          )
         );
       });
   };

--- a/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
+++ b/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
@@ -3,26 +3,24 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { IoMdSpeedometer } from 'react-icons/io';
 import type { IconType } from 'react-icons';
-import type { SerializedError } from '@reduxjs/toolkit';
 
 import TIVsSVGFile from 'assets/pictures/layersicons/layer_tivs.svg';
 
 import DotsLoader from 'common/DotsLoader/DotsLoader';
 import { useInfraID } from 'common/osrdContext';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import type { ApiError } from 'common/api/baseGeneratedApis';
 import SelectImprovedSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import SwitchSNCF, { SWITCH_TYPES } from 'common/BootstrapSNCF/SwitchSNCF/SwitchSNCF';
 import {
   FormatSwitch as SimpleFormatSwitch,
   Icon2SVG,
 } from 'common/Map/Settings/MapSettingsLayers';
-
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
 import { getMap } from 'reducers/map/selectors';
 import { updateLayersSettings } from 'reducers/map';
 import type { MapState } from 'reducers/map';
+import { castErrorToFailure } from 'utils/error';
 
 type FormatSwitchProps = {
   name: keyof MapState['layersSettings'];
@@ -76,12 +74,11 @@ const FormatSwitch = ({ name, icon: IconComponent, color = '', disabled }: Forma
   useEffect(() => {
     if (isGetSpeedLimitTagsError && getSpeedLimitTagsError) {
       dispatch(
-        setFailure({
-          name: t('errorMessages.unableToRetrieveTags'),
-          message:
-            `${(getSpeedLimitTagsError as ApiError).data.message}` ||
-            `${(getSpeedLimitTagsError as SerializedError).message}}`,
-        })
+        setFailure(
+          castErrorToFailure(getSpeedLimitTagsError, {
+            name: t('errorMessages.unableToRetrieveTags'),
+          })
+        )
       );
     }
   }, [isGetSpeedLimitTagsError]);

--- a/front/src/common/Pathfinding/Pathfinding.tsx
+++ b/front/src/common/Pathfinding/Pathfinding.tsx
@@ -4,21 +4,18 @@ import type { Position } from 'geojson';
 import bbox from '@turf/bbox';
 import { useTranslation } from 'react-i18next';
 import { compact, isEqual, omit } from 'lodash';
-import { Alert, CheckCircle, Stop } from '@osrd-project/ui-icons';
 
+import { Alert, CheckCircle, Stop } from '@osrd-project/ui-icons';
 import type { ArrayElement } from 'utils/types';
 import { conditionalStringConcat, formatKmValue } from 'utils/strings';
-
+import { castErrorToFailure } from 'utils/error';
 import type { PathResponse, PathfindingRequest, PathfindingStep } from 'common/api/osrdEditoastApi';
-
 import infraLogo from 'assets/pictures/components/tracks.svg';
 import type { PointOnMap } from 'applications/operationalStudies/consts';
 import InfraLoadingState from 'applications/operationalStudies/components/Scenario/InfraLoadingState';
-
 import { Spinner } from 'common/Loaders';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
-
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
 
@@ -420,12 +417,7 @@ function Pathfinding({ zoomToFeature, path }: PathfindingProps) {
         })
         .catch((e) => {
           if (e.error) {
-            dispatch(
-              setFailure({
-                name: t('pathfinding'),
-                message: e.error,
-              })
-            );
+            dispatch(setFailure(castErrorToFailure(e, { name: t('pathfinding') })));
             pathfindingDispatch({ type: 'PATHFINDING_ERROR', message: 'failedRequest' });
           } else if (e?.data?.message) {
             pathfindingDispatch({ type: 'PATHFINDING_ERROR', message: e.data.message });

--- a/front/src/common/Pathfinding/TypeAndPath.tsx
+++ b/front/src/common/Pathfinding/TypeAndPath.tsx
@@ -13,12 +13,10 @@ import type { Position } from 'geojson';
 import cx from 'classnames';
 
 import { useDebounce } from 'utils/helpers';
-
+import { castErrorToFailure } from 'utils/error';
 import { loadPathFinding } from 'modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify';
-
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useInfraID, useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
-
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
 
@@ -134,12 +132,7 @@ export default function TypeAndPath({ zoomToFeature }: PathfindingProps) {
           loadPathFinding(itineraryCreated, dispatch, osrdActions);
         })
         .catch((e) => {
-          dispatch(
-            setFailure({
-              name: e.data.name,
-              message: e.data.message,
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(e)));
         });
     }
   }

--- a/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
+++ b/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
@@ -1,11 +1,12 @@
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors, useOsrdConfActions, useInfraID } from 'common/osrdContext';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store';
+
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { useOsrdConfSelectors, useOsrdConfActions, useInfraID } from 'common/osrdContext';
 import { setFailure } from 'reducers/main';
+import { castErrorToFailure } from 'utils/error';
 
 export const useStoreDataForSpeedLimitByTagSelector = () => {
   const dispatch = useAppDispatch();
@@ -32,12 +33,7 @@ export const useStoreDataForSpeedLimitByTagSelector = () => {
     // Update the document title using the browser API
     if (error) {
       dispatch(
-        setFailure({
-          name: t('errorMessages.unableToRetrieveTags'),
-          message: `${(error as FetchBaseQueryError).status} : ${JSON.stringify(
-            (error as FetchBaseQueryError).data
-          )}`,
-        })
+        setFailure(castErrorToFailure(error, { name: t('errorMessages.unableToRetrieveTags') }))
       );
     }
   }, [error]);

--- a/front/src/i18n.ts
+++ b/front/src/i18n.ts
@@ -22,4 +22,8 @@ i18n
     },
   });
 
+// Errors namespace must be initialized so t function
+// can be used in plain old function (see utils/error)
+i18n.loadNamespaces('errors');
+
 export default i18n;

--- a/front/src/modules/infra/components/InfraSelector/InfraSelector.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelector.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { castErrorToFailure } from 'utils/error';
 import { useInfraID } from 'common/osrdContext';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
-
 import InfraSelectorModal from './InfraSelectorModal';
 
 type InfraSelectorProps = {
@@ -24,10 +23,7 @@ const InfraSelector = ({ isInEditor }: InfraSelectorProps) => {
       .unwrap()
       .catch((e) =>
         dispatch(
-          setFailure({
-            name: t('errorMessages.unableToRetrieveInfra'),
-            message: e.message,
-          })
+          setFailure(castErrorToFailure(e, { name: t('errorMessages.unableToRetrieveInfra') }))
         )
       );
   };

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -8,6 +8,7 @@ import { Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
 import InfraLockState from 'modules/infra/consts';
+import { castErrorToFailure } from 'utils/error';
 
 type ActionBarProps = {
   infra: Infra;
@@ -39,12 +40,7 @@ export default function ActionsBar({ infra, isFocused, setIsFocused, inputValue 
         }
       } catch (e) {
         if (e instanceof Error) {
-          dispatch(
-            setFailure({
-              name: e.name,
-              message: e.message,
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(e)));
         }
       } finally {
         setIsWaiting(false);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBarDelete.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBarDelete.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Countdown from 'react-countdown';
+
 import { Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useAppDispatch } from 'store';
 import { setFailure, setSuccess } from 'reducers/main';
 import { Spinner } from 'common/Loaders';
+import { castErrorToFailure } from 'utils/error';
 
 type InfraSelectorEditionActionsBarDeleteProps = {
   infra: Infra;
@@ -33,12 +35,7 @@ export default function InfraSelectorEditionActionsBarDelete({
       );
     } catch (e) {
       if (e instanceof Error) {
-        dispatch(
-          setFailure({
-            name: e.name,
-            message: e.message,
-          })
-        );
+        dispatch(setFailure(castErrorToFailure(e)));
       }
     }
   }

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { MdEditNote, MdList } from 'react-icons/md';
+
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import icon from 'assets/pictures/components/tracks.svg';
 import iconEdition from 'assets/pictures/components/tracks_edit.svg';
 import { useDebounce } from 'utils/helpers';
+import { castErrorToFailure } from 'utils/error';
 import { Loader } from 'common/Loaders';
-import { MdEditNote, MdList } from 'react-icons/md';
 import { Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
-import { ApiError } from 'common/api/baseGeneratedApis';
-import { SerializedError } from '@reduxjs/toolkit';
 import InfraSelectorModalBodyEdition from './InfraSelectorModalBodyEdition';
 import InfraSelectorModalBodyStandard from './InfraSelectorModalBodyStandard';
 
@@ -57,10 +57,11 @@ const InfraSelectorModal = ({ onlySelectionMode = false, isInEditor }: InfraSele
   useEffect(() => {
     if (isError && error) {
       dispatch(
-        setFailure({
-          name: t('infraManagement:errorMessages.unableToRetrieveInfraList'),
-          message: `${(error as ApiError)?.data?.message || (error as SerializedError)?.message}`,
-        })
+        setFailure(
+          castErrorToFailure(error, {
+            name: t('infraManagement:errorMessages.unableToRetrieveInfraList'),
+          })
+        )
       );
     }
   }, [isError]);

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -8,18 +8,14 @@ import { Pencil, Trash } from '@osrd-project/ui-icons';
 import { RiMoneyEuroCircleLine } from 'react-icons/ri';
 import { MdBusinessCenter, MdDescription, MdTitle } from 'react-icons/md';
 import ReactMarkdown from 'react-markdown';
-import { SerializedError } from '@reduxjs/toolkit';
 import remarkGfm from 'remark-gfm';
 
 import { useDebounce } from 'utils/helpers';
-
 import PictureUploader from 'applications/operationalStudies/components/Project/PictureUploader';
-
 import { useOsrdConfActions } from 'common/osrdContext';
 import { postDocument } from 'common/api/documentApi';
 import ChipsSNCF from 'common/BootstrapSNCF/ChipsSNCF';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
-import type { ApiError } from 'common/api/baseGeneratedApis';
 import TextareaSNCF from 'common/BootstrapSNCF/TextareaSNCF';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
@@ -27,7 +23,6 @@ import ModalFooterSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalFooterSNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import type { ProjectWithStudies, ProjectCreateForm } from 'common/api/osrdEditoastApi';
-
 import { useAppDispatch } from 'store';
 import { setFailure, setSuccess } from 'reducers/main';
 import { getUserSafeWord } from 'reducers/user/userSelectors';
@@ -35,6 +30,7 @@ import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import useInputChange from 'utils/hooks/useInputChange';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
+import { castErrorToFailure } from 'utils/error';
 
 const emptyProject: ProjectCreateForm = {
   budget: undefined,
@@ -113,15 +109,10 @@ export default function AddOrEditProjectModal({
     try {
       const imageId = await postDocument(image as Blob);
       return imageId;
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        dispatch(
-          setFailure({
-            name: t('error.unableToPostDocumentTitle'),
-            message: t('error.unableToPostDocument'),
-          })
-        );
-      }
+    } catch (error) {
+      dispatch(
+        setFailure(castErrorToFailure(error, { name: t('error.unableToPostDocumentTitle') }))
+      );
       return null;
     }
   };
@@ -147,11 +138,11 @@ export default function AddOrEditProjectModal({
           })
           .catch((error) => {
             dispatch(
-              setFailure({
-                name: t('error.unableToCreateProjectTitle'),
-                message: t('error.unableToCreateProject'),
-                cause: error,
-              })
+              setFailure(
+                castErrorToFailure(error, {
+                  name: t('error.unableToCreateProjectTitle'),
+                })
+              )
             );
             console.error('Create project error', error);
           });
@@ -193,11 +184,11 @@ export default function AddOrEditProjectModal({
           })
           .catch((error) => {
             dispatch(
-              setFailure({
-                name: t('error.unableToUpdateProjectTitle'),
-                message: t('error.unableToUpdateProject'),
-                cause: error,
-              })
+              setFailure(
+                castErrorToFailure(error, {
+                  name: t('error.unableToUpdateProjectTitle'),
+                })
+              )
             );
             console.error('Patch project error', error);
           });
@@ -224,10 +215,11 @@ export default function AddOrEditProjectModal({
         })
         .catch((e) => {
           dispatch(
-            setFailure({
-              name: t('error.unableToDeleteProject'),
-              message: `${(e as ApiError)?.data?.message || (e as SerializedError)?.message}`,
-            })
+            setFailure(
+              castErrorToFailure(e, {
+                name: t('error.unableToDeleteProject'),
+              })
+            )
           );
         });
     }

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardDetail.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardDetail.tsx
@@ -13,6 +13,7 @@ import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 
 import type { EffortCurveForms } from 'modules/rollingStock/types';
 import type { RollingStockComfortType, RollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+import { castErrorToFailure } from 'utils/error';
 
 type RollingStockCardDetailProps = {
   id: number;
@@ -64,10 +65,12 @@ export default function RollingStockCardDetail({
   useEffect(() => {
     if (error) {
       dispatch(
-        setFailure({
-          name: t('errorMessages.unableToRetrieveRollingStockMessage'),
-          message: t('errorMessages.unableToRetrieveRollingStock'),
-        })
+        setFailure(
+          castErrorToFailure(error, {
+            name: t('errorMessages.unableToRetrieveRollingStockMessage'),
+            message: t('errorMessages.unableToRetrieveRollingStock'),
+          })
+        )
       );
     }
   }, [error]);

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorButtons.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorButtons.tsx
@@ -10,6 +10,7 @@ import { Duplicate, Pencil, Trash } from '@osrd-project/ui-icons';
 import RollingStockEditorFormModal from 'modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormModal';
 
 import type { RollingStock } from 'common/api/osrdEditoastApi';
+import { castErrorToFailure, getErrorStatus } from 'utils/error';
 
 type RollingStockEditorButtonsProps = {
   rollingStock: RollingStock;
@@ -48,7 +49,7 @@ const RollingStockEditorButtons = ({
           );
         })
         .catch((error) => {
-          if (error.status === 409) {
+          if (getErrorStatus(error) === 409) {
             openModal(
               <RollingStockEditorFormModal
                 mainText={t('messages.rollingStockNotDeleted')}
@@ -57,10 +58,12 @@ const RollingStockEditorButtons = ({
             );
           }
           dispatch(
-            setFailure({
-              name: t('messages.failure'),
-              message: t('messages.rollingStockNotDeleted'),
-            })
+            setFailure(
+              castErrorToFailure(error, {
+                name: t('messages.failure'),
+                message: t('messages.rollingStockNotDeleted'),
+              })
+            )
           );
         });
   };
@@ -85,21 +88,7 @@ const RollingStockEditorButtons = ({
         );
       })
       .catch((error) => {
-        if (error.data?.message.includes('duplicate')) {
-          dispatch(
-            setFailure({
-              name: t('messages.failure'),
-              message: t('messages.rollingStockDuplicateName'),
-            })
-          );
-        } else {
-          dispatch(
-            setFailure({
-              name: t('messages.failure'),
-              message: t('messages.rollingStockNotAdded'),
-            })
-          );
-        }
+        dispatch(setFailure(castErrorToFailure(error, { name: t('messages.failure') })));
       });
   };
 

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
@@ -30,6 +30,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { TabProps } from 'common/Tabs';
 import { useAppDispatch } from 'store';
+import { castErrorToFailure } from 'utils/error';
 
 type RollingStockParametersProps = {
   rollingStockData?: RollingStockWithLiveries;
@@ -112,21 +113,13 @@ const RollingStockEditorForm = ({
         setAddOrEditState(false);
       })
       .catch((error) => {
-        if (error.data?.message.includes('duplicate')) {
-          dispatch(
-            setFailure({
+        dispatch(
+          setFailure(
+            castErrorToFailure(error, {
               name: t('messages.failure'),
-              message: t('messages.rollingStockDuplicateName'),
             })
-          );
-        } else {
-          dispatch(
-            setFailure({
-              name: t('messages.failure'),
-              message: t('messages.rollingStockNotAdded'),
-            })
-          );
-        }
+          )
+        );
       });
   };
 
@@ -147,21 +140,13 @@ const RollingStockEditorForm = ({
           setAddOrEditState(false);
         })
         .catch((error) => {
-          if (error.data?.message.includes('used')) {
-            dispatch(
-              setFailure({
+          dispatch(
+            setFailure(
+              castErrorToFailure(error, {
                 name: t('messages.failure'),
-                message: t('messages.rollingStockDuplicateName'),
               })
-            );
-          } else {
-            dispatch(
-              setFailure({
-                name: t('messages.failure'),
-                message: t('messages.rollingStockNotUpdated'),
-              })
-            );
-          }
+            )
+          );
         });
     }
   };

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
@@ -1,18 +1,18 @@
 import React, { useState, useEffect, useContext, useMemo, type MutableRefObject } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
-import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
+
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
+import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
+import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { useOsrdConfSelectors } from 'common/osrdContext';
-
 import { Loader } from 'common/Loaders';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import RollingStockCard from 'modules/rollingStock/components/RollingStockCard/RollingStockCard';
-import SearchRollingStock from 'modules/rollingStock/components/RollingStockSelector/SearchRollingStock';
-
 import type { LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
+import SearchRollingStock from 'modules/rollingStock/components/RollingStockSelector/SearchRollingStock';
+import { castErrorToFailure } from 'utils/error';
 
 interface RollingStockModal {
   ref2scroll: MutableRefObject<HTMLDivElement | null>;
@@ -49,16 +49,8 @@ function RollingStockModal({ ref2scroll }: RollingStockModal) {
   }, [ref2scroll.current]);
 
   useEffect(() => {
-    if (isError && error && 'status' in error) {
-      dispatch(
-        setFailure({
-          name: t('rollingstock:errorMessages.unableToRetrieveRollingStock'),
-          message:
-            error.status === 404
-              ? t('rollingstock:errorMessages.ressourcesNotFound')
-              : t('rollingstock:errorMessages.unableToRetrieveRollingStockMessage'),
-        })
-      );
+    if (isError && error) {
+      dispatch(setFailure(castErrorToFailure(error)));
     }
   }, [isError]);
 

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -29,6 +29,7 @@ import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import useInputChange from 'utils/hooks/useInputChange';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
+import { castErrorToFailure } from 'utils/error';
 
 type ScenarioForm = ScenarioPatchForm & {
   id?: number;
@@ -160,13 +161,7 @@ export default function AddOrEditScenarioModal({
         })
 
         .catch((error) => {
-          console.error(error);
-          dispatch(
-            setFailure({
-              name: t('errorMessages.error'),
-              message: t('errorMessages.unableToCreateScenarioMessage'),
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(error)));
         });
     }
   };
@@ -192,13 +187,7 @@ export default function AddOrEditScenarioModal({
           closeModal();
         })
         .catch((error) => {
-          console.error(error);
-          dispatch(
-            setFailure({
-              name: t('errorMessages.error'),
-              message: t('errorMessages.unableToUpdateScenarioMessage'),
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(error)));
         });
     }
   };

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
@@ -16,7 +16,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { useAppDispatch } from 'store';
 import { setFailure } from 'reducers/main';
-
+import { castErrorToFailure } from 'utils/error';
 import { ProjectMiniCard, StudyMiniCard, ScenarioMiniCard } from './MiniCards';
 
 export type ScenarioExplorerProps = {
@@ -59,13 +59,7 @@ const ScenarioExplorerModal = ({
 
   useEffect(() => {
     if (isProjectsError) {
-      dispatch(
-        setFailure({
-          name: t('errorMessages.error'),
-          message: t('errorMessages.unableToRetrieveProjectsMessage'),
-        })
-      );
-      console.error('error : ', projectsError);
+      dispatch(setFailure(castErrorToFailure(projectsError)));
     }
   }, [isProjectsError]);
 

--- a/front/src/modules/study/components/AddOrEditStudyModal.tsx
+++ b/front/src/modules/study/components/AddOrEditStudyModal.tsx
@@ -32,6 +32,7 @@ import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import useInputChange from 'utils/hooks/useInputChange';
 import useOutsideClick from 'utils/hooks/useOutsideClick';
+import { castErrorToFailure } from 'utils/error';
 
 export interface StudyForm extends StudyCreateForm {
   id?: number;
@@ -70,11 +71,11 @@ export default function AddOrEditStudyModal({ editionMode, study }: Props) {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const [createStudies, { isError: isCreateStudyError }] =
+  const [createStudies, { error: createStudyError }] =
     osrdEditoastApi.usePostProjectsByProjectIdStudiesMutation();
-  const [patchStudies, { isError: isPatchStudyError }] =
+  const [patchStudies, { error: patchStudyError }] =
     osrdEditoastApi.usePatchProjectsByProjectIdStudiesAndStudyIdMutation();
-  const [deleteStudies, { isError: isDeleteStudyError }] =
+  const [deleteStudies, { error: deleteStudyError }] =
     osrdEditoastApi.useDeleteProjectsByProjectIdStudiesAndStudyIdMutation();
 
   const studyStateOptions = createSelectOptions('studyStates', studyStates);
@@ -186,16 +187,16 @@ export default function AddOrEditStudyModal({ editionMode, study }: Props) {
     }
   }, [study]);
 
+  /* Notify API errors */
   useEffect(() => {
-    if (isCreateStudyError || isPatchStudyError || isDeleteStudyError) {
-      dispatch(
-        setFailure({
-          name: t('errorHappened'),
-          message: t('errorHappened'),
-        })
-      );
-    }
-  }, [isCreateStudyError, isPatchStudyError, isDeleteStudyError]);
+    if (createStudyError) dispatch(setFailure(castErrorToFailure(createStudyError)));
+  }, [createStudyError]);
+  useEffect(() => {
+    if (patchStudyError) dispatch(setFailure(castErrorToFailure(patchStudyError)));
+  }, [patchStudyError]);
+  useEffect(() => {
+    if (deleteStudyError) dispatch(setFailure(castErrorToFailure(deleteStudyError)));
+  }, [deleteStudyError]);
 
   useModalFocusTrap(modalRef, closeModal);
 

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -113,9 +113,6 @@ export default function ImportTrainScheduleConfig({
           message: t('errorMessage.errorImport'),
         })
       );
-      console.error(
-        'Invalid data format: can not convert response into TrainSchedules. Expected format : { trainNumber: string; rollingStock: string; departureTime: string; arrivalTime: string; departure: string; steps: ({uic: number; yard?: string; name: string; trigram: string; latitude: number; longitude: number; arrivalTime: string; departureTime: string; })[]; transilienName?: string; }'
-      );
       return null;
     }
     return importedTrainSchedules as ImportedTrainSchedule[];

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfAddTrainSchedule.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import { Plus } from '@osrd-project/ui-icons';
 import { time2sec, sec2time } from 'utils/timeManipulation';
-
+import { castErrorToFailure } from 'utils/error';
 import formatConf from 'modules/trainschedule/components/ManageTrainSchedule/helpers/formatConf';
 import trainNameWithNum from 'modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper';
-
 import { useOsrdConfSelectors } from 'common/osrdContext';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { Infra, TrainScheduleBatchItem } from 'common/api/osrdEditoastApi';
-
 import { setFailure, setSuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
-import { Plus } from '@osrd-project/ui-icons';
 
 type SubmitConfAddTrainScheduleProps = {
   infraState?: Infra['state'];
@@ -21,17 +19,6 @@ type SubmitConfAddTrainScheduleProps = {
   refetchConflicts: () => void;
   setIsWorking: (isWorking: boolean) => void;
   setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
-};
-
-type error400 = {
-  status: 400;
-  data: {
-    cause: string;
-    errorType: string;
-    message: string;
-    trace: unknown;
-    type: string;
-  };
 };
 
 export default function SubmitConfAddTrainSchedule({
@@ -108,24 +95,9 @@ export default function SubmitConfAddTrainSchedule({
         setTrainResultsToFetch(newTrainIds);
         refetchTimetable();
         refetchConflicts();
-      } catch (e: unknown) {
+      } catch (e) {
         setIsWorking(false);
-        if (e instanceof Error) {
-          dispatch(
-            setFailure({
-              name: e.name,
-              message: t(`errorMessages.${e.message}`),
-            })
-          );
-        } else {
-          const error = { ...(e as error400) };
-          dispatch(
-            setFailure({
-              name: t('errorMessages.error'),
-              message: t(`errorMessages.${error.data.errorType}`),
-            })
-          );
-        }
+        dispatch(setFailure(castErrorToFailure(e)));
       }
     }
   }

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/SubmitConfUpdateTrainSchedules.tsx
@@ -2,19 +2,15 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
-import { extractMessageFromError } from 'utils/error';
-
+import { Pencil } from '@osrd-project/ui-icons';
+import { castErrorToFailure } from 'utils/error';
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
-
 import formatConf from 'modules/trainschedule/components/ManageTrainSchedule/helpers/formatConf';
-
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
-
 import { useAppDispatch } from 'store';
 import { setFailure, setSuccess } from 'reducers/main';
 import { updateSelectedProjection, updateSelectedTrainId } from 'reducers/osrdsimulation/actions';
-import { Pencil } from '@osrd-project/ui-icons';
 
 type SubmitConfUpdateTrainSchedulesProps = {
   setIsWorking: (isWorking: boolean) => void;
@@ -70,14 +66,8 @@ export default function SubmitConfUpdateTrainSchedules({
             })
               .unwrap()
               .catch((e) => {
-                extractMessageFromError(e);
                 callSuccess = false;
-                dispatch(
-                  setFailure({
-                    name: t('errorMessages.error'),
-                    message: t(`errorMessages.${e.data.type}`),
-                  })
-                );
+                dispatch(setFailure(castErrorToFailure(e)));
               });
           })
         );
@@ -100,16 +90,9 @@ export default function SubmitConfUpdateTrainSchedules({
           setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.none);
           dispatch(updateTrainScheduleIDsToModify([]));
         }
-      } catch (e: unknown) {
+      } catch (e) {
         setIsWorking(false);
-        if (e instanceof Error) {
-          dispatch(
-            setFailure({
-              name: e.name,
-              message: t(`errorMessages.${e.message}`),
-            })
-          );
-        }
+        dispatch(setFailure(castErrorToFailure(e)));
       }
     }
   }

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -35,6 +35,7 @@ import { updateSelectedTrainId, updateSimulation } from 'reducers/osrdsimulation
 import { getSelectedProjection } from 'reducers/osrdsimulation/selectors';
 import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
 import OptionsSNCF from 'common/BootstrapSNCF/OptionsSNCF';
+import { castErrorToFailure } from 'utils/error';
 
 type TimetableProps = {
   setDisplayTrainScheduleManagement: (mode: string) => void;
@@ -272,18 +273,11 @@ export default function Timetable({
           })
         );
       })
-      .catch((e: unknown) => {
-        console.error(e);
+      .catch((e) => {
         if (selectedTrainId && selectedTrainIds.includes(selectedTrainId)) {
           dispatch(updateSelectedTrainId(selectedTrainId));
-        }
-        if (e instanceof Error) {
-          dispatch(
-            setFailure({
-              name: e.name,
-              message: e.message,
-            })
-          );
+        } else {
+          dispatch(setFailure(castErrorToFailure(e)));
         }
       });
   };

--- a/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GiPathDistance } from 'react-icons/gi';
-import { Pencil, Trash } from '@osrd-project/ui-icons';
 import { MdAvTimer, MdContentCopy } from 'react-icons/md';
 import nextId from 'react-id-generator';
 import cx from 'classnames';
 
+import { Pencil, Trash } from '@osrd-project/ui-icons';
 import invalidInfra from 'assets/pictures/components/missing_tracks.svg';
 import invalidRollingStock from 'assets/pictures/components/missing_train.svg';
-
 import { jouleToKwh, mToKmOneDecimal } from 'utils/physics';
 import { durationInSeconds, sec2time } from 'utils/timeManipulation';
-
+import { castErrorToFailure } from 'utils/error';
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
-
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import trainNameWithNum from 'modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper';
-
 import { useOsrdConfActions } from 'common/osrdContext';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { SimulationReport, TrainScheduleValidation } from 'common/api/osrdEditoastApi';
-
 import { useAppDispatch } from 'store';
 import { setFailure, setSuccess } from 'reducers/main';
 import type { Projection, ScheduledTrain, SimulationSnapshot } from 'reducers/osrdsimulation/types';
@@ -126,14 +122,8 @@ function TimetableTrainCard({
           })
         );
       })
-      .catch((e: unknown) => {
-        console.error(e);
-        dispatch(
-          setFailure({
-            name: t('errorMessages.error'),
-            message: t('errorMessages.unableToDeleteTrain'),
-          })
-        );
+      .catch((e) => {
+        dispatch(setFailure(castErrorToFailure(e)));
         if (isSelected) {
           dispatch(updateSelectedTrainId(train.id));
         }
@@ -149,13 +139,8 @@ function TimetableTrainCard({
 
     const trainDetail = await getTrainScheduleById({ id: train.id })
       .unwrap()
-      .catch(() => {
-        dispatch(
-          setFailure({
-            name: t('errorMessages.error'),
-            message: t('errorMessages.unableToRetrieveTrain'),
-          })
-        );
+      .catch((e) => {
+        dispatch(setFailure(castErrorToFailure(e)));
       });
 
     if (trainDetail) {
@@ -185,13 +170,7 @@ function TimetableTrainCard({
           );
         })
         .catch((e) => {
-          console.error(e);
-          dispatch(
-            setFailure({
-              name: t('errorMessages.error'),
-              message: t('errorMessages.unableToDuplicateATrain'),
-            })
-          );
+          dispatch(setFailure(castErrorToFailure(e)));
         });
     }
   };

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -12,10 +12,9 @@ import {
   entityToDeleteOperation,
 } from 'applications/editor/data/utils';
 import { EditorEntity, EditorSchema } from 'applications/editor/typesEditorEntity';
-
 import type { Operation } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-
+import { castErrorToFailure } from 'utils/error';
 import { updateIssuesSettings } from 'reducers/map';
 import infra_schema from 'reducers/osrdconf/infra_schema.json';
 import { setLoading, setSuccess, setFailure, setSuccessWithoutMessage } from 'reducers/main';
@@ -64,8 +63,7 @@ export function loadDataModel() {
         dispatch(setSuccessWithoutMessage());
         dispatch(loadDataModelAction(schema));
       } catch (e) {
-        console.error(e);
-        dispatch(setFailure(e as Error));
+        dispatch(setFailure(castErrorToFailure(e)));
       }
     }
   };
@@ -109,8 +107,7 @@ export function updateTotalsIssue(infraID: number | undefined) {
       }
       dispatch(updateTotalsIssueAction({ total, filterTotal }));
     } catch (e) {
-      dispatch(setFailure(e as Error));
-      throw e;
+      dispatch(setFailure(castErrorToFailure(e)));
     } finally {
       dispatch(setSuccessWithoutMessage());
     }
@@ -189,10 +186,12 @@ export function saveOperations(
       throw new Error(JSON.stringify(response.error));
     } catch (e) {
       dispatch(
-        setFailure({
-          name: i18next.t('common.failure.save.title'),
-          message: i18next.t('common.failure.save.text'),
-        })
+        setFailure(
+          castErrorToFailure(e, {
+            name: i18next.t('common.failure.save.title'),
+            message: i18next.t('common.failure.save.text'),
+          })
+        )
       );
       throw e;
     } finally {

--- a/front/src/reducers/osrdsimulation/simulation.ts
+++ b/front/src/reducers/osrdsimulation/simulation.ts
@@ -9,8 +9,7 @@ import {
   TrainSchedulePatch,
   osrdEditoastApi,
 } from 'common/api/osrdEditoastApi';
-import { ApiError } from 'common/api/baseGeneratedApis';
-import { SerializedError } from '@reduxjs/toolkit';
+import { castErrorToFailure } from 'utils/error';
 import { OsrdSimulationState, SimulationSnapshot, Train } from './types';
 import {
   UPDATE_SIMULATION,
@@ -67,26 +66,24 @@ export const changeTrain =
       );
       if ('error' in response) {
         dispatch(
-          setFailure({
-            name: i18n.t('operationalStudies/manageTrainSchedule:errorMessages.unableToPatchTrain'),
-            message: `${
-              (response.error as ApiError)?.data?.message ||
-              (response.error as SerializedError)?.message
-            }`,
-          })
+          setFailure(
+            castErrorToFailure(response.error, {
+              name: i18n.t(
+                'operationalStudies/manageTrainSchedule:errorMessages.unableToPatchTrain'
+              ),
+            })
+          )
         );
       }
     } else if (isGetTrainDetailsError && getTrainDetailsError) {
       dispatch(
-        setFailure({
-          name: i18n.t(
-            'operationalStudies/manageTrainSchedule:errorMessages.unableToRetrieveTrain'
-          ),
-          message: `${
-            (getTrainDetailsError as ApiError)?.data?.message ||
-            (getTrainDetailsError as SerializedError)?.message
-          }`,
-        })
+        setFailure(
+          castErrorToFailure(getTrainDetailsError, {
+            name: i18n.t(
+              'operationalStudies/manageTrainSchedule:errorMessages.unableToRetrieveTrain'
+            ),
+          })
+        )
       );
     }
   };
@@ -123,14 +120,7 @@ const apiSyncOnDiff = (
       try {
         dispatch(osrdEditoastApi.endpoints.deleteTrainScheduleById.initiate({ id }));
       } catch (deleteTrainScheduleError) {
-        dispatch(
-          setFailure({
-            name: i18n.t(''),
-            message:
-              `${(deleteTrainScheduleError as ApiError).data.message}` ||
-              `${(deleteTrainScheduleError as SerializedError).message}`,
-          })
-        );
+        dispatch(setFailure(castErrorToFailure(deleteTrainScheduleError)));
       }
     } else if (
       JSON.stringify(apiDetailsForNextTrain) !== JSON.stringify(apiDetailsForPresentTrain)

--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -1,19 +1,70 @@
-import { SerializedError } from '@reduxjs/toolkit';
+import i18n from 'i18n';
+import { isObject } from 'lodash';
 
 import { ApiError } from 'common/api/baseGeneratedApis';
-import i18n from 'i18n';
 
-// eslint-disable-next-line import/prefer-default-export
-export const extractMessageFromError = (error: ApiError | SerializedError | Error): string => {
-  let message = i18n.t('default', { ns: ['errors'] });
-  if ('data' in error) {
-    const { type, context } = error.data;
-    const i18nId = type.split(':').join('.');
-    message = i18n.t(i18nId, error.data.message, { context, ns: ['errors'] });
-  } else if (error.message) {
-    message = error.message;
+// function loadIfNeededI18NErrorsNamespace(): void {
+//   if (!i18n.hasLoadedNamespace('errors')) {
+//     i18n.loadNamespaces('errors');
+//   }
+// }
+
+/**
+ * Given an error, return the associated i18n name.
+ * If name can't be found, a default one is return (or the default value specified)
+ */
+export function getErrorName(error: unknown, defaultValue?: string): string {
+  let name = defaultValue || i18n.t('error', { ns: ['errors'] });
+  if (isObject(error) && 'name' in error) {
+    const i18nName = `${error.name}`;
+    name = i18n.t(i18nName, i18nName, { ns: ['errors'] });
+  }
+  return name;
+}
+
+/**
+ * Given an error, return the associated i18n message.
+ * If message can't be found, a default one is return (or the default value specified)
+ */
+export function getErrorMessage(error: unknown, defaultValue?: string): string {
+  let message = defaultValue || i18n.t('default', { ns: ['errors'] });
+  if (isObject(error)) {
+    // check if it's an APIError
+    if ('data' in error && 'status' in error) {
+      const { type, message: i18nMsg, context } = (error as ApiError).data;
+      const i18nId = type.split(':').join('.');
+      message = i18n.t(i18nId, i18nMsg, { ...context, ns: ['errors'] });
+    }
+    // Check if the object has a message prop (like standard Error)
+    else if ('message' in error) {
+      message = `${error.message}`;
+    }
   }
   return message;
-};
+}
 
-export const extractStatusFromError = (error: ApiError) => (error as ApiError)?.status;
+/**
+ * Given an error, return it's status code.
+ */
+export function getErrorStatus(error: unknown): number | undefined {
+  if (isObject(error) && 'status' in error) {
+    return (error as ApiError).status;
+  }
+  return undefined;
+}
+
+/**
+ * Given an error, it retuns an object that can be used with `setFailure`.
+ * Ex: `setFailure(castErrorToFailure(e))`
+ */
+export function castErrorToFailure(
+  error: unknown,
+  defaultValue?: { name?: string; message?: string }
+): { name: string; message: string } {
+  if (error instanceof Error) console.error(error);
+
+  return {
+    name: getErrorName(error, defaultValue?.name),
+    message: getErrorMessage(error, defaultValue?.message),
+  };
+}


### PR DESCRIPTION
See https://github.com/osrd-project/osrd-confidential/issues/281#issuecomment-1948412084 for more details

Follows the PR on the generation of I18N keys for API errors. This PR :
- centralized the code where we cast error for notification
- use i18n for name and message