### PR TITLE
scripts: fix sync-openapi.sh

### DIFF
--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -5,7 +5,7 @@ set -e
 root_path="$(realpath "$(dirname "$0")"/..)"
 
 echo "Generating editoast's openapi"
-docker run osrd/editoast editoast openapi > "${root_path}"/editoast/openapi.yaml
+( cd "${root_path}/editoast" && cargo run openapi > "${root_path}"/editoast/openapi.yaml )
 
 echo "Generating the typescript client"
 yarn --cwd "${root_path}"/front generate-types


### PR DESCRIPTION
We don't tag images with osrd/editoast since a few month ago. We should probably just run with the local version anyways