### PR TITLE
core: conflicts: do not panic on empty list of train requirements

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionEndpointV2.kt
@@ -23,6 +23,12 @@ class ConflictDetectionEndpointV2 : Take {
                 conflictRequestAdapter.fromJson(body)
                     ?: return RsWithStatus(RsText("missing request body"), 400)
 
+            if (request.trainsRequirements.isEmpty()) {
+                return RsJson(
+                    RsWithBody(conflictResponseAdapter.toJson(ConflictDetectionResponse(listOf())))
+                )
+            }
+
             val minStartTime = request.trainsRequirements.values.minBy { it.startTime }.startTime
             val trainRequirements =
                 parseRawTrainsRequirements(request.trainsRequirements, minStartTime)


### PR DESCRIPTION
An empty list of train requirements should probably not panic, but just return an empty list of conflict. 