### PR TITLE
core: improve handling of node groups with multiple connections

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -59,7 +59,7 @@ import kotlin.time.Duration
 
 class TrackNodeConfigDescriptor(
     val name: String,
-    val portLink: Pair<TrackNodePortId, TrackNodePortId>,
+    val portLinks: List<Pair<TrackNodePortId, TrackNodePortId>>,
 )
 
 class TrackNodeDescriptor(
@@ -351,9 +351,10 @@ class RawInfraImpl(
         config: TrackNodeConfigId,
         entryPort: TrackNodePortId
     ): OptStaticIdx<TrackNodePort> {
-        val ports = trackNodePool[trackNode].configs[config].portLink
-        if (ports.first == entryPort) return OptStaticIdx(ports.second.index)
-        if (ports.second == entryPort) return OptStaticIdx(ports.first.index)
+        for (link in trackNodePool[trackNode].configs[config].portLinks) {
+            if (link.first == entryPort) return OptStaticIdx(link.second.index)
+            if (link.second == entryPort) return OptStaticIdx(link.first.index)
+        }
         return OptStaticIdx()
     }
 


### PR DESCRIPTION
Before, each connection was handled as a separate `TrackNodeConfigDescriptor`.
This was (at least) incorrectly pessimistic when using consecutively multiple connections of the same group (move delay was applied but shouldn't).

TODO:

- [x] decide if test must be added (~inspired from https://github.com/osrd-project/osrd/blob/dev/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt but with a crossing node?~)
  > Not necessary as delay and conflicts are not features that are challenged for now. Testing the resulting infra instead (number of groups and correct connections).