### PR TITLE
Fix cartographic tile cache expiration time

### DIFF
--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -184,7 +184,9 @@ async fn cache_and_get_mvt_tile(
     );
 
     let mut redis = redis_client.get_connection().await?;
-    let cached_value: Option<Vec<u8>> = redis.get(&cache_key).await?;
+    let cached_value: Option<Vec<u8>> = redis
+        .get_ex(&cache_key, redis::Expiry::EX(view.cache_duration as usize))
+        .await?;
 
     if let Some(value) = cached_value {
         return Ok(HttpResponse::Ok()


### PR DESCRIPTION
When a tile was queried and the cache was hit, the tile's expiry time was not reset.