### PR TITLE
core: build zones of kotlin infra from itself only (partially-filled)

### DIFF
--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.signaling
 import fr.sncf.osrd.signaling.impl.MockSigSystemManager
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
@@ -28,7 +28,7 @@ class BlockBuilderTest {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilderImpl()
+        val builder = RawInfraFromRjsBuilder()
         // region switches
         val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
         // endregion

--- a/core/kt-osrd-sim-infra/build.gradle
+++ b/core/kt-osrd-sim-infra/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     api project(":osrd-railjson")
     api project(":osrd-reporting")
     implementation libs.kotlin.stdlib
+    implementation libs.kotlin.logging
     testImplementation libs.kotlin.test
 
     // Use JUnit Jupiter API for testing.

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -386,9 +386,8 @@ class RawInfraImpl(
         // initialize zone names
         for (zone in zonePool) {
             val name =
-                getZoneBounds(zone)
-                    .sortedBy { id -> id.index }
-                    .map { "${getDetectorName(it.value)}:${it.direction}" }
+                getZoneBounds(zone).map { "${getDetectorName(it.value)}:${it.direction}" }.sorted()
+
             zonePool[zone].name = "zone.${name}"
             zoneNameMap[zonePool[zone].name] = zone
         }

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.sim.interlocking.api.ZoneReservationStatus.*
 import fr.sncf.osrd.sim.interlocking.api.ZoneState
 import fr.sncf.osrd.sim.interlocking.impl.*
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableArenaMap
@@ -38,7 +38,7 @@ class TestReservation {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilderImpl()
+            val builder = RawInfraFromRjsBuilder()
             val switch = builder.node("A", ZERO, StaticPool(), StaticPool())
 
             val zoneA = builder.zone(listOf())

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -8,7 +8,7 @@ import fr.sncf.osrd.sim.interlocking.impl.reservationSim
 import fr.sncf.osrd.sim.interlocking.impl.routingSim
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticPool
@@ -42,7 +42,7 @@ class TestRouting {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilderImpl()
+            val builder = RawInfraFromRjsBuilder()
             // region switches
             val switch = builder.node("S", 10L.milliseconds, StaticPool(), StaticPool())
             // endregion

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -6,7 +6,7 @@ import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilderImpl
+import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
@@ -31,7 +31,7 @@ class TestBALtoBAL {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilderImpl()
+        val builder = RawInfraFromRjsBuilder()
         // region switches
         val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
         // endregion

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
@@ -41,7 +41,7 @@ value class OptStaticIdx<T>(private val data: UInt) {
 
 @JvmInline
 value class EndpointStaticIdx<T>(val data: UInt) : NumIdx {
-    public constructor(
+    constructor(
         value: StaticIdx<T>,
         endpoint: Endpoint
     ) : this(
@@ -142,6 +142,12 @@ value class StaticPool<IndexT, ValueT>(private val items: MutableList<ValueT>) :
 
     override fun iterator(): StaticIdxIterator<IndexT> {
         return StaticIdxSpaceIterator(items.size.toUInt())
+    }
+
+    fun <NewValueT> map(f: (ValueT) -> NewValueT): StaticPool<IndexT, NewValueT> {
+        val result = mutableListOf<NewValueT>()
+        for (it in items) result.add(f(it))
+        return StaticPool(result)
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -4,7 +4,6 @@ import com.google.common.collect.BiMap
 import com.google.common.collect.HashBiMap
 import com.google.common.collect.ImmutableList
 import fr.sncf.osrd.infra.api.Direction
-import fr.sncf.osrd.infra.api.reservation.DetectionSection
 import fr.sncf.osrd.infra.api.reservation.DiDetector
 import fr.sncf.osrd.infra.api.reservation.ReservationRoute
 import fr.sncf.osrd.infra.api.signaling.SignalingInfra
@@ -32,7 +31,6 @@ import fr.sncf.osrd.sim_infra.api.TrackNodeConfigId
 import fr.sncf.osrd.sim_infra.api.TrackNodeId
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.TrackSectionId
-import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.sim_infra.api.ZonePath
 import fr.sncf.osrd.sim_infra.api.ZonePathId
 import fr.sncf.osrd.sim_infra.api.decreasing
@@ -51,7 +49,6 @@ import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.MutableOffsetArrayList
@@ -59,12 +56,10 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import fr.sncf.osrd.utils.units.metersPerSecond
 import kotlin.collections.set
-import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.seconds
 
 class SimInfraAdapter(
     val simInfra: RawInfra,
-    val zoneMap: BiMap<DetectionSection, ZoneId>,
     val detectorMap: BiMap<Detector, DetectorId>,
     val trackNodeMap: BiMap<Switch, TrackNodeId>,
     val trackNodeGroupsMap: Map<Switch, Map<String, TrackNodeConfigId>>,
@@ -91,7 +86,6 @@ data class TrackSignal(
 
 fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     val builder = RawInfraBuilderImpl()
-    val zoneMap = HashBiMap.create<DetectionSection, ZoneId>()
     val detectorMap = HashBiMap.create<Detector, DetectorId>()
     val trackNodeMap = HashBiMap.create<Switch, TrackNodeId>()
     val trackSectionMap = HashBiMap.create<TrackEdge, TrackSectionId>()
@@ -180,17 +174,13 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
     }
 
     // create zones
-    val switchToZone = mutableMapOf<Switch, ZoneId>()
     for (detectionSection in infra.detectionSections) {
         val oldSwitches = detectionSection!!.switches!!
         val oldDiDetectors = detectionSection.detectors!!
-        val switches = mutableStaticIdxArraySetOf<TrackNode>()
-        for (oldSwitch in oldSwitches) switches.add(trackNodeMap[oldSwitch]!!)
+        val switches = oldSwitches.map { trackNodeMap[it]!! }.toList()
         val detectors = mutableListOf<DirDetectorId>()
         for (oldDiDetector in oldDiDetectors) detectors.add(getOrCreateDet(oldDiDetector!!))
-        val zoneId = builder.zone(switches, detectors)
-        for (oldSwitch in oldSwitches) switchToZone[oldSwitch] = zoneId
-        zoneMap[detectionSection] = zoneId
+        builder.zone(switches, detectors)
     }
 
     // parse signals
@@ -289,7 +279,6 @@ fun adaptRawInfra(infra: SignalingInfra): SimInfraAdapter {
 
     return SimInfraAdapter(
         builder.build(),
-        zoneMap,
         detectorMap,
         trackNodeMap,
         trackNodeGroupsMap,

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.utils
 
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.TrackChunk
@@ -7,6 +8,7 @@ import fr.sncf.osrd.sim_infra.api.TrackChunkId
 import fr.sncf.osrd.sim_infra.api.TrackNodeId
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.TrackSection
+import fr.sncf.osrd.sim_infra.api.ZoneId
 import fr.sncf.osrd.sim_infra_adapter.SimInfraAdapter
 import fr.sncf.osrd.stdcm.graph.logger
 import fr.sncf.osrd.utils.units.Offset
@@ -184,7 +186,10 @@ class ComparableNode(simInfra: RawInfra, nodeIdx: TrackNodeId) {
     }
 }
 
+data class ComparableZone(val name: String, val nodes: Set<String>)
+
 fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
+    // detectors
     val leftDetectors = mutableSetOf<String>()
     for (d in left.simInfra.detectors) {
         leftDetectors.add(left.simInfra.getDetectorName(d)!!)
@@ -197,6 +202,7 @@ fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
     assert(right.simInfra.detectors.size.toInt() == rightDetectors.size)
     assert(leftDetectors == rightDetectors)
 
+    // track-sections
     assert(left.simInfra.trackSections.size == right.simInfra.trackSections.size)
     val leftTrackChunks = mutableMapOf<Pair<String, Offset<TrackSection>>, ComparableChunk>()
     for (t in left.simInfra.trackSections) {
@@ -220,6 +226,7 @@ fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
     }
     assert(leftTrackChunks == rightTrackChunks)
 
+    // nodes
     val leftNodes = mutableSetOf<ComparableNode>()
     for (n in left.simInfra.trackNodes) {
         val leftNode = ComparableNode(left.simInfra, n)
@@ -234,9 +241,83 @@ fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
     }
     assert(leftNodes == rightNodes)
 
+    // zones
+    val leftZones = mutableMapOf<ZoneId, ComparableZone>()
+    for (z in left.simInfra.zones) {
+        leftZones[z] =
+            ComparableZone(
+                left.simInfra.getZoneName(z),
+                left.simInfra
+                    .getMovableElements(z)
+                    .map { left.simInfra.getTrackNodeName(it) }
+                    .toSet()
+            )
+    }
+    val rightZones = mutableMapOf<ZoneId, ComparableZone>()
+    for (z in right.simInfra.zones) {
+        rightZones[z] =
+            ComparableZone(
+                right.simInfra.getZoneName(z),
+                right.simInfra
+                    .getMovableElements(z)
+                    .map { right.simInfra.getTrackNodeName(it) }
+                    .toSet()
+            )
+    }
+
+    val leftDetToNextZone = mutableMapOf<String, ComparableZone?>()
+    val leftZoneToDet = mutableMapOf<ComparableZone, MutableSet<DirDetectorId>>()
+    for (detIdx in left.simInfra.detectors) {
+        for (dir in Direction.entries) {
+            val dirDet = DirDetectorId(detIdx, dir)
+            val nextZoneIdx = left.simInfra.getNextZone(dirDet)
+            leftDetToNextZone["${left.getDetectorName(dirDet.value)}.${dirDet.direction}"] =
+                if (nextZoneIdx != null) leftZones[nextZoneIdx] else null
+            if (nextZoneIdx != null) {
+                if (!leftZoneToDet.containsKey(leftZones[nextZoneIdx]))
+                    leftZoneToDet[leftZones[nextZoneIdx]!!] = mutableSetOf()
+                leftZoneToDet[leftZones[nextZoneIdx]]!!.add(dirDet)
+            }
+        }
+    }
+    val rightDetToNextZone = mutableMapOf<String, ComparableZone?>()
+    val rightZoneToDet = mutableMapOf<ComparableZone, MutableSet<DirDetectorId>>()
+    for (detIdx in right.simInfra.detectors) {
+        for (dir in Direction.entries) {
+            val dirDet = DirDetectorId(detIdx, dir)
+            val nextZoneIdx = right.simInfra.getNextZone(dirDet)
+            rightDetToNextZone["${right.getDetectorName(dirDet.value)}.${dirDet.direction}"] =
+                if (nextZoneIdx != null) rightZones[nextZoneIdx] else null
+            if (nextZoneIdx != null) {
+                if (!rightZoneToDet.containsKey(rightZones[nextZoneIdx]))
+                    rightZoneToDet[rightZones[nextZoneIdx]!!] = mutableSetOf()
+                rightZoneToDet[rightZones[nextZoneIdx]]!!.add(dirDet)
+            }
+        }
+    }
+
+    val extraLeftZones = leftZones.values.toSet().minus(rightZones.values.toSet())
+    val extraRightZones = rightZones.values.toSet().minus(leftZones.values.toSet())
+    // check that different zones are only the "suspect" ones with 0 or 1 detector bound
+    for (zone in extraLeftZones) {
+        assert(!leftZoneToDet.containsKey(zone) || leftZoneToDet[zone]!!.size < 2)
+    }
+    for (zone in extraRightZones) {
+        assert(!rightZoneToDet.containsKey(zone) || rightZoneToDet[zone]!!.size < 2)
+    }
+
+    val extraLeftDet = leftDetToNextZone.entries.minus(rightDetToNextZone.entries)
+    val extraRightDet = rightDetToNextZone.entries.minus(leftDetToNextZone.entries)
+    // check that different detectors are bounding only "suspect" zones
+    for ((_, zone) in extraLeftDet) {
+        assert(zone == null || extraLeftZones.contains(zone))
+    }
+    for ((_, zone) in extraRightDet) {
+        assert(zone == null || extraRightZones.contains(zone))
+    }
+
     // TODO complete simInfra checks
 
-    assert(left.zoneMap == right.zoneMap)
     assert(left.detectorMap.size == right.detectorMap.size)
     for (l in left.detectorMap) {
         assert(right.detectorMap.containsKey(l.key))

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -54,7 +54,7 @@ class BlockAvailabilityTests {
             "zone.[det.center.1:INCREASING, det.center.2:DECREASING]",
             "zone.[det.center.2:INCREASING, det.center.3:DECREASING]",
             "zone.[det.b1.nf:DECREASING, det.b2.nf:DECREASING, det.center.3:INCREASING]",
-            "zone.[det.b1.nf:INCREASING, bf.b1:DECREASING]"
+            "zone.[bf.b1:DECREASING, det.b1.nf:INCREASING]"
         )
 
     @BeforeEach


### PR DESCRIPTION
Also:
* remove unused switchToZone and zoneMap in RawInfraAdapter
* stabilize detector sorting used for zone's name

Note:
* keep zone() method in Builder to let Adapter orchestrate and pass map of track sections to detectors
* raises warnings on 5 zones with <2 detectors on Germany (import edge-cases).
  ```
   4   │ [16:05:56,478] [WARN]        [RawInfraBuilder] Invalid detection zone delimited by detector(s) [573418174] and containing node(s) [691570452]
   5   │ [16:05:56,490] [WARN]        [RawInfraBuilder] Invalid detection zone delimited by detector(s) [1141072995] and containing node(s) [3233572434]
   6   │ [16:05:56,502] [WARN]        [RawInfraBuilder] Invalid detection zone delimited by detector(s) [3923371281] and containing node(s) [1398993150]
   7   │ [16:05:56,509] [WARN]        [RawInfraBuilder] Invalid detection zone delimited by detector(s) [] and containing node(s) [7663005738, 7663005739]
   8   │ [16:05:56,509] [WARN]        [RawInfraBuilder] Invalid detection zone delimited by detector(s) [] and containing node(s) [8618898998, 7997895383]
  ```

Final part of partial issue https://github.com/osrd-project/osrd-confidential/issues/307
🔍 Better review by commit