### PR TITLE
Split ModelV2 codegen in multiple submodules (part 1)

### DIFF
--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -25,7 +25,9 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let row_decl = config.row_decl();
     let changeset_decl = config.changeset_decl();
 
-    let identifiers_impls = config.make_identifiers_impls();
+    let identifiable_impls = config.identifiable_impls();
+    let preferred_id_impl = config.preferred_id_impl();
+
     let from_impls = config.make_from_impls();
 
     let cs_builder = config.make_builder(true);
@@ -38,7 +40,9 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #row_decl
         #changeset_decl
 
-        #identifiers_impls
+        #(#identifiable_impls)*
+        #preferred_id_impl
+
         #from_impls
         #cs_builder
         #patch_builder

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -28,6 +28,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let identifiable_impls = config.identifiable_impls();
     let preferred_id_impl = config.preferred_id_impl();
 
+    let model_from_row_impl = config.model_from_row_impl();
     let from_impls = config.make_from_impls();
 
     let cs_builder = config.make_builder(true);
@@ -42,6 +43,8 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
 
         #(#identifiable_impls)*
         #preferred_id_impl
+
+        #model_from_row_impl
 
         #from_impls
         #cs_builder

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -19,10 +19,13 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_name = &input.ident;
     let model_vis = &input.vis;
     let options = ModelArgs::from_derive_input(input)?;
-    let config = ModelConfig::from_macro_args(options, model_name.clone())?;
+    let config = ModelConfig::from_macro_args(options, model_name.clone(), model_vis.clone())?;
+
+    let model_impl = config.model_impl();
+    let row_decl = config.row_decl();
+    let changeset_decl = config.changeset_decl();
 
     let identifiers_impls = config.make_identifiers_impls();
-    let model_decl = config.make_model_decl(model_vis);
     let from_impls = config.make_from_impls();
 
     let cs_builder = config.make_builder(true);
@@ -31,8 +34,11 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_impls = config.make_model_traits_impl();
 
     Ok(quote! {
+        #model_impl
+        #row_decl
+        #changeset_decl
+
         #identifiers_impls
-        #model_decl
         #from_impls
         #cs_builder
         #patch_builder

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -31,8 +31,8 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_from_row_impl = config.model_from_row_impl();
     let changeset_from_model_impl = config.changeset_from_model_impl();
 
-    let cs_builder = config.make_builder(true);
-    let patch_builder = config.make_builder(false);
+    let changeset_builder = config.changeset_builder_impl_block();
+    let patch_builder = config.patch_builder_impl_block();
 
     let model_impls = config.make_model_traits_impl();
 
@@ -47,8 +47,9 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #model_from_row_impl
         #changeset_from_model_impl
 
-        #cs_builder
+        #changeset_builder
         #patch_builder
+
         #model_impls
     })
 }

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -29,7 +29,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let preferred_id_impl = config.preferred_id_impl();
 
     let model_from_row_impl = config.model_from_row_impl();
-    let from_impls = config.make_from_impls();
+    let changeset_from_model_impl = config.changeset_from_model_impl();
 
     let cs_builder = config.make_builder(true);
     let patch_builder = config.make_builder(false);
@@ -45,8 +45,8 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #preferred_id_impl
 
         #model_from_row_impl
+        #changeset_from_model_impl
 
-        #from_impls
         #cs_builder
         #patch_builder
         #model_impls

--- a/editoast/editoast_derive/src/modelv2/args.rs
+++ b/editoast/editoast_derive/src/modelv2/args.rs
@@ -68,4 +68,12 @@ impl GeneratedTypeArgs {
     pub fn ident(&self) -> syn::Ident {
         syn::Ident::new(self.type_name.as_ref().unwrap(), Span::call_site())
     }
+
+    pub fn visibility(&self) -> syn::Visibility {
+        if self.public {
+            syn::Visibility::Public(Default::default())
+        } else {
+            syn::Visibility::Inherited
+        }
+    }
 }

