### PR TITLE
core: handle constraints in infraExplorer instead of pathfinding for stdcm

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -3,10 +3,7 @@ package fr.sncf.osrd.api.pathfinding
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.InfraManager
-import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints
-import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints
-import fr.sncf.osrd.api.pathfinding.constraints.SignalingSystemConstraints
-import fr.sncf.osrd.api.pathfinding.constraints.makeSignalingSystemConstraints
+import fr.sncf.osrd.api.pathfinding.constraints.*
 import fr.sncf.osrd.api.pathfinding.request.PathfindingRequest
 import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint
 import fr.sncf.osrd.api.pathfinding.response.PathfindingResult
@@ -211,16 +208,7 @@ fun runPathfinding(
         for (waypoint in step) allStarts.addAll(findWaypointBlocks(infra, waypoint))
         waypoints.add(allStarts)
     }
-
-    // Initializes the constraints
-    val loadingGaugeConstraints =
-        LoadingGaugeConstraints(infra.blockInfra, infra.rawInfra, rollingStocks!!)
-    val electrificationConstraints =
-        ElectrificationConstraints(infra.blockInfra, infra.rawInfra, rollingStocks)
-    val signalisationSystemConstraints =
-        makeSignalingSystemConstraints(infra.blockInfra, infra.signalingSimulator, rollingStocks)
-    val constraints =
-        listOf(loadingGaugeConstraints, electrificationConstraints, signalisationSystemConstraints)
+    val constraints = initConstraints(infra, rollingStocks!!)
     val remainingDistanceEstimators = makeHeuristics(infra, waypoints)
 
     // Compute the paths from the entry waypoint to the exit waypoint
