### PR TITLE
core: add v2 conflict detection endpoint

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.sim_infra.utils
 
+import fr.sncf.osrd.reporting.exceptions.ErrorType
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.*
 
@@ -116,7 +118,9 @@ private fun findRoute(
             return routeId
         }
     }
-    throw RuntimeException("Couldn't find a route matching the given chunk list")
+    val error = OSRDError(ErrorType.ScheduleMetadataExtractionFailed)
+    error.context["reason"] = "Couldn't find a route matching the given chunk list"
+    throw error
 }
 
 /** Returns false if the route differs from the path */

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -32,7 +32,7 @@ public enum ErrorType {
     InfraLoadingInvalidStatusException("infra_loading:invalid_status", "Status doesn’t exist", ErrorCause.INTERNAL),
     InfraInvalidStatusWhileWaitingStable(
             "infra_loading:invalid_status_waiting_stable", "invalid status after waitUntilStable", ErrorCause.INTERNAL),
-    InfraNotLoadedException("infra:not_loaded", "Infra not loaded", ErrorCause.USER),
+    InfraNotLoadedException("infra:not_loaded", "Infra not loaded", ErrorCause.USER, false),
     InfraInvalidVersionException("infra:invalid_version", "Invalid infra version", ErrorCause.USER),
     PathfindingGenericError("no_path_found", "No path could be found", ErrorCause.USER),
     PathfindingGaugeError("no_path_found:gauge", "No path could be found with compatible Gauge", ErrorCause.USER),
@@ -138,7 +138,11 @@ public enum ErrorType {
             "Electrical profile set had invalid status after loading",
             ErrorCause.INTERNAL),
     PathWithRepeatedTracks(
-            "path_with_repeated_tracks", "the path goes over the same track multiple times", ErrorCause.USER),
+            "path_with_repeated_tracks", "the path goes over the same track multiple times", ErrorCause.INTERNAL),
+    PathHasInvalidItemPositions(
+            "path_has_invalid_item_positions", "the path has invalid item positions", ErrorCause.INTERNAL),
+    ScheduleMetadataExtractionFailed(
+            "schedule_metadata_extraction_failed", "schedule metadata extraction failed", ErrorCause.INTERNAL),
     AllowanceRangeOutOfBounds("allowance_range", "Allowance ranges are out of bounds", ErrorCause.USER),
     AllowanceOutOfBounds("allowance", "Allowance is out of bounds", ErrorCause.USER),
     InvalidSpeedLimitValue("speed_limit_value", "Speed limit must be greater than 0", ErrorCause.USER),
