### PR TITLE
core, editoast, gateway: add taplo to the CI checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,6 +292,19 @@ jobs:
           cd python/osrd_schemas
           poetry run pytype -j auto
 
+  check_toml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install taplo
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: taplo-cli
+          locked: true
+      - name: Check TOML format
+        run: taplo fmt --check --diff
+
   check_infra_schema_sync:
     runs-on: ubuntu-latest
     steps:

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,24 @@
+[formatting]
+align_comments = false
+reorder_arrays = true
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["dependencies", "dev-dependencies", "workspace.dependencies"]
+
+[rule.formatting]
+reorder_keys = true
+
+[[rule]]
+include = ["libs.versions.toml"]
+keys = ["librairies", "plugins", "versions"]
+
+[rule.formatting]
+reorder_keys = true
+
+[[rule]]
+include = ["**/pyproject.toml"]
+keys = ["tool.poetry.dependencies", "tool.poetry.group.dev.dependencies"]
+
+[rule.formatting]
+reorder_keys = true

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -25,43 +25,43 @@ otel = '1.34.1'
 
 [libraries]
 # kotlin stuff
-kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib', version.ref = 'kotlin' }  # Apache 2.0
-kotlin-logging = { module = 'io.github.microutils:kotlin-logging', version = '3.0.5' }  # Apache 2.0
-kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' }  # Apache 2.0
-kotlin-test = { module = 'org.jetbrains.kotlin:kotlin-test', version.ref = 'kotlin' }  # Apache 2.0
-kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' }  # Apache 2.0
-kotlinx-coroutines-test = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-test', version.ref = 'kotlinx-coroutines' }  # Apache 2.0
-ksp-symbol-processing-api = { module = 'com.google.devtools.ksp:symbol-processing-api', version.ref = 'ksp' }  # Apache 2.0
+kotlin-stdlib = { module = 'org.jetbrains.kotlin:kotlin-stdlib', version.ref = 'kotlin' } # Apache 2.0
+kotlin-logging = { module = 'io.github.microutils:kotlin-logging', version = '3.0.5' } # Apache 2.0
+kotlin-reflect = { module = 'org.jetbrains.kotlin:kotlin-reflect', version.ref = 'kotlin' } # Apache 2.0
+kotlin-test = { module = 'org.jetbrains.kotlin:kotlin-test', version.ref = 'kotlin' } # Apache 2.0
+kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' } # Apache 2.0
+kotlinx-coroutines-test = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-test', version.ref = 'kotlinx-coroutines' } # Apache 2.0
+ksp-symbol-processing-api = { module = 'com.google.devtools.ksp:symbol-processing-api', version.ref = 'ksp' } # Apache 2.0
 
 # common
-logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback' }  # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
-logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback' }  # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
+logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback' } # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
+logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback' } # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
 
 # java stuff
