### PR TITLE
editoast: make 'Result' more flexible

### DIFF
--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -19,7 +19,7 @@ crate::schemas! {
     InternalError,
 }
 
-pub type Result<T> = StdResult<T, InternalError>;
+pub type Result<T, E = InternalError> = StdResult<T, E>;
 
 /// Trait for all errors that can be returned by editoast
 pub trait EditoastError: Error + Send + Sync {


### PR DESCRIPTION
When defining a new `Result`, it's sometimes annoying having a `Result` available and trying to use it as `Result<T, E>` but actually, there is only one generic argument.

Replacing `type Result<T> = StdResult<T, InternalError>` by `type Result<T, E = InternalError> = StdResult<T, E>` keep the bonus of using a custom `Result` (always returning our `InternalError`) but leaving the possibility to opt-out easily by specifying the second generic argument.

Note: this seems to alleviate the CI problem on https://github.com/osrd-project/osrd/pull/6791. If someone is willing to dig more why these two seemingly unrelated things seem to interact, please do and share, I'm curious.