### PR TITLE
readme: add link to OSRD deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ xdg-open http://localhost:4000/
 
 (Linux users can use `docker-compose-host.yml` to enable host networking)
 
+## Deployment
+
+To deploy the application on a server, check out the [deployment guide](https://osrd.fr/en/docs/guides/deploy/).
+
 ## Get in touch
 
 - Chat with us on IRC at [libera.chat#osrd](https://web.libera.chat/#osrd)


### PR DESCRIPTION
A person wishing to deploy OSRD today would probably simply read the README and not the article of our website dedicated to deployment.

There is a peculiarity of our stack (setting the `ROOT_URL` env var, see https://github.com/OpenRailAssociation/osrd-website/pull/199), which needs to be documented somewhere and the website seems to be the best place for it. 
