### PR TITLE
nix: add integration tests dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,15 @@
           ps.progress
           ps.tqdm
           ps.ipywidgets
+
+          # Tests
+          (ps.callPackage (import ./nix/osrd-schemas.nix) {})
+          (ps.callPackage (import ./nix/railjson-generator.nix) {})
+          ps.pytest
+          ps.pytest-cov
+
+          # TOOLS
+          ps.python-lsp-server
         ];
 
         fixedNode = pkgs.nodejs-18_x;
@@ -106,7 +115,8 @@
 
                 # API
                 (python311.withPackages pythonPackages)
-
+                ruff-lsp
+                
                 # Core
                 gradle
                 jdk17

--- a/nix/osrd-schemas.nix
+++ b/nix/osrd-schemas.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  buildPythonPackage,
+}:
+buildPythonPackage rec {
+  pname = "osrd-schemas";
+  version = "0.8.11";
+
+  src = ../python/osrd_schemas;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "OSRD schemas";
+  };
+}

--- a/nix/railjson-generator.nix
+++ b/nix/railjson-generator.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  buildPythonPackage,
+}:
+buildPythonPackage rec {
+  pname = "railjson-generator";
+  version = "0.4.7";
+
+  src = ../python/railjson_generator;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Railjson generator";
+  };
+}

--- a/python/osrd_schemas/setup.py
+++ b/python/osrd_schemas/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='osrd-schemas',
+      version='0.8.11',
+      description='OSRD schemas',
+      url='https://github.com/OpenRailAssociation/osrd/',
+      packages=['osrd_schemas'],
+     )

--- a/python/railjson_generator/setup.py
+++ b/python/railjson_generator/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='railjson-generator',
+      version='0.4.7',
+      description='Railjson generator',
+      url='https://github.com/OpenRailAssociation/osrd/',
+      packages=['railjson_generator'],
+     )


### PR DESCRIPTION
Trying to add all the necessary dependencies to run the integration tests. So far, I've been trying to package `railjson_generator` and `osrd_schemas`... but seems like I still have some problems when trying to execute the tests with `pytest`.

```
$ pytest -m "not e2e"
================================================================================= test session starts =================================================================================
platform linux -- Python 3.11.9, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/woshilapin/projects/osrd/tests
configfile: pyproject.toml
plugins: cov-4.1.0, anyio-4.3.0, typeguard-4.2.1
collected 18 items / 2 errors / 1 deselected / 17 selected

======================================================================================= ERRORS ========================================================================================
_____________________________________________________________________ ERROR collecting tests/test_regressions.py ______________________________________________________________________
ImportError while importing test module '/home/woshilapin/projects/osrd/tests/tests/test_regressions.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/k3701zl6gmx3la7y4dnflcvf3xfy88kh-python3-3.11.9/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_regressions.py:8: in <module>
    from fuzzer.fuzzer import create_scenario, get_infra
fuzzer/fuzzer.py:13: in <module>
    from osrd_schemas.switch_type import builtin_node_types
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/osrd_schemas/switch_type.py:1: in <module>
    from .infra import SwitchPortConnection, SwitchType
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/osrd_schemas/infra.py:5: in <module>
    from geojson_pydantic import LineString
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/__init__.py:3: in <module>
    from .features import Feature, FeatureCollection  # noqa
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/features.py:8: in <module>
    from geojson_pydantic.geometries import Geometry
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/geometries.py:7: in <module>
    from pydantic.error_wrappers import ErrorWrapper
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/pydantic/_migration.py:302: in wrapper
    raise PydanticImportError(f'`{import_path}` has been removed in V2.')
E   pydantic.errors.PydanticImportError: `pydantic.error_wrappers:ErrorWrapper` has been removed in V2.
E
E   For further information visit https://errors.pydantic.dev/2.6/u/import-error
_____________________________________________________________________ ERROR collecting tests/test_with_fuzzer.py ______________________________________________________________________
ImportError while importing test module '/home/woshilapin/projects/osrd/tests/tests/test_with_fuzzer.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/k3701zl6gmx3la7y4dnflcvf3xfy88kh-python3-3.11.9/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_with_fuzzer.py:4: in <module>
    from fuzzer import fuzzer
fuzzer/fuzzer.py:13: in <module>
    from osrd_schemas.switch_type import builtin_node_types
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/osrd_schemas/switch_type.py:1: in <module>
    from .infra import SwitchPortConnection, SwitchType
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/osrd_schemas/infra.py:5: in <module>
    from geojson_pydantic import LineString
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/__init__.py:3: in <module>
    from .features import Feature, FeatureCollection  # noqa
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/features.py:8: in <module>
    from geojson_pydantic.geometries import Geometry
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/geojson_pydantic/geometries.py:7: in <module>
    from pydantic.error_wrappers import ErrorWrapper
/nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/pydantic/_migration.py:302: in wrapper
    raise PydanticImportError(f'`{import_path}` has been removed in V2.')
E   pydantic.errors.PydanticImportError: `pydantic.error_wrappers:ErrorWrapper` has been removed in V2.
E
E   For further information visit https://errors.pydantic.dev/2.6/u/import-error
================================================================================== warnings summary ===================================================================================
../../../../../nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/pydantic/_migration.py:283
../../../../../nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/pydantic/_migration.py:283
  /nix/store/wp67a1jr6r8x7x7zlr910hl6gjwhz91v-python3-3.11.9-env/lib/python3.11/site-packages/pydantic/_migration.py:283: UserWarning: `pydantic.generics:GenericModel` has been moved to `pydantic.BaseModel`.
    warnings.warn(f'`{import_path}` has been moved to `{new_location}`.')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== short test summary info ===============================================================================
ERROR tests/test_regressions.py
ERROR tests/test_with_fuzzer.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================================== 1 deselected, 2 warnings, 2 errors in 0.20s =====================================================================
```