### PR TITLE
Fix add via on Map

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayVias.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/DisplayVias.tsx
@@ -70,9 +70,10 @@ export default function DisplayVias({ zoomToFeaturePoint }: DisplayViasProps) {
 
   return (
     <DragDropContext
-      onDragEnd={(e) =>
-        e.destination &&
-        dispatchAndRun(permuteVias(osrdconf.vias, e.source.index, e.destination.index))
+      onDragEnd={({ destination, source }) =>
+        destination &&
+        source.index !== destination.index &&
+        dispatchAndRun(permuteVias(osrdconf.vias, source.index, destination.index))
       }
     >
       <Droppable droppableId="droppableVias">
@@ -81,7 +82,7 @@ export default function DisplayVias({ zoomToFeaturePoint }: DisplayViasProps) {
             {osrdconf.vias.map((place, index) => (
               <Draggable
                 key={`drag-key-${place.id}-${place.path_offset}`}
-                draggableId={`drag-vias-${index}`}
+                draggableId={`drag-vias-${place.location?.track_section}-${place.location?.offset}`}
                 index={index}
               >
                 {(providedDraggable) => (

--- a/front/src/reducers/osrdconf/__tests__/helpers.spec.ts
+++ b/front/src/reducers/osrdconf/__tests__/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { computeLinkedOriginTimes } from '../helpers';
+import { computeLinkedOriginTimes, insertVia } from '../helpers';
 
 describe('computeLinkedOriginTimes', () => {
   describe('should throw error', () => {
@@ -124,5 +124,29 @@ describe('computeLinkedOriginTimes', () => {
         newOriginUpperBoundDate: '2023-11-22',
       });
     });
+  });
+});
+
+describe('insertVias', () => {
+  const brest = { coordinates: [-4.486076, 48.390394] };
+  const strasbourg = { coordinates: [7.750713, 48.583148] };
+  const mans = { coordinates: [0.199556, 48.00611] };
+  const rennes = { coordinates: [-1.677793, 48.117266] };
+  const nancy = { coordinates: [6.184417, 48.693722] };
+
+  it('should insert a new via at the beginning of the route', () => {
+    expect(insertVia([mans], brest, strasbourg, rennes)).toEqual([rennes, mans]);
+  });
+
+  it('should insert a via in the middle of the route', () => {
+    expect(insertVia([rennes, nancy], brest, strasbourg, mans)).toEqual([rennes, mans, nancy]);
+  });
+
+  it('should insert a via at the end of the route', () => {
+    expect(insertVia([rennes], brest, strasbourg, nancy)).toEqual([rennes, nancy]);
+  });
+
+  it('should handle insertion for a route with no existing stops', () => {
+    expect(insertVia([], brest, strasbourg, nancy)).toEqual([nancy]);
   });
 });

--- a/front/src/reducers/osrdconf/helpers.ts
+++ b/front/src/reducers/osrdconf/helpers.ts
@@ -1,3 +1,8 @@
+// import distance from '@turf/distance';
+import length from '@turf/length';
+import { lineString, point } from '@turf/helpers';
+import nearestPointOnLine from '@turf/nearest-point-on-line';
+import { PointOnMap } from 'applications/operationalStudies/consts';
 import { formatIsoDate } from 'utils/date';
 import { sec2time, time2sec } from 'utils/timeManipulation';
 
@@ -69,4 +74,33 @@ export const computeLinkedOriginTimes = (
       originUpperBoundDate
     ),
   };
+};
+
+export const insertVia = (
+  vias: PointOnMap[],
+  origin: PointOnMap,
+  destination: PointOnMap,
+  newVia: PointOnMap
+): PointOnMap[] => {
+  const updatedVias = [...vias];
+  const fullRouteCoordinates = [
+    origin.coordinates!,
+    ...vias.map((v) => v.coordinates!),
+    destination.coordinates!,
+  ];
+  const newViaPoint = point(newVia.coordinates!);
+
+  const nearestPointOnPath = nearestPointOnLine(lineString(fullRouteCoordinates), newViaPoint);
+
+  const insertIndex = fullRouteCoordinates.findIndex((_, index) => {
+    if (index === 0) return false;
+    if (index === fullRouteCoordinates.length - 1) return true;
+    // Makes the function imperfect as insert might fail in a curvy path
+    const segmentToPoint = lineString(fullRouteCoordinates.slice(0, index + 1));
+    return nearestPointOnPath.properties.location! <= length(segmentToPoint);
+  });
+
+  const adjustedIndex = Math.max(0, insertIndex - 1);
+  updatedVias.splice(adjustedIndex, 0, newVia);
+  return updatedVias;
 };

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
@@ -358,16 +358,75 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
     expect(state.vias).toBe(newVias);
   });
 
-  it('should handle addVias', () => {
-    const via1 = testDataBuilder.buildPointOnMap({ id: 'via-1' });
-    const via2 = testDataBuilder.buildPointOnMap({ id: 'via-2' });
-    const store = createStore(slice, {
-      vias: [via1],
+  describe('should handle addVias', () => {
+    const brest = testDataBuilder.buildPointOnMap({
+      id: 'brest',
+      coordinates: [48.390394, -4.486076],
+    });
+    const rennes = testDataBuilder.buildPointOnMap({
+      id: 'rennes',
+      coordinates: [48.117266, -1.6777926],
+    });
+    const mans = testDataBuilder.buildPointOnMap({
+      id: 'mans',
+      coordinates: [48.00611, 0.199556],
+    });
+    const paris = testDataBuilder.buildPointOnMap({
+      id: 'paris',
+      coordinates: [48.8566, 2.3522],
+    });
+    const strasbourg = testDataBuilder.buildPointOnMap({
+      id: 'paris',
+      coordinates: [7.750713, 48.583148],
     });
 
-    store.dispatch(slice.actions.addVias(via2));
-    const state = store.getState()[slice.name];
-    expect(state.vias).toStrictEqual([via1, via2]);
+    it('should handle insertion for a route with no existing via', () => {
+      const store = createStore(slice, {
+        origin: brest,
+        destination: strasbourg,
+        vias: [],
+      });
+
+      store.dispatch(slice.actions.addVias(mans));
+      const state = store.getState()[slice.name];
+      expect(state.vias).toStrictEqual([mans]);
+    });
+
+    it('should correctly append a new via point when the existing via is closer to the origin', () => {
+      const store = createStore(slice, {
+        origin: brest,
+        destination: strasbourg,
+        vias: [mans],
+      });
+
+      store.dispatch(slice.actions.addVias(rennes));
+      const state = store.getState()[slice.name];
+      expect(state.vias).toStrictEqual([rennes, mans]);
+    });
+
+    it('should insert a via between two existing ones based on distance from origin', () => {
+      const store = createStore(slice, {
+        origin: brest,
+        destination: strasbourg,
+        vias: [rennes, paris],
+      });
+
+      store.dispatch(slice.actions.addVias(mans));
+      const state = store.getState()[slice.name];
+      expect(state.vias).toStrictEqual([rennes, mans, paris]);
+    });
+
+    it('should insert a via at the end of the route', () => {
+      const store = createStore(slice, {
+        origin: brest,
+        destination: strasbourg,
+        vias: [rennes, mans],
+      });
+
+      store.dispatch(slice.actions.addVias(paris));
+      const state = store.getState()[slice.name];
+      expect(state.vias).toStrictEqual([rennes, mans, paris]);
+    });
   });
 
   it('should handle updateViaStopTime', () => {

--- a/front/src/reducers/osrdconf/osrdConfCommon/index.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/index.ts
@@ -4,7 +4,7 @@ import { omit } from 'lodash';
 
 import { formatIsoDate } from 'utils/date';
 
-import { computeLinkedOriginTimes } from 'reducers/osrdconf/helpers';
+import { computeLinkedOriginTimes, insertVia } from 'reducers/osrdconf/helpers';
 import { InfraStateReducers, buildInfraStateReducers, infraState } from 'reducers/infra';
 import type { PointOnMap } from 'applications/operationalStudies/consts';
 import type {
@@ -221,7 +221,9 @@ export function buildCommonConfReducers<S extends OsrdConfState>(): CommonConfRe
       state.vias = action.payload;
     },
     addVias(state: Draft<S>, action: PayloadAction<PointOnMap>) {
-      state.vias.push(action.payload);
+      if (state.origin && state.destination) {
+        state.vias = insertVia(state.vias, state.origin, state.destination, action.payload);
+      }
     },
     clearVias(state: Draft<S>) {
       state.vias = [];


### PR DESCRIPTION
Fixed #6642 - Now, in most cases, you can place stop points (vias) exactly where they should be.
Fixed #6700 - Made dragging and dropping stop points (vias) work right.