### PR TITLE
editoast: remove payloads from DB telemetry

### DIFF
--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -26,7 +26,7 @@ impl ToTokens for CreateBatchImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatch<#changeset> for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
+                #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
                     C: Default + std::iter::Extend<Self> + Send + std::fmt::Debug,
@@ -39,8 +39,6 @@ impl ToTokens for CreateBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
-                    let values = values.into_iter().collect::<Vec<_>>();
-                    tracing::Span::current().record("query_ids", tracing::field::debug(&values));
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
                         values,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -39,6 +39,7 @@ impl ToTokens for CreateBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    let values = values.into_iter().collect::<Vec<_>>();
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
                         values,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -31,7 +31,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::CreateBatchWithKey<#changeset, #ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch_with_key<
                     I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, Self)> + Send + std::fmt::Debug,
@@ -46,7 +46,6 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
                     let values = values.into_iter().collect::<Vec<_>>();
-                    tracing::Span::current().record("query_ids", tracing::field::debug(&values));
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
                         values,

--- a/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
@@ -22,7 +22,7 @@ impl ToTokens for CreateImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Create<#model> for #changeset {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err)]
+                #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create(
                     self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
@@ -20,7 +20,7 @@ impl ToTokens for ListImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::prelude::List for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(
                     nb_filters = settings.filters.len(),
                     nb_sorts = settings.sorts.len(),
                     paginate_counting = settings.paginate_counting,

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -67,7 +67,7 @@ impl ToTokens for RetrieveBatchImpl {
                     })
                 }
 
-                #[tracing::instrument(name = #span_name_with_key, skip_all)]
+                #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_id))]
                 async fn retrieve_batch_with_key_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send + std::fmt::Debug,
@@ -81,6 +81,8 @@ impl ToTokens for RetrieveBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    let ids = ids.into_iter().collect::<Vec<_>>();
+                    tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
                         #params_per_row,
                         ids,

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -31,7 +31,7 @@ impl ToTokens for RetrieveBatchImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::RetrieveBatchUnchecked<#ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<#model> + Send + std::fmt::Debug,

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
@@ -30,7 +30,7 @@ impl ToTokens for RetrieveImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Retrieve<#ty> for #model {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve(
                     conn: &mut crate::modelsv2::DbConnection,
                     #id_ident: #ty,

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -35,7 +35,7 @@ impl ToTokens for UpdateBatchImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::UpdateBatchUnchecked<#model, #ty> for #changeset {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_ids))]
                 async fn update_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<#model> + Send + std::fmt::Debug,

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -74,7 +74,7 @@ impl ToTokens for UpdateBatchImpl {
                     })
                 }
 
-                #[tracing::instrument(name = #span_name_with_key, skip_all)]
+                #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_ids))]
                 async fn update_batch_with_key_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send,
@@ -89,6 +89,8 @@ impl ToTokens for UpdateBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    let ids = ids.into_iter().collect::<Vec<_>>();
+                    tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
                         // FIXME: that count is correct for each row, but the maximum buffer size
                         // should be libpq's max MINUS the size of the changeset

--- a/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
@@ -32,7 +32,7 @@ impl ToTokens for UpdateImpl {
             #[automatically_derived]
             #[async_trait::async_trait]
             impl crate::modelsv2::Update<#ty, #model> for #changeset {
-                #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
+                #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn update(
                     self,
                     conn: &mut crate::modelsv2::DbConnection,

--- a/editoast/src/modelsv2/prelude/mod.rs
+++ b/editoast/src/modelsv2/prelude/mod.rs
@@ -128,9 +128,8 @@ macro_rules! chunked_for_libpq {
         const ASYNC_SUBDIVISION: usize = 2_usize;
         const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
         let mut result = Vec::new();
-        let values = $values.into_iter().collect::<Vec<_>>();
-        let chunks = values.chunks(CHUNK_SIZE);
-        for $chunk in chunks.into_iter() {
+        let chunks = $values.chunks(CHUNK_SIZE);
+        for $chunk in chunks {
             let chunk_result = $query;
             result.push(chunk_result);
         }
@@ -143,9 +142,8 @@ macro_rules! chunked_for_libpq {
         const ASYNC_SUBDIVISION: usize = 2_usize;
         const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
         let mut result = $result;
-        let values = $values.into_iter().collect::<Vec<_>>();
-        let chunks = values.chunks(CHUNK_SIZE);
-        for $chunk in chunks.into_iter() {
+        let chunks = $values.chunks(CHUNK_SIZE);
+        for $chunk in chunks {
             let chunk_result = $query;
             result.extend(chunk_result);
         }


### PR DESCRIPTION
Remove the payloads from the telemetry. It's creating too much noise in the terminal in the logging.

Follow-up of #7389 