### PR TITLE
editoast: reorganize all 'use' as unique items

### DIFF
--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -2,16 +2,23 @@ mod postgres_config;
 mod redis_config;
 mod telemetry_config;
 
-use crate::error::Result;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use std::env;
+use std::path::PathBuf;
+
+use clap::Args;
+use clap::Parser;
+use clap::Subcommand;
+use clap::ValueEnum;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
 pub use postgres_config::PostgresConfig;
 pub use redis_config::RedisConfig;
-use std::{env, path::PathBuf};
-pub use telemetry_config::{TelemetryConfig, TelemetryKind};
+pub use telemetry_config::TelemetryConfig;
+pub use telemetry_config::TelemetryKind;
 use thiserror::Error;
 use url::Url;
+
+use crate::error::Result;
 
 #[derive(Parser, Debug)]
 #[command(author, version)]

--- a/editoast/src/client/postgres_config.rs
+++ b/editoast/src/client/postgres_config.rs
@@ -1,9 +1,10 @@
-use crate::error::Result;
 use clap::Args;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
 use thiserror::Error;
 use url::Url;
+
+use crate::error::Result;
 
 #[derive(Args, Debug, Derivative, Clone)]
 #[derivative(Default)]

--- a/editoast/src/client/redis_config.rs
+++ b/editoast/src/client/redis_config.rs
@@ -1,9 +1,10 @@
-use crate::error::Result;
 use clap::Args;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
 use thiserror::Error;
 use url::Url;
+
+use crate::error::Result;
 
 #[derive(Args, Debug, Derivative, Clone)]
 #[derivative(Default)]

--- a/editoast/src/client/telemetry_config.rs
+++ b/editoast/src/client/telemetry_config.rs
@@ -1,4 +1,5 @@
-use clap::{Args, ValueEnum};
+use clap::Args;
+use clap::ValueEnum;
 use derivative::Derivative;
 use url::Url;
 

--- a/editoast/src/converters/generate_routes.rs
+++ b/editoast/src/converters/generate_routes.rs
@@ -4,8 +4,10 @@
 //! - part 2: build the graph
 //! - part 3: compute the routes
 
-use crate::schema::{utils::Identifier, *};
 use std::collections::HashMap;
+
+use crate::schema::utils::Identifier;
+use crate::schema::*;
 
 /* Part 1: type definitions */
 // When building the graph, a node can be a trackEndPoint, a detector or a buffer stop

--- a/editoast/src/converters/osm_to_railjson.rs
+++ b/editoast/src/converters/osm_to_railjson.rs
@@ -1,8 +1,14 @@
-use super::utils::*;
-use crate::{converters::generate_routes, schema::*};
-use tracing::{debug, error, info};
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::PathBuf;
 
-use std::{collections::HashMap, error::Error, path::PathBuf};
+use tracing::debug;
+use tracing::error;
+use tracing::info;
+
+use super::utils::*;
+use crate::converters::generate_routes;
+use crate::schema::*;
 /// Run the osm-to-railjson subcommand
 /// Converts OpenStreetMap pbf file to railjson
 pub fn osm_to_railjson(
@@ -121,13 +127,12 @@ pub fn parse_osm(osm_pbf_in: PathBuf) -> Result<RailJson, Box<dyn Error + Send +
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        converters::*,
-        schema::{utils::Identifier, *},
-    };
     use std::collections::HashMap;
 
     use super::parse_osm;