--- a/editoast/editoast_derive/src/modelv2/codegen.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen.rs
@@ -16,20 +16,19 @@ use super::Identifier;
 use super::ModelConfig;
 
 impl ModelConfig {
-    pub fn make_model_decl(&self, vis: &syn::Visibility) -> TokenStream {
-        let model = &self.model;
-        let table = &self.table;
-
-        let model_impl = ModelImpl {
-            model: model.clone(),
+    pub(crate) fn model_impl(&self) -> ModelImpl {
+        ModelImpl {
+            model: self.model.clone(),
             row: self.row.ident(),
             changeset: self.changeset.ident(),
-        };
+        }
+    }
 
-        let row_decl = RowDecl {
-            vis: vis.clone(),
+    pub(crate) fn row_decl(&self) -> RowDecl {
+        RowDecl {
+            vis: self.visibility.clone(),
             ident: self.row.ident(),
-            table: table.clone(),
+            table: self.table.clone(),
             additional_derives: self.row.derive.clone(),
             fields: self
                 .iter_fields()
@@ -40,12 +39,14 @@ impl ModelConfig {
                     column: field.column.clone(),
                 })
                 .collect(),
-        };
+        }
+    }
 
-        let cs_decl = ChangesetDecl {
-            vis: vis.clone(),
+    pub(crate) fn changeset_decl(&self) -> ChangesetDecl {
+        ChangesetDecl {
+            vis: self.visibility.clone(),
             ident: self.changeset.ident(),
-            table: table.clone(),
+            table: self.table.clone(),
             additional_derives: self.changeset.derive.clone(),
             fields: self
                 .iter_fields()
@@ -57,12 +58,6 @@ impl ModelConfig {
                     column: field.column.clone(),
                 })
                 .collect(),
-        };
-
-        quote! {
-            #model_impl
-            #row_decl
-            #cs_decl
         }
     }
 

--- a/editoast/editoast_derive/src/modelv2/codegen/changeset_builder_impl_block.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/changeset_builder_impl_block.rs
@@ -1,0 +1,93 @@
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::quote;
+use quote::ToTokens;
+use syn::parse_quote;
+
+use crate::modelv2::ModelField;
+
+pub(super) enum BuilderType {
+    Changeset,
+    Patch,
+}
+
+pub(crate) struct ChangesetBuilderImplBlock {
+    pub(super) builder_type: BuilderType,
+    pub(super) model: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) fields: Vec<ModelField>,
+}
+
+impl ChangesetBuilderImplBlock {
+    fn impl_decl(&self) -> TokenStream {
+        let Self {
+            model, changeset, ..
+        } = self;
+        match self.builder_type {
+            BuilderType::Changeset => quote! { impl #changeset },
+            BuilderType::Patch => quote! {  impl<'a> crate::modelsv2::Patch<'a, #model> },
+        }
+    }
+
+    fn builder_field_fn_decl(&self, field: &ModelField) -> syn::ItemFn {
+        let ident = &field.ident;
+        let ty = &field.ty;
+        let value = field.into_transformed(parse_quote! { #ident });
+        let statement = match self.builder_type {
+            BuilderType::Changeset => quote! { self.#ident = Some(#value) },
+            BuilderType::Patch => quote! { self.changeset.#ident = Some(#value) },
+        };
+        parse_quote! {
+            pub fn #ident(mut self, #ident: #ty) -> Self {
+                #statement;
+                self
+            }
+        }
+    }
+
+    fn builder_flat_fn_decl(&self, field: &ModelField) -> syn::ItemFn {
+        let ident = &field.ident;
+        let ty = &field.ty;
+        let value = field.into_transformed(parse_quote! { #ident });
+        let statement = match self.builder_type {
+            BuilderType::Changeset => quote! { self.#ident = #ident.map(|#ident| #value) },
+            BuilderType::Patch => quote! { self.changeset.#ident = #ident.map(|#ident| #value) },
+        };
+        let name = syn::Ident::new(&format!("flat_{}", &field.builder_ident), Span::call_site());
+        parse_quote! {
+            pub fn #name(mut self, #ident: Option<#ty>) -> Self {
+                #statement;
+                self
+            }
+        }
+    }
+}
+
+impl ToTokens for ChangesetBuilderImplBlock {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let impl_decl = self.impl_decl();
+        let field_fns = self
+            .fields
+            .iter()
+            .map(|field| self.builder_field_fn_decl(field));
+        let flat_fns = self
+            .fields
+            .iter()
+            .map(|field| self.builder_flat_fn_decl(field));
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #impl_decl {
+                #(
+                    #[allow(unused)]
+                    #[must_use = "builder methods are intended to be chained"]
+                    #field_fns
+                )*
+                #(
+                    #[allow(unused)]
+                    #[must_use = "builder methods are intended to be chained"]
+                    #flat_fns
+                )*
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/changeset_decl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/changeset_decl.rs
@@ -1,0 +1,52 @@
+use super::np;
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct ChangesetDecl {
+    pub(super) vis: syn::Visibility,
+    pub(super) ident: syn::Ident,
+    pub(super) table: syn::Path,
+    pub(super) additional_derives: darling::util::PathList,
+    pub(super) fields: Vec<ChangesetFieldDecl>,
+}
+
+pub(crate) struct ChangesetFieldDecl {
+    pub(super) vis: syn::Visibility,
+    pub(super) name: syn::Ident,
+    pub(super) ty: syn::Type,
+    pub(super) column: String,
+}
+
+impl ToTokens for ChangesetDecl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            vis,
+            ident,
+            table,
+            additional_derives,
+            fields,
+        } = self;
+        let np!(field_column, field_vis, field_name, field_type): np!(vec4) = fields
+            .iter()
+            .map(|field| {
+                let ChangesetFieldDecl {
+                    vis,
+                    name,
+                    ty,
+                    column,
+                } = field;
+                np!(column, vis, name, ty)
+            })
+            .unzip();
+        tokens.extend(quote! {
+            #[derive(Default, Queryable, AsChangeset, Insertable, #(#additional_derives),*)]
+            #[diesel(table_name = #table)]
+            #vis struct #ident {
+                #(
+                    #[diesel(deserialize_as = #field_type, column_name = #field_column)]
+                    #field_vis #field_name: Option<#field_type>
+                ),*
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/changeset_from_model.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/changeset_from_model.rs
@@ -1,0 +1,39 @@
+use crate::modelv2::utils::np;
+use crate::modelv2::ModelField;
+use quote::quote;
+use quote::ToTokens;
+use syn::parse_quote;
+
+pub(crate) struct ChangesetFromModelImpl {
+    pub(super) model: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) fields: Vec<ModelField>,
+}
+
+impl ToTokens for ChangesetFromModelImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            changeset,
+            fields,
+        } = self;
+        let np!(field, value): np!(vec2) = fields
+            .iter()
+            .map(|field| {
+                let ident = &field.ident;
+                let expr = field.into_transformed(parse_quote! { model.#ident });
+                (ident, expr)
+            })
+            .unzip();
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl From<#model> for #changeset {
+                fn from(model: #model) -> Self {
+                    Self {
+                        #( #field: Some(#value) ),*
+                    }
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/identifiable_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/identifiable_impl.rs
@@ -1,0 +1,22 @@
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct IdentifiableImpl {
+    pub(super) model: syn::Ident,
+    pub(super) ty: syn::Type,
+    pub(super) fields: Vec<syn::Ident>,
+}
+
+impl ToTokens for IdentifiableImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self { model, ty, fields } = self;
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl crate::models::Identifiable<#ty> for #model {
+                fn get_id(&self) -> #ty {
+                    (#(self.#fields.clone()),*)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/model_from_row_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/model_from_row_impl.rs
@@ -1,0 +1,35 @@
+use crate::modelv2::utils::np;
+use crate::modelv2::ModelField;
+use quote::quote;
+use quote::ToTokens;
+use syn::parse_quote;
+
+pub(crate) struct ModelFromRowImpl {
+    pub(super) model: syn::Ident,
+    pub(super) row: syn::Ident,
+    pub(super) fields: Vec<ModelField>,
+}
+
+impl ToTokens for ModelFromRowImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self { model, row, fields } = self;
+        let np!(field, value): np!(vec2) = fields
+            .iter()
+            .map(|field| {
+                let ident = &field.ident;
+                let expr = field.from_transformed(parse_quote! { row.#ident });
+                (ident, expr)
+            })
+            .unzip();
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl From<#row> for #model {
+                fn from(row: #row) -> Self {
+                    Self {
+                        #( #field: #value ),*
+                    }
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/model_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/model_impl.rs
@@ -1,0 +1,24 @@
+use quote::{quote, ToTokens};
+
+pub(crate) struct ModelImpl {
+    pub(super) model: syn::Ident,
+    pub(super) row: syn::Ident,
+    pub(super) changeset: syn::Ident,
+}
+
+impl ToTokens for ModelImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            row,
+            changeset,
+        } = self;
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl crate::modelsv2::Model for #model {
+                type Row = #row;
+                type Changeset = #changeset;
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/preferred_id_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/preferred_id_impl.rs
@@ -1,0 +1,17 @@
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct PreferredIdImpl {
+    pub(super) model: syn::Ident,
+    pub(super) ty: syn::Type,
+}
+
+impl ToTokens for PreferredIdImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self { model, ty } = self;
+        tokens.extend(quote! {
+            #[automatically_derived]
+            impl crate::models::PreferredId<#ty> for #model {}
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/row_decl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/row_decl.rs
@@ -1,0 +1,49 @@
+use super::np;
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct RowDecl {
+    pub(super) vis: syn::Visibility,
+    pub(super) ident: syn::Ident,
+    pub(super) table: syn::Path,
+    pub(super) additional_derives: darling::util::PathList,
+    pub(super) fields: Vec<RowFieldDecl>,
+}
+
+pub(crate) struct RowFieldDecl {
+    pub(super) vis: syn::Visibility,
+    pub(super) name: syn::Ident,
+    pub(super) ty: syn::Type,
+    pub(super) column: String,
+}
+
+impl ToTokens for RowDecl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            vis,
+            ident,
+            table,
+            additional_derives,
+            fields,
+        } = self;
+        let np!(field_column, field_vis, field_name, field_type): np!(vec4) = fields
+            .iter()
+            .map(|field| {
+                let RowFieldDecl {
+                    vis,
+                    name,
+                    ty,
+                    column,
+                } = field;
+                np!(column, vis, name, ty)
+            })
+            .unzip();
+        tokens.extend(quote! {
+            #[derive(Queryable, QueryableByName, #(#additional_derives),*)]
+            #[diesel(table_name = #table)]
+            #vis struct #ident {
+                #(#[diesel(column_name = #field_column)] #field_vis #field_name: #field_type),*
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -12,6 +12,7 @@ use super::{args::GeneratedTypeArgs, identifier::Identifier};
 #[derive(Debug, PartialEq)]
 pub struct ModelConfig {
     pub model: syn::Ident,
+    pub visibility: syn::Visibility,
     pub table: syn::Path,
     pub fields: Fields,
     pub row: GeneratedTypeArgs,

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -126,16 +126,16 @@ impl ModelField {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_transformed(&self, expr: TokenStream) -> TokenStream {
+    pub fn from_transformed(&self, expr: syn::Expr) -> syn::Expr {
         match self.transform {
-            Some(FieldTransformation::Remote(_)) => quote! { #expr.into() },
-            Some(FieldTransformation::Json) => quote! { #expr.0 },
+            Some(FieldTransformation::Remote(_)) => parse_quote! { #expr.into() },
+            Some(FieldTransformation::Json) => parse_quote! { #expr.0 },
             Some(FieldTransformation::Geo) => unimplemented!("to be designed"),
-            Some(FieldTransformation::ToString) => quote! { String::from(#expr.parse()) },
+            Some(FieldTransformation::ToString) => parse_quote! { String::from(#expr.parse()) },
             Some(FieldTransformation::ToEnum(ref ty)) => {
-                quote! { #ty::from_repr(#expr as usize).expect("Invalid variant repr") }
+                parse_quote! { #ty::from_repr(#expr as usize).expect("Invalid variant repr") }
             }
-            None => quote! { #expr },
+            None => parse_quote! { #expr },
         }
     }
 

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -3,8 +3,6 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use proc_macro2::TokenStream;
-use quote::quote;
 use syn::parse_quote;
 
 use super::{args::GeneratedTypeArgs, identifier::Identifier};
@@ -112,16 +110,16 @@ impl ModelConfig {
 
 impl ModelField {
     #[allow(clippy::wrong_self_convention)]
-    pub fn into_transformed(&self, expr: TokenStream) -> TokenStream {
+    pub fn into_transformed(&self, expr: syn::Expr) -> syn::Expr {
         match self.transform {
-            Some(FieldTransformation::Remote(_)) => quote! { #expr.into() },
-            Some(FieldTransformation::Json) => quote! { diesel_json::Json(#expr) },
+            Some(FieldTransformation::Remote(_)) => parse_quote! { #expr.into() },
+            Some(FieldTransformation::Json) => parse_quote! { diesel_json::Json(#expr) },
             Some(FieldTransformation::Geo) => unimplemented!("to be designed"),
-            Some(FieldTransformation::ToString) => quote! { #expr.to_string() },
+            Some(FieldTransformation::ToString) => parse_quote! { #expr.to_string() },
             Some(FieldTransformation::ToEnum(_)) => {
-                quote! { #expr as i16 }
+                parse_quote! { #expr as i16 }
             }
-            None => quote! { #expr },
+            None => parse_quote! { #expr },
         }
     }
 

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -5,6 +5,7 @@ use std::{
 
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::parse_quote;
 
 use super::{args::GeneratedTypeArgs, identifier::Identifier};
 
@@ -140,15 +141,15 @@ impl ModelField {
         }
     }
 
-    pub fn transform_type(&self) -> TokenStream {
+    pub fn transform_type(&self) -> syn::Type {
         let ty = &self.ty;
         match self.transform {
-            Some(FieldTransformation::Remote(ref ty)) => quote! { #ty },
-            Some(FieldTransformation::Json) => quote! { diesel_json::Json<#ty> },
+            Some(FieldTransformation::Remote(ref ty)) => parse_quote! { #ty },
+            Some(FieldTransformation::Json) => parse_quote! { diesel_json::Json<#ty> },
             Some(FieldTransformation::Geo) => unimplemented!("to be designed"),
-            Some(FieldTransformation::ToString) => quote! { String },
-            Some(FieldTransformation::ToEnum(_)) => quote! { i16 },
-            None => quote! { #ty },
+            Some(FieldTransformation::ToString) => parse_quote! { String },
+            Some(FieldTransformation::ToEnum(_)) => parse_quote! { i16 },
+            None => ty.clone(),
         }
     }
 }

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -75,17 +75,14 @@ impl Identifier {
         }
     }
 
-    pub fn type_expr(&self, config: &ModelConfig) -> TokenStream {
+    pub fn type_expr(&self, config: &ModelConfig) -> syn::Type {
         match self {
-            Self::Field(_) => {
-                let ty = &self.get_field(config).unwrap().ty;
-                quote! { #ty }
-            }
+            Self::Field(_) => self.get_field(config).unwrap().ty.clone(),
             Self::Compound(idents) => {
                 let ty = idents
                     .iter()
                     .map(|ident| &config.fields.get(ident).unwrap().ty);
-                quote! { (#(#ty),*) }
+                syn::parse_quote! { (#(#ty),*) } // tuple type
             }
         }
     }

--- a/editoast/editoast_derive/src/modelv2/parsing.rs
+++ b/editoast/editoast_derive/src/modelv2/parsing.rs
@@ -10,7 +10,11 @@ use super::{
 };
 
 impl ModelConfig {
-    pub fn from_macro_args(options: ModelArgs, model_name: syn::Ident) -> darling::Result<Self> {
+    pub fn from_macro_args(
+        options: ModelArgs,
+        model_name: syn::Ident,
+        visibility: syn::Visibility,
+    ) -> darling::Result<Self> {
         let row = GeneratedTypeArgs {
             type_name: options.row.type_name.or(Some(format!("{}Row", model_name))),
             ..options.row
@@ -104,6 +108,7 @@ impl ModelConfig {
 
         Ok(Self {
             model: model_name,
+            visibility,
             table: options.table,
             fields,
             identifiers,


### PR DESCRIPTION
Defines for each generated code block (struct definition, impl block, trait implementation) a struct
implementing `ToTokens` to isolate (almost) all quoting into `modelv2::codegen`.

This PR contains this refactoring for all blocks _except_ the DB access ModelV2 traits implementations.
These will come in another PR.

> [!TIP]
> This PR can be reviewed commit by commit.
 
