### PR TITLE
editoast: infra: order objects when downloading a railjson

### DIFF
--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -50,7 +50,7 @@ async fn get_railjson(infra: Path<i64>, db_pool: Data<DbPool>) -> Result<impl Re
             let mut conn = conn_future.await?;
             let table = get_table(&object_type);
             let query =
-                format!("SELECT (x.data)::text AS railjson FROM {table} x WHERE x.infra_id = $1");
+                format!("SELECT (x.data)::text AS railjson FROM {table} x WHERE x.infra_id = $1 ORDER BY x.obj_id");
 
             let result: Result<_> = Ok((
                 object_type,


### PR DESCRIPTION
This PR is there to compensate the fact that railjson import loads objects (track sections, signals, ...) in a random order in the db.

Then, if you import and export a railjson, the order of the objects change randomly. This randomness affects the results of the circulation import benchmark (today if you import the same railjson twice, and run the circulation import benchmark on each, the results aren't the same). This PR tries to fix that.


I ran this code before and after.

```python 
INFRA_ID = 3  # France
url = f"http://localhost:8090/infra/{INFRA_ID}/railjson"

# first call
start = time()
response = requests.get(url)
first_call_time = time() - start

# run ten times
times = []
for _ in tqdm(range(100)):
    start = time()
    response = requests.get(url)
    times.append(time() - start)
```

*Before*:
first call: 2.50 seconds
mean: 2.11 seconds
stdev: 0.05 seconds

*After*:
first call: 2.65 seconds
mean: 2.34 seconds
stdev: 0.04 seconds

I'm not 100% certain that the results can be trusted, the performance of the endpoint seems very variable depending on the context.

So there is a bit more than a 10% of time increase with this PR, do you think it's acceptable ? If not, I can try adding indexes to the `obj_id` columns and run another benchmark.