### PR TITLE
schemas: adding source extension for tracksection

### DIFF
--- a/editoast/src/schema/track_section.rs
+++ b/editoast/src/schema/track_section.rs
@@ -35,6 +35,7 @@ pub struct TrackSection {
 #[serde(deny_unknown_fields)]
 pub struct TrackSectionExtensions {
     pub sncf: Option<TrackSectionSncfExtension>,
+    pub source: Option<TrackSectionSourceExtension>,
 }
 
 #[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -47,6 +48,14 @@ pub struct TrackSectionSncfExtension {
     pub track_number: i32,
     #[derivative(Default(value = r#""track_test".into()"#))]
     pub track_name: NonBlankString,
+}
+
+#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[derivative(Default)]
+pub struct TrackSectionSourceExtension {
+    pub name: NonBlankString,
+    pub id: NonBlankString,
 }
 
 impl OSRDTyped for TrackSection {

--- a/front/src/reducers/osrdconf/infra_schema.json
+++ b/front/src/reducers/osrdconf/infra_schema.json
@@ -1677,6 +1677,14 @@
                         }
                     ],
                     "default": null
+                },
+                "source": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/TrackSectionSourceExtension"
+                        }
+                    ],
+                    "default": null
                 }
             },
             "title": "TrackSectionExtensions",
@@ -1715,6 +1723,26 @@
                 "track_name"
             ],
             "title": "TrackSectionSncfExtension",
+            "type": "object"
+        },
+        "TrackSectionSourceExtension": {
+            "properties": {
+                "id": {
+                    "description": "ID used for the line in the source",
+                    "title": "Id",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the source",
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "id"
+            ],
+            "title": "TrackSectionSourceExtension",
             "type": "object"
         },
         "Tvm300System": {

--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -561,6 +561,12 @@ class TrackSectionSncfExtension(BaseModel):
     track_name: NonBlankStr = Field(description="Name corresponding to the track used")
 
 
+@register_extension(object=TrackSection, name="source")
+class TrackSectionSourceExtension(BaseModel):
+    name: str = Field(description="Name of the source")
+    id: str = Field(description="ID used for the line in the source")
+
+
 @register_extension(object=OperationalPoint, name="sncf")
 class OperationalPointSncfExtension(BaseModel):
     ci: int = Field(description="THOR immutable code of the operational point")

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osrd_schemas"
-version = "0.8.10"
+version = "0.8.11"
 description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 


### PR DESCRIPTION
see #6997

Implementing the source extension in `osrd-schema` (and `editoast`) for `TrackSection`.
Its data are composed of a `name` and an `id`.

`osrd-schema` has been bumped to `0.8.11`