### PR TITLE
core: stdcm: avoid calling spacing requirements on empty paths

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -71,6 +71,10 @@ data class InfraExplorerWithEnvelopeImpl(
     override fun getSpacingRequirements(): List<SpacingRequirement> {
         val cached = spacingRequirementsCache?.get()
         if (cached != null) return cached
+        if (getFullEnvelope().endPos == 0.0) {
+            // This case can happen when we start right at the end of a block
+            return listOf()
+        }
         spacingRequirementAutomaton.incrementalPath = getIncrementalPath()
         // Path is complete and has been completely simulated
         val simulationComplete = getIncrementalPath().pathComplete && getLookahead().size == 0


### PR DESCRIPTION
Fix https://github.com/osrd-project/osrd/issues/7092