### PR TITLE
core: stdcm: remove envelopes in stdcm edges

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -63,8 +63,8 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
      * actual simulations.
      */
     private fun getSlowestRunningTime(edges: List<STDCMEdge>): Double {
-        val beginSpeed = edges.first().envelope.beginSpeed
-        val endSpeed = edges.last().envelope.endSpeed
+        val beginSpeed = edges.first().beginSpeed
+        val endSpeed = edges.last().endSpeed
         val blockRanges =
             edges.map {
                 PathfindingEdgeRangeId(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -7,6 +7,8 @@ import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.TrainStop
+import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
+import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.min
@@ -297,10 +299,10 @@ internal constructor(
         }
         val endStopDuration = getEndStopDuration()
         val endAtStop = endStopDuration != null
+        val standardAllowanceSpeedRatio = graph.getStandardAllowanceSpeedRatio(envelope!!)
         var res: STDCMEdge? =
             STDCMEdge(
                 infraExplorer,
-                envelope!!,
                 getExplorerWithNewEnvelope()!!,
                 actualStartTime,
                 maximumDelay,
@@ -315,11 +317,15 @@ internal constructor(
                 prevNode,
                 startOffset,
                 (actualStartTime / 60).toInt(),
-                graph.getStandardAllowanceSpeedRatio(envelope!!),
+                standardAllowanceSpeedRatio,
                 waypointIndex,
-                endAtStop
+                endAtStop,
+                envelope!!.beginSpeed,
+                envelope!!.endSpeed,
+                Length(fromMeters(envelope!!.endPos)),
+                envelope!!.totalTime / standardAllowanceSpeedRatio,
             )
-        res = graph.backtrackingManager.backtrack(res!!)
+        res = graph.backtrackingManager.backtrack(res!!, envelope!!)
         return if (res == null || graph.delayManager.isRunTimeTooLong(res)) null else res
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -129,14 +129,7 @@ private fun totalCostUntilEdgeLocation(
     range: EdgeLocation<STDCMEdge, STDCMEdge>,
     searchTimeRange: Double
 ): Double {
-    val envelope = range.edge.envelope
-    val timeEnd =
-        interpolateTime(
-            envelope,
-            range.offset,
-            range.edge.timeStart,
-            range.edge.standardAllowanceSpeedFactor
-        )
+    val timeEnd = range.edge.getApproximateTimeAtLocation(range.offset)
     if (areTimesEqual(searchTimeRange, 0.0))
         return timeEnd // Avoid multiplying by 0, we can't have time shift anyway
     val pathDuration = timeEnd - range.edge.totalDepartureTimeShift

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -62,7 +62,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 timeStep,
                 comfort,
                 trainTag,
-                areSpeedsEqual(0.0, ranges.last().edge.envelope.endSpeed)
+                areSpeedsEqual(0.0, ranges.last().edge.endSpeed)
             )
         val departureTime = computeDepartureTime(ranges, startTime)
         val withAllowance =

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -27,7 +27,6 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 
@@ -137,18 +136,6 @@ private fun makeSinglePointEnvelope(speed: Double): Envelope {
             doubleArrayOf()
         )
     )
-}
-
-/** Returns the time at which the offset on the given edge is reached */
-fun interpolateTime(
-    envelope: Envelope,
-    edgeOffset: Offset<STDCMEdge>,
-    startTime: Double,
-    speedRatio: Double
-): Double {
-    assert(edgeOffset.distance <= fromMeters(envelope.endPos))
-    assert(edgeOffset.distance >= 0.meters)
-    return startTime + envelope.interpolateTotalTime(edgeOffset.distance.meters) / speedRatio
 }
 
 /** returns an envelope for a block that already has an envelope, but with a different end speed */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -1,10 +1,5 @@
 package fr.sncf.osrd.stdcm.graph
 
-import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.envelope.part.EnvelopePart
-import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
-import fr.sncf.osrd.envelope_sim.PhysicsPath
-import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
 import fr.sncf.osrd.graph.Pathfinding.EdgeRange
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
@@ -16,38 +11,6 @@ import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.*
-import kotlin.math.min
-
-/** Combines all the envelopes in the given edge ranges */
-fun mergeEnvelopeRanges(edges: List<EdgeRange<STDCMEdge, STDCMEdge>>, path: PhysicsPath): Envelope {
-    val parts = ArrayList<EnvelopePart>()
-    var offset = 0.0
-    for (edge in edges) {
-        val envelope = edge.edge.envelope
-        var sliceUntil = min(envelope.endPos, (edge.end - edge.start).absoluteValue.meters)
-        if (sliceUntil == 0.0) continue
-        if (TrainPhysicsIntegrator.arePositionsEqual(sliceUntil, envelope.endPos))
-            sliceUntil = envelope.endPos // The diff between longs and floats can break things here
-        val slicedEnvelope = Envelope.make(*envelope.slice(0.0, sliceUntil))
-        for (part in slicedEnvelope) parts.add(part.copyAndShift(offset, 0.0, path.length))
-        offset = parts[parts.size - 1].endPos
-    }
-    val newEnvelope = Envelope.make(*parts.toTypedArray<EnvelopePart>())
-    assert(newEnvelope.continuous)
-    return newEnvelope
-}
-
-/** Combines all the envelopes in the given edges */
-fun mergeEnvelopes(
-    graph: STDCMGraph,
-    edges: List<STDCMEdge>,
-    context: EnvelopeSimContext
-): Envelope {
-    return mergeEnvelopeRanges(
-        edges.stream().map { e: STDCMEdge -> EdgeRange(e, Offset(0.meters), e.length) }.toList(),
-        context.path
-    )
-}
 
 /** Returns the offset of the stops on the given block, starting at startOffset */
 fun getStopOnBlock(


### PR DESCRIPTION
Keep the envelope's relevant metadata in stdcm edges so as to remove the envelope from the edges.
Closes #6982 and #6983.