### PR TITLE
core: import signals directly from RailJSON

### DIFF
--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/Array.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/Array.kt
@@ -62,6 +62,46 @@ private fun CollectionItemType.generateArray(context: GeneratorContext, currentF
                     set(index.toInt(), value)
                 }
 
+                /**
+                 * Array must be sorted.
+                 * If the array contains the value, return its index.
+                 * Otherwise returns -(insertion offset) - 1, where insertion offset is
+                 * where to insert the new value to keep the array sorted.
+                 */
+                fun binarySearch(
+                    value: $type,
+                    comparator: ${simpleName}Comparator${paramsUse},
+                    fromIndex: Int,
+                    toIndex: Int,
+                ): Int {
+                    var low = fromIndex
+                    var high = toIndex - 1
+
+                    while (low <= high) {
+                        val mid = (low + high) ushr 1
+                        val midVal = data[mid]
+                        val cmp = comparator.compare(${storageType.fromPrimitive("midVal")}, value)
+
+                        if (cmp < 0)
+                            low = mid + 1
+                        else if (cmp > 0)
+                            high = mid - 1
+                        else
+                            return mid
+                    }
+                    return -(low + 1)
+                }
+
+                /**
+                 * Array must be sorted.
+                 * If the array contains the value, return its index.
+                 * Otherwise returns -(insertion offset) - 1, where insertion offset is
+                 * where to insert the new value to keep the array sorted.
+                 */
+                fun binarySearch(value: $type, comparator: ${simpleName}Comparator${paramsUse}): Int {
+                    return binarySearch(value, comparator, 0, data.size)
+                }
+
                 /** Creates an iterator over the elements of the array. */
                 operator fun iterator(): Iterator<$type> {
                     return object : Iterator<$type> {
@@ -144,6 +184,33 @@ private fun CollectionItemType.generateArray(context: GeneratorContext, currentF
 
                 fun copyOf(size: Int): ${simpleName}Array${paramsUse} {
                     return ${simpleName}Array${paramsUse}(data.copyOf(size))
+                }
+                fun binarySearch(
+                    value: $type,
+                    comparator: ${simpleName}Comparator${paramsUse},
+                    fromIndex: Int,
+                    toIndex: Int,
+                ): Int {
+                    var low = fromIndex
+                    var high = toIndex - 1
+
+                    while (low <= high) {
+                        val mid = (low + high) ushr 1
+                        val midVal = data[mid]
+                        val cmp = comparator.compare(${storageType.fromPrimitive("midVal")}, value)
+
+                        if (cmp < 0)
+                            low = mid + 1
+                        else if (cmp > 0)
+                            high = mid - 1
+                        else
+                            return mid
+                    }
+                    return -(low + 1)
+                }
+
+                fun binarySearch(value: $type, comparator: ${simpleName}Comparator${paramsUse}): Int {
+                    return binarySearch(value, comparator, 0, data.size)
                 }
 
                 /** Creates an iterator over the elements of the array. */

--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/Interfaces.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/Interfaces.kt
@@ -31,6 +31,10 @@ private fun CollectionItemType.generateInterfaces(context: GeneratorContext, cur
                 val size: Int
             }
 
+            fun interface ${simpleName}Comparator${paramsDecl} {
+                fun compare(a: $type, b: $type): Int
+            }
+
             /** GENERATED CODE */
             @Suppress("INAPPLICABLE_JVM_NAME")
             interface ${simpleName}List${paramsDecl} : ${simpleName}Collection${paramsUse} {

--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -3,16 +3,15 @@ package fr.sncf.osrd.signaling
 import fr.sncf.osrd.signaling.impl.MockSigSystemManager
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
 import fr.sncf.osrd.sim_infra.impl.blockInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.*
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 
 class BlockBuilderTest {
     @Test
@@ -28,9 +27,13 @@ class BlockBuilderTest {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilder()
+        val builder = rawInfraBuilder()
         // region switches
-        val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
+        val switch =
+            builder.movableElement("S", delay = 10L.milliseconds) {
+                config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
+            }
         // endregion
 
         // region zones

--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -60,13 +60,14 @@ class BlockBuilderTest {
         // endregion
 
         // region signals
+        // TODO: add actual track sections
         val parameters = RawSignalParameters(mapOf(Pair("jaune_cli", "false")), mapOf())
         val signalX =
-            builder.physicalSignal("X", 300.meters) {
+            builder.physicalSignal("X", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), parameters)
             }
         val signalV =
-            builder.physicalSignal("Y", 300.meters) {
+            builder.physicalSignal("Y", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), parameters)
             }
         // endregion

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
@@ -35,7 +35,7 @@ interface LocationInfra : TrackNetworkInfra, TrackInfra, TrackProperties {
 
     fun getPreviousZone(dirDet: DirDetectorId): ZoneId?
 
-    fun getDetectorName(det: DetectorId): String?
+    fun getDetectorName(det: DetectorId): String
 }
 
 fun LocationInfra.isBufferStop(detector: StaticIdx<Detector>): Boolean {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.sim_infra.api
 
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
 import fr.sncf.osrd.sim_infra.impl.PathPropertiesImpl
 import fr.sncf.osrd.sim_infra.impl.buildChunkPath
 import fr.sncf.osrd.utils.DistanceRangeMap

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/RawSignalingInfra.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.StaticIdxSpace
 import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.OffsetList
 
 /** A fixed size signaling block */
@@ -45,6 +46,11 @@ interface RawSignalingInfra : RoutingInfra {
     fun getLogicalSignals(signal: PhysicalSignalId): StaticIdxList<LogicalSignal>
 
     fun getPhysicalSignal(signal: LogicalSignalId): PhysicalSignalId
+
+    fun getPhysicalSignalTrack(signal: PhysicalSignalId): TrackSectionId
+
+    /** This offset is undirected */
+    fun getPhysicalSignalTrackOffset(signal: PhysicalSignalId): Offset<TrackSection>
 
     fun getPhysicalSignalName(signal: PhysicalSignalId): String?
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -1,14 +1,65 @@
 package fr.sncf.osrd.sim_infra.api
 
 import fr.sncf.osrd.geom.LineString
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
-import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.Speed
+import java.util.*
+
+class SpeedSection(
+    val default: Speed,
+    val speedByTrainTag: Map<String, Speed>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SpeedSection) return false
+        if (default != other.default) return false
+        if (speedByTrainTag != other.speedByTrainTag) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(default, speedByTrainTag)
+    }
+
+    companion object {
+        fun merge(a: SpeedSection, b: SpeedSection): SpeedSection {
+            val default = Speed.min(a.default, b.default)
+            val trainTags = a.speedByTrainTag.keys union b.speedByTrainTag.keys
+            val speedByTrainTag = mutableMapOf<String, Speed>()
+            for (tag in trainTags) {
+                val speedA = a.speedByTrainTag.getOrDefault(tag, a.default)
+                val speedB = b.speedByTrainTag.getOrDefault(tag, b.default)
+                speedByTrainTag[tag] = Speed.min(speedA, speedB)
+            }
+            return SpeedSection(default, speedByTrainTag)
+        }
+    }
+}
+
+class NeutralSection(
+    val lowerPantograph: Boolean,
+    val isAnnouncement: Boolean,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is NeutralSection) return false
+        if (lowerPantograph != other.lowerPantograph) return false
+        if (isAnnouncement != other.isAnnouncement) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(lowerPantograph, isAnnouncement)
+    }
+
+    override fun toString(): String {
+        return "NeutralSection(lowerPantograph=$lowerPantograph, isAnnouncement=$isAnnouncement)"
+    }
+}
 
 /**
  * An operational point is a special location (such as a station). It has an ID and a set of

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
@@ -84,8 +84,8 @@ fun makeBlock(rawInfra: RawInfra, blockInfra: BlockInfra, id: StaticIdx<Block>):
     return BlockViewer(
         blockInfra.getBlockPath(id).map { path -> makeZonePath(rawInfra, path) },
         id,
-        makeDirViewer(entry, rawInfra.getDetectorName(entry.value)!!),
-        makeDirViewer(exit, rawInfra.getDetectorName(exit.value)!!),
+        makeDirViewer(entry, rawInfra.getDetectorName(entry.value)),
+        makeDirViewer(exit, rawInfra.getDetectorName(exit.value)),
         blockInfra.getBlockLength(id),
     )
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -218,9 +218,13 @@ class RouteDescriptorImpl(
 ) : RouteDescriptor
 
 interface RestrictedRawInfraBuilder {
-    fun detector(name: String?): DetectorId
+    fun movableElement(
+        name: String,
+        delay: Duration,
+        init: MovableElementDescriptorBuilder.() -> Unit
+    ): TrackNodeId
 
-    fun linkZones(zoneA: ZoneId, zoneB: ZoneId): DetectorId
+    fun detector(name: String): DetectorId
 
     fun linkZones(detector: DetectorId, zoneA: ZoneId, zoneB: ZoneId)
 
@@ -291,7 +295,7 @@ class RawInfraBuilderImpl : RawInfraBuilder {
     private val trackChunkPool = StaticPool<TrackChunk, TrackChunkDescriptor>()
     private val nodeAtEndpoint = IdxMap<EndpointTrackSectionId, TrackNodeId>()
     private val zonePool = StaticPool<Zone, ZoneDescriptor>()
-    private val detectorPool = StaticPool<Detector, String?>()
+    private val detectorPool = StaticPool<Detector, String>()
     private val nextZones = IdxMap<DirDetectorId, ZoneId>()
     private val routePool = StaticPool<Route, RouteDescriptor>()
     private val logicalSignalPool = StaticPool<LogicalSignal, LogicalSignalDescriptor>()
@@ -301,7 +305,7 @@ class RawInfraBuilderImpl : RawInfraBuilder {
     private val operationalPointPartPool =
         StaticPool<OperationalPointPart, OperationalPointPartDescriptor>()
 
-    fun movableElement(
+    override fun movableElement(
         name: String,
         delay: Duration,
         init: MovableElementDescriptorBuilder.() -> Unit
@@ -312,14 +316,8 @@ class RawInfraBuilderImpl : RawInfraBuilder {
         return trackNodePool.add(movableElement)
     }
 
-    override fun detector(name: String?): DetectorId {
+    override fun detector(name: String): DetectorId {
         return detectorPool.add(name)
-    }
-
-    override fun linkZones(zoneA: ZoneId, zoneB: ZoneId): DetectorId {
-        val det = detector(null)
-        linkZones(det, zoneA, zoneB)
-        return det
     }
 
     override fun linkZones(detector: DetectorId, zoneA: ZoneId, zoneB: ZoneId) {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -81,6 +81,8 @@ interface PhysicalSignalBuilder {
 class PhysicalSignalBuilderImpl(
     private val name: String?,
     private val sightDistance: Distance,
+    private val trackSection: TrackSectionId,
+    private val offset: Offset<TrackSection>,
     private val globalPool: StaticPool<LogicalSignal, LogicalSignalDescriptor>,
 ) : PhysicalSignalBuilder {
     private val children: MutableStaticIdxList<LogicalSignal> = MutableStaticIdxArrayList()
@@ -100,7 +102,7 @@ class PhysicalSignalBuilderImpl(
     }
 
     fun build(): PhysicalSignalDescriptor {
-        return PhysicalSignalDescriptor(name, children, sightDistance)
+        return PhysicalSignalDescriptor(name, children, sightDistance, trackSection, offset)
     }
 }
 
@@ -258,6 +260,8 @@ interface RestrictedRawInfraBuilder {
     fun physicalSignal(
         name: String?,
         sightDistance: Distance,
+        trackSection: TrackSectionId,
+        offset: Offset<TrackSection>,
         init: PhysicalSignalBuilder.() -> Unit
     ): PhysicalSignalId
 }
@@ -395,9 +399,12 @@ class RawInfraBuilderImpl : RawInfraBuilder {
     override fun physicalSignal(
         name: String?,
         sightDistance: Distance,
+        trackSection: TrackSectionId,
+        offset: Offset<TrackSection>,
         init: PhysicalSignalBuilder.() -> Unit
     ): PhysicalSignalId {
-        val builder = PhysicalSignalBuilderImpl(name, sightDistance, logicalSignalPool)
+        val builder =
+            PhysicalSignalBuilderImpl(name, sightDistance, trackSection, offset, logicalSignalPool)
         builder.init()
         return physicalSignalPool.add(builder.build())
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -87,6 +87,8 @@ class PhysicalSignalDescriptor(
     val name: String?,
     val logicalSignals: StaticIdxList<LogicalSignal>,
     val sightDistance: Distance,
+    val trackSection: TrackSectionId,
+    val offset: Offset<TrackSection>,
 )
 
 open class ZonePathSpec(
@@ -454,6 +456,14 @@ class RawInfraImpl(
 
     override fun getPhysicalSignal(signal: LogicalSignalId): PhysicalSignalId {
         return parentSignalMap[signal]!!
+    }
+
+    override fun getPhysicalSignalTrack(signal: PhysicalSignalId): TrackSectionId {
+        return physicalSignalPool[signal].trackSection
+    }
+
+    override fun getPhysicalSignalTrackOffset(signal: PhysicalSignalId): Offset<TrackSection> {
+        return physicalSignalPool[signal].offset
     }
 
     override fun getPhysicalSignalName(signal: PhysicalSignalId): String? {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/new_impl/RawInfraImplFromRjs.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/new_impl/RawInfraImplFromRjs.kt
@@ -605,6 +605,14 @@ class RawInfraImplFromRjs(
         return parentSignalMap[signal]!!
     }
 
+    override fun getPhysicalSignalTrack(signal: PhysicalSignalId): TrackSectionId {
+        return physicalSignalPool[signal].dirTrackSectionId.value
+    }
+
+    override fun getPhysicalSignalTrackOffset(signal: PhysicalSignalId): Offset<TrackSection> {
+        return physicalSignalPool[signal].undirectedTrackOffset
+    }
+
     override fun getPhysicalSignalName(signal: PhysicalSignalId): String? {
         return physicalSignalPool[signal].name
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.sim_infra.utils
 
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestLocation.kt
@@ -4,23 +4,25 @@ import fr.sncf.osrd.sim.interlocking.api.Train
 import fr.sncf.osrd.sim.interlocking.api.ZoneOccupation
 import fr.sncf.osrd.sim.interlocking.impl.locationSim
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
+import fr.sncf.osrd.sim_infra.impl.rawInfra
 import fr.sncf.osrd.utils.indexing.MutableArena
-import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.dynIdxArraySetOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.*
 
 class TestLocation {
     @Test
     fun lockOccupyLeave() = runBlocking {
         // setup test data
-        val infra = rawInfraFromRjs {
+        val infra = rawInfra {
             // create a test switch
-            val switchA = node("A", ZERO, StaticPool(), StaticPool())
-
+            val switchA =
+                movableElement("A", delay = 42L.milliseconds) {
+                    config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                    config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
+                }
             val zoneA = zone(listOf(switchA))
 
             val detectorA = detector("A")

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestMovableElement.kt
@@ -3,9 +3,8 @@ package fr.sncf.osrd.sim
 import fr.sncf.osrd.sim.interlocking.api.MovableElementInitPolicy
 import fr.sncf.osrd.sim.interlocking.api.withLock
 import fr.sncf.osrd.sim.interlocking.impl.MovableElementSimImpl
-import fr.sncf.osrd.sim_infra.impl.TrackNodeConfigDescriptor
-import fr.sncf.osrd.sim_infra.impl.rawInfraFromRjs
-import fr.sncf.osrd.utils.indexing.StaticPool
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.impl.rawInfra
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
@@ -18,18 +17,11 @@ class TestMovableElements {
     @Test
     fun lockMoveTest() = runTest {
         // setup test data
-        val infra = rawInfraFromRjs {
-            node(
-                "A",
-                42L.milliseconds,
-                StaticPool(),
-                StaticPool(
-                    mutableListOf(
-                        TrackNodeConfigDescriptor("a", listOf()),
-                        TrackNodeConfigDescriptor("b", listOf())
-                    )
-                )
-            )
+        val infra = rawInfra {
+            movableElement("A", delay = 42L.milliseconds) {
+                config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
+            }
         }
 
         val sim = MovableElementSimImpl(infra, MovableElementInitPolicy.PESSIMISTIC)

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestReservation.kt
@@ -6,15 +6,14 @@ import fr.sncf.osrd.sim.interlocking.api.ZoneReservationStatus.*
 import fr.sncf.osrd.sim.interlocking.api.ZoneState
 import fr.sncf.osrd.sim.interlocking.impl.*
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
-import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableArenaMap
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
@@ -38,9 +37,12 @@ class TestReservation {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilder()
-            val switch = builder.node("A", ZERO, StaticPool(), StaticPool())
-
+            val builder = rawInfraBuilder()
+            val switch =
+                builder.movableElement("A", delay = 42L.milliseconds) {
+                    config("a", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                    config("b", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
+                }
             val zoneA = builder.zone(listOf())
             val zoneB = builder.zone(listOf())
             val zoneC = builder.zone(listOf(switch))

--- a/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
+++ b/core/kt-osrd-sim-interlocking/src/test/kotlin/fr/sncf/osrd/sim/TestRouting.kt
@@ -6,12 +6,12 @@ import fr.sncf.osrd.sim.interlocking.impl.LocationSimImpl
 import fr.sncf.osrd.sim.interlocking.impl.movableElementSim
 import fr.sncf.osrd.sim.interlocking.impl.reservationSim
 import fr.sncf.osrd.sim.interlocking.impl.routingSim
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
 import fr.sncf.osrd.utils.indexing.MutableArena
 import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -42,9 +42,13 @@ class TestRouting {
             //  <-- reverse     normal -->
 
             // region build the test infrastructure
-            val builder = RawInfraFromRjsBuilder()
+            val builder = rawInfraBuilder()
             // region switches
-            val switch = builder.node("S", 10L.milliseconds, StaticPool(), StaticPool())
+            val switch =
+                builder.movableElement("S", delay = 10L.milliseconds) {
+                    config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                    config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(2u)))
+                }
             // endregion
 
             // region zones

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -63,12 +63,13 @@ class TestBALtoBAL {
         // region signals
         val parameters = RawSignalParameters(mapOf(Pair("jaune_cli", "false")), mapOf())
 
+        // TODO: add an actual track graph
         val signalX =
-            builder.physicalSignal("X", 300.meters) {
+            builder.physicalSignal("X", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), parameters)
             }
         val signalV =
-            builder.physicalSignal("V", 300.meters) {
+            builder.physicalSignal("V", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), parameters)
             }
         // endregion

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -4,16 +4,15 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticPool
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 
 class TestBALtoBAL {
     @Test
@@ -29,9 +28,13 @@ class TestBALtoBAL {
         //  <-- reverse     normal -->
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilder()
+        val builder = rawInfraBuilder()
         // region switches
-        val switch = builder.node("S", ZERO, StaticPool(), StaticPool())
+        val switch =
+            builder.movableElement("S", delay = 10L.milliseconds) {
+                config("xy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+                config("vy", Pair(TrackNodePortId(0u), TrackNodePortId(1u)))
+            }
         // endregion
 
         // region zones

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
+import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -50,8 +51,9 @@ class TestBAPRtoBAL {
         // region signals
         val balParameters = RawSignalParameters(mapOf(Pair("jaune_cli", "false")), mapOf())
         val baprParameters = RawSignalParameters(mapOf(), mapOf())
+        // TODO: add an actual track graph
         val signalm =
-            builder.physicalSignal("m", 300.meters) {
+            builder.physicalSignal("m", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal(
                     "BAPR",
                     listOf("BAPR"),
@@ -60,7 +62,7 @@ class TestBAPRtoBAL {
                 )
             }
         val signalM =
-            builder.physicalSignal("M", 300.meters) {
+            builder.physicalSignal("M", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal(
                     "BAPR",
                     listOf("BAPR"),
@@ -72,7 +74,7 @@ class TestBAPRtoBAL {
                 )
             }
         val signaln =
-            builder.physicalSignal("n", 300.meters) {
+            builder.physicalSignal("n", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal(
                     "BAPR",
                     listOf("BAL"),
@@ -81,7 +83,7 @@ class TestBAPRtoBAL {
                 )
             }
         val signalN =
-            builder.physicalSignal("N", 300.meters) {
+            builder.physicalSignal("N", 300.meters, StaticIdx(42u), Offset(42.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), balParameters)
             }
 

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -7,7 +7,7 @@ import fr.sncf.osrd.signaling.bapr.BAPRtoBAPR
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraFromRjsBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -28,7 +28,7 @@ class TestBAPRtoBAL {
         // N: BAL
 
         // region build the test infrastructure
-        val builder = RawInfraFromRjsBuilder()
+        val builder = rawInfraBuilder()
 
         // region zones
         val zoneA = builder.zone(listOf())

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
@@ -5,7 +5,8 @@ import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.signaling.tvm300.TVM300
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
+import fr.sncf.osrd.sim_infra.impl.rawInfraBuilder
+import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -25,7 +26,7 @@ class TestTVM300toBAL {
         // N: BAL
 
         // region build the test infrastructure
-        val builder = RawInfraBuilder()
+        val builder = rawInfraBuilder()
 
         // region zones
         val zoneA = builder.zone(listOf())
@@ -48,7 +49,7 @@ class TestTVM300toBAL {
         val balParameters = RawSignalParameters(mapOf(Pair("jaune_cli", "false")), mapOf())
         val tvmParameters = RawSignalParameters(mapOf(), mapOf())
         val signalM =
-            builder.physicalSignal("M", 0.meters) {
+            builder.physicalSignal("M", 0.meters, StaticIdx(0u), Offset(0.meters)) {
                 logicalSignal(
                     "TVM300",
                     listOf("BAL"),
@@ -59,7 +60,7 @@ class TestTVM300toBAL {
                 )
             }
         val signalN =
-            builder.physicalSignal("N", 300.meters) {
+            builder.physicalSignal("N", 300.meters, StaticIdx(0u), Offset(0.meters)) {
                 logicalSignal("BAL", listOf("BAL"), mapOf(Pair("Nf", "true")), balParameters)
             }
 

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/indexing/StaticIdx.kt
@@ -19,7 +19,6 @@ import fr.sncf.osrd.utils.Endpoint
 
 @JvmInline
 value class OptStaticIdx<T>(private val data: UInt) {
-
     constructor() : this(UInt.MAX_VALUE)
 
     val isNone: Boolean

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Distance.kt
@@ -16,6 +16,7 @@
 package fr.sncf.osrd.utils.units
 
 import fr.sncf.osrd.fast_collections.PrimitiveWrapperCollections
+import fr.sncf.osrd.utils.Direction
 import kotlin.math.absoluteValue
 
 @JvmInline
@@ -108,6 +109,47 @@ value class Offset<T>(val distance: Distance) : Comparable<Offset<T>> {
 
         fun <T> max(a: Offset<T>, b: Offset<T>) = Offset<T>(Distance.max(a.distance, b.distance))
     }
+}
+
+fun <T> OffsetArray<T>.binarySearch(offset: Offset<T>): Int {
+    return binarySearch(offset) { a, b -> (a - b).millimeters.toInt() }
+}
+
+/**
+ * Given an array of segment boundaries, return the index of the segment which contains the given
+ * offset. When the offset is a segment boundary, returns the index of the first encountered segment
+ * along the provided direction.
+ *
+ * For example, if there are two segments, one from offset 2 to 4, and one from 4 to 6, their
+ * boundary array is [2, 4, 6]. The following statements are true:
+ * - findSegment(1, INCREASING) == -1 // out of bounds
+ * - findSegment(2, INCREASING) == 0
+ * - findSegment(2, DECREASING) == 0
+ * - findSegment(3, INCREASING) == 0
+ * - findSegment(3, DECREASING) == 0
+ * - findSegment(4, INCREASING) == 0
+ * - findSegment(4, DECREASING) == 1
+ */
+fun <T> OffsetArray<T>.findSegment(offset: Offset<T>, direction: Direction): Int {
+    val sectionCount = size - 1
+
+    if (offset < Offset(0.meters) || offset > this[sectionCount]) return -1
+    val boundIndex = binarySearch(offset)
+
+    // the position falls exactly on a boundary
+    if (boundIndex >= 0) {
+        if (boundIndex == 0) return 0
+        if (boundIndex == sectionCount) return sectionCount - 1
+        return when (direction) {
+            Direction.INCREASING -> boundIndex - 1
+            Direction.DECREASING -> boundIndex
+        }
+    }
+
+    // the position falls within a section
+    val insertionPos = -(boundIndex + 1)
+    assert(insertionPos in 1..sectionCount)
+    return insertionPos - 1
 }
 
 typealias Length<T> = Offset<T>

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/ReservationInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/reservation/ReservationInfraBuilder.java
@@ -261,7 +261,9 @@ public class ReservationInfraBuilder {
                     }
                 }
                 // We didn't find a next edge
-                if (newEdge == edge) throw newDiscontinuousRouteError(rjsRoute.id);
+                if (newEdge == edge) {
+                    throw newDiscontinuousRouteError(rjsRoute.id);
+                }
             }
             position = edge.getDirection() == FORWARD ? 0 : edge.getEdge().getLength();
         }

