### PR TITLE
core: infra load refactor bootstrap with duplicate and compare results

### DIFF
--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.signaling
 import fr.sncf.osrd.signaling.impl.MockSigSystemManager
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
@@ -27,7 +27,7 @@ class BlockBuilderTest {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraBuilder()
+        val builder = RawInfraFromRjsBuilder()
         // region switches
         val switch =
             builder.movableElement("S", delay = 10L.milliseconds) {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.sim_infra.api
 
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.sim_infra.impl.NeutralSection
+import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
@@ -41,6 +42,8 @@ interface TrackProperties {
     fun getTrackChunkElectrificationVoltage(trackChunk: TrackChunkId): DistanceRangeMap<String>
 
     fun getTrackChunkNeutralSections(trackChunk: DirTrackChunkId): DistanceRangeMap<NeutralSection>
+
+    fun getTrackChunkSpeedSections(trackChunk: DirTrackChunkId): DistanceRangeMap<SpeedSection>
 
     fun getTrackChunkSpeedSections(
         trackChunk: DirTrackChunkId,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraFromRjsBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraFromRjsBuilder.kt
@@ -1,0 +1,349 @@
+package fr.sncf.osrd.sim_infra.impl
+
+import fr.sncf.osrd.geom.LineString
+import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.sim_infra.api.Detector
+import fr.sncf.osrd.sim_infra.api.DetectorId
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.api.EndpointTrackSectionId
+import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
+import fr.sncf.osrd.sim_infra.api.LogicalSignal
+import fr.sncf.osrd.sim_infra.api.OperationalPointPart
+import fr.sncf.osrd.sim_infra.api.OperationalPointPartId
+import fr.sncf.osrd.sim_infra.api.PhysicalSignal
+import fr.sncf.osrd.sim_infra.api.PhysicalSignalId
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.RouteId
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackChunkId
+import fr.sncf.osrd.sim_infra.api.TrackNode
+import fr.sncf.osrd.sim_infra.api.TrackNodeConfig
+import fr.sncf.osrd.sim_infra.api.TrackNodeId
+import fr.sncf.osrd.sim_infra.api.TrackSection
+import fr.sncf.osrd.sim_infra.api.TrackSectionId
+import fr.sncf.osrd.sim_infra.api.Zone
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.ZonePath
+import fr.sncf.osrd.sim_infra.api.ZonePathId
+import fr.sncf.osrd.sim_infra.api.decreasing
+import fr.sncf.osrd.sim_infra.api.increasing
+import fr.sncf.osrd.utils.DirectionalMap
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.DirStaticIdxList
+import fr.sncf.osrd.utils.indexing.IdxMap
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArraySet
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.StaticIdxSortedSet
+import fr.sncf.osrd.utils.indexing.StaticPool
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetList
+import kotlin.collections.set
+import kotlin.time.Duration
+
+class RawInfraFromRjsBuilderImpl : RawInfraBuilder {
+    private val trackNodePool = StaticPool<TrackNode, TrackNodeDescriptor>()
+    private val trackSectionPool = StaticPool<TrackSection, TrackSectionDescriptor>()
+    private val trackChunkPool = StaticPool<TrackChunk, TrackChunkDescriptor>()
+    private val nodeAtEndpoint = IdxMap<EndpointTrackSectionId, TrackNodeId>()
+    private val zonePool = StaticPool<Zone, ZoneDescriptor>()
+    private val detectorPool = StaticPool<Detector, String?>()
+    private val nextZones = IdxMap<DirDetectorId, ZoneId>()
+    private val routePool = StaticPool<Route, RouteDescriptor>()
+    private val logicalSignalPool = StaticPool<LogicalSignal, LogicalSignalDescriptor>()
+    private val physicalSignalPool = StaticPool<PhysicalSignal, PhysicalSignalDescriptor>()
+    private val zonePathPool = StaticPool<ZonePath, ZonePathDescriptor>()
+    private val zonePathMap = mutableMapOf<ZonePathSpec, ZonePathId>()
+    private val operationalPointPartPool =
+        StaticPool<OperationalPointPart, OperationalPointPartDescriptor>()
+
+    override fun movableElement(
+        name: String,
+        delay: Duration,
+        init: MovableElementDescriptorBuilder.() -> Unit
+    ): TrackNodeId {
+        val movableElementBuilder =
+            MovableElementDescriptorBuilderImpl(name, delay, StaticPool(), StaticPool())
+        movableElementBuilder.init()
+        val movableElement = movableElementBuilder.build()
+        return trackNodePool.add(movableElement)
+    }
+
+    override fun detector(name: String?): DetectorId {
+        return detectorPool.add(name)
+    }
+
+    override fun linkZones(zoneA: ZoneId, zoneB: ZoneId): DetectorId {
+        val det = detector(null)
+        linkZones(det, zoneA, zoneB)
+        return det
+    }
+
+    override fun linkZones(detector: DetectorId, zoneA: ZoneId, zoneB: ZoneId) {
+        nextZones[detector.increasing] = zoneA
+        nextZones[detector.decreasing] = zoneB
+    }
+
+    override fun setNextZone(detector: DirDetectorId, zone: ZoneId) {
+        nextZones[detector] = zone
+    }
+
+    override fun zone(movableElements: StaticIdxSortedSet<TrackNode>): ZoneId {
+        return zonePool.add(ZoneDescriptor(movableElements))
+    }
+
+    override fun zone(movableElements: List<TrackNodeId>): ZoneId {
+        val set = MutableStaticIdxArraySet<TrackNode>()
+        for (item in movableElements) set.add(item)
+        return zonePool.add(ZoneDescriptor(set))
+    }
+
+    override fun zone(
+        movableElements: StaticIdxSortedSet<TrackNode>,
+        bounds: List<DirDetectorId>
+    ): ZoneId {
+        val zone = zonePool.add(ZoneDescriptor(movableElements))
+        for (detectorDir in bounds) setNextZone(detectorDir, zone)
+        return zone
+    }
+
+    override fun zonePath(
+        entry: DirDetectorId,
+        exit: DirDetectorId,
+        length: Length<ZonePath>,
+        init: ZonePathBuilder.() -> Unit
+    ): ZonePathId {
+        val builder = ZonePathBuilderImpl(entry, exit, length)
+        builder.init()
+        val zonePathDesc = builder.build()
+        return zonePathMap.getOrPut(zonePathDesc) { zonePathPool.add(zonePathDesc) }
+    }
+
+    override fun zonePath(
+        entry: DirDetectorId,
+        exit: DirDetectorId,
+        length: Length<ZonePath>,
+        movableElements: StaticIdxList<TrackNode>,
+        movableElementsConfigs: StaticIdxList<TrackNodeConfig>,
+        movableElementsDistances: OffsetList<ZonePath>,
+        signals: StaticIdxList<PhysicalSignal>,
+        signalPositions: OffsetList<ZonePath>,
+        chunks: DirStaticIdxList<TrackChunk>,
+    ): ZonePathId {
+        val zonePathDesc =
+            ZonePathDescriptor(
+                entry,
+                exit,
+                length,
+                movableElements,
+                movableElementsConfigs,
+                movableElementsDistances,
+                signals,
+                signalPositions,
+                chunks
+            )
+        return zonePathMap.getOrPut(zonePathDesc) { zonePathPool.add(zonePathDesc) }
+    }
+
+    override fun zonePath(
+        entry: DirDetectorId,
+        exit: DirDetectorId,
+        length: Length<ZonePath>
+    ): ZonePathId {
+        val builder = ZonePathBuilderImpl(entry, exit, length)
+        val zonePathDesc = builder.build()
+        return zonePathMap.getOrPut(zonePathDesc) { zonePathPool.add(zonePathDesc) }
+    }
+
+    override fun route(name: String?, init: RouteBuilder.() -> Unit): RouteId {
+        val builder = RouteBuilderImpl(name)
+        builder.init()
+        return routePool.add(builder.build())
+    }
+
+    override fun physicalSignal(
+        name: String?,
+        sightDistance: Distance,
+        init: PhysicalSignalBuilder.() -> Unit
+    ): PhysicalSignalId {
+        val builder = PhysicalSignalBuilderImpl(name, sightDistance, logicalSignalPool)
+        builder.init()
+        return physicalSignalPool.add(builder.build())
+    }
+
+    override fun trackSection(name: String?, init: TrackSectionBuilder.() -> Unit): TrackSectionId {
+        val builder = TrackSectionBuilderImpl(name)
+        builder.init()
+        return trackSectionPool.add(builder.build())
+    }
+
+    override fun trackChunk(
+        geo: LineString,
+        slopes: DirectionalMap<DistanceRangeMap<Double>>,
+        length: Length<TrackChunk>,
+        offset: Offset<TrackSection>,
+        curves: DirectionalMap<DistanceRangeMap<Double>>,
+        gradients: DirectionalMap<DistanceRangeMap<Double>>,
+        loadingGaugeConstraints: DistanceRangeMap<LoadingGaugeConstraint>,
+        electrificationVoltage: DistanceRangeMap<String>,
+        neutralSections: DirectionalMap<DistanceRangeMap<NeutralSection>>,
+        speedSections: DirectionalMap<DistanceRangeMap<SpeedSection>>
+    ): TrackChunkId {
+        return trackChunkPool.add(
+            TrackChunkDescriptor(
+                geo,
+                slopes,
+                curves,
+                gradients,
+                length,
+                // Route IDs will be filled later on, the routes are not initialized and don't have
+                // IDs
+                // yet
+                DirectionalMap(MutableStaticIdxArrayList(), MutableStaticIdxArrayList()),
+                StaticIdx(0u), // The track ID will be filled later on for the same reason as routes
+                offset,
+                MutableStaticIdxArrayList(), // Same
+                loadingGaugeConstraints,
+                electrificationVoltage,
+                neutralSections,
+                speedSections
+            )
+        )
+    }
+
+    override fun operationalPointPart(
+        name: String,
+        chunkOffset: Offset<TrackChunk>,
+        chunk: TrackChunkId
+    ): OperationalPointPartId {
+        return operationalPointPartPool.add(
+            OperationalPointPartDescriptor(name, chunkOffset, chunk)
+        )
+    }
+
+    override fun build(): RawInfra {
+        resolveReferences()
+        return RawInfraImpl(
+            trackNodePool,
+            trackSectionPool,
+            trackChunkPool,
+            nodeAtEndpoint,
+            zonePool,
+            detectorPool,
+            nextZones,
+            routePool,
+            logicalSignalPool,
+            physicalSignalPool,
+            zonePathPool,
+            zonePathMap,
+            operationalPointPartPool,
+            makeTrackNameMap(),
+            makeRouteNameMap(),
+            makeDetEntryToRouteMap(),
+            makeDetExitToRouteMap(),
+        )
+    }
+
+    /** Create the mapping from each dir detector to routes that start there */
+    private fun makeDetEntryToRouteMap(): Map<DirStaticIdx<Detector>, StaticIdxList<Route>> {
+        val res = HashMap<DirStaticIdx<Detector>, MutableStaticIdxArrayList<Route>>()
+        for (routeId in routePool) {
+            val firstZonePath = routePool[routeId].path.first()
+            val entry = zonePathPool[firstZonePath].entry
+            res.computeIfAbsent(entry) { mutableStaticIdxArrayListOf() }.add(routeId)
+        }
+        return res
+    }
+
+    /** Create the mapping from each dir detector to routes that end there */
+    private fun makeDetExitToRouteMap(): Map<DirStaticIdx<Detector>, StaticIdxList<Route>> {
+        val res = HashMap<DirStaticIdx<Detector>, MutableStaticIdxArrayList<Route>>()
+        for (routeId in routePool) {
+            val lastZonePath = routePool[routeId].path.last()
+            val exit = zonePathPool[lastZonePath].exit
+            res.computeIfAbsent(exit) { mutableStaticIdxArrayListOf() }.add(routeId)
+        }
+        return res
+    }
+
+    /** Create the mapping from track name to id */
+    private fun makeTrackNameMap(): Map<String, TrackSectionId> {
+        val res = HashMap<String, TrackSectionId>()
+        for (trackId in trackSectionPool) res[trackSectionPool[trackId].name] = trackId
+        return res
+    }
+
+    /** Create the mapping from route name to id */
+    private fun makeRouteNameMap(): Map<String, RouteId> {
+        val res = HashMap<String, RouteId>()
+        for (routeId in routePool) {
+            val routeName = routePool[routeId].name
+            if (res[routePool[routeId].name!!] != null)
+                throw OSRDError.newDuplicateRouteError(routeName)
+            else if (routeName != null) res[routePool[routeId].name!!] = routeId
+        }
+        return res
+    }
+
+    /**
+     * Some objects have cross-reference (such as routes and chunks, or track sections and chunks).
+     * This method needs to be called to set the references that couldn't be set during
+     * initialization.
+     */
+    private fun resolveReferences() {
+        // Resolve route references
+        for (route in routePool) {
+            val chunkListOnRoute = routePool[route].chunks as MutableDirStaticIdxArrayList
+            var routeLength = Distance.ZERO
+            for (zonePath in routePool[route].path) {
+                routeLength += zonePathPool[zonePath].length.distance
+                for (dirChunk in zonePathPool[zonePath].chunks) {
+                    val chunk = dirChunk.value
+                    val dir = dirChunk.direction
+                    val routeList =
+                        trackChunkPool[chunk].routes.get(dir) as MutableStaticIdxArrayList
+                    routeList.add(route)
+                    chunkListOnRoute.add(dirChunk)
+                }
+            }
+            routePool[route].length = Length(routeLength)
+        }
+
+        // Resolve track references
+        for (track in trackSectionPool) for (chunk in
+            trackSectionPool[track].chunks) trackChunkPool[chunk].track = track
+
+        // Resolve operational points
+        for (op in operationalPointPartPool) {
+            val chunk = trackChunkPool[operationalPointPartPool[op].chunk]
+            val opList = chunk.operationalPointParts as MutableStaticIdxArrayList
+            opList.add(op)
+        }
+
+        // Build a map from track section endpoint to track node
+        for (trackNode in trackNodePool) {
+            val nodeDescriptor = trackNodePool[trackNode]
+            for (port in nodeDescriptor.ports) {
+                val connectedEndpoint = nodeDescriptor.ports[port]
+                nodeAtEndpoint.getOrPut(connectedEndpoint) { trackNode }
+            }
+        }
+    }
+}
+
+fun RawInfraFromRjsBuilder(): RawInfraBuilder {
+    return RawInfraFromRjsBuilderImpl()
+}
+
+inline fun rawInfraFromRjs(init: RestrictedRawInfraBuilder.() -> Unit): RawInfra {
+    val infraBuilder = RawInfraFromRjsBuilderImpl()
+    infraBuilder.init()
+    return infraBuilder.build()
+}

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -310,6 +310,12 @@ class RawInfraImpl(
     }
 
     override fun getTrackChunkSpeedSections(
+        trackChunk: DirTrackChunkId
+    ): DistanceRangeMap<SpeedSection> {
+        return trackChunkPool[trackChunk.value].speedSections.get(trackChunk.direction)
+    }
+
+    override fun getTrackChunkSpeedSections(
         trackChunk: DirTrackChunkId,
         trainTag: String?
     ): DistanceRangeMap<Speed> {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -55,6 +55,8 @@ import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.OffsetList
 import fr.sncf.osrd.utils.units.Speed
+import java.util.Objects
+import kotlin.collections.HashMap
 import kotlin.time.Duration
 
 class TrackNodeConfigDescriptor(
@@ -162,12 +164,36 @@ class OperationalPointPartDescriptor(
 class SpeedSection(
     val default: Speed,
     val speedByTrainTag: Map<String, Speed>,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SpeedSection) return false
+        if (default != other.default) return false
+        if (speedByTrainTag != other.speedByTrainTag) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(default, speedByTrainTag)
+    }
+}
 
 class NeutralSection(
     val lowerPantograph: Boolean,
     val isAnnouncement: Boolean,
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NeutralSection) return false
+        if (lowerPantograph != other.lowerPantograph) return false
+        if (isAnnouncement != other.isAnnouncement) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(lowerPantograph, isAnnouncement)
+    }
+}
 
 class RawInfraImpl(
     val trackNodePool: StaticPool<TrackNode, TrackNodeDescriptor>,

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.sim.interlocking.api.Train
 import fr.sncf.osrd.sim.interlocking.api.ZoneOccupation
 import fr.sncf.osrd.sim.interlocking.impl.locationSim
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.rawInfra
+import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.dynIdxArraySetOf
 import kotlin.test.Test
@@ -16,7 +16,7 @@ class TestLocation {
     @Test
     fun lockOccupyLeave() = runBlocking {
         // setup test data
-        val infra = rawInfra {
+        val infra = rawInfraFromRjs {
             // create a test switch
             val switchA =
                 movableElement("A", delay = 42L.milliseconds) {

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.api.withLock
 import fr.sncf.osrd.sim.interlocking.impl.MovableElementSimImpl
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
-import fr.sncf.osrd.sim_infra.impl.rawInfra
+import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
@@ -17,7 +17,7 @@ class TestMovableElements {
     @Test
     fun lockMoveTest() = runTest {
         // setup test data
-        val infra = rawInfra {
+        val infra = rawInfraFromRjs {
             movableElement("A", delay = 42L.milliseconds) {
                 config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
                 config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.sim.interlocking.api.ZoneReservationStatus.*
 import fr.sncf.osrd.sim.interlocking.api.ZoneState
 import fr.sncf.osrd.sim.interlocking.impl.*
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.mutableArenaMap
 import fr.sncf.osrd.utils.units.Length
@@ -37,7 +37,7 @@ class TestReservation {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraBuilder()
+            val builder = RawInfraFromRjsBuilder()
             val switch =
                 builder.movableElement("A", delay = 42L.milliseconds) {
                     config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.sim.interlocking.impl.routingSim
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Length
@@ -42,7 +42,7 @@ class TestRouting {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraBuilder()
+            val builder = RawInfraFromRjsBuilder()
             // region switches
             val switch =
                 builder.movableElement("S", delay = 10L.milliseconds) {

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
@@ -31,7 +31,7 @@ class TestBALtoBAL {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraBuilder()
+        val builder = RawInfraFromRjsBuilder()
         // region switches
         val switch =
             builder.movableElement("S", delay = 10L.milliseconds) {

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.signaling.bapr.BAPRtoBAPR
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.IdxMap
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
@@ -29,7 +29,7 @@ class TestBAPRtoBAL {
         // N: BAL
 
         // region build the test infrastructure
-        val builder = RawInfraBuilder()
+        val builder = RawInfraFromRjsBuilder()
 
         // region zones
         val zoneA = builder.zone(listOf())

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DirectionalMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DirectionalMap.kt
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.utils
 
+import java.util.Objects
+
 /** Simple utility class to store a pair of values, each linked to a direction */
 class DirectionalMap<T>(
     private val forwards: T,
@@ -10,5 +12,17 @@ class DirectionalMap<T>(
             Direction.INCREASING -> forwards
             Direction.DECREASING -> backwards
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DirectionalMap<*>) return false
+        if (forwards != other.forwards) return false
+        if (backwards != other.backwards) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(forwards, backwards)
     }
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMapImpl.kt
@@ -3,6 +3,7 @@ package fr.sncf.osrd.utils
 import com.google.common.collect.RangeMap
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.MutableDistanceArrayList
+import java.util.Objects
 import java.util.PriorityQueue
 import java.util.function.BiFunction
 import kotlin.math.min
@@ -269,6 +270,18 @@ data class DistanceRangeMapImpl<T>(
     /** Asserts that the internal state is consistent */
     private fun validate() {
         assert(bounds.size == values.size + 1 || (bounds.size == 0 && values.isEmpty()))
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DistanceRangeMapImpl<*>) return false
+        if (bounds != other.bounds) return false
+        if (values != other.values) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(bounds, values)
     }
 
     companion object {

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.utils.units
 private const val multiplier = 1000.0
 
 @JvmInline
-value class Speed(val millimetersPerSecond: ULong) {
+value class Speed(val millimetersPerSecond: ULong) : Comparable<Speed> {
     val metersPerSecond
         get() = millimetersPerSecond.toDouble() / multiplier
 
@@ -12,6 +12,10 @@ value class Speed(val millimetersPerSecond: ULong) {
         val decimal = metersPerSecond % multiplier.toUInt()
         if (decimal == 0UL) return String.format("%sm/s", metersPerSecond)
         else return String.format("%s.%sm/s", metersPerSecond, decimal)
+    }
+
+    override fun compareTo(other: Speed): Int {
+        return millimetersPerSecond.compareTo(other.millimetersPerSecond)
     }
 
     companion object {

--- a/core/src/main/java/fr/sncf/osrd/api/FullInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/api/FullInfra.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.api;
 
-import static fr.sncf.osrd.sim_infra_adapter.RawInfraAdapterKt.adaptRawInfra;
+import static fr.sncf.osrd.sim_infra_adapter.RawInfraFromRjsAdapterKt.adaptRawInfra;
 
 import fr.sncf.osrd.infra.implementation.signaling.SignalingInfraBuilder;
 import fr.sncf.osrd.infra.implementation.signaling.modules.bal3.BAL3;
@@ -31,7 +31,7 @@ public record FullInfra(
                 SignalingInfraBuilder.fromRJSInfra(rjsInfra, Set.of(new BAL3(diagnosticRecorder)), diagnosticRecorder);
 
         logger.info("adaptation to kotlin");
-        var rawInfra = adaptRawInfra(infra);
+        var rawInfra = adaptRawInfra(infra, rjsInfra);
 
         logger.info("loading signals");
         var loadedSignalInfra = signalingSimulator.loadSignals(rawInfra);

--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api;
 
 import static fr.sncf.osrd.api.SignalingSimulatorKt.makeSignalingSimulator;
-import static fr.sncf.osrd.sim_infra_adapter.RawInfraAdapterKt.adaptRawInfra;
+import static fr.sncf.osrd.sim_infra_adapter.RawInfraFromRjsAdapterKt.adaptRawInfra;
 
 import com.squareup.moshi.JsonDataException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -136,14 +136,9 @@ public class InfraManager extends APIClient {
             final var infra = SignalingInfraBuilder.fromRJSInfra(
                     rjsInfra, Set.of(new BAL3(diagnosticRecorder)), diagnosticRecorder);
 
-            // Attempt to ease memory pressure by making the RailJSON deserialized copy
-            // orphan, and calling the garbage collector.
-            rjsInfra = null;
-            System.gc();
-
             logger.info("adaptation to kotlin of {}", request.url());
             cacheEntry.transitionTo(InfraStatus.ADAPTING_KOTLIN);
-            var rawInfra = adaptRawInfra(infra);
+            var rawInfra = adaptRawInfra(infra, rjsInfra);
             logger.info("loading signals of {}", request.url());
             cacheEntry.transitionTo(InfraStatus.LOADING_SIGNALS);
             var loadedSignalInfra = signalingSimulator.loadSignals(rawInfra);

--- a/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.cli;
 
 import static fr.sncf.osrd.api.SignalingSimulatorKt.makeSignalingSimulator;
-import static fr.sncf.osrd.sim_infra_adapter.RawInfraAdapterKt.adaptRawInfra;
+import static fr.sncf.osrd.sim_infra_adapter.RawInfraFromRjsAdapterKt.adaptRawInfra;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -35,7 +35,7 @@ public class ValidateInfra implements CliCommand {
             logger.info("loading legacy infra");
             var infra = SignalingInfraBuilder.fromRJSInfra(rjs, Set.of(new BAL3(recorder)), recorder);
             logger.info("adapting raw infra");
-            var rawInfra = adaptRawInfra(infra);
+            var rawInfra = adaptRawInfra(infra, rjs);
             logger.info("loading signals");
             SignalingSimulator signalingSimulator = makeSignalingSimulator();
             var loadedSignalInfra = signalingSimulator.loadSignals(rawInfra);

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/LoadingGaugeConstraintImpl.kt
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/LoadingGaugeConstraintImpl.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
 import fr.sncf.osrd.sim_infra.api.LoadingGaugeTypeId
+import java.util.Objects
 
 class LoadingGaugeConstraintImpl(blockedTypes: ImmutableSet<RJSLoadingGaugeType>) :
     LoadingGaugeConstraint {
@@ -19,5 +20,16 @@ class LoadingGaugeConstraintImpl(blockedTypes: ImmutableSet<RJSLoadingGaugeType>
 
     override fun isCompatibleWith(trainType: LoadingGaugeTypeId): Boolean {
         return !blockedTypes.contains(trainType)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LoadingGaugeConstraintImpl) return false
+        if (blockedTypes != other.blockedTypes) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(blockedTypes)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -106,7 +106,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     for (edge in infra.trackGraph.edges()) {
         val track = edge as? TrackSection
         if (track != null) {
-            val trackLength = Distance.fromMeters(track.length)
+            val trackLength = track.length.meters
             var lastOffset = 0.meters
             trackSectionMap[track] =
                 builder.trackSection(track.id) {
@@ -114,7 +114,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
                     for (d in track.detectors) {
                         val detectorId = builder.detector(d.id)
                         detectorMap[d] = detectorId
-                        val endOffset = Distance.fromMeters(d.offset)
+                        val endOffset = d.offset.meters
                         makeChunk(
                             builder,
                             track,
@@ -133,8 +133,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
 
     // parse operational points
     for (track in infra.trackGraph.edges()) for (op in track.operationalPoints) {
-        val (chunkId, offset) =
-            getChunkLocation(track, Distance.fromMeters(op.offset), trackChunkMap)
+        val (chunkId, offset) = getChunkLocation(track, op.offset.meters, trackChunkMap)
         builder.operationalPointPart(op.id, offset, chunkId)
     }
 
@@ -190,15 +189,6 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     }
 
     fun getOrCreateDet(oldDiDetector: DiDetector): DirDetectorId {
-        val oldDetector = oldDiDetector.detector
-        val detector = detectorMap[oldDetector!!]!!
-        return when (oldDiDetector.direction!!) {
-            Direction.FORWARD -> detector.increasing
-            Direction.BACKWARD -> detector.decreasing
-        }
-    }
-
-    fun getDet(oldDiDetector: DiDetector): DirDetectorId {
         val oldDetector = oldDiDetector.detector
         val detector = detectorMap[oldDetector!!]!!
         return when (oldDiDetector.direction!!) {
@@ -275,8 +265,8 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
                 for (startDetIndex in 0 until oldPath.size - 1) {
                     val oldStartDet = oldPath[startDetIndex]
                     val oldEndDet = oldPath[startDetIndex + 1]
-                    val entry = getDet(oldStartDet)
-                    val exit = getDet(oldEndDet)
+                    val entry = getOrCreateDet(oldStartDet)
+                    val exit = getOrCreateDet(oldEndDet)
                     val zonePathId =
                         buildZonePath(
                             viewIterator,
@@ -362,8 +352,8 @@ private fun makeChunk(
                     mapEntry.value!!.metersPerSecond
                 }
             res.put(
-                Distance.fromMeters(entry.key.lowerEndpoint()),
-                Distance.fromMeters(entry.key.upperEndpoint()),
+                entry.key.lowerEndpoint().meters,
+                entry.key.upperEndpoint().meters,
                 SpeedSection(legacySpeedLimit.defaultSpeedLimit.metersPerSecond, map)
             )
         }
@@ -380,8 +370,8 @@ private fun makeChunk(
             for (entry in rangeMap.asMapOfRanges()) {
                 val legacyNeutralSection = entry.value
                 res.put(
-                    Distance.fromMeters(entry.key.lowerEndpoint()),
-                    Distance.fromMeters(entry.key.upperEndpoint()),
+                    entry.key.lowerEndpoint().meters,
+                    entry.key.upperEndpoint().meters,
                     SimNeutralSection(legacyNeutralSection.lowerPantograph, isAnnouncement)
                 )
             }
@@ -531,7 +521,7 @@ private fun buildZonePath(
             // They can and should be ignored, adding the chunk starting there would add an extra
             // chunk.
             // We assert that we are at a track transition, and move on
-            assert(range.end == Distance.fromMeters(range.track.length) || range.end == 0.meters)
+            assert(range.end == range.track.length.meters || range.end == 0.meters)
         } else {
             val chunk = trackChunkMap[range.track]!![range.begin]!!
             chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
@@ -76,7 +76,7 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
     for (edge in infra.trackGraph.edges()) {
         val track = edge as? TrackSection
         if (track != null) {
-            val trackLength = Distance.fromMeters(track.length)
+            val trackLength = track.length.meters
             var lastOffset = 0.meters
             trackSectionMap[track] =
                 builder.trackSection(track.id) {
@@ -84,7 +84,7 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
                     for (d in track.detectors) {
                         val detectorId = builder.detector(d.id)
                         detectorMap[d] = detectorId
-                        val endOffset = Distance.fromMeters(d.offset)
+                        val endOffset = d.offset.meters
                         makeChunk(
                             builder,
                             track,
@@ -103,8 +103,7 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
 
     // parse operational points
     for (track in infra.trackGraph.edges()) for (op in track.operationalPoints) {
-        val (chunkId, offset) =
-            getChunkLocation(track, Distance.fromMeters(op.offset), trackChunkMap)
+        val (chunkId, offset) = getChunkLocation(track, op.offset.meters, trackChunkMap)
         builder.operationalPointPart(op.id, offset, chunkId)
     }
 
@@ -160,15 +159,6 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
     }
 
     fun getOrCreateDet(oldDiDetector: DiDetector): DirDetectorId {
-        val oldDetector = oldDiDetector.detector
-        val detector = detectorMap[oldDetector!!]!!
-        return when (oldDiDetector.direction!!) {
-            Direction.FORWARD -> detector.increasing
-            Direction.BACKWARD -> detector.decreasing
-        }
-    }
-
-    fun getDet(oldDiDetector: DiDetector): DirDetectorId {
         val oldDetector = oldDiDetector.detector
         val detector = detectorMap[oldDetector!!]!!
         return when (oldDiDetector.direction!!) {
@@ -245,8 +235,8 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
                 for (startDetIndex in 0 until oldPath.size - 1) {
                     val oldStartDet = oldPath[startDetIndex]
                     val oldEndDet = oldPath[startDetIndex + 1]
-                    val entry = getDet(oldStartDet)
-                    val exit = getDet(oldEndDet)
+                    val entry = getOrCreateDet(oldStartDet)
+                    val exit = getOrCreateDet(oldEndDet)
                     val zonePathId =
                         buildZonePath(
                             viewIterator,
@@ -332,8 +322,8 @@ private fun makeChunk(
                     mapEntry.value!!.metersPerSecond
                 }
             res.put(
-                Distance.fromMeters(entry.key.lowerEndpoint()),
-                Distance.fromMeters(entry.key.upperEndpoint()),
+                entry.key.lowerEndpoint().meters,
+                entry.key.upperEndpoint().meters,
                 SpeedSection(legacySpeedLimit.defaultSpeedLimit.metersPerSecond, map)
             )
         }
@@ -350,8 +340,8 @@ private fun makeChunk(
             for (entry in rangeMap.asMapOfRanges()) {
                 val legacyNeutralSection = entry.value
                 res.put(
-                    Distance.fromMeters(entry.key.lowerEndpoint()),
-                    Distance.fromMeters(entry.key.upperEndpoint()),
+                    entry.key.lowerEndpoint().meters,
+                    entry.key.upperEndpoint().meters,
                     SimNeutralSection(legacyNeutralSection.lowerPantograph, isAnnouncement)
                 )
             }
@@ -501,7 +491,7 @@ private fun buildZonePath(
             // They can and should be ignored, adding the chunk starting there would add an extra
             // chunk.
             // We assert that we are at a track transition, and move on
-            assert(range.end == Distance.fromMeters(range.track.length) || range.end == 0.meters)
+            assert(range.end == range.track.length.meters || range.end == 0.meters)
         } else {
             val chunk = trackChunkMap[range.track]!![range.begin]!!
             chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
@@ -1,0 +1,552 @@
+package fr.sncf.osrd.sim_infra_adapter
+
+import com.google.common.collect.HashBiMap
+import fr.sncf.osrd.infra.api.Direction
+import fr.sncf.osrd.infra.api.reservation.DetectionSection
+import fr.sncf.osrd.infra.api.reservation.DiDetector
+import fr.sncf.osrd.infra.api.reservation.ReservationRoute
+import fr.sncf.osrd.infra.api.signaling.SignalingInfra
+import fr.sncf.osrd.infra.api.tracks.undirected.Detector
+import fr.sncf.osrd.infra.api.tracks.undirected.Switch
+import fr.sncf.osrd.infra.api.tracks.undirected.SwitchBranch
+import fr.sncf.osrd.infra.api.tracks.undirected.SwitchPort
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackEdge
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackNode.Joint
+import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection
+import fr.sncf.osrd.infra.implementation.tracks.directed.DiTrackEdgeImpl
+import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView
+import fr.sncf.osrd.railjson.schema.infra.RJSInfra
+import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
+import fr.sncf.osrd.sim_infra.api.DetectorId
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.api.EndpointTrackSectionId
+import fr.sncf.osrd.sim_infra.api.PhysicalSignal
+import fr.sncf.osrd.sim_infra.api.PhysicalSignalId
+import fr.sncf.osrd.sim_infra.api.RouteId
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackChunkId
+import fr.sncf.osrd.sim_infra.api.TrackNode
+import fr.sncf.osrd.sim_infra.api.TrackNodeConfig
+import fr.sncf.osrd.sim_infra.api.TrackNodeConfigId
+import fr.sncf.osrd.sim_infra.api.TrackNodeId
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.api.TrackSectionId
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.ZonePath
+import fr.sncf.osrd.sim_infra.api.ZonePathId
+import fr.sncf.osrd.sim_infra.api.decreasing
+import fr.sncf.osrd.sim_infra.api.increasing
+import fr.sncf.osrd.sim_infra.impl.NeutralSection as SimNeutralSection
+import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.SpeedSection
+import fr.sncf.osrd.sim_infra.impl.TrackSectionBuilder
+import fr.sncf.osrd.utils.DirectionalMap
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.Endpoint
+import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.MutableOffsetArrayList
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.metersPerSecond
+import kotlin.collections.set
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
+
+fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
+    val builder = RawInfraBuilder()
+    val zoneMap = HashBiMap.create<DetectionSection, ZoneId>()
+    val detectorMap = HashBiMap.create<Detector, DetectorId>()
+    val trackNodeMap = HashBiMap.create<Switch, TrackNodeId>()
+    val trackSectionMap = HashBiMap.create<TrackEdge, TrackSectionId>()
+    val trackNodeGroupsMap = mutableMapOf<Switch, Map<String, TrackNodeConfigId>>()
+    val signalsPerTrack: MutableMap<String, MutableList<TrackSignal>> = mutableMapOf()
+    val signalMap = HashBiMap.create<String, PhysicalSignalId>()
+    val rjsSignalMap = HashBiMap.create<String, RJSSignal>()
+    val routeMap = HashBiMap.create<ReservationRoute, RouteId>()
+    val trackChunkMap = mutableMapOf<TrackSection, Map<Distance, TrackChunkId>>()
+
+    // parse tracks
+    for (edge in infra.trackGraph.edges()) {
+        val track = edge as? TrackSection
+        if (track != null) {
+            val trackLength = Distance.fromMeters(track.length)
+            var lastOffset = 0.meters
+            trackSectionMap[track] =
+                builder.trackSection(track.id) {
+                    val chunkMap = mutableMapOf<Distance, TrackChunkId>()
+                    for (d in track.detectors) {
+                        val detectorId = builder.detector(d.id)
+                        detectorMap[d] = detectorId
+                        val endOffset = Distance.fromMeters(d.offset)
+                        makeChunk(
+                            builder,
+                            track,
+                            lastOffset,
+                            endOffset,
+                            this@trackSection,
+                            chunkMap
+                        )
+                        lastOffset = endOffset
+                    }
+                    makeChunk(builder, track, lastOffset, trackLength, this@trackSection, chunkMap)
+                    trackChunkMap[track] = chunkMap
+                }
+        }
+    }
+
+    // parse operational points
+    for (track in infra.trackGraph.edges()) for (op in track.operationalPoints) {
+        val (chunkId, offset) =
+            getChunkLocation(track, Distance.fromMeters(op.offset), trackChunkMap)
+        builder.operationalPointPart(op.id, offset, chunkId)
+    }
+
+    // parse switches
+    for (switchEntry in infra.switches) {
+        val oldSwitch = switchEntry.value!!
+        val nodeGraph = oldSwitch.graph!!
+        val infraGraph = infra.trackGraph!!
+        trackNodeMap[oldSwitch] =
+            builder.movableElement(oldSwitch.id, oldSwitch.groupChangeDelay.seconds) {
+                val nodeMap: MutableMap<SwitchPort, TrackNodePortId> = mutableMapOf()
+                for (node in nodeGraph.nodes()) {
+                    var track: TrackEdge? = null
+                    for (edge in infraGraph.incidentEdges(node)) {
+                        if (edge is TrackSection) {
+                            track = edge
+                            break
+                        }
+                    }
+                    track!!
+                    val endpoint =
+                        if (infraGraph.incidentNodes(track).nodeU() == node) Endpoint.START
+                        else Endpoint.END
+                    nodeMap[node] = port(EndpointTrackSectionId(trackSectionMap[track]!!, endpoint))
+                }
+                val switchGroups = mutableMapOf<String, TrackNodeConfigId>()
+                for (group in oldSwitch.groups.entries()) {
+                    val groupName = group.key!!
+                    val nodes = nodeGraph.incidentNodes(group.value!!)
+                    val portPair = Pair(nodeMap[nodes.nodeU()]!!, nodeMap[nodes.nodeV()]!!)
+                    switchGroups[groupName] = config(groupName, portPair)
+                }
+                trackNodeGroupsMap[oldSwitch] = switchGroups
+            }
+    }
+
+    // parse track links
+    for (node in infra.trackGraph.nodes()) {
+        if (node is Joint) {
+            val edges = infra.trackGraph.incidentEdges(node)
+            assert(edges.count() == 2)
+            builder.movableElement(node.id, ZERO) {
+                val ports = ArrayList<TrackNodePortId>()
+                for (edge in edges) {
+                    val endpoint =
+                        if (infra.trackGraph.incidentNodes(edge).nodeU() == node) Endpoint.START
+                        else Endpoint.END
+                    ports.add(port(EndpointTrackSectionId(trackSectionMap[edge]!!, endpoint)))
+                }
+                config("default", Pair(ports[0], ports[1]))
+            }
+        }
+    }
+
+    fun getOrCreateDet(oldDiDetector: DiDetector): DirDetectorId {
+        val oldDetector = oldDiDetector.detector
+        val detector = detectorMap[oldDetector!!]!!
+        return when (oldDiDetector.direction!!) {
+            Direction.FORWARD -> detector.increasing
+            Direction.BACKWARD -> detector.decreasing
+        }
+    }
+
+    fun getDet(oldDiDetector: DiDetector): DirDetectorId {
+        val oldDetector = oldDiDetector.detector
+        val detector = detectorMap[oldDetector!!]!!
+        return when (oldDiDetector.direction!!) {
+            Direction.FORWARD -> detector.increasing
+            Direction.BACKWARD -> detector.decreasing
+        }
+    }
+
+    // create zones
+    val switchToZone = mutableMapOf<Switch, ZoneId>()
+    for (detectionSection in infra.detectionSections) {
+        val oldSwitches = detectionSection!!.switches!!
+        val oldDiDetectors = detectionSection.detectors!!
+        val switches = mutableStaticIdxArraySetOf<TrackNode>()
+        for (oldSwitch in oldSwitches) switches.add(trackNodeMap[oldSwitch]!!)
+        val detectors = mutableListOf<DirDetectorId>()
+        for (oldDiDetector in oldDiDetectors) detectors.add(getOrCreateDet(oldDiDetector!!))
+        val zoneId = builder.zone(switches, detectors)
+        for (oldSwitch in oldSwitches) switchToZone[oldSwitch] = zoneId
+        zoneMap[detectionSection] = zoneId
+    }
+
+    // parse signals
+    for (rjsSignal in infra.signalMap.keys()) {
+        rjsSignalMap[rjsSignal.id] = rjsSignal
+        val trackSignals = signalsPerTrack.getOrPut(rjsSignal.track!!) { mutableListOf() }
+        val signalId =
+            builder.physicalSignal(rjsSignal.id, rjsSignal.sightDistance.meters) {
+                if (rjsSignal.logicalSignals == null) return@physicalSignal
+                for (rjsLogicalSignal in rjsSignal.logicalSignals) {
+                    assert(
+                        rjsLogicalSignal.signalingSystem != null &&
+                            rjsLogicalSignal.signalingSystem.isNotEmpty()
+                    )
+                    assert(rjsLogicalSignal.nextSignalingSystems != null)
+                    assert(rjsLogicalSignal.settings != null)
+                    for (sigSystem in rjsLogicalSignal.nextSignalingSystems) assert(
+                        sigSystem.isNotEmpty()
+                    )
+                    logicalSignal(
+                        rjsLogicalSignal.signalingSystem,
+                        rjsLogicalSignal.nextSignalingSystems,
+                        rjsLogicalSignal.settings
+                    )
+                }
+            }
+        signalMap[rjsSignal.id] = signalId
+        trackSignals.add(
+            TrackSignal(
+                rjsSignal.position.meters,
+                Direction.fromEdgeDir(rjsSignal.direction),
+                signalId
+            )
+        )
+    }
+
+    // sort signals by tracks
+    for (trackSignals in signalsPerTrack.values) trackSignals.sortBy { it.position }
+
+    // translate routes
+    for (route in infra.reservationRouteMap.values) {
+        routeMap[route] =
+            builder.route(route.id) {
+                val oldPath = route.detectorPath!!
+                val oldReleasePoints = route.releasePoints!!
+                val viewIterator = TrackRangeViewIterator(route!!.trackRanges)
+
+                // as we iterate over the detection sections, we need to compute the length of each
+                // detection section path as well as the position of switches contained within.
+                // sadly, these two iteration processes were combined by the idiot behind this code:
+                // myself
+                // parse the zone path and switch positions for this route
+                var releaseIndex = 0
+                for (startDetIndex in 0 until oldPath.size - 1) {
+                    val oldStartDet = oldPath[startDetIndex]
+                    val oldEndDet = oldPath[startDetIndex + 1]
+                    val entry = getDet(oldStartDet)
+                    val exit = getDet(oldEndDet)
+                    val zonePathId =
+                        buildZonePath(
+                            viewIterator,
+                            oldStartDet,
+                            oldEndDet,
+                            entry,
+                            exit,
+                            trackNodeMap,
+                            trackNodeGroupsMap,
+                            trackChunkMap,
+                            signalsPerTrack,
+                            builder
+                        )
+
+                    // check if the zone is a release zone
+                    if (
+                        releaseIndex < oldReleasePoints.size &&
+                            oldEndDet.detector!! == oldReleasePoints[releaseIndex]
+                    ) {
+                        releaseZone(startDetIndex)
+                        releaseIndex++
+                    }
+                    this@route.zonePath(zonePathId)
+                }
+
+                // if the old route did not have a release point at its last detector,
+                // add the missing implicit end release point
+                if (
+                    oldReleasePoints.isEmpty() || oldReleasePoints.last() != oldPath.last().detector
+                ) {
+                    releaseZone(oldPath.size - 2)
+                }
+            }
+    }
+
+    // TODO: check the length of built routes is the same as on the base infra
+    // assert(route.length.meters == routeLength)
+
+    return SimInfraAdapter(
+        builder.build(),
+        zoneMap,
+        detectorMap,
+        trackNodeMap,
+        trackNodeGroupsMap,
+        routeMap,
+        signalMap,
+        rjsSignalMap
+    )
+}
+
+private fun makeChunk(
+    builder: RawInfraBuilder,
+    track: TrackSection,
+    startOffset: Distance,
+    endOffset: Distance,
+    trackSectionBuilder: TrackSectionBuilder,
+    chunkMap: MutableMap<Distance, TrackChunkId>
+) {
+    if (startOffset == endOffset) return
+    val rangeViewForward =
+        TrackRangeView(
+            startOffset.meters,
+            endOffset.meters,
+            DiTrackEdgeImpl(track, Direction.FORWARD)
+        )
+    val rangeViewBackward =
+        TrackRangeView(
+            startOffset.meters,
+            endOffset.meters,
+            DiTrackEdgeImpl(track, Direction.BACKWARD)
+        )
+
+    fun <T> makeDirectionalMap(f: (range: TrackRangeView) -> T): DirectionalMap<T> {
+        return DirectionalMap(f.invoke(rangeViewForward), f.invoke(rangeViewBackward))
+    }
+
+    fun makeSpeedSections(range: TrackRangeView): DistanceRangeMap<SpeedSection> {
+        val res = distanceRangeMapOf<SpeedSection>()
+        for (entry in range.speedSections.asMapOfRanges()) {
+            val legacySpeedLimit = entry.value
+            val map =
+                legacySpeedLimit.speedLimitByTag.mapValues { mapEntry ->
+                    mapEntry.value!!.metersPerSecond
+                }
+            res.put(
+                Distance.fromMeters(entry.key.lowerEndpoint()),
+                Distance.fromMeters(entry.key.upperEndpoint()),
+                SpeedSection(legacySpeedLimit.defaultSpeedLimit.metersPerSecond, map)
+            )
+        }
+        return res
+    }
+
+    fun makeNeutralSection(range: TrackRangeView): DistanceRangeMap<SimNeutralSection> {
+        val res = distanceRangeMapOf<SimNeutralSection>()
+        for ((rangeMap, isAnnouncement) in
+            listOf(
+                Pair(range.neutralSections, false),
+                Pair(range.neutralSectionAnnouncements, true),
+            )) {
+            for (entry in rangeMap.asMapOfRanges()) {
+                val legacyNeutralSection = entry.value
+                res.put(
+                    Distance.fromMeters(entry.key.lowerEndpoint()),
+                    Distance.fromMeters(entry.key.upperEndpoint()),
+                    SimNeutralSection(legacyNeutralSection.lowerPantograph, isAnnouncement)
+                )
+            }
+        }
+        return res
+    }
+
+    val chunkId =
+        builder.trackChunk(
+            rangeViewForward.geo,
+            makeDirectionalMap { range -> DistanceRangeMapImpl.from(range.slopes) },
+            Length(endOffset - startOffset),
+            Offset(startOffset),
+            makeDirectionalMap { range -> DistanceRangeMapImpl.from(range.curves) },
+            makeDirectionalMap { range -> DistanceRangeMapImpl.from(range.gradients) },
+            DistanceRangeMapImpl.from(rangeViewForward.blockedGaugeTypes),
+            DistanceRangeMapImpl.from(rangeViewForward.electrificationVoltages),
+            makeDirectionalMap { range -> makeNeutralSection(range) },
+            makeDirectionalMap { range -> makeSpeedSections(range) },
+        )
+    trackSectionBuilder.chunk(chunkId)
+    chunkMap[startOffset] = chunkId
+}
+
+private fun buildZonePath(
+    viewIterator: TrackRangeViewIterator,
+    oldStartDet: DiDetector,
+    oldEndDet: DiDetector,
+    entry: DirDetectorId,
+    exit: DirDetectorId,
+    trackNodeMap: HashBiMap<Switch, TrackNodeId>,
+    trackNodeGroupsMap: MutableMap<Switch, Map<String, TrackNodeConfigId>>,
+    trackChunkMap: MutableMap<TrackSection, Map<Distance, TrackChunkId>>,
+    signalsPerTrack: Map<String, MutableList<TrackSignal>>,
+    builder: RawInfraBuilder
+): ZonePathId {
+    // at this point, we have trackRangeIndex pointing to the track range which contains the entry
+    // detector
+    // we need iterate on track range until we reach the track range which contains the end
+    // detector.
+    // meanwhile, we also need to:
+    // 1) locate switches inside the zone path
+    // 2) compute the length of each zone path
+    // 3) compute the zone path's track section path in order to find signals
+
+    var zonePathLength = Offset<ZonePath>(0.meters)
+    val movableElements = MutableStaticIdxArrayList<TrackNode>()
+    val movableElementsConfigs = MutableStaticIdxArrayList<TrackNodeConfig>()
+    val movableElementsDistances = MutableOffsetArrayList<ZonePath>()
+
+    val zoneTrackPath = mutableListOf<ZonePathTrackSpan>()
+    assert(viewIterator.view.track.edge == oldStartDet.detector.trackSection)
+    if (oldStartDet.detector.trackSection == oldEndDet.detector.trackSection) {
+        val track = oldStartDet.detector.trackSection
+        // if the start and end detectors are on the same track, we don't need to increment anything
+        assert(viewIterator.view.track.edge == track)
+        val startOffset = oldStartDet.detector.offset.meters
+        val endOffset = oldEndDet.detector.offset.meters
+        val span =
+            if (startOffset < endOffset)
+                ZonePathTrackSpan(track, startOffset, endOffset, Direction.FORWARD)
+            else ZonePathTrackSpan(track, endOffset, startOffset, Direction.BACKWARD)
+        zoneTrackPath.add(span)
+        zonePathLength += span.length
+    } else {
+        // when the start and end detectors are not on the same track
+        while (true) {
+            val curView = viewIterator.view
+            val edge = curView.track!!.edge
+            if (edge is SwitchBranch) {
+                // We assume SwitchBranch have zero length
+                assert(curView.end.meters == curView.begin.meters)
+                // We assume paths do not end on a SwitchBranch
+                assert(curView.track.edge != oldEndDet.detector.trackSection)
+                val movableElement = trackNodeMap[edge.switch]!!
+                val branchGroup = edge.switch!!.findBranchGroup(edge)!!
+                val movableElementConfig = trackNodeGroupsMap[edge.switch]!![branchGroup]!!
+                movableElements.add(movableElement)
+                movableElementsConfigs.add(movableElementConfig)
+                movableElementsDistances.add(zonePathLength)
+                viewIterator.next()
+                continue
+            }
+            val trackSection = edge as TrackSection
+            val trackSpan = zonePathTrackSpan(trackSection, curView, oldStartDet, oldEndDet)
+            zoneTrackPath.add(trackSpan)
+            zonePathLength += trackSpan.length
+
+            if (curView.track.edge == oldEndDet.detector.trackSection) {
+                break
+            }
+            viewIterator.next()
+        }
+    }
+
+    // iterate on the route's track ranges, and fetch the signals which belong there
+    data class ZonePathSignal(val position: Offset<ZonePath>, val signal: PhysicalSignalId)
+
+    val zonePathSignals: MutableList<ZonePathSignal> = mutableListOf()
+    // the current position along the route, in millimeters
+    var zonePathPosition = Offset<ZonePath>(Distance.ZERO)
+    for (range in zoneTrackPath) {
+        val edge = range.track
+        val rangeBegin = range.begin
+        val rangeEnd = range.end
+        val trackSignals = signalsPerTrack[edge.id]
+        if (trackSignals == null) {
+            zonePathPosition += (rangeEnd - rangeBegin)
+            continue
+        }
+
+        for (trackSignal in trackSignals) {
+            // if the signal is not visible along the route's path, ignore it
+            if (trackSignal.direction != range.direction) continue
+            if (trackSignal.position < rangeBegin || trackSignal.position > rangeEnd) continue
+
+            // compute the signal's position relative to the start of the zone path range
+            val sigRangeStartDistance =
+                if (trackSignal.direction == Direction.FORWARD) trackSignal.position - rangeBegin
+                else rangeEnd - trackSignal.position
+
+            val position = zonePathPosition + sigRangeStartDistance
+            if (position.distance == Distance.ZERO) continue
+
+            zonePathSignals.add(ZonePathSignal(position, trackSignal.signal))
+        }
+        zonePathPosition += (rangeEnd - rangeBegin)
+    }
+
+    val zoneLength = zonePathPosition
+
+    zonePathSignals.sortBy { it.position }
+    val signals = MutableStaticIdxArrayList<PhysicalSignal>()
+    val signalPositions = MutableOffsetArrayList<ZonePath>()
+    for (zonePathSignal in zonePathSignals) {
+        assert(zonePathSignal.position.distance >= Distance.ZERO)
+        assert(zonePathSignal.position <= zoneLength)
+        signals.add(zonePathSignal.signal)
+        signalPositions.add(zonePathSignal.position)
+    }
+
+    // Build chunk list
+    val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
+    for (range in zoneTrackPath) {
+        if (range.begin == range.end) {
+            // 0-length ranges can happen at track transition.
+            // They can and should be ignored, adding the chunk starting there would add an extra
+            // chunk.
+            // We assert that we are at a track transition, and move on
+            assert(range.end == Distance.fromMeters(range.track.length) || range.end == 0.meters)
+        } else {
+            val chunk = trackChunkMap[range.track]!![range.begin]!!
+            chunks.add(DirStaticIdx(chunk, range.direction.toKtDirection()))
+        }
+    }
+
+    return builder.zonePath(
+        entry,
+        exit,
+        Length(zonePathLength.distance),
+        movableElements,
+        movableElementsConfigs,
+        movableElementsDistances,
+        signals,
+        signalPositions,
+        chunks
+    )
+}
+
+/**
+ * Compute the length of the part of a zone path segments which spans a given track. Only works for
+ * zone paths which span multiple tracks.
+ */
+private fun zonePathTrackSpan(
+    track: TrackSection,
+    curView: TrackRangeView,
+    oldStartDiDet: DiDetector,
+    oldEndDiDet: DiDetector
+): ZonePathTrackSpan {
+    val oldStartDet = oldStartDiDet.detector
+    val oldEndDet = oldEndDiDet.detector
+    assert(oldStartDet.trackSection != oldEndDet.trackSection)
+    val trackLen = track.length.meters
+    val direction = curView.track.direction
+    return if (track == oldStartDet.trackSection) {
+        assert(direction == oldStartDiDet.direction)
+        if (direction == Direction.FORWARD)
+            ZonePathTrackSpan(track, oldStartDet.offset.meters, trackLen, Direction.FORWARD)
+        else ZonePathTrackSpan(track, 0.meters, oldStartDet.offset.meters, Direction.BACKWARD)
+    } else if (track == oldEndDet.trackSection) {
+        assert(direction == oldEndDiDet.direction)
+        if (direction == Direction.FORWARD)
+            ZonePathTrackSpan(track, 0.meters, oldEndDet.offset.meters, Direction.FORWARD)
+        else ZonePathTrackSpan(track, oldEndDet.offset.meters, trackLen, Direction.BACKWARD)
+    } else {
+        ZonePathTrackSpan(track, 0.meters, trackLen, direction)
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraFromRjsAdapter.kt
@@ -44,6 +44,7 @@ import fr.sncf.osrd.utils.DirectionalMap
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMapImpl
 import fr.sncf.osrd.utils.Endpoint
+import fr.sncf.osrd.utils.assertEqualSimInfra
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
@@ -275,16 +276,20 @@ fun adaptRawInfra(infra: SignalingInfra, rjsInfra: RJSInfra): SimInfraAdapter {
     // TODO: check the length of built routes is the same as on the base infra
     // assert(route.length.meters == routeLength)
 
-    return SimInfraAdapter(
-        builder.build(),
-        zoneMap,
-        detectorMap,
-        trackNodeMap,
-        trackNodeGroupsMap,
-        routeMap,
-        signalMap,
-        rjsSignalMap
-    )
+    val rawInfra =
+        SimInfraAdapter(
+            builder.build(),
+            zoneMap,
+            detectorMap,
+            trackNodeMap,
+            trackNodeGroupsMap,
+            routeMap,
+            signalMap,
+            rjsSignalMap
+        )
+    val controlInfra = adaptRawInfra(infra)
+    assertEqualSimInfra(rawInfra, controlInfra)
+    return rawInfra
 }
 
 private fun makeChunk(

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
@@ -1,0 +1,185 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackChunkId
+import fr.sncf.osrd.sim_infra.api.TrackSection
+import fr.sncf.osrd.sim_infra_adapter.SimInfraAdapter
+import fr.sncf.osrd.stdcm.graph.logger
+import fr.sncf.osrd.utils.units.Offset
+import java.util.Objects
+import kotlin.collections.HashSet
+
+open class ComparableOperationalPointPart(
+    val name: String,
+    val track: String,
+    val trackOffset: Offset<TrackSection>,
+    val chunkOffset: Offset<TrackChunk>
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ComparableOperationalPointPart) return false
+        if (name != other.name) return false
+        if (track != other.track) return false
+        if (trackOffset != other.trackOffset) return false
+        if (chunkOffset != other.chunkOffset) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(name, track, trackOffset, chunkOffset)
+    }
+}
+
+open class ComparableChunk(simInfra: RawInfra, chunkId: TrackChunkId) {
+    val geo = simInfra.getTrackChunkGeom(chunkId)
+    val slopes =
+        DirectionalMap(
+            simInfra.getTrackChunkSlope(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getTrackChunkSlope(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+    val curves =
+        DirectionalMap(
+            simInfra.getTrackChunkCurve(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getTrackChunkCurve(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+    val gradients =
+        DirectionalMap(
+            simInfra.getTrackChunkGradient(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getTrackChunkGradient(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+    val length = simInfra.getTrackChunkLength(chunkId)
+    val routes =
+        DirectionalMap(
+            simInfra.getRoutesOnTrackChunk(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getRoutesOnTrackChunk(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+    val track = simInfra.getTrackSectionName(simInfra.getTrackFromChunk(chunkId))
+    val offset = simInfra.getTrackChunkOffset(chunkId)
+
+    val operationalPointParts = HashSet<ComparableOperationalPointPart>()
+
+    init {
+        for (opp in simInfra.getTrackChunkOperationalPointParts(chunkId)) {
+            val incomingOpp =
+                ComparableOperationalPointPart(
+                    simInfra.getOperationalPointPartName(opp),
+                    simInfra.getTrackSectionName(
+                        simInfra.getTrackFromChunk(simInfra.getOperationalPointPartChunk(opp))
+                    ),
+                    simInfra.getTrackChunkOffset(simInfra.getOperationalPointPartChunk(opp)),
+                    simInfra.getOperationalPointPartChunkOffset(opp)
+                )
+            if (operationalPointParts.contains(incomingOpp)) {
+                logger.warn("Duplicate operational point part: $incomingOpp")
+            } else {
+                operationalPointParts.add(incomingOpp)
+            }
+        }
+
+        for (opp in simInfra.getTrackChunkOperationalPointParts(chunkId)) {
+            assert(simInfra.getOperationalPointPartChunk(opp) == chunkId)
+        }
+    }
+
+    val loadingGaugeConstraints = simInfra.getTrackChunkLoadingGaugeConstraints(chunkId)
+    val electrificationVoltage = simInfra.getTrackChunkElectrificationVoltage(chunkId)
+    val neutralSections =
+        DirectionalMap(
+            simInfra.getTrackChunkNeutralSections(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getTrackChunkNeutralSections(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+    val speedSections =
+        DirectionalMap(
+            simInfra.getTrackChunkSpeedSections(DirTrackChunkId(chunkId, Direction.INCREASING)),
+            simInfra.getTrackChunkSpeedSections(DirTrackChunkId(chunkId, Direction.DECREASING))
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ComparableChunk) return false
+        if (!geo.equalsWithTolerance(other.geo, 1E-8)) return false
+        if (slopes != other.slopes) return false
+        if (curves != other.curves) return false
+        if (gradients != other.gradients) return false
+        if (length != other.length) return false
+        if (routes != other.routes) return false
+        if (track != other.track) return false
+        if (offset != other.offset) return false
+        if (operationalPointParts != other.operationalPointParts) return false
+        if (loadingGaugeConstraints != other.loadingGaugeConstraints) return false
+        if (electrificationVoltage != other.electrificationVoltage) return false
+        if (neutralSections != other.neutralSections) return false
+        if (speedSections != other.speedSections) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(
+            geo,
+            slopes,
+            curves,
+            gradients,
+            length,
+            routes,
+            track,
+            offset,
+            operationalPointParts,
+            loadingGaugeConstraints,
+            electrificationVoltage,
+            neutralSections,
+            speedSections
+        )
+    }
+}
+
+fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
+    val leftDetectors = mutableSetOf<String>()
+    for (d in left.simInfra.detectors) {
+        leftDetectors.add(left.simInfra.getDetectorName(d)!!)
+    }
+    assert(left.simInfra.detectors.size.toInt() == leftDetectors.size)
+    val rightDetectors = mutableSetOf<String>()
+    for (d in right.simInfra.detectors) {
+        rightDetectors.add(left.simInfra.getDetectorName(d)!!)
+    }
+    assert(right.simInfra.detectors.size.toInt() == rightDetectors.size)
+    assert(leftDetectors == rightDetectors)
+
+    assert(left.simInfra.trackSections.size == right.simInfra.trackSections.size)
+    val leftTrackChunks = mutableMapOf<Pair<String, Offset<TrackSection>>, ComparableChunk>()
+    for (t in left.simInfra.trackSections) {
+        for (c in left.simInfra.getTrackSectionChunks(t)) {
+            assert(t == left.simInfra.getTrackFromChunk(c))
+            val chunkKey =
+                Pair(left.simInfra.getTrackSectionName(t), left.simInfra.getTrackChunkOffset(c))
+            assert(!leftTrackChunks.containsKey(chunkKey))
+            leftTrackChunks[chunkKey] = ComparableChunk(left.simInfra, c)
+        }
+    }
+    val rightTrackChunks = mutableMapOf<Pair<String, Offset<TrackSection>>, ComparableChunk>()
+    for (t in right.simInfra.trackSections) {
+        for (c in right.simInfra.getTrackSectionChunks(t)) {
+            assert(t == right.simInfra.getTrackFromChunk(c))
+            val chunkKey =
+                Pair(right.simInfra.getTrackSectionName(t), right.simInfra.getTrackChunkOffset(c))
+            assert(!rightTrackChunks.containsKey(chunkKey))
+            rightTrackChunks[chunkKey] = ComparableChunk(right.simInfra, c)
+        }
+    }
+    assert(leftTrackChunks == rightTrackChunks)
+
+    // TODO complete simInfra checks
+
+    assert(left.zoneMap == right.zoneMap)
+    assert(left.detectorMap.size == right.detectorMap.size)
+    for (l in left.detectorMap) {
+        assert(right.detectorMap.containsKey(l.key))
+    }
+    assert(left.trackNodeMap == right.trackNodeMap)
+    assert(left.trackNodeGroupsMap == right.trackNodeGroupsMap)
+    assert(left.routeMap == right.routeMap)
+    assert(left.signalMap == right.signalMap)
+    assert(left.rjsSignalMap == right.rjsSignalMap)
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -52,7 +52,7 @@ class PathPropertiesTests {
                     )
         }
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val path =
             pathFromTracks(
@@ -122,7 +122,7 @@ class PathPropertiesTests {
                 )
             )
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         val path =
             pathFromTracks(
                 infra,
@@ -189,7 +189,7 @@ class PathPropertiesTests {
                     RJSCurve(1_000.0, 2_000.0, 10_000.0),
                 )
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         val pathBackward =
             pathFromTracks(infra, listOf("TA0"), Direction.DECREASING, 500.meters, 1_500.meters)
         val slopesBackward = pathBackward.getCurves()
@@ -230,7 +230,7 @@ class PathPropertiesTests {
                 )
         }
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         val pathBackward =
             pathFromTracks(infra, listOf("TA0"), Direction.DECREASING, 500.meters, 1_500.meters)
         val slopesBackward = pathBackward.getGradients()
@@ -263,7 +263,7 @@ class PathPropertiesTests {
                 track.geo = RJSLineString.make(listOf(1.0, 2.0, 2.0), listOf(1.0, 1.0, 1.95))
         }
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val path =
             pathFromTracks(
@@ -344,7 +344,7 @@ class PathPropertiesTests {
                 )
             )
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val path =
             pathFromTracks(
@@ -405,7 +405,7 @@ class PathPropertiesTests {
                     )
         }
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val pathBackward =
             pathFromTracks(

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
@@ -18,14 +18,14 @@ class RawInfraAdapterTest {
     fun smokeAdaptTinyInfra() {
         val rjsInfra = Helpers.getExampleInfra("tiny_infra/infra.json")
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        adaptRawInfra(oldInfra)
+        adaptRawInfra(oldInfra, rjsInfra)
     }
 
     @Test
     fun smokeAdaptSmallInfra() {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        adaptRawInfra(oldInfra)
+        adaptRawInfra(oldInfra, rjsInfra)
     }
 
     @ParameterizedTest
@@ -35,7 +35,7 @@ class RawInfraAdapterTest {
             1e-2 // fairly high value, because we compare integer millimeters with float meters
         val rjsInfra = Helpers.getExampleInfra(infraPath)
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         for (route in infra.routes.iterator()) {
             val oldRoute = oldInfra.reservationRouteMap[infra.getRouteName(route)]!!
             val chunks = infra.getChunksOnRoute(route)
@@ -68,7 +68,7 @@ class RawInfraAdapterTest {
     fun testChunkSlopes(infraPath: String) {
         val rjsInfra = Helpers.getExampleInfra(infraPath)
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         for (route in infra.routes.iterator()) {
             val oldRoute = oldInfra.reservationRouteMap[infra.getRouteName(route)]!!
             val chunks = infra.getChunksOnRoute(route)
@@ -111,6 +111,6 @@ class RawInfraAdapterTest {
         newRoute.switchesDirections["PA0"] = "A_B1"
         rjsInfra.routes = listOf(newRoute)
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        adaptRawInfra(oldInfra)
+        adaptRawInfra(oldInfra, rjsInfra)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/SignalLoadingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/SignalLoadingTest.kt
@@ -13,7 +13,7 @@ class SignalLoadingTest {
     fun smokeLoadSignalTinyInfra() {
         val rjsInfra = Helpers.getExampleInfra("tiny_infra/infra.json")
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val simulator = SignalingSimulatorImpl(balSigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)
@@ -24,7 +24,7 @@ class SignalLoadingTest {
     fun smokeLoadSignalSmallInfra() {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val infra = adaptRawInfra(oldInfra)
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
 
         val simulator = SignalingSimulatorImpl(balSigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.NeutralSection
+import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.*
 import kotlin.time.Duration
@@ -387,6 +388,13 @@ class DummyInfra : RawInfra, BlockInfra {
             else desc.neutralSectionBackward
         return if (neutralSection == null) DistanceRangeMapImpl()
         else makeRangeMap(desc.length, neutralSection)
+    }
+
+    override fun getTrackChunkSpeedSections(
+        trackChunk: DirTrackChunkId,
+    ): DistanceRangeMap<SpeedSection> {
+        val desc = blockPool[trackChunk.value.index]
+        return makeRangeMap(desc.length, SpeedSection(desc.allowedSpeed.metersPerSecond, mapOf()))
     }
 
     override fun getTrackChunkSpeedSections(


### PR DESCRIPTION
Duplicate the previous infra adapter and builder to create a new one and compare the result.

The goal is to initiate a double-running infra-loader and a comparison of the 2 results (units tests + manual local tests).
The comparison only targets track-section, track-chunks and operational-points currently.

🎯 This PR targets a temporary branch (not `dev`)
  * The first 2 commits ought to be squashed before merge (separated to ease review)
  * The equal-assertion commit will be reverted before final merge to `dev` (will stay on the temporary branch, though)

🔍 Please review by commit with message

part of https://github.com/osrd-project/osrd-confidential/issues/307