### PR TITLE
editoast: move `ApplicableDirectionsTrackRange` to `editoast_schemas`

### DIFF
--- a/editoast/editoast_schemas/src/infra.rs
+++ b/editoast/editoast_schemas/src/infra.rs
@@ -1,4 +1,5 @@
 mod applicable_directions;
+mod applicable_directions_track_range;
 mod direction;
 mod directional_track_range;
 mod endpoint;
@@ -11,6 +12,7 @@ mod track_range;
 mod waypoint;
 
 pub use applicable_directions::ApplicableDirections;
+pub use applicable_directions_track_range::ApplicableDirectionsTrackRange;
 pub use direction::Direction;
 pub use directional_track_range::DirectionalTrackRange;
 pub use endpoint::Endpoint;

--- a/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
+++ b/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
@@ -1,0 +1,34 @@
+use derivative::Derivative;
+use editoast_common::Identifier;
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::ApplicableDirections;
+
+#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+#[derivative(Default)]
+pub struct ApplicableDirectionsTrackRange {
+    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    pub track: Identifier,
+    pub begin: f64,
+    #[derivative(Default(value = "100."))]
+    pub end: f64,
+    pub applicable_directions: ApplicableDirections,
+}
+
+impl ApplicableDirectionsTrackRange {
+    pub fn new<T: AsRef<str>>(
+        track: T,
+        begin: f64,
+        end: f64,
+        applicable_directions: ApplicableDirections,
+    ) -> Self {
+        Self {
+            track: track.as_ref().into(),
+            begin,
+            end,
+            applicable_directions,
+        }
+    }
+}

--- a/editoast/src/converters/utils.rs
+++ b/editoast/src/converters/utils.rs
@@ -1,4 +1,5 @@
 use editoast_schemas::infra::ApplicableDirections;
