### PR TITLE
editoast: add telemetry on database requests

### DIFF
--- a/editoast/editoast_derive/src/modelv2/codegen.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen.rs
@@ -66,6 +66,15 @@ impl RawIdentifier {
             }
         }
     }
+
+    fn get_ref_ident_lvalue(&self) -> syn::Expr {
+        match self {
+            Self::Field(ident) => parse_quote! { &#ident },
+            Self::Compound(idents) => {
+                parse_quote! { (#(&#idents),*) }
+            }
+        }
+    }
 }
 
 impl Identifier {
@@ -76,6 +85,10 @@ impl Identifier {
 
     fn get_lvalue(&self) -> syn::Expr {
         self.raw.get_ident_lvalue()
+    }
+
+    fn get_ref_lvalue(&self) -> syn::Expr {
+        self.raw.get_ref_ident_lvalue()
     }
 
     fn get_diesel_eqs(&self) -> Vec<syn::Expr> {

--- a/editoast/editoast_derive/src/modelv2/codegen/changeset_decl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/changeset_decl.rs
@@ -39,7 +39,7 @@ impl ToTokens for ChangesetDecl {
             })
             .unzip();
         tokens.extend(quote! {
-            #[derive(Default, Queryable, AsChangeset, Insertable, #(#additional_derives),*)]
+            #[derive(Debug, Default, Queryable, AsChangeset, Insertable, #(#additional_derives),*)]
             #[diesel(table_name = #table)]
             #vis struct #ident {
                 #(

--- a/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
@@ -15,7 +15,12 @@ impl ToTokens for CountImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::prelude::Count for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(
+                    nb_filters = settings.filters.len(),
+                    paginate_counting = settings.paginate_counting,
+                    limit,
+                    offset,
+                ))]
                 async fn count(
                     conn: &'async_trait mut crate::modelsv2::DbConnection,
                     settings: crate::modelsv2::prelude::SelectionSettings<Self>,
@@ -33,10 +38,12 @@ impl ToTokens for CountImpl {
 
                     if settings.paginate_counting {
                         if let Some(limit) = settings.limit {
+                            tracing::Span::current().record("limit", limit);
                             query = query.limit(limit);
                         }
 
                         if let Some(offset) = settings.offset {
+                            tracing::Span::current().record("offset", offset);
                             query = query.offset(offset);
                         }
                     }

--- a/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
@@ -9,11 +9,13 @@ pub(crate) struct CountImpl {
 impl ToTokens for CountImpl {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self { model, table_mod } = self;
+        let span_name = format!("model:list<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::prelude::Count for #model {
+                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
                 async fn count(
                     conn: &'async_trait mut crate::modelsv2::DbConnection,
                     settings: crate::modelsv2::prelude::SelectionSettings<Self>,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -26,10 +26,10 @@ impl ToTokens for CreateBatchImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatch<#changeset> for #model {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
                 async fn create_batch<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
-                    C: Default + std::iter::Extend<Self> + Send,
+                    C: Default + std::iter::Extend<Self> + Send + std::fmt::Debug,
                 >(
                     conn: &mut crate::modelsv2::DbConnection,
                     values: I,
@@ -39,6 +39,8 @@ impl ToTokens for CreateBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    let values = values.into_iter().collect::<Vec<_>>();
+                    tracing::Span::current().record("query_ids", tracing::field::debug(&values));
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
                         values,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -20,11 +20,13 @@ impl ToTokens for CreateBatchImpl {
             changeset,
             field_count,
         } = self;
+        let span_name = format!("model:create_batch<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatch<#changeset> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn create_batch<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
                     C: Default + std::iter::Extend<Self> + Send,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -25,11 +25,13 @@ impl ToTokens for CreateBatchWithKeyImpl {
             identifier,
         } = self;
         let ty = identifier.get_type();
+        let span_name = format!("model:create_batch_with_key<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatchWithKey<#changeset, #ty> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn create_batch_with_key<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, Self)> + Send,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -31,10 +31,10 @@ impl ToTokens for CreateBatchWithKeyImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatchWithKey<#changeset, #ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn create_batch_with_key<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
-                    C: Default + std::iter::Extend<(#ty, Self)> + Send,
+                    C: Default + std::iter::Extend<(#ty, Self)> + Send + std::fmt::Debug,
                 >(
                     conn: &mut crate::modelsv2::DbConnection,
                     values: I,
@@ -45,6 +45,8 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    let values = values.into_iter().collect::<Vec<_>>();
+                    tracing::Span::current().record("query_ids", tracing::field::debug(&values));
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
                         values,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
@@ -16,11 +16,13 @@ impl ToTokens for CreateImpl {
             row,
             changeset,
         } = self;
+        let span_name = format!("model:create<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Create<#model> for #changeset {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn create(
                     self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
@@ -22,7 +22,7 @@ impl ToTokens for CreateImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Create<#model> for #changeset {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
                 async fn create(
                     self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -28,7 +28,7 @@ impl ToTokens for DeleteBatchImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::DeleteBatch<#ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
                 async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait>(
                     conn: &mut crate::modelsv2::DbConnection,
                     ids: I,
@@ -36,6 +36,8 @@ impl ToTokens for DeleteBatchImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
+                    let ids = ids.into_iter().collect::<Vec<_>>();
+                    tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     let counts = crate::chunked_for_libpq! {
                         #params_per_row,
                         ids,

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -22,11 +22,13 @@ impl ToTokens for DeleteBatchImpl {
         let id_ident = identifier.get_lvalue();
         let params_per_row = identifier.get_idents().len();
         let filters = identifier.get_diesel_eq_and_fold();
+        let span_name = format!("model:delete_batch<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::DeleteBatch<#ty> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait>(
                     conn: &mut crate::modelsv2::DbConnection,
                     ids: I,

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
@@ -20,7 +20,7 @@ impl ToTokens for DeleteImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Delete for #model {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id = ?self.#primary_key))]
                 async fn delete(
                     &self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
@@ -14,11 +14,13 @@ impl ToTokens for DeleteImpl {
             table_mod,
             primary_key,
         } = self;
+        let span_name = format!("model:delete<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Delete for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn delete(
                     &self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
@@ -20,6 +20,7 @@ impl ToTokens for DeleteStaticImpl {
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
+        let id_ref_ident = identifier.get_ref_lvalue();
         let eqs = identifier.get_diesel_eqs();
         let span_name = format!("model:delete_static<{}>", model);
 
@@ -27,7 +28,7 @@ impl ToTokens for DeleteStaticImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::DeleteStatic<#ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn delete_static(
                     conn: &mut crate::modelsv2::DbConnection,
                     #id_ident: #ty,
@@ -35,6 +36,7 @@ impl ToTokens for DeleteStaticImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
+                    tracing::Span::current().record("query_id", tracing::field::debug(#id_ref_ident));
                     diesel::delete(dsl::#table_name.#(filter(#eqs)).*)
                         .execute(conn)
                         .await

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
@@ -21,11 +21,13 @@ impl ToTokens for DeleteStaticImpl {
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
         let eqs = identifier.get_diesel_eqs();
+        let span_name = format!("model:delete_static<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::DeleteStatic<#ty> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn delete_static(
                     conn: &mut crate::modelsv2::DbConnection,
                     #id_ident: #ty,

--- a/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
@@ -21,11 +21,13 @@ impl ToTokens for ExistsImpl {
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
         let eqs = identifier.get_diesel_eqs();
+        let span_name = format!("model:exists<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Exists<#ty> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn exists(
                     conn: &mut crate::modelsv2::DbConnection,
                     #id_ident: #ty,

--- a/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
@@ -20,7 +20,13 @@ impl ToTokens for ListImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::prelude::List for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
+                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(
+                    nb_filters = settings.filters.len(),
+                    nb_sorts = settings.sorts.len(),
+                    paginate_counting = settings.paginate_counting,
+                    limit,
+                    offset,
+                ))]
                 async fn list(
                     conn: &'async_trait mut crate::modelsv2::DbConnection,
                     settings: crate::modelsv2::prelude::SelectionSettings<Self>,
@@ -42,10 +48,12 @@ impl ToTokens for ListImpl {
                     }
 
                     if let Some(limit) = settings.limit {
+                        tracing::Span::current().record("limit", limit);
                         query = query.limit(limit);
                     }
 
                     if let Some(offset) = settings.offset {
+                        tracing::Span::current().record("offset", offset);
                         query = query.offset(offset);
                     }
 

--- a/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
@@ -14,11 +14,13 @@ impl ToTokens for ListImpl {
             table_mod,
             row,
         } = self;
+        let span_name = format!("model:list<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::prelude::List for #model {
+                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
                 async fn list(
                     conn: &'async_trait mut crate::modelsv2::DbConnection,
                     settings: crate::modelsv2::prelude::SelectionSettings<Self>,

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -24,11 +24,14 @@ impl ToTokens for RetrieveBatchImpl {
         let id_ident = identifier.get_lvalue();
         let params_per_row = identifier.get_idents().len();
         let filters = identifier.get_diesel_eq_and_fold();
+        let span_name = format!("model:retrieve_batch_unchecked<{}>", model);
+        let span_name_with_key = format!("model:retrieve_batch_with_key_unchecked<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::RetrieveBatchUnchecked<#ty> for #model {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn retrieve_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<#model> + Send,
@@ -62,6 +65,7 @@ impl ToTokens for RetrieveBatchImpl {
                     })
                 }
 
+                #[tracing::instrument(name = #span_name_with_key, skip_all)]
                 async fn retrieve_batch_with_key_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send,

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
@@ -23,11 +23,13 @@ impl ToTokens for RetrieveImpl {
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
         let eqs = identifier.get_diesel_eqs();
+        let span_name = format!("model:retrieve<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Retrieve<#ty> for #model {
+                #[tracing::instrument(name = #span_name, skip(conn))]
                 async fn retrieve(
                     conn: &mut crate::modelsv2::DbConnection,
                     #id_ident: #ty,

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -28,11 +28,14 @@ impl ToTokens for UpdateBatchImpl {
         let id_ident = identifier.get_lvalue();
         let params_per_row = identifier.get_idents().len();
         let filters = identifier.get_diesel_eq_and_fold();
+        let span_name = format!("model:update_batch_unchecked<{}>", model);
+        let span_name_with_key = format!("model:update_batch_unchecked<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::UpdateBatchUnchecked<#model, #ty> for #changeset {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn update_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<#model> + Send,
@@ -69,6 +72,7 @@ impl ToTokens for UpdateBatchImpl {
                     })
                 }
 
+                #[tracing::instrument(name = #span_name_with_key, skip_all)]
                 async fn update_batch_with_key_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send,

--- a/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
@@ -25,11 +25,13 @@ impl ToTokens for UpdateImpl {
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
         let eqs = identifier.get_diesel_eqs();
+        let span_name = format!("model:update<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Update<#ty, #model> for #changeset {
+                #[tracing::instrument(name = #span_name, skip_all)]
                 async fn update(
                     self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -157,7 +157,7 @@ mod tests {
             }
         }
 
-        #[derive(Clone, ModelV2)]
+        #[derive(Debug, Clone, ModelV2)]
         #[model(table = crate::tables::document)]
         struct Document {
             id: i64,

--- a/editoast/src/modelsv2/prelude/create.rs
+++ b/editoast/src/modelsv2/prelude/create.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::error::EditoastError;
 use crate::error::Result;
 use crate::modelsv2::DbConnection;
@@ -48,7 +50,7 @@ where
     /// ```
     async fn create_batch<
         I: IntoIterator<Item = Cs> + Send + 'async_trait,
-        C: Default + std::iter::Extend<Self> + Send,
+        C: Default + std::iter::Extend<Self> + Send + Debug,
     >(
         conn: &mut DbConnection,
         values: I,
@@ -72,7 +74,7 @@ where
     /// Just like [CreateBatch::create_batch] but the returned models are paired with their key
     async fn create_batch_with_key<
         I: IntoIterator<Item = Cs> + Send + 'async_trait,
-        C: Default + std::iter::Extend<(K, Self)> + Send,
+        C: Default + std::iter::Extend<(K, Self)> + Send + Debug,
     >(
         conn: &mut DbConnection,
         values: I,

--- a/editoast/src/modelsv2/prelude/mod.rs
+++ b/editoast/src/modelsv2/prelude/mod.rs
@@ -31,7 +31,7 @@ use diesel::QueryableByName;
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
 // FIXME: that Clone requirement is not necessary, see problematic line below
-pub trait Model: Clone + Sized + Send {
+pub trait Model: std::fmt::Debug + Clone + Sized + Send {
     type Row: QueryableByName<Pg> + Into<Self> + Send;
     type Changeset: AsChangeset + Default + From<Self> + Send;
     type Table: diesel::Table + Send;

--- a/editoast/src/modelsv2/prelude/retrieve.rs
+++ b/editoast/src/modelsv2/prelude/retrieve.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::error::EditoastError;
 use crate::error::Result;
 use crate::modelsv2::DbConnection;
@@ -53,9 +55,9 @@ where
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
 #[async_trait::async_trait]
-pub trait RetrieveBatchUnchecked<K>: Sized
+pub trait RetrieveBatchUnchecked<K>: Sized + Debug
 where
-    for<'async_trait> K: Send + 'async_trait,
+    for<'async_trait> K: Send + Debug + 'async_trait,
 {
     /// Retrieves a batch of rows from the database given an iterator of keys
     ///
@@ -66,7 +68,7 @@ where
     /// Unless you know what you're doing, you should use these functions instead.
     async fn retrieve_batch_unchecked<
         I: IntoIterator<Item = K> + Send + 'async_trait,
-        C: Default + std::iter::Extend<Self> + Send,
+        C: Default + std::iter::Extend<Self> + Send + Debug,
     >(
         conn: &mut DbConnection,
         ids: I,
@@ -81,7 +83,7 @@ where
     /// Unless you know what you're doing, you should use these functions instead.
     async fn retrieve_batch_with_key_unchecked<
         I: IntoIterator<Item = K> + Send + 'async_trait,
-        C: Default + std::iter::Extend<(K, Self)> + Send,
+        C: Default + std::iter::Extend<(K, Self)> + Send + Debug,
     >(
         conn: &mut DbConnection,
         ids: I,
@@ -99,7 +101,7 @@ where
 #[async_trait::async_trait]
 pub trait RetrieveBatch<K>: RetrieveBatchUnchecked<K>
 where
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + Debug + 'async_trait,
 {
     /// Retrieves a batch of rows from the database given an iterator of keys
     ///
@@ -249,6 +251,6 @@ where
 impl<M, K> RetrieveBatch<K> for M
 where
     M: RetrieveBatchUnchecked<K>,
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + Debug + 'async_trait,
 {
 }

--- a/editoast/src/modelsv2/prelude/update.rs
+++ b/editoast/src/modelsv2/prelude/update.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use diesel::result::Error::NotFound;
 
 use crate::error::EditoastError;
@@ -143,7 +145,7 @@ where
     /// Unless you know what you're doing, you should use these functions instead.
     async fn update_batch_unchecked<
         I: IntoIterator<Item = K> + Send + 'async_trait,
-        C: Default + std::iter::Extend<M> + Send,
+        C: Default + std::iter::Extend<M> + Send + Debug,
     >(
         self,
         conn: &mut DbConnection,


### PR DESCRIPTION
The second commit tries to add identifiers in metadata of the traces. However, it seems that it would be not trivial to do it without the `valuable` feature... which is unstable.

⚠️ Weirdly, the build with Docker seems to ignore the configuration `.cargo/config.toml` (hence the build is failing). Needs some investigation if we want to go that path.