### PR TITLE
Fix editoast search cache refresh query

### DIFF
--- a/editoast/src/views/search/search_object.rs
+++ b/editoast/src/views/search/search_object.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use utoipa::ToSchema;
 
 use super::typing::TypeSpec;
@@ -210,10 +211,16 @@ DROP FUNCTION IF EXISTS {update_trigger_function};
             .as_ref()
             .expect("no migration for search config");
         let table = &self.table;
+        let cache_columns = self
+            .criterias
+            .iter()
+            .map(|c| format!("\"{}\"", c.name))
+            .collect_vec()
+            .join(", ");
         let select_terms = self.select_terms();
         format!(
             r#"
-INSERT INTO "{table}"
+INSERT INTO "{table}" (id, {cache_columns})
 SELECT
     "{src_table}"."{pk}" AS id,
     {select_terms}


### PR DESCRIPTION
Adds the ordered list of columns in the INSERT statements in case the real table columns do not follow the declaration order in objects.rs.
