### PR TITLE
core: improve stdcm heuristic using actual remaining distance

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/MRSP.java
+++ b/core/src/main/java/fr/sncf/osrd/envelope_sim_infra/MRSP.java
@@ -8,8 +8,8 @@ import fr.sncf.osrd.envelope.Envelope;
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile;
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock;
 import fr.sncf.osrd.sim_infra.api.PathProperties;
-import fr.sncf.osrd.train.RollingStock;
 import java.util.List;
 
 /** MRSP = most restrictive speed profile: maximum speed allowed at any given point. */
@@ -26,7 +26,7 @@ public class MRSP {
      * @return the corresponding MRSP as an Envelope.
      */
     public static Envelope computeMRSP(
-            PathProperties path, RollingStock rollingStock, boolean addRollingStockLength, String trainTag) {
+            PathProperties path, PhysicsRollingStock rollingStock, boolean addRollingStockLength, String trainTag) {
         var builder = new MRSPEnvelopeBuilder();
         var pathLength = toMeters(path.getLength());
 
@@ -34,9 +34,9 @@ public class MRSP {
         builder.addPart(EnvelopePart.generateTimes(
                 List.of(EnvelopeProfile.CONSTANT_SPEED, MRSPEnvelopeBuilder.LimitKind.TRAIN_LIMIT),
                 new double[] {0, pathLength},
-                new double[] {rollingStock.maxSpeed, rollingStock.maxSpeed}));
+                new double[] {rollingStock.getMaxSpeed(), rollingStock.getMaxSpeed()}));
 
-        var offset = addRollingStockLength ? rollingStock.length : 0.;
+        var offset = addRollingStockLength ? rollingStock.getLength() : 0.;
         var speedLimits = path.getSpeedLimits(trainTag);
         for (var speedLimit : speedLimits) {
             // Compute where this limit is active from and to

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/Pathfinding.kt
@@ -310,7 +310,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
                     filteredRange.edge,
                     filteredRange.end
                 )
-        queue.add(
+        val newStep =
             Step(
                 filteredRange,
                 prev,
@@ -319,7 +319,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
                 nPassedTargets,
                 targets
             )
-        )
+        if (newStep.weight.isFinite()) queue.add(newStep)
     }
 
     companion object {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -1,0 +1,201 @@
+package fr.sncf.osrd.stdcm
+
+import fr.sncf.osrd.api.pathfinding.makePathProps
+import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
+import fr.sncf.osrd.envelope_sim_infra.MRSP
+import fr.sncf.osrd.graph.AStarHeuristic
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.utils.getBlockEntry
+import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import java.util.PriorityQueue
+import kotlin.math.max
+
+/**
+ * This file implements the A* heuristic used by STDCM.
+ *
+ * Starting at the destination and going backwards in every direction, we cache for each block the
+ * minimum time it would take to reach the destination. The remaining time is estimated using the
+ * MRSP, ignoring the accelerations and decelerations. We account for the number of steps that have
+ * been reached.
+ *
+ * Because it's optimistic, we know that we still find the best (fastest) solution.
+ *
+ * It could eventually be improved further by using lookahead or route data, but this adds a fair
+ * amount of complexity to the implementation.
+ */
+
+/** Describes a pending block, ready to be added to the cached blocks. */
+private data class PendingBlock(
+    val block: BlockId,
+    val stepIndex: Int, // Number of steps that have been reached
+    val remainingTimeAtBlockStart: Double,
+) : Comparable<PendingBlock> {
+    /** Used to find the lowest remaining time at block start in a priority queue. */
+    override fun compareTo(other: PendingBlock): Int {
+        return remainingTimeAtBlockStart.compareTo(other.remainingTimeAtBlockStart)
+    }
+}
+
+/** Runs all the pre-processing and initialize the STDCM A* heuristic. */
+fun makeSTDCMHeuristics(
+    blockInfra: BlockInfra,
+    rawInfra: RawInfra,
+    steps: List<STDCMStep>,
+    maxRunningTime: Double,
+    rollingStock: PhysicsRollingStock,
+    maxDepartureDelay: Double,
+): List<AStarHeuristic<STDCMEdge, STDCMEdge>> {
+    // One map per number of reached pathfinding step
+    val maps = mutableListOf<MutableMap<BlockId, Double>>()
+    for (i in 0 until steps.size - 1) maps.add(mutableMapOf())
+
+    // Build the cached values
+    // We run a kind of Dijkstra, but starting from the end
+    val pendingBlocks = initFirstBlocks(rawInfra, blockInfra, steps, rollingStock)
+    while (true) {
+        val block = pendingBlocks.poll() ?: break
+        val index = max(0, block.stepIndex - 1)
+        if (maps[index].contains(block.block)) {
+            continue
+        }
+        maps[index][block.block] = block.remainingTimeAtBlockStart
+        if (block.stepIndex > 0) {
+            pendingBlocks.addAll(
+                getPredecessors(blockInfra, rawInfra, steps, maxRunningTime, block, rollingStock)
+            )
+        }
+    }
+
+    // We build one function (`AStarHeuristic`) per number of reached step
+    val res = mutableListOf<AStarHeuristic<STDCMEdge, STDCMEdge>>()
+    for (nPassedSteps in maps.indices) {
+        res.add { edge, offset ->
+            // We need to iterate through the previous maps,
+            // to handle cases where several steps are on the same block
+            for (i in (0..nPassedSteps).reversed()) {
+                val cachedRemainingDistance = maps[i][edge.block] ?: continue
+                val blockOffset = edge.envelopeStartOffset + offset.distance
+                val remainingTime =
+                    cachedRemainingDistance -
+                        getBlockTime(rawInfra, blockInfra, edge.block, rollingStock, blockOffset)
+
+                // Accounts for the math in the `costToEdgeLocation`.
+                // We need the resulting value to be in the same referential as the cost
+                // used as STDCM cost function, which scales the running time
+                return@add remainingTime * maxDepartureDelay
+            }
+            return@add Double.POSITIVE_INFINITY
+        }
+    }
+    return res
+}
+
+/**
+ * Generates all the pending blocks that can lead to the given block, as long as the pending blocks'
+ * remaining times stay below `maximumRunningTime`.
+ */
+private fun getPredecessors(
+    blockInfra: BlockInfra,
+    rawInfra: RawInfra,
+    steps: List<STDCMStep>,
+    maxRunningTime: Double,
+    pendingBlock: PendingBlock,
+    rollingStock: PhysicsRollingStock,
+): Collection<PendingBlock> {
+    if (pendingBlock.remainingTimeAtBlockStart > maxRunningTime) return emptyList()
+    val detector = blockInfra.getBlockEntry(rawInfra, pendingBlock.block)
+    val blocks = blockInfra.getBlocksEndingAtDetector(detector)
+    val res = mutableListOf<PendingBlock>()
+    for (block in blocks) {
+        val newBlock =
+            makePendingBlock(
+                rawInfra,
+                blockInfra,
+                rollingStock,
+                block,
+                null,
+                steps,
+                pendingBlock.stepIndex,
+                pendingBlock.remainingTimeAtBlockStart
+            )
+        res.add(newBlock)
+    }
+    return res
+}
+
+/** Initialize the priority queue with the blocks that contain the destination. */
+private fun initFirstBlocks(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    steps: List<STDCMStep>,
+    rollingStock: PhysicsRollingStock
+): PriorityQueue<PendingBlock> {
+    val res = PriorityQueue<PendingBlock>()
+    val stepCount = steps.size
+    for (wp in steps[stepCount - 1].locations) {
+        res.add(
+            makePendingBlock(
+                rawInfra,
+                blockInfra,
+                rollingStock,
+                wp.edge,
+                wp.offset,
+                steps,
+                stepCount - 1,
+                0.0
+            )
+        )
+    }
+    return res
+}
+
+/** Instantiate one pending block. */
+private fun makePendingBlock(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    rollingStock: PhysicsRollingStock,
+    block: StaticIdx<Block>,
+    offset: Offset<Block>?,
+    steps: List<STDCMStep>,
+    currentIndex: Int,
+    remainingTime: Double
+): PendingBlock {
+    var newIndex = currentIndex
+    val actualOffset = offset ?: blockInfra.getBlockLength(block)
+    var remainingTimeWithStops = remainingTime
+    while (newIndex > 0) {
+        val step = steps[newIndex - 1]
+        if (step.locations.none { it.edge == block && it.offset <= actualOffset }) {
+            break
+        }
+        if (step.stop) remainingTimeWithStops += step.duration!!
+        newIndex--
+    }
+    return PendingBlock(
+        block,
+        newIndex,
+        remainingTimeWithStops + getBlockTime(rawInfra, blockInfra, block, rollingStock, offset)
+    )
+}
+
+/** Returns the time it takes to go through the given block, until `endOffset` if specified. */
+private fun getBlockTime(
+    rawInfra: RawInfra,
+    blockInfra: BlockInfra,
+    block: BlockId,
+    rollingStock: PhysicsRollingStock,
+    endOffset: Offset<Block>?,
+): Double {
+    if (endOffset?.distance == 0.meters) return 0.0
+    val actualLength = endOffset ?: blockInfra.getBlockLength(block)
+    val pathProps =
+        makePathProps(blockInfra, rawInfra, block, endOffset = actualLength, routes = listOf())
+    val mrsp = MRSP.computeMRSP(pathProps, rollingStock, false, null)
+    return mrsp.totalTime
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -16,6 +16,8 @@ import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
 import fr.sncf.osrd.envelope_sim_infra.MRSP.computeMRSP
 import fr.sncf.osrd.graph.PathfindingEdgeRangeId
 import fr.sncf.osrd.reporting.exceptions.OSRDError
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.sumDistances
 import java.util.*
 
 /**
@@ -35,12 +37,14 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
             findAffectedEdges(prevNode.previousEdge, expectedStartTime - prevNode.time)
         if (affectedEdges.isEmpty()) return false // No space to try the allowance
 
-        if (affectedEdges.sumOf { it.length.distance.meters } > 20_000) {
+        val length = affectedEdges.map { it.length.distance }.sumDistances()
+        if (length > 20_000.meters) {
             // If the allowance area is large enough to reasonably stop and accelerate again, we
             // just accept the solution. This avoids computation on very large paths
             // (which can be quite time expensive)
             return true
         }
+        if (length == 0.meters) return false
 
         // We try to run a simulation with the slowest running time while keeping the end time
         // identical.

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -134,4 +134,8 @@ data class STDCMEdge(
         val offsetRatio = offset.distance.meters / length.distance.meters
         return timeStart + (totalTime * offsetRatio)
     }
+
+    override fun toString(): String {
+        return "STDCMEdge(timeStart=$timeStart, block=$block)"
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -14,7 +14,6 @@ import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.standalone_sim.result.ResultTrain
-import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -76,7 +75,7 @@ fun initInfraExplorerWithEnvelope(
     fullInfra: FullInfra,
     location: PathfindingEdgeLocationId<Block>,
     endBlocks: Collection<BlockId> = setOf(),
-    rollingStock: RollingStock,
+    rollingStock: PhysicsRollingStock,
     constraints: List<PathfindingConstraint<Block>> = listOf()
 ): Collection<InfraExplorerWithEnvelope> {
     return initInfraExplorer(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -1,0 +1,151 @@
+package fr.sncf.osrd.stdcm.preprocessing
+
+import fr.sncf.osrd.envelope_sim.SimpleRollingStock
+import fr.sncf.osrd.graph.AStarHeuristic
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.stdcm.STDCMStep
+import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.makeSTDCMHeuristics
+import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Length
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class STDCMHeuristicTests {
+
+    private val maxDepartureDelay = 3600.0
+
+    @Test
+    fun multipleStepsTest() {
+        /*
+        a ------> b ------> c ------> d ------> e
+             ^       ^   ^   ^                ^
+             0       1   2   3                4
+         */
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b", allowedSpeed = 1.0),
+                infra.addBlock("b", "c", allowedSpeed = 1.0),
+                infra.addBlock("c", "d", allowedSpeed = 1.0),
+                infra.addBlock("d", "e", allowedSpeed = 1.0),
+            )
+
+        val steps =
+            listOf(
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[0], Offset(50.meters))),
+                    null,
+                    false
+                ),
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(25.meters))),
+                    null,
+                    false
+                ),
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[1], Offset(75.meters))),
+                    null,
+                    false
+                ),
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[2], Offset(0.meters))),
+                    null,
+                    false
+                ),
+                STDCMStep(
+                    listOf(PathfindingEdgeLocationId(blocks[3], Offset(100.meters))),
+                    1.0,
+                    true
+                ),
+            )
+
+        val heuristics =
+            makeSTDCMHeuristics(
+                infra,
+                infra,
+                steps,
+                Double.POSITIVE_INFINITY,
+                SimpleRollingStock.STANDARD_TRAIN,
+                maxDepartureDelay,
+            )
+        assertEquals(4, heuristics.size)
+
+        assertEquals(
+            400.0 - 50.0,
+            getLocationRemainingTime(infra, blocks[0], 0.meters, 50.meters, heuristics[0])
+        )
+        assertEquals(
+            400.0 - 75.0 - 10.0,
+            getLocationRemainingTime(infra, blocks[0], 75.meters, 10.meters, heuristics[0])
+        )
+        assertEquals(
+            400.0 - 180.0,
+            getLocationRemainingTime(infra, blocks[1], 0.meters, 80.meters, heuristics[1])
+        )
+        assertEquals(
+            400.0 - 180.0,
+            getLocationRemainingTime(infra, blocks[1], 0.meters, 80.meters, heuristics[2])
+        )
+        assertEquals(
+            400.0 - 200.0,
+            getLocationRemainingTime(infra, blocks[2], 0.meters, 0.meters, heuristics[3])
+        )
+        assertEquals(
+            400.0 - 350.0,
+            getLocationRemainingTime(infra, blocks[3], 25.meters, 25.meters, heuristics[3])
+        )
+        assertEquals(
+            Double.POSITIVE_INFINITY,
+            getLocationRemainingTime(infra, blocks[3], 0.meters, 50.meters, heuristics[0])
+        )
+    }
+
+    /**
+     * Returns the estimated remaining time at the given location. The instantiated stdcm edge
+     * starts at edgeStart, the edgeOffset references this edge.
+     */
+    private fun getLocationRemainingTime(
+        infra: DummyInfra,
+        block: BlockId,
+        edgeStart: Distance,
+        edgeOffset: Distance,
+        heuristic: AStarHeuristic<STDCMEdge, STDCMEdge>
+    ): Double {
+        val explorer =
+            initInfraExplorerWithEnvelope(
+                    infra.fullInfra(),
+                    PathfindingEdgeLocationId(block, Offset(0.meters)),
+                    listOf(),
+                    SimpleRollingStock.STANDARD_TRAIN
+                )
+                .first()
+        val edge =
+            STDCMEdge(
+                explorer,
+                explorer,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                null,
+                Offset(edgeStart),
+                0,
+                0.0,
+                0,
+                false,
+                0.0,
+                0.0,
+                Length(edgeOffset),
+                0.0,
+                0.0,
+            )
+        return heuristic.apply(edge, Offset(edgeOffset)) / maxDepartureDelay
+    }
+}


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/6605


The implementation could be improved in some ways but it seems good enough and simple enough for now. 


Average execution time is divided by roughly 2, same for std. 
Execution time goes slightly up for the fastest requests.

Only one request goes above 100s now, it reaches the timeout limit (120s) but actually stops naturally with a "no path found" just before the exception would be raised. 

The preprocessing only takes ~ 5% of the execution time, so we have quite a lot of margin to improve it further later on. 


Benchmark on realistic requests (everything is in seconds, `describe` is from pandas):

> old.time.describe()

count    303.000000
mean       8.215783
std       20.534878
min        1.708356
25%        1.905426
50%        2.161869
75%        3.846870
max      123.005467
Name: time, dtype: float64


> new.time.describe()

count    303.000000
mean       4.904902
std       11.438471
min        1.705818
25%        2.036432
50%        2.208790
75%        2.850309
max      120.813108
Name: time, dtype: float64

> (new.time - old.time).describe()

count    303.000000
mean      -3.310882
std       14.979293
min     -120.109074
25%       -0.550600
50%       -0.024111
75%        0.159067
max       33.703450
Name: time, dtype: float64