### PR TITLE
core: fix tvm to bal transitions

### DIFF
--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300toBAL.kt
@@ -21,8 +21,8 @@ object TVM300toBAL : SignalDriver {
             "220A" -> "VL"
             "160A" -> "VL"
             "080A" -> "VL"
-            "000" -> "A"
-            "RRR" -> "C"
+            "000" -> "VL"
+            "RRR" -> "A"
             "OCCUPIED" -> "C"
             else -> throw OSRDError.newAspectError(aspect)
         }


### PR DESCRIPTION
Going from a RRR block to BAL should output a warning, not a stop signal