### PR TITLE
feat: add telemetry propagators between gateway and editoast

### DIFF
--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -44,6 +44,8 @@ use modelsv2::{
     Retrieve as RetrieveV2, RetrieveBatch,
 };
 use modelsv2::{Changeset, RollingStockModel};
+use opentelemetry_datadog::DatadogPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use schema::v2::trainschedule::TrainScheduleBase;
 use views::v2::train_schedule::{TrainScheduleForm, TrainScheduleResult};
 
@@ -122,6 +124,7 @@ fn init_tracing(mode: EditoastMode, telemetry_config: &client::TelemetryConfig) 
             let layer = tracing_opentelemetry::layer()
                 .with_tracer(datadog_tracer)
                 .boxed();
+            opentelemetry::global::set_text_map_propagator(DatadogPropagator::default());
             Some(layer)
         }
         client::TelemetryKind::Opentelemetry => {
@@ -144,6 +147,7 @@ fn init_tracing(mode: EditoastMode, telemetry_config: &client::TelemetryConfig) 
             let layer = tracing_opentelemetry::layer()
                 .with_tracer(otlp_tracer)
                 .boxed();
+            opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
             Some(layer)
         }
     };

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -6,6 +6,7 @@ use figment::{
 };
 use log::info;
 use opentelemetry::global;
+use opentelemetry_datadog::DatadogPropagator;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator, runtime::TokioCurrentThread, trace::TracerProvider,
@@ -80,6 +81,7 @@ impl TracingTelemetry {
             .with_batch_exporter(exporter, TokioCurrentThread)
             .build();
 
+        global::set_text_map_propagator(DatadogPropagator::default());
         global::set_tracer_provider(provider);
     }
 


### PR DESCRIPTION
This will allow traces to flow through services like they should. Here is an example in Datadog

![image](https://github.com/osrd-project/osrd/assets/2520723/9312bb00-9a0f-4e9c-a6a5-e4afbd519726)

Closes #6347