@@ -150,10 +154,16 @@ public enum ErrorType {
     public final String type;
     public final String message;
     public final ErrorCause cause;
+    public final boolean isCacheable;
 
     ErrorType(String type, String message, ErrorCause cause) {
+        this(type, message, cause, true);
+    }
+
+    ErrorType(String type, String message, ErrorCause cause, boolean isCacheable) {
         this.type = "core:" + type;
         this.message = message;
         this.cause = cause;
+        this.isCacheable = isCacheable;
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import fr.sncf.osrd.api.*;
+import fr.sncf.osrd.api.api_v2.conflicts.ConflictDetectionEndpointV2;
 import fr.sncf.osrd.api.api_v2.path_properties.PathPropEndpoint;
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlocksEndpointV2;
 import fr.sncf.osrd.api.api_v2.project_signals.SignalProjectionEndpointV2;
@@ -97,6 +98,7 @@ public final class ApiServerCommand implements CliCommand {
                     new FkRegex("/project_signals", new SignalProjectionEndpoint(infraManager)),
                     new FkRegex("/v2/project_signals", new SignalProjectionEndpointV2(infraManager)),
                     new FkRegex("/detect_conflicts", new ConflictDetectionEndpoint()),
+                    new FkRegex("/v2/conflict_detection", new ConflictDetectionEndpointV2()),
                     new FkRegex("/cache_status", new InfraCacheStatusEndpoint(infraManager)),
                     new FkRegex("/version", new VersionEndpoint()),
                     new FkRegex("/stdcm", new STDCMEndpoint(infraManager)),

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -96,7 +96,7 @@ public final class ApiServerCommand implements CliCommand {
                             "/v2/standalone_simulation",
                             new SimulationEndpoint(infraManager, electricalProfileSetManager)),
                     new FkRegex("/project_signals", new SignalProjectionEndpoint(infraManager)),
-                    new FkRegex("/v2/project_signals", new SignalProjectionEndpointV2(infraManager)),
+                    new FkRegex("/v2/signal_projection", new SignalProjectionEndpointV2(infraManager)),
                     new FkRegex("/detect_conflicts", new ConflictDetectionEndpoint()),
                     new FkRegex("/v2/conflict_detection", new ConflictDetectionEndpointV2()),
                     new FkRegex("/cache_status", new InfraCacheStatusEndpoint(infraManager)),

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -9,6 +9,8 @@ import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
+import fr.sncf.osrd.reporting.exceptions.ErrorType
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
@@ -581,7 +583,9 @@ fun trainPathBlockOffset(
             }
         }
     }
-    throw RuntimeException("Couldn't find first chunk on the block path")
+    val error = OSRDError(ErrorType.ScheduleMetadataExtractionFailed)
+    error.context["reason"] = "Couldn't find first chunk on the block path"
+    throw error
 }
 
 fun simplifyPositions(positions: ArrayList<ResultPosition>): ArrayList<ResultPosition> {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
@@ -30,3 +30,23 @@ class SignalSighting(
     val position: Offset<Path>,
     val state: String,
 )
+
+class RoutingRequirement(
+    val route: String,
+    @Json(name = "begin_time") val beginTime: TimeDelta,
+    val zones: List<RoutingZoneRequirement>
+)
+
+class RoutingZoneRequirement(
+    val zone: String,
+    @Json(name = "entry_detector") val entryDetector: String,
+    @Json(name = "exit_detector") val exitDetector: String,
+    val switches: Map<String, String>,
+    @Json(name = "end_time") val endTime: TimeDelta,
+)
+
+class SpacingRequirement(
+    val zone: String,
+    @Json(name = "begin_time") val beginTime: TimeDelta,
+    @Json(name = "end_time") val endTime: TimeDelta,
+)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionEndpointV2.kt
@@ -1,0 +1,96 @@
+package fr.sncf.osrd.api.api_v2.conflicts
+
+import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult
+import fr.sncf.osrd.api.ExceptionHandler
+import fr.sncf.osrd.conflicts.TrainRequirements
+import fr.sncf.osrd.conflicts.detectConflicts
+import fr.sncf.osrd.standalone_sim.result.ResultTrain
+import fr.sncf.osrd.utils.units.TimeDelta
+import java.time.Duration
+import java.time.Duration.between
+import java.time.ZonedDateTime
+import org.takes.Request
+import org.takes.Response
+import org.takes.Take
+import org.takes.rq.RqPrint
+import org.takes.rs.RsJson
+import org.takes.rs.RsText
+import org.takes.rs.RsWithBody
+import org.takes.rs.RsWithStatus
+
+class ConflictDetectionEndpointV2 : Take {
+    override fun act(req: Request?): Response {
+        return try {
+            val body = RqPrint(req).printBody()
+            val request =
+                conflictRequestAdapter.fromJson(body)
+                    ?: return RsWithStatus(RsText("missing request body"), 400)
+
+            val minStartTime = request.trainsRequirements.values.minBy { it.startTime }.startTime
+            val trainRequirements = makeTrainRequirements(request.trainsRequirements, minStartTime)
+            val conflicts = detectConflicts(trainRequirements)
+            val res = makeConflictDetectionResponse(conflicts, minStartTime)
+
+            RsJson(RsWithBody(conflictResponseAdapter.toJson(res)))
+        } catch (ex: Throwable) {
+            ExceptionHandler.handle(ex)
+        }
+    }
+}
+
+private fun makeTrainRequirements(
+    trainsReqs: Map<Long, TrainRequirementsRequest>,
+    startTime: ZonedDateTime
+): List<TrainRequirements> {
+    val trainRequirements = mutableListOf<TrainRequirements>()
+    for ((id, trainReqs) in trainsReqs) {
+        val delta = TimeDelta(between(startTime, trainReqs.startTime).toMillis())
+        val routingRequirements = mutableListOf<ResultTrain.RoutingRequirement>()
+        for (routingReq in trainReqs.routingRequirements) {
+            routingRequirements.add(
+                ResultTrain.RoutingRequirement(
+                    routingReq.route,
+                    (routingReq.beginTime + delta).seconds,
+                    routingReq.zones.map {
+                        ResultTrain.RoutingZoneRequirement(
+                            it.zone,
+                            it.entryDetector,
+                            it.exitDetector,
+                            it.switches,
+                            (it.endTime + delta).seconds
+                        )
+                    }
+                )
+            )
+        }
+        val spacingRequirements = mutableListOf<ResultTrain.SpacingRequirement>()
+        for (spacingReq in trainReqs.spacingRequirements) {
+            spacingRequirements.add(
+                ResultTrain.SpacingRequirement(
+                    spacingReq.zone,
+                    (spacingReq.beginTime + delta).seconds,
+                    (spacingReq.endTime + delta).seconds,
+                    true
+                )
+            )
+        }
+        trainRequirements.add(TrainRequirements(id, spacingRequirements, routingRequirements))
+    }
+    return trainRequirements
+}
+
+private fun makeConflictDetectionResponse(
+    conflicts: Collection<ConflictDetectionResult.Conflict>,
+    startTime: ZonedDateTime
+): ConflictDetectionResponse {
+    return ConflictDetectionResponse(
+        conflicts.map {
+            Conflict(
+                it.trainIds,
+                startTime.plus(Duration.ofMillis((it.startTime * 1000).toLong())),
+                startTime.plus(Duration.ofMillis((it.endTime * 1000).toLong())),
+                it.conflictType
+            )
+        }
+    )
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionRequest.kt
@@ -1,0 +1,27 @@
+package fr.sncf.osrd.api.api_v2.conflicts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.api_v2.RoutingRequirement
+import fr.sncf.osrd.api.api_v2.SpacingRequirement
+import fr.sncf.osrd.utils.json.UnitAdapterFactory
+import java.time.ZonedDateTime
+
+class ConflictDetectionRequest(
+    @Json(name = "trains_requirements") val trainsRequirements: Map<Long, TrainRequirementsRequest>,
+)
+
+class TrainRequirementsRequest(
+    @Json(name = "start_time") val startTime: ZonedDateTime,
+    @Json(name = "spacing_requirements") val spacingRequirements: Collection<SpacingRequirement>,
+    @Json(name = "routing_requirements") val routingRequirements: Collection<RoutingRequirement>,
+)
+
+val conflictRequestAdapter: JsonAdapter<ConflictDetectionRequest> =
+    Moshi.Builder()
+        .addLast(UnitAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(ConflictDetectionRequest::class.java)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionResponse.kt
@@ -1,0 +1,28 @@
+package fr.sncf.osrd.api.api_v2.conflicts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.ConflictDetectionEndpoint
+import fr.sncf.osrd.utils.json.UnitAdapterFactory
+import java.time.ZonedDateTime
+
+class ConflictDetectionResponse(
+    val conflicts: Collection<Conflict>,
+)
+
+class Conflict(
+    @Json(name = "train_ids") val trainIds: Collection<Long>,
+    @Json(name = "start_time") val startTime: ZonedDateTime,
+    @Json(name = "end_time") val endTime: ZonedDateTime,
+    @Json(name = "conflict_type")
+    val conflictType: ConflictDetectionEndpoint.ConflictDetectionResult.Conflict.ConflictType,
+)
+
+val conflictResponseAdapter: JsonAdapter<ConflictDetectionResponse> =
+    Moshi.Builder()
+        .addLast(UnitAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(ConflictDetectionResponse::class.java)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.TrackRange
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Length
@@ -74,6 +75,10 @@ class IncompatibleSignalingSystem(
     incompatibleRanges: List<List<Offset<Path>>> // List of pairs
 ) : IncompatibleConstraint(blocks, routes, trackSectionRanges, length, incompatibleRanges)
 
+class PathfindingFailed(
+    @Json(name = "core_error") val coreError: OSRDError,
+) : PathfindingBlockResponse
+
 class NotEnoughPathItems : PathfindingBlockResponse
 
 val polymorphicAdapter: PolymorphicJsonAdapterFactory<PathfindingBlockResponse> =
@@ -86,6 +91,7 @@ val polymorphicAdapter: PolymorphicJsonAdapterFactory<PathfindingBlockResponse> 
         .withSubtype(IncompatibleLoadingGauge::class.java, "incompatible_loading_gauge")
         .withSubtype(IncompatibleSignalingSystem::class.java, "incompatible_signaling_system")
         .withSubtype(NotEnoughPathItems::class.java, "not_enough_path_items")
+        .withSubtype(PathfindingFailed::class.java, "pathfinding_failed")
 
 val pathfindingResponseAdapter: JsonAdapter<PathfindingBlockResponse> =
     Moshi.Builder()

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.api.ElectricalProfileSetManager
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.InfraManager
 import fr.sncf.osrd.api.pathfinding.makeChunkPath
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.api.Route
@@ -68,8 +69,14 @@ class SimulationEndpoint(
                     request.initialSpeed,
                     request.margins,
                 )
-
-            return RsJson(RsWithBody(SimulationResponse.adapter.toJson(res)))
+            return RsJson(RsWithBody(simulationResponseAdapter.toJson(res)))
+        } catch (error: OSRDError) {
+            if (!error.osrdErrorType.isCacheable) {
+                return ExceptionHandler.handle(error)
+            } else {
+                val response = SimulationFailed(error)
+                return RsJson(RsWithBody(simulationResponseAdapter.toJson(response)))
+            }
         } catch (ex: Throwable) {
             return ExceptionHandler.handle(ex)
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
@@ -4,7 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.api_v2.RoutingRequirement
 import fr.sncf.osrd.api.api_v2.SignalSighting
+import fr.sncf.osrd.api.api_v2.SpacingRequirement
 import fr.sncf.osrd.api.api_v2.ZoneUpdate
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
@@ -43,26 +45,6 @@ class CompleteReportTrain(
     @Json(name = "spacing_requirements") val spacingRequirements: List<SpacingRequirement>,
     @Json(name = "routing_requirements") val routingRequirements: List<RoutingRequirement>
 ) : ReportTrain(positions, times, speeds, energyConsumption)
-
-class SpacingRequirement(
-    val zone: String,
-    @Json(name = "begin_time") val beginTime: TimeDelta,
-    @Json(name = "end_time") val endTime: TimeDelta,
-)
-
-class RoutingRequirement(
-    val route: String,
-    @Json(name = "begin_time") val beginTime: TimeDelta,
-    val zones: List<RoutingZoneRequirement>
-)
-
-class RoutingZoneRequirement(
-    val zone: String,
-    @Json(name = "entry_detector") val entryDetector: String,
-    @Json(name = "exit_detector") val exitDetector: String,
-    val switches: Map<String, String>,
-    @Json(name = "end_time") val endTime: TimeDelta,
-)
 
 open class ReportTrain(
     val positions: List<Offset<Path>>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
@@ -3,32 +3,27 @@ package fr.sncf.osrd.api.api_v2.standalone_sim
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.RoutingRequirement
 import fr.sncf.osrd.api.api_v2.SignalSighting
 import fr.sncf.osrd.api.api_v2.SpacingRequirement
 import fr.sncf.osrd.api.api_v2.ZoneUpdate
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 
-class SimulationResponse(
+interface SimulationResponse
+
+class SimulationSuccess(
     val base: ReportTrain,
     val provisional: ReportTrain,
     @Json(name = "final_output") val finalOutput: CompleteReportTrain,
     val mrsp: MRSPResponse,
     @Json(name = "power_restrictions") val powerRestrictions: List<PowerRestriction>,
-) {
-    companion object {
-        val adapter: JsonAdapter<SimulationResponse> =
-            Moshi.Builder()
-                .addLast(UnitAdapterFactory())
-                .addLast(KotlinJsonAdapterFactory())
-                .build()
-                .adapter(SimulationResponse::class.java)
-    }
-}
+) : SimulationResponse
 
 class MRSPResponse(
     val positions: List<Offset<Path>>,
@@ -59,3 +54,20 @@ class PowerRestriction(
     val code: String,
     val handled: Boolean
 )
+
+class SimulationFailed(
+    @Json(name = "core_error") val coreError: OSRDError,
+) : SimulationResponse
+
+val polymorphicAdapter: PolymorphicJsonAdapterFactory<SimulationResponse> =
+    PolymorphicJsonAdapterFactory.of(SimulationResponse::class.java, "status")
+        .withSubtype(SimulationSuccess::class.java, "success")
+        .withSubtype(SimulationFailed::class.java, "simulation_failed")
+
+val simulationResponseAdapter: JsonAdapter<SimulationResponse> =
+    Moshi.Builder()
+        .add(polymorphicAdapter)
+        .addLast(UnitAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+        .adapter(SimulationResponse::class.java)

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -1,8 +1,7 @@
 package fr.sncf.osrd.standalone_sim
 
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.api_v2.SignalSighting
-import fr.sncf.osrd.api.api_v2.ZoneUpdate
+import fr.sncf.osrd.api.api_v2.*
 import fr.sncf.osrd.api.api_v2.standalone_sim.*
 import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope.Envelope

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -49,7 +49,7 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-): SimulationResponse {
+): SimulationSuccess {
     // MRSP & SpeedLimits
     val mrsp = MRSP.computeMRSP(pathProps, rollingStock, true, speedLimitTag)
     val speedLimits = MRSP.computeMRSP(pathProps, rollingStock, false, speedLimitTag)
@@ -129,7 +129,7 @@ fun runStandaloneSimulation(
             schedule
         )
 
-    return SimulationResponse(
+    return SimulationSuccess(
         base = maxEffortResult,
         provisional = provisionalResult,
         finalOutput = finalEnvelopeResult,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -221,6 +221,41 @@ components:
       - end_time
       - conflict_type
       type: object
+    ConflictDetectionResponse:
+      properties:
+        conflicts:
+          description: List of conflicts detected
+          items:
+            properties:
+              conflict_type:
+                enum:
+                - Spacing
+                - Routing
+                type: string
+              end_time:
+                description: Datetime of the end of the conflict
+                format: date-time
+                type: string
+              start_time:
+                description: Datetime of the start of the conflict
+                format: date-time
+                type: string
+              train_ids:
+                description: List of train ids involved in the conflict
+                items:
+                  format: int64
+                  type: integer
+                type: array
+            required:
+            - train_ids
+            - start_time
+            - end_time
+            - conflict_type
+            type: object
+          type: array
+      required:
+      - conflicts
+      type: object
     ConflictType:
       enum:
       - Spacing
@@ -229,25 +264,26 @@ components:
     ConflictV2:
       properties:
         conflict_type:
-          $ref: '#/components/schemas/ConflictType'
+          enum:
+          - Spacing
+          - Routing
+          type: string
         end_time:
+          description: Datetime of the end of the conflict
           format: date-time
           type: string
         start_time:
+          description: Datetime of the start of the conflict
           format: date-time
           type: string
         train_ids:
+          description: List of train ids involved in the conflict
           items:
             format: int64
             type: integer
           type: array
-        train_names:
-          items:
-            type: string
-          type: array
       required:
       - train_ids
-      - train_names
       - start_time
       - end_time
       - conflict_type
@@ -862,6 +898,7 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorStartDateAfterEndDate'
+      - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotLoaded'
       - $ref: '#/components/schemas/EditoastTimetableErrorNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorNotFound'
@@ -2419,6 +2456,30 @@ components:
         type:
           enum:
           - editoast:study:StartDateAfterEndDate
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTimetableErrorInfraNotFound:
+      properties:
+        context:
+          properties:
+            infra_id:
+              type: integer
+          required:
+          - infra_id
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 404
+          type: integer
+        type:
+          enum:
+          - editoast:timetable:InfraNotFound
           type: string
       required:
       - type
@@ -5011,6 +5072,17 @@ components:
         - rolling_stock_name
         - status
         type: object
+      - properties:
+          core_error:
+            $ref: '#/components/schemas/InternalError'
+          status:
+            enum:
+            - pathfinding_failed
+            type: string
+        required:
+        - core_error
+        - status
+        type: object
     PathfindingStep:
       properties:
         duration:
@@ -7097,7 +7169,7 @@ components:
       - electrification_ranges
       - power_restriction_ranges
       type: object
-    SimulationResult:
+    SimulationResponse:
       oneOf:
       - properties:
           base:
@@ -7210,40 +7282,56 @@ components:
     SimulationSummaryResult:
       oneOf:
       - properties:
-          Success:
-            properties:
-              energy_consumption:
-                format: double
-                type: number
-              length:
-                format: int64
-                minimum: 0
-                type: integer
-              time:
-                format: int64
-                minimum: 0
-                type: integer
-            required:
-            - length
-            - time
-            - energy_consumption
-            type: object
+          energy_consumption:
+            format: double
+            type: number
+          length:
+            format: int64
+            minimum: 0
+            type: integer
+          status:
+            enum:
+            - success
+            type: string
+          time:
+            format: int64
+            minimum: 0
+            type: integer
         required:
-        - Success
+        - length
+        - time
+        - energy_consumption
+        - status
         type: object
-      - enum:
-        - PathfindingFailed
-        type: string
       - properties:
-          SimulationFailed:
-            properties:
-              error_type:
-                type: string
-            required:
-            - error_type
-            type: object
+          status:
+            enum:
+            - pathfinding_not_found
+            type: string
         required:
-        - SimulationFailed
+        - status
+        type: object
+      - properties:
+          error_type:
+            type: string
+          status:
+            enum:
+            - pathfinding_failed
+            type: string
+        required:
+        - error_type
+        - status
+        type: object
+      - properties:
+          error_type:
+            type: string
+          status:
+            enum:
+            - simulation_failed
+            type: string
+        required:
+        - error_type
+        - status
         type: object
     SingleSimulationRequest:
       allOf:
@@ -11636,15 +11724,14 @@ paths:
     get:
       description: Retrieve the list of conflict of the timetable (invalid trains are ignored)
       parameters:
-      - description: The timetable id
+      - description: A timetable ID
         in: path
         name: id
         required: true
         schema:
           format: int64
           type: integer
-      - description: The infra id
-        in: query
+      - in: query
         name: infra_id
         required: true
         schema:
@@ -11658,7 +11745,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ConflictV2'
                 type: array
-          description: list of conflict
+          description: List of conflict
       summary: Retrieve the list of conflict of the timetable (invalid trains are ignored)
       tags:
       - timetablev2
@@ -11756,8 +11843,8 @@ paths:
   /v2/train_schedule/simulation_summary/:
     get:
       description: |-
-        Retrieve simulation information for a given train list.
-        Useful for finding out whether pathfinding/simulation was successful.
+        Associate each train id with its simulation summary response
+        If the simulation fails, it associates the reason: pathfinding failed or running time failed
       parameters:
       - description: The infra id
         in: query
@@ -11783,8 +11870,8 @@ paths:
                 additionalProperties:
                   $ref: '#/components/schemas/SimulationSummaryResult'
                 type: object
-          description: Project Path Output
-      summary: Retrieve simulation information for a given train list.
+          description: Associate each train id with its simulation summary
+      summary: Associate each train id with its simulation summary response
       tags:
       - train_schedulev2
   /v2/train_schedule/{id}/:
@@ -11887,7 +11974,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SimulationResult'
+                $ref: '#/components/schemas/SimulationResponse'
           description: Simulation Output
       summary: Retrieve the space, speed and time curve of a given train
       tags:

--- a/editoast/src/core/conflicts.rs
+++ b/editoast/src/core/conflicts.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::v2::conflict_detection::ConflictType;
 use super::AsCoreRequest;
 use super::Json;
 use crate::models::RoutingRequirement;
 use crate::models::SpacingRequirement;
-use crate::views::timetable::ConflictType;
 
 #[derive(Debug, Serialize)]
 pub struct ConflicDetectionRequest {

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -40,6 +40,7 @@ editoast_common::schemas! {
     simulation::schemas(),
     v2::simulation::schemas(),
     v2::pathfinding::schemas(),
+    v2::conflict_detection::schemas(),
 }
 
 const MAX_RETRIES: u8 = 5;

--- a/editoast/src/core/v2/conflict_detection.rs
+++ b/editoast/src/core/v2/conflict_detection.rs
@@ -1,0 +1,63 @@
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+use crate::core::{AsCoreRequest, Json};
+
+use super::simulation::RoutingRequirement;
+use super::simulation::SpacingRequirement;
+
+editoast_common::schemas! {
+    ConflictDetectionResponse,
+    Conflict,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConflictDetectionRequest {
+    /// List of requirements for each train
+    pub trains_requirements: HashMap<i64, TrainRequirements>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrainRequirements {
+    pub start_time: DateTime<Utc>,
+    pub spacing_requirements: Vec<SpacingRequirement>,
+    pub routing_requirements: Vec<RoutingRequirement>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ConflictDetectionResponse {
+    /// List of conflicts detected
+    #[schema(inline)]
+    pub conflicts: Vec<Conflict>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[schema(as=ConflictV2)]
+pub struct Conflict {
+    /// List of train ids involved in the conflict
+    pub train_ids: Vec<i64>,
+    /// Datetime of the start of the conflict
+    pub start_time: DateTime<Utc>,
+    /// Datetime of the end of the conflict
+    pub end_time: DateTime<Utc>,
+    /// Type of the conflict
+    #[schema(inline)]
+    pub conflict_type: ConflictType,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+pub enum ConflictType {
+    /// Conflict caused by two trains being too close to each other
+    Spacing,
+    /// Conflict caused by two trains requiring incompatible routes at the same time
+    Routing,
+}
+
+impl AsCoreRequest<Json<ConflictDetectionResponse>> for ConflictDetectionRequest {
+    const METHOD: reqwest::Method = reqwest::Method::POST;
+    const URL_PATH: &'static str = "/v2/conflict_detection";
+}

--- a/editoast/src/core/v2/mod.rs
+++ b/editoast/src/core/v2/mod.rs
@@ -1,4 +1,5 @@
+pub mod conflict_detection;
 pub mod path_properties;
 pub mod pathfinding;
-pub mod signal_updates;
+pub mod signal_projection;
 pub mod simulation;

--- a/editoast/src/core/v2/pathfinding.rs
+++ b/editoast/src/core/v2/pathfinding.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::core::{AsCoreRequest, Json};
+use crate::error::InternalError;
 
 editoast_common::schemas! {
     PathfindingResult,
@@ -95,6 +96,9 @@ pub enum PathfindingResult {
     NotEnoughPathItems,
     RollingStockNotFound {
         rolling_stock_name: String,
+    },
+    PathfindingFailed {
+        core_error: InternalError,
     },
 }
 

--- a/editoast/src/core/v2/signal_projection.rs
+++ b/editoast/src/core/v2/signal_projection.rs
@@ -61,5 +61,5 @@ pub struct SignalUpdatesResponse {
 
 impl<'a> AsCoreRequest<Json<SignalUpdatesResponse>> for SignalUpdatesRequest<'a> {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/project_signals";
+    const URL_PATH: &'static str = "/v2/signal_projection";
 }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -12,6 +12,7 @@ use utoipa::ToSchema;
 
 use crate::core::conflicts::ConflicDetectionRequest;
 use crate::core::conflicts::TrainRequirement;
+use crate::core::v2::conflict_detection::ConflictType;
 use crate::core::AsCoreRequest;
 use crate::core::CoreClient;
 use crate::error::Result;
@@ -76,12 +77,6 @@ async fn get(
     let timetable_with_schedules = timetable.with_detailed_train_schedules(db_pool).await?;
 
     Ok(Json(timetable_with_schedules))
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub enum ConflictType {
-    Spacing,
-    Routing,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -159,6 +159,7 @@
     },
     "timetable": {
       "InfraNotLoaded": "Infra '{{infra_id}}' is not loaded",
+      "InfraNotFound": "Infra {{infra_id}} does not exist",
       "NotFound": "Timetable '{{timetable_id}}' could not be found"
     },
     "train_schedule": {

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -161,6 +161,7 @@
     },
     "timetable": {
       "InfraNotLoaded": "L'infrastructure '{{infra_id}}' n'est pas chargée",
+      "InfraNotFound": "Infra '{{infra_id}}' non trouvée",
       "NotFound": "Grille horaire '{{timetable_id}}' non trouvée"
     },
     "train_schedule": {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1685,11 +1685,10 @@ export type PutV2TimetableByIdApiArg = {
   timetableForm: TimetableForm;
 };
 export type GetV2TimetableByIdConflictsApiResponse =
-  /** status 200 list of conflict */ ConflictV2[];
+  /** status 200 List of conflict */ ConflictV2[];
 export type GetV2TimetableByIdConflictsApiArg = {
-  /** The timetable id */
+  /** A timetable ID */
   id: number;
-  /** The infra id */
   infraId: number;
 };
 export type DeleteV2TrainScheduleApiResponse = unknown;
@@ -1713,9 +1712,10 @@ export type PostV2TrainScheduleProjectPathApiArg = {
   ids: number[];
   projectPathInput: ProjectPathInput;
 };
-export type GetV2TrainScheduleSimulationSummaryApiResponse = /** status 200 Project Path Output */ {
-  [key: string]: SimulationSummaryResult;
-};
+export type GetV2TrainScheduleSimulationSummaryApiResponse =
+  /** status 200 Associate each train id with its simulation summary */ {
+    [key: string]: SimulationSummaryResult;
+  };
 export type GetV2TrainScheduleSimulationSummaryApiArg = {
   /** The infra id */
   infra: number;
@@ -1742,7 +1742,7 @@ export type GetV2TrainScheduleByIdPathApiArg = {
   infraId: number;
 };
 export type GetV2TrainScheduleByIdSimulationApiResponse =
-  /** status 200 Simulation Output */ SimulationResult;
+  /** status 200 Simulation Output */ SimulationResponse;
 export type GetV2TrainScheduleByIdSimulationApiArg = {
   /** A train schedule ID */
   id: number;
@@ -3097,6 +3097,10 @@ export type PathfindingResult =
   | {
       rolling_stock_name: string;
       status: 'rolling_stock_not_found';
+    }
+  | {
+      core_error: InternalError;
+      status: 'pathfinding_failed';
     };
 export type PathfindingInputV2 = {
   /** List of waypoints given to the pathfinding */
@@ -3194,11 +3198,13 @@ export type TimetableDetailedResult = {
   train_ids: number[];
 };
 export type ConflictV2 = {
-  conflict_type: ConflictType;
+  conflict_type: 'Spacing' | 'Routing';
+  /** Datetime of the end of the conflict */
   end_time: string;
+  /** Datetime of the start of the conflict */
   start_time: string;
+  /** List of train ids involved in the conflict */
   train_ids: number[];
-  train_names: string[];
 };
 export type Distribution = 'STANDARD' | 'MARECO';
 export type TrainScheduleBase = {
@@ -3312,17 +3318,21 @@ export type ProjectPathInput = {
 };
 export type SimulationSummaryResult =
   | {
-      Success: {
-        energy_consumption: number;
-        length: number;
-        time: number;
-      };
+      energy_consumption: number;
+      length: number;
+      status: 'success';
+      time: number;
     }
-  | 'PathfindingFailed'
   | {
-      SimulationFailed: {
-        error_type: string;
-      };
+      status: 'pathfinding_not_found';
+    }
+  | {
+      error_type: string;
+      status: 'pathfinding_failed';
+    }
+  | {
+      error_type: string;
+      status: 'simulation_failed';
     };
 export type ReportTrainV2 = {
   energy_consumption: number;
@@ -3330,7 +3340,7 @@ export type ReportTrainV2 = {
   speeds: number[];
   times: number[];
 };
-export type SimulationResult =
+export type SimulationResponse =
   | {
       base: ReportTrainV2;
       final_output: ReportTrainV2 & {


### PR DESCRIPTION
Fixes #6905. Convert V2 payload to V1 structs to use them in `Conflicts.kt`, because stdcm is not v2 yet and still calls conflict detection with v1 structs.