### PR TITLE
front: review length field on editor

### DIFF
--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -20,7 +20,7 @@ import i18n from 'i18n';
 import { getEditorState } from 'reducers/editor/selectors';
 import { getErrorMessage } from 'utils/error';
 
-import { FormComponent, FormLineStringLength } from './LinearMetadata';
+import { FormComponent } from './LinearMetadata';
 
 const fields = {
   ArrayField: FormComponent,
@@ -103,12 +103,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
         validator={validator}
         method={undefined}
         schema={isFrench ? translatedSchema : schema}
-        uiSchema={{
-          length: {
-            'ui:widget': FormLineStringLength,
-          },
-          ...(overrideUiSchema || {}),
-        }}
+        uiSchema={overrideUiSchema || {}}
         formData={formData}
         formContext={{
           geometry: data.geometry,


### PR DESCRIPTION
fix #7489

On the editor, the length field directly impacts curves & slopes. 

When changing from `10800` to `11000`, you need to pass through the value `1` ,which trigger a re-computation of curves, and you lost all the data from `1` to `10800`.

To avoid that, a debounce of 1.5sec has been set on this field, but it introduces  a new bug : if you change the value and press enter in less than 1.5sec, the new value is not send to the backend.

So to fix those issues, this commit : 
- put the length on the top of the form with a separator
- add a user validation mechanism  via a button

The design has been done Thibaut.