### PR TITLE
core: mute opentelemetry warnings for logs and metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,10 @@ services:
       CORE_EDITOAST_URL: "http://osrd-editoast"
       JAVA_TOOL_OPTIONS: "-javaagent:/app/opentelemetry-javaagent.jar"
       CORE_MONITOR_TYPE: "opentelemetry"
-      OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
+      OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: "grpc"
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://jaeger:4317"
+      OTEL_METRICS_EXPORTER: "none"
+      OTEL_LOGS_EXPORTER: "none"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       start_period: 4s


### PR DESCRIPTION
We do not create logs and metrics in the application so it's not necessary to export them.
Note that it currently failed because we export to Jaeger that only support traces.