### PR TITLE
core: constraints: cache the constraints in the combiner

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/constraints/ConstraintCombiner.kt
@@ -7,12 +7,17 @@ import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.train.RollingStock
 
-class ConstraintCombiner<EdgeT, OffsetType> : EdgeToRanges<EdgeT, OffsetType> {
-    @JvmField val functions: MutableList<EdgeToRanges<EdgeT, OffsetType>> = ArrayList()
+class ConstraintCombiner<EdgeT, OffsetType>(
+    val functions: MutableList<EdgeToRanges<EdgeT, OffsetType>> = ArrayList()
+) : EdgeToRanges<EdgeT, OffsetType> {
+    private val cache = mutableMapOf<EdgeT, Collection<Pathfinding.Range<OffsetType>>>()
 
     override fun apply(edge: EdgeT): Collection<Pathfinding.Range<OffsetType>> {
+        val cached = cache[edge]
+        if (cached != null) return cached
         val res = HashSet<Pathfinding.Range<OffsetType>>()
         for (f in functions) res.addAll(f.apply(edge))
+        cache[edge] = res
         return res
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -174,7 +174,8 @@ private fun convertLocations(
 ): Set<EdgeLocation<STDCMEdge, STDCMEdge>> {
     val res = HashSet<EdgeLocation<STDCMEdge, STDCMEdge>>()
     val fullInfra = graph.fullInfra
-    val constraints = initConstraints(fullInfra, listOf(rollingStock))
+    val constraints =
+        ConstraintCombiner(initConstraints(fullInfra, listOf(rollingStock)).toMutableList())
 
     for (location in locations) {
         val infraExplorers =
@@ -183,7 +184,7 @@ private fun convertLocations(
                 location,
                 endBlocks,
                 rollingStock,
-                constraints
+                listOf(constraints)
             )
         val extended = infraExplorers.flatMap { extendLookaheadUntil(it, 4) }
         for (explorer in extended) {


### PR DESCRIPTION
Small optimization for stdcm, roughly 15% speedup