### PR TITLE
editoast, doc: move batch dependency description closer to code

### DIFF
--- a/editoast/README.md
+++ b/editoast/README.md
@@ -76,3 +76,20 @@ OpenApi when a change has been made to an endpoint, run the following command:
 ```sh
 cargo run openapi > openapi.yaml
 ```
+
+## Batch dependency updates
+
+We use dependabot on the project to notify when dependencies are outdated.
+We do not use dependabot to automatically update dependencies, as we want to merge all updates at
+once and review the changes (and avoid flooding `dev` branch with dependency-bump commits).
+
+Here is the process to update dependencies:
+
+1. Change the versions.
+    * *If you're using VSCode* you can install the [`serayuzgur.crates`](https://marketplace.visualstudio.com/items?itemName=serayuzgur.crates) extension and run the "update all dependencies" command.  
+    Make sure that the new chosen version is stable, and that loose constraints are not overwritten in your commit.
+    * *If you're not*, you can go check the versions used by dependabot in [its PRs](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) and update the versions manually.
+2. Run `cargo update` to update the Cargo.lock file (even sub-dependencies).
+3. Check that all [dependabot editoast PRs](https://github.com/osrd-project/osrd/pulls?q=is%3Aopen+label%3Aarea%3Aeditoast+label%3Adependencies) are included in your update.
+4. Adapt the code to the new versions, if needed.
+5. Create a PR with your changes, and link all dependabot PRs in the description.


### PR DESCRIPTION
This section was in osrd-website (see https://github.com/osrd-project/osrd-website/pull/178).
This should allow for all components to easily document it separately close to the code, without overwhelming general documentation.