### PR TITLE
core: bump dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,8 +76,8 @@ dependencies {
     implementation libs.opentelemetry.instrumentation.annotations
 
     // DataDog
-    implementation 'io.opentracing:opentracing-util:0.33.0'
-    implementation 'com.datadoghq:dd-trace-api:1.31.2'
+    implementation libs.opentracing.util
+    implementation libs.dd.trace.api
 
     // Geographic computations
     implementation libs.geodesy

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -15,13 +15,13 @@
 
 [versions]
 kotlin = '1.9.23'
-ksp = '1.9.23-1.0.19'
-kotlinx-coroutines = '1.7.+'
+ksp = '1.9.23-1.0.20'
+kotlinx-coroutines = '1.8.+'
 logback = '1.5.+'
 moshi = '1.15.1'
 junit = '5.10.+'
 mockito = '5.2.+'
-otel = '1.34.1'
+otel = '1.36.0'
 
 [libraries]
 # kotlin stuff
@@ -38,7 +38,7 @@ logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback'
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback' } # EPL 1.0 (incompatible) and LGPL 2.1 (compatible)
 
 # java stuff
-guava = { module = 'com.google.guava:guava', version = '33.0.0-jre' } # Apache 2.0
+guava = { module = 'com.google.guava:guava', version = '33.1.0-jre' } # Apache 2.0
 jcommander = { module = 'com.beust:jcommander', version = '1.82' } # Apache 2.0
 hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' } # Apache 2.0
 moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' } # Apache 2.0
@@ -50,7 +50,7 @@ okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.12.0' } # Apache
 classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' } # MIT
 jmathplot = { module = 'com.github.yannrichet:JMathPlot', version = '1.0.1' } # BSD
 slf4j = { module = 'org.slf4j:slf4j-api', version = '2.0.+' } # MIT
-sentry = { module = 'io.sentry:sentry', version = '7.3.+' } # MIT
+sentry = { module = 'io.sentry:sentry', version = '7.6.+' } # MIT
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' } # EPL 2.0
 junit-jupiter-params = { module = 'org.junit.jupiter:junit-jupiter-params', version.ref = 'junit' } # EPL 2.0
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' } # EPL 2.0
@@ -65,6 +65,9 @@ geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' } # Apache 2.0
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
 opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.2.0' }
+
+opentracing-util = { module = 'io.opentracing:opentracing-util', version = '0.33.0' }
+dd-trace-api = { module = 'com.datadoghq:dd-trace-api', version = '1.31.2' }
 
 [plugins]
 # kotlin


### PR DESCRIPTION
Also move the datadog related dependencies to the version library.