### PR TITLE
ci: don't fail if codecov does

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,7 +368,7 @@ jobs:
           directory: ./core/build/reports/jacoco/testCodeCoverageReport
           files: testCodeCoverageReport.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
       - name: Report JUnit failures
@@ -437,7 +437,7 @@ jobs:
         with:
           name: codecov
           flags: editoast
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./output/lcov.info
@@ -528,7 +528,7 @@ jobs:
         with:
           name: codecov
           flags: gateway
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./output/lcov.info
@@ -571,7 +571,7 @@ jobs:
         with:
           name: codecov
           flags: front
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./output/coverage/clover.xml


### PR DESCRIPTION
Since we changed from [github.com/osrd-project](github.com/osrd-project) to [github.com/OpenRailAssociation](github.com/OpenRailAssociation), some PR systematically fails the Codecov report upload. It's probably due to some token available on PR only for developers, and not for bots like `dependabot`. We need some admin of the organization to unlock the situation. In the meantime, let's not block us.