### PR TITLE
core: add more context to assert errors

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -147,7 +147,7 @@ public enum ErrorType {
     public final ErrorCause cause;
 
     ErrorType(String type, String message, ErrorCause cause) {
-        this.type = type;
+        this.type = "core:" + type;
         this.message = message;
         this.cause = cause;
     }

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
@@ -96,8 +96,10 @@ public final class OSRDError extends RuntimeException {
      */
     public static OSRDError newAssertionWrapper(AssertionError assertionError) {
         var error = new OSRDError(ErrorType.AssertionError);
-        error.context.put("message", assertionError.getMessage());
-        error.context.put("stack_trace", convertStackTrace(assertionError.getStackTrace()));
+        var stackTrace = convertStackTrace(assertionError.getStackTrace());
+        error.context.put("assert_message", assertionError.getMessage());
+        error.context.put("stack_trace", stackTrace);
+        error.context.put("file_location", stackTrace.get(0));
         return error;
     }
 

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -8,6 +8,9 @@
   "504": "The server did not respond.",
   "default": "An error has occurred.",
   "pageNotFound": "The page you are looking for does not exist.",
+  "core": {
+    "assert_error": "Assert error at {{file_location}}: {{assert_message}}"
+  },
   "editoast": {
     "attached": {
       "TrackNotFound": "Track {{track_id}} not found"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -8,6 +8,9 @@
   "504": "Le serveur n'a pas répondu.",
   "default": "Une erreur est survenue.",
   "pageNotFound": "La page que vous recherchez n'existe pas.",
+  "core": {
+    "assert_error": "Assertion échouée à {{file_location}}: {{assert_message}}"
+  },
   "editoast": {
     "attached": {
       "TrackNotFound": "Section de ligne {{track_id}} non trouvée"


### PR DESCRIPTION
The main change in this PR is that all error types from core are prefixed with `core:`. It doesn't *seem* to break anything, but it's the kind of change where the implications can be difficult to track.

When an assertion is triggered, the displayed error is now `Assert error at {{file_location}}: {{assert_message}}`.