### PR TITLE
editoast: move train schedule v2 structs to schemas

### DIFF
--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -9,6 +9,9 @@ mod path_item;
 pub use path_item::PathItem;
 pub use path_item::PathItemLocation;
 
+mod train_schedule_options;
+pub use train_schedule_options::TrainScheduleOptions;
+
 mod allowance;
 pub use allowance::Allowance;
 pub use allowance::AllowanceDistribution;
@@ -24,6 +27,7 @@ editoast_common::schemas! {
     margins::schemas(),
     schedule_item::schemas(),
     path_item::schemas(),
+    train_schedule_options::schemas(),
     // TODO TrainSchedule V1 (it will be removed)
     allowance::schemas(),
     rjs_power_restriction_range::schemas(),

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -15,6 +15,9 @@ pub use train_schedule_options::TrainScheduleOptions;
 mod power_restriction_item;
 pub use power_restriction_item::PowerRestrictionItem;
 
+mod distribution;
+pub use distribution::Distribution;
+
 mod allowance;
 pub use allowance::Allowance;
 pub use allowance::AllowanceDistribution;
@@ -32,6 +35,7 @@ editoast_common::schemas! {
     path_item::schemas(),
     train_schedule_options::schemas(),
     power_restriction_item::schemas(),
+    distribution::schemas(),
     // TODO TrainSchedule V1 (it will be removed)
     allowance::schemas(),
     rjs_power_restriction_range::schemas(),

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -18,6 +18,9 @@ pub use power_restriction_item::PowerRestrictionItem;
 mod distribution;
 pub use distribution::Distribution;
 
+mod comfort;
+pub use comfort::Comfort;
+
 mod allowance;
 pub use allowance::Allowance;
 pub use allowance::AllowanceDistribution;
@@ -36,6 +39,7 @@ editoast_common::schemas! {
     train_schedule_options::schemas(),
     power_restriction_item::schemas(),
     distribution::schemas(),
+    comfort::schemas(),
     // TODO TrainSchedule V1 (it will be removed)
     allowance::schemas(),
     rjs_power_restriction_range::schemas(),

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -12,6 +12,9 @@ pub use path_item::PathItemLocation;
 mod train_schedule_options;
 pub use train_schedule_options::TrainScheduleOptions;
 
+mod power_restriction_item;
+pub use power_restriction_item::PowerRestrictionItem;
+
 mod allowance;
 pub use allowance::Allowance;
 pub use allowance::AllowanceDistribution;
@@ -28,6 +31,7 @@ editoast_common::schemas! {
     schedule_item::schemas(),
     path_item::schemas(),
     train_schedule_options::schemas(),
+    power_restriction_item::schemas(),
     // TODO TrainSchedule V1 (it will be removed)
     allowance::schemas(),
     rjs_power_restriction_range::schemas(),

--- a/editoast/editoast_schemas/src/train_schedule/comfort.rs
+++ b/editoast/editoast_schemas/src/train_schedule/comfort.rs
@@ -1,0 +1,17 @@
+use serde::Deserialize;
+use serde::Serialize;
+use strum::FromRepr;
+use utoipa::ToSchema;
+
+editoast_common::schemas! {
+    Comfort,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Comfort {
+    #[default]
+    Standard,
+    AirConditioning,
+    Heating,
+}

--- a/editoast/editoast_schemas/src/train_schedule/distribution.rs
+++ b/editoast/editoast_schemas/src/train_schedule/distribution.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+use serde::Serialize;
+use strum::FromRepr;
+use utoipa::ToSchema;
+
+editoast_common::schemas! {
+    Distribution,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Distribution {
+    #[default]
+    Standard,
+    Mareco,
+}

--- a/editoast/editoast_schemas/src/train_schedule/power_restriction_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/power_restriction_item.rs
@@ -1,0 +1,18 @@
+use editoast_common::NonBlankString;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+editoast_common::schemas! {
+    PowerRestrictionItem,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PowerRestrictionItem {
+    #[schema(inline)]
+    pub from: NonBlankString,
+    #[schema(inline)]
+    pub to: NonBlankString,
+    pub value: String,
+}

--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
@@ -1,0 +1,22 @@
+use derivative::Derivative;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+editoast_common::schemas! {
+    TrainScheduleOptions,
+}
+
+#[derive(Debug, Derivative, Clone, Serialize, Deserialize, ToSchema, Hash)]
+#[serde(deny_unknown_fields)]
+#[schema(as = TrainScheduleOptionsV2)] // Avoiding conflict with v1. TODO: remove after migration to v2
+#[derivative(Default)]
+pub struct TrainScheduleOptions {
+    #[derivative(Default(value = "true"))]
+    #[serde(default = "default_use_electrical_profiles")]
+    use_electrical_profiles: bool,
+}
+
+fn default_use_electrical_profiles() -> bool {
+    true
+}

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7312,6 +7312,12 @@ components:
           nullable: true
           type: boolean
       type: object
+    TrainScheduleOptionsV2:
+      additionalProperties: false
+      properties:
+        use_electrical_profiles:
+          type: boolean
+      type: object
     TrainSchedulePatch:
       description: A patch of a train schedule
       properties:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -90,6 +90,12 @@ components:
       maxItems: 2
       minItems: 2
       type: array
+    Comfort:
+      enum:
+      - STANDARD
+      - AIR_CONDITIONING
+      - HEATING
+      type: string
     CompleteReportTrain:
       allOf:
       - $ref: '#/components/schemas/ReportTrainV2'

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4770,6 +4770,22 @@ components:
       required:
       - power_restriction
       type: object
+    PowerRestrictionItem:
+      additionalProperties: false
+      properties:
+        from:
+          minLength: 1
+          type: string
+        to:
+          minLength: 1
+          type: string
+        value:
+          type: string
+      required:
+      - from
+      - to
+      - value
+      type: object
     ProfilesOnPathResponse:
       description: |-
         A list of ranges associated to electrical profile values. When a profile overlapping another is found,

--- a/editoast/src/core/v2/simulation.rs
+++ b/editoast/src/core/v2/simulation.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::Gamma;
 use editoast_schemas::rolling_stock::RollingResistance;
+use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::MarginValue;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
@@ -12,7 +13,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::{AsCoreRequest, Json};
-use crate::schema::v2::trainschedule::Comfort;
 use crate::views::v2::path::TrackRange;
 use crate::views::v2::train_schedule::CompleteReportTrain;
 use crate::views::v2::train_schedule::Mrsp;

--- a/editoast/src/core/v2/simulation.rs
+++ b/editoast/src/core/v2/simulation.rs
@@ -5,13 +5,14 @@ use chrono::Utc;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::Gamma;
 use editoast_schemas::rolling_stock::RollingResistance;
+use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::MarginValue;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::{AsCoreRequest, Json};
-use crate::schema::v2::trainschedule::{Comfort, Distribution};
+use crate::schema::v2::trainschedule::Comfort;
 use crate::views::v2::path::TrackRange;
 use crate::views::v2::train_schedule::CompleteReportTrain;
 use crate::views::v2::train_schedule::Mrsp;

--- a/editoast/src/core/v2/simulation.rs
+++ b/editoast/src/core/v2/simulation.rs
@@ -6,11 +6,11 @@ use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::Gamma;
 use editoast_schemas::rolling_stock::RollingResistance;
 use editoast_schemas::train_schedule::MarginValue;
+use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::core::{AsCoreRequest, Json};
-use crate::schema::v2::trainschedule::TrainScheduleOptions;
 use crate::schema::v2::trainschedule::{Comfort, Distribution};
 use crate::views::v2::path::TrackRange;
 use crate::views::v2::train_schedule::CompleteReportTrain;

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -3,12 +3,12 @@ use chrono::Utc;
 use editoast_derive::ModelV2;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
+use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 use crate::schema::v2::trainschedule::Comfort;
 use crate::schema::v2::trainschedule::Distribution;
-use crate::schema::v2::trainschedule::PowerRestrictionItem;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::train_schedule_v2)]

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -1,6 +1,7 @@
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_derive::ModelV2;
+use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
@@ -8,7 +9,6 @@ use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 use crate::schema::v2::trainschedule::Comfort;
-use crate::schema::v2::trainschedule::Distribution;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::train_schedule_v2)]

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -1,14 +1,13 @@
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_derive::ModelV2;
+use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
-
-use crate::schema::v2::trainschedule::Comfort;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::train_schedule_v2)]

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -4,11 +4,11 @@ use editoast_derive::ModelV2;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 use crate::schema::v2::trainschedule::Comfort;
 use crate::schema::v2::trainschedule::Distribution;
 use crate::schema::v2::trainschedule::PowerRestrictionItem;
-use crate::schema::v2::trainschedule::TrainScheduleOptions;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = crate::tables::train_schedule_v2)]

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_common::NonBlankString;
+use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
@@ -159,14 +160,6 @@ pub enum Comfort {
     Standard,
     AirConditioning,
     Heating,
-}
-
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum Distribution {
-    #[default]
-    Standard,
-    Mareco,
 }
 
 #[cfg(test)]

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::hash::Hash;
 
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_common::NonBlankString;
+use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
@@ -14,7 +14,6 @@ use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::de::Error as SerdeError;
 use serde::Deserialize;
 use serde::Serialize;
