### PR TITLE
core: use endpoint's uri for span's name

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/TkDataDog.kt
@@ -8,6 +8,7 @@ import org.takes.Response
 import org.takes.Take
 import org.takes.rq.RqHref
 import org.takes.rq.RqMethod
+import org.takes.rq.RqRequestLine
 import org.takes.rs.RsStatus
 import org.takes.tk.TkWrap
 
@@ -16,6 +17,8 @@ class TkDataDog(take: Take) : TkWrap(Take { request: Request -> datadog(take, re
         @Trace
         private fun datadog(take: Take, request: Request): Response {
             val span = GlobalTracer.get().activeSpan()
+            val uri = RqRequestLine.Base(request).uri()
+            span.setOperationName(uri)
             val method = RqMethod.Base(request).method()
             span.setTag(Tags.HTTP_METHOD, method)
             val path = RqHref.Base(request).href().path()

--- a/core/src/main/java/fr/sncf/osrd/cli/TkOpenTelemetry.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/TkOpenTelemetry.kt
@@ -9,6 +9,7 @@ import org.takes.Response
 import org.takes.Take
 import org.takes.rq.RqHref
 import org.takes.rq.RqMethod
+import org.takes.rq.RqRequestLine
 import org.takes.rs.RsStatus
 import org.takes.tk.TkWrap
 
@@ -18,6 +19,10 @@ class TkOpenTelemetry(take: Take) :
         @WithSpan(value = "endpoint", kind = SpanKind.SERVER)
         private fun opentelemetry(take: Take, request: Request): Response {
             val span = Span.current()
+
+            val uri = RqRequestLine.Base(request).uri()
+            span.updateName(uri)
+            span.setAttribute("http.route", uri)
             val method = RqMethod.Base(request).method()
             span.setAttribute("http.request.method", method)
             val path = RqHref.Base(request).href().path()


### PR DESCRIPTION
Before:

![image](https://github.com/OpenRailAssociation/osrd/assets/2520723/a8af0e20-2878-440d-aea8-09b7cc0832f6)

After:

![image](https://github.com/OpenRailAssociation/osrd/assets/2520723/586372e0-a579-44d2-8c55-bdd84060251b)

Should much easier to dig through the traces of the endpoints. I just hope it works as expected for Datadog.