### PR TITLE
core: stdcm: fix cost function when departure time range is 0

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints
 import fr.sncf.osrd.api.pathfinding.constraints.makeSignalingSystemConstraints
 import fr.sncf.osrd.api.pathfinding.makeHeuristics
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
@@ -166,6 +167,8 @@ private fun totalCostUntilEdgeLocation(
             range.edge.timeStart,
             range.edge.standardAllowanceSpeedFactor
         )
+    if (areTimesEqual(searchTimeRange, 0.0))
+        return timeEnd // Avoid multiplying by 0, we can't have time shift anyway
     val pathDuration = timeEnd - range.edge.totalDepartureTimeShift
     return pathDuration * searchTimeRange + range.edge.totalDepartureTimeShift
 }


### PR DESCRIPTION
fix https://github.com/osrd-project/osrd/issues/6841

We used to multiply the time by 0 in that case, the solution wasn't the optimal one anymore