+    use crate::converters::*;
+    use crate::schema::utils::Identifier;
+    use crate::schema::*;
     #[test]
     fn convert_osm_to_railjson() {
         let output = tempfile::NamedTempFile::new().unwrap();

--- a/editoast/src/converters/utils.rs
+++ b/editoast/src/converters/utils.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
+use std::str::FromStr;
+
+use osm4routing::Coord;
+use osm4routing::Edge;
+use osm4routing::NodeId;
+use osmpbfreader::Node;
+use tracing::error;
+use tracing::warn;
 
 use crate::schema::utils::Identifier;
 use crate::schema::*;
-use osm4routing::{Coord, Edge, NodeId};
-use osmpbfreader::Node;
-use std::str::FromStr;
-use tracing::{error, warn};
 
 // Given an edge and a coordinate, returns the coordinates used to compute the angle
 // It uses the nearest OpenStreetMap node, and the other as the the rails might do a loop

--- a/editoast/src/core/conflicts.rs
+++ b/editoast/src/core/conflicts.rs
@@ -1,7 +1,10 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
-use super::{AsCoreRequest, Json};
-use crate::models::{RoutingRequirement, SpacingRequirement};
+use super::AsCoreRequest;
+use super::Json;
+use crate::models::RoutingRequirement;
+use crate::models::SpacingRequirement;
 use crate::views::timetable::ConflictType;
 
 #[derive(Debug, Serialize)]

--- a/editoast/src/core/http_client.rs
+++ b/editoast/src/core/http_client.rs
@@ -1,4 +1,8 @@
-use reqwest::{Client, ClientBuilder, Method, RequestBuilder, Url};
+use reqwest::Client;
+use reqwest::ClientBuilder;
+use reqwest::Method;
+use reqwest::RequestBuilder;
+use reqwest::Url;
 
 pub trait HttpClientBuilder {
     fn build_base_url(self, base_url: Url) -> HttpClient;

--- a/editoast/src/core/infra_loading.rs
+++ b/editoast/src/core/infra_loading.rs
@@ -1,5 +1,6 @@
-use super::AsCoreRequest;
 use serde::Serialize;
+
+use super::AsCoreRequest;
 
 /// A Core infra load request
 #[derive(Debug, Serialize)]

--- a/editoast/src/core/infra_state.rs
+++ b/editoast/src/core/infra_state.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use crate::views::infra::InfraState;
-
-use super::{AsCoreRequest, Json};
 use derivative::Derivative;
 use serde::Serialize;
 use serde_derive::Deserialize;
+
+use super::AsCoreRequest;
+use super::Json;
+use crate::views::infra::InfraState;
 
 /// A Core infra load request
 #[derive(Debug, Serialize, Derivative)]

--- a/editoast/src/core/mocking.rs
+++ b/editoast/src/core/mocking.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use super::{CoreClient, CoreResponse};
 use actix_http::StatusCode;
 use reqwest::Body;
 use serde::Serialize;
+
+use super::CoreClient;
+use super::CoreResponse;
 
 /// A mocking core client maintaining a list of stub requests to simulate
 ///

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -9,23 +9,31 @@ pub mod simulation;
 pub mod stdcm;
 pub mod version;
 
-use std::{collections::HashMap, fmt::Display, marker::PhantomData};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::marker::PhantomData;
 
-use crate::error::{InternalError, Result};
 use actix_http::StatusCode;
 use async_trait::async_trait;
-use colored::{ColoredString, Colorize};
+use colored::ColoredString;
+use colored::Colorize;
 use editoast_derive::EditoastError;
-pub use http_client::{HttpClient, HttpClientBuilder};
+pub use http_client::HttpClient;
+pub use http_client::HttpClientBuilder;
 use reqwest::Url;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use serde_derive::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::debug;
+use tracing::error;
+use tracing::info;
 
 #[cfg(test)]
 use crate::core::mocking::MockingError;
+use crate::error::InternalError;
+use crate::error::Result;
 
 crate::schemas! {
     simulation::schemas(),
@@ -376,10 +384,10 @@ mod test {
     use serde_derive::Serialize;
     use serde_json::json;
 
-    use crate::{
-        core::{mocking::MockingClient, AsCoreRequest, Bytes},
-        error::InternalError,
-    };
+    use crate::core::mocking::MockingClient;
+    use crate::core::AsCoreRequest;
+    use crate::core::Bytes;
+    use crate::error::InternalError;
 
     #[rstest::rstest]
     async fn test_expected_empty_response() {

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -1,13 +1,17 @@
 use derivative::Derivative;
-use geos::geojson::{Geometry, Value::LineString};
-use serde::{Deserialize, Serialize};
+use geos::geojson::Geometry;
+use geos::geojson::Value::LineString;
+use serde::Deserialize;
+use serde::Serialize;
 
-use crate::models::{CurveGraph, SlopeGraph};
+use super::AsCoreRequest;
+use super::Json;
+use crate::models::CurveGraph;
+use crate::models::RoutePath;
+use crate::models::SlopeGraph;
 use crate::schema::rolling_stock::RollingStock;
+use crate::schema::Direction;
 use crate::schema::TrackLocation;
-use crate::{models::RoutePath, schema::Direction};
-
-use super::{AsCoreRequest, Json};
 
 pub type PathfindingWaypoints = Vec<Vec<Waypoint>>;
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -1,16 +1,25 @@
-use super::{AsCoreRequest, Json};
-use crate::models::train_schedule::{
-    ElectrificationRange, Mrsp, RjsPowerRestrictionRange, SimulationPowerRestrictionRange,
-    TrainScheduleOptions,
-};
-use crate::models::{
-    Allowance, Pathfinding, PathfindingPayload, ResultTrain, RoutePath, ScheduledPoint,
-    SignalSighting, ZoneUpdate,
-};
-use crate::schema::rolling_stock::{RollingStock, RollingStockComfortType};
-use crate::schema::TrackLocation;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use utoipa::ToSchema;
+
+use super::AsCoreRequest;
+use super::Json;
+use crate::models::train_schedule::ElectrificationRange;
+use crate::models::train_schedule::Mrsp;
+use crate::models::train_schedule::RjsPowerRestrictionRange;
+use crate::models::train_schedule::SimulationPowerRestrictionRange;
+use crate::models::train_schedule::TrainScheduleOptions;
+use crate::models::Allowance;
+use crate::models::Pathfinding;
+use crate::models::PathfindingPayload;
+use crate::models::ResultTrain;
+use crate::models::RoutePath;
+use crate::models::ScheduledPoint;
+use crate::models::SignalSighting;
+use crate::models::ZoneUpdate;
+use crate::schema::rolling_stock::RollingStock;
+use crate::schema::rolling_stock::RollingStockComfortType;
+use crate::schema::TrackLocation;
 
 crate::schemas! {
     SignalUpdate,

--- a/editoast/src/core/stdcm.rs
+++ b/editoast/src/core/stdcm.rs
@@ -1,13 +1,15 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
-use crate::core::{pathfinding::Waypoint, simulation::SimulationResponse};
+use super::pathfinding::PathfindingResponse;
+use super::AsCoreRequest;
+use super::Json;
+use crate::core::pathfinding::Waypoint;
+use crate::core::simulation::SimulationResponse;
 use crate::models::SpacingRequirement;
 use crate::modelsv2::RollingStockModel;
 use crate::schema::rolling_stock::RollingStockComfortType;
 use crate::views::stdcm::AllowanceValue;
-
-use super::pathfinding::PathfindingResponse;
-use super::{AsCoreRequest, Json};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct STDCMCoreRequest {

--- a/editoast/src/core/version.rs
+++ b/editoast/src/core/version.rs
@@ -1,7 +1,9 @@
-use super::{AsCoreRequest, Json};
-use crate::views::Version;
 use derivative::Derivative;
 use serde::Serialize;
+
+use super::AsCoreRequest;
+use super::Json;
+use crate::views::Version;
 
 /// A Core infra load request
 #[derive(Debug, Serialize, Derivative)]

--- a/editoast/src/generated_data/buffer_stop.rs
+++ b/editoast/src/generated_data/buffer_stop.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/detector.rs
+++ b/editoast/src/generated_data/detector.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/electrification.rs
+++ b/editoast/src/generated_data/electrification.rs
@@ -1,3 +1,13 @@
+use async_trait::async_trait;
+use diesel::delete;
+use diesel::query_dsl::methods::FilterDsl;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
+
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
 use crate::diesel::ExpressionMethods;
@@ -5,12 +15,6 @@ use crate::error::Result;
 use crate::infra_cache::InfraCache;
 use crate::schema::ObjectType;
 use crate::tables::infra_layer_electrification::dsl;
-use async_trait::async_trait;
-use diesel::delete;
-use diesel::query_dsl::methods::FilterDsl;
-use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
 
 pub struct ElectrificationLayer;
 

--- a/editoast/src/generated_data/error/buffer_stops.rs
+++ b/editoast/src/generated_data/error/buffer_stops.rs
@@ -1,9 +1,14 @@
-use crate::infra_cache::Graph;
-
-use super::{GlobalErrorGenerator, NoContext};
+use super::GlobalErrorGenerator;
+use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{Endpoint, InfraError, ObjectRef, ObjectType, TrackEndpoint};
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::Endpoint;
+use crate::schema::InfraError;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::TrackEndpoint;
 
 // TODO: Use a macro instead to force order and priority continuity
 // Example: `static_priority_array![[check_invalid_ref], [check_out_of_range]]`
@@ -156,17 +161,20 @@ fn check_missing(infra_cache: &InfraCache, graph: &Graph) -> Vec<InfraError> {
 
 #[cfg(test)]
 pub mod tests {
+    use rstest::rstest;
+
     use super::check_invalid_ref;
     use super::check_out_of_range;
     use super::InfraError;
     use crate::generated_data::error::buffer_stops::check_missing;
     use crate::generated_data::error::buffer_stops::check_odd_location;
+    use crate::infra_cache::tests::create_buffer_stop_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::tests::create_track_section_cache;
-    use crate::infra_cache::tests::{create_buffer_stop_cache, create_small_infra_cache};
     use crate::infra_cache::Graph;
     use crate::schema::Endpoint;
-    use crate::schema::{ObjectRef, ObjectType};
-    use rstest::rstest;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/detectors.rs
+++ b/editoast/src/generated_data/error/detectors.rs
@@ -1,8 +1,11 @@
 use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, ObjectRef, ObjectType};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_invalid_ref),
@@ -51,13 +54,14 @@ pub fn check_out_of_range(
 }
 #[cfg(test)]
 mod tests {
-    use crate::infra_cache::tests::{create_detector_cache, create_small_infra_cache};
-    use crate::schema::{ObjectRef, ObjectType};
-
     use super::check_invalid_ref;
     use super::check_out_of_range;
     use super::InfraError;
+    use crate::infra_cache::tests::create_detector_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/electrifications.rs
+++ b/editoast/src/generated_data/error/electrifications.rs
@@ -1,12 +1,18 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use rangemap::RangeMap;
 
-use super::{GlobalErrorGenerator, NoContext};
+use super::GlobalErrorGenerator;
+use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, OSRDIdentified, ObjectRef, ObjectType};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::OSRDIdentified;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
@@ -111,7 +117,8 @@ mod tests {
     use crate::infra_cache::tests::create_electrification_cache;
     use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;
-    use crate::schema::{ObjectRef, ObjectType};
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -9,25 +9,34 @@ pub mod switch_types;
 pub mod switches;
 pub mod track_sections;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::pin::Pin;
 
 use async_trait::async_trait;
 use diesel::prelude::*;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Json, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Json;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use futures_util::Future;
 use itertools::Itertools;
 use serde_json::to_value;
-use sha1::{Digest, Sha1};
-use std::pin::Pin;
+use sha1::Digest;
+use sha1::Sha1;
 use tracing::warn;
 
 use super::GeneratedData;
 use crate::error::Result;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, OSRDObject, ObjectType};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::OSRDObject;
+use crate::schema::ObjectType;
 
 /// Empty context used when no context is needed
 #[derive(Debug, Default)]
@@ -416,13 +425,20 @@ impl GeneratedData for ErrorLayer {
 mod test {
     use rstest::rstest;
 
-    use super::{
-        buffer_stops, detectors, electrifications, generate_errors, operational_points, routes,
-        signals, speed_sections, switch_types, switches, track_sections, Graph,
-    };
-
-    use crate::infra_cache::tests::{create_buffer_stop_cache, create_small_infra_cache};
-
+    use super::buffer_stops;
+    use super::detectors;
+    use super::electrifications;
+    use super::generate_errors;
+    use super::operational_points;
+    use super::routes;
+    use super::signals;
+    use super::speed_sections;
+    use super::switch_types;
+    use super::switches;
+    use super::track_sections;
+    use super::Graph;
+    use crate::infra_cache::tests::create_buffer_stop_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
     use crate::schema::ObjectType;
 
     #[rstest]

--- a/editoast/src/generated_data/error/operational_points.rs
+++ b/editoast/src/generated_data/error/operational_points.rs
@@ -1,8 +1,11 @@
 use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, ObjectRef, ObjectType};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
@@ -55,12 +58,13 @@ pub fn check_op_parts(op: &ObjectCache, infra_cache: &InfraCache, _: &Graph) -> 
 
 #[cfg(test)]
 mod tests {
-    use crate::infra_cache::tests::{create_operational_point_cache, create_small_infra_cache};
-    use crate::schema::{ObjectRef, ObjectType};
-
     use super::check_op_parts;
     use super::InfraError;
+    use crate::infra_cache::tests::create_operational_point_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/routes.rs
+++ b/editoast/src/generated_data/error/routes.rs
@@ -1,10 +1,17 @@
-use std::collections::{HashMap, HashSet};
-
-use crate::generated_data::error::ObjectErrorGenerator;
-use crate::infra_cache::{Graph, InfraCache, ObjectCache};
-use crate::schema::{InfraError, OSRDIdentified, OSRDObject, ObjectRef, ObjectType, Waypoint};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use super::GlobalErrorGenerator;
+use crate::generated_data::error::ObjectErrorGenerator;
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::OSRDIdentified;
+use crate::schema::OSRDObject;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::Waypoint;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<Context>; 5] = [
     ObjectErrorGenerator::new(1, check_entry_point_ref),
@@ -206,17 +213,22 @@ fn check_missing(
 
 #[cfg(test)]
 mod tests {
-    use crate::generated_data::error::routes::{
-        check_entry_point_ref, check_exit_point_ref, check_missing, check_path,
-        check_release_detectors_ref, check_switches_directions_ref,
-    };
-    use crate::infra_cache::tests::{
-        create_detector_cache, create_route_cache, create_small_infra_cache,
-    };
-    use crate::infra_cache::Graph;
-    use crate::schema::{Direction, OSRDObject, ObjectRef, ObjectType, Waypoint};
-
     use super::InfraError;
+    use crate::generated_data::error::routes::check_entry_point_ref;
+    use crate::generated_data::error::routes::check_exit_point_ref;
+    use crate::generated_data::error::routes::check_missing;
+    use crate::generated_data::error::routes::check_path;
+    use crate::generated_data::error::routes::check_release_detectors_ref;
+    use crate::generated_data::error::routes::check_switches_directions_ref;
+    use crate::infra_cache::tests::create_detector_cache;
+    use crate::infra_cache::tests::create_route_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::Graph;
+    use crate::schema::Direction;
+    use crate::schema::OSRDObject;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
+    use crate::schema::Waypoint;
 
     #[test]
     fn invalid_ref_entry_point() {

--- a/editoast/src/generated_data/error/signals.rs
+++ b/editoast/src/generated_data/error/signals.rs
@@ -1,8 +1,11 @@
 use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{InfraError, ObjectRef, ObjectType};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_invalid_ref),
@@ -53,9 +56,11 @@ mod tests {
     use super::check_invalid_ref;
     use super::check_out_of_range;
     use super::InfraError;
-    use crate::infra_cache::tests::{create_signal_cache, create_small_infra_cache};
+    use crate::infra_cache::tests::create_signal_cache;
+    use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;
-    use crate::schema::{ObjectRef, ObjectType};
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/speed_sections.rs
+++ b/editoast/src/generated_data/error/speed_sections.rs
@@ -1,14 +1,20 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use rangemap::RangeMap;
 
-use super::{GlobalErrorGenerator, NoContext};
+use super::GlobalErrorGenerator;
+use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::schema::{
-    ApplicableDirections, Direction, InfraError, OSRDIdentified, ObjectRef, ObjectType,
-};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::ApplicableDirections;
+use crate::schema::Direction;
+use crate::schema::InfraError;
+use crate::schema::OSRDIdentified;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
     ObjectErrorGenerator::new(1, check_empty),
@@ -141,10 +147,12 @@ mod tests {
     use super::check_speed_section_track_ranges;
     use super::InfraError;
     use crate::generated_data::error::speed_sections::check_overlapping;
-    use crate::infra_cache::tests::{create_small_infra_cache, create_speed_section_cache};
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::tests::create_speed_section_cache;
     use crate::infra_cache::Graph;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
     use crate::schema::Speed;
-    use crate::schema::{ObjectRef, ObjectType};
 
     #[test]
     fn invalid_ref() {

--- a/editoast/src/generated_data/error/switch_types.rs
+++ b/editoast/src/generated_data/error/switch_types.rs
@@ -1,9 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
 use crate::schema::InfraError;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 1] =
@@ -60,7 +62,8 @@ mod tests {
     use super::check_switch_types;
     use super::InfraError;
     use crate::infra_cache;
-    use crate::infra_cache::tests::{create_switch_connection, create_switch_type_cache};
+    use crate::infra_cache::tests::create_switch_connection;
+    use crate::infra_cache::tests::create_switch_type_cache;
     use crate::infra_cache::Graph;
 
     #[test]

--- a/editoast/src/generated_data/error/switches.rs
+++ b/editoast/src/generated_data/error/switches.rs
@@ -1,8 +1,15 @@
-use crate::infra_cache::{Graph, InfraCache, ObjectCache};
-use crate::schema::{InfraError, OSRDIdentified, ObjectRef, ObjectType, TrackEndpoint};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use super::ObjectErrorGenerator;
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::InfraError;
+use crate::schema::OSRDIdentified;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::TrackEndpoint;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<Context>; 5] = [
     ObjectErrorGenerator::new(1, check_invalid_ref_ports),
@@ -126,17 +133,20 @@ fn check_overlapping(
 
 #[cfg(test)]
 mod tests {
-    use crate::generated_data::error::switches::{check_endpoints_unicity, Context};
-    use crate::infra_cache::tests::{
-        create_small_infra_cache, create_switch_cache_point, create_track_endpoint,
-    };
-    use crate::schema::{Endpoint, OSRDIdentified, ObjectRef, ObjectType};
-
     use super::check_invalid_ref_ports;
     use super::check_invalid_ref_switch_type;
     use super::check_match_ports_type;
     use super::check_overlapping;
     use super::InfraError;
+    use crate::generated_data::error::switches::check_endpoints_unicity;
+    use crate::generated_data::error::switches::Context;
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::tests::create_switch_cache_point;
+    use crate::infra_cache::tests::create_track_endpoint;
+    use crate::schema::Endpoint;
+    use crate::schema::OSRDIdentified;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_ref_track() {

--- a/editoast/src/generated_data/error/track_sections.rs
+++ b/editoast/src/generated_data/error/track_sections.rs
@@ -1,7 +1,8 @@
 use super::NoContext;
 use crate::generated_data::error::ObjectErrorGenerator;
 use crate::infra_cache::Graph;
-use crate::infra_cache::{InfraCache, ObjectCache};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
 use crate::schema::InfraError;
 
 pub const OBJECT_GENERATORS: [ObjectErrorGenerator<NoContext>; 2] = [
@@ -51,12 +52,16 @@ pub fn check_curve_out_of_range(track: &ObjectCache, _: &InfraCache, _: &Graph) 
 
 #[cfg(test)]
 mod tests {
-    use super::InfraError;
-    use super::{check_curve_out_of_range, check_slope_out_of_range};
-    use crate::infra_cache::tests::{create_small_infra_cache, create_track_section_cache};
-    use crate::infra_cache::Graph;
-    use crate::schema::{Curve, Slope};
     use rstest::rstest;
+
+    use super::check_curve_out_of_range;
+    use super::check_slope_out_of_range;
+    use super::InfraError;
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::tests::create_track_section_cache;
+    use crate::infra_cache::Graph;
+    use crate::schema::Curve;
+    use crate::schema::Slope;
 
     #[rstest]
     #[case(50., false)]

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -13,12 +13,15 @@ mod speed_section;
 mod switch;
 mod track_section;
 
-pub use error::generate_infra_errors;
-
 use async_trait::async_trait;
 use buffer_stop::BufferStopLayer;
 use detector::DetectorLayer;
+use diesel::sql_query;
+use diesel::sql_types::BigInt;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use electrification::ElectrificationLayer;
+pub use error::generate_infra_errors;
 use error::ErrorLayer;
 use neutral_section::NeutralSectionLayer;
 use neutral_sign::NeutralSignLayer;
@@ -33,9 +36,6 @@ use track_section::TrackSectionLayer;
 use crate::error::Result;
 use crate::infra_cache::InfraCache;
 use crate::schema::operation::CacheOperation;
-use diesel::sql_query;
-use diesel::sql_types::BigInt;
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
 
 /// This trait define how a generated data table should be handled
 #[async_trait]
@@ -154,11 +154,14 @@ pub async fn update_all(
 
 #[cfg(test)]
 pub mod tests {
-    use crate::fixtures::tests::db_pool;
-    use crate::generated_data::{clear_all, refresh_all, update_all};
-    use crate::modelsv2::infra::tests::test_infra_transaction;
     use actix_web::test as actix_test;
     use diesel_async::scoped_futures::ScopedFutureExt;
+
+    use crate::fixtures::tests::db_pool;
+    use crate::generated_data::clear_all;
+    use crate::generated_data::refresh_all;
+    use crate::generated_data::update_all;
+    use crate::modelsv2::infra::tests::test_infra_transaction;
 
     #[actix_test] // Slow test
     async fn refresh_all_test() {

--- a/editoast/src/generated_data/neutral_section.rs
+++ b/editoast/src/generated_data/neutral_section.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::GeneratedData;
 use crate::error::Result;

--- a/editoast/src/generated_data/neutral_sign.rs
+++ b/editoast/src/generated_data/neutral_sign.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/operational_point.rs
+++ b/editoast/src/generated_data/operational_point.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/psl_sign.rs
+++ b/editoast/src/generated_data/psl_sign.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/signal.rs
+++ b/editoast/src/generated_data/signal.rs
@@ -1,18 +1,24 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Nullable, Text};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::Text;
 use diesel_async::AsyncPgConnection as PgConnection;
-use std::collections::HashMap;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
 use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::InfraCache;
-use crate::schema::sprite_config::{SpriteConfig, SpriteConfigs};
-use crate::schema::{LogicalSignal, ObjectType};
+use crate::schema::sprite_config::SpriteConfig;
+use crate::schema::sprite_config::SpriteConfigs;
+use crate::schema::LogicalSignal;
+use crate::schema::ObjectType;
 use crate::tables::infra_layer_signal::dsl;
 
 pub struct SignalLayer;

--- a/editoast/src/generated_data/speed_section.rs
+++ b/editoast/src/generated_data/speed_section.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;

--- a/editoast/src/generated_data/switch.rs
+++ b/editoast/src/generated_data/switch.rs
@@ -1,13 +1,16 @@
-use crate::error::Result;
-use crate::infra_cache::InfraCache;
-use crate::schema::ObjectType;
+use async_trait::async_trait;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
-use async_trait::async_trait;
-use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::schema::ObjectType;
 
 pub struct SwitchLayer;
 

--- a/editoast/src/generated_data/track_section.rs
+++ b/editoast/src/generated_data/track_section.rs
@@ -1,14 +1,17 @@
-use crate::error::Result;
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
 use crate::diesel::ExpressionMethods;
+use crate::error::Result;
 use crate::infra_cache::InfraCache;
 use crate::schema::ObjectType;
 use crate::tables::infra_layer_track_section::dsl;

--- a/editoast/src/generated_data/utils.rs
+++ b/editoast/src/generated_data/utils.rs
@@ -1,9 +1,11 @@
 use std::collections::HashSet;
 
-use crate::{
-    infra_cache::{InfraCache, ObjectCache},
-    schema::{operation::CacheOperation, OSRDIdentified, OSRDObject, ObjectType},
-};
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::schema::operation::CacheOperation;
+use crate::schema::OSRDIdentified;
+use crate::schema::OSRDObject;
+use crate::schema::ObjectType;
 
 /// This struct gives a set of objects that needs to be updated or deleted given a list of operations.
 #[derive(Debug, Clone, Default)]
@@ -61,11 +63,13 @@ mod test {
     use std::collections::HashSet;
 
     use super::InvolvedObjects;
-
     use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::ObjectCache;
     use crate::schema::operation::CacheOperation;
-    use crate::schema::{DetectorCache, ObjectRef, ObjectType, TrackSectionCache};
+    use crate::schema::DetectorCache;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
+    use crate::schema::TrackSectionCache;
 
     #[test]
     fn track_section_deleted() {

--- a/editoast/src/infra_cache/graph.rs
+++ b/editoast/src/infra_cache/graph.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use crate::infra_cache::InfraCache;
 use crate::schema::utils::Identifier;
-use crate::schema::{SwitchCache, TrackEndpoint};
+use crate::schema::SwitchCache;
+use crate::schema::TrackEndpoint;
 
 #[derive(Default, Clone, Debug)]
 pub struct Graph<'a> {
@@ -87,16 +88,12 @@ impl<'a> Graph<'a> {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::schema::Endpoint;
-    use crate::{
-        infra_cache::{
-            tests::{create_small_infra_cache, create_track_endpoint},
-            InfraCache,
-        },
-        schema::utils::Identifier,
-    };
-
     use super::Graph;
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::tests::create_track_endpoint;
+    use crate::infra_cache::InfraCache;
+    use crate::schema::utils::Identifier;
+    use crate::schema::Endpoint;
 
     #[test]
     fn create_empty_graph() {

--- a/editoast/src/map/bounding_box.rs
+++ b/editoast/src/map/bounding_box.rs
@@ -1,6 +1,9 @@
 use editoast_derive::EditoastError;
-use geos::geojson::{self, Geometry, Value::LineString};
-use serde::{Deserialize, Serialize};
+use geos::geojson::Geometry;
+use geos::geojson::Value::LineString;
+use geos::geojson::{self};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
 

--- a/editoast/src/map/layer_cache.rs
+++ b/editoast/src/map/layer_cache.rs
@@ -32,7 +32,10 @@ pub fn get_cache_tile_key(view_prefix: &str, tile: &Tile) -> String {
 #[cfg(test)]
 mod tests {
 
-    use super::{get_cache_tile_key, get_layer_cache_prefix, get_view_cache_prefix, Tile};
+    use super::get_cache_tile_key;
+    use super::get_layer_cache_prefix;
+    use super::get_view_cache_prefix;
+    use super::Tile;
 
     #[test]
     fn test_get_layer_cache_prefix() {

--- a/editoast/src/map/layers.rs
+++ b/editoast/src/map/layers.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 // select C.stuff from A inner join B C on C.id = C.id;
 //                       \___________________________/

--- a/editoast/src/map/mod.rs
+++ b/editoast/src/map/mod.rs
@@ -2,14 +2,18 @@ mod bounding_box;
 mod layer_cache;
 mod layers;
 
-use crate::error::Result;
-pub use bounding_box::{BoundingBox, Zone};
-pub use layers::{Layer, MapLayers, View};
+pub use bounding_box::BoundingBox;
+pub use bounding_box::Zone;
+pub use layers::Layer;
+pub use layers::MapLayers;
+pub use layers::View;
 use redis::AsyncCommands;
 
-pub use self::layer_cache::{
-    get_cache_tile_key, get_layer_cache_prefix, get_view_cache_prefix, Tile,
-};
+pub use self::layer_cache::get_cache_tile_key;
+pub use self::layer_cache::get_layer_cache_prefix;
+pub use self::layer_cache::get_view_cache_prefix;
+pub use self::layer_cache::Tile;
+use crate::error::Result;
 use crate::RedisConnection;
 
 crate::schemas! {

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -5,23 +5,37 @@ mod text_array;
 mod timetable;
 pub mod train_schedule;
 
-use crate::modelsv2::projects;
-use crate::DbPool;
-use crate::{error::Result, views::pagination::PaginatedResponse};
 use actix_web::web::Data;
 use async_trait::async_trait;
 use diesel_async::AsyncPgConnection as PgConnection;
+pub use scenario::Scenario;
+pub use scenario::ScenarioWithCountTrains;
+pub use scenario::ScenarioWithDetails;
+pub use text_array::TextArray;
+pub use timetable::check_train_validity;
+pub use timetable::Timetable;
+pub use timetable::TimetableWithSchedulesDetails;
+pub use train_schedule::Allowance;
+pub use train_schedule::FullResultStops;
+pub use train_schedule::ResultPosition;
+pub use train_schedule::ResultSpeed;
+pub use train_schedule::ResultStops;
+pub use train_schedule::ResultTrain;
+pub use train_schedule::RoutingRequirement;
+pub use train_schedule::ScheduledPoint;
+pub use train_schedule::SignalSighting;
+pub use train_schedule::SimulationOutput;
+pub use train_schedule::SimulationOutputChangeset;
+pub use train_schedule::SpacingRequirement;
+pub use train_schedule::TrainSchedule;
+pub use train_schedule::TrainScheduleChangeset;
+pub use train_schedule::ZoneUpdate;
 
 pub use self::pathfinding::*;
-pub use scenario::{Scenario, ScenarioWithCountTrains, ScenarioWithDetails};
-pub use text_array::TextArray;
-pub use timetable::{check_train_validity, Timetable, TimetableWithSchedulesDetails};
-pub use train_schedule::{
-    Allowance, FullResultStops, ResultPosition, ResultSpeed, ResultStops, ResultTrain,
-    RoutingRequirement, ScheduledPoint, SignalSighting, SimulationOutput,
-    SimulationOutputChangeset, SpacingRequirement, TrainSchedule, TrainScheduleChangeset,
-    ZoneUpdate,
-};
+use crate::error::Result;
+use crate::modelsv2::projects;
+use crate::views::pagination::PaginatedResponse;
+use crate::DbPool;
 
 crate::schemas! {
     projects::schemas(),

--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -2,20 +2,25 @@
 
 use std::collections::HashSet;
 
+use chrono::NaiveDateTime;
+use chrono::Utc;
+use derivative::Derivative;
+use diesel::result::Error as DieselError;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::RunQueryDsl;
+use editoast_derive::Model;
+use geos::geojson;
+use postgis_diesel::types::*;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
 use crate::models::Identifiable;
 use crate::schema::Direction;
 use crate::schema::DirectionalTrackRange;
 use crate::schema::TrackLocation;
 use crate::tables::pathfinding;
-use chrono::{NaiveDateTime, Utc};
-use derivative::Derivative;
-use diesel::{result::Error as DieselError, ExpressionMethods, QueryDsl};
-use diesel_async::RunQueryDsl;
-use editoast_derive::Model;
-use geos::geojson;
-use postgis_diesel::types::*;
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 crate::schemas! {
     Slope,
@@ -245,12 +250,12 @@ impl Identifiable for Pathfinding {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::fixtures::tests::TestFixture;
-    use crate::models::Create;
-    use crate::DbPool;
     use actix_web::web::Data;
 
     use super::*;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::Create;
+    use crate::DbPool;
 
     pub fn simple_pathfinding(infra_id: i64) -> Pathfinding {
         //    T1       T2        T3       T4      T5

--- a/editoast/src/models/rolling_stock/mod.rs
+++ b/editoast/src/models/rolling_stock/mod.rs
@@ -1,8 +1,9 @@
-use crate::modelsv2::rolling_stock_model::{
-    RollingStockModel, RollingStockSupportedSignalingSystems,
-};
+use crate::modelsv2::rolling_stock_model::RollingStockModel;
+use crate::modelsv2::rolling_stock_model::RollingStockSupportedSignalingSystems;
 use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLiveryMetadata;
-use crate::schema::rolling_stock::{RollingStock, RollingStockCommon, RollingStockWithLiveries};
+use crate::schema::rolling_stock::RollingStock;
+use crate::schema::rolling_stock::RollingStockCommon;
+use crate::schema::rolling_stock::RollingStockWithLiveries;
 use crate::schema::track_section::LoadingGaugeType;
 
 crate::schemas! {
@@ -53,18 +54,20 @@ impl From<RollingStockModel> for RollingStock {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::error::InternalError;
-    use crate::fixtures::tests::{
-        db_pool, get_other_rolling_stock_form, named_fast_rolling_stock, named_other_rolling_stock,
-    };
-    use crate::modelsv2::Changeset;
-    use crate::views::rolling_stocks::{map_diesel_error, RollingStockError};
-    use crate::DbPool;
+    use actix_web::web::Data;
     use rstest::*;
     use serde_json::to_value;
 
     use super::RollingStockModel;
-    use actix_web::web::Data;
+    use crate::error::InternalError;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::get_other_rolling_stock_form;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::fixtures::tests::named_other_rolling_stock;
+    use crate::modelsv2::Changeset;
+    use crate::views::rolling_stocks::map_diesel_error;
+    use crate::views::rolling_stocks::RollingStockError;
+    use crate::DbPool;
 
     pub fn get_invalid_effort_curves() -> &'static str {
         include_str!("../../tests/example_rolling_stock_3.json")

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -1,25 +1,34 @@
+use actix_web::web::Data;
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use chrono::Utc;
+use derivative::Derivative;
+use diesel::delete;
+use diesel::result::Error as DieselError;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::Text;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
+use editoast_derive::Model;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use super::List;
 use crate::error::Result;
 use crate::models::train_schedule::LightTrainSchedule;
-use crate::models::{Delete, TextArray};
+use crate::models::Delete;
+use crate::models::TextArray;
+use crate::modelsv2::projects::Ordering;
 use crate::tables::scenario;
 use crate::views::pagination::Paginate;
 use crate::views::pagination::PaginatedResponse;
 use crate::DbPool;
-use actix_web::web::Data;
-use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
-use derivative::Derivative;
-use diesel::result::Error as DieselError;
-use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Nullable, Text};
-use diesel::{delete, ExpressionMethods, QueryDsl};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
-use editoast_derive::Model;
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
-
-use super::List;
-use crate::modelsv2::projects::Ordering;
 
 #[derive(
     Clone,
@@ -210,14 +219,18 @@ impl List<(i64, Ordering)> for ScenarioWithCountTrains {
 
 #[cfg(test)]
 pub mod test {
+    use rstest::rstest;
+
     use super::*;
-    use crate::fixtures::tests::{db_pool, scenario_fixture_set, ScenarioFixtureSet, TestFixture};
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::scenario_fixture_set;
+    use crate::fixtures::tests::ScenarioFixtureSet;
+    use crate::fixtures::tests::TestFixture;
     use crate::models::Delete;
     use crate::models::List;
     use crate::models::Retrieve;
     use crate::models::Timetable;
     use crate::modelsv2::Ordering;
-    use rstest::rstest;
 
     #[rstest]
     async fn create_delete_scenario(db_pool: Data<DbPool>) {

--- a/editoast/src/models/text_array.rs
+++ b/editoast/src/models/text_array.rs
@@ -1,6 +1,9 @@
 use diesel::backend::Backend;
-use diesel::deserialize::{FromSql, Queryable};
-use diesel::sql_types::{Array, Nullable, Text};
+use diesel::deserialize::FromSql;
+use diesel::deserialize::Queryable;
+use diesel::sql_types::Array;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::Text;
 
 /// This type is used to represent a postgresql array of text.
 /// It is used to handle nullability of the array elements.

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -1,15 +1,5 @@
 use std::collections::HashMap;
 
-use crate::error::Result;
-use crate::models::{
-    train_schedule::{
-        LightTrainSchedule, MechanicalEnergyConsumedBaseEco, TrainSchedule, TrainScheduleSummary,
-    },
-    SimulationOutput,
-};
-use crate::modelsv2::{LightRollingStockModel, Retrieve};
-use crate::tables::timetable;
-use crate::DbPool;
 use actix_web::web::Data;
 use derivative::Derivative;
 use diesel::prelude::*;
@@ -18,11 +8,22 @@ use diesel_async::AsyncPgConnection as PgConnection;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
 use futures::future::try_join_all;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::train_schedule::TrainScheduleValidation;
 use super::Scenario;
+use crate::error::Result;
+use crate::models::train_schedule::LightTrainSchedule;
+use crate::models::train_schedule::MechanicalEnergyConsumedBaseEco;
+use crate::models::train_schedule::TrainSchedule;
+use crate::models::train_schedule::TrainScheduleSummary;
+use crate::models::SimulationOutput;
+use crate::modelsv2::LightRollingStockModel;
+use crate::modelsv2::Retrieve;
+use crate::tables::timetable;
+use crate::DbPool;
 
 crate::schemas! {
     Timetable,

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -1,24 +1,26 @@
 use std::collections::HashMap;
 
-use crate::error::Result;
-use crate::modelsv2::{LightRollingStockModel, Retrieve};
-use crate::tables::train_schedule;
-use crate::{
-    models::{Identifiable, Timetable},
-    tables::simulation_output,
-};
-use crate::{DbPool, DieselJson};
 use actix_web::web::Data;
 use derivative::Derivative;
 use diesel::result::Error as DieselError;
-use diesel::{ExpressionMethods, QueryDsl};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
-
 use editoast_derive::Model;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::check_train_validity;
+use crate::error::Result;
+use crate::models::Identifiable;
+use crate::models::Timetable;
+use crate::modelsv2::LightRollingStockModel;
+use crate::modelsv2::Retrieve;
+use crate::tables::simulation_output;
+use crate::tables::train_schedule;
+use crate::DbPool;
+use crate::DieselJson;
 
 crate::schemas! {
     TrainSchedule,

--- a/editoast/src/modelsv2/electrical_profiles.rs
+++ b/editoast/src/modelsv2/electrical_profiles.rs
@@ -1,11 +1,14 @@
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
+use editoast_derive::ModelV2;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
 use crate::diesel::QueryDsl;
 use crate::error::Result;
 use crate::schema::electrical_profiles::ElectricalProfileSetData;
 use crate::tables::electrical_profile_set;
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
-use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
 
 #[derive(Clone, Debug, Serialize, Deserialize, ModelV2, ToSchema)]
 #[model(table = crate::tables::electrical_profile_set)]
@@ -34,13 +37,15 @@ pub struct LightElectricalProfileSet {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, dummy_electrical_profile_set, electrical_profile_set, TestFixture,
-    };
-    use crate::DbPool;
     use actix_web::web::Data;
     use rstest::rstest;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::dummy_electrical_profile_set;
+    use crate::fixtures::tests::electrical_profile_set;
+    use crate::fixtures::tests::TestFixture;
+    use crate::DbPool;
 
     #[rstest]
     async fn test_list_light(

--- a/editoast/src/modelsv2/infra.rs
+++ b/editoast/src/modelsv2/infra.rs
@@ -1,32 +1,42 @@
 use std::pin::Pin;
 
-use crate::models::{List, NoParams};
-use crate::{
-    error::Result,
-    generated_data,
-    infra_cache::InfraCache,
-    modelsv2::{
-        get_geometry_layer_table, get_table, prelude::*, railjson::persist_railjson, Create,
-    },
-    schema::{ObjectType, RailJson, RAILJSON_VERSION},
-    tables::infra::dsl,
-    views::pagination::{Paginate, PaginatedResponse},
-    DbPool,
-};
-
 use actix_web::web::Data;
 use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
+use chrono::Utc;
 use derivative::Derivative;
-use diesel::{sql_query, sql_types::BigInt, QueryDsl};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_query;
+use diesel::sql_types::BigInt;
+use diesel::QueryDsl;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
 use futures::future::try_join_all;
 use futures::Future;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use strum::IntoEnumIterator;
-use tracing::{debug, error};
+use tracing::debug;
+use tracing::error;
 use uuid::Uuid;
+
+use crate::error::Result;
+use crate::generated_data;
+use crate::infra_cache::InfraCache;
+use crate::models::List;
+use crate::models::NoParams;
+use crate::modelsv2::get_geometry_layer_table;
+use crate::modelsv2::get_table;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::railjson::persist_railjson;
+use crate::modelsv2::Create;
+use crate::schema::ObjectType;
+use crate::schema::RailJson;
+use crate::schema::RAILJSON_VERSION;
+use crate::tables::infra::dsl;
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
+use crate::DbPool;
 
 /// The default version of a newly created infrastructure
 ///
@@ -230,25 +240,26 @@ impl List<NoParams> for Infra {
 
 #[cfg(test)]
 pub mod tests {
-    use super::Infra;
-    use crate::{
-        error::EditoastError,
-        fixtures::tests::{db_pool, small_infra, IntoFixture},
-        modelsv2::{
-            infra::DEFAULT_INFRA_VERSION,
-            prelude::*,
-            railjson::{find_all_schemas, RailJsonError},
-        },
-        schema::{RailJson, RAILJSON_VERSION},
-    };
     use actix_web::test as actix_test;
     use diesel::result::Error;
-    use diesel_async::{
-        scoped_futures::{ScopedBoxFuture, ScopedFutureExt},
-        AsyncConnection, AsyncPgConnection as PgConnection,
-    };
+    use diesel_async::scoped_futures::ScopedBoxFuture;
+    use diesel_async::scoped_futures::ScopedFutureExt;
+    use diesel_async::AsyncConnection;
+    use diesel_async::AsyncPgConnection as PgConnection;
     use rstest::rstest;
     use uuid::Uuid;
+
+    use super::Infra;
+    use crate::error::EditoastError;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::small_infra;
+    use crate::fixtures::tests::IntoFixture;
+    use crate::modelsv2::infra::DEFAULT_INFRA_VERSION;
+    use crate::modelsv2::prelude::*;
+    use crate::modelsv2::railjson::find_all_schemas;
+    use crate::modelsv2::railjson::RailJsonError;
+    use crate::schema::RailJson;
+    use crate::schema::RAILJSON_VERSION;
 
     pub async fn test_infra_transaction<'a, F>(fn_test: F)
     where

--- a/editoast/src/modelsv2/infra_objects.rs
+++ b/editoast/src/modelsv2/infra_objects.rs
@@ -1,10 +1,14 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use editoast_derive::ModelV2;
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::modelsv2::prelude::*;
 use crate::schema;
 use crate::schema::ObjectType;
 use crate::tables::*;
-use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
 
 pub trait ModelBackedSchema: Sized {
     type Model: SchemaModel + Into<Self>;
@@ -243,7 +247,8 @@ impl OperationalPointModel {
         uic: &[i64],
     ) -> crate::error::Result<Vec<Self>> {
         use diesel::sql_query;
-        use diesel::sql_types::{Array, BigInt};
+        use diesel::sql_types::Array;
+        use diesel::sql_types::BigInt;
         use diesel_async::RunQueryDsl;
         let query = {
             "SELECT * FROM infra_object_operational_point
@@ -265,7 +270,9 @@ impl OperationalPointModel {
         trigrams: &[String],
     ) -> crate::error::Result<Vec<Self>> {
         use diesel::sql_query;
-        use diesel::sql_types::{Array, BigInt, Text};
+        use diesel::sql_types::Array;
+        use diesel::sql_types::BigInt;
+        use diesel::sql_types::Text;
         use diesel_async::RunQueryDsl;
         let query = {
             "SELECT * FROM infra_object_operational_point
@@ -285,8 +292,9 @@ impl OperationalPointModel {
 
 #[cfg(test)]
 mod test_persist {
-    use super::*;
     use diesel_async::scoped_futures::ScopedFutureExt;
+
+    use super::*;
 
     macro_rules! test_persist {
         ($obj:ident) => {

--- a/editoast/src/modelsv2/light_rolling_stock.rs
+++ b/editoast/src/modelsv2/light_rolling_stock.rs
@@ -1,23 +1,31 @@
+use std::collections::HashMap;
+
+use actix_web::web::Data;
+use diesel::sql_query;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
+use diesel_async::RunQueryDsl;
+use editoast_derive::ModelV2;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use super::Row;
 use crate::error::Result;
 use crate::modelsv2::rolling_stock_livery::RollingStockLiveryMetadataModel;
 use crate::modelsv2::rolling_stock_model::RollingStockSupportedSignalingSystems;
 use crate::modelsv2::Model;
-use crate::schema::rolling_stock::light_rolling_stock::{
-    LightEffortCurves, LightRollingStock, LightRollingStockWithLiveriesModel,
-};
-use crate::schema::rolling_stock::{EnergySource, Gamma, RollingResistance, RollingStockMetadata};
+use crate::schema::rolling_stock::light_rolling_stock::LightEffortCurves;
+use crate::schema::rolling_stock::light_rolling_stock::LightRollingStock;
+use crate::schema::rolling_stock::light_rolling_stock::LightRollingStockWithLiveriesModel;
+use crate::schema::rolling_stock::EnergySource;
+use crate::schema::rolling_stock::Gamma;
+use crate::schema::rolling_stock::RollingResistance;
+use crate::schema::rolling_stock::RollingStockMetadata;
 use crate::schema::track_section::LoadingGaugeType;
-use crate::views::pagination::{Paginate, PaginatedResponse};
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
 use crate::DbPool;
-use actix_web::web::Data;
-use diesel::{sql_query, ExpressionMethods, QueryDsl, SelectableHelper};
-use diesel_async::RunQueryDsl;
-use editoast_derive::ModelV2;
-use serde::Serialize;
-use std::collections::HashMap;
-use utoipa::ToSchema;
-
-use super::Row;
 
 #[derive(Debug, Clone, ModelV2, Serialize, ToSchema)]
 #[model(table = crate::tables::rolling_stock)]
@@ -136,13 +144,14 @@ impl From<LightRollingStockModel> for LightRollingStock {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::fixtures::tests::{db_pool, named_fast_rolling_stock};
-    use crate::modelsv2::Retrieve;
-    use crate::DbPool;
     use actix_web::web::Data;
     use rstest::*;
 
     use super::LightRollingStockModel;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::modelsv2::Retrieve;
+    use crate::DbPool;
 
     #[rstest]
     async fn get_light_rolling_stock(db_pool: Data<DbPool>) {

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -13,31 +13,70 @@ pub mod study;
 pub mod timetable;
 pub mod train_schedule;
 
+use async_trait::async_trait;
+use diesel::pg::Pg;
+use diesel::result::Error::NotFound;
+use diesel::AsChangeset;
+use diesel::QueryableByName;
 pub use documents::Document;
 pub use electrical_profiles::ElectricalProfileSet;
 pub use infra::Infra;
 pub use infra_objects::*;
 pub use light_rolling_stock::LightRollingStockModel;
-pub use projects::{Ordering, Project, Tags};
+pub use projects::Ordering;
+pub use projects::Project;
+pub use projects::Tags;
 pub use rolling_stock_image::RollingStockSeparatedImageModel;
 pub use rolling_stock_model::RollingStockModel;
 pub use study::Study;
 
-use async_trait::async_trait;
-use diesel::{pg::Pg, result::Error::NotFound, AsChangeset, QueryableByName};
-
-use crate::error::{EditoastError, Result};
-
-pub use crate::models::{Identifiable, PreferredId};
+use crate::error::EditoastError;
+use crate::error::Result;
+pub use crate::models::Identifiable;
+pub use crate::models::PreferredId;
 
 /// A module that exposes all the ModelV2 traits and utils, but not the models themselves
 pub mod prelude {
     #[allow(unused_imports)]
-    pub use super::{
-        Changeset, Create, CreateBatch, CreateBatchWithKey, Delete, DeleteBatch, DeleteStatic,
-        Exists, Model, ModelBackedSchema, Patch, Retrieve, RetrieveBatch, RetrieveBatchUnchecked,
-        Row, Save, SchemaModel, Update, UpdateBatch, UpdateBatchUnchecked,
-    };
+    pub use super::Changeset;
+    #[allow(unused_imports)]
+    pub use super::Create;
+    #[allow(unused_imports)]
+    pub use super::CreateBatch;
+    #[allow(unused_imports)]
+    pub use super::CreateBatchWithKey;
+    #[allow(unused_imports)]
+    pub use super::Delete;
+    #[allow(unused_imports)]
+    pub use super::DeleteBatch;
+    #[allow(unused_imports)]
+    pub use super::DeleteStatic;
+    #[allow(unused_imports)]
+    pub use super::Exists;
+    #[allow(unused_imports)]
+    pub use super::Model;
+    #[allow(unused_imports)]
+    pub use super::ModelBackedSchema;
+    #[allow(unused_imports)]
+    pub use super::Patch;
+    #[allow(unused_imports)]
+    pub use super::Retrieve;
+    #[allow(unused_imports)]
+    pub use super::RetrieveBatch;
+    #[allow(unused_imports)]
+    pub use super::RetrieveBatchUnchecked;
+    #[allow(unused_imports)]
+    pub use super::Row;
+    #[allow(unused_imports)]
+    pub use super::Save;
+    #[allow(unused_imports)]
+    pub use super::SchemaModel;
+    #[allow(unused_imports)]
+    pub use super::Update;
+    #[allow(unused_imports)]
+    pub use super::UpdateBatch;
+    #[allow(unused_imports)]
+    pub use super::UpdateBatchUnchecked;
 }
 
 /// A struct that can be saved to and read from the database using diesel's interface
@@ -929,11 +968,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::prelude::*;
-    use crate::fixtures::tests::{db_pool, TestFixture};
+    use std::collections::HashSet;
+
     use editoast_derive::ModelV2;
     use itertools::Itertools;
-    use std::collections::HashSet;
+
+    use super::prelude::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::TestFixture;
 
     #[derive(Debug, Default, Clone, ModelV2)]
     #[model(table = crate::tables::document)]

--- a/editoast/src/modelsv2/projects.rs
+++ b/editoast/src/modelsv2/projects.rs
@@ -1,18 +1,31 @@
-use crate::error::Result;
-use crate::modelsv2::{Changeset, DeleteStatic, Document, Model, Retrieve, Row, Save, Update};
-use crate::views::pagination::{Paginate, PaginatedResponse};
-use crate::views::projects::ProjectError;
-use crate::DbPool;
 use actix_web::web::Data;
 use async_trait::async_trait;
-use chrono::{NaiveDateTime, Utc};
-use diesel::{sql_query, ExpressionMethods, QueryDsl};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use chrono::NaiveDateTime;
+use chrono::Utc;
+use diesel::sql_query;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::error::Result;
 use crate::models::List;
+use crate::modelsv2::Changeset;
+use crate::modelsv2::DeleteStatic;
+use crate::modelsv2::Document;
+use crate::modelsv2::Model;
+use crate::modelsv2::Retrieve;
+use crate::modelsv2::Row;
+use crate::modelsv2::Save;
+use crate::modelsv2::Update;
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::projects::ProjectError;
+use crate::DbPool;
 
 crate::schemas! {
     Ordering,
@@ -173,12 +186,18 @@ impl List<Ordering> for Project {
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use crate::fixtures::tests::{db_pool, project, TestFixture};
-    use crate::models::List;
-    use crate::modelsv2::{DeleteStatic, Model, Ordering, Retrieve};
     use actix_web::web::Data;
     use rstest::rstest;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::project;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::List;
+    use crate::modelsv2::DeleteStatic;
+    use crate::modelsv2::Model;
+    use crate::modelsv2::Ordering;
+    use crate::modelsv2::Retrieve;
 
     #[rstest]
     async fn create_delete_project(#[future] project: TestFixture<Project>, db_pool: Data<DbPool>) {

--- a/editoast/src/modelsv2/railjson.rs
+++ b/editoast/src/modelsv2/railjson.rs
@@ -2,12 +2,13 @@ use std::sync::Arc;
 
 use editoast_derive::EditoastError;
 
-use crate::{
-    error::{InternalError, Result},
-    modelsv2::{infra_objects::*, prelude::*},
-    schema::{RailJson, RAILJSON_VERSION},
-    DbPool,
-};
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::modelsv2::infra_objects::*;
+use crate::modelsv2::prelude::*;
+use crate::schema::RailJson;
+use crate::schema::RAILJSON_VERSION;
+use crate::DbPool;
 
 #[derive(Debug, thiserror::Error, EditoastError)]
 #[editoast_error(base_id = "railjson")]

--- a/editoast/src/modelsv2/rolling_stock_livery.rs
+++ b/editoast/src/modelsv2/rolling_stock_livery.rs
@@ -1,16 +1,16 @@
 use derivative::Derivative;
-use diesel::sql_types::{BigInt, Text};
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
 use diesel_async::AsyncPgConnection;
 use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
-
-use crate::error::Result;
-use crate::schema::rolling_stock::rolling_stock_livery::{
-    RollingStockLivery, RollingStockLiveryMetadata,
-};
-use crate::tables::rolling_stock_livery;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::Document;
+use crate::error::Result;
+use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLivery;
+use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLiveryMetadata;
+use crate::tables::rolling_stock_livery;
 
 /// Rolling Stock Livery
 ///
@@ -82,11 +82,13 @@ impl From<RollingStockLiveryMetadataModel> for RollingStockLiveryMetadata {
 
 #[cfg(test)]
 pub mod tests {
-    use super::RollingStockLiveryModel;
-    use crate::fixtures::tests::{db_pool, rolling_stock_livery};
-    use crate::modelsv2::Document;
     use actix_web::web::Data;
     use rstest::*;
+
+    use super::RollingStockLiveryModel;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::rolling_stock_livery;
+    use crate::modelsv2::Document;
 
     #[rstest]
     async fn create_get_delete_rolling_stock_livery(db_pool: Data<crate::DbPool>) {

--- a/editoast/src/modelsv2/rolling_stock_model.rs
+++ b/editoast/src/modelsv2/rolling_stock_model.rs
@@ -1,20 +1,29 @@
+use std::collections::HashMap;
+
 use actix_web::web::Data;
 use derivative::Derivative;
-use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
 use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
-use validator::{Validate, ValidationError, ValidationErrors};
+use validator::Validate;
+use validator::ValidationError;
+use validator::ValidationErrors;
 
 use crate::error::Result;
 use crate::modelsv2::prelude::*;
 use crate::modelsv2::rolling_stock_livery::RollingStockLiveryMetadataModel;
-use crate::schema::rolling_stock::{
-    EffortCurves, EnergySource, Gamma, RollingResistance, RollingStock, RollingStockMetadata,
-    RollingStockWithLiveries,
-};
+use crate::schema::rolling_stock::EffortCurves;
+use crate::schema::rolling_stock::EnergySource;
+use crate::schema::rolling_stock::Gamma;
+use crate::schema::rolling_stock::RollingResistance;
+use crate::schema::rolling_stock::RollingStock;
+use crate::schema::rolling_stock::RollingStockMetadata;
+use crate::schema::rolling_stock::RollingStockWithLiveries;
 use crate::schema::track_section::LoadingGaugeType;
 use crate::DbPool;
 

--- a/editoast/src/modelsv2/scenario.rs
+++ b/editoast/src/modelsv2/scenario.rs
@@ -1,16 +1,25 @@
-use crate::error::Result;
-use crate::models::List;
-use crate::modelsv2::{Model, Ordering, Row, Tags};
-use crate::views::pagination::{Paginate, PaginatedResponse};
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Text};
-use diesel::{ExpressionMethods, QueryDsl};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::models::List;
+use crate::modelsv2::Model;
+use crate::modelsv2::Ordering;
+use crate::modelsv2::Row;
+use crate::modelsv2::Tags;
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
 
 #[derive(Debug, Clone, ModelV2, Deserialize, Serialize, ToSchema)]
 #[schema(as = ScenarioV2)]

--- a/editoast/src/modelsv2/study.rs
+++ b/editoast/src/modelsv2/study.rs
@@ -1,22 +1,30 @@
-use crate::error::Result;
-use crate::models::List;
-use crate::modelsv2::{Changeset, Model, Row, Save};
-use crate::views::pagination::{Paginate, PaginatedResponse};
-use crate::DbPool;
 use actix_web::web::Data;
 use async_trait::async_trait;
 use chrono::NaiveDate;
-use chrono::{NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
+use chrono::Utc;
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::modelsv2::projects::{Ordering, Tags};
+use crate::error::Result;
+use crate::models::List;
+use crate::modelsv2::projects::Ordering;
+use crate::modelsv2::projects::Tags;
+use crate::modelsv2::Changeset;
+use crate::modelsv2::Model;
+use crate::modelsv2::Row;
+use crate::modelsv2::Save;
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
+use crate::DbPool;
 
 #[derive(Clone, Debug, Serialize, Deserialize, ModelV2, ToSchema)]
 #[model(table = crate::tables::study)]
@@ -108,11 +116,18 @@ impl List<(i64, Ordering)> for Study {
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use crate::fixtures::tests::{db_pool, study_fixture_set, StudyFixtureSet, TestFixture};
-    use crate::models::List;
-    use crate::modelsv2::{DeleteStatic, Model, Ordering, Retrieve};
     use rstest::rstest;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::study_fixture_set;
+    use crate::fixtures::tests::StudyFixtureSet;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::List;
+    use crate::modelsv2::DeleteStatic;
+    use crate::modelsv2::Model;
+    use crate::modelsv2::Ordering;
+    use crate::modelsv2::Retrieve;
 
     #[rstest]
     async fn create_delete_study(

--- a/editoast/src/modelsv2/timetable.rs
+++ b/editoast/src/modelsv2/timetable.rs
@@ -1,16 +1,20 @@
+use async_trait::async_trait;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Nullable;
+use diesel_async::AsyncPgConnection as PgConnection;
+use editoast_derive::ModelV2;
+
 use crate::diesel::query_dsl::methods::DistinctDsl;
 use crate::error::Result;
 use crate::models::List;
 use crate::models::NoParams;
-use crate::modelsv2::{Retrieve, Row};
+use crate::modelsv2::Retrieve;
+use crate::modelsv2::Row;
 use crate::tables::timetable_v2::dsl;
 use crate::views::pagination::Paginate;
 use crate::views::pagination::PaginatedResponse;
-use async_trait::async_trait;
-use diesel::sql_query;
-use diesel::sql_types::{Array, BigInt, Nullable};
-use diesel_async::AsyncPgConnection as PgConnection;
-use editoast_derive::ModelV2;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::timetable_v2)]

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -1,9 +1,14 @@
-use crate::schema::v2::trainschedule::{
-    Comfort, Distribution, Margins, PathItem, PowerRestrictionItem, ScheduleItem,
-    TrainScheduleOptions,
-};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use chrono::Utc;
 use editoast_derive::ModelV2;
+
+use crate::schema::v2::trainschedule::Comfort;
+use crate::schema::v2::trainschedule::Distribution;
+use crate::schema::v2::trainschedule::Margins;
+use crate::schema::v2::trainschedule::PathItem;
+use crate::schema::v2::trainschedule::PowerRestrictionItem;
+use crate::schema::v2::trainschedule::ScheduleItem;
+use crate::schema::v2::trainschedule::TrainScheduleOptions;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::train_schedule_v2)]

--- a/editoast/src/schema/buffer_stop.rs
+++ b/editoast/src/schema/buffer_stop.rs
@@ -1,10 +1,15 @@
-use super::{OSRDIdentified, OSRDTyped, ObjectType};
+use derivative::Derivative;
+use diesel::sql_types::Double;
+use diesel::sql_types::Text;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utils::Identifier;
-use crate::infra_cache::{Cache, ObjectCache};
-use derivative::Derivative;
-use diesel::sql_types::{Double, Text};
-use serde::{Deserialize, Serialize};
+use super::OSRDIdentified;
+use super::OSRDTyped;
+use super::ObjectType;
+use crate::infra_cache::Cache;
+use crate::infra_cache::ObjectCache;
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/editoast/src/schema/detector.rs
+++ b/editoast/src/schema/detector.rs
@@ -1,15 +1,15 @@
-use super::OSRDIdentified;
+use derivative::Derivative;
+use diesel::sql_types::Double;
+use diesel::sql_types::Text;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utils::Identifier;
+use super::OSRDIdentified;
 use super::OSRDTyped;
 use super::ObjectType;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
-use derivative::Derivative;
-use diesel::sql_types::{Double, Text};
-
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/editoast/src/schema/electrical_profiles.rs
+++ b/editoast/src/schema/electrical_profiles.rs
@@ -1,7 +1,10 @@
-use crate::schema::TrackRange;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
+
+use crate::schema::TrackRange;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, ToSchema)]
 pub struct ElectricalProfile {

--- a/editoast/src/schema/electrification.rs
+++ b/editoast/src/schema/electrification.rs
@@ -1,16 +1,15 @@
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
+
 use super::utils::Identifier;
 use super::utils::NonBlankString;
 use super::ApplicableDirectionsTrackRange;
 use super::OSRDIdentified;
-
 use super::OSRDTyped;
 use super::ObjectType;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
-use derivative::Derivative;
-
-use serde::{Deserialize, Serialize};
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[derivative(Default)]

--- a/editoast/src/schema/errors.rs
+++ b/editoast/src/schema/errors.rs
@@ -1,7 +1,12 @@
-use super::{Endpoint, OSRDIdentified, OSRDObject, ObjectType};
-use crate::schema::ObjectRef;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use strum_macros::EnumVariantNames;
+
+use super::Endpoint;
+use super::OSRDIdentified;
+use super::OSRDObject;
+use super::ObjectType;
+use crate::schema::ObjectRef;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(deny_unknown_fields)]

--- a/editoast/src/schema/geo_json.rs
+++ b/editoast/src/schema/geo_json.rs
@@ -1,6 +1,6 @@
 use mvt::GeomType;
-
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 /// GeoJson representation
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -19,26 +19,41 @@ pub mod track_section;
 pub mod utils;
 pub mod v2;
 
-pub use buffer_stop::{BufferStop, BufferStopCache};
-pub use detector::{Detector, DetectorCache};
+pub use buffer_stop::BufferStop;
+pub use buffer_stop::BufferStopCache;
+pub use detector::Detector;
+pub use detector::DetectorCache;
 pub use electrification::Electrification;
-pub use errors::{InfraError, InfraErrorType};
+pub use errors::InfraError;
+pub use errors::InfraErrorType;
 pub use geo_json::GeoJson;
 pub use neutral_section::NeutralSection;
-pub use operational_point::{
-    OperationalPoint, OperationalPointCache, OperationalPointExtensions,
-    OperationalPointIdentifierExtension, OperationalPointPart,
-};
-pub use railjson::{RailJson, RAILJSON_VERSION};
+pub use operational_point::OperationalPoint;
+pub use operational_point::OperationalPointCache;
+pub use operational_point::OperationalPointExtensions;
+pub use operational_point::OperationalPointIdentifierExtension;
+pub use operational_point::OperationalPointPart;
+pub use railjson::RailJson;
+pub use railjson::RAILJSON_VERSION;
 pub use route::Route;
-pub use signal::{LogicalSignal, Signal, SignalCache, SignalExtensions, SignalSncfExtension};
-pub use speed_section::{Speed, SpeedSection};
-pub use switch::{Switch, SwitchCache};
-pub use switch_type::{
-    builtin_node_types_list, Crossing, DoubleSlipSwitch, Link, PointSwitch, SingleSlipSwitch,
-    SwitchType,
-};
-pub use track_section::{TrackSection, TrackSectionCache};
+pub use signal::LogicalSignal;
+pub use signal::Signal;
+pub use signal::SignalCache;
+pub use signal::SignalExtensions;
+pub use signal::SignalSncfExtension;
+pub use speed_section::Speed;
+pub use speed_section::SpeedSection;
+pub use switch::Switch;
+pub use switch::SwitchCache;
+pub use switch_type::builtin_node_types_list;
+pub use switch_type::Crossing;
+pub use switch_type::DoubleSlipSwitch;
+pub use switch_type::Link;
+pub use switch_type::PointSwitch;
+pub use switch_type::SingleSlipSwitch;
+pub use switch_type::SwitchType;
+pub use track_section::TrackSection;
+pub use track_section::TrackSectionCache;
 
 cfg_if! {
     if #[cfg(test)] {
@@ -49,13 +64,16 @@ cfg_if! {
     }
 }
 
-use self::utils::{Identifier, NonBlankString};
-
 use derivative::Derivative;
 use enum_map::Enum;
-use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumIter};
+use serde::Deserialize;
+use serde::Serialize;
+use strum_macros::Display;
+use strum_macros::EnumIter;
 use utoipa::ToSchema;
+
+use self::utils::Identifier;
+use self::utils::NonBlankString;
 
 crate::schemas! {
     ObjectType,

--- a/editoast/src/schema/neutral_section.rs
+++ b/editoast/src/schema/neutral_section.rs
@@ -1,10 +1,13 @@
-use super::{OSRDIdentified, OSRDTyped, ObjectType, Sign};
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utils::Identifier;
 use super::DirectionalTrackRange;
-
-use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use super::OSRDIdentified;
+use super::OSRDTyped;
+use super::ObjectType;
+use super::Sign;
 
 /// Neutral sections are portions of track where trains aren't allowed to pull power from electrifications. They have to rely on inertia to cross such sections.
 ///

--- a/editoast/src/schema/operation/create.rs
+++ b/editoast/src/schema/operation/create.rs
@@ -1,17 +1,31 @@
-use crate::error::Result;
-use crate::modelsv2::get_table;
-use crate::schema::{
-    BufferStop, Detector, Electrification, NeutralSection, OSRDIdentified, OSRDObject, ObjectType,
-    OperationalPoint, Route, Signal, SpeedSection, Switch, SwitchType, TrackSection,
-};
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Json, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Json;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
 use json_patch::Patch;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value;
 
 use super::OperationError;
+use crate::error::Result;
+use crate::modelsv2::get_table;
+use crate::schema::BufferStop;
+use crate::schema::Detector;
+use crate::schema::Electrification;
+use crate::schema::NeutralSection;
+use crate::schema::OSRDIdentified;
+use crate::schema::OSRDObject;
+use crate::schema::ObjectType;
+use crate::schema::OperationalPoint;
+use crate::schema::Route;
+use crate::schema::Signal;
+use crate::schema::SpeedSection;
+use crate::schema::Switch;
+use crate::schema::SwitchType;
+use crate::schema::TrackSection;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "obj_type", deny_unknown_fields)]
@@ -234,11 +248,18 @@ pub mod tests {
     use diesel_async::AsyncPgConnection as PgConnection;
 
     use crate::modelsv2::infra::tests::test_infra_transaction;
-    use crate::schema::operation::create::{apply_create_operation, RailjsonObject};
-    use crate::schema::{
-        BufferStop, Detector, Electrification, OperationalPoint, Route, Signal, SpeedSection,
-        Switch, SwitchType, TrackSection,
-    };
+    use crate::schema::operation::create::apply_create_operation;
+    use crate::schema::operation::create::RailjsonObject;
+    use crate::schema::BufferStop;
+    use crate::schema::Detector;
+    use crate::schema::Electrification;
+    use crate::schema::OperationalPoint;
+    use crate::schema::Route;
+    use crate::schema::Signal;
+    use crate::schema::SpeedSection;
+    use crate::schema::Switch;
+    use crate::schema::SwitchType;
+    use crate::schema::TrackSection;
 
     pub async fn create_track(
         conn: &mut PgConnection,

--- a/editoast/src/schema/operation/delete.rs
+++ b/editoast/src/schema/operation/delete.rs
@@ -1,12 +1,16 @@
+use diesel::sql_query;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
+use serde::Deserialize;
+use serde::Serialize;
+
 use super::OperationError;
 use crate::error::Result;
 use crate::modelsv2::get_table;
 use crate::schema::ObjectRef;
 use crate::schema::ObjectType;
-use diesel::sql_query;
-use diesel::sql_types::{BigInt, Text};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
@@ -58,18 +62,25 @@ impl From<ObjectRef> for DeleteOperation {
 
 #[cfg(test)]
 mod tests {
-    use crate::modelsv2::infra::tests::test_infra_transaction;
-    use crate::schema::operation::create::tests::{
-        create_buffer_stop, create_detector, create_electrification, create_op, create_route,
-        create_signal, create_speed, create_switch, create_track,
-    };
-    use crate::schema::operation::delete::DeleteOperation;
-    use crate::schema::{OSRDIdentified, OSRDObject};
     use actix_web::test as actix_test;
     use diesel::sql_query;
     use diesel::sql_types::BigInt;
     use diesel_async::scoped_futures::ScopedFutureExt;
     use diesel_async::RunQueryDsl;
+
+    use crate::modelsv2::infra::tests::test_infra_transaction;
+    use crate::schema::operation::create::tests::create_buffer_stop;
+    use crate::schema::operation::create::tests::create_detector;
+    use crate::schema::operation::create::tests::create_electrification;
+    use crate::schema::operation::create::tests::create_op;
+    use crate::schema::operation::create::tests::create_route;
+    use crate::schema::operation::create::tests::create_signal;
+    use crate::schema::operation::create::tests::create_speed;
+    use crate::schema::operation::create::tests::create_switch;
+    use crate::schema::operation::create::tests::create_track;
+    use crate::schema::operation::delete::DeleteOperation;
+    use crate::schema::OSRDIdentified;
+    use crate::schema::OSRDObject;
 
     #[derive(QueryableByName)]
     struct Count {

--- a/editoast/src/schema/operation/mod.rs
+++ b/editoast/src/schema/operation/mod.rs
@@ -2,18 +2,22 @@ pub mod create;
 mod delete;
 mod update;
 
-use super::{OSRDObject as _, ObjectRef};
-use crate::{error::Result, infra_cache::ObjectCache};
+use std::ops::Deref as _;
+
+pub use create::RailjsonObject;
 use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
-use std::ops::Deref as _;
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
+pub use update::UpdateOperation;
 use utoipa::ToSchema;
 
 pub use self::delete::DeleteOperation;
-pub use create::RailjsonObject;
-pub use update::UpdateOperation;
+use super::OSRDObject as _;
+use super::ObjectRef;
+use crate::error::Result;
+use crate::infra_cache::ObjectCache;
 
 crate::schemas! { Operation, }
 

--- a/editoast/src/schema/operation/update.rs
+++ b/editoast/src/schema/operation/update.rs
@@ -1,16 +1,25 @@
+use diesel::result::Error as DieselError;
+use diesel::sql_query;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Json;
+use diesel::sql_types::Jsonb;
+use diesel::sql_types::Text;
+use diesel::QueryableByName;
+use diesel_async::AsyncPgConnection as PgConnection;
+use diesel_async::RunQueryDsl;
+use json_patch::Patch;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::from_value;
+use serde_json::json;
+use serde_json::Value;
+
+use super::OperationError;
 use crate::error::Result;
 use crate::modelsv2::get_table;
 use crate::schema::operation::RailjsonObject;
-use crate::schema::{OSRDIdentified, ObjectType};
-use diesel::result::Error as DieselError;
-use diesel::sql_types::{BigInt, Json, Jsonb, Text};
-use diesel::{sql_query, QueryableByName};
-use diesel_async::{AsyncPgConnection as PgConnection, RunQueryDsl};
-use json_patch::Patch;
-use serde::{Deserialize, Serialize};
-use serde_json::{from_value, json, Value};
-
-use super::OperationError;
+use crate::schema::OSRDIdentified;
+use crate::schema::ObjectType;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -110,20 +119,24 @@ impl DataObject {
 
 #[cfg(test)]
 mod tests {
-    use super::UpdateOperation;
-    use crate::error::EditoastError;
-    use crate::modelsv2::infra::tests::test_infra_transaction;
-    use crate::schema::operation::create::tests::{
-        create_signal, create_speed, create_switch, create_track,
-    };
-    use crate::schema::operation::OperationError;
-    use crate::schema::{OSRDIdentified, ObjectType};
     use actix_web::test as actix_test;
     use diesel::sql_query;
-    use diesel::sql_types::{Double, Text};
+    use diesel::sql_types::Double;
+    use diesel::sql_types::Text;
     use diesel_async::scoped_futures::ScopedFutureExt;
     use diesel_async::RunQueryDsl;
     use serde_json::from_str;
+
+    use super::UpdateOperation;
+    use crate::error::EditoastError;
+    use crate::modelsv2::infra::tests::test_infra_transaction;
+    use crate::schema::operation::create::tests::create_signal;
+    use crate::schema::operation::create::tests::create_speed;
+    use crate::schema::operation::create::tests::create_switch;
+    use crate::schema::operation::create::tests::create_track;
+    use crate::schema::operation::OperationError;
+    use crate::schema::OSRDIdentified;
+    use crate::schema::ObjectType;
 
     #[derive(QueryableByName)]
     struct Value {

--- a/editoast/src/schema/operational_point.rs
+++ b/editoast/src/schema/operational_point.rs
@@ -1,18 +1,17 @@
-use super::OSRDIdentified;
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
 
 use super::utils::Identifier;
 use super::utils::NonBlankString;
+use super::OSRDIdentified;
 use super::OSRDTyped;
 use super::ObjectType;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use crate::modelsv2::OperationalPointModel;
 use crate::schema::TrackOffset;
-use derivative::Derivative;
-use utoipa::ToSchema;
-
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
@@ -168,8 +167,9 @@ impl From<OperationalPointPart> for OperationalPointPartCache {
 
 #[cfg(test)]
 mod test {
-    use super::OperationalPointExtensions;
     use serde_json::from_str;
+
+    use super::OperationalPointExtensions;
 
     #[test]
     fn test_op_extensions_deserialization() {

--- a/editoast/src/schema/railjson.rs
+++ b/editoast/src/schema/railjson.rs
@@ -1,10 +1,18 @@
-use super::{
-    BufferStop, Detector, Electrification, NeutralSection, OperationalPoint, Route, Signal,
-    SpeedSection, Switch, SwitchType, TrackSection,
-};
-
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::BufferStop;
+use super::Detector;
+use super::Electrification;
+use super::NeutralSection;
+use super::OperationalPoint;
+use super::Route;
+use super::Signal;
+use super::SpeedSection;
+use super::Switch;
+use super::SwitchType;
+use super::TrackSection;
 
 pub const RAILJSON_VERSION: &str = "3.4.11";
 

--- a/editoast/src/schema/rolling_stock/light_rolling_stock.rs
+++ b/editoast/src/schema/rolling_stock/light_rolling_stock.rs
@@ -1,15 +1,16 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
-use super::{
-    rolling_stock_livery::RollingStockLiveryMetadata, EnergySource, Gamma, RollingResistance,
-    RollingStockMetadata,
-};
-use crate::modelsv2::{
-    rolling_stock_livery::RollingStockLiveryMetadataModel,
-    rolling_stock_model::RollingStockSupportedSignalingSystems,
-};
+use super::rolling_stock_livery::RollingStockLiveryMetadata;
+use super::EnergySource;
+use super::Gamma;
+use super::RollingResistance;
+use super::RollingStockMetadata;
+use crate::modelsv2::rolling_stock_livery::RollingStockLiveryMetadataModel;
+use crate::modelsv2::rolling_stock_model::RollingStockSupportedSignalingSystems;
 use crate::schema::track_section::LoadingGaugeType;
 
 crate::schemas! {

--- a/editoast/src/schema/rolling_stock/mod.rs
+++ b/editoast/src/schema/rolling_stock/mod.rs
@@ -1,17 +1,19 @@
 pub mod light_rolling_stock;
 pub mod rolling_stock_livery;
 
-use derivative::Derivative;
-use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
-use strum_macros::{Display, EnumString};
+
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use strum_macros::Display;
+use strum_macros::EnumString;
 use utoipa::ToSchema;
 
 use crate::modelsv2::rolling_stock_model::RollingStockSupportedSignalingSystems;
-use crate::schema::rolling_stock::rolling_stock_livery::{
-    RollingStockLivery, RollingStockLiveryMetadata,
-};
-
+use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLivery;
+use crate::schema::rolling_stock::rolling_stock_livery::RollingStockLiveryMetadata;
 use crate::schema::track_section::LoadingGaugeType;
 
 crate::schemas! {
@@ -303,8 +305,10 @@ pub enum EnergySource {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::from_value;
+    use serde_json::json;
+
     use crate::schema::rolling_stock::EffortCurve;
-    use serde_json::{from_value, json};
 
     #[test]
     fn test_de_effort_curve_valid() {

--- a/editoast/src/schema/rolling_stock/rolling_stock_livery.rs
+++ b/editoast/src/schema/rolling_stock/rolling_stock_livery.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
 
 #[derive(Debug, Deserialize, Serialize, ToSchema)]

--- a/editoast/src/schema/route.rs
+++ b/editoast/src/schema/route.rs
@@ -1,12 +1,22 @@
-use derivative::Derivative;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::{
-    Direction, DirectionalTrackRange, Endpoint, Identifier, OSRDIdentified, OSRDTyped, ObjectType,
-    TrackEndpoint, Waypoint,
-};
-use crate::infra_cache::{Cache, Graph, InfraCache, ObjectCache};
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::Direction;
+use super::DirectionalTrackRange;
+use super::Endpoint;
+use super::Identifier;
+use super::OSRDIdentified;
+use super::OSRDTyped;
+use super::ObjectType;
+use super::TrackEndpoint;
+use super::Waypoint;
+use crate::infra_cache::Cache;
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -159,7 +169,8 @@ impl Route {
 mod test {
 
     use super::Route;
-    use crate::infra_cache::{tests::create_small_infra_cache, Graph};
+    use crate::infra_cache::tests::create_small_infra_cache;
+    use crate::infra_cache::Graph;
 
     #[test]
     fn test_compute_track_ranges_1() {

--- a/editoast/src/schema/signal.rs
+++ b/editoast/src/schema/signal.rs
@@ -1,20 +1,22 @@
 use std::collections::HashMap;
 
-use super::Direction;
-use super::OSRDIdentified;
+use derivative::Derivative;
+use diesel::sql_types::Double;
+use diesel::sql_types::Jsonb;
+use diesel::sql_types::Text;
+use diesel_json::Json as DieselJson;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utils::Identifier;
 use super::utils::NonBlankString;
+use super::Direction;
+use super::OSRDIdentified;
 use super::OSRDTyped;
 use super::ObjectType;
 use super::Side;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
-use derivative::Derivative;
-use diesel::sql_types::{Double, Jsonb, Text};
-use diesel_json::Json as DieselJson;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -137,8 +139,9 @@ impl From<Signal> for SignalCache {
 
 #[cfg(test)]
 mod test {
-    use super::SignalExtensions;
     use serde_json::from_str;
+
+    use super::SignalExtensions;
 
     #[test]
     fn test_signal_extensions_deserialization() {

--- a/editoast/src/schema/speed_section.rs
+++ b/editoast/src/schema/speed_section.rs
@@ -1,12 +1,18 @@
-use super::{
-    utils::{Identifier, NonBlankString},
-    ApplicableDirectionsTrackRange, OSRDIdentified, OSRDTyped, ObjectType, Sign,
-};
-use crate::infra_cache::{Cache, ObjectCache};
+use std::collections::HashMap;
 
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::utils::Identifier;
+use super::utils::NonBlankString;
+use super::ApplicableDirectionsTrackRange;
+use super::OSRDIdentified;
+use super::OSRDTyped;
+use super::ObjectType;
+use super::Sign;
+use crate::infra_cache::Cache;
+use crate::infra_cache::ObjectCache;
 
 #[derive(Debug, Derivative, Clone, Serialize, PartialEq, Copy)]
 pub struct Speed(pub f64);
@@ -87,8 +93,12 @@ impl Cache for SpeedSection {
 
 #[cfg(test)]
 mod test {
-    use super::{SpeedSection, SpeedSectionExtensions};
-    use serde_json::{from_str, from_value, json};
+    use serde_json::from_str;
+    use serde_json::from_value;
+    use serde_json::json;
+
+    use super::SpeedSection;
+    use super::SpeedSectionExtensions;
 
     #[test]
     fn test_speed_section_extensions_deserialization() {

--- a/editoast/src/schema/sprite_config.rs
+++ b/editoast/src/schema/sprite_config.rs
@@ -1,5 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
 
 pub type SpriteConfigs = HashMap<String, SpriteConfig>;
 

--- a/editoast/src/schema/switch.rs
+++ b/editoast/src/schema/switch.rs
@@ -1,17 +1,17 @@
-use super::OSRDIdentified;
+use std::collections::HashMap;
+
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::utils::Identifier;
 use super::utils::NonBlankString;
+use super::OSRDIdentified;
 use super::OSRDTyped;
 use super::ObjectType;
 use super::TrackEndpoint;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
-use derivative::Derivative;
-
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/editoast/src/schema/switch_type.rs
+++ b/editoast/src/schema/switch_type.rs
@@ -1,16 +1,15 @@
-use super::OSRDIdentified;
-
-use super::utils::Identifier;
-use super::OSRDTyped;
-use super::ObjectType;
-
-use crate::infra_cache::Cache;
-use crate::infra_cache::ObjectCache;
+use std::collections::HashMap;
 
 use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
 
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use super::utils::Identifier;
+use super::OSRDIdentified;
+use super::OSRDTyped;
+use super::ObjectType;
+use crate::infra_cache::Cache;
+use crate::infra_cache::ObjectCache;
 
 type StaticPortConnection = (&'static str, &'static str);
 type StaticMap = (&'static str, &'static [StaticPortConnection]);

--- a/editoast/src/schema/track_section.rs
+++ b/editoast/src/schema/track_section.rs
@@ -1,3 +1,11 @@
+use derivative::Derivative;
+use geos::geojson::Geometry;
+use geos::geojson::Value::LineString;
+use serde::Deserialize;
+use serde::Serialize;
+use strum_macros::FromRepr;
+use utoipa::ToSchema;
+
 use super::utils::Identifier;
 use super::utils::NonBlankString;
 use super::Endpoint;
@@ -5,16 +13,9 @@ use super::OSRDIdentified;
 use super::OSRDTyped;
 use super::ObjectType;
 use super::TrackEndpoint;
-
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use crate::map::BoundingBox;
-
-use derivative::Derivative;
-use geos::geojson::{Geometry, Value::LineString};
-use serde::{Deserialize, Serialize};
-use strum_macros::FromRepr;
-use utoipa::ToSchema;
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -192,10 +193,11 @@ impl Cache for TrackSectionCache {
 
 #[cfg(test)]
 mod test {
-    use super::TrackSectionExtensions;
-    use crate::map::BoundingBox;
     use geos::geojson;
     use serde_json::from_str;
+
+    use super::TrackSectionExtensions;
+    use crate::map::BoundingBox;
 
     /// Test bounding box from linestring
     #[test]

--- a/editoast/src/schema/utils/duration.rs
+++ b/editoast/src/schema/utils/duration.rs
@@ -21,10 +21,13 @@
 //! assert!(serde_json::from_str::<MyStruct>(err_s).is_err());
 //! ```
 
+use std::ops::Deref;
+use std::str::FromStr;
+
 use chrono::Duration as ChronoDuration;
 use iso8601::Duration as IsoDuration;
-use serde::{Deserialize, Serialize};
-use std::{ops::Deref, str::FromStr};
+use serde::Deserialize;
+use serde::Serialize;
 
 /// Wrapper for `chrono::Duration` to use with Serde.
 /// This is useful to serialize `chrono::Duration` using the ISO 8601 duration format.
@@ -135,9 +138,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
+    use serde::Serialize;
+    use serde_json::from_str;
+    use serde_json::to_string;
+
     use super::Duration;
-    use serde::{Deserialize, Serialize};
-    use serde_json::{from_str, to_string};
 
     #[derive(Serialize, Deserialize)]
     struct MyStruct {

--- a/editoast/src/schema/utils/geometry.rs
+++ b/editoast/src/schema/utils/geometry.rs
@@ -1,6 +1,9 @@
-use geos::geojson::{self, Geometry};
-use postgis_diesel::types::{LineString, Point};
-use serde_derive::{Deserialize, Serialize};
+use geos::geojson::Geometry;
+use geos::geojson::{self};
+use postgis_diesel::types::LineString;
+use postgis_diesel::types::Point;
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use utoipa::ToSchema;
 
 use crate::schemas;

--- a/editoast/src/schema/utils/identifier.rs
+++ b/editoast/src/schema/utils/identifier.rs
@@ -1,8 +1,17 @@
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Display;
-use std::ops::{Deref, DerefMut};
-use utoipa::openapi::{ObjectBuilder, RefOr, Schema};
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use rand::distributions::Alphanumeric;
+use rand::thread_rng;
+use rand::Rng;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use utoipa::openapi::ObjectBuilder;
+use utoipa::openapi::RefOr;
+use utoipa::openapi::Schema;
 use uuid::Uuid;
 
 /// A wrapper around a String that ensures that the string is not empty and not longer than 255 characters.

--- a/editoast/src/schema/utils/non_blank_string.rs
+++ b/editoast/src/schema/utils/non_blank_string.rs
@@ -1,11 +1,17 @@
-use std::{
-    fmt::Display,
-    ops::{Deref, DerefMut},
-};
+use std::fmt::Display;
+use std::ops::Deref;
+use std::ops::DerefMut;
 
-use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use utoipa::openapi::{ObjectBuilder, RefOr, Schema};
+use rand::distributions::Alphanumeric;
+use rand::thread_rng;
+use rand::Rng;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use utoipa::openapi::ObjectBuilder;
+use utoipa::openapi::RefOr;
+use utoipa::openapi::Schema;
 
 /// A wrapper around a String that ensures that the string is not empty.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -1,16 +1,21 @@
-use crate::schema::utils::{Duration, Identifier, NonBlankString};
-use crate::schema::TrackOffset;
-use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::str::FromStr;
+
+use chrono::DateTime;
+use chrono::Utc;
 use derivative::Derivative;
 use serde::de::Error as SerdeError;
-use serde::{Deserialize, Serialize};
-use std::hash::Hash;
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-};
+use serde::Deserialize;
+use serde::Serialize;
 use strum_macros::FromRepr;
 use utoipa::ToSchema;
+
+use crate::schema::utils::Duration;
+use crate::schema::utils::Identifier;
+use crate::schema::utils::NonBlankString;
+use crate::schema::TrackOffset;
 
 #[derive(Debug, Default, Clone, Serialize, ToSchema)]
 pub struct TrainScheduleBase {
@@ -330,11 +335,16 @@ pub enum Distribution {
 
 #[cfg(test)]
 mod tests {
-    use super::{MarginValue, Margins, PathItem, PathItemLocation};
-    use crate::schema::v2::trainschedule::{ScheduleItem, TrainScheduleBase};
-
     use chrono::Duration;
-    use serde_json::{from_str, to_string};
+    use serde_json::from_str;
+    use serde_json::to_string;
+
+    use super::MarginValue;
+    use super::Margins;
+    use super::PathItem;
+    use super::PathItemLocation;
+    use crate::schema::v2::trainschedule::ScheduleItem;
+    use crate::schema::v2::trainschedule::TrainScheduleBase;
 
     /// Test that the `MarginValue` enum can be deserialized from a string
     #[test]

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -1,14 +1,21 @@
-use crate::error::Result;
-use crate::modelsv2::*;
-use crate::DbPool;
 use actix_http::StatusCode;
+use actix_web::delete;
+use actix_web::get;
 use actix_web::http::header::ContentType;
-use actix_web::web::{Bytes, Data, Header, Path};
-use actix_web::{delete, get, post, HttpResponse};
+use actix_web::post;
+use actix_web::web::Bytes;
+use actix_web::web::Data;
+use actix_web::web::Header;
+use actix_web::web::Path;
+use actix_web::HttpResponse;
 use editoast_derive::EditoastError;
 use serde_derive::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::modelsv2::*;
+use crate::DbPool;
 
 crate::routes! {
     "/documents" => {
@@ -117,12 +124,16 @@ async fn delete(db_pool: Data<DbPool>, document_key: Path<i64>) -> Result<HttpRe
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use actix_web::test::{call_and_read_body_json, call_service, TestRequest};
+    use actix_web::test::call_and_read_body_json;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde::Deserialize;
 
-    use crate::fixtures::tests::{db_pool, document_example, TestFixture};
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::document_example;
+    use crate::fixtures::tests::TestFixture;
     use crate::views::tests::create_test_service;
 
     #[rstest]

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -1,19 +1,30 @@
-use crate::error::Result;
-use crate::modelsv2::electrical_profiles::{ElectricalProfileSet, LightElectricalProfileSet};
-use crate::modelsv2::{Create, DeleteStatic, Model, Retrieve};
-use crate::schema::electrical_profiles::{
-    ElectricalProfile, ElectricalProfileSetData, LevelValues,
-};
-use crate::schema::TrackRange;
-use crate::DbPool;
+use std::collections::HashMap;
 
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, post, HttpResponse};
+use actix_web::delete;
+use actix_web::get;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
 use editoast_derive::EditoastError;
 use serde::Deserialize;
-use std::collections::HashMap;
 use thiserror::Error;
 use utoipa::IntoParams;
+
+use crate::error::Result;
+use crate::modelsv2::electrical_profiles::ElectricalProfileSet;
+use crate::modelsv2::electrical_profiles::LightElectricalProfileSet;
+use crate::modelsv2::Create;
+use crate::modelsv2::DeleteStatic;
+use crate::modelsv2::Model;
+use crate::modelsv2::Retrieve;
+use crate::schema::electrical_profiles::ElectricalProfile;
+use crate::schema::electrical_profiles::ElectricalProfileSetData;
+use crate::schema::electrical_profiles::LevelValues;
+use crate::schema::TrackRange;
+use crate::DbPool;
 
 crate::routes! {
     "/electrical_profile_set" => {
@@ -173,19 +184,21 @@ pub enum ElectricalProfilesError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, dummy_electrical_profile_set, electrical_profile_set, TestFixture,
-    };
-    use crate::schema::electrical_profiles::ElectricalProfile;
-    use crate::views::tests::create_test_service;
     use actix_http::StatusCode;
     use actix_web::test as actix_test;
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
     use actix_web::test::TestRequest;
-    use actix_web::test::{call_service, read_body_json};
-
-    use crate::schema::TrackRange;
     use rstest::rstest;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::dummy_electrical_profile_set;
+    use crate::fixtures::tests::electrical_profile_set;
+    use crate::fixtures::tests::TestFixture;
+    use crate::schema::electrical_profiles::ElectricalProfile;
+    use crate::schema::TrackRange;
+    use crate::views::tests::create_test_service;
 
     #[rstest]
     async fn test_list(

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -1,16 +1,21 @@
-use crate::{
-    error::Result, infra_cache::InfraCache, modelsv2::prelude::*, modelsv2::Infra,
-    schema::ObjectType, views::infra::InfraApiError, DbPool,
-};
-use actix_web::{
-    get,
-    web::{Data, Json, Path},
-};
+use std::collections::HashMap;
+
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use chashmap::CHashMap;
 use editoast_derive::EditoastError;
 use serde_derive::Deserialize;
-use std::collections::HashMap;
 use thiserror::Error;
+
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
+use crate::schema::ObjectType;
+use crate::views::infra::InfraApiError;
+use crate::DbPool;
 
 crate::routes! { attached }
 
@@ -95,15 +100,21 @@ mod tests {
     use std::collections::HashMap;
 
     use actix_http::StatusCode;
-    use actix_web::test::{call_and_read_body_json, call_service, TestRequest};
+    use actix_web::test::call_and_read_body_json;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
+    use rstest::rstest;
 
-    use crate::fixtures::tests::{empty_infra, TestFixture};
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::TestFixture;
     use crate::modelsv2::Infra;
     use crate::schema::operation::RailjsonObject;
-    use crate::schema::{Detector, OSRDIdentified, ObjectType, TrackSection};
+    use crate::schema::Detector;
+    use crate::schema::OSRDIdentified;
+    use crate::schema::ObjectType;
+    use crate::schema::TrackSection;
     use crate::views::infra::tests::create_object_request;
     use crate::views::tests::create_test_service;
-    use rstest::rstest;
 
     #[rstest]
     async fn get_attached_detector(#[future] empty_infra: TestFixture<Infra>) {

--- a/editoast/src/views/infra/auto_fixes/buffer_stop.rs
+++ b/editoast/src/views/infra/auto_fixes/buffer_stop.rs
@@ -1,9 +1,15 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    BufferStopCache, InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::BufferStopCache;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub fn fix_buffer_stop(
     buffer_stop: &BufferStopCache,

--- a/editoast/src/views/infra/auto_fixes/detector.rs
+++ b/editoast/src/views/infra/auto_fixes/detector.rs
@@ -1,9 +1,15 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    DetectorCache, InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::DetectorCache;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
 
 pub fn fix_detector(
     detector: &DetectorCache,

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -1,12 +1,25 @@
-use super::{Fix, OrderedOperation};
-use crate::schema::{
-    operation::{CacheOperation, DeleteOperation, Operation, RailjsonObject, UpdateOperation},
-    Electrification, InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef,
-};
-use itertools::Itertools as _;
-use json_patch::{Patch, PatchOperation, RemoveOperation};
 use std::collections::HashMap;
-use tracing::{debug, error};
+
+use itertools::Itertools as _;
+use json_patch::Patch;
+use json_patch::PatchOperation;
+use json_patch::RemoveOperation;
+use tracing::debug;
+use tracing::error;
+
+use super::Fix;
+use super::OrderedOperation;
+use crate::schema::operation::CacheOperation;
+use crate::schema::operation::DeleteOperation;
+use crate::schema::operation::Operation;
+use crate::schema::operation::RailjsonObject;
+use crate::schema::operation::UpdateOperation;
+use crate::schema::Electrification;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDIdentified as _;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
 
 fn invalid_reference_to_ordered_operation(
     electrification: &Electrification,
@@ -78,15 +91,17 @@ pub fn fix_electrification(
 mod tests {
     use json_patch::Patch;
 
-    use crate::{
-        infra_cache::ObjectCache,
-        schema::{
-            operation::{CacheOperation, Operation},
-            utils::Identifier,
-            ApplicableDirections, ApplicableDirectionsTrackRange, Electrification, InfraError,
-            OSRDObject as _, ObjectRef, ObjectType,
-        },
-    };
+    use crate::infra_cache::ObjectCache;
+    use crate::schema::operation::CacheOperation;
+    use crate::schema::operation::Operation;
+    use crate::schema::utils::Identifier;
+    use crate::schema::ApplicableDirections;
+    use crate::schema::ApplicableDirectionsTrackRange;
+    use crate::schema::Electrification;
+    use crate::schema::InfraError;
+    use crate::schema::OSRDObject as _;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
 
     #[test]
     fn invalid_refs_ordered_electrification() {

--- a/editoast/src/views/infra/auto_fixes/operational_point.rs
+++ b/editoast/src/views/infra/auto_fixes/operational_point.rs
@@ -1,9 +1,14 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, OperationalPointCache,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::OperationalPointCache;
 
 pub fn fix_operational_point(
     operational_point: &OperationalPointCache,

--- a/editoast/src/views/infra/auto_fixes/route.rs
+++ b/editoast/src/views/infra/auto_fixes/route.rs
@@ -1,9 +1,16 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef, ObjectType, Route,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDIdentified as _;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::Route;
 
 pub fn fix_route(
     route: &Route,

--- a/editoast/src/views/infra/auto_fixes/signal.rs
+++ b/editoast/src/views/infra/auto_fixes/signal.rs
@@ -1,9 +1,15 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType, SignalCache,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::SignalCache;
 
 pub fn fix_signal(
     signal: &SignalCache,

--- a/editoast/src/views/infra/auto_fixes/speed_section.rs
+++ b/editoast/src/views/infra/auto_fixes/speed_section.rs
@@ -1,12 +1,25 @@
-use super::{Fix, OrderedOperation};
-use crate::schema::{
-    operation::{CacheOperation, DeleteOperation, Operation, RailjsonObject, UpdateOperation},
-    InfraError, InfraErrorType, OSRDIdentified as _, OSRDObject as _, ObjectRef, SpeedSection,
-};
-use itertools::Itertools as _;
-use json_patch::{Patch, PatchOperation, RemoveOperation};
 use std::collections::HashMap;
-use tracing::{debug, error};
+
+use itertools::Itertools as _;
+use json_patch::Patch;
+use json_patch::PatchOperation;
+use json_patch::RemoveOperation;
+use tracing::debug;
+use tracing::error;
+
+use super::Fix;
+use super::OrderedOperation;
+use crate::schema::operation::CacheOperation;
+use crate::schema::operation::DeleteOperation;
+use crate::schema::operation::Operation;
+use crate::schema::operation::RailjsonObject;
+use crate::schema::operation::UpdateOperation;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDIdentified as _;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::SpeedSection;
 
 fn invalid_reference_to_ordered_operation(
     speed_section: &SpeedSection,
@@ -78,15 +91,17 @@ pub fn fix_speed_section(
 mod tests {
     use json_patch::Patch;
 
-    use crate::{
-        infra_cache::ObjectCache,
-        schema::{
-            operation::{CacheOperation, Operation},
-            utils::Identifier,
-            ApplicableDirections, ApplicableDirectionsTrackRange, InfraError, OSRDObject as _,
-            ObjectRef, ObjectType, SpeedSection,
-        },
-    };
+    use crate::infra_cache::ObjectCache;
+    use crate::schema::operation::CacheOperation;
+    use crate::schema::operation::Operation;
+    use crate::schema::utils::Identifier;
+    use crate::schema::ApplicableDirections;
+    use crate::schema::ApplicableDirectionsTrackRange;
+    use crate::schema::InfraError;
+    use crate::schema::OSRDObject as _;
+    use crate::schema::ObjectRef;
+    use crate::schema::ObjectType;
+    use crate::schema::SpeedSection;
 
     #[test]
     fn invalid_refs_ordered_speed_section() {

--- a/editoast/src/views/infra/auto_fixes/switch.rs
+++ b/editoast/src/views/infra/auto_fixes/switch.rs
@@ -1,9 +1,15 @@
-use super::{new_ref_fix_delete_pair, Fix};
-use crate::schema::{
-    InfraError, InfraErrorType, OSRDObject as _, ObjectRef, ObjectType, SwitchCache,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
+
+use super::new_ref_fix_delete_pair;
+use super::Fix;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::ObjectType;
+use crate::schema::SwitchCache;
 
 pub fn fix_switch(
     switch: &SwitchCache,

--- a/editoast/src/views/infra/auto_fixes/track_section.rs
+++ b/editoast/src/views/infra/auto_fixes/track_section.rs
@@ -1,11 +1,20 @@
-use super::{new_ref_fix_create_pair, Fix};
-use crate::schema::{
-    operation::RailjsonObject, utils::Identifier, BufferStop, Endpoint, InfraError, InfraErrorType,
-    OSRDIdentified as _, OSRDObject as _, ObjectRef, TrackSectionCache,
-};
 use std::collections::HashMap;
+
 use tracing::debug;
 use uuid::Uuid;
+
+use super::new_ref_fix_create_pair;
+use super::Fix;
+use crate::schema::operation::RailjsonObject;
+use crate::schema::utils::Identifier;
+use crate::schema::BufferStop;
+use crate::schema::Endpoint;
+use crate::schema::InfraError;
+use crate::schema::InfraErrorType;
+use crate::schema::OSRDIdentified as _;
+use crate::schema::OSRDObject as _;
+use crate::schema::ObjectRef;
+use crate::schema::TrackSectionCache;
 
 pub fn fix_track_section(
     track_section: &TrackSectionCache,
@@ -42,13 +51,10 @@ mod tests {
     use std::ops::Deref;
 
     use super::*;
-    use crate::{
-        infra_cache::ObjectCache,
-        schema::{
-            operation::{CacheOperation, Operation},
-            TrackSection,
-        },
-    };
+    use crate::infra_cache::ObjectCache;
+    use crate::schema::operation::CacheOperation;
+    use crate::schema::operation::Operation;
+    use crate::schema::TrackSection;
 
     #[test]
     fn missing_buffer_stop() {

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -1,19 +1,26 @@
-use crate::error::Result;
-use crate::views::infra::InfraApiError;
-use crate::RedisClient;
 use actix_web::post;
-use actix_web::web::{Data, Json, Path};
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use chashmap::CHashMap;
 use diesel_async::AsyncPgConnection as PgConnection;
+use editoast_derive::EditoastError;
 use thiserror::Error;
 
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::map::{self, MapLayers};
+use crate::error::Result;
+use crate::generated_data;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::map::MapLayers;
+use crate::map::{self};
 use crate::modelsv2::prelude::*;
 use crate::modelsv2::Infra;
-use crate::schema::operation::{CacheOperation, Operation, RailjsonObject};
-use crate::{generated_data, DbPool};
-use editoast_derive::EditoastError;
+use crate::schema::operation::CacheOperation;
+use crate::schema::operation::Operation;
+use crate::schema::operation::RailjsonObject;
+use crate::views::infra::InfraApiError;
+use crate::DbPool;
+use crate::RedisClient;
 
 /// CRUD for edit an infrastructure. Takes a batch of operations.
 #[post("")]

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -1,17 +1,26 @@
-use crate::error::Result;
-use crate::schema::InfraErrorType;
-use crate::views::pagination::{Paginate, PaginatedResponse, PaginationQueryParam};
-use crate::DbPool;
 use actix_web::dev::HttpServiceFactory;
 use actix_web::get;
-use actix_web::web::{Data, Json as WebJson, Path, Query};
+use actix_web::web::Data;
+use actix_web::web::Json as WebJson;
+use actix_web::web::Path;
+use actix_web::web::Query;
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Json, Text};
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Json;
+use diesel::sql_types::Text;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 use strum::VariantNames;
 use thiserror::Error;
+
+use crate::error::Result;
+use crate::schema::InfraErrorType;
+use crate::views::pagination::Paginate;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::DbPool;
 
 /// Return `/infra/<infra_id>/errors` routes
 pub fn routes() -> impl HttpServiceFactory {
@@ -113,13 +122,16 @@ async fn get_paginated_infra_errors(
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::tests::{empty_infra, TestFixture};
+    use actix_http::StatusCode;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
+    use rstest::rstest;
+
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::TestFixture;
     use crate::modelsv2::Infra;
     use crate::views::infra::errors::check_error_type_query;
     use crate::views::tests::create_test_service;
-    use actix_http::StatusCode;
-    use actix_web::test::{call_service, TestRequest};
-    use rstest::rstest;
 
     #[test]
     fn check_error_type() {

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -1,16 +1,20 @@
-use crate::error::Result;
-use crate::infra_cache::{InfraCache, ObjectCache};
-use crate::map::Zone;
-use crate::modelsv2::prelude::*;
-use crate::modelsv2::Infra;
-
-use crate::views::infra::InfraApiError;
-use crate::{views::infra::InfraIdParam, DbPool};
 use actix_web::get;
-use actix_web::web::{Data, Json, Path};
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use chashmap::CHashMap;
 use editoast_derive::EditoastError;
 use thiserror::Error;
+
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::infra_cache::ObjectCache;
+use crate::map::Zone;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
+use crate::views::infra::InfraApiError;
+use crate::views::infra::InfraIdParam;
+use crate::DbPool;
 
 crate::routes! {
     "/lines/{line_code}/bbox" => {

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -1,21 +1,32 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 use actix_web::dev::HttpServiceFactory;
 use actix_web::post;
-use actix_web::web::{Data, Json, Path};
-use diesel::sql_types::{Array, BigInt, Jsonb, Nullable, Text};
-use diesel::{sql_query, QueryableByName};
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use diesel::sql_query;
+use diesel::sql_types::Array;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Jsonb;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::Text;
+use diesel::QueryableByName;
 use diesel_async::RunQueryDsl;
 use diesel_json::Json as DieselJson;
-use serde::{Deserialize, Serialize};
+use editoast_derive::EditoastError;
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
 
 use crate::error::Result;
-use crate::modelsv2::{get_geometry_layer_table, get_table};
-use crate::schema::{GeoJson, ObjectType};
+use crate::modelsv2::get_geometry_layer_table;
+use crate::modelsv2::get_table;
+use crate::schema::GeoJson;
+use crate::schema::ObjectType;
 use crate::DbPool;
-use editoast_derive::EditoastError;
 
 /// Return `/infra/<infra_id>/objects` routes
 pub fn routes() -> impl HttpServiceFactory {
@@ -122,18 +133,24 @@ async fn get_objects(
 #[cfg(test)]
 mod tests {
     use actix_web::http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
-    use serde_json::{json, Value as JsonValue};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
+    use rstest::*;
+    use serde_json::json;
+    use serde_json::Value as JsonValue;
 
-    use crate::fixtures::tests::{db_pool, empty_infra, TestFixture};
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::TestFixture;
     use crate::modelsv2::Infra;
     use crate::schema::operation::Operation;
     use crate::schema::OSRDIdentified;
-    use crate::schema::{Switch, SwitchType};
+    use crate::schema::Switch;
+    use crate::schema::SwitchType;
     use crate::views::infra::objects::ObjectQueryable;
     use crate::views::infra::tests::create_object_request;
     use crate::views::tests::create_test_service;
-    use rstest::*;
 
     #[rstest]
     async fn check_invalid_ids(#[future] empty_infra: TestFixture<Infra>) {

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -1,24 +1,34 @@
 use std::collections::HashMap;
 
 use actix_web::post;
-use actix_web::web::{Data, Json, Path, Query};
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
 use chashmap::CHashMap;
 use derivative::Derivative;
+use editoast_derive::EditoastError;
 use pathfinding::prelude::yen;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
+use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::infra_cache::{Graph, InfraCache};
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
 use crate::modelsv2::prelude::*;
 use crate::modelsv2::Infra;
 use crate::schema::utils::Identifier;
-use crate::schema::{Direction, DirectionalTrackRange, Endpoint, ObjectType, TrackEndpoint};
+use crate::schema::Direction;
+use crate::schema::DirectionalTrackRange;
+use crate::schema::Endpoint;
+use crate::schema::ObjectType;
+use crate::schema::TrackEndpoint;
 use crate::views::infra::InfraApiError;
 use crate::views::infra::InfraIdParam;
 use crate::DbPool;
-use editoast_derive::EditoastError;
 
 crate::routes! {
     "/pathfinding" => {
@@ -402,8 +412,10 @@ mod tests {
     use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;
     use crate::schema::utils::Identifier;
-    use crate::schema::{Direction, DirectionalTrackRange};
-    use crate::views::infra::pathfinding::{PathfindingInput, PathfindingTrackLocationInput};
+    use crate::schema::Direction;
+    use crate::schema::DirectionalTrackRange;
+    use crate::views::infra::pathfinding::PathfindingInput;
+    use crate::views::infra::pathfinding::PathfindingTrackLocationInput;
 
     fn expected_path() -> Vec<DirectionalTrackRange> {
         vec![

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -1,24 +1,37 @@
-use crate::error::Result;
-use crate::infra_cache::InfraCache;
-use crate::modelsv2::{get_table, prelude::*, Infra};
-use crate::schema::{ObjectType, RailJson, RAILJSON_VERSION};
-use crate::views::infra::InfraApiError;
-use crate::DbPool;
-
 use actix_web::dev::HttpServiceFactory;
+use actix_web::get;
 use actix_web::http::header::ContentType;
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{get, post, services, HttpResponse, Responder};
+use actix_web::post;
+use actix_web::services;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
+use actix_web::Responder;
 use chashmap::CHashMap;
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Text};
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
 use editoast_derive::EditoastError;
 use enum_map::EnumMap;
 use futures::future::try_join_all;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use strum::IntoEnumIterator;
 use thiserror::Error;
+
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::modelsv2::get_table;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
+use crate::schema::ObjectType;
+use crate::schema::RailJson;
+use crate::schema::RAILJSON_VERSION;
+use crate::views::infra::InfraApiError;
+use crate::DbPool;
 
 /// Return `/infra/<infra_id>/railjson` routes
 pub fn routes() -> impl HttpServiceFactory {
@@ -163,16 +176,19 @@ async fn post_railjson(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use actix_http::StatusCode;
     use actix_web::test as actix_test;
-    use actix_web::test::{call_service, read_body_json};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use rstest::*;
 
-    use crate::fixtures::tests::{db_pool, empty_infra, TestFixture};
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::TestFixture;
     use crate::schema::SwitchType;
     use crate::views::infra::tests::create_object_request;
     use crate::views::tests::create_test_service;
-    use rstest::*;
 
     #[rstest]
     #[serial_test::serial]

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -1,31 +1,32 @@
 use std::collections::HashMap;
 
-use crate::{
-    error::Result,
-    infra_cache::{Graph, InfraCache},
-    modelsv2::prelude::*,
-    modelsv2::Infra,
-    schema::DirectionalTrackRange,
-    views::{
-        infra::{InfraApiError, InfraIdParam},
-        params::List,
-    },
-    DbPool,
-};
-use actix_web::{
-    get, post,
-    web::{Data, Json, Path, Query},
-};
+use actix_web::get;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
 use chashmap::CHashMap;
-use diesel::{
-    sql_query,
-    sql_types::{BigInt, Bool, Text},
-};
+use diesel::sql_query;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Bool;
+use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
-
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use strum_macros::Display;
 use utoipa::ToSchema;
+
+use crate::error::Result;
+use crate::infra_cache::Graph;
+use crate::infra_cache::InfraCache;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
+use crate::schema::DirectionalTrackRange;
+use crate::views::infra::InfraApiError;
+use crate::views::infra::InfraIdParam;
+use crate::views::params::List;
+use crate::DbPool;
 
 crate::routes! {
     "/routes" => {
@@ -224,20 +225,26 @@ async fn get_routes_nodes(
 #[cfg(test)]
 mod tests {
     use actix_http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
 
-    use crate::{
-        assert_status_and_read,
-        fixtures::tests::{db_pool, empty_infra, small_infra},
-        schema::{operation::Operation, BufferStop, Detector, Route, TrackSection, Waypoint},
-        views::{
-            infra::routes::{RoutesResponse, WaypointType},
-            tests::create_test_service,
-        },
-    };
+    use crate::assert_status_and_read;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::small_infra;
+    use crate::schema::operation::Operation;
+    use crate::schema::BufferStop;
+    use crate::schema::Detector;
+    use crate::schema::Route;
+    use crate::schema::TrackSection;
+    use crate::schema::Waypoint;
+    use crate::views::infra::routes::RoutesResponse;
+    use crate::views::infra::routes::WaypointType;
+    use crate::views::tests::create_test_service;
 
     #[rstest]
     async fn get_routes_nodes() {

--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -2,22 +2,36 @@ mod mvt_utils;
 
 use std::collections::HashMap;
 
-use crate::client::{get_root_url, MapLayersConfig};
-use crate::error::Result;
-use crate::map::{get_cache_tile_key, get_view_cache_prefix, Layer, MapLayers, Tile};
-use crate::DbPool;
-use crate::RedisClient;
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{get, HttpResponse};
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
 use diesel::sql_query;
 use diesel::sql_types::Integer;
 use diesel_async::RunQueryDsl;
 use editoast_derive::EditoastError;
-use mvt_utils::{create_and_fill_mvt_tile, get_geo_json_sql_query, GeoJsonAndData};
+use mvt_utils::create_and_fill_mvt_tile;
+use mvt_utils::get_geo_json_sql_query;
+use mvt_utils::GeoJsonAndData;
 use redis::AsyncCommands;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
+use crate::client::get_root_url;
+use crate::client::MapLayersConfig;
+use crate::error::Result;
+use crate::map::get_cache_tile_key;
+use crate::map::get_view_cache_prefix;
+use crate::map::Layer;
+use crate::map::MapLayers;
+use crate::map::Tile;
+use crate::DbPool;
+use crate::RedisClient;
 
 crate::routes! {
      "/layers" => {
@@ -220,18 +234,19 @@ async fn cache_and_get_mvt_tile(
 mod tests {
     use std::collections::HashMap;
 
-    use crate::map::MapLayers;
-    use crate::views::tests::create_test_service;
-    use crate::{error::InternalError, views::layers::ViewMetadata};
-    use actix_web::{
-        http::StatusCode,
-        test::{call_service, read_body_json, TestRequest},
-    };
+    use actix_web::http::StatusCode;
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde::de::DeserializeOwned;
     use serde_json::to_value;
 
     use super::LayersError;
+    use crate::error::InternalError;
+    use crate::map::MapLayers;
+    use crate::views::layers::ViewMetadata;
+    use crate::views::tests::create_test_service;
 
     /// Run a simple get query on `uri` and check the status code and json body
     async fn test_get_query<T: DeserializeOwned + PartialEq + std::fmt::Debug>(

--- a/editoast/src/views/layers/mvt_utils.rs
+++ b/editoast/src/views/layers/mvt_utils.rs
@@ -1,9 +1,15 @@
-use diesel::sql_types::{Jsonb, Text};
-use mvt::{Feature, GeomData, GeomEncoder, Tile as MvtTile};
-use serde::{Deserialize, Serialize};
+use diesel::sql_types::Jsonb;
+use diesel::sql_types::Text;
+use mvt::Feature;
+use mvt::GeomData;
+use mvt::GeomEncoder;
+use mvt::Tile as MvtTile;
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::Value as JsonValue;
 
-use crate::{map::View, schema::GeoJson};
+use crate::map::View;
+use crate::schema::GeoJson;
 
 #[derive(Clone, QueryableByName, Queryable, Debug, Serialize, Deserialize)]
 pub struct GeoJsonAndData {
@@ -167,9 +173,10 @@ pub fn get_geo_json_sql_query(table_name: &str, view: &View) -> String {
 mod tests {
     use serde_json::json;
 
+    use super::create_and_fill_mvt_tile;
+    use super::get_geo_json_sql_query;
+    use super::GeoJsonAndData;
     use crate::map::MapLayers;
-
-    use super::{create_and_fill_mvt_tile, get_geo_json_sql_query, GeoJsonAndData};
 
     #[test]
     fn test_query_creation() {

--- a/editoast/src/views/light_rolling_stocks.rs
+++ b/editoast/src/views/light_rolling_stocks.rs
@@ -1,11 +1,19 @@
-use crate::error::Result;
-use crate::modelsv2::{LightRollingStockModel, Retrieve};
-use crate::schema::rolling_stock::light_rolling_stock::LightRollingStockWithLiveries;
-use crate::views::pagination::{PaginatedResponse, PaginationQueryParam};
-use crate::views::rolling_stocks::{RollingStockError, RollingStockIdParam};
-use crate::{decl_paginated_response, DbPool};
 use actix_web::get;
-use actix_web::web::{Data, Json, Path, Query};
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+
+use crate::decl_paginated_response;
+use crate::error::Result;
+use crate::modelsv2::LightRollingStockModel;
+use crate::modelsv2::Retrieve;
+use crate::schema::rolling_stock::light_rolling_stock::LightRollingStockWithLiveries;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::views::rolling_stocks::RollingStockError;
+use crate::views::rolling_stocks::RollingStockIdParam;
+use crate::DbPool;
 
 crate::routes! {
     "/light_rolling_stock" => {
@@ -80,18 +88,25 @@ async fn get(
 
 #[cfg(test)]
 mod tests {
-    use crate::fixtures::tests::{db_pool, named_fast_rolling_stock, rolling_stock_livery};
-    use crate::schema::rolling_stock::light_rolling_stock::LightRollingStockWithLiveries;
-    use crate::views::pagination::{PaginatedResponse, PaginationError};
-    use crate::views::tests::create_test_service;
-    use crate::DbPool;
-    use crate::{assert_response_error_type_match, assert_status_and_read};
+    use std::collections::HashSet;
+
     use actix_http::StatusCode;
     use actix_web::test as actix_test;
-    use actix_web::test::{call_service, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use actix_web::web::Data;
     use rstest::*;
-    use std::collections::HashSet;
+
+    use crate::assert_response_error_type_match;
+    use crate::assert_status_and_read;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::fixtures::tests::rolling_stock_livery;
+    use crate::schema::rolling_stock::light_rolling_stock::LightRollingStockWithLiveries;
+    use crate::views::pagination::PaginatedResponse;
+    use crate::views::pagination::PaginationError;
+    use crate::views::tests::create_test_service;
+    use crate::DbPool;
 
     #[actix_test]
     async fn list_light_rolling_stock() {

--- a/editoast/src/views/openapi.rs
+++ b/editoast/src/views/openapi.rs
@@ -2,20 +2,23 @@
 //! OpenAPI with the new generated one incrementally in order to avoid protential
 //! breaking changes.
 
-use std::{
-    collections::{BTreeMap, VecDeque},
-    path::Path,
-};
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+use std::path::Path;
 
 use actix_web::dev::HttpServiceFactory;
 use serde_json::Value as Json;
 use tracing::warn;
-use utoipa::{
-    openapi::{
-        path::PathItemBuilder, schema::AnyOf, AllOf, Array, Object, OneOf, PathItem, RefOr, Schema,
-    },
-    ToSchema,
-};
+use utoipa::openapi::path::PathItemBuilder;
+use utoipa::openapi::schema::AnyOf;
+use utoipa::openapi::AllOf;
+use utoipa::openapi::Array;
+use utoipa::openapi::Object;
+use utoipa::openapi::OneOf;
+use utoipa::openapi::PathItem;
+use utoipa::openapi::RefOr;
+use utoipa::openapi::Schema;
+use utoipa::ToSchema;
 
 pub struct Routes<F: HttpServiceFactory> {
     pub service: F,
@@ -653,8 +656,10 @@ impl OpenApiMerger {
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
-    use rstest::{fixture, rstest};
-    use serde_json::{json, Value};
+    use rstest::fixture;
+    use rstest::rstest;
+    use serde_json::json;
+    use serde_json::Value;
 
     use super::OpenApiMerger;
 

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -1,19 +1,20 @@
-use crate::error::Result;
 use diesel::pg::Pg;
 use diesel::query_builder::*;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Untyped;
-use diesel::{QueryResult, QueryableByName};
+use diesel::QueryResult;
+use diesel::QueryableByName;
 use diesel_async::methods::LoadQuery;
 use diesel_async::AsyncPgConnection as PgConnection;
+use editoast_derive::EditoastError;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use tracing::warn;
-
-use editoast_derive::EditoastError;
 use utoipa::IntoParams;
+
+use crate::error::Result;
 
 const DEFAULT_PAGE_SIZE: i64 = 25;
 

--- a/editoast/src/views/params.rs
+++ b/editoast/src/views/params.rs
@@ -1,5 +1,8 @@
-use serde::{de::Error, Deserialize, Deserializer};
 use std::str::FromStr;
+
+use serde::de::Error;
+use serde::Deserialize;
+use serde::Deserializer;
 
 /// This parameter is used to deserialized a list of `T`
 #[derive(Debug, Default, Clone)]

--- a/editoast/src/views/pathfinding/electrical_profiles.rs
+++ b/editoast/src/views/pathfinding/electrical_profiles.rs
@@ -1,24 +1,32 @@
-use crate::error::{InternalError, Result};
-use crate::models::{pathfinding::Pathfinding, Retrieve};
-use crate::modelsv2::{electrical_profiles::ElectricalProfileSet, LightRollingStockModel};
-use crate::schema::electrical_profiles::ElectricalProfileSetData;
-use crate::views::electrical_profiles::ElectricalProfilesError;
-use crate::views::pathfinding::PathfindingIdParam;
-use crate::views::pathfinding::{
-    path_rangemap::{make_path_range_map, TrackMap},
-    PathfindingError,
-};
-use crate::DbPool;
-use actix_web::{
-    get,
-    web::{Data, Json, Path, Query},
-};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Debug;
+
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
 use osrd_containers::rangemap_utils::RangedValue;
 use rangemap::RangeMap;
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use utoipa::{IntoParams, ToSchema};
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::pathfinding::Pathfinding;
+use crate::models::Retrieve;
+use crate::modelsv2::electrical_profiles::ElectricalProfileSet;
+use crate::modelsv2::LightRollingStockModel;
+use crate::schema::electrical_profiles::ElectricalProfileSetData;
+use crate::views::electrical_profiles::ElectricalProfilesError;
+use crate::views::pathfinding::path_rangemap::make_path_range_map;
+use crate::views::pathfinding::path_rangemap::TrackMap;
+use crate::views::pathfinding::PathfindingError;
+use crate::views::pathfinding::PathfindingIdParam;
+use crate::DbPool;
 
 crate::routes! {
     electrical_profiles_on_path
@@ -129,16 +137,24 @@ async fn electrical_profiles_on_path(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::fixtures::tests::{db_pool, empty_infra, named_fast_rolling_stock, TestFixture};
-    use crate::models::pathfinding::tests::simple_pathfinding_fixture;
-    use crate::modelsv2::{prelude::*, Infra};
-    use crate::schema::{electrical_profiles::ElectricalProfile, TrackRange};
-    use crate::views::tests::create_test_service;
     use actix_http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use osrd_containers::range_map;
     use rstest::*;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::pathfinding::tests::simple_pathfinding_fixture;
+    use crate::modelsv2::prelude::*;
+    use crate::modelsv2::Infra;
+    use crate::schema::electrical_profiles::ElectricalProfile;
+    use crate::schema::TrackRange;
+    use crate::views::tests::create_test_service;
 
     #[fixture]
     async fn electrical_profile_set(db_pool: Data<DbPool>) -> TestFixture<ElectricalProfileSet> {

--- a/editoast/src/views/pathfinding/electrifications.rs
+++ b/editoast/src/views/pathfinding/electrifications.rs
@@ -1,22 +1,31 @@
-use crate::error::{InternalError, Result};
-use crate::infra_cache::InfraCache;
-use crate::models::{pathfinding::Pathfinding, Retrieve};
-use crate::modelsv2::{Infra, Retrieve as RetrieveV2};
-use crate::schema::ObjectType;
-use crate::views::pathfinding::path_rangemap::{make_path_range_map, TrackMap};
-use crate::views::pathfinding::{PathfindingError, PathfindingIdParam};
-use crate::DbPool;
-use actix_web::{
-    get,
-    web::{Data, Json, Path},
-};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Debug;
+
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use chashmap::CHashMap;
 use osrd_containers::rangemap_utils::RangedValue;
 use rangemap::RangeMap;
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
+
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::infra_cache::InfraCache;
+use crate::models::pathfinding::Pathfinding;
+use crate::models::Retrieve;
+use crate::modelsv2::Infra;
+use crate::modelsv2::Retrieve as RetrieveV2;
+use crate::schema::ObjectType;
+use crate::views::pathfinding::path_rangemap::make_path_range_map;
+use crate::views::pathfinding::path_rangemap::TrackMap;
+use crate::views::pathfinding::PathfindingError;
+use crate::views::pathfinding::PathfindingIdParam;
+use crate::DbPool;
 
 crate::routes! {
     electrifications_on_path,
@@ -125,23 +134,26 @@ async fn electrifications_on_path(
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    use crate::{
-        fixtures::tests::{db_pool, empty_infra, TestFixture},
-        models::pathfinding::tests::simple_pathfinding_fixture,
-        modelsv2::{prelude::*, ElectrificationModel},
-        schema::{
-            ApplicableDirections, ApplicableDirectionsTrackRange,
-            Electrification as ElectrificationSchema,
-        },
-        views::tests::create_test_service,
-    };
     use actix_http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use osrd_containers::range_map;
     use rstest::*;
     use serde_json::from_value;
     use ApplicableDirections::*;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::pathfinding::tests::simple_pathfinding_fixture;
+    use crate::modelsv2::prelude::*;
+    use crate::modelsv2::ElectrificationModel;
+    use crate::schema::ApplicableDirections;
+    use crate::schema::ApplicableDirectionsTrackRange;
+    use crate::schema::Electrification as ElectrificationSchema;
+    use crate::views::tests::create_test_service;
 
     #[fixture]
     fn simple_mode_map() -> TrackMap<String> {

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -2,48 +2,61 @@ mod electrical_profiles;
 mod electrifications;
 mod path_rangemap;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 
-use actix_web::{
-    delete, get, post, put,
-    web::{Data, Json, Path},
-    HttpResponse, Responder,
-};
-use chrono::{DateTime, Utc};
+use actix_web::delete;
+use actix_web::get;
+use actix_web::post;
+use actix_web::put;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::HttpResponse;
+use actix_web::Responder;
+use chrono::DateTime;
+use chrono::Utc;
 use derivative::Derivative;
 use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
-use geos::geojson::{self, Geometry};
+use geos::geojson::Geometry;
+use geos::geojson::{self};
 use geos::Geom;
-
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use crate::{
-    core::{
-        pathfinding::{
-            PathfindingRequest as CorePathfindingRequest, PathfindingResponse,
-            PathfindingWaypoints, Waypoint as CoreWaypoint,
-        },
-        AsCoreRequest, CoreClient,
-    },
-    error::Result,
-    models::{
-        Create, Curve, Delete, PathWaypoint, Pathfinding, PathfindingChangeset, PathfindingPayload,
-        Retrieve, Slope, Update,
-    },
-    modelsv2::{
-        infra_objects::TrackSectionModel, Infra, OperationalPointModel, Retrieve as RetrieveV2,
-        RollingStockModel,
-    },
-    schema::{
-        rolling_stock::RollingStock,
-        utils::geometry::{diesel_linestring_to_geojson, geojson_to_diesel_linestring},
-        ApplicableDirectionsTrackRange, OperationalPoint, TrackRange, TrackSection,
-    },
-    DbPool,
-};
+use crate::core::pathfinding::PathfindingRequest as CorePathfindingRequest;
+use crate::core::pathfinding::PathfindingResponse;
+use crate::core::pathfinding::PathfindingWaypoints;
+use crate::core::pathfinding::Waypoint as CoreWaypoint;
+use crate::core::AsCoreRequest;
+use crate::core::CoreClient;
+use crate::error::Result;
+use crate::models::Create;
+use crate::models::Curve;
+use crate::models::Delete;
+use crate::models::PathWaypoint;
+use crate::models::Pathfinding;
+use crate::models::PathfindingChangeset;
+use crate::models::PathfindingPayload;
+use crate::models::Retrieve;
+use crate::models::Slope;
+use crate::models::Update;
+use crate::modelsv2::infra_objects::TrackSectionModel;
+use crate::modelsv2::Infra;
+use crate::modelsv2::OperationalPointModel;
+use crate::modelsv2::Retrieve as RetrieveV2;
+use crate::modelsv2::RollingStockModel;
+use crate::schema::rolling_stock::RollingStock;
+use crate::schema::utils::geometry::diesel_linestring_to_geojson;
+use crate::schema::utils::geometry::geojson_to_diesel_linestring;
+use crate::schema::ApplicableDirectionsTrackRange;
+use crate::schema::OperationalPoint;
+use crate::schema::TrackRange;
+use crate::schema::TrackSection;
+use crate::DbPool;
 
 crate::routes! {
     "/pathfinding" => {
@@ -572,19 +585,26 @@ async fn del_pf(params: Path<PathfindingIdParam>, db_pool: Data<DbPool>) -> Resu
 #[cfg(test)]
 mod test {
     use actix_http::StatusCode;
-    use actix_web::test::{call_service, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use serde_json::json;
 
+    use crate::assert_response_error_type_match;
+    use crate::assert_status_and_read;
     use crate::core::mocking::MockingClient;
-    use crate::fixtures::tests::{
-        db_pool, empty_infra, named_fast_rolling_stock, pathfinding, small_infra, TestFixture,
-    };
-    use crate::models::{Pathfinding, Retrieve};
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::fixtures::tests::pathfinding;
+    use crate::fixtures::tests::small_infra;
+    use crate::fixtures::tests::TestFixture;
+    use crate::models::Pathfinding;
+    use crate::models::Retrieve;
     use crate::modelsv2::Infra;
-    use crate::views::pathfinding::{PathResponse, PathfindingError};
+    use crate::views::pathfinding::PathResponse;
+    use crate::views::pathfinding::PathfindingError;
     use crate::views::tests::create_test_service;
     use crate::views::tests::create_test_service_with_core_client;
-    use crate::{assert_response_error_type_match, assert_status_and_read};
 
     #[rstest::rstest]
     async fn test_get_pf(#[future] pathfinding: TestFixture<Pathfinding>) {

--- a/editoast/src/views/pathfinding/path_rangemap.rs
+++ b/editoast/src/views/pathfinding/path_rangemap.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
+use osrd_containers::rangemap_utils::clip_range_map;
+use osrd_containers::rangemap_utils::extend_range_map;
+use osrd_containers::rangemap_utils::travel_range_map;
+use osrd_containers::rangemap_utils::Float;
+use osrd_containers::rangemap_utils::TravelDir;
+use rangemap::RangeMap;
+
 use crate::models::pathfinding::Pathfinding;
 use crate::schema::Direction;
-
-use osrd_containers::rangemap_utils::{
-    clip_range_map, extend_range_map, travel_range_map, Float, TravelDir,
-};
-use rangemap::RangeMap;
 
 /// A map of track IDs to range maps
 pub type TrackMap<T> = HashMap<String, RangeMap<Float, T>>;
@@ -47,9 +49,10 @@ pub fn make_path_range_map<T: Eq + Clone>(
 
 #[cfg(test)]
 mod tests {
+    use osrd_containers::range_map;
+
     use super::*;
     use crate::models::pathfinding::tests::simple_pathfinding;
-    use osrd_containers::range_map;
 
     #[test]
     fn test_make_path_range_map() {

--- a/editoast/src/views/projects.rs
+++ b/editoast/src/views/projects.rs
@@ -1,23 +1,36 @@
-use crate::decl_paginated_response;
-use crate::error::Result;
-use crate::models::List;
-use crate::modelsv2::{
-    projects::Tags, Changeset, Create, Document, Model, Ordering, Project, Retrieve,
-};
-use crate::views::pagination::{PaginatedResponse, PaginationQueryParam};
-use crate::DbPool;
-
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, patch, post, HttpResponse};
+use actix_web::delete;
+use actix_web::get;
+use actix_web::patch;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
 use chrono::Utc;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use super::study;
+use crate::decl_paginated_response;
+use crate::error::Result;
+use crate::models::List;
+use crate::modelsv2::projects::Tags;
+use crate::modelsv2::Changeset;
+use crate::modelsv2::Create;
+use crate::modelsv2::Document;
+use crate::modelsv2::Model;
+use crate::modelsv2::Ordering;
+use crate::modelsv2::Project;
+use crate::modelsv2::Retrieve;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::DbPool;
 
 crate::routes! {
     "/projects" => {
@@ -310,16 +323,21 @@ async fn patch(
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use crate::fixtures::tests::{db_pool, project, TestFixture};
-    use crate::modelsv2::DeleteStatic;
-    use crate::views::tests::create_test_service;
     use actix_http::Request;
     use actix_web::http::StatusCode;
     use actix_web::test as actix_test;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::project;
+    use crate::fixtures::tests::TestFixture;
+    use crate::modelsv2::DeleteStatic;
+    use crate::views::tests::create_test_service;
 
     fn delete_project_request(project_id: i64) -> Request {
         TestRequest::delete()

--- a/editoast/src/views/rolling_stocks/rolling_stock_form.rs
+++ b/editoast/src/views/rolling_stocks/rolling_stock_form.rs
@@ -1,14 +1,17 @@
 use derivative::Derivative;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use utoipa::ToSchema;
-use validator::{Validate, ValidationError};
+use validator::Validate;
+use validator::ValidationError;
 
-use crate::{
-    modelsv2::{rolling_stock_model::validate_rolling_stock, Changeset, Model, RollingStockModel},
-    schema::rolling_stock::{
-        RollingStockCommon, RollingStockMetadata, ROLLING_STOCK_RAILJSON_VERSION,
-    },
-};
+use crate::modelsv2::rolling_stock_model::validate_rolling_stock;
+use crate::modelsv2::Changeset;
+use crate::modelsv2::Model;
+use crate::modelsv2::RollingStockModel;
+use crate::schema::rolling_stock::RollingStockCommon;
+use crate::schema::rolling_stock::RollingStockMetadata;
+use crate::schema::rolling_stock::ROLLING_STOCK_RAILJSON_VERSION;
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate, Derivative)]
 #[derivative(PartialEq)]

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -1,34 +1,47 @@
-use crate::decl_paginated_response;
-use crate::error::{InternalError, Result};
-use crate::models::train_schedule::LightTrainSchedule;
-use crate::models::{
-    Create, Delete, List, Retrieve, ScenarioWithCountTrains, ScenarioWithDetails, Timetable, Update,
-};
-use crate::modelsv2::{Project, Study};
-use crate::views::pagination::{PaginatedResponse, PaginationQueryParam};
-use crate::views::projects::{ProjectError, ProjectIdParam};
-use crate::views::study::{StudyError, StudyIdParam};
-use crate::{models::Scenario, DbPool};
-use actix_web::{delete, HttpResponse};
-
+use actix_web::delete;
 use actix_web::get;
 use actix_web::patch;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use actix_web::web::Query;
-use actix_web::{
-    post,
-    web::{Data, Json, Path},
-};
+use actix_web::HttpResponse;
 use chrono::Utc;
 use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
+use utoipa::ToSchema;
 
 use super::projects::QueryParams;
+use crate::decl_paginated_response;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::train_schedule::LightTrainSchedule;
+use crate::models::Create;
+use crate::models::Delete;
+use crate::models::List;
+use crate::models::Retrieve;
+use crate::models::Scenario;
+use crate::models::ScenarioWithCountTrains;
+use crate::models::ScenarioWithDetails;
+use crate::models::Timetable;
+use crate::models::Update;
+use crate::modelsv2::Project;
+use crate::modelsv2::Study;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::views::projects::ProjectError;
+use crate::views::projects::ProjectIdParam;
+use crate::views::study::StudyError;
+use crate::views::study::StudyIdParam;
+use crate::DbPool;
 
 crate::routes! {
     "/scenarios" => {
@@ -374,19 +387,24 @@ async fn list(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, empty_infra, scenario_fixture_set, study_fixture_set, ScenarioFixtureSet,
-        StudyFixtureSet, TestFixture,
-    };
-
-    use crate::modelsv2::Infra;
-    use crate::views::tests::create_test_service;
     use actix_http::Request;
     use actix_web::http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::empty_infra;
+    use crate::fixtures::tests::scenario_fixture_set;
+    use crate::fixtures::tests::study_fixture_set;
+    use crate::fixtures::tests::ScenarioFixtureSet;
+    use crate::fixtures::tests::StudyFixtureSet;
+    use crate::fixtures::tests::TestFixture;
+    use crate::modelsv2::Infra;
+    use crate::views::tests::create_test_service;
 
     pub fn easy_scenario_url(scenario_fixture_set: &ScenarioFixtureSet, detail: bool) -> String {
         scenario_url(

--- a/editoast/src/views/search/context.rs
+++ b/editoast/src/views/search/context.rs
@@ -1,16 +1,15 @@
 //! Defines [QueryContext] and operations to enrich or exploring it
 
-use std::{collections::HashMap, rc::Rc};
+use std::collections::HashMap;
+use std::rc::Rc;
 
-use crate::error::Result;
 use editoast_derive::EditoastError;
-
-use super::{
-    sqlquery::SqlQuery,
-    typing::{AstType, TypeSpec},
-};
-
 use thiserror::Error;
+
+use super::sqlquery::SqlQuery;
+use super::typing::AstType;
+use super::typing::TypeSpec;
+use crate::error::Result;
 
 /// Represents a [super::searchast::SearchAst] that also carries valid type information
 ///

--- a/editoast/src/views/search/dsl.rs
+++ b/editoast/src/views/search/dsl.rs
@@ -1,16 +1,16 @@
 //! Defines the trait [Type] and the functions [QueryContext::def_function_1()]
 //! and [QueryContext::def_function_2()] that allows inserting new functions
 //! into the context more easily
-use std::{marker::PhantomData, rc::Rc};
+use std::marker::PhantomData;
+use std::rc::Rc;
 
+use super::context::ProcessingError;
+use super::context::QueryContext;
+use super::typing::TypeSpec;
+use super::AstType;
+use super::TypedAst;
 use crate::error::Result;
 use crate::views::search::sqlquery::SqlQuery;
-
-use super::{
-    context::{ProcessingError, QueryContext},
-    typing::TypeSpec,
-    AstType, TypedAst,
-};
 
 /// Trait that should be implemented by all DSL specifiers types to provide
 /// the required compile-time information to the [QueryContext::def_function_1()]-like

--- a/editoast/src/views/search/mod.rs
+++ b/editoast/src/views/search/mod.rs
@@ -204,29 +204,37 @@ pub mod searchast;
 pub mod sqlquery;
 pub mod typing;
 
-pub use self::search_object::*;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
+use actix_web::Responder;
+use diesel::pg::Pg;
+use diesel::query_builder::BoxedSqlQuery;
+use diesel::sql_query;
+use diesel::sql_types::Jsonb;
+use diesel::sql_types::Text;
+use diesel::QueryableByName;
+use diesel_async::RunQueryDsl;
+use editoast_derive::EditoastError;
 pub use objects::SearchConfigFinder;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::value::Value as JsonValue;
+use thiserror::Error;
 use utoipa::ToSchema;
 
+use self::context::QueryContext;
+use self::context::TypedAst;
+use self::process::create_processing_context;
+pub use self::search_object::*;
+use self::searchast::SearchAst;
+use self::typing::AstType;
+use self::typing::TypeSpec;
 use crate::error::Result;
 use crate::views::pagination::PaginationQueryParam;
 use crate::DbPool;
-use actix_web::web::{Data, Json, Query};
-use actix_web::{post, HttpResponse, Responder};
-use diesel::pg::Pg;
-use diesel::query_builder::BoxedSqlQuery;
-use diesel::sql_types::{Jsonb, Text};
-use diesel::{sql_query, QueryableByName};
-use diesel_async::RunQueryDsl;
-use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
-use serde_json::value::Value as JsonValue;
-use thiserror::Error;
-
-use self::context::{QueryContext, TypedAst};
-use self::process::create_processing_context;
-use self::searchast::SearchAst;
-use self::typing::{AstType, TypeSpec};
 
 crate::routes! {
     search

--- a/editoast/src/views/search/objects.rs
+++ b/editoast/src/views/search/objects.rs
@@ -1,5 +1,6 @@
 use chrono::NaiveDateTime;
-use editoast_derive::{Search, SearchConfigStore};
+use editoast_derive::Search;
+use editoast_derive::SearchConfigStore;
 use serde_derive::Serialize;
 use utoipa::ToSchema;
 

--- a/editoast/src/views/search/process.rs
+++ b/editoast/src/views/search/process.rs
@@ -2,13 +2,14 @@
 
 use std::rc::Rc;
 
-use super::{
-    context::{ProcessingError, QueryContext, TypedAst},
-    dsl,
-    searchast::SearchAst,
-    sqlquery::SqlQuery,
-    typing::{AstType, TypeSpec},
-};
+use super::context::ProcessingError;
+use super::context::QueryContext;
+use super::context::TypedAst;
+use super::dsl;
+use super::searchast::SearchAst;
+use super::sqlquery::SqlQuery;
+use super::typing::AstType;
+use super::typing::TypeSpec;
 use crate::error::Result;
 
 impl QueryContext {
@@ -213,8 +214,10 @@ pub fn create_processing_context() -> QueryContext {
 mod tests {
     use std::rc::Rc;
 
+    use serde_json::json;
+    use serde_json::Value;
+
     use super::*;
-    use serde_json::{json, Value};
 
     fn test_env() -> QueryContext {
         let mut env = create_processing_context();

--- a/editoast/src/views/search/searchast.rs
+++ b/editoast/src/views/search/searchast.rs
@@ -1,10 +1,12 @@
 //! Defines [SearchAst]
 
-use crate::error::Result;
+use std::fmt::Debug;
+
 use editoast_derive::EditoastError;
 use serde_json::Value;
-use std::fmt::Debug;
 use thiserror::Error;
+
+use crate::error::Result;
 
 #[derive(Debug, PartialEq, Error, EditoastError)]
 #[editoast_error(base_id = "search")]
@@ -101,8 +103,9 @@ impl SearchAst {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn from_null() {

--- a/editoast/src/views/search/sqlquery.rs
+++ b/editoast/src/views/search/sqlquery.rs
@@ -2,10 +2,9 @@
 
 use std::fmt::Display;
 
-use super::{
-    context::TypedAst,
-    typing::{AstType, TypeSpec},
-};
+use super::context::TypedAst;
+use super::typing::AstType;
+use super::typing::TypeSpec;
 
 /// A small wrapper around SQL expression syntax that is more convenient
 /// and reliable to use (as opposed to multiple string interpolations)
@@ -172,9 +171,9 @@ fn value_to_sql(value: &TypedAst, string_bindings: &mut Vec<String>) -> String {
 #[cfg(test)]
 mod test {
 
-    use crate::views::search::{context::TypedAst, typing::AstType};
-
     use super::SqlQuery;
+    use crate::views::search::context::TypedAst;
+    use crate::views::search::typing::AstType;
 
     #[test]
     fn render_literal() {

--- a/editoast/src/views/search/typing.rs
+++ b/editoast/src/views/search/typing.rs
@@ -1,15 +1,17 @@
 //! Defines the low-level structures used by typecheking operations
-use std::{
-    collections::{hash_map::DefaultHasher, VecDeque},
-    fmt::Display,
-    hash::{self, Hash, Hasher},
-    ops::Shr,
-};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::VecDeque;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::hash::{self};
+use std::ops::Shr;
 
-use crate::error::Result;
 use editoast_derive::EditoastError;
 use serde::Deserialize;
 use thiserror::Error;
+
+use crate::error::Result;
 
 #[derive(Debug, PartialEq, Error, EditoastError)]
 #[editoast_error(base_id = "search")]
@@ -338,9 +340,9 @@ impl Eq for TypeSpec {}
 #[cfg(test)]
 mod tests {
 
-    use crate::views::search::typing::{hash_eq, TypeSpec};
-
     use super::AstType;
+    use crate::views::search::typing::hash_eq;
+    use crate::views::search::typing::TypeSpec;
 
     #[test]
     fn test_rhs_function_signature() {

--- a/editoast/src/views/single_simulation.rs
+++ b/editoast/src/views/single_simulation.rs
@@ -1,23 +1,36 @@
-use crate::core::simulation::{
-    CoreTrainSchedule, SimulationRequest, SimulationResponse, TrainStop,
-};
-use crate::core::{AsCoreRequest, CoreClient};
-use crate::error::{InternalError, Result};
-use crate::models::train_schedule::{
-    Allowance, ElectrificationRange, Mrsp, ResultTrain, RjsPowerRestrictionRange, ScheduledPoint,
-    SimulationPowerRestrictionRange, TrainScheduleOptions,
-};
-use crate::models::{Pathfinding, Retrieve};
-use crate::modelsv2::electrical_profiles::ElectricalProfileSet;
-use crate::modelsv2::{Exists, RollingStockModel};
-use crate::schema::rolling_stock::RollingStockComfortType;
-use crate::{schemas, DbPool};
 use actix_web::post;
-use actix_web::web::{Data, Json};
+use actix_web::web::Data;
+use actix_web::web::Json;
 use editoast_derive::EditoastError;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
+
+use crate::core::simulation::CoreTrainSchedule;
+use crate::core::simulation::SimulationRequest;
+use crate::core::simulation::SimulationResponse;
+use crate::core::simulation::TrainStop;
+use crate::core::AsCoreRequest;
+use crate::core::CoreClient;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::train_schedule::Allowance;
+use crate::models::train_schedule::ElectrificationRange;
+use crate::models::train_schedule::Mrsp;
+use crate::models::train_schedule::ResultTrain;
+use crate::models::train_schedule::RjsPowerRestrictionRange;
+use crate::models::train_schedule::ScheduledPoint;
+use crate::models::train_schedule::SimulationPowerRestrictionRange;
+use crate::models::train_schedule::TrainScheduleOptions;
+use crate::models::Pathfinding;
+use crate::models::Retrieve;
+use crate::modelsv2::electrical_profiles::ElectricalProfileSet;
+use crate::modelsv2::Exists;
+use crate::modelsv2::RollingStockModel;
+use crate::schema::rolling_stock::RollingStockComfortType;
+use crate::schemas;
+use crate::DbPool;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "single_simulation")]
@@ -186,19 +199,23 @@ async fn standalone_simulation(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use crate::core::mocking::MockingClient;
-    use crate::fixtures::tests::{
-        db_pool, electrical_profile_set, named_fast_rolling_stock, pathfinding,
-    };
-    use crate::views::tests::create_test_service_with_core_client;
-    use crate::{assert_response_error_type_match, assert_status_and_read};
-    use actix_web::test::{call_service, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use pretty_assertions::assert_eq;
-    use reqwest::{Method, StatusCode};
+    use reqwest::Method;
+    use reqwest::StatusCode;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::assert_response_error_type_match;
+    use crate::assert_status_and_read;
+    use crate::core::mocking::MockingClient;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::electrical_profile_set;
+    use crate::fixtures::tests::named_fast_rolling_stock;
+    use crate::fixtures::tests::pathfinding;
+    use crate::views::tests::create_test_service_with_core_client;
 
     fn create_core_client() -> (MockingClient, SimulationResponse) {
         let mut core_client = MockingClient::new();

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -1,11 +1,13 @@
+use actix_files::NamedFile;
+use actix_web::get;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use editoast_derive::EditoastError;
+use thiserror::Error;
+
 use crate::client::get_assets_path;
 use crate::error::Result;
 use crate::schema::sprite_config::SpriteConfig;
-use actix_files::NamedFile;
-use actix_web::get;
-use actix_web::web::{Json, Path};
-use editoast_derive::EditoastError;
-use thiserror::Error;
 
 crate::routes! {
     "/sprites" => {

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -1,28 +1,43 @@
-use crate::decl_paginated_response;
-use crate::error::InternalError;
-use crate::error::Result;
-use crate::models::List;
-use crate::modelsv2::{Changeset, Create, DeleteStatic, Model, Project, Study, Tags, Update};
-use crate::views::pagination::{PaginatedResponse, PaginationQueryParam};
-use crate::views::projects::ProjectError;
-use crate::views::projects::ProjectIdParam;
-use crate::views::projects::QueryParams;
-use crate::DbPool;
+use actix_web::delete;
+use actix_web::get;
 use actix_web::patch;
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, post, HttpResponse};
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
 use chrono::NaiveDate;
 use chrono::Utc;
 use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use super::scenario;
+use crate::decl_paginated_response;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::List;
+use crate::modelsv2::Changeset;
+use crate::modelsv2::Create;
+use crate::modelsv2::DeleteStatic;
+use crate::modelsv2::Model;
+use crate::modelsv2::Project;
+use crate::modelsv2::Study;
+use crate::modelsv2::Tags;
+use crate::modelsv2::Update;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::views::projects::ProjectError;
+use crate::views::projects::ProjectIdParam;
+use crate::views::projects::QueryParams;
+use crate::DbPool;
 
 crate::routes! {
     "/studies" => {
@@ -390,17 +405,24 @@ async fn patch(
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, project, study_fixture_set, StudyFixtureSet, TestFixture,
-    };
-    use crate::modelsv2::{DeleteStatic, Project, Study};
-    use crate::views::tests::create_test_service;
     use actix_http::Request;
     use actix_web::http::StatusCode;
-    use actix_web::test::{call_service, read_body_json, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::read_body_json;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::project;
+    use crate::fixtures::tests::study_fixture_set;
+    use crate::fixtures::tests::StudyFixtureSet;
+    use crate::fixtures::tests::TestFixture;
+    use crate::modelsv2::DeleteStatic;
+    use crate::modelsv2::Project;
+    use crate::modelsv2::Study;
+    use crate::views::tests::create_test_service;
 
     fn easy_study_url(study_fixture_set: &StudyFixtureSet, detail: bool) -> String {
         format!(

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,23 +1,27 @@
 use std::collections::HashMap;
 
-use crate::core::conflicts::{ConflicDetectionRequest, TrainRequirement};
-
-use crate::core::{AsCoreRequest, CoreClient};
-use crate::error::Result;
-
-use crate::models::{
-    Retrieve, SimulationOutput, Timetable, TimetableWithSchedulesDetails, TrainSchedule,
-};
-
-use crate::views::train_schedule::TrainScheduleError;
-use crate::DbPool;
 use actix_web::get;
-use actix_web::web::{Data, Json, Path};
-
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use utoipa::ToSchema;
+
+use crate::core::conflicts::ConflicDetectionRequest;
+use crate::core::conflicts::TrainRequirement;
+use crate::core::AsCoreRequest;
+use crate::core::CoreClient;
+use crate::error::Result;
+use crate::models::Retrieve;
+use crate::models::SimulationOutput;
+use crate::models::Timetable;
+use crate::models::TimetableWithSchedulesDetails;
+use crate::models::TrainSchedule;
+use crate::views::train_schedule::TrainScheduleError;
+use crate::DbPool;
 
 mod import;
 
@@ -94,9 +98,13 @@ pub async fn get_simulated_schedules_from_timetable(
     db_pool: Data<DbPool>,
 ) -> Result<(Vec<TrainSchedule>, Vec<SimulationOutput>)> {
     let mut conn = db_pool.get().await?;
-    use crate::tables::train_schedule;
-    use diesel::{BelongingToDsl, ExpressionMethods, GroupedBy, QueryDsl};
+    use diesel::BelongingToDsl;
+    use diesel::ExpressionMethods;
+    use diesel::GroupedBy;
+    use diesel::QueryDsl;
     use diesel_async::RunQueryDsl;
+
+    use crate::tables::train_schedule;
 
     let train_schedules = train_schedule::table
         .filter(train_schedule::timetable_id.eq(timetable_id))
@@ -223,17 +231,17 @@ async fn get_conflicts(
 pub mod test {
 
     use actix_http::StatusCode;
-    use actix_web::test::{call_service, TestRequest};
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
 
-    use crate::{
-        assert_status_and_read,
-        fixtures::tests::{
-            db_pool, get_other_rolling_stock_form, train_with_simulation_output_fixture_set,
-        },
-        models::{train_schedule::TrainScheduleValidation, TimetableWithSchedulesDetails},
-        views::tests::create_test_service,
-    };
+    use crate::assert_status_and_read;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::get_other_rolling_stock_form;
+    use crate::fixtures::tests::train_with_simulation_output_fixture_set;
+    use crate::models::train_schedule::TrainScheduleValidation;
+    use crate::models::TimetableWithSchedulesDetails;
+    use crate::views::tests::create_test_service;
 
     #[rstest]
     async fn newer_rolling_stock_version() {

--- a/editoast/src/views/timetable/import.rs
+++ b/editoast/src/views/timetable/import.rs
@@ -1,29 +1,48 @@
-use crate::modelsv2::{OperationalPointModel, RetrieveBatch};
-use crate::schema::OperationalPointPart;
-use crate::views::timetable::TimetableError;
-use crate::{core::CoreClient, views::timetable::Path, DbPool};
-use actix_web::{post, web::Data};
-use chrono::{DateTime, Utc};
-use diesel_async::AsyncPgConnection;
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use crate::core::pathfinding::{PathfindingRequest, PathfindingWaypoints, Waypoint};
-use crate::core::simulation::{CoreTrainSchedule, SimulationRequest, TrainStop};
-use crate::core::AsCoreRequest;
-use crate::error::{InternalError, Result};
-use crate::models::{Pathfinding, ScheduledPoint, Timetable, TrainSchedule};
-use crate::modelsv2::{prelude::*, Infra, RollingStockModel};
-use crate::schema::rolling_stock::{RollingStock, RollingStockComfortType};
-use crate::views::infra::{call_core_infra_state, InfraApiError, InfraState};
-use crate::views::pathfinding::save_core_pathfinding;
-use crate::views::train_schedule::process_simulation_response;
+use actix_web::post;
+use actix_web::web::Data;
 use actix_web::web::Json;
+use chrono::DateTime;
 use chrono::Timelike;
+use chrono::Utc;
+use diesel_async::AsyncPgConnection;
 use futures::future::try_join_all;
-
+use serde::Deserialize;
+use serde::Serialize;
 use utoipa::ToSchema;
+
+use crate::core::pathfinding::PathfindingRequest;
+use crate::core::pathfinding::PathfindingWaypoints;
+use crate::core::pathfinding::Waypoint;
+use crate::core::simulation::CoreTrainSchedule;
+use crate::core::simulation::SimulationRequest;
+use crate::core::simulation::TrainStop;
+use crate::core::AsCoreRequest;
+use crate::core::CoreClient;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::Pathfinding;
+use crate::models::ScheduledPoint;
+use crate::models::Timetable;
+use crate::models::TrainSchedule;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
+use crate::modelsv2::OperationalPointModel;
+use crate::modelsv2::RetrieveBatch;
+use crate::modelsv2::RollingStockModel;
+use crate::schema::rolling_stock::RollingStock;
+use crate::schema::rolling_stock::RollingStockComfortType;
+use crate::schema::OperationalPointPart;
+use crate::views::infra::call_core_infra_state;
+use crate::views::infra::InfraApiError;
+use crate::views::infra::InfraState;
+use crate::views::pathfinding::save_core_pathfinding;
+use crate::views::timetable::Path;
+use crate::views::timetable::TimetableError;
+use crate::views::train_schedule::process_simulation_response;
+use crate::DbPool;
 
 crate::routes! {
     post_timetable,
@@ -560,9 +579,8 @@ fn build_simulation_request(
 
 #[cfg(test)]
 mod tests {
-    use crate::schema::utils::Identifier;
-
     use super::*;
+    use crate::schema::utils::Identifier;
 
     #[test]
     fn test_waypoints_from_steps() {

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::models::PathfindingPayload;
-use crate::schema::{utils::Identifier, DirectionalTrackRange};
-use serde::{Deserialize, Serialize};
+use crate::schema::utils::Identifier;
+use crate::schema::DirectionalTrackRange;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Projection {

--- a/editoast/src/views/train_schedule/simulation_report.rs
+++ b/editoast/src/views/train_schedule/simulation_report.rs
@@ -1,30 +1,40 @@
-use crate::{
-    core::{
-        simulation::{SignalProjectionRequest, SignalUpdate},
-        AsCoreRequest, CoreClient,
-    },
-    error,
-    models::{
-        train_schedule::{ElectrificationRange, Mrsp, SimulationPowerRestrictionRange},
-        Curve, FullResultStops, PathWaypoint, Pathfinding, PathfindingPayload, ResultPosition,
-        ResultSpeed, ResultStops, ResultTrain, Retrieve, SimulationOutput,
-        SimulationOutputChangeset, Slope, TrainSchedule,
-    },
-    modelsv2::RollingStockModel,
-    schema::utils::Identifier,
-    views::{
-        pathfinding::make_track_map,
-        train_schedule::{projection::Projection, TrainScheduleError::UnsimulatedTrainSchedule},
-    },
-    DbPool,
-};
-
 use actix_web::web::Data;
-use diesel::{ExpressionMethods, QueryDsl};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
 use futures::future::OptionFuture;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
 use utoipa::ToSchema;
+
+use crate::core::simulation::SignalProjectionRequest;
+use crate::core::simulation::SignalUpdate;
+use crate::core::AsCoreRequest;
+use crate::core::CoreClient;
+use crate::error;
+use crate::models::train_schedule::ElectrificationRange;
+use crate::models::train_schedule::Mrsp;
+use crate::models::train_schedule::SimulationPowerRestrictionRange;
+use crate::models::Curve;
+use crate::models::FullResultStops;
+use crate::models::PathWaypoint;
+use crate::models::Pathfinding;
+use crate::models::PathfindingPayload;
+use crate::models::ResultPosition;
+use crate::models::ResultSpeed;
+use crate::models::ResultStops;
+use crate::models::ResultTrain;
+use crate::models::Retrieve;
+use crate::models::SimulationOutput;
+use crate::models::SimulationOutputChangeset;
+use crate::models::Slope;
+use crate::models::TrainSchedule;
+use crate::modelsv2::RollingStockModel;
+use crate::schema::utils::Identifier;
+use crate::views::pathfinding::make_track_map;
+use crate::views::train_schedule::projection::Projection;
+use crate::views::train_schedule::TrainScheduleError::UnsimulatedTrainSchedule;
+use crate::DbPool;
 
 crate::schemas! {
     SimulationReport,

--- a/editoast/src/views/v2/path.rs
+++ b/editoast/src/views/v2/path.rs
@@ -2,15 +2,17 @@ mod pathfinding;
 mod properties;
 
 use diesel_async::AsyncPgConnection as PgConnection;
-use serde::{Deserialize, Serialize};
+use editoast_derive::EditoastError;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::error::Result;
-use crate::modelsv2::{prelude::*, Infra};
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::Infra;
 use crate::schema::utils::Identifier;
 use crate::schema::Direction;
-use editoast_derive::EditoastError;
-use thiserror::Error;
 
 /// Expiration time for the cache of the pathfinding and path properties.
 /// Note: 604800 seconds = 1 week

--- a/editoast/src/views/v2/path/pathfinding.rs
+++ b/editoast/src/views/v2/path/pathfinding.rs
@@ -1,25 +1,34 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use diesel_async::AsyncPgConnection as PgConnection;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
 use super::CACHE_PATH_EXPIRATION;
 use crate::error::Result;
-use crate::modelsv2::{
-    OperationalPointModel, RetrieveBatch, RetrieveBatchUnchecked, TrackSectionModel,
-};
-use crate::redis_utils::{RedisClient, RedisConnection};
+use crate::modelsv2::OperationalPointModel;
+use crate::modelsv2::RetrieveBatch;
+use crate::modelsv2::RetrieveBatchUnchecked;
+use crate::modelsv2::TrackSectionModel;
+use crate::redis_utils::RedisClient;
+use crate::redis_utils::RedisConnection;
 use crate::schema::operational_point::OperationalPoint;
 use crate::schema::track_section::LoadingGaugeType;
 use crate::schema::utils::Identifier;
 use crate::schema::v2::trainschedule::PathItemLocation;
 use crate::schema::TrackOffset;
 use crate::views::get_app_version;
-use crate::views::v2::path::{retrieve_infra_version, TrackRange};
+use crate::views::v2::path::retrieve_infra_version;
+use crate::views::v2::path::TrackRange;
 use crate::DbPool;
-use actix_web::post;
-use actix_web::web::{Data, Json, Path};
-use diesel_async::AsyncPgConnection as PgConnection;
-use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
-use utoipa::ToSchema;
 
 type TrackOffsetResult = std::result::Result<Vec<Vec<TrackOffset>>, PathfindingResult>;
 

--- a/editoast/src/views/v2/scenario.rs
+++ b/editoast/src/views/v2/scenario.rs
@@ -1,29 +1,45 @@
-use crate::decl_paginated_response;
-use crate::error::{InternalError, Result};
-use crate::models::train_schedule::LightTrainSchedule;
-use crate::models::List;
-use crate::modelsv2::{
-    prelude::*,
-    scenario::{Scenario, ScenarioWithDetails},
-    timetable::Timetable,
-    Infra, Project, Study, Tags,
-};
-use crate::views::pagination::{PaginatedResponse, PaginationQueryParam};
-use crate::views::projects::{ProjectIdParam, QueryParams};
-use crate::views::scenario::{check_project_study, check_project_study_conn, ScenarioIdParam};
-use crate::views::study::StudyIdParam;
-use crate::DbPool;
-
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, patch, post, HttpResponse};
+use actix_web::delete;
+use actix_web::get;
+use actix_web::patch;
+use actix_web::post;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
 use chrono::Utc;
 use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
+use crate::decl_paginated_response;
+use crate::error::InternalError;
+use crate::error::Result;
+use crate::models::train_schedule::LightTrainSchedule;
+use crate::models::List;
+use crate::modelsv2::prelude::*;
+use crate::modelsv2::scenario::Scenario;
+use crate::modelsv2::scenario::ScenarioWithDetails;
+use crate::modelsv2::timetable::Timetable;
+use crate::modelsv2::Infra;
+use crate::modelsv2::Project;
+use crate::modelsv2::Study;
+use crate::modelsv2::Tags;
+use crate::views::pagination::PaginatedResponse;
+use crate::views::pagination::PaginationQueryParam;
+use crate::views::projects::ProjectIdParam;
+use crate::views::projects::QueryParams;
+use crate::views::scenario::check_project_study;
+use crate::views::scenario::check_project_study_conn;
+use crate::views::scenario::ScenarioIdParam;
+use crate::views::study::StudyIdParam;
+use crate::DbPool;
 
 crate::routes! {
     "/v2/projects/{project_id}/studies/{study_id}/scenarios" => {
@@ -402,17 +418,23 @@ async fn list(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, scenario_v2_fixture_set, small_infra, timetable_v2, ScenarioV2FixtureSet,
-        TestFixture,
-    };
-    use crate::modelsv2::{timetable::Timetable as TimetableV2, Infra};
-    use crate::views::tests::create_test_service;
     use actix_web::http::StatusCode;
-    use actix_web::test::{call_and_read_body_json, call_service, TestRequest};
+    use actix_web::test::call_and_read_body_json;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::scenario_v2_fixture_set;
+    use crate::fixtures::tests::small_infra;
+    use crate::fixtures::tests::timetable_v2;
+    use crate::fixtures::tests::ScenarioV2FixtureSet;
+    use crate::fixtures::tests::TestFixture;
+    use crate::modelsv2::timetable::Timetable as TimetableV2;
+    use crate::modelsv2::Infra;
+    use crate::views::tests::create_test_service;
 
     pub fn scenario_url(project_id: i64, study_id: i64, scenario_id: Option<i64>) -> String {
         format!(

--- a/editoast/src/views/v2/timetable.rs
+++ b/editoast/src/views/v2/timetable.rs
@@ -1,25 +1,39 @@
+use actix_web::delete;
+use actix_web::get;
+use actix_web::post;
+use actix_web::put;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
+use chrono::DateTime;
+use chrono::Utc;
+use derivative::Derivative;
+use editoast_derive::EditoastError;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
 use crate::decl_paginated_response;
 use crate::error::Result;
 use crate::models::List;
 use crate::models::NoParams;
-use crate::modelsv2::timetable::{Timetable, TimetableWithTrains};
-use crate::modelsv2::{Create, DeleteStatic, Model, Retrieve, Update};
+use crate::modelsv2::timetable::Timetable;
+use crate::modelsv2::timetable::TimetableWithTrains;
+use crate::modelsv2::Create;
+use crate::modelsv2::DeleteStatic;
+use crate::modelsv2::Model;
+use crate::modelsv2::Retrieve;
+use crate::modelsv2::Update;
 use crate::views::pagination::PaginatedResponse;
 use crate::views::pagination::PaginationQueryParam;
 use crate::views::timetable::ConflictType;
 use crate::CoreClient;
 use crate::DbPool;
 use crate::RedisClient;
-
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, post, put, HttpResponse};
-use chrono::DateTime;
-use chrono::Utc;
-use derivative::Derivative;
-use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
 
 crate::routes! {
     "/v2/timetable" => {
@@ -268,13 +282,18 @@ pub async fn conflicts(
 #[cfg(test)]
 mod tests {
 
-    use super::*;
-    use crate::fixtures::tests::{db_pool, timetable_v2, TestFixture};
-    use crate::modelsv2::Delete;
-    use crate::views::tests::create_test_service;
-    use actix_web::test::{call_and_read_body_json, call_service, TestRequest};
+    use actix_web::test::call_and_read_body_json;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::timetable_v2;
+    use crate::fixtures::tests::TestFixture;
+    use crate::modelsv2::Delete;
+    use crate::views::tests::create_test_service;
 
     #[rstest]
     async fn get_timetable(#[future] timetable_v2: TestFixture<Timetable>, db_pool: Data<DbPool>) {

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -1,23 +1,36 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use actix_web::delete;
+use actix_web::get;
+use actix_web::post;
+use actix_web::put;
+use actix_web::web::Data;
+use actix_web::web::Json;
+use actix_web::web::Path;
+use actix_web::web::Query;
+use actix_web::HttpResponse;
+use editoast_derive::EditoastError;
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_qs::actix::QsQuery;
+use thiserror::Error;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
+
 use crate::core::CoreClient;
 use crate::error::Result;
 use crate::models::RoutingRequirement;
 use crate::models::SpacingRequirement;
-use crate::modelsv2::train_schedule::{TrainSchedule, TrainScheduleChangeset};
+use crate::modelsv2::train_schedule::TrainSchedule;
+use crate::modelsv2::train_schedule::TrainScheduleChangeset;
 use crate::modelsv2::Model;
 use crate::schema::utils::Identifier;
 use crate::schema::v2::trainschedule::Distribution;
 use crate::schema::v2::trainschedule::TrainScheduleBase;
-
-use crate::{DbPool, RedisClient};
-use actix_web::web::{Data, Json, Path, Query};
-use actix_web::{delete, get, post, put, HttpResponse};
-use editoast_derive::EditoastError;
-use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use serde_qs::actix::QsQuery;
-use std::collections::{HashMap, HashSet};
-use thiserror::Error;
-use utoipa::{IntoParams, ToSchema};
+use crate::DbPool;
+use crate::RedisClient;
 
 crate::routes! {
     "/v2/train_schedule" => {
@@ -471,16 +484,22 @@ pub async fn simulations_summary(
 #[cfg(test)]
 mod tests {
 
-    use super::*;
-    use crate::fixtures::tests::{
-        db_pool, timetable_v2, train_schedule_v2, TestFixture, TrainScheduleV2FixtureSet,
-    };
-    use crate::modelsv2::timetable::Timetable;
-    use crate::modelsv2::{Delete, DeleteStatic};
-    use crate::views::tests::create_test_service;
-    use actix_web::test::{call_and_read_body_json, call_service, TestRequest};
+    use actix_web::test::call_and_read_body_json;
+    use actix_web::test::call_service;
+    use actix_web::test::TestRequest;
     use rstest::rstest;
     use serde_json::json;
+
+    use super::*;
+    use crate::fixtures::tests::db_pool;
+    use crate::fixtures::tests::timetable_v2;
+    use crate::fixtures::tests::train_schedule_v2;
+    use crate::fixtures::tests::TestFixture;
+    use crate::fixtures::tests::TrainScheduleV2FixtureSet;
+    use crate::modelsv2::timetable::Timetable;
+    use crate::modelsv2::Delete;
+    use crate::modelsv2::DeleteStatic;
+    use crate::views::tests::create_test_service;
 
     #[rstest]
     async fn get_trainschedule(


### PR DESCRIPTION
Can be configured with `rustfmt.toml` with the following options:

```
unstable_features = true
group_imports = "StdExternalCrate"
imports_granularity = "Item"
```

Then `cargo +nightly fmt`.

Note that we do not enforce that styling in CI for now since that would impose using `nightly` (necessary for unstable features) on developers.