### PR TITLE
docker: switch to valkey

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,15 +22,15 @@ services:
       interval: 5s
 
   redis:
-    image: redis
+    image: valkey/valkey:alpine
     container_name: osrd-redis
     restart: unless-stopped
     ports: ["6379:6379"]
     volumes:
       - "redis_data:/data"
-    command: "redis-server --save 30 1 --loglevel warning"
+    command: "valkey-server --save 30 1 --loglevel warning"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       start_period: 4s
       interval: 5s
 


### PR DESCRIPTION
Recently-ish redis has switched to another license which isn't open-source. An open-source fork named valkey has been established under the Linux Foundation umbrella:
https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community

See also this LWN article:
https://lwn.net/Articles/966631/

valkey is a drop-in replacement for redis. Switch to valkey to avoid depending on proprietary software.

(Note, I've only done some basic testing to make sure this works as expected, by playing with the UI a bit.)