### PR TITLE
feat: activate opentelemetry by default in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,10 @@ services:
     command: "java -ea -jar /app/osrd_core.jar api -p 8080"
     environment:
       CORE_EDITOAST_URL: "http://osrd-editoast"
+      JAVA_TOOL_OPTIONS: "-javaagent:/app/opentelemetry-javaagent.jar"
+      CORE_MONITOR_TYPE: "opentelemetry"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       start_period: 4s
@@ -95,6 +99,7 @@ services:
       OSRD_BACKEND_URL: "http://osrd-core:8080"
       DATABASE_URL: "postgres://osrd:password@postgres/osrd"
       TELEMETRY_KIND: "opentelemetry"
+      TELEMETRY_ENDPOINT: "http://jaeger:4317"
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
Let's go the extra mile and activate OpenTelemetry everywhere for the Docker Compose, by default.