-guava = { module = 'com.google.guava:guava', version = '33.0.0-jre' }  # Apache 2.0
-jcommander = { module = 'com.beust:jcommander', version = '1.82' }  # Apache 2.0
-hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' }  # Apache 2.0
-moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' }  # Apache 2.0
-moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' }  # Apache 2.0
-moshi-kotlin = { module = 'com.squareup.moshi:moshi-kotlin', version.ref = 'moshi'} # Apache 2.0
-takes = { module = 'org.takes:takes', version = '1.24.+' }  # MIT
-javax-json-api = { module = 'javax.json:javax.json-api', version = '1.1.4' }  # GPLv2 with classpath exemption
-okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.12.0' }  # Apache 2.0
-classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' }  # MIT
-jmathplot = { module = 'com.github.yannrichet:JMathPlot', version = '1.0.1' }  # BSD
-slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' }  # MIT
-sentry = { module = 'io.sentry:sentry', version = '7.3.+' }  # MIT
-junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }  # EPL 2.0
-junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' }  # EPL 2.0
-junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }  # EPL 2.0
-assertj = { module = 'org.assertj:assertj-core', version = '3.25.3'}  # Apache 2.0
-jqwik = { module = 'net.jqwik:jqwik', version = '1.8.+' }  # EPL 2.0
-mockito-inline = { module = 'org.mockito:mockito-inline', version.ref = 'mockito' }  # MIT
-mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.ref = 'mockito'  }  # MIT
-junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.10.+' }  # EPL 2.0
-jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' }  # CC Attribution
-spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' }  # LGPLv2.1
-geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' }  # Apache 2.0
+guava = { module = 'com.google.guava:guava', version = '33.0.0-jre' } # Apache 2.0
+jcommander = { module = 'com.beust:jcommander', version = '1.82' } # Apache 2.0
+hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' } # Apache 2.0
+moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' } # Apache 2.0
+moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' } # Apache 2.0
+moshi-kotlin = { module = 'com.squareup.moshi:moshi-kotlin', version.ref = 'moshi' } # Apache 2.0
+takes = { module = 'org.takes:takes', version = '1.24.+' } # MIT
+javax-json-api = { module = 'javax.json:javax.json-api', version = '1.1.4' } # GPLv2 with classpath exemption
+okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.12.0' } # Apache 2.0
+classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' } # MIT
+jmathplot = { module = 'com.github.yannrichet:JMathPlot', version = '1.0.1' } # BSD
+slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' } # MIT
+sentry = { module = 'io.sentry:sentry', version = '7.3.+' } # MIT
+junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' } # EPL 2.0
+junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' } # EPL 2.0
+junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' } # EPL 2.0
+assertj = { module = 'org.assertj:assertj-core', version = '3.25.3' } # Apache 2.0
+jqwik = { module = 'net.jqwik:jqwik', version = '1.8.+' } # EPL 2.0
+mockito-inline = { module = 'org.mockito:mockito-inline', version.ref = 'mockito' } # MIT
+mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.ref = 'mockito' } # MIT
+junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.10.+' } # EPL 2.0
+jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' } # CC Attribution
+spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' } # LGPLv2.1
+geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' } # Apache 2.0
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
 opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.2.0' }

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -5,99 +5,99 @@ edition = "2021"
 license = "LGPL-3.0"
 
 [workspace]
-members = [".", "editoast_derive", "editoast_common", "editoast_schemas"]
+members = [".", "editoast_common", "editoast_derive", "editoast_schemas"]
 
 [workspace.dependencies]
 rangemap = "1.4.0"
 serde = "1.0.195"
 serde_derive = "1.0.195"
 serde_json = "1.0.115"
-utoipa = { version = "4.2.0", features = ["actix_extras", "chrono", "uuid"] }
 strum = { version = "0.26.2", features = ["derive"] }
+utoipa = { version = "4.2.0", features = ["actix_extras", "chrono", "uuid"] }
 
 [dependencies]
 # For batch dependcy updates see https://osrd.fr/en/docs/guides/contribute/batch-updating-dependencies/
 
+actix-cors = "0.7.0"
+actix-files = "0.6.5"
+actix-http = "3.6.0"
+actix-multipart = "0.6.1"
+actix-web = "4.4.1"
+actix-web-opentelemetry = { version = "0.17.0", features = ["awc"] }
 async-trait = "0.1.79"
+cfg-if = "1.0.0"
 chashmap = "2.2.2"
+chrono = { version = "0.4.37", features = ["serde"] }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 colored = "2.1.0"
-chrono = { version = "0.4.37", features = ["serde"] }
 derivative = "2.2.0"
-uuid = { version = "1.8.0", features = ["v4"] }
 diesel = { version = "2.1.5", features = [
-    "postgres",
-    "serde_json",
-    "chrono",
-    "uuid",
+  "chrono",
+  "postgres",
+  "serde_json",
+  "uuid",
 ] }
-diesel-async = { version = "0.4.1", features = ["postgres", "deadpool"] }
-tokio = "*"
-tokio-postgres = "*"
-postgres-openssl = "0.5.0"
-openssl = "*"
-futures-util = "*"
+diesel-async = { version = "0.4.1", features = ["deadpool", "postgres"] }
 diesel_json = "0.2.1"
+editoast_common = { path = "./editoast_common" }
+editoast_derive = { path = "./editoast_derive" }
+editoast_schemas = { path = "./editoast_schemas" }
+enum-map = "2.7.3"
+enumset = "1.1.3"
+futures = "0.3.30"
+futures-util = "*"
+geos = { version = "8.3.1", features = ["json"] }
+heck = "0.5.0"
 image = "0.25.1"
+inventory = "0.3"
+iso8601 = "0.6.1"
+itertools = "0.12.0"
 json-patch = "1.2.0"
