### PR TITLE
core: infra: ignore OP parts on missing tracks

### DIFF
--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -5,11 +5,7 @@ import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeEndpoint
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
-import fr.sncf.osrd.railjson.schema.infra.RJSInfra
-import fr.sncf.osrd.railjson.schema.infra.RJSRoute
-import fr.sncf.osrd.railjson.schema.infra.RJSSwitch
-import fr.sncf.osrd.railjson.schema.infra.RJSSwitchType
-import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
+import fr.sncf.osrd.railjson.schema.infra.*
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSRouteWaypoint
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSElectrification
@@ -789,12 +785,16 @@ fun parseRJSInfra(rjsInfra: RJSInfra): RawInfra {
                 props["trigram"] = sncf.trigram
             }
             if (opPart.extensions?.sncf != null) props["kp"] = opPart.extensions!!.sncf!!.kp
-            builder.operationalPointPart(
-                operationalPointId,
-                trackSectionName,
-                trackSectionOffset,
-                props
-            )
+            val partId =
+                builder.operationalPointPart(
+                    operationalPointId,
+                    trackSectionName,
+                    trackSectionOffset,
+                    props
+                )
+            if (partId == null) {
+                // TODO warning
+            }
         }
     }
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/new_impl/RawInfraFromRjsBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/new_impl/RawInfraFromRjsBuilder.kt
@@ -9,7 +9,6 @@ import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.*
 import java.util.*
-import kotlin.collections.HashMap
 import kotlin.collections.set
 import kotlin.time.Duration
 
@@ -531,7 +530,10 @@ class RawInfraFromRjsBuilder {
         trackSectionName: String,
         trackSectionOffset: Offset<TrackSection>,
         props: Map<String, String>
-    ): OperationalPointPartId {
+    ): OperationalPointPartId? {
+        if (!trackSectionNameToIdxMap.contains(trackSectionName)) {
+            return null
+        }
         val trackSectionChunks = getTrackSectionDistanceSortedChunks(trackSectionName)
         val chunkDistanceIdx = trackSectionChunks.floorEntry(trackSectionOffset.distance)
         val opPartIdx =


### PR DESCRIPTION
This isn't an error in the infra editor and can't really be fixed, and users prefer that we go toward the "ignore/warning" route.

I would have included an actual warning, but that requires https://github.com/OpenRailAssociation/osrd/issues/6925 first.