### PR TITLE
front: update IGN layers to new endpoints

### DIFF
--- a/front/src/common/Map/Layers/IGN_BD_ORTHO.tsx
+++ b/front/src/common/Map/Layers/IGN_BD_ORTHO.tsx
@@ -34,9 +34,10 @@ export default function IGN_BD_ORTHO(props: IGN_BD_ORTHO_Props) {
       id="ignbdortho"
       type="raster"
       tiles={[
-        'https://wxs.ign.fr/essentiels/geoportail/r/wms?bbox={bbox-epsg-3857}&styles=normal&SERVICE=WMS&VERSION=1.3.0&format=image/jpeg&service=WMS&REQUEST=GetMap&CRS=EPSG:3857&width=256&height=256&layers=ORTHOIMAGERY.ORTHOPHOTOS',
+        'https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
       ]}
       tileSize={256}
+      attribution="© IGN"
     >
       <OrderedLayer {...IGN_BD_ORTHO_Params} layerOrder={layerOrder} />
     </Source>

--- a/front/src/common/Map/Layers/IGN_CADASTRE.tsx
+++ b/front/src/common/Map/Layers/IGN_CADASTRE.tsx
@@ -31,9 +31,10 @@ export default function IGN_CADASTRE(props: IGN_Cadastre_Props) {
       id="igncadastre"
       type="raster"
       tiles={[
-        'https://wxs.ign.fr/essentiels/geoportail/r/wms?bbox={bbox-epsg-3857}&styles=normal&SERVICE=WMS&VERSION=1.3.0&format=image/jpeg&service=WMS&REQUEST=GetMap&CRS=EPSG:3857&width=256&height=256&layers=CADASTRALPARCELS.PARCELLAIRE_EXPRESS',
+        'https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
       ]}
       tileSize={256}
+      attribution="© IGN"
     >
       <OrderedLayer {...IGN_Cadastre_Params} layerOrder={layerOrder} />
     </Source>

--- a/front/src/common/Map/Layers/IGN_SCAN25.tsx
+++ b/front/src/common/Map/Layers/IGN_SCAN25.tsx
@@ -31,10 +31,14 @@ export default function IGN_SCAN25(props: IGN_SCAN25_Props) {
       id="ignscan25"
       type="raster"
       tiles={[
-        // 'https://wxs.ign.fr/d2lkke4ru7ermncm52c97k51/geoportail/r/wms?bbox={bbox-epsg-3857}&styles=normal&SERVICE=WMS&VERSION=1.3.0&format=image/jpeg&service=WMS&REQUEST=GetMap&CRS=EPSG:3857&width=256&height=256&layers=SCAN25TOUR_PYR-JPEG_WLD_WM',
-        'https://wxs.ign.fr/d2lkke4ru7ermncm52c97k51/geoportail/r/wms?bbox={bbox-epsg-3857}&styles=normal&SERVICE=WMS&VERSION=1.3.0&format=image/jpeg&service=WMS&REQUEST=GetMap&CRS=EPSG:3857&width=256&height=256&layers=GEOGRAPHICALGRIDSYSTEMS.MAPS',
+        /**
+         * WARNING: When new IGN's authorization system will be available (current 2024), we'll have to get a dedicated token to use this endpoint
+         * https://geoservices.ign.fr/actualites/2023-11-20-acces-donnesnonlibres-gpf
+         */
+        'https://data.geopf.fr/private/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetTile&apikey=ign_scan_ws&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
       ]}
       tileSize={256}
+      attribution="© IGN"
     >
       <OrderedLayer {...IGN_SCAN25_Params} layerOrder={layerOrder} />
     </Source>


### PR DESCRIPTION
IGN change their free endpoints, we have to update them.
Special warning for `GEOGRAPHICALGRIDSYSTEMS.MAPS`, access is currently token-free, but this will change in 2024, when we'll need to register and create a token specifically for our use (it will remain free, as our project is opensource). We'll also need to restrict its use by setting the REFERER in the future interface proposed by IGN.

More informations here: https://geoservices.ign.fr/actualites/2023-11-20-acces-donnesnonlibres-gpf

Close #6910 