### PR TITLE
Adapt editoast undeprecated chrono functions

### DIFF
--- a/editoast/src/schema/utils/duration.rs
+++ b/editoast/src/schema/utils/duration.rs
@@ -120,19 +120,13 @@ where
                     "years and months are not supported",
                 ));
             }
-            ChronoDuration::try_days(day as i64)
-                .ok_or_else(|| serde::de::Error::custom("value for days is not valid"))?
-                + ChronoDuration::try_hours(hour as i64)
-                    .ok_or_else(|| serde::de::Error::custom("value for hours is not valid"))?
-                + ChronoDuration::try_minutes(minute as i64)
-                    .ok_or_else(|| serde::de::Error::custom("value for minutes is not valid"))?
-                + ChronoDuration::try_seconds(second as i64)
-                    .ok_or_else(|| serde::de::Error::custom("value for seconds is not valid"))?
-                + ChronoDuration::try_milliseconds(millisecond as i64)
-                    .ok_or_else(|| serde::de::Error::custom("value for millisecond is not valid"))?
+            ChronoDuration::days(day as i64)
+                + ChronoDuration::hours(hour as i64)
+                + ChronoDuration::minutes(minute as i64)
+                + ChronoDuration::seconds(second as i64)
+                + ChronoDuration::milliseconds(millisecond as i64)
         }
-        IsoDuration::Weeks(weeks) => ChronoDuration::try_weeks(weeks as i64)
-            .ok_or_else(|| serde::de::Error::custom("value for weeks is not valid"))?,
+        IsoDuration::Weeks(weeks) => ChronoDuration::weeks(weeks as i64),
     })
 }
 
@@ -163,7 +157,7 @@ mod tests {
     fn test_serialize() {
         let s = r#"{"duration":"PT3600S"}"#; // 1 hour
         let my_struct = MyStruct {
-            duration: Duration::from(chrono::Duration::try_hours(1).unwrap()),
+            duration: Duration::from(chrono::Duration::hours(1)),
         };
         assert_eq!(s, to_string(&my_struct).unwrap());
     }

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -501,7 +501,7 @@ mod tests {
             path: vec![path_item.clone(), path_item.clone()],
             schedule: vec![ScheduleItem {
                 at: "a".into(),
-                arrival: Some(Duration::try_minutes(5).unwrap().into()),
+                arrival: Some(Duration::minutes(5).into()),
                 stop_for: None,
                 locked: false,
             }],


### PR DESCRIPTION
Chrono reverted `TimeDelta` deprecations so we can simplify our code.

Ref: https://github.com/chronotope/chrono/releases/tag/v0.4.36