### PR TITLE
editoast: move train schedule base to schemas

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
 name = "editoast_schemas"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "derivative",
  "editoast_common",
  "enum-map",

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "LGPL-3.0"
 
 [dependencies]
+chrono.workspace = true
 derivative.workspace = true
 editoast_common.workspace = true
 enum-map.workspace = true

--- a/editoast/editoast_schemas/src/tests/train_schedule_simple.json
+++ b/editoast/editoast_schemas/src/tests/train_schedule_simple.json
@@ -1,0 +1,75 @@
+{
+  "train_name": "ABC3615",
+  "rolling_stock_name": "R2D2",
+  "labels": [
+    "choo-choo",
+    "tchou-tchou"
+  ],
+  "speed_limit_tag": "MA100",
+  "start_time": "2023-12-21T08:51:30+00:00",
+  "path": [
+    {
+      "id": "a",
+      "uic": 1
+    },
+    {
+      "id": "b",
+      "track": "TC0",
+      "offset": 340
+    },
+    {
+      "id": "c",
+      "deleted": true,
+      "trigram": "MWS"
+    },
+    {
+      "id": "d",
+      "operational_point": "Mid_East_station"
+    }
+  ],
+  "constraint_distribution": "MARECO",
+  "schedule": [
+    {
+      "at": "a",
+      "stop_for": "PT5M",
+      "locked": true
+    },
+    {
+      "at": "b",
+      "arrival": "PT10M",
+      "stop_for": "PT5M"
+    },
+    {
+      "at": "c",
+      "stop_for": "PT5M"
+    },
+    {
+      "at": "d",
+      "arrival": "PT50M",
+      "locked": true
+    }
+  ],
+  "margins": {
+    "boundaries": [
+      "b",
+      "c"
+    ],
+    "values": [
+      "5%",
+      "3min/km",
+      "none"
+    ]
+  },
+  "initial_speed": 2.5,
+  "power_restrictions": [
+    {
+      "from": "b",
+      "to": "c",
+      "value": "M1C1"
+    }
+  ],
+  "comfort": "AIR_CONDITIONING",
+  "options": {
+    "use_electrical_profiles": true
+  }
+}

--- a/editoast/editoast_schemas/src/train_schedule.rs
+++ b/editoast/editoast_schemas/src/train_schedule.rs
@@ -21,6 +21,9 @@ pub use distribution::Distribution;
 mod comfort;
 pub use comfort::Comfort;
 
+mod train_schedule_base;
+pub use train_schedule_base::TrainScheduleBase;
+
 mod allowance;
 pub use allowance::Allowance;
 pub use allowance::AllowanceDistribution;
