### PR TITLE
Adapt route calculation

### DIFF
--- a/editoast/src/infra_cache/mod.rs
+++ b/editoast/src/infra_cache/mod.rs
@@ -833,8 +833,14 @@ impl InfraCache {
 
             let switch = graph.get_switch(&endpoint)?;
             let switch_id = switch.get_id();
-            // Check we found the switch in the route
-            let group = route.switches_directions.get(&switch_id.clone().into())?;
+            let switch_type = self.get_switch_type(&switch.switch_type).ok()?;
+            let group = if switch_type.groups.len() == 1 {
+                // Check if switch has one group
+                switch_type.groups.keys().next()?
+            } else {
+                // Check we found the switch in the route
+                route.switches_directions.get(&switch_id.clone().into())?
+            };
             used_switches.insert(switch_id.clone().into(), group.clone());
             let next_endpoint = graph.get_neighbour(&endpoint, group)?;
 


### PR DESCRIPTION
## Description

close https://github.com/osrd-project/osrd-confidential/issues/496

Allow implicit nodes when they have one group.
> [!NOTE]
> We still have a nonambiguous description of the route.
> We don't need a migration since it's optional to provide implicit node positions.

## Motivation

We can now split tracks in the editor. This creates a new "track section link" and breaks a lot of routes doing so. We could:
- Lookup for all routes that should be updated
- Change how routes are built in editoast and core to allow implicit nodes with only one group/config.