### PR TITLE
front: search: ops: display CI but search in UIC

### DIFF
--- a/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/MapSearchOperationalPoint.tsx
@@ -67,7 +67,7 @@ const MapSearchOperationalPoint = ({
       : [
           'or',
           ['search', ['name'], debouncedSearchTerm],
-          ['like', ['to_string', ['ci']], `%${debouncedSearchTerm}%`],
+          ['like', ['to_string', ['uic']], `%${debouncedSearchTerm}%`],
         ];
     const payload = {
       object: 'operationalpoint',
@@ -178,7 +178,7 @@ const MapSearchOperationalPoint = ({
                 {searchResult.name}
                 <span className="ch">{searchResult.ch}</span>
               </span>
-              <span className="uic">{searchResult.uic}</span>
+              <span className="uic">{searchResult.ci}</span>
             </button>
           ))}
       </div>


### PR DESCRIPTION
The complete UIC code was displayed but we weren't able to search with complete UIC code.

This PR fixes this behaviour: only CI code is displayed, but we can search for complete UIC or CI.