### PR TITLE
core: add error detail when using a route that has no exit signal

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -104,6 +104,10 @@ public enum ErrorType {
     UnknownRoute("unknown_route", "unknown route", ErrorCause.USER),
     DuplicateRoute("duplicate_route", "Two routes have the same name", ErrorCause.USER),
     MissingAttributeError("missing_attribute", "referencing missing attribute", ErrorCause.INTERNAL),
+    MissingSignalOnRouteTransition(
+            "missing_signal_on_route_transition",
+            "The path uses a route that ends on a detector without signal",
+            ErrorCause.USER),
     EnvelopeStopIndexOutOfBounds("envelope_error", "Stop at index %d is out of bounds", ErrorCause.USER),
     EnvelopePartsNotContiguous(
             "envelope_error", "invalid envelope, envelope parts are not contiguous", ErrorCause.INTERNAL),

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -736,7 +736,7 @@ class PathfindingTest : ApiTest() {
                 path,
                 DiagnosticRecorderImpl(true)
             )
-        validatePathfindingResult(res, waypoints, infra.rawInfra)
+        validatePathfindingResult(path, res, infra.rawInfra, infra.blockInfra)
         assertEquals(
             listOf(
                 PathWaypointResult(


### PR DESCRIPTION
Using a path that included a route that doesn't end on a block or buffer stop used to cause obscure errors at the simulation step. With this change, the error happens during the pathfinding with a error clearly pointing where to fix the infra problem.