### PR TITLE
gateway: relax versions to minimal acceptable versions

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "async-trait"
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1076,9 +1076,9 @@ checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "figment"
-version = "0.10.15"
+version = "0.10.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7270677e7067213e04f323b55084586195f18308cd7546cfac9f873344ccceb6"
+checksum = "fdefe49ed1057d124dc81a0681c30dd07de56ad96e32adc7b64e8f28eaab31c4"
 dependencies = [
  "atomic",
  "pear",
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2868,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa",
@@ -2889,9 +2889,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -12,22 +12,22 @@ default-members = [".", "actix_auth", "actix_proxy"]
 
 [workspace.dependencies]
 # common utils
-dyn-clone = "1"
+dyn-clone = "1.0.10"
 either = "1"
 env_logger = "0.10"
 futures = "0.3"
-futures-util = "0.3"
-log = "0.4"
-smallvec = "1"
-thiserror = "1"
+futures-util = "0.3.17"
+log = "0.4.8"
+smallvec = "1.10.0"
+thiserror = "1.0.7"
 
 # main crate
 actix-files = "0.6"
 actix-session = "0.8"
-actix-web = "4"
+actix-web = "4.2"
 actix-web-opentelemetry = { version = "0.16.0", features = ["awc", "metrics"] }
-base64ct = "1"
-figment = "0.10"
+base64ct = "1.4"
+figment = "0.10.1"
 humantime = "2"
 humantime-serde = "1"
 opentelemetry = "0.21"
@@ -37,25 +37,25 @@ opentelemetry_sdk = { version = "0.21.2", features = [
   "metrics",
   "rt-tokio-current-thread",
 ] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.157", features = ["derive"] }
 serde_json = "1"
 
 # reverse proxy dependencies
 actix = "0.13"
-actix-web-actors = "4"
+actix-web-actors = "4.1"
 awc = { version = "3", features = ["rustls"] } # the http / ws client
 bytestring = "1"
-ipnet = "2"
-percent-encoding = "2"
+ipnet = "2.3"
+percent-encoding = "2.3"
 phf = "0.11"
 
 # actix_auth
 actix-web-httpauth = "0.8"
-openidconnect = { version = "3", default-features = false }
+openidconnect = { version = "3.4", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-url = "2"
+url = "2.4"
 
 
 [dependencies]


### PR DESCRIPTION
A recent commit did relax all versions in `gateway` (see https://github.com/OpenRailAssociation/osrd/commit/748e2d43ec5518c676dd0eafa8d5bc5cd8b20ace).

However, it's probably too relaxed. For example, `actix_auth` now depends on `openidconnect:3` with the feature `jwk-alg`, but this feature is only available starting `openidconnect:3.4`. So I believe relaxing is more than OK, but only if the lower bound is good enough for compiling which is not the case anymore.

You can try this to see the effect (see [documentation of this nightly feature](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#direct-minimal-versions)).

```
cargo +nightly update -Zdirect-minimal-versions
cargo check
```

Once you fix one, then another constraint comes up and another minimal bound need to be fixed. This PR should provide all the minimal versions in which `gateway` can be compiled, hopefully.

For comparison, here the [original commit](https://github.com/OpenRailAssociation/osrd/commit/748e2d43ec5518c676dd0eafa8d5bc5cd8b20ac), and [here is the comparison the current PR](https://github.com/OpenRailAssociation/osrd/compare/8adeabb17a111689a16d4f1d28c5194a167d8268...18e320141a8454cb8cb5f10eb42b8cfd58752096#diff-d7ecede1b6263f0230e5f5584c1ec79f80f3cf1e204753e25dcdfe0371d1ed33) would have made. It still relax a bunch of the constraints, but not as much.

Happy to hear opinions on that.