-use strum::FromRepr;
 use utoipa::ToSchema;
 
 #[derive(Debug, Default, Clone, Serialize, ToSchema)]
@@ -151,15 +150,6 @@ impl<'de> Deserialize<'de> for TrainScheduleBase {
             options: internal.options,
         })
     }
-}
-
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Comfort {
-    #[default]
-    Standard,
-    AirConditioning,
-    Heating,
 }
 
 #[cfg(test)]

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -4,11 +4,11 @@ use std::hash::Hash;
 
 use chrono::DateTime;
 use chrono::Utc;
-use derivative::Derivative;
 use editoast_common::NonBlankString;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::de::Error as SerdeError;
 use serde::Deserialize;
 use serde::Serialize;
@@ -159,19 +159,6 @@ pub struct PowerRestrictionItem {
     #[schema(inline)]
     pub to: NonBlankString,
     pub value: String,
-}
-
-#[derive(Debug, Derivative, Clone, Serialize, Deserialize, ToSchema, Hash)]
-#[serde(deny_unknown_fields)]
-#[derivative(Default)]
-pub struct TrainScheduleOptions {
-    #[derivative(Default(value = "true"))]
-    #[serde(default = "default_use_electrical_profiles")]
-    use_electrical_profiles: bool,
-}
-
-fn default_use_electrical_profiles() -> bool {
-    true
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]

