### PR TITLE
core: spacing-requirements: handle several zones before first signal

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -133,11 +133,26 @@ class SpacingRequirementAutomaton(
                 break
             }
         }
-
         assert(startZone != -1)
-        // the simulation start time is 0)
-        addZonePendingRequirement(startZone, 0.0)
-        lastEmittedZone = startZone
+
+        // We need to add a requirement for each zone between the start
+        // and the first required zone
+        val firstSignal = pendingSignals.firstOrNull()
+        val firstProtectedZone =
+            if (firstSignal != null) {
+                getSignalProtectedZone(firstSignal)
+            } else {
+                startZone + 1
+            }
+
+        for (i in startZone until firstProtectedZone) {
+            // The simulation start time is 0.
+            // The zones are not all reached right at the start, but
+            // because they're part of the block the train starts on,
+            // they can be considered as "required" from the beginning.
+            addZonePendingRequirement(i, 0.0)
+            lastEmittedZone = i
+        }
     }
 
     private fun addSignalRequirements(beginZoneIndex: Int, endZoneIndex: Int, sightTime: Double) {


### PR DESCRIPTION
Fix a rare bug that has been identified by the fuzzer, there's a regression test on the branch `ech/ts2-fuzzer` (though it's not related to train schedules v2). 

We properly generate requirement only from the first seen signal, with a special case for the first zone. That special case needs to be generalized to all zones between the start and first signal.