@@ -268,7 +256,7 @@ fun makeHeuristics(
 private fun computePaths(
     infra: FullInfra,
     waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>,
-    constraints: List<EdgeToRangesId<Block>>,
+    constraints: List<PathfindingConstraint<Block>>,
     remainingDistanceEstimators: List<AStarHeuristicId<Block>>,
     timeout: Double?
 ): PathfindingResultId<Block> {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
@@ -1,7 +1,11 @@
 package fr.sncf.osrd.api.pathfinding.constraints
 
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.graph.EdgeToRanges
 import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.graph.PathfindingConstraint
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.train.RollingStock
 
 class ConstraintCombiner<EdgeT, OffsetType> : EdgeToRanges<EdgeT, OffsetType> {
     @JvmField val functions: MutableList<EdgeToRanges<EdgeT, OffsetType>> = ArrayList()
@@ -11,4 +15,28 @@ class ConstraintCombiner<EdgeT, OffsetType> : EdgeToRanges<EdgeT, OffsetType> {
         for (f in functions) res.addAll(f.apply(edge))
         return res
     }
+}
+
+/** Initialize the constraints used to determine whether a block can be explored of not */
+fun initConstraints(
+    fullInfra: FullInfra,
+    rollingStockList: Collection<RollingStock>
+): List<PathfindingConstraint<Block>> {
+
+    val loadingGaugeConstraints =
+        LoadingGaugeConstraints(fullInfra.blockInfra, fullInfra.rawInfra, rollingStockList)
+    val electrificationConstraints =
+        ElectrificationConstraints(fullInfra.blockInfra, fullInfra.rawInfra, rollingStockList)
+    val signalisationSystemConstraints =
+        makeSignalingSystemConstraints(
+            fullInfra.blockInfra,
+            fullInfra.signalingSimulator,
+            rollingStockList
+        )
+
+    return listOf(
+        loadingGaugeConstraints,
+        electrificationConstraints,
+        signalisationSystemConstraints
+    )
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ElectrificationConstraints.kt
@@ -4,8 +4,8 @@ import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.api.pathfinding.makePathProps
-import fr.sncf.osrd.graph.EdgeToRangesId
 import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -17,7 +17,7 @@ data class ElectrificationConstraints(
     val blockInfra: BlockInfra,
     val rawInfra: RawSignalingInfra,
     val rollingStocks: Collection<RollingStock>
-) : EdgeToRangesId<Block> {
+) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): MutableCollection<Pathfinding.Range<Block>> {
         val res = HashSet<Pathfinding.Range<Block>>()
         val path = makePathProps(blockInfra, rawInfra, edge)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/LoadingGaugeConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/LoadingGaugeConstraints.kt
@@ -1,8 +1,8 @@
 package fr.sncf.osrd.api.pathfinding.constraints
 
 import fr.sncf.osrd.api.pathfinding.makePathProps
-import fr.sncf.osrd.graph.EdgeToRangesId
 import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -13,7 +13,7 @@ data class LoadingGaugeConstraints(
     val blockInfra: BlockInfra,
     val infra: RawSignalingInfra,
     val rollingStocks: Collection<RollingStock>
-) : EdgeToRangesId<Block> {
+) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): Collection<Pathfinding.Range<Block>> {
         val res = HashSet<Pathfinding.Range<Block>>()
         val path = makePathProps(blockInfra, infra, edge)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/SignalingSystemConstraints.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/SignalingSystemConstraints.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.pathfinding.constraints
 
-import fr.sncf.osrd.graph.EdgeToRangesId
 import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.train.RollingStock
@@ -11,11 +11,11 @@ import fr.sncf.osrd.utils.units.meters
 data class SignalingSystemConstraints(
     val blockInfra: BlockInfra,
     val rollingStocksSupportedSigSystems: List<List<SignalingSystemId>>
-) : EdgeToRangesId<Block> {
+) : PathfindingConstraint<Block> {
     override fun apply(edge: BlockId): MutableCollection<Pathfinding.Range<Block>> {
         val res = HashSet<Pathfinding.Range<Block>>()
-        for (rollingStocksigSystems in rollingStocksSupportedSigSystems) {
-            val edgeBlockedRanges = getBlockedRanges(edge, blockInfra, rollingStocksigSystems)
+        for (rollingStockSigSystems in rollingStocksSupportedSigSystems) {
+            val edgeBlockedRanges = getBlockedRanges(edge, blockInfra, rollingStockSigSystems)
             if (edgeBlockedRanges.isNotEmpty()) {
                 res.addAll(edgeBlockedRanges)
                 break // if this edge is blocked for 2 RS, we will have the same exact range (the

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Interfaces.kt
@@ -51,7 +51,7 @@ typealias EdgeRangeCostId<T> = EdgeRangeCost<StaticIdx<T>, T>
 
 typealias EdgeToLengthId<T> = EdgeToLength<StaticIdx<T>, T>
 
-typealias EdgeToRangesId<T> = EdgeToRanges<StaticIdx<T>, T>
+typealias PathfindingConstraint<T> = EdgeToRanges<StaticIdx<T>, T>
 
 typealias TargetsOnEdgeId<T> = TargetsOnEdge<StaticIdx<T>, T>
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -1,11 +1,13 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
 import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.pathfinding.constraints.*
 import fr.sncf.osrd.conflicts.IncrementalRequirementEnvelopeAdapter
 import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
 import fr.sncf.osrd.envelope.EnvelopeConcat
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -73,13 +75,15 @@ fun initInfraExplorerWithEnvelope(
     fullInfra: FullInfra,
     location: PathfindingEdgeLocationId<Block>,
     endBlocks: Collection<BlockId> = setOf(),
-    rollingStock: RollingStock
+    rollingStock: RollingStock,
+    constraints: List<PathfindingConstraint<Block>> = listOf()
 ): Collection<InfraExplorerWithEnvelope> {
     return initInfraExplorer(
             fullInfra.rawInfra,
             fullInfra.blockInfra,
             location,
-            endBlocks = endBlocks
+            endBlocks = endBlocks,
+            constraints
         )
         .map { explorer ->
             InfraExplorerWithEnvelopeImpl(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -1,9 +1,11 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
+import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
+import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.Helpers
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class InfraExplorerTests {
+
     @Test
     fun testSingleEdge() {
         /*
@@ -171,8 +174,82 @@ class InfraExplorerTests {
         )
     }
 
+    @Test
+    fun testBlockedPath() {
+        /*
+                 c1
+                ^  \
+               /    v
+        a --> b     d --> e
+               \    ^
+                v  /
+                 c2
+
+         Same as testTwoDifferentPaths(), but with constraints applied on one of the path.
+         */
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b"),
+                infra.addBlock("b", "c1"),
+                infra.addBlock("c1", "d"),
+                infra.addBlock("b", "c2"),
+                infra.addBlock("c2", "d"),
+                infra.addBlock("d", "e"),
+            )
+
+        // Every block is electrified, except b->c1
+        for (block in infra.blockPool) block.voltage = "25000V"
+        infra.blockPool[1].voltage = ""
+
+        val electrificationConstraints =
+            ElectrificationConstraints(infra, infra, listOf(TestTrains.FAST_ELECTRIC_TRAIN))
+        val constraints = listOf(electrificationConstraints)
+
+        // a --> b
+        val firstExplorers =
+            initInfraExplorer(
+                infra,
+                infra,
+                PathfindingEdgeLocationId(blocks[0], Offset(0.meters)),
+                constraints = constraints
+            )
+        assertEquals(1, firstExplorers.size)
+        val firstExplorer = firstExplorers.first()
+
+        // current block a->b, since b->c1 is not electrified, the lookahead is b->c2
+        val firstExplorerExtended = firstExplorer.cloneAndExtendLookahead().toList()
+        assertEquals(1, firstExplorerExtended.size)
+
+        // we add the block c2->d in the lookahead
+        val firstExplorerExtended2 =
+            firstExplorerExtended.first().cloneAndExtendLookahead().toList()
+        assertEquals(1, firstExplorerExtended2.size)
+
+        // we add the block d->e in the lookahead
+        val firstExplorerExtended3 =
+            firstExplorerExtended2.first().cloneAndExtendLookahead().toList()
+        assertEquals(1, firstExplorerExtended3.size)
+
+        firstExplorerExtended3.first().moveForward()
+        assertEquals(
+            blocks[3],
+            firstExplorerExtended3.first().getCurrentBlock(),
+        )
+        firstExplorerExtended3.first().moveForward()
+        assertEquals(
+            blocks[4],
+            firstExplorerExtended3.first().getCurrentBlock(),
+        )
+        firstExplorerExtended3.first().moveForward()
+        assertEquals(
+            blocks[5],
+            firstExplorerExtended3.first().getCurrentBlock(),
+        )
+    }
+
     /**
-     * Test that there are two instances of InfraExplorer when starting on a point with overlaping
+     * Test that there are two instances of InfraExplorer when starting on a point with overlapping
      * routes
      */
     @Test


### PR DESCRIPTION
First part of #6335 