### PR TITLE
kt-fast-collections: fix array init performance bug

### DIFF
--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/Array.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/Array.kt
@@ -29,9 +29,16 @@ private fun CollectionItemType.generateArray(context: GeneratorContext, currentF
 
             import ${type.qualifiedName}
 
+            // regular lambda types are compiled to a generic Function<In, Out> type, which boxes
+            // its arguments and return value. It's a significant performance bug.
+            fun interface ${simpleName}ArrayInitializer${paramsDecl} {
+                fun call(idx: Int): $type
+            }
+
             @JvmInline
             value class Mutable${simpleName}Array${paramsDecl}(private val data: $bufferType) {
-                public constructor(size: Int, init: (Int) -> $type) : this($bufferType(size) { i -> ${storageType.toPrimitive("init(i)")} })
+                public constructor(size: Int, init: ${simpleName}ArrayInitializer${paramsUse})
+                    : this($bufferType(size) { i -> ${storageType.toPrimitive("init.call(i)")} })
 
                 val size get() = data.size
 


### PR DESCRIPTION
## Before
![2024-03-06_12-03-1709723817](https://github.com/osrd-project/osrd/assets/5047140/19982808-1ea2-4741-a7d8-64169ce2a549)

## After
![2024-03-06_12-03-1709725297](https://github.com/osrd-project/osrd/assets/5047140/1c7dc54e-2eb6-453f-9b76-405ee02f5852)
