### PR TITLE
kt-fast-collections: fix mutable array set binary search bounds

### DIFF
--- a/core/kt-fast-collections-generator/src/main/kotlin/collections/ArraySortedSet.kt
+++ b/core/kt-fast-collections-generator/src/main/kotlin/collections/ArraySortedSet.kt
@@ -129,7 +129,7 @@ private fun CollectionItemType.generateArraySortedSet(
                 }
 
                 private fun binarySearch(value: $type): Int {
-                    return binarySearch(value, 0, buffer.size)
+                    return binarySearch(value, 0, size)
                 }
 
                 private fun internalAdd(newElement: $type): Boolean {
@@ -218,9 +218,9 @@ private fun CollectionItemType.generateArraySortedSet(
                 }
 
                 override fun toString(): String {
-                    val builder = StringBuilder(2 + usedElements * 6)
+                    val builder = StringBuilder(2 + size * 6)
                     builder.append('{')
-                    for (i in 0 until usedElements) {
+                    for (i in 0 until size) {
                         if (i != 0)
                             builder.append(", ")
                         builder.append(buffer[i].toString())
@@ -309,7 +309,7 @@ private fun CollectionItemType.generateArraySortedSet(
                 }
 
                 private fun binarySearch(value: $type): Int {
-                    return binarySearch(value, 0, buffer.size)
+                    return binarySearch(value, 0, size)
                 }
 
                 override fun getAtIndex(index: Int): $type {
@@ -347,9 +347,9 @@ private fun CollectionItemType.generateArraySortedSet(
                 }
 
                 override fun toString(): String {
-                    val builder = StringBuilder(2 + buffer.size * 6)
+                    val builder = StringBuilder(2 + size * 6)
                     builder.append('{')
-                    for (i in 0 until buffer.size) {
+                    for (i in 0 until size) {
                         if (i != 0)
                             builder.append(", ")
                         builder.append(buffer[i].toString())

--- a/core/kt-fast-collections/src/test/kotlin/TestArraySet.kt
+++ b/core/kt-fast-collections/src/test/kotlin/TestArraySet.kt
@@ -1,0 +1,18 @@
+package fr.sncf.osrd.fast_collections
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ArrayTestTest {
+    @Test
+    fun `test basic search`() {
+        val arrayList = MutableIntArraySet(14)
+        arrayList.add(1)
+        arrayList.add(2)
+        arrayList.add(3)
+        arrayList.add(4)
+        arrayList.add(5)
+        arrayList.add(8)
+        assertTrue(arrayList.contains(5))
+    }
+}


### PR DESCRIPTION
The binary search bounds were good for the immutable array set, but were not valid anymore once copied over to the mutable variant.

This change also makes some minor changes in other methods to avoid further confusion.