### PR TITLE
Add budget field in editoast search study response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6345,7 +6345,13 @@ components:
     SearchResultItemStudy:
       description: A search result item for a query with `object = "study"`
       properties:
+        budget:
+          format: int32
+          minimum: 0
+          nullable: true
+          type: integer
         description:
+          nullable: true
           type: string
         id:
           format: int64
@@ -6376,6 +6382,7 @@ components:
       - description
       - last_modification
       - tags
+      - budget
       type: object
     SearchResultItemTrack:
       description: A search result item for a query with `object = "track"`

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -251,6 +251,9 @@ pub struct MakeMigrationArgs {
     #[arg(short, long)]
     /// Overwrites the existing up.sql and down.sql files' content
     pub force: bool,
+    #[arg(long)]
+    /// Skips the default generation of down.sql to have smarter rollbacks
+    pub skip_down: bool,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -802,6 +802,7 @@ fn make_search_migration(args: MakeMigrationArgs) -> Result<(), Box<dyn Error + 
         object,
         migration,
         force,
+        skip_down,
     } = args;
     let Some(search_config) = SearchConfigFinder::find(&object) else {
         let error = format!("❌ No search object found for {object}");
@@ -844,11 +845,13 @@ fn make_search_migration(args: MakeMigrationArgs) -> Result<(), Box<dyn Error + 
         return Err(Box::new(CliError::new(2, error)));
     }
     println!("➡️  Wrote to {up_path_str}");
-    if let Err(err) = fs::write(down_path, down) {
-        let error = format!("❌ Failed to write to {down_path_str}: {err}");
-        return Err(Box::new(CliError::new(2, error)));
+    if !skip_down {
+        if let Err(err) = fs::write(down_path, down) {
+            let error = format!("❌ Failed to write to {down_path_str}: {err}");
+            return Err(Box::new(CliError::new(2, error)));
+        }
+        println!("➡️  Wrote to {down_path_str}");
     }
-    println!("➡️  Wrote to {down_path_str}");
     println!(
         "✅ Migration {} generated!\n🚨 Don't forget to run {} or {} to apply it",
         migration.to_str().unwrap_or("<unprintable path>"),

--- a/editoast/src/views/search/objects.rs
+++ b/editoast/src/views/search/objects.rs
@@ -121,10 +121,10 @@ pub(super) struct SearchResultItemOperationalPointTrackSections {
         src_table = "infra_object_signal",
         query_joins = "
             INNER JOIN infra_object_track_section AS track_section
-            ON track_section.infra_id = infra_object_signal.infra_id 
+            ON track_section.infra_id = infra_object_signal.infra_id
                 AND track_section.obj_id = infra_object_signal.data->>'track'
             INNER JOIN infra_layer_signal AS layer
-            ON layer.infra_id = infra_object_signal.infra_id 
+            ON layer.infra_id = infra_object_signal.infra_id
                 AND layer.obj_id = infra_object_signal.obj_id",
     ),
     column(
@@ -236,12 +236,16 @@ pub(super) struct SearchResultItemProject {
 #[search(
     name = "study",
     table = "search_study",
+    migration(src_table = "study"),
     joins = "INNER JOIN study ON study.id = search_study.id",
-    column(name = "id", data_type = "integer"),
-    column(name = "name", data_type = "string"),
-    column(name = "description", data_type = "string"),
-    column(name = "tags", data_type = "string"),
-    column(name = "project_id", data_type = "integer")
+    column(name = "name", data_type = "TEXT", sql = "study.name"),
+    column(name = "description", data_type = "TEXT", sql = "study.description"),
+    column(
+        name = "tags",
+        data_type = "TEXT",
+        sql = "osrd_prepare_for_search_tags(study.tags)"
+    ),
+    column(name = "project_id", data_type = "INTEGER", sql = "study.project_id")
 )]
 #[allow(unused)]
 /// A search result item for a query with `object = "study"`
@@ -257,11 +261,15 @@ pub(super) struct SearchResultItemStudy {
     )]
     scenarios_count: u64,
     #[search(sql = "study.description")]
-    description: String,
+    #[schema(required)]
+    description: Option<String>,
     #[search(sql = "study.last_modification")]
     last_modification: NaiveDateTime,
     #[search(sql = "study.tags")]
     tags: Vec<String>,
+    #[search(sql = "study.budget")]
+    #[schema(required)]
+    budget: Option<u32>,
 }
 
 #[derive(Search, Serialize, ToSchema)]

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -2484,7 +2484,8 @@ export type SearchResultItemProject = {
   tags: string[];
 };
 export type SearchResultItemStudy = {
-  description: string;
+  budget: number | null;
+  description: string | null;
   id: number;
   last_modification: string;
   name: string;


### PR DESCRIPTION
Also adds the migration definition block that was missing for the study object.