+use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 use editoast_schemas::infra::Direction;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -749,7 +749,6 @@ pub mod tests {
     use crate::infra_cache::SwitchCache;
     use crate::map::BoundingBox;
     use crate::modelsv2::infra::tests::test_infra_transaction;
-    use crate::schema::ApplicableDirectionsTrackRange;
     use crate::schema::Electrification;
     use crate::schema::OperationalPoint;
     use crate::schema::OperationalPointPartCache;
@@ -761,6 +760,7 @@ pub mod tests {
     use editoast_common::Identifier;
     use editoast_common::NonBlankString;
     use editoast_schemas::infra::ApplicableDirections;
+    use editoast_schemas::infra::ApplicableDirectionsTrackRange;
     use editoast_schemas::infra::Direction;
     use editoast_schemas::infra::Endpoint;
     use editoast_schemas::infra::TrackEndpoint;

--- a/editoast/src/schema/electrification.rs
+++ b/editoast/src/schema/electrification.rs
@@ -2,13 +2,13 @@ use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::ApplicableDirectionsTrackRange;
 use super::OSRDIdentified;
 use super::ObjectType;
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_common::Identifier;
 use editoast_common::NonBlankString;
+use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 use editoast_schemas::primitives::OSRDTyped;
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/editoast/src/schema/mod.rs
+++ b/editoast/src/schema/mod.rs
@@ -19,7 +19,6 @@ pub use buffer_stop::BufferStop;
 pub use buffer_stop::BufferStopCache;
 pub use detector::Detector;
 pub use detector::DetectorCache;
-use editoast_schemas::infra::ApplicableDirections;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::ObjectType;
 pub use electrification::Electrification;
@@ -63,42 +62,9 @@ cfg_if! {
 }
 
 use crate::infra_cache::operation;
-use derivative::Derivative;
-use serde::Deserialize;
-use serde::Serialize;
-
-use editoast_common::Identifier;
 
 editoast_common::schemas! {
     utils::schemas(),
     editoast_schemas::schemas(),
     operation::schemas(),
-}
-
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-#[derivative(Default)]
-pub struct ApplicableDirectionsTrackRange {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
-    pub track: Identifier,
-    pub begin: f64,
-    #[derivative(Default(value = "100."))]
-    pub end: f64,
-    pub applicable_directions: ApplicableDirections,
-}
-
-impl ApplicableDirectionsTrackRange {
-    pub fn new<T: AsRef<str>>(
-        track: T,
-        begin: f64,
-        end: f64,
-        applicable_directions: ApplicableDirections,
-    ) -> Self {
-        Self {
-            track: track.as_ref().into(),
-            begin,
-            end,
-            applicable_directions,
-        }
-    }
 }

--- a/editoast/src/schema/speed_section.rs
+++ b/editoast/src/schema/speed_section.rs
@@ -4,13 +4,13 @@ use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::ApplicableDirectionsTrackRange;
 use super::OSRDIdentified;
 use super::ObjectType;
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_common::Identifier;
 use editoast_common::NonBlankString;
+use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 use editoast_schemas::infra::Sign;
 use editoast_schemas::primitives::OSRDTyped;
 

--- a/editoast/src/views/infra/auto_fixes/electrifications.rs
+++ b/editoast/src/views/infra/auto_fixes/electrifications.rs
@@ -94,11 +94,11 @@ mod tests {
     use crate::infra_cache::operation::CacheOperation;
     use crate::infra_cache::operation::Operation;
     use crate::infra_cache::ObjectCache;
-    use crate::schema::ApplicableDirectionsTrackRange;
     use crate::schema::Electrification;
     use crate::schema::InfraError;
     use editoast_common::Identifier;
     use editoast_schemas::infra::ApplicableDirections;
+    use editoast_schemas::infra::ApplicableDirectionsTrackRange;
     use editoast_schemas::primitives::OSRDObject as _;
     use editoast_schemas::primitives::ObjectRef;
     use editoast_schemas::primitives::ObjectType;

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -333,7 +333,6 @@ mod tests {
     use crate::infra_cache::operation::Operation;
     use crate::infra_cache::operation::RailjsonObject;
     use crate::infra_cache::InfraCacheEditoastError;
-    use crate::schema::ApplicableDirectionsTrackRange;
     use crate::schema::BufferStop;
     use crate::schema::BufferStopCache;
     use crate::schema::BufferStopExtension;
@@ -352,6 +351,7 @@ mod tests {
     use crate::views::pagination::PaginatedResponse;
     use crate::views::tests::create_test_service;
     use editoast_common::Identifier;
+    use editoast_schemas::infra::ApplicableDirectionsTrackRange;
     use editoast_schemas::infra::Endpoint;
     use editoast_schemas::infra::TrackEndpoint;
     use editoast_schemas::infra::Waypoint;

--- a/editoast/src/views/infra/auto_fixes/speed_section.rs
+++ b/editoast/src/views/infra/auto_fixes/speed_section.rs
@@ -94,11 +94,11 @@ mod tests {
     use crate::infra_cache::operation::CacheOperation;
     use crate::infra_cache::operation::Operation;
     use crate::infra_cache::ObjectCache;
-    use crate::schema::ApplicableDirectionsTrackRange;
     use crate::schema::InfraError;
     use crate::schema::SpeedSection;
     use editoast_common::Identifier;
     use editoast_schemas::infra::ApplicableDirections;
+    use editoast_schemas::infra::ApplicableDirectionsTrackRange;
     use editoast_schemas::primitives::OSRDObject as _;
     use editoast_schemas::primitives::ObjectRef;
     use editoast_schemas::primitives::ObjectType;

--- a/editoast/src/views/pathfinding/electrifications.rs
+++ b/editoast/src/views/pathfinding/electrifications.rs
@@ -150,10 +150,10 @@ pub mod tests {
     use crate::models::pathfinding::tests::simple_pathfinding_fixture;
     use crate::modelsv2::prelude::*;
     use crate::modelsv2::ElectrificationModel;
-    use crate::schema::ApplicableDirectionsTrackRange;
     use crate::schema::Electrification as ElectrificationSchema;
     use crate::views::tests::create_test_service;
     use editoast_schemas::infra::ApplicableDirections;
+    use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 
     #[fixture]
     fn simple_mode_map() -> TrackMap<String> {

--- a/editoast/src/views/pathfinding/mod.rs
+++ b/editoast/src/views/pathfinding/mod.rs
@@ -53,10 +53,10 @@ use crate::modelsv2::Infra;
 use crate::modelsv2::OperationalPointModel;
 use crate::modelsv2::Retrieve as RetrieveV2;
 use crate::modelsv2::RollingStockModel;
-use crate::schema::ApplicableDirectionsTrackRange;
 use crate::schema::OperationalPoint;
 use crate::schema::TrackSection;
 use crate::DbPool;
+use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 
 crate::routes! {
     "/pathfinding" => {


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/7048