### PR TITLE
front: limit op search to 100 results

### DIFF
--- a/front/public/locales/en/map-search.json
+++ b/front/public/locales/en/map-search.json
@@ -19,6 +19,7 @@
   "resultsCount_one": "1 result",
   "resultsCount_other": "{{ count }} results",
   "resultsCount_zero": "No results",
+  "resultsCountTooMuch": "There are more than 100 results, please refine your search.",
   "search": "Search",
   "signal": "Signal",
   "signalbox": "Switchbox",

--- a/front/public/locales/fr/map-search.json
+++ b/front/public/locales/fr/map-search.json
@@ -19,6 +19,7 @@
   "resultsCount_one": "1 résultat",
   "resultsCount_other": "{{ count }} résultats",
   "resultsCount_zero": "Aucun résultat",
+  "resultsCountTooMuch": "Il y a plus de 100 résultats, merci d'affiner votre recherche.",
   "search": "Rechercher",
   "signal": "Signal",
   "signalbox": "Poste",

--- a/front/src/common/Map/Search/MapSearchStation.tsx
+++ b/front/src/common/Map/Search/MapSearchStation.tsx
@@ -68,6 +68,7 @@ const MapSearchStation = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchS
 
     await postSearch({
       searchPayload: payload,
+      pageSize: 101,
     })
       .unwrap()
       .then((results) => {
@@ -180,11 +181,13 @@ const MapSearchStation = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchS
         </span>
       </div>
       <h2 className="text-center mt-3">
-        {t('map-search:resultsCount', {
-          count: searchResults.length,
-        })}
+        {searchResults.length > 100
+          ? t('map-search:resultsCountTooMuch')
+          : t('map-search:resultsCount', {
+              count: searchResults.length,
+            })}
       </h2>
-      {searchResults.length > 0 && (
+      {searchResults.length > 0 && searchResults.length <= 100 && (
         <StationCardsList
           operationalPoints={searchResults}
           stationCHcodes={stationCHcodes}


### PR DESCRIPTION
fixes #6373

Limit is set to 100 results max: for 101 and more, a message is displayed inviting user to refine his search.