--- a/editoast/src/schema/v2/trainschedule.rs
+++ b/editoast/src/schema/v2/trainschedule.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use editoast_common::NonBlankString;
 use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
+use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::de::Error as SerdeError;
@@ -149,16 +150,6 @@ impl<'de> Deserialize<'de> for TrainScheduleBase {
             options: internal.options,
         })
     }
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct PowerRestrictionItem {
-    #[schema(inline)]
-    pub from: NonBlankString,
-    #[schema(inline)]
-    pub to: NonBlankString,
-    pub value: String,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, Hash)]

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -26,7 +26,6 @@ use crate::modelsv2::train_schedule::TrainScheduleChangeset;
 use crate::modelsv2::Model;
 use crate::modelsv2::Retrieve;
 use crate::modelsv2::RetrieveBatch;
-use crate::schema::v2::trainschedule::Distribution;
 use crate::schema::v2::trainschedule::TrainScheduleBase;
 use crate::views::v2::path::pathfinding_from_train;
 use crate::views::v2::path::PathfindingError;
@@ -64,7 +63,6 @@ crate::routes! {
 }
 
 editoast_common::schemas! {
-    Distribution,
     TrainScheduleBase,
     TrainScheduleForm,
     TrainScheduleResult,


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/7048

- move TrainScheduleOptions
- move PowerRestrictionItem
- move Distribution
- move Comfort