### PR TITLE
front: fix no data display when no train in timetable in op studies

### DIFF
--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -135,9 +135,7 @@ export default function SimulationResults({
     }
   }, [selectedTrain]);
 
-  return simulation.trains.length === 0 && !isUpdating ? (
-    <h1 className="text-center mt-5">{t('noData')}</h1>
-  ) : (
+  return simulation.trains.length === 0 && !isUpdating ? null : (
     <div className="simulation-results">
       {/* SIMULATION : STICKY BAR */}
       <div


### PR DESCRIPTION
closes #5468 