### PR TITLE
front: editor - better handle api error on forms

### DIFF
--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -90,7 +90,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
     <div>
       {submited && error !== null && (
         <div className="form-error mt-3 mb-3">
-          <p>{error}</p>
+          <p className="mb-0">{error}</p>
         </div>
       )}
       <Form

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -183,7 +183,7 @@ export function saveOperations(
         );
         return response.data;
       }
-      throw new Error(JSON.stringify(response.error));
+      throw response.error;
     } catch (e) {
       dispatch(
         setFailure(

--- a/front/src/utils/error.ts
+++ b/front/src/utils/error.ts
@@ -3,12 +3,6 @@ import { isObject } from 'lodash';
 
 import { ApiError } from 'common/api/baseGeneratedApis';
 
-// function loadIfNeededI18NErrorsNamespace(): void {
-//   if (!i18n.hasLoadedNamespace('errors')) {
-//     i18n.loadNamespaces('errors');
-//   }
-// }
-
 /**
  * Given an error, return the associated i18n name.
  * If name can't be found, a default one is return (or the default value specified)


### PR DESCRIPTION
Fix #6729

- When saving an object, throw the error data without casting it to error
- remove unsued code in utils/error (was commented)
- remove margin-botton on <p> on form's error so message is centered