### PR TITLE
core: load node part of kotlin infra directly from railjson

### DIFF
--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -3,15 +3,16 @@ package fr.sncf.osrd.signaling
 import fr.sncf.osrd.signaling.impl.MockSigSystemManager
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
 import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.*
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.ZERO
 
 class BlockBuilderTest {
     @Test
@@ -27,13 +28,9 @@ class BlockBuilderTest {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilder()
+        val builder = RawInfraFromRjsBuilderImpl()
         // region switches
-        val switch =
-            builder.movableElement("S", delay = 10L.milliseconds) {
-                config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
-            }
+        val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
         // endregion
 
         // region zones

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -252,12 +252,6 @@ class RouteDescriptorImpl(
 ) : RouteDescriptor
 
 interface RestrictedRawInfraBuilder {
-    fun movableElement(
-        name: String,
-        delay: Duration,
-        init: MovableElementDescriptorBuilder.() -> Unit
-    ): TrackNodeId
-
     fun detector(name: String?): DetectorId
 
     fun linkZones(zoneA: ZoneId, zoneB: ZoneId): DetectorId
@@ -348,7 +342,7 @@ class RawInfraBuilderImpl : RawInfraBuilder {
     private val operationalPointPartPool =
         StaticPool<OperationalPointPart, OperationalPointPartDescriptor>()
 
-    override fun movableElement(
+    fun movableElement(
         name: String,
         delay: Duration,
         init: MovableElementDescriptorBuilder.() -> Unit

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraFromRjsBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraFromRjsBuilder.kt
@@ -419,10 +419,6 @@ class RawInfraFromRjsBuilderImpl : RawInfraBuilder {
             routePool[route].length = Length(routeLength)
         }
 
-        // Resolve track references
-        for (track in trackSectionPool) for (chunk in
-            trackSectionPool[track].chunks) trackChunkPool[chunk].track = track
-
         // Build a map from track section endpoint to track node
         for (trackNode in trackNodePool) {
             val nodeDescriptor = trackNodePool[trackNode]

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
@@ -6,10 +6,11 @@ import fr.sncf.osrd.sim.interlocking.impl.locationSim
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
 import fr.sncf.osrd.utils.indexing.MutableArena
+import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.dynIdxArraySetOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.ZERO
 import kotlinx.coroutines.*
 
 class TestLocation {
@@ -18,11 +19,7 @@ class TestLocation {
         // setup test data
         val infra = rawInfraFromRjs {
             // create a test switch
-            val switchA =
-                movableElement("A", delay = 42L.milliseconds) {
-                    config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                    config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
-                }
+            val switchA = node("A", ZERO, StaticPool(), StaticPool())
 
             val zoneA = zone(listOf(switchA))
 

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
@@ -3,8 +3,9 @@ package fr.sncf.osrd.sim
 import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.api.withLock
 import fr.sncf.osrd.sim.interlocking.impl.MovableElementSimImpl
-import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.impl.TrackNodeConfigDescriptor
 import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
+import fr.sncf.osrd.utils.indexing.StaticPool
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
@@ -18,10 +19,17 @@ class TestMovableElements {
     fun lockMoveTest() = runTest {
         // setup test data
         val infra = rawInfraFromRjs {
-            movableElement("A", delay = 42L.milliseconds) {
-                config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
-            }
+            node(
+                "A",
+                42L.milliseconds,
+                StaticPool(),
+                StaticPool(
+                    mutableListOf(
+                        TrackNodeConfigDescriptor("a", listOf()),
+                        TrackNodeConfigDescriptor("b", listOf())
+                    )
+                )
+            )
         }
 
         val sim = MovableElementSimImpl(infra, MovableElementInitPolicy.PESSIMISTIC)

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -6,14 +6,15 @@ import fr.sncf.osrd.sim.interlocking.api.ZoneReservationStatus.*
 import fr.sncf.osrd.sim.interlocking.api.ZoneState
 import fr.sncf.osrd.sim.interlocking.impl.*
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
 import fr.sncf.osrd.utils.indexing.MutableArena
+import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableArenaMap
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.ZERO
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
@@ -37,12 +38,8 @@ class TestReservation {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilder()
-            val switch =
-                builder.movableElement("A", delay = 42L.milliseconds) {
-                    config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                    config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
-                }
+            val builder = RawInfraFromRjsBuilderImpl()
+            val switch = builder.node("A", ZERO, StaticPool(), StaticPool())
 
             val zoneA = builder.zone(listOf())
             val zoneB = builder.zone(listOf())

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -6,12 +6,12 @@ import fr.sncf.osrd.sim.interlocking.impl.LocationSimImpl
 import fr.sncf.osrd.sim.interlocking.impl.movableElementSim
 import fr.sncf.osrd.sim.interlocking.impl.reservationSim
 import fr.sncf.osrd.sim.interlocking.impl.routingSim
-import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -42,14 +42,9 @@ class TestRouting {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilder()
+            val builder = RawInfraFromRjsBuilderImpl()
             // region switches
-            val switch =
-                builder.movableElement("S", delay = 10L.milliseconds) {
-                    config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                    config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
-                }
-
+            val switch = builder.node("S", 10L.milliseconds, StaticPool(), StaticPool())
             // endregion
 
             // region zones

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -4,18 +4,18 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
 import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.ZERO
 
 class TestBALtoBAL {
     @Test
@@ -31,13 +31,9 @@ class TestBALtoBAL {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilder()
+        val builder = RawInfraFromRjsBuilderImpl()
         // region switches
-        val switch =
-            builder.movableElement("S", delay = 10L.milliseconds) {
-                config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-                config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
-            }
+        val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
         // endregion
 
         // region zones

--- a/core/kt-osrd-utils/build.gradle
+++ b/core/kt-osrd-utils/build.gradle
@@ -17,6 +17,7 @@ java {
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
     implementation project(':kt-fast-collections')
+    implementation project(':osrd-railjson')
     ksp project(':kt-fast-collections-generator')
     api project(':osrd-reporting')
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Endpoint.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Endpoint.kt
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.utils
 
+import fr.sncf.osrd.railjson.schema.common.graph.EdgeEndpoint
+
 /** An endpoint on an oriented segment */
 enum class Endpoint {
     /** The point at the start of the oriented segment */
@@ -23,4 +25,10 @@ enum class Endpoint {
 
     val directionFrom: Direction
         get() = directionAway.opposite
+
+    companion object {
+        fun fromEdgeEndpoint(edgeEndpoint: EdgeEndpoint): Endpoint {
+            if (edgeEndpoint == EdgeEndpoint.BEGIN) return START else return END
+        }
+    }
 }

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
@@ -396,6 +396,39 @@ public final class OSRDError extends RuntimeException {
     }
 
     /**
+     * Creates a new OSRDError for an invalid infrastructure error.
+     *
+     * @param errorType the error type
+     * @param id the ID associated with the error
+     * @return a new OSRDError instance
+     */
+    public static OSRDError newInvalidRangeError(ErrorType errorType, String id) {
+        var error = new OSRDError(errorType);
+        error.context.put("track_id", id);
+        return error;
+    }
+
+    /**
+     * Creates a new OSRDError for an invalid infrastructure error with an RJS switch ID, switch
+     * type, and switch ports.
+     *
+     * @param rjsSwitchID the RJS switch ID associated with the error
+     * @param switchType the switch type
+     * @param switchTypePorts the expected switch ports
+     * @param switchPorts the received switch ports
+     * @return a new OSRDError instance
+     */
+    public static OSRDError newWrongSwitchPortsError(
+            String rjsSwitchID, String switchType, Object switchTypePorts, Object switchPorts) {
+        var error = new OSRDError(ErrorType.InvalidInfraWrongSwitchPorts);
+        error.context.put("rjs_switch_id", rjsSwitchID);
+        error.context.put("switch_type", switchType);
+        error.context.put("expected_switch_ports", switchTypePorts);
+        error.context.put("got_switch_ports", switchPorts);
+        return error;
+    }
+
+    /**
      * Returns the error message.
      *
      * @return the error message

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -81,39 +81,6 @@ public class UndirectedInfraBuilder {
         builder = NetworkBuilder.directed().immutable();
     }
 
-    /**
-     * Creates a new OSRDError for an invalid infrastructure error.
-     *
-     * @param errorType the error type
-     * @param id the ID associated with the error
-     * @return a new OSRDError instance
-     */
-    public static OSRDError newInvalidRangeError(ErrorType errorType, String id) {
-        var error = new OSRDError(errorType);
-        error.context.put("track_id", id);
-        return error;
-    }
-
-    /**
-     * Creates a new OSRDError for an invalid infrastructure error with an RJS switch ID, switch
-     * type, and switch ports.
-     *
-     * @param rjsSwitchID the RJS switch ID associated with the error
-     * @param switchType the switch type
-     * @param switchTypePorts the expected switch ports
-     * @param switchPorts the received switch ports
-     * @return a new OSRDError instance
-     */
-    public static OSRDError newWrongSwitchPortsError(
-            String rjsSwitchID, String switchType, Object switchTypePorts, Object switchPorts) {
-        var error = new OSRDError(ErrorType.InvalidInfraWrongSwitchPorts);
-        error.context.put("rjs_switch_id", rjsSwitchID);
-        error.context.put("switch_type", switchType);
-        error.context.put("expected_switch_ports", switchTypePorts);
-        error.context.put("got_switch_ports", switchPorts);
-        return error;
-    }
-
     /** Creates a TrackInfra from a railjson infra */
     public static TrackInfra parseInfra(RJSInfra infra, DiagnosticRecorder diagnosticRecorder) {
         return new UndirectedInfraBuilder(diagnosticRecorder).parse(infra);
@@ -360,7 +327,7 @@ public class UndirectedInfraBuilder {
             for (var rjsCurve : track.curves) {
                 rjsCurve.simplify();
                 if (rjsCurve.begin < 0 || rjsCurve.end > track.length)
-                    throw newInvalidRangeError(ErrorType.InvalidInfraTrackCurveWithInvalidRange, track.id);
+                    throw OSRDError.newInvalidRangeError(ErrorType.InvalidInfraTrackCurveWithInvalidRange, track.id);
                 if (rjsCurve.radius != 0.) {
                     for (var dir : Direction.values())
                         curves.get(dir)
@@ -385,7 +352,7 @@ public class UndirectedInfraBuilder {
             for (var rjsSlope : track.slopes) {
                 rjsSlope.simplify();
                 if (rjsSlope.begin < 0 || rjsSlope.end > track.length)
-                    throw newInvalidRangeError(ErrorType.InvalidInfraTrackSlopeWithInvalidRange, track.id);
+                    throw OSRDError.newInvalidRangeError(ErrorType.InvalidInfraTrackSlopeWithInvalidRange, track.id);
                 if (rjsSlope.gradient != 0.) {
                     for (var dir : Direction.values())
                         slopes.get(dir)
@@ -460,7 +427,7 @@ public class UndirectedInfraBuilder {
         var switchTypePorts = new HashSet<>(switchType.ports);
         var switchPorts = rjsSwitch.ports.keySet();
         if (!switchTypePorts.equals(switchPorts))
-            throw newWrongSwitchPortsError(rjsSwitch.id, switchType.id, switchTypePorts, switchPorts);
+            throw OSRDError.newWrongSwitchPortsError(rjsSwitch.id, switchType.id, switchTypePorts, switchPorts);
 
         var groupChangeDelay = rjsSwitch.groupChangeDelay;
         if (Double.isNaN(groupChangeDelay)) groupChangeDelay = 0.0;

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -13,7 +13,6 @@ import fr.sncf.osrd.infra.api.tracks.undirected.Switch
 import fr.sncf.osrd.infra.api.tracks.undirected.SwitchBranch
 import fr.sncf.osrd.infra.api.tracks.undirected.SwitchPort
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackEdge
-import fr.sncf.osrd.infra.api.tracks.undirected.TrackNode.Joint
 import fr.sncf.osrd.infra.api.tracks.undirected.TrackSection
 import fr.sncf.osrd.infra.implementation.tracks.directed.DiTrackEdgeImpl
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView
@@ -169,24 +168,6 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
                 }
                 trackNodeGroupsMap[oldSwitch] = switchGroups
             }
-    }
-
-    // parse track links
-    for (node in infra.trackGraph.nodes()) {
-        if (node is Joint) {
-            val edges = infra.trackGraph.incidentEdges(node)
-            assert(edges.count() == 2)
-            builder.movableElement(node.id, ZERO) {
-                val ports = ArrayList<TrackNodePortId>()
-                for (edge in edges) {
-                    val endpoint =
-                        if (infra.trackGraph.incidentNodes(edge).nodeU() == node) Endpoint.START
-                        else Endpoint.END
-                    ports.add(port(EndpointTrackSectionId(trackSectionMap[edge]!!, endpoint)))
-                }
-                config("default", Pair(ports[0], ports[1]))
-            }
-        }
     }
 
     fun getOrCreateDet(oldDiDetector: DiDetector): DirDetectorId {


### PR DESCRIPTION
Also:
* add converter from EdgeEndpoint (railjson) in Endpoint (kt).
* add comparison tests on node part of the resulting infra
* cleanup in first 2 commits
* update test to use new builder's interface.
* continues on track-section's directions:
  * drop more parts of RawInfraBuilder interface.
  * maintain stitching to connect "new" loading of part of the infra and "old" loading of the rest of the infra.

Tested locally on France and Germany infra ✅
🔍 better reviewed by commit with message

Part of https://github.com/osrd-project/osrd-confidential/issues/307