@@ -33,6 +36,7 @@ mod rjs_power_restriction_range;
 pub use rjs_power_restriction_range::RjsPowerRestrictionRange;
 
 editoast_common::schemas! {
+    train_schedule_base::schemas(),
     margins::schemas(),
     schedule_item::schemas(),
     path_item::schemas(),

--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_base.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_base.rs
@@ -4,17 +4,22 @@ use std::collections::HashSet;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_common::NonBlankString;
-use editoast_schemas::train_schedule::Comfort;
-use editoast_schemas::train_schedule::Distribution;
-use editoast_schemas::train_schedule::Margins;
-use editoast_schemas::train_schedule::PathItem;
-use editoast_schemas::train_schedule::PowerRestrictionItem;
-use editoast_schemas::train_schedule::ScheduleItem;
-use editoast_schemas::train_schedule::TrainScheduleOptions;
 use serde::de::Error as SerdeError;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
+
+use super::Comfort;
+use super::Distribution;
+use super::Margins;
+use super::PathItem;
+use super::PowerRestrictionItem;
+use super::ScheduleItem;
+use super::TrainScheduleOptions;
+
+editoast_common::schemas! {
+    TrainScheduleBase,
+}
 
 #[derive(Debug, Default, Clone, Serialize, ToSchema)]
 pub struct TrainScheduleBase {
@@ -155,19 +160,20 @@ impl<'de> Deserialize<'de> for TrainScheduleBase {
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use editoast_schemas::train_schedule::Margins;
-    use editoast_schemas::train_schedule::PathItemLocation;
-    use editoast_schemas::train_schedule::ScheduleItem;
     use serde_json::from_str;
     use serde_json::to_string;
 
+    use crate::train_schedule::Margins;
+    use crate::train_schedule::PathItemLocation;
+    use crate::train_schedule::ScheduleItem;
+    use crate::train_schedule::TrainScheduleBase;
+
     use super::PathItem;
-    use crate::schema::v2::trainschedule::TrainScheduleBase;
 
     /// Test deserialize a valid train schedule example
     #[test]
     fn deserialize_train_schedule() {
-        let train_schedule = include_str!("../../tests/train_schedules/simple.json");
+        let train_schedule = include_str!("../tests/train_schedule_simple.json");
         assert!(from_str::<TrainScheduleBase>(train_schedule).is_ok());
     }
 

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -16,7 +16,7 @@ pub mod tests {
             train_schedule::TrainSchedule as TrainScheduleV2, Changeset, Document,
             ElectricalProfileSet, Infra, Model, Project, RollingStockModel, Study,
         },
-        schema::{v2::trainschedule::TrainScheduleBase, RailJson},
+        schema::RailJson,
         views::{
             rolling_stocks::rolling_stock_form::RollingStockForm,
             v2::train_schedule::TrainScheduleForm,
@@ -31,6 +31,7 @@ pub mod tests {
     use editoast_schemas::infra::ElectricalProfileSetData;
     use editoast_schemas::infra::TrackRange;
     use editoast_schemas::rolling_stock::RollingStock;
+    use editoast_schemas::train_schedule::TrainScheduleBase;
     use futures::executor;
     use postgis_diesel::types::LineString;
     use rstest::*;

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -38,6 +38,7 @@ use client::{
 };
 use editoast_schemas::infra::ElectricalProfileSetData;
 use editoast_schemas::rolling_stock::RollingStock;
+use editoast_schemas::train_schedule::TrainScheduleBase;
 use modelsv2::{
     timetable::Timetable, timetable::TimetableWithTrains, train_schedule::TrainSchedule,
     train_schedule::TrainScheduleChangeset,
@@ -45,7 +46,6 @@ use modelsv2::{
 use modelsv2::{Changeset, RollingStockModel};
 use opentelemetry_datadog::DatadogPropagator;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use schema::v2::trainschedule::TrainScheduleBase;
 use views::v2::train_schedule::{TrainScheduleForm, TrainScheduleResult};
 
 use colored::*;

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -1,7 +1,6 @@
 mod errors;
 mod railjson;
 pub mod track_section;
-pub mod v2;
 
 pub use errors::InfraError;
 pub use errors::InfraErrorType;

--- a/editoast/src/schema/v2/mod.rs
+++ b/editoast/src/schema/v2/mod.rs
@@ -1,1 +1,0 @@
-pub mod trainschedule;

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -6,6 +6,7 @@ use std::hash::Hasher;
 
 use diesel_async::AsyncPgConnection as PgConnection;
 use editoast_derive::EditoastError;
+use editoast_schemas::train_schedule::TrainScheduleBase;
 use itertools::Itertools;
 use serde_qs::actix::QsQuery;
 use thiserror::Error;
@@ -27,7 +28,6 @@ use crate::modelsv2::train_schedule::TrainScheduleChangeset;
 use crate::modelsv2::Model;
 use crate::modelsv2::Retrieve;
 use crate::modelsv2::RetrieveBatch;
-use crate::schema::v2::trainschedule::TrainScheduleBase;
 use crate::views::v2::path::pathfinding_from_train;
 use crate::views::v2::path::PathfindingError;
 use crate::views::v2::path::TrackRange;


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/7048

- [ ] Maybe rename TrainScheduleBase to TrainSchedule ?
- [x] Move train schedule base to schemas
- [x] Move tests to schemas
- [x] Copy a json file exemple of train schedule for testing