### PR TITLE
core: fix v2 simulation response electrical profiles

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
@@ -25,7 +25,12 @@ class SimulationSuccess(
 sealed class ElectricalProfileValue {
     data class Profile(var profile: String) : ElectricalProfileValue()
 
-    class NoProfile : ElectricalProfileValue()
+    class NoProfile : ElectricalProfileValue() {
+        override fun equals(other: Any?): Boolean {
+            if (other is NoProfile) return true
+            return super.equals(other)
+        }
+    }
 }
 
 class MRSPResponse(


### PR DESCRIPTION
Merge connected NoProfile ranges in electrical profiles by ignoring reference comparison.