### PR TITLE
front: add time in hh:mm:ss format for trainschedule export, less decimals for values

### DIFF
--- a/front/src/modules/trainschedule/components/DriverTrainSchedule/driverTrainScheduleExportCSV.ts
+++ b/front/src/modules/trainschedule/components/DriverTrainSchedule/driverTrainScheduleExportCSV.ts
@@ -6,6 +6,7 @@ import type {
   SpeedPosition,
   Train,
 } from 'reducers/osrdsimulation/types';
+import { timestampToHHMMSS } from 'utils/date';
 
 import type { BaseOrEcoType } from './DriverTrainScheduleTypes';
 
@@ -24,6 +25,7 @@ enum CSVKeys {
   position = 'position',
   speed = 'speed',
   speedLimit = 'speedLimit',
+  seconds = 'seconds',
   time = 'time',
 }
 
@@ -141,12 +143,13 @@ export default function driverTrainScheduleExportCSV(train: Train, baseOrEco: Ba
       ch: speed.ch || '',
       lineCode: speed.lineCode || '',
       trackName: speed.trackName || '',
-      position: pointToComma(speed.position / 1000),
-      speed: pointToComma(speed.speed * 3.6),
+      position: pointToComma(+(speed.position / 1000).toFixed(3)),
+      speed: pointToComma(+(speed.speed * 3.6).toFixed(3)),
       speedLimit: pointToComma(
         Math.round((speed.speedLimit ?? getStepSpeedLimit(speed.position, train.vmax)) * 3.6)
       ),
-      time: pointToComma(speed.time),
+      seconds: pointToComma(+speed.time.toFixed(1)),
+      time: timestampToHHMMSS(speed.time),
     }));
     if (steps) createFakeLinkWithData(train, baseOrEco, spreadTrackAndLineNames(steps));
   }

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -9,6 +9,11 @@ dayjs.locale('fr');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+export function timestampToHHMMSS(timestamp: number) {
+  const date = new Date(timestamp * 1000);
+  return date.toISOString().substring(11, 19);
+}
+
 export function formatIsoDate(date: Date) {
   return date.toISOString().substring(0, 10);
 }


### PR DESCRIPTION
As asked by our user, new column with time in hh:mm:ss format.

Moreover, there's less decimals for values, it was overkill before. Export filesize is reduced by 40% .

close #7061

![image](https://github.com/osrd-project/osrd/assets/6003856/e56377f5-9764-475b-8590-8be4a9668099)
