### PR TITLE
front: tests: get pathfinding by trigram search

### DIFF
--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -62,8 +62,6 @@ export default defineConfig({
         ...devices['Desktop Firefox'],
       },
       dependencies: ['setup'],
-      // ! we ignore tests that use canvas because it's not well supported in firefox with playwright
-      testIgnore: /.005-operational-studies.spec.ts/,
     },
   ],
 

--- a/front/src/common/Pathfinding/Pathfinding.tsx
+++ b/front/src/common/Pathfinding/Pathfinding.tsx
@@ -535,7 +535,7 @@ function Pathfinding({ zoomToFeature, path }: PathfindingProps) {
 
       {!pathfindingState.error && !pathfindingState.running && path && origin && destination && (
         <div className="content pathfinding-done">
-          <span className="lead">
+          <span className="lead" data-testid="result-pathfinding-done">
             <CheckCircle />
           </span>
           <span className="flex-grow-1">{t('pathfindingDone')}</span>

--- a/front/src/common/Pathfinding/TypeAndPath.tsx
+++ b/front/src/common/Pathfinding/TypeAndPath.tsx
@@ -46,6 +46,7 @@ function OpTooltips({ opList }: { opList: SearchResultItemOperationalPoint[] }) 
               key={`typeandpath-op-${idx}-${op.trigram}`}
               style={{ left: `${leftMargin}rem` }}
               title={op.name}
+              data-testid={`typeandpath-op-${op.trigram}`}
             >
               {op.name ? op.name : <Alert />}
             </div>
@@ -155,6 +156,7 @@ export default function TypeAndPath({ zoomToFeature }: PathfindingProps) {
     <div
       className="type-and-path"
       style={{ minWidth: `${monospaceOneCharREMWidth * inputText.length + 5.5}rem` }} // To grow input field & whole div along text size
+      data-testid="type-and-path-container"
     >
       <div className="help">{opList.length === 0 && t('inputOPTrigrams')}</div>
       <OpTooltips opList={opList} />
@@ -171,6 +173,7 @@ export default function TypeAndPath({ zoomToFeature }: PathfindingProps) {
             onChange={(e) => handleInput(e.target.value)}
             placeholder={t('inputOPTrigramsExample')}
             autoFocus
+            data-testid="type-and-path-input"
           />
           <span className="form-control-state" />
         </div>
@@ -181,6 +184,7 @@ export default function TypeAndPath({ zoomToFeature }: PathfindingProps) {
           title={t('launchPathFinding')}
           onClick={launchPathFinding}
           disabled={isInvalid || opList.length < 2}
+          data-testid="submit-search-by-trigram"
         >
           <TriangleRight />
         </button>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/Itinerary.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Itinerary/Itinerary.tsx
@@ -101,6 +101,7 @@ function Itinerary({ path }: ItineraryProps) {
           aria-label={t('toggleTrigramSearch')}
           title={t('toggleTrigramSearch')}
           onClick={() => setDisplayTypeAndPath(!displayTypeAndPath)}
+          data-testid="rocket-button"
         >
           <Rocket />
         </button>

--- a/front/tests/pages/scenario-page-model.ts
+++ b/front/tests/pages/scenario-page-model.ts
@@ -63,6 +63,16 @@ class PlaywrightScenarioPage {
 
   readonly getPathfindingState: Locator;
 
+  readonly getSearchByTrigramButton: Locator;
+
+  readonly getSearchByTrigramContainer: Locator;
+
+  readonly getSearchByTrigramInput: Locator;
+
+  readonly getSearchByTrigramsubmit: Locator;
+
+  readonly getResultPathfindingDone: Locator;
+
   readonly getTimetableList: Locator;
 
   readonly getTrainEditBtn: Locator;
@@ -111,6 +121,11 @@ class PlaywrightScenarioPage {
     this.getScenarioName = page.locator('.scenario-details-name .scenario-name');
     this.getScenarioDescription = page.locator('.scenario-details-description');
     this.getScenarioInfraName = page.locator('.scenario-infra-name');
+    this.getSearchByTrigramButton = page.getByTestId('rocket-button');
+    this.getSearchByTrigramContainer = page.getByTestId('type-and-path-container');
+    this.getSearchByTrigramInput = page.getByTestId('type-and-path-input');
+    this.getSearchByTrigramsubmit = page.getByTestId('submit-search-by-trigram');
+    this.getResultPathfindingDone = page.getByTestId('result-pathfinding-done');
     this.getResultPathfindingDistance = page.getByTestId('result-pathfinding-distance');
     this.getInfraLoadState = page.locator('.infra-loading-state');
     this.getTrainCountInput = page.locator('#osrdconf-traincount');
@@ -246,6 +261,18 @@ class PlaywrightScenarioPage {
 
   async checkPathfingingStateText(text: string | RegExp) {
     await expect(this.getPathfindingState).toHaveText(text);
+  }
+
+  async getPathfindingByTriGramSearch(firstTrigram: string, secondTrigram: string) {
+    await this.getSearchByTrigramButton.click();
+    await expect(this.getSearchByTrigramContainer).toBeVisible();
+    await this.getSearchByTrigramInput.fill(`${firstTrigram} ${secondTrigram}`);
+    await expect(
+      this.page.getByTestId(`typeandpath-op-${firstTrigram}`) &&
+        this.page.getByTestId(`typeandpath-op-${secondTrigram}`)
+    ).toBeVisible();
+    await this.getSearchByTrigramsubmit.click();
+    await expect(this.getResultPathfindingDone).toBeVisible();
   }
 
   async clickBtnByName(name: string) {


### PR DESCRIPTION
- add data-testid to TypeAndPath elements needed
- create a new scenario for each 005 e2e-test to keep parallelism
- add search by trigram replacing search by clicking on map

close #6683