### PR TITLE
front: avoid horizontal scroll on editor panel

### DIFF
--- a/front/src/styles/scss/_overrideBootstrapSNCF.scss
+++ b/front/src/styles/scss/_overrideBootstrapSNCF.scss
@@ -108,7 +108,6 @@ label,
 .labels {
   display: flex !important;
   align-items: center !important;
-  white-space: nowrap;
   height: 1.4rem;
   gap: 0.5rem;
 }

--- a/front/src/styles/scss/applications/editor/_editor.scss
+++ b/front/src/styles/scss/applications/editor/_editor.scss
@@ -111,6 +111,7 @@
     width: 400px;
     height: 100%;
     overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .nav-box {


### PR DESCRIPTION
fix #7320

Now, `label` can wraps and the left panel of the editor has a `overflow-x` hidden.
I checked the app for the label wrap, and I see no regression.