+mvt = "0.9.0"
+openssl = "*"
+opentelemetry = "0.21.0"
+opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
+opentelemetry-otlp = "0.14.0"
+opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "trace"] }
+osm4routing = "0.6.1"
+osmpbfreader = "0.16.1"
+paste = "1.0.14"
 pathfinding = "4.8.2"
+postgis_diesel = { version = "2.3.0", features = ["serde"] }
+postgres-openssl = "0.5.0"
 rand = "0.8.5"
-actix-files = "0.6.5"
-actix-web = "4.4.1"
-actix-http = "3.6.0"
-actix-cors = "0.7.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing = { version = "0.1.40", features = ["log"] }
+rangemap.workspace = true
 redis = { version = "0.25.2", features = [
-    "tokio-comp",
-    "connection-manager",
-    "cluster-async",
-    "tokio-native-tls-comp",
+  "cluster-async",
+  "connection-manager",
+  "tokio-comp",
+  "tokio-native-tls-comp",
 ] }
+reqwest = { version = "0.11.23", features = ["json"] }
 sentry = "0.32.1"
 sentry-actix = "0.32.1"
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-strum.workspace = true
+serde_qs = { version = "0.12.0", features = ["actix4"] }
 serde_yaml = "0.9.34"
 sha1 = "0.10"
+strum.workspace = true
 thiserror = "1.0.58"
-enum-map = "2.7.3"
-editoast_derive = { path = "./editoast_derive" }
-editoast_schemas = { path = "./editoast_schemas" }
-editoast_common = { path = "./editoast_common" }
-mvt = "0.9.0"
-futures = "0.3.30"
-postgis_diesel = { version = "2.3.0", features = ["serde"] }
-geos = { version = "8.3.1", features = ["json"] }
-rangemap.workspace = true
-actix-multipart = "0.6.1"
-reqwest = { version = "0.11.23", features = ["json"] }
-osm4routing = "0.6.1"
-osmpbfreader = "0.16.1"
-itertools = "0.12.0"
-utoipa.workspace = true
-paste = "1.0.14"
-url = "2.5.0"
-cfg-if = "1.0.0"
-validator = { version = "0.17.0", features = ["derive"] }
-inventory = "0.3"
-heck = "0.5.0"
-iso8601 = "0.6.1"
-opentelemetry = "0.21.0"
-opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "trace"] }
-opentelemetry-otlp = "0.14.0"
-opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
-opentelemetry-semantic-conventions = "0.14.0"
+tokio = "*"
+tokio-postgres = "*"
+tracing = { version = "0.1.40", features = ["log"] }
 tracing-opentelemetry = "0.22.0"
