### PR TITLE
core: signaling: add BAPR/TVM transitions

### DIFF
--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoTVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoTVM300.kt
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.signaling.bal
+
+import fr.sncf.osrd.signaling.*
+import fr.sncf.osrd.sim_infra.api.SigSettings
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.SigStateSchema
+
+object BALtoTVM300 : SignalDriver {
+    override val name = "BAL-TVM300"
+    override val inputSignalingSystem = "BAL"
+    override val outputSignalingSystem = "TVM300"
+
+    override fun evalSignal(
+        signal: SigSettings,
+        stateSchema: SigStateSchema,
+        maView: MovementAuthorityView?,
+        limitView: SpeedLimitView?
+    ): SigState {
+        return stateSchema { value("aspect", "VL") }
+    }
+
+    override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}
+}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoTVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BALtoTVM430.kt
@@ -1,4 +1,4 @@
-package fr.sncf.osrd.signaling.tvm430
+package fr.sncf.osrd.signaling.bal
 
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigSettings

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoTVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoTVM300.kt
@@ -1,13 +1,13 @@
-package fr.sncf.osrd.signaling.tvm300
+package fr.sncf.osrd.signaling.bapr
 
 import fr.sncf.osrd.signaling.*
 import fr.sncf.osrd.sim_infra.api.SigSettings
 import fr.sncf.osrd.sim_infra.api.SigState
 import fr.sncf.osrd.sim_infra.api.SigStateSchema
 
-object BALtoTVM300 : SignalDriver {
-    override val name = "BAL-TVM300"
-    override val inputSignalingSystem = "BAL"
+object BAPRtoTVM300 : SignalDriver {
+    override val name = "BAPR-TVM300"
+    override val inputSignalingSystem = "BAPR"
     override val outputSignalingSystem = "TVM300"
 
     override fun evalSignal(

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoTVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPRtoTVM430.kt
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.signaling.bapr
+
+import fr.sncf.osrd.signaling.*
+import fr.sncf.osrd.sim_infra.api.SigSettings
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.SigStateSchema
+
+object BAPRtoTVM430 : SignalDriver {
+    override val name = "BAPR-TVM430"
+    override val inputSignalingSystem = "BAPR"
+    override val outputSignalingSystem = "TVM430"
+
+    override fun evalSignal(
+        signal: SigSettings,
+        stateSchema: SigStateSchema,
+        maView: MovementAuthorityView?,
+        limitView: SpeedLimitView?
+    ): SigState {
+        return stateSchema { value("aspect", "VL") }
+    }
+
+    override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}
+}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toBAPR.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toBAPR.kt
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.signaling.tvm300
+
+import fr.sncf.osrd.signaling.*
+import fr.sncf.osrd.sim_infra.api.SigSettings
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.SigStateSchema
+
+object TVM300toBAPR : SignalDriver {
+    override val name = "TVM300-BAPR"
+    override val inputSignalingSystem = "TVM300"
+    override val outputSignalingSystem = "BAPR"
+
+    override fun evalSignal(
+        signal: SigSettings,
+        stateSchema: SigStateSchema,
+        maView: MovementAuthorityView?,
+        limitView: SpeedLimitView?
+    ): SigState {
+        return stateSchema { value("aspect", "VL") }
+    }
+
+    override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}
+}

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toBAPR.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toBAPR.kt
@@ -1,0 +1,23 @@
+package fr.sncf.osrd.signaling.tvm430
+
+import fr.sncf.osrd.signaling.*
+import fr.sncf.osrd.sim_infra.api.SigSettings
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.SigStateSchema
+
+object TVM430toBAPR : SignalDriver {
+    override val name = "TVM430-BAPR"
+    override val inputSignalingSystem = "TVM430"
+    override val outputSignalingSystem = "BAPR"
+
+    override fun evalSignal(
+        signal: SigSettings,
+        stateSchema: SigStateSchema,
+        maView: MovementAuthorityView?,
+        limitView: SpeedLimitView?
+    ): SigState {
+        return stateSchema { value("aspect", "VL") }
+    }
+
+    override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}
+}

--- a/core/src/main/java/fr/sncf/osrd/api/SignalingSimulator.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/SignalingSimulator.kt
@@ -2,9 +2,7 @@ package fr.sncf.osrd.api
 
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.bal.*
-import fr.sncf.osrd.signaling.bapr.BAPR
-import fr.sncf.osrd.signaling.bapr.BAPRtoBAL
-import fr.sncf.osrd.signaling.bapr.BAPRtoBAPR
+import fr.sncf.osrd.signaling.bapr.*
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.signaling.tvm300.*
@@ -23,16 +21,20 @@ fun makeSignalingSimulator(): SignalingSimulator {
 
     sigSystemManager.addSignalDriver(BALtoBAL)
     sigSystemManager.addSignalDriver(BALtoBAPR)
-    sigSystemManager.addSignalDriver(BAPRtoBAPR)
-    sigSystemManager.addSignalDriver(BAPRtoBAL)
-    sigSystemManager.addSignalDriver(TVM300toTVM300)
-    sigSystemManager.addSignalDriver(TVM300toBAL)
-    sigSystemManager.addSignalDriver(TVM300toTVM430)
     sigSystemManager.addSignalDriver(BALtoTVM300)
-    sigSystemManager.addSignalDriver(TVM430toTVM430)
-    sigSystemManager.addSignalDriver(TVM430toBAL)
     sigSystemManager.addSignalDriver(BALtoTVM430)
+    sigSystemManager.addSignalDriver(BAPRtoBAL)
+    sigSystemManager.addSignalDriver(BAPRtoBAPR)
+    sigSystemManager.addSignalDriver(BAPRtoTVM300)
+    sigSystemManager.addSignalDriver(BAPRtoTVM430)
+    sigSystemManager.addSignalDriver(TVM300toBAL)
+    sigSystemManager.addSignalDriver(TVM300toBAPR)
+    sigSystemManager.addSignalDriver(TVM300toTVM300)
+    sigSystemManager.addSignalDriver(TVM300toTVM430)
+    sigSystemManager.addSignalDriver(TVM430toBAL)
+    sigSystemManager.addSignalDriver(TVM430toBAPR)
     sigSystemManager.addSignalDriver(TVM430toTVM300)
+    sigSystemManager.addSignalDriver(TVM430toTVM430)
 
     return SignalingSimulatorImpl(sigSystemManager)
 }


### PR DESCRIPTION
Fix https://github.com/osrd-project/osrd/issues/6871

I added the new modules, moved a couple so that the `XXX->YYY` transition is placed in the `XXX` module (it was inconsistent), and sorted the `.addSignalDriver` lines