--- a/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
+++ b/core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java
@@ -92,9 +92,9 @@ public class UndirectedInfraBuilder {
             return BUILTIN_NODE_TYPES_LIST;
         }
 
-        switchTypeList.addAll(BUILTIN_NODE_TYPES_LIST);
-
-        return switchTypeList;
+        var res = new ArrayList<>(BUILTIN_NODE_TYPES_LIST);
+        res.addAll(switchTypeList);
+        return res;
     }
 
     /** Parse the railjson to build an infra */

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -19,7 +19,6 @@ import fr.sncf.osrd.sim_infra.utils.BlockPathElement
 import fr.sncf.osrd.sim_infra.utils.chunksToRoutes
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
 import fr.sncf.osrd.sim_infra.utils.toList
-import fr.sncf.osrd.sim_infra_adapter.SimInfraAdapter
 import fr.sncf.osrd.standalone_sim.result.*
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingZoneRequirement
@@ -71,7 +70,7 @@ fun run(
 ): ResultTrain {
     assert(envelope.continuous)
 
-    val rawInfra = fullInfra.rawInfra as SimInfraAdapter
+    val rawInfra = fullInfra.rawInfra
     val loadedSignalInfra = fullInfra.loadedSignalInfra
     val blockInfra = fullInfra.blockInfra
     val simulator = fullInfra.signalingSimulator
@@ -463,7 +462,7 @@ private fun zoneOccupationChangeEvents(
     blockPath: StaticIdxList<Block>,
     blockInfra: BlockInfra,
     envelope: EnvelopeTimeInterpolate,
-    rawInfra: SimInfraAdapter,
+    rawInfra: RawInfra,
     trainLength: Double
 ): MutableList<ZoneOccupationChangeEvent> {
     var zoneCount = 0

--- a/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapter.kt
@@ -17,10 +17,8 @@ import fr.sncf.osrd.infra.implementation.tracks.directed.DiTrackEdgeImpl
 import fr.sncf.osrd.infra.implementation.tracks.directed.TrackRangeView
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.NeutralSection as SimNeutralSection
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilderImpl
-import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.sim_infra.impl.TrackSectionBuilder
 import fr.sncf.osrd.utils.DirectionalMap
 import fr.sncf.osrd.utils.DistanceRangeMap
@@ -333,8 +331,8 @@ private fun makeChunk(
         return res
     }
 
-    fun makeNeutralSection(range: TrackRangeView): DistanceRangeMap<SimNeutralSection> {
-        val res = distanceRangeMapOf<SimNeutralSection>()
+    fun makeNeutralSection(range: TrackRangeView): DistanceRangeMap<NeutralSection> {
+        val res = distanceRangeMapOf<NeutralSection>()
         for ((rangeMap, isAnnouncement) in
             listOf(
                 Pair(range.neutralSections, false),
@@ -345,7 +343,7 @@ private fun makeChunk(
                 res.put(
                     entry.key.lowerEndpoint().meters,
                     entry.key.upperEndpoint().meters,
-                    SimNeutralSection(legacyNeutralSection.lowerPantograph, isAnnouncement)
+                    NeutralSection(legacyNeutralSection.lowerPantograph, isAnnouncement)
                 )
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
@@ -4,8 +4,8 @@ import fr.sncf.osrd.envelope_sim.electrification.Electrification
 import fr.sncf.osrd.envelope_sim.electrification.Electrified
 import fr.sncf.osrd.envelope_sim.electrification.Neutral
 import fr.sncf.osrd.envelope_sim.electrification.NonElectrified
+import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.sim_infra.api.PathProperties
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
 import fr.sncf.osrd.utils.units.Distance
 
 /** Builds the ElectrificationMap */

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/SimInfraAdapterComparatorUtils.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.utils
 
 import fr.sncf.osrd.sim_infra.api.DirDetectorId
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
+import fr.sncf.osrd.sim_infra.api.PhysicalSignal
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.TrackChunk
 import fr.sncf.osrd.sim_infra.api.TrackChunkId
@@ -9,9 +10,13 @@ import fr.sncf.osrd.sim_infra.api.TrackNodeId
 import fr.sncf.osrd.sim_infra.api.TrackNodePortId
 import fr.sncf.osrd.sim_infra.api.TrackSection
 import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.ZonePath
+import fr.sncf.osrd.sim_infra.api.ZonePathId
 import fr.sncf.osrd.sim_infra_adapter.SimInfraAdapter
 import fr.sncf.osrd.stdcm.graph.logger
+import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.OffsetList
 import java.util.Objects
 import kotlin.collections.HashSet
 
@@ -315,6 +320,20 @@ fun assertEqualSimInfra(left: SimInfraAdapter, right: SimInfraAdapter) {
     for ((_, zone) in extraRightDet) {
         assert(zone == null || extraRightZones.contains(zone))
     }
+
+    val leftZonePathToSignal =
+        mutableMapOf<ZonePathId, Pair<OffsetList<ZonePath>, StaticIdxList<PhysicalSignal>>>()
+    for (zonePath in left.zonePaths) {
+        leftZonePathToSignal[zonePath] =
+            Pair(left.getSignalPositions(zonePath), left.getSignals(zonePath))
+    }
+    val rightZonePathToSignal =
+        mutableMapOf<ZonePathId, Pair<OffsetList<ZonePath>, StaticIdxList<PhysicalSignal>>>()
+    for (zonePath in right.zonePaths) {
+        rightZonePathToSignal[zonePath] =
+            Pair(right.getSignalPositions(zonePath), right.getSignals(zonePath))
+    }
+    assert(leftZonePathToSignal == rightZonePathToSignal)
 
     // TODO complete simInfra checks
 

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingElectrificationTest.kt
@@ -7,8 +7,8 @@ import fr.sncf.osrd.infra.api.Direction
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.sim_infra.api.NeutralSection
 import fr.sncf.osrd.sim_infra.api.RouteId
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
 import java.util.stream.Stream

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/RawInfraAdapterTest.kt
@@ -112,8 +112,7 @@ class RawInfraAdapterTest {
         rjsInfra.routes = listOf(rjsRoute)
 
         val oldInfra = Helpers.infraFromRJS(rjsInfra)
-        val result = adaptRawInfra(oldInfra, rjsInfra)
-        val infra = result.simInfra
+        val infra = adaptRawInfra(oldInfra, rjsInfra)
         val route = infra.getRouteFromName("route")
         val signalMap = infra.physicalSignals.associateBy { infra.getPhysicalSignalName(it)!! }
         val signalU = signalMap["U"]!!
@@ -257,7 +256,7 @@ class RawInfraAdapterTest {
     @Test
     fun loadSmallInfraNodes() {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")
-        val rawInfra = adaptRawInfra(Helpers.infraFromRJS(rjsInfra), rjsInfra).simInfra
+        val rawInfra = adaptRawInfra(Helpers.infraFromRJS(rjsInfra), rjsInfra)
         val nodeNameToIdxMap =
             rawInfra.trackNodes
                 .map { nodeIdx -> Pair(rawInfra.getTrackNodeName(nodeIdx), nodeIdx) }
@@ -295,7 +294,7 @@ class RawInfraAdapterTest {
     @Test
     fun loadSmallInfraCrossingZone() {
         val rjsInfra = Helpers.getExampleInfra("small_infra/infra.json")
-        val rawInfra = adaptRawInfra(Helpers.infraFromRJS(rjsInfra), rjsInfra).simInfra
+        val rawInfra = adaptRawInfra(Helpers.infraFromRJS(rjsInfra), rjsInfra)
 
         // Check that for crossing nodes, only one zone is generated.
         // In small_infra, PD0 and PD1 are crossings, linked by track-section TF0 (no detector on

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -119,6 +119,14 @@ class DummyInfra : RawInfra, BlockInfra {
         return convertId(signal)
     }
 
+    override fun getPhysicalSignalTrack(signal: PhysicalSignalId): TrackSectionId {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPhysicalSignalTrackOffset(signal: PhysicalSignalId): Offset<TrackSection> {
+        TODO("Not yet implemented")
+    }
+
     override fun getPhysicalSignalName(signal: PhysicalSignalId): String {
         return "BAL"
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -7,8 +7,6 @@ import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.impl.NeutralSection
-import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.*
 import kotlin.time.Duration
@@ -268,8 +266,8 @@ class DummyInfra : RawInfra, BlockInfra {
         TODO("Not yet implemented")
     }
 
-    override fun getDetectorName(det: DetectorId): String? {
-        return detectorMap.inverse()[DirDetectorId(det, Direction.INCREASING)]
+    override fun getDetectorName(det: DetectorId): String {
+        return detectorMap.inverse()[DirDetectorId(det, Direction.INCREASING)]!!
     }
 
     override fun getNextTrackSection(


### PR DESCRIPTION
* Split RawInfra impls (legacy and new)
* Simplify signal-build api (more responsibility to RawInfraFromRjsBuilder, easier to use for zone-path parsing). Requires more info when building detectors.
* Ensure (hack) that signals at the exact end of a track-section are correctly handled (in RawInfraImplFromRjs init). Corresponding test is `routeEndsOnTrackLinkWithSignal`.

Also:
* Switch back tests to use of legacy RawInfraBuilder (avoid complete use of new interface): restore legacy api on the way.
* Add `findSection()` to `OffsetArray` (and `binarySearch()` to `Array` macro).
* Move `SpeedSection` and `NeutralSection` to sim_infra/api/TrackProperties (more accurate the RawInfra).
* Move `rjsSpeedSection` parsing back to new Builder instead of constructor of `SpeedSection`.
* fix useless side-effect for legacy load of switch-types (in core/src/main/java/fr/sncf/osrd/infra/implementation/tracks/undirected/UndirectedInfraBuilder.java)
* Add `getPhysicalSignalTrack()` and `getPhysicalSignalTrackOffset()` to RawInfra (RawSignalingInfra interface) to [drop SimInfraAdapter](https://github.com/osrd-project/osrd/pull/7084/commits/de81834cb88d65ecb2989f4476e4837cc35b5059) (that was onboarding extra maps which are now useless).
* Add comparators on zone-pathes' signals (legacy vs. new infra)

Fix: https://github.com/osrd-project/osrd/issues/7054