### PR TITLE
Add editoast `--no-cache` option

### DIFF
--- a/editoast/src/client/redis_config.rs
+++ b/editoast/src/client/redis_config.rs
@@ -9,6 +9,10 @@ use crate::error::Result;
 #[derive(Args, Debug, Derivative, Clone)]
 #[derivative(Default)]
 pub struct RedisConfig {
+    /// Disable cache. This should not be used in production.
+    #[derivative(Default(value = "false"))]
+    #[clap(long, env, default_value_t = false)]
+    pub no_cache: bool,
     #[derivative(Default(value = "false"))]
     #[clap(long, env, default_value_t = false)]
     pub is_cluster_client: bool,


### PR DESCRIPTION
This option allows to disable caching. 
It's useful for developers working on core and using editoast endpoints.