### PR TITLE
ci: run all editoast workspace tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,7 +415,7 @@ jobs:
           docker run --name=editoast-test --net=host -v $PWD/output:/output \
             -e DATABASE_URL="postgres://osrd:password@localhost:5432/osrd" \
             ${{ fromJSON(needs.build.outputs.stable_tags).editoast-test }} \
-            /bin/bash -c "diesel migration run --locked-schema && cargo test --verbose -- --test-threads=4 && grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o /output/lcov.info"
+            /bin/bash -c "diesel migration run --locked-schema && cargo test --workspace --verbose -- --test-threads=4 && grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o /output/lcov.info"
 
           exit $(docker wait editoast-test)
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -1076,7 +1076,7 @@ fn test_construction() {
         struct Document {
             #[model(column = "id", preferred, primary)]
             id_: i64,
-            #[model(identifier, json, geo)]
+            #[model(identifier, json)]
             content_type: String,
             data: Vec<u8>,
         }


### PR DESCRIPTION
We only run editoast tests, but we will need to run editoast_schemas tests too

Fix the modelv2 macro tests that weren't executed. The `geo` attribute is unimplemented!