### PR TITLE
front: fix display of error summary

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -446,7 +446,7 @@ const Editor = () => {
 
               {mapRef.current &&
                 editorState.editorLayers.has('errors') &&
-                editorState.issues.total && (
+                editorState.issues.total > 0 && (
                   <div className="error-box">
                     <InfraErrorMapControl mapRef={mapRef.current} switchTool={switchTool} />
                     <InfraErrorCorrector />


### PR DESCRIPTION
What this PR does : 

- if an infra has no error, a '0' was displayed at the bottom of the map (check the vertical scroll).
- When updating error total, the first RTK query (ie the one to retrieve the total number of error) is sometimes not yet initialized. So we put 0 in the state. 
- Don't do twice the same API call

How to test the initial issue : 
- go on the editor (and keep the error layer)
- select a track section
- refresh the page 
- now you can check that the error summary is not present. A "0" is displayed


