### PR TITLE
Split ModelV2 codegen in multiple submodules (part 2)

### DIFF
--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -42,6 +42,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let create_impl = config.create_impl();
     let delete_impl = config.delete_impl();
     let create_batch_impl = config.create_batch_impl();
+    let create_batch_with_key_impls = config.create_batch_with_key_impls();
 
     Ok(quote! {
         #model_impl
@@ -65,6 +66,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #create_impl
         #delete_impl
         #create_batch_impl
+        #(#create_batch_with_key_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -39,6 +39,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let retrieve_impls = config.retrieve_impls();
     let update_impls = config.update_impls();
     let delete_static_impls = config.delete_static_impls();
+    let create_impl = config.create_impl();
 
     Ok(quote! {
         #model_impl
@@ -59,6 +60,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #(#retrieve_impls)*
         #(#update_impls)*
         #(#delete_static_impls)*
+        #create_impl
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -38,6 +38,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let exist_impls = config.exists_impls();
     let retrieve_impls = config.retrieve_impls();
     let update_impls = config.update_impls();
+    let delete_static_impls = config.delete_static_impls();
 
     Ok(quote! {
         #model_impl
@@ -57,6 +58,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #(#exist_impls)*
         #(#retrieve_impls)*
         #(#update_impls)*
+        #(#delete_static_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -36,6 +36,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
 
     let model_impls = config.make_model_traits_impl();
     let exist_impls = config.exists_impls();
+    let retrieve_impls = config.retrieve_impls();
 
     Ok(quote! {
         #model_impl
@@ -53,6 +54,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
 
         #model_impls
         #(#exist_impls)*
+        #(#retrieve_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -37,6 +37,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_impls = config.make_model_traits_impl();
     let exist_impls = config.exists_impls();
     let retrieve_impls = config.retrieve_impls();
+    let update_impls = config.update_impls();
 
     Ok(quote! {
         #model_impl
@@ -55,6 +56,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #model_impls
         #(#exist_impls)*
         #(#retrieve_impls)*
+        #(#update_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -41,6 +41,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let delete_static_impls = config.delete_static_impls();
     let create_impl = config.create_impl();
     let delete_impl = config.delete_impl();
+    let create_batch_impl = config.create_batch_impl();
 
     Ok(quote! {
         #model_impl
@@ -63,6 +64,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #(#delete_static_impls)*
         #create_impl
         #delete_impl
+        #create_batch_impl
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -34,7 +34,6 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let changeset_builder = config.changeset_builder_impl_block();
     let patch_builder = config.patch_builder_impl_block();
 
-    let model_impls = config.make_model_traits_impl();
     let exist_impls = config.exists_impls();
     let retrieve_impls = config.retrieve_impls();
     let update_impls = config.update_impls();
@@ -45,6 +44,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let create_batch_with_key_impls = config.create_batch_with_key_impls();
     let retrieve_batch_impls = config.retrieve_batch_impls();
     let update_batch_impls = config.update_batch_impls();
+    let delete_batch_impls = config.delete_batch_impls();
 
     Ok(quote! {
         #model_impl
@@ -60,7 +60,6 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #changeset_builder
         #patch_builder
 
-        #model_impls
         #(#exist_impls)*
         #(#retrieve_impls)*
         #(#update_impls)*
@@ -71,6 +70,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #(#create_batch_with_key_impls)*
         #(#retrieve_batch_impls)*
         #(#update_batch_impls)*
+        #(#delete_batch_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -35,6 +35,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let patch_builder = config.patch_builder_impl_block();
 
     let model_impls = config.make_model_traits_impl();
+    let exist_impls = config.exists_impls();
 
     Ok(quote! {
         #model_impl
@@ -51,6 +52,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #patch_builder
 
         #model_impls
+        #(#exist_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -44,6 +44,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let create_batch_impl = config.create_batch_impl();
     let create_batch_with_key_impls = config.create_batch_with_key_impls();
     let retrieve_batch_impls = config.retrieve_batch_impls();
+    let update_batch_impls = config.update_batch_impls();
 
     Ok(quote! {
         #model_impl
@@ -69,6 +70,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #create_batch_impl
         #(#create_batch_with_key_impls)*
         #(#retrieve_batch_impls)*
+        #(#update_batch_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -13,7 +13,7 @@ use syn::DeriveInput;
 
 use args::ModelArgs;
 use config::*;
-use identifier::Identifier;
+use identifier::RawIdentifier;
 
 pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_name = &input.ident;

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -43,6 +43,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let delete_impl = config.delete_impl();
     let create_batch_impl = config.create_batch_impl();
     let create_batch_with_key_impls = config.create_batch_with_key_impls();
+    let retrieve_batch_impls = config.retrieve_batch_impls();
 
     Ok(quote! {
         #model_impl
@@ -67,6 +68,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #delete_impl
         #create_batch_impl
         #(#create_batch_with_key_impls)*
+        #(#retrieve_batch_impls)*
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -40,6 +40,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let update_impls = config.update_impls();
     let delete_static_impls = config.delete_static_impls();
     let create_impl = config.create_impl();
+    let delete_impl = config.delete_impl();
 
     Ok(quote! {
         #model_impl
@@ -61,6 +62,7 @@ pub fn model(input: &DeriveInput) -> Result<TokenStream> {
         #(#update_impls)*
         #(#delete_static_impls)*
         #create_impl
+        #delete_impl
     })
 }
 

--- a/editoast/editoast_derive/src/modelv2/args.rs
+++ b/editoast/editoast_derive/src/modelv2/args.rs
@@ -1,4 +1,4 @@
-use super::Identifier;
+use super::RawIdentifier;
 use darling::{
     ast,
     util::{self, PathList},
@@ -19,9 +19,9 @@ pub struct ModelArgs {
     #[darling(default)]
     pub changeset: GeneratedTypeArgs,
     #[darling(multiple, rename = "identifier")]
-    pub identifiers: Vec<Identifier>,
+    pub identifiers: Vec<RawIdentifier>,
     #[darling(default)]
-    pub preferred: Option<Identifier>,
+    pub preferred: Option<RawIdentifier>,
     pub data: ast::Data<util::Ignored, ModelFieldArgs>,
 }
 

--- a/editoast/editoast_derive/src/modelv2/args.rs
+++ b/editoast/editoast_derive/src/modelv2/args.rs
@@ -12,64 +12,64 @@ use proc_macro2::Span;
     forward_attrs(allow, doc, cfg),
     supports(struct_named)
 )]
-pub struct ModelArgs {
-    pub table: syn::Path,
+pub(super) struct ModelArgs {
+    pub(super) table: syn::Path,
     #[darling(default)]
-    pub row: GeneratedTypeArgs,
+    pub(super) row: GeneratedTypeArgs,
     #[darling(default)]
-    pub changeset: GeneratedTypeArgs,
+    pub(super) changeset: GeneratedTypeArgs,
     #[darling(multiple, rename = "identifier")]
-    pub identifiers: Vec<RawIdentifier>,
+    pub(super) identifiers: Vec<RawIdentifier>,
     #[darling(default)]
-    pub preferred: Option<RawIdentifier>,
-    pub data: ast::Data<util::Ignored, ModelFieldArgs>,
+    pub(super) preferred: Option<RawIdentifier>,
+    pub(super) data: ast::Data<util::Ignored, ModelFieldArgs>,
 }
 
 #[derive(FromMeta, Default, Debug, PartialEq)]
-pub struct GeneratedTypeArgs {
+pub(super) struct GeneratedTypeArgs {
     #[darling(default)]
-    pub type_name: Option<String>,
+    pub(super) type_name: Option<String>,
     #[darling(default)]
-    pub derive: PathList,
+    pub(super) derive: PathList,
     #[darling(default)]
-    pub public: bool,
+    pub(super) public: bool,
 }
 
 #[derive(FromField, Debug)]
 #[darling(attributes(model), forward_attrs(allow, doc, cfg))]
-pub struct ModelFieldArgs {
-    pub ident: Option<syn::Ident>,
-    pub ty: syn::Type,
+pub(super) struct ModelFieldArgs {
+    pub(super) ident: Option<syn::Ident>,
+    pub(super) ty: syn::Type,
     #[darling(default)]
-    pub builder_fn: Option<syn::Ident>,
+    pub(super) builder_fn: Option<syn::Ident>,
     #[darling(default)]
-    pub column: Option<String>,
+    pub(super) column: Option<String>,
     #[darling(default)]
-    pub builder_skip: bool,
+    pub(super) builder_skip: bool,
     #[darling(default)]
-    pub identifier: bool,
+    pub(super) identifier: bool,
     #[darling(default)]
-    pub preferred: bool,
+    pub(super) preferred: bool,
     #[darling(default)]
-    pub primary: bool,
+    pub(super) primary: bool,
     #[darling(default)]
-    pub json: bool,
+    pub(super) json: bool,
     #[darling(default)]
-    pub geo: bool,
+    pub(super) geo: bool,
     #[darling(default)]
-    pub to_string: bool,
+    pub(super) to_string: bool,
     #[darling(default)]
-    pub to_enum: bool,
+    pub(super) to_enum: bool,
     #[darling(default)]
-    pub remote: Option<syn::Type>,
+    pub(super) remote: Option<syn::Type>,
 }
 
 impl GeneratedTypeArgs {
-    pub fn ident(&self) -> syn::Ident {
+    pub(super) fn ident(&self) -> syn::Ident {
         syn::Ident::new(self.type_name.as_ref().unwrap(), Span::call_site())
     }
 
-    pub fn visibility(&self) -> syn::Visibility {
+    pub(super) fn visibility(&self) -> syn::Visibility {
         if self.public {
             syn::Visibility::Public(Default::default())
         } else {

--- a/editoast/editoast_derive/src/modelv2/codegen.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen.rs
@@ -44,12 +44,12 @@ use self::retrieve_impl::RetrieveImpl;
 use self::update_batch_impl::UpdateBatchImpl;
 use self::update_impl::UpdateImpl;
 
-use super::identifier::TypedIdentifier;
+use super::identifier::Identifier;
 use super::utils::np;
-use super::Identifier;
 use super::ModelConfig;
+use super::RawIdentifier;
 
-impl Identifier {
+impl RawIdentifier {
     fn get_ident_lvalue(&self) -> syn::Expr {
         match self {
             Self::Field(ident) => parse_quote! { #ident },
@@ -60,14 +60,14 @@ impl Identifier {
     }
 }
 
-impl TypedIdentifier {
+impl Identifier {
     fn get_type(&self) -> syn::Type {
         let ty = self.field_types.iter();
         syn::parse_quote! { (#(#ty),*) } // tuple type
     }
 
     fn get_lvalue(&self) -> syn::Expr {
-        self.identifier.get_ident_lvalue()
+        self.raw.get_ident_lvalue()
     }
 
     fn get_diesel_eqs(&self) -> Vec<syn::Expr> {
@@ -151,7 +151,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn identifiable_impls(&self) -> Vec<IdentifiableImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| IdentifiableImpl {
                 model: self.model.clone(),
@@ -164,7 +164,7 @@ impl ModelConfig {
     pub(crate) fn preferred_id_impl(&self) -> PreferredIdImpl {
         PreferredIdImpl {
             model: self.model.clone(),
-            ty: self.preferred_typed_identifier.get_type(),
+            ty: self.preferred_identifier.get_type(),
         }
     }
 
@@ -185,7 +185,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn retrieve_impls(&self) -> Vec<RetrieveImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| RetrieveImpl {
                 model: self.model.clone(),
@@ -198,7 +198,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn exists_impls(&self) -> Vec<ExistsImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| ExistsImpl {
                 model: self.model.clone(),
@@ -210,7 +210,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn update_impls(&self) -> Vec<UpdateImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| UpdateImpl {
                 model: self.model.clone(),
@@ -224,7 +224,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn delete_static_impls(&self) -> Vec<DeleteStaticImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| DeleteStaticImpl {
                 model: self.model.clone(),
@@ -264,7 +264,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn create_batch_with_key_impls(&self) -> Vec<CreateBatchWithKeyImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| CreateBatchWithKeyImpl {
                 model: self.model.clone(),
@@ -279,7 +279,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn retrieve_batch_impls(&self) -> Vec<RetrieveBatchImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| RetrieveBatchImpl {
                 model: self.model.clone(),
@@ -292,7 +292,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn update_batch_impls(&self) -> Vec<UpdateBatchImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| UpdateBatchImpl {
                 model: self.model.clone(),
@@ -307,7 +307,7 @@ impl ModelConfig {
     }
 
     pub(crate) fn delete_batch_impls(&self) -> Vec<DeleteBatchImpl> {
-        self.typed_identifiers
+        self.identifiers
             .iter()
             .map(|identifier| DeleteBatchImpl {
                 model: self.model.clone(),

--- a/editoast/editoast_derive/src/modelv2/codegen.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen.rs
@@ -20,14 +20,10 @@ mod update_impl;
 
 use syn::parse_quote;
 
-use crate::modelv2::codegen::changeset_decl::ChangesetDecl;
-use crate::modelv2::codegen::changeset_decl::ChangesetFieldDecl;
-use crate::modelv2::codegen::model_impl::ModelImpl;
-use crate::modelv2::codegen::row_decl::RowDecl;
-use crate::modelv2::codegen::row_decl::RowFieldDecl;
-
 use self::changeset_builder_impl_block::BuilderType;
 use self::changeset_builder_impl_block::ChangesetBuilderImplBlock;
+use self::changeset_decl::ChangesetDecl;
+use self::changeset_decl::ChangesetFieldDecl;
 use self::changeset_from_model::ChangesetFromModelImpl;
 use self::create_batch_impl::CreateBatchImpl;
 use self::create_batch_with_key_impl::CreateBatchWithKeyImpl;
@@ -38,9 +34,12 @@ use self::delete_static_impl::DeleteStaticImpl;
 use self::exists_impl::ExistsImpl;
 use self::identifiable_impl::IdentifiableImpl;
 use self::model_from_row_impl::ModelFromRowImpl;
+use self::model_impl::ModelImpl;
 use self::preferred_id_impl::PreferredIdImpl;
 use self::retrieve_batch_impl::RetrieveBatchImpl;
 use self::retrieve_impl::RetrieveImpl;
+use self::row_decl::RowDecl;
+use self::row_decl::RowFieldDecl;
 use self::update_batch_impl::UpdateBatchImpl;
 use self::update_impl::UpdateImpl;
 

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -1,0 +1,57 @@
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct CreateBatchImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) field_count: usize,
+}
+
+impl ToTokens for CreateBatchImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            changeset,
+            field_count,
+        } = self;
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::CreateBatch<#changeset> for #model {
+                async fn create_batch<
+                    I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<Self> + Send,
+                >(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    values: I,
+                ) -> crate::error::Result<C> {
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        #field_count,
+                        values,
+                        C::default(),
+                        chunk => {
+                            diesel::insert_into(dsl::#table_name)
+                                .values(chunk)
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
+                                .await?
+                        }
+                    })
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -1,0 +1,69 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct CreateBatchWithKeyImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) field_count: usize,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for CreateBatchWithKeyImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            changeset,
+            field_count,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::CreateBatchWithKey<#changeset, #ty> for #model {
+                async fn create_batch_with_key<
+                    I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<(#ty, Self)> + Send,
+                >(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    values: I,
+                ) -> crate::error::Result<C> {
+                    use crate::models::Identifiable;
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        #field_count,
+                        values,
+                        C::default(),
+                        chunk => {
+                            diesel::insert_into(dsl::#table_name)
+                                .values(chunk)
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| {
+                                    s.map_ok(|row| {
+                                        let model = <#model as Model>::from_row(row);
+                                        (model.get_id(), model)
+                                    })
+                                    .try_collect::<Vec<_>>()
+                                })?
+                                .await?
+                        }
+                    })
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct CreateBatchWithKeyImpl {
     pub(super) model: syn::Ident,
@@ -10,7 +10,7 @@ pub(crate) struct CreateBatchWithKeyImpl {
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
     pub(super) field_count: usize,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for CreateBatchWithKeyImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -1,0 +1,53 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct DeleteBatchImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for DeleteBatchImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let params_per_row = identifier.get_idents().len();
+        let filters = identifier.get_diesel_eq_and_fold();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::DeleteBatch<#ty> for #model {
+                async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait>(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    ids: I,
+                ) -> crate::error::Result<usize> {
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    let counts = crate::chunked_for_libpq! {
+                        #params_per_row,
+                        ids,
+                        chunk => {
+                            let mut query = diesel::delete(dsl::#table_name).into_boxed();
+                            for #id_ident in chunk.into_iter() {
+                                query = query.or_filter(#filters);
+                            }
+                            query.execute(conn).await?
+                        }
+                    };
+                    Ok(counts.into_iter().sum())
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -1,13 +1,13 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct DeleteBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for DeleteBatchImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
@@ -1,0 +1,39 @@
+use quote::quote;
+use quote::ToTokens;
+
+pub(crate) struct DeleteImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) primary_key: syn::Ident,
+}
+
+impl ToTokens for DeleteImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_mod,
+            primary_key,
+        } = self;
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Delete for #model {
+                async fn delete(
+                    &self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                ) -> crate::error::Result<bool> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    let id = self.#primary_key;
+                    diesel::delete(#table_mod::table.find(id))
+                        .execute(conn)
+                        .await
+                        .map(|n| n == 1)
+                        .map_err(Into::into)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
@@ -1,0 +1,45 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct DeleteStaticImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for DeleteStaticImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let eqs = identifier.get_diesel_eqs();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::DeleteStatic<#ty> for #model {
+                async fn delete_static(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    #id_ident: #ty,
+                ) -> crate::error::Result<bool> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    diesel::delete(dsl::#table_name.#(filter(#eqs)).*)
+                        .execute(conn)
+                        .await
+                        .map(|n| n == 1)
+                        .map_err(Into::into)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
@@ -1,13 +1,13 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct DeleteStaticImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for DeleteStaticImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
@@ -1,0 +1,44 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct ExistsImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for ExistsImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let eqs = identifier.get_diesel_eqs();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Exists<#ty> for #model {
+                async fn exists(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    #id_ident: #ty,
+                ) -> crate::error::Result<bool> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    diesel::select(diesel::dsl::exists(dsl::#table_name.#(filter(#eqs)).*))
+                        .get_result(conn)
+                        .await
+                        .map_err(Into::into)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
@@ -1,13 +1,13 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct ExistsImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for ExistsImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -1,14 +1,14 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct RetrieveBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
     pub(super) row: syn::Ident,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for RetrieveBatchImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -1,0 +1,104 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct RetrieveBatchImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for RetrieveBatchImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let params_per_row = identifier.get_idents().len();
+        let filters = identifier.get_diesel_eq_and_fold();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::RetrieveBatchUnchecked<#ty> for #model {
+                async fn retrieve_batch_unchecked<
+                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<#model> + Send,
+                >(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    ids: I,
+                ) -> crate::error::Result<C> {
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        #params_per_row,
+                        ids,
+                        C::default(),
+                        chunk => {
+                            // Diesel doesn't allow `(col1, col2).eq_any(iterator<(&T, &U)>)` because it imposes restrictions
+                            // on tuple usage. Doing it this way is the suggested workaround (https://github.com/diesel-rs/diesel/issues/3222#issuecomment-1177433434).
+                            // eq_any reallocates its argument anyway so the additional cost with this method are the boxing and the diesel wrappers.
+                            let mut query = dsl::#table_name.into_boxed();
+                            for #id_ident in chunk.into_iter() {
+                                query = query.or_filter(#filters);
+                            }
+                            query
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
+                                .await?
+                        }
+                    })
+                }
+
+                async fn retrieve_batch_with_key_unchecked<
+                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<(#ty, #model)> + Send,
+                >(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    ids: I,
+                ) -> crate::error::Result<C> {
+                    use crate::models::Identifiable;
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        #params_per_row,
+                        ids,
+                        C::default(),
+                        chunk => {
+                            let mut query = dsl::#table_name.into_boxed();
+                            for #id_ident in chunk.into_iter() {
+                                query = query.or_filter(#filters);
+                            }
+                            query
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| {
+                                    s.map_ok(|row| {
+                                        let model = <#model as Model>::from_row(row);
+                                        (model.get_id(), model)
+                                    })
+                                    .try_collect::<Vec<_>>()
+                                })?
+                                .await?
+                        }
+                    })
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
@@ -1,0 +1,49 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct RetrieveImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for RetrieveImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let eqs = identifier.get_diesel_eqs();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Retrieve<#ty> for #model {
+                async fn retrieve(
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    #id_ident: #ty,
+                ) -> crate::error::Result<Option<#model>> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    dsl::#table_name
+                        .#(filter(#eqs)).*
+                        .first::<#row>(conn)
+                        .await
+                        .map(Into::into)
+                        .optional()
+                        .map_err(Into::into)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
@@ -1,14 +1,14 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct RetrieveImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
     pub(super) row: syn::Ident,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for RetrieveImpl {

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -1,0 +1,116 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct UpdateBatchImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) identifier: TypedIdentifier,
+    pub(super) primary_key_column: syn::Ident,
+}
+
+impl ToTokens for UpdateBatchImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            identifier,
+            changeset,
+            primary_key_column,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let params_per_row = identifier.get_idents().len();
+        let filters = identifier.get_diesel_eq_and_fold();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::UpdateBatchUnchecked<#model, #ty> for #changeset {
+                async fn update_batch_unchecked<
+                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<#model> + Send,
+                >(
+                    self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    ids: I,
+                ) -> crate::error::Result<C> {
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        // FIXME: that count is correct for each row, but the maximum buffer size
+                        // should be libpq's max MINUS the size of the changeset
+                        #params_per_row,
+                        ids,
+                        C::default(),
+                        chunk => {
+                            // We have to do it this way because we can't .or_filter() on a boxed update statement
+                            let mut query = dsl::#table_name.select(dsl::#primary_key_column).into_boxed();
+                            for #id_ident in chunk.into_iter() {
+                                query = query.or_filter(#filters);
+                            }
+                            diesel::update(dsl::#table_name)
+                                .filter(dsl::#primary_key_column.eq_any(query))
+                                .set(&self)
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
+                                .await?
+                        }
+                    })
+                }
+
+                async fn update_batch_with_key_unchecked<
+                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    C: Default + std::iter::Extend<(#ty, #model)> + Send,
+                >(
+                    self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    ids: I,
+                ) -> crate::error::Result<C> {
+                    use crate::models::Identifiable;
+                    use crate::modelsv2::Model;
+                    use #table_mod::dsl;
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use futures_util::stream::TryStreamExt;
+                    Ok(crate::chunked_for_libpq! {
+                        // FIXME: that count is correct for each row, but the maximum buffer size
+                        // should be libpq's max MINUS the size of the changeset
+                        #params_per_row,
+                        ids,
+                        C::default(),
+                        chunk => {
+                            let mut query = dsl::#table_name.select(dsl::#primary_key_column).into_boxed();
+                            for #id_ident in chunk.into_iter() {
+                                query = query.or_filter(#filters);
+                            }
+                            diesel::update(dsl::#table_name)
+                                .filter(dsl::#primary_key_column.eq_any(query))
+                                .set(&self)
+                                .load_stream::<#row>(conn)
+                                .await
+                                .map(|s| {
+                                    s.map_ok(|row| {
+                                        let model = <#model as Model>::from_row(row);
+                                        (model.get_id(), model)
+                                    })
+                                    .try_collect::<Vec<_>>()
+                                })?
+                                .await?
+                        }
+                    })
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct UpdateBatchImpl {
     pub(super) model: syn::Ident,
@@ -9,7 +9,7 @@ pub(crate) struct UpdateBatchImpl {
     pub(super) table_mod: syn::Path,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
     pub(super) primary_key_column: syn::Ident,
 }
 

--- a/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
@@ -1,0 +1,52 @@
+use quote::quote;
+use quote::ToTokens;
+
+use crate::modelv2::identifier::TypedIdentifier;
+
+pub(crate) struct UpdateImpl {
+    pub(super) model: syn::Ident,
+    pub(super) table_name: syn::Ident,
+    pub(super) table_mod: syn::Path,
+    pub(super) row: syn::Ident,
+    pub(super) changeset: syn::Ident,
+    pub(super) identifier: TypedIdentifier,
+}
+
+impl ToTokens for UpdateImpl {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let Self {
+            model,
+            table_name,
+            table_mod,
+            row,
+            changeset,
+            identifier,
+        } = self;
+        let ty = identifier.get_type();
+        let id_ident = identifier.get_lvalue();
+        let eqs = identifier.get_diesel_eqs();
+
+        tokens.extend(quote! {
+            #[automatically_derived]
+            #[async_trait::async_trait]
+            impl crate::modelsv2::Update<#ty, #model> for #changeset {
+                async fn update(
+                    self,
+                    conn: &mut diesel_async::AsyncPgConnection,
+                    #id_ident: #ty,
+                ) -> crate::error::Result<Option<#model>> {
+                    use diesel::prelude::*;
+                    use diesel_async::RunQueryDsl;
+                    use #table_mod::dsl;
+                    diesel::update(dsl::#table_name.#(filter(#eqs)).*)
+                        .set(&self)
+                        .get_result::<#row>(conn)
+                        .await
+                        .map(Into::into)
+                        .optional()
+                        .map_err(Into::into)
+                }
+            }
+        });
+    }
+}

--- a/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use quote::ToTokens;
 
-use crate::modelv2::identifier::TypedIdentifier;
+use crate::modelv2::identifier::Identifier;
 
 pub(crate) struct UpdateImpl {
     pub(super) model: syn::Ident,
@@ -9,7 +9,7 @@ pub(crate) struct UpdateImpl {
     pub(super) table_mod: syn::Path,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
-    pub(super) identifier: TypedIdentifier,
+    pub(super) identifier: Identifier,
 }
 
 impl ToTokens for UpdateImpl {

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -11,33 +11,33 @@ use super::{
 };
 
 #[derive(Debug, PartialEq)]
-pub struct ModelConfig {
-    pub model: syn::Ident,
-    pub visibility: syn::Visibility,
-    pub table: syn::Path,
-    pub fields: Fields,
-    pub row: GeneratedTypeArgs,
-    pub changeset: GeneratedTypeArgs,
+pub(crate) struct ModelConfig {
+    pub(crate) model: syn::Ident,
+    pub(crate) visibility: syn::Visibility,
+    pub(crate) table: syn::Path,
+    pub(crate) fields: Fields,
+    pub(crate) row: GeneratedTypeArgs,
+    pub(crate) changeset: GeneratedTypeArgs,
     pub(crate) identifiers: HashSet<Identifier>, // identifiers ⊆ fields
     pub(crate) preferred_identifier: Identifier, // preferred_identifier ∈ identifiers
     pub(crate) primary_identifier: Identifier,   // primary_identifier ∈ identifiers
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct ModelField {
-    pub ident: syn::Ident,
-    pub column: String,
-    pub builder_ident: syn::Ident,
-    pub ty: syn::Type,
-    pub builder_skip: bool,
-    pub identifier: bool,
-    pub preferred: bool,
-    pub primary: bool,
-    pub transform: Option<FieldTransformation>,
+pub(crate) struct ModelField {
+    pub(crate) ident: syn::Ident,
+    pub(crate) column: String,
+    pub(crate) builder_ident: syn::Ident,
+    pub(crate) ty: syn::Type,
+    pub(crate) builder_skip: bool,
+    pub(crate) identifier: bool,
+    pub(crate) preferred: bool,
+    pub(crate) primary: bool,
+    pub(crate) transform: Option<FieldTransformation>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum FieldTransformation {
+pub(crate) enum FieldTransformation {
     Remote(syn::Type),
     Json,
     Geo,
@@ -46,7 +46,7 @@ pub enum FieldTransformation {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Fields(pub Vec<ModelField>);
+pub(crate) struct Fields(pub(crate) Vec<ModelField>);
 
 impl Deref for Fields {
     type Target = Vec<ModelField>;
@@ -63,21 +63,21 @@ impl DerefMut for Fields {
 }
 
 impl Fields {
-    pub fn get(&self, ident: &syn::Ident) -> Option<&ModelField> {
+    pub(crate) fn get(&self, ident: &syn::Ident) -> Option<&ModelField> {
         self.iter().find(|field| &field.ident == ident)
     }
 }
 
 impl ModelConfig {
-    pub fn iter_fields(&self) -> impl Iterator<Item = &ModelField> {
+    pub(crate) fn iter_fields(&self) -> impl Iterator<Item = &ModelField> {
         self.fields.iter()
     }
 
-    pub fn is_primary(&self, field: &ModelField) -> bool {
+    pub(crate) fn is_primary(&self, field: &ModelField) -> bool {
         field.ident == self.get_primary_field_ident()
     }
 
-    pub fn table_name(&self) -> syn::Ident {
+    pub(crate) fn table_name(&self) -> syn::Ident {
         let table = self
             .table
             .segments
@@ -113,7 +113,7 @@ impl ModelConfig {
 
 impl ModelField {
     #[allow(clippy::wrong_self_convention)]
-    pub fn into_transformed(&self, expr: syn::Expr) -> syn::Expr {
+    pub(crate) fn into_transformed(&self, expr: syn::Expr) -> syn::Expr {
         match self.transform {
             Some(FieldTransformation::Remote(_)) => parse_quote! { #expr.into() },
             Some(FieldTransformation::Json) => parse_quote! { diesel_json::Json(#expr) },
@@ -127,7 +127,7 @@ impl ModelField {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_transformed(&self, expr: syn::Expr) -> syn::Expr {
+    pub(crate) fn from_transformed(&self, expr: syn::Expr) -> syn::Expr {
         match self.transform {
             Some(FieldTransformation::Remote(_)) => parse_quote! { #expr.into() },
             Some(FieldTransformation::Json) => parse_quote! { #expr.0 },
@@ -140,7 +140,7 @@ impl ModelField {
         }
     }
 
-    pub fn transform_type(&self) -> syn::Type {
+    pub(crate) fn transform_type(&self) -> syn::Type {
         let ty = &self.ty;
         match self.transform {
             Some(FieldTransformation::Remote(ref ty)) => parse_quote! { #ty },
@@ -152,7 +152,7 @@ impl ModelField {
         }
     }
 
-    pub(super) fn column_ident(&self) -> syn::Ident {
+    pub(crate) fn column_ident(&self) -> syn::Ident {
         syn::Ident::new(&self.column, self.ident.span())
     }
 }

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -18,14 +18,11 @@ pub struct ModelConfig {
     pub fields: Fields,
     pub row: GeneratedTypeArgs,
     pub changeset: GeneratedTypeArgs,
-    pub identifiers: HashSet<Identifier>, // identifiers ⊆ fields
-    pub preferred_identifier: Identifier, // preferred_identifier ∈ identifiers
-    pub primary_field: Identifier,        // primary_field ∈ identifiers
     // NOTE: duplication is temporary, will replace plain identifers once
     // the ToTokens refactoring is complete
-    pub(crate) typed_identifiers: HashSet<TypedIdentifier>,
-    pub(crate) preferred_typed_identifier: TypedIdentifier,
-    pub(crate) primary_typed_identifier: TypedIdentifier,
+    pub(crate) typed_identifiers: HashSet<TypedIdentifier>, // identifiers ⊆ fields
+    pub(crate) preferred_typed_identifier: TypedIdentifier, // preferred_identifier ∈ identifiers
+    pub(crate) primary_typed_identifier: TypedIdentifier,   // primary_field ∈ identifiers
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -79,10 +76,7 @@ impl ModelConfig {
     }
 
     pub fn is_primary(&self, field: &ModelField) -> bool {
-        match &self.primary_field {
-            Identifier::Field(ident) => ident == &field.ident,
-            Identifier::Compound(_) => false,
-        }
+        field.ident == self.get_primary_field_ident()
     }
 
     pub fn table_name(&self) -> syn::Ident {

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -121,6 +121,13 @@ impl ModelConfig {
             Identifier::Compound(_) => panic!("Model: compound primary field should be impossible"),
         }
     }
+
+    pub(super) fn changeset_fields(&self) -> impl Iterator<Item = &ModelField> {
+        self.fields
+            .iter()
+            .filter(|field| !self.is_primary(field))
+            .filter(|field| !field.builder_skip)
+    }
 }
 
 impl ModelField {

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -5,7 +5,10 @@ use std::{
 
 use syn::parse_quote;
 
-use super::{args::GeneratedTypeArgs, identifier::Identifier};
+use super::{
+    args::GeneratedTypeArgs,
+    identifier::{Identifier, TypedIdentifier},
+};
 
 #[derive(Debug, PartialEq)]
 pub struct ModelConfig {
@@ -18,6 +21,11 @@ pub struct ModelConfig {
     pub identifiers: HashSet<Identifier>, // identifiers ⊆ fields
     pub preferred_identifier: Identifier, // preferred_identifier ∈ identifiers
     pub primary_field: Identifier,        // primary_field ∈ identifiers
+    // NOTE: duplication is temporary, will replace plain identifers once
+    // the ToTokens refactoring is complete
+    pub(crate) typed_identifiers: HashSet<TypedIdentifier>,
+    pub(crate) preferred_typed_identifier: TypedIdentifier,
+    pub(crate) primary_typed_identifier: TypedIdentifier,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -147,5 +155,9 @@ impl ModelField {
             Some(FieldTransformation::ToEnum(_)) => parse_quote! { i16 },
             None => ty.clone(),
         }
+    }
+
+    pub(super) fn column_ident(&self) -> syn::Ident {
+        syn::Ident::new(&self.column, self.ident.span())
     }
 }

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -114,6 +114,13 @@ impl ModelConfig {
             .expect("Model: invalid table value");
         table.ident.clone()
     }
+
+    pub(super) fn get_primary_field_ident(&self) -> syn::Ident {
+        match &self.primary_typed_identifier.identifier {
+            Identifier::Field(ident) => ident.clone(),
+            Identifier::Compound(_) => panic!("Model: compound primary field should be impossible"),
+        }
+    }
 }
 
 impl ModelField {

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -122,6 +122,14 @@ impl ModelConfig {
         }
     }
 
+    pub(super) fn get_primary_field_column(&self) -> syn::Ident {
+        match self.primary_typed_identifier.columns.as_slice() {
+            [column] => column.clone(),
+            [] => panic!("Model: primary field should have exactly one column"),
+            _ => panic!("Model: compound primary field should be impossible"),
+        }
+    }
+
     pub(super) fn changeset_fields(&self) -> impl Iterator<Item = &ModelField> {
         self.fields
             .iter()

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -73,27 +73,6 @@ impl Fields {
     }
 }
 
-impl Identifier {
-    pub fn get_field<'a>(&self, config: &'a ModelConfig) -> Option<&'a ModelField> {
-        match self {
-            Self::Field(ident) => config.fields.get(ident),
-            Self::Compound(_) => None,
-        }
-    }
-
-    pub fn type_expr(&self, config: &ModelConfig) -> syn::Type {
-        match self {
-            Self::Field(_) => self.get_field(config).unwrap().ty.clone(),
-            Self::Compound(idents) => {
-                let ty = idents
-                    .iter()
-                    .map(|ident| &config.fields.get(ident).unwrap().ty);
-                syn::parse_quote! { (#(#ty),*) } // tuple type
-            }
-        }
-    }
-}
-
 impl ModelConfig {
     pub fn iter_fields(&self) -> impl Iterator<Item = &ModelField> {
         self.fields.iter()

--- a/editoast/editoast_derive/src/modelv2/identifier.rs
+++ b/editoast/editoast_derive/src/modelv2/identifier.rs
@@ -1,13 +1,13 @@
 use super::Fields;
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
-pub enum RawIdentifier {
+pub(crate) enum RawIdentifier {
     Field(syn::Ident),
     Compound(Vec<syn::Ident>),
 }
 
 impl RawIdentifier {
-    pub fn get_idents(&self) -> Vec<syn::Ident> {
+    pub(crate) fn get_idents(&self) -> Vec<syn::Ident> {
         match self {
             Self::Field(ident) => vec![ident.clone()],
             Self::Compound(idents) => idents.clone(),

--- a/editoast/editoast_derive/src/modelv2/identifier.rs
+++ b/editoast/editoast_derive/src/modelv2/identifier.rs
@@ -1,12 +1,12 @@
 use super::Fields;
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
-pub enum Identifier {
+pub enum RawIdentifier {
     Field(syn::Ident),
     Compound(Vec<syn::Ident>),
 }
 
-impl Identifier {
+impl RawIdentifier {
     pub fn get_idents(&self) -> Vec<syn::Ident> {
         match self {
             Self::Field(ident) => vec![ident.clone()],
@@ -16,22 +16,22 @@ impl Identifier {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
-pub(crate) struct TypedIdentifier {
-    pub(crate) identifier: Identifier,
+pub(crate) struct Identifier {
+    pub(crate) raw: RawIdentifier,
     pub(crate) field_types: Vec<syn::Type>,
     pub(crate) columns: Vec<syn::Ident>,
 }
 
-impl TypedIdentifier {
-    pub(crate) fn new(identifier: Identifier, fields: &Fields) -> Self {
+impl Identifier {
+    pub(crate) fn new(identifier: RawIdentifier, fields: &Fields) -> Self {
         let (field_types, columns) = {
             let fields = match &identifier {
-                Identifier::Field(ident) => {
+                RawIdentifier::Field(ident) => {
                     vec![fields
                         .get(ident)
                         .expect("identifier should exist in the provided config")]
                 }
-                Identifier::Compound(idents) => idents
+                RawIdentifier::Compound(idents) => idents
                     .iter()
                     .map(|ident| {
                         fields
@@ -45,21 +45,21 @@ impl TypedIdentifier {
             (field_types, columns)
         };
         Self {
-            identifier,
+            raw: identifier,
             field_types,
             columns,
         }
     }
 
     pub(crate) fn get_idents(&self) -> Vec<syn::Ident> {
-        self.identifier.get_idents()
+        self.raw.get_idents()
     }
 }
 
-impl darling::FromMeta for Identifier {
+impl darling::FromMeta for RawIdentifier {
     fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
         match expr {
-            syn::Expr::Path(path) => Ok(Identifier::Field(extract_ident_of_path(&path.path)?)),
+            syn::Expr::Path(path) => Ok(RawIdentifier::Field(extract_ident_of_path(&path.path)?)),
             syn::Expr::Tuple(tuple) => {
                 let mut idents = Vec::new();
                 for expr in tuple.elems.iter() {
@@ -72,7 +72,7 @@ impl darling::FromMeta for Identifier {
                         )),
                     }
                 }
-                Ok(Identifier::Compound(idents))
+                Ok(RawIdentifier::Compound(idents))
             }
             _ => Err(darling::Error::custom(
                 "Model: invalid 'identifier' expression",

--- a/editoast/editoast_derive/src/modelv2/parsing.rs
+++ b/editoast/editoast_derive/src/modelv2/parsing.rs
@@ -122,14 +122,9 @@ impl ModelConfig {
             fields,
             row,
             changeset,
-
             typed_identifiers,
             preferred_typed_identifier,
             primary_typed_identifier,
-
-            identifiers: raw_identfiers,
-            preferred_identifier,
-            primary_field,
         })
     }
 }

--- a/editoast/editoast_derive/src/modelv2/parsing.rs
+++ b/editoast/editoast_derive/src/modelv2/parsing.rs
@@ -10,7 +10,7 @@ use super::{
 };
 
 impl ModelConfig {
-    pub fn from_macro_args(
+    pub(crate) fn from_macro_args(
         options: ModelArgs,
         model_name: syn::Ident,
         visibility: syn::Visibility,

--- a/editoast/editoast_derive/src/modelv2/parsing.rs
+++ b/editoast/editoast_derive/src/modelv2/parsing.rs
@@ -5,7 +5,7 @@ use proc_macro2::Span;
 
 use super::{
     args::{GeneratedTypeArgs, ModelArgs, ModelFieldArgs},
-    identifier::{Identifier, TypedIdentifier},
+    identifier::{Identifier, RawIdentifier},
     FieldTransformation, Fields, ModelConfig, ModelField,
 };
 
@@ -60,7 +60,7 @@ impl ModelConfig {
                 field_map
                     .values()
                     .filter(|field| field.identifier)
-                    .map(|field| Identifier::Field(field.ident.clone())),
+                    .map(|field| RawIdentifier::Field(field.ident.clone())),
             )
             .collect();
 
@@ -71,10 +71,10 @@ impl ModelConfig {
             .collect::<Vec<_>>()
             .as_slice()
         {
-            [pf] => Identifier::Field(pf.ident.clone()),
+            [pf] => RawIdentifier::Field(pf.ident.clone()),
             [] => {
                 let id = syn::Ident::new("id", Span::call_site());
-                Identifier::Field(
+                RawIdentifier::Field(
                     field_map
                         .get(&id)
                         .map(|f| f.ident.clone())
@@ -94,7 +94,7 @@ impl ModelConfig {
                 .as_slice(),
         ) {
             (Some(id), []) => id.clone(),
-            (None, [field]) => Identifier::Field(field.ident.clone()),
+            (None, [field]) => RawIdentifier::Field(field.ident.clone()),
             (None, []) => primary_field.clone(),
             _ => {
                 return Err(Error::custom(
@@ -109,11 +109,10 @@ impl ModelConfig {
         let typed_identifiers = raw_identfiers
             .iter()
             .cloned()
-            .map(|id| TypedIdentifier::new(id, &fields))
+            .map(|id| Identifier::new(id, &fields))
             .collect();
-        let preferred_typed_identifier =
-            TypedIdentifier::new(preferred_identifier.clone(), &fields);
-        let primary_typed_identifier = TypedIdentifier::new(primary_field.clone(), &fields);
+        let preferred_typed_identifier = Identifier::new(preferred_identifier.clone(), &fields);
+        let primary_typed_identifier = Identifier::new(primary_field.clone(), &fields);
 
         Ok(Self {
             model: model_name,
@@ -122,9 +121,9 @@ impl ModelConfig {
             fields,
             row,
             changeset,
-            typed_identifiers,
-            preferred_typed_identifier,
-            primary_typed_identifier,
+            identifiers: typed_identifiers,
+            preferred_identifier: preferred_typed_identifier,
+            primary_identifier: primary_typed_identifier,
         })
     }
 }


### PR DESCRIPTION
Defines for each generated code block (struct definition, impl block, trait implementation) a struct
implementing `ToTokens` to isolate (almost) all quoting into `modelv2::codegen`.

A little refactoring of `Identifiers` was necessary to make the `-Impl` struct API convenient.

> [!TIP]
> This PR can be reviewed commit by commit.
 
