### PR TITLE
Set editoast `serde_qs` to non strict for simulation summary endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -948,6 +948,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorUnsimulatedTrainSchedule'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorBatchTrainScheduleNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorInvalidQueryParams'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
       - $ref: '#/components/schemas/EditoastTypeCheckErrorArgMissing'
       - $ref: '#/components/schemas/EditoastTypeCheckErrorArgTypeMismatch'
@@ -2729,6 +2730,30 @@ components:
         type:
           enum:
           - editoast:train_schedule_v2:InfraNotFound
+          type: string
+      required:
+      - type
+      - status
+      - message
+      type: object
+    EditoastTrainScheduleErrorInvalidQueryParams:
+      properties:
+        context:
+          properties:
+            message:
+              type: string
+          required:
+          - message
+          type: object
+        message:
+          type: string
+        status:
+          enum:
+          - 400
+          type: integer
+        type:
+          enum:
+          - editoast:train_schedule_v2:InvalidQueryParams
           type: string
       required:
       - type

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -183,7 +183,8 @@
     "train_schedule_v2": {
       "BatchTrainScheduleNotFound": "'{{number}}' train schedule(s) could not be found",
       "NotFound": "Train Schedule '{{train_schedule_id}}' could not be found",
-      "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found"
+      "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
+      "InvalidQueryParams": "Invalid query params '{{message}}'"
     },
     "url": {
       "InvalidUrl": "Invalid url '{{url}}'"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -185,7 +185,8 @@
     "train_schedule_v2": {
       "BatchTrainScheduleNotFound": "'{{number}}' circulation(s) n'ont pas pu être trouvée(s)",
       "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
-      "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée"
+      "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
+      "InvalidQueryParams": "Paramètres de la requête invalides '{{message}}'"
     },
     "url": {
       "InvalidUrl": "Url invalide '{{url}}'"


### PR DESCRIPTION
close #7481

> [!NOTE]
> Soon we'll be adapting some TS2 endpoints by moving the query parameters into the request body.