### PR TITLE
core: signaling: lazy evaluation of route set

### DIFF
--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -143,7 +143,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
     ): Map<LogicalSignalId, SigState> {
         assert(evaluatedPathEnd > 0)
         assert(evaluatedPathEnd <= fullPath.size)
-        val routeSet = routes.toSet()
+        val routeSet by lazy { routes.toSet() }
 
         // compute the offset of each block's first zone inside the partial path
         val blockZoneMap = IntArray(evaluatedPathEnd + 1)


### PR DESCRIPTION
It was expensive to compute (contains all routes from the path start) and rarely used

Reduces the time of stdcm requests by 12%