### PR TITLE
core: load track-section part of kotlin infra directly from railjson

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -284,27 +284,6 @@ interface RestrictedRawInfraBuilder {
         sightDistance: Distance,
         init: PhysicalSignalBuilder.() -> Unit
     ): PhysicalSignalId
-
-    fun trackSection(name: String?, init: TrackSectionBuilder.() -> Unit): TrackSectionId
-
-    fun trackChunk(
-        geo: LineString,
-        slopes: DirectionalMap<DistanceRangeMap<Double>>,
-        length: Length<TrackChunk>,
-        offset: Offset<TrackSection>,
-        curves: DirectionalMap<DistanceRangeMap<Double>>,
-        gradients: DirectionalMap<DistanceRangeMap<Double>>,
-        loadingGaugeConstraints: DistanceRangeMap<LoadingGaugeConstraint>,
-        electrificationVoltage: DistanceRangeMap<String>,
-        neutralSections: DirectionalMap<DistanceRangeMap<NeutralSection>>,
-        speedSections: DirectionalMap<DistanceRangeMap<SpeedSection>>
-    ): TrackChunkId
-
-    fun operationalPointPart(
-        name: String,
-        chunkOffset: Offset<TrackChunk>,
-        chunk: TrackChunkId
-    ): OperationalPointPartId
 }
 
 interface TrackSectionBuilder {
@@ -464,13 +443,13 @@ class RawInfraBuilderImpl : RawInfraBuilder {
         return physicalSignalPool.add(builder.build())
     }
 
-    override fun trackSection(name: String?, init: TrackSectionBuilder.() -> Unit): TrackSectionId {
+    fun trackSection(name: String?, init: TrackSectionBuilder.() -> Unit): TrackSectionId {
         val builder = TrackSectionBuilderImpl(name)
         builder.init()
         return trackSectionPool.add(builder.build())
     }
 
-    override fun trackChunk(
+    fun trackChunk(
         geo: LineString,
         slopes: DirectionalMap<DistanceRangeMap<Double>>,
         length: Length<TrackChunk>,
@@ -504,7 +483,7 @@ class RawInfraBuilderImpl : RawInfraBuilder {
         )
     }
 
-    override fun operationalPointPart(
+    fun operationalPointPart(
         name: String,
         chunkOffset: Offset<TrackChunk>,
         chunk: TrackChunkId

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -29,6 +29,16 @@ value class Speed(val millimetersPerSecond: ULong) : Comparable<Speed> {
         fun toMetersPerSecond(speed: Speed): Double {
             return speed.metersPerSecond
         }
+
+        fun min(a: Speed, b: Speed) =
+            Speed(
+                millimetersPerSecond = a.millimetersPerSecond.coerceAtMost(b.millimetersPerSecond)
+            )
+
+        fun max(a: Speed, b: Speed) =
+            Speed(
+                millimetersPerSecond = a.millimetersPerSecond.coerceAtLeast(b.millimetersPerSecond)
+            )
     }
 }
 

--- a/core/osrd-railjson/build.gradle
+++ b/core/osrd-railjson/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation libs.moshi
     implementation libs.moshi.adapters
 
+    implementation libs.guava
+
     // for linter annotations
     compileOnly libs.jcip.annotations
     compileOnly libs.spotbugs.annotations

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/infra/trackranges/RJSOperationalPointPart.java
@@ -2,11 +2,24 @@ package fr.sncf.osrd.railjson.schema.infra.trackranges;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSTrackObject;
+import java.util.Objects;
 
 @SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
 public class RJSOperationalPointPart extends RJSTrackObject {
     public RJSOperationalPointPart(String track, double position) {
         this.track = track;
         this.position = position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RJSOperationalPointPart that)) return false;
+        return Double.compare(position, that.position) == 0 && Objects.equals(track, that.track);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(position, track);
     }
 }

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSLoadingGaugeType.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSLoadingGaugeType.java
@@ -1,6 +1,8 @@
 package fr.sncf.osrd.railjson.schema.rollingstock;
 
+import com.google.common.collect.Sets;
 import com.squareup.moshi.Json;
+import java.util.Set;
 
 public enum RJSLoadingGaugeType {
     G1,
@@ -13,5 +15,21 @@ public enum RJSLoadingGaugeType {
     FR3_3,
     @Json(name = "FR3.3/GB/G2")
     FR3_3_GB_G2,
-    GLOTT
+    GLOTT;
+
+    /** Returns all the rolling stock gauge types compatible with the given track type
+     * Returns null if the type is invalid for a track */
+    public Set<RJSLoadingGaugeType> getCompatibleGaugeTypes() {
+        return switch (this) {
+            case G1 -> Set.of(G1);
+            case GA -> Sets.union(Set.of(GA), G1.getCompatibleGaugeTypes());
+            case GB -> Sets.union(Set.of(GB, FR3_3_GB_G2), GA.getCompatibleGaugeTypes());
+            case GB1 -> Sets.union(Set.of(GB1), GB.getCompatibleGaugeTypes());
+            case GC -> Sets.union(Set.of(GC), GB1.getCompatibleGaugeTypes());
+            case G2 -> Sets.union(Set.of(G2, FR3_3_GB_G2), G1.getCompatibleGaugeTypes());
+            case FR3_3 -> Set.of(FR3_3, FR3_3_GB_G2);
+            case GLOTT -> Set.of(GLOTT);
+            default -> null;
+        };
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -40,6 +40,7 @@ import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
 import fr.sncf.osrd.sim_infra.impl.NeutralSection as SimNeutralSection
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraBuilderImpl
 import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.sim_infra.impl.TrackSectionBuilder
 import fr.sncf.osrd.utils.DirectionalMap
@@ -90,7 +91,7 @@ data class TrackSignal(
 )
 
 fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
-    val builder = RawInfraBuilder()
+    val builder = RawInfraBuilderImpl()
     val zoneMap = HashBiMap.create<DetectionSection, ZoneId>()
     val detectorMap = HashBiMap.create<Detector, DetectorId>()
     val trackNodeMap = HashBiMap.create<Switch, TrackNodeId>()
@@ -318,7 +319,7 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
 }
 
 private fun makeChunk(
-    builder: RawInfraBuilder,
+    builder: RawInfraBuilderImpl,
     track: TrackSection,
     startOffset: Distance,
     endOffset: Distance,


### PR DESCRIPTION
Notes:
* RawInfraBuilder interface looses some parts (specific to adapter). So `RawInfra*Adapter` is now tied to corresponding `RawInfra*BuilderImpl`.
* Dropping use of `DiagnosticRecorder`.
* Some stitching is done to connect "new" loading of track-section and "old" loading of the rest of the infra.

Tested locally on France and Germany infra ✅ 

Part of https://github.com/osrd-project/osrd-confidential/issues/307