### PR TITLE
core: tvm: fix placeholder value of tvm 430 -> 300

### DIFF
--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toTVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430toTVM300.kt
@@ -18,7 +18,7 @@ object TVM430toTVM300 : SignalDriver {
         maView: MovementAuthorityView?,
         limitView: SpeedLimitView?
     ): SigState {
-        return stateSchema { value("aspect", "VL") }
+        return stateSchema { value("aspect", "300VL") }
     }
 
     override fun checkSignal(reporter: SignalDiagReporter, signal: SigSettings, block: SigBlock) {}


### PR DESCRIPTION
VL isn't a compatible aspect anymore, this causes an error

EDIT: wait, this is a larger problem and this fix isn't the right way. We seem to invert the aspect enum somewhere on signaling system transitions.
Closing this PR. 