-actix-web-opentelemetry = { version = "0.17.0", features = ["awc"] }
-serde_qs = { version = "0.12.0", features = ["actix4"] }
-enumset = "1.1.3"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+url = "2.5.0"
+utoipa.workspace = true
+uuid = { version = "1.8.0", features = ["v4"] }
+validator = { version = "0.17.0", features = ["derive"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
-rstest = "0.18.2"
-tempfile = "3.9.0"
 pretty_assertions = "1.4.0"
+rstest = "0.18.2"
 serial_test = "3.0.0"
+tempfile = "3.9.0"

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -27,7 +27,7 @@ FROM base_builder AS test_builder
 RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
     rustup component add clippy && \
-    cargo install grcov
+    cargo install --locked grcov
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/editoast_derive/ editoast_derive
 COPY --from=test_data . /tests/data

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -46,6 +46,7 @@ cargo test -- --test-threads=4
 Here a list of components to help you in your development (see CI jobs if necessary):
 
 - [rustfmt](https://github.com/rust-lang/rustfmt): Format the whole code `cargo fmt`
+- [taplo](https://taplo.tamasfe.dev/): Format the TOML files with `taplo fmt`
 - [clippy](https://github.com/rust-lang/rust-clippy): Run a powerful linter `cargo clippy --all-features --all-targets -- -D warnings`
 - [grcov](https://github.com/mozilla/grcov): Check code coverage (see documentation on GitHub)
 
@@ -53,6 +54,12 @@ To install `rustfmt` and `clippy`, simply run:
 
 ```sh
 rustup component add rustfmt clippy
+```
+
+To install `taplo`, run:
+
+```sh
+cargo install --locked taplo-cli
 ```
 
 To setup `grcov`, please see [its documentation](https://github.com/mozilla/grcov#how-to-get-grcov)

--- a/editoast/diesel.toml
+++ b/editoast/diesel.toml
@@ -5,7 +5,7 @@
 file = "src/tables.rs"
 generate_missing_sql_type_definitions = false
 filter = { except_tables = ["spatial_ref_sys"] }
-import_types = ["diesel::sql_types::*","postgis_diesel::sql_types::*"]
+import_types = ["diesel::sql_types::*", "postgis_diesel::sql_types::*"]
 
 [migrations_directory]
 dir = "migrations"

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "2.0"
-quote = "1.0"
-proc-macro2 = "1.0"
 darling = "0.20"
+proc-macro2 = "1.0"
+quote = "1.0"
 serde_json.workspace = true
+syn = "2.0"
 
 [lib]
 proc-macro = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -6,75 +6,80 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = [".", "actix_proxy", "actix_auth"]
+members = [".", "actix_auth", "actix_proxy"]
 # used for cargo test, build, fix, package, bench, doc, tree
-default-members = [".", "actix_proxy", "actix_auth"]
+default-members = [".", "actix_auth", "actix_proxy"]
 
 [workspace.dependencies]
 # common utils
-log = "0.4.20"
-env_logger = "0.10.2"
-either = "1.9.0"
-thiserror = "1.0.53"
 dyn-clone = "1.0.16"
-futures-util = "0.3.30"
+either = "1.9.0"
+env_logger = "0.10.2"
 futures = "0.3.29"
+futures-util = "0.3.30"
+log = "0.4.20"
 smallvec = "1.13.1"
+thiserror = "1.0.53"
 
 # main crate
+actix-files = "0.6.5"
+actix-session = "0.8"
+actix-web = "4.4.1"
+actix-web-opentelemetry = { version = "0.16.0", features = ["awc", "metrics"] }
+base64ct = "1.6.0"
 figment = "0.10.14"
-serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.109"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
-actix-web = "4.4.1"
-actix-session = "0.8"
-actix-files = "0.6.5"
-base64ct = "1.6.0"
 opentelemetry = "0.21.0"
-opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio-current-thread", "metrics"] }
 opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
 opentelemetry-otlp = "0.14.0"
-actix-web-opentelemetry = { version = "0.16.0", features = ["awc", "metrics"] }
+opentelemetry_sdk = { version = "0.21.2", features = [
+  "metrics",
+  "rt-tokio-current-thread",
+] }
+serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.109"
 
 # reverse proxy dependencies
-ipnet = "2.9"
-awc = { version = "3.3.0", features = ["rustls"] }  # the http / ws client
 actix = "0.13.3"
 actix-web-actors = "4.2.0"
+awc = { version = "3.3.0", features = ["rustls"] } # the http / ws client
 bytestring = "1.3.1"
-phf = "0.11.2"
+ipnet = "2.9"
 percent-encoding = "2.3.1"
+phf = "0.11.2"
 
 # actix_auth
-reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls-native-roots"] }
-openidconnect = { version = "3.5.0", default-features = false }
-url = "2.5.0"
 actix-web-httpauth = "0.8"
+openidconnect = { version = "3.5.0", default-features = false }
+reqwest = { version = "0.11.24", default-features = false, features = [
+  "rustls-tls-native-roots",
+] }
+url = "2.5.0"
 
 
 [dependencies]
-log.workspace = true
-env_logger.workspace = true
 either.workspace = true
+env_logger.workspace = true
+log.workspace = true
 
 # configuration parsing
-figment = { workspace = true, features = ["toml", "env"] }
-serde.workspace = true
-base64ct.workspace = true  # to parse the session secret key
+base64ct.workspace = true # to parse the session secret key
+figment = { workspace = true, features = ["env", "toml"] }
 humantime.workspace = true
 humantime-serde.workspace = true
+serde.workspace = true
 
 # web server
-actix-web.workspace = true
 actix-files.workspace = true
 actix-session = { workspace = true, features = ["cookie-session"] }
+actix-web.workspace = true
 actix_auth = { path = "./actix_auth" }
 actix_proxy = { path = "./actix_proxy" }
 
 # tracing / metrics
-opentelemetry.workspace = true
-opentelemetry_sdk.workspace = true
-opentelemetry-otlp.workspace = true
-opentelemetry-datadog.workspace = true
 actix-web-opentelemetry.workspace = true
+opentelemetry.workspace = true
+opentelemetry-datadog.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo install --locked --path .
 FROM chef AS testing_env
 RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
-    cargo install grcov
+    cargo install --locked grcov
 COPY --from=planner /app/recipe.json recipe.json
 
 ENV RUSTFLAGS="-Cinstrument-coverage"

--- a/gateway/actix_auth/Cargo.toml
+++ b/gateway/actix_auth/Cargo.toml
@@ -10,17 +10,17 @@ edition = "2021"
 [dependencies]
 
 # common dependencies
-log.workspace = true
-actix-web.workspace = true
 actix-session.workspace = true
-serde.workspace = true
-thiserror.workspace = true
+actix-web.workspace = true
 dyn-clone.workspace = true
 futures-util.workspace = true
+log.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 
 # oidc
+openidconnect = { workspace = true, features = ["jwk-alg", "reqwest"] }
 reqwest = { workspace = true, features = ["json"] }
-openidconnect = { workspace = true, features = ["reqwest", "jwk-alg"] }
 url.workspace = true
 
 # bearer

--- a/gateway/actix_proxy/Cargo.toml
+++ b/gateway/actix_proxy/Cargo.toml
@@ -9,20 +9,20 @@ edition = "2021"
 
 [dependencies]
 # common dependencies
-log.workspace = true
-futures-util.workspace = true
 dyn-clone.workspace = true
 either.workspace = true
+futures-util.workspace = true
+log.workspace = true
 
 # common proxying infrastructure
 actix-web.workspace = true
+awc.workspace = true # the http / ws client
 ipnet.workspace = true
-awc.workspace = true  # the http / ws client
 percent-encoding.workspace = true
 
 # header classifier
-smallvec.workspace = true
 phf = { workspace = true, features = ["macros"] } # static hop-by-hop header map
+smallvec.workspace = true
 
 # websocket proxy
 actix.workspace = true
@@ -30,6 +30,6 @@ actix-web-actors.workspace = true
 bytestring.workspace = true
 
 # tracing / metrics
-opentelemetry.workspace = true
 actix-web-opentelemetry.workspace = true
+opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -5,15 +5,15 @@ description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-pydantic = "^2.1.1"
 geojson-pydantic = "^1.0.0"
+pydantic = "^2.1.1"
+python = ">=3.9,<3.12"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23"
 isort = "^5.12.0"
 pyproject-flake8 = "^6.0.0.post1"
-pytype = { platform="linux", version="^2023.10.17" }
+pytype = { platform = "linux", version = "^2023.10.17" }
 
 [tool.flake8]
 ignore = "W503,E203"

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -5,16 +5,16 @@ description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
 osrd-schemas = { path = "../osrd_schemas/", develop = false }
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
+python = ">=3.9,<3.12"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 isort = "^5.12.0"
 pyproject-flake8 = "^6.0.0.post1"
-pytype = { platform="linux", version="^2023.10.17" }
+pytype = { platform = "linux", version = "^2023.10.17" }
 
 [tool.flake8]
 ignore = "W503,E203"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -5,18 +5,18 @@ description = "Integration tests"
 authors = ["OSRD <contact@osrd.fr>"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
-requests = "^2.31.0"
 osrd-schemas = { path = "../python/osrd_schemas/", develop = true }
-railjson-generator = { path = "../python/railjson_generator/", develop = true }
 pytest = "^7.2.2"
 pytest-cov = "^4.1.0"
+python = ">=3.9,<3.12"
+railjson-generator = { path = "../python/railjson_generator/", develop = true }
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 isort = "^5.12.0"
 pyproject-flake8 = "^6.0.0.post1"
-pytype = { platform="linux", version="^2023.10.17" }
+pytype = { platform = "linux", version = "^2023.10.17" }
 
 [tool.flake8]
 ignore = "W503,E203"
@@ -31,7 +31,7 @@ profile = "black"
 multi_line_output = 3
 
 [tool.pytype]
-inputs = ["tests", "fuzzer", "infra-scripts"]
+inputs = ["fuzzer", "infra-scripts", "tests"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
`cargo tomlfmt` will check formatting of `Cargo.toml` files.

Note that even if the tool does a relatively useful job, it's pretty old meaning it doesn't support some recent syntax evolution in `Cargo.toml` like the following:

```
serde.workspace = true
```

but it's a minor inconvenient that can be bypass with the following

```
serde = { workspace = true }
```