### PR TITLE
core: ignore impossible allowance constraints

### DIFF
--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
@@ -10,7 +10,6 @@ import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.TIME_STEP;
 import static fr.sncf.osrd.envelope_sim.SimpleContextBuilder.makeSimpleContext;
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.primitives.Doubles;
@@ -331,8 +330,7 @@ public class AllowanceRangesTests {
                         new AllowanceRange(0, 301, new AllowanceValue.FixedTime(50)),
                         new AllowanceRange(301, testPath.getLength(), new AllowanceValue.Percentage(50))));
         var maxEffortEnvelope = makeSimpleMaxEffortEnvelope(testContext, 80, stops);
-        var err = assertThrows(OSRDError.class, () -> allowance.apply(maxEffortEnvelope, testContext));
-        assertEquals(err.osrdErrorType, ErrorType.AllowanceConvergenceTooMuchTime);
+        allowance.apply(maxEffortEnvelope, testContext);
     }
 
     /**


### PR DESCRIPTION
In this case the user wants a result that's realistic and as close to the input times as possible, rather than an error. This is in line with how we ignore impossible scheduled points. It should fix a significant amount of regression in the basic import (caused by a bug in the previous version that would result in too little ranges).

We would ideally raise a warning here, but that's not supported yet (see https://github.com/OpenRailAssociation/osrd/issues/6925).

The implementation isn't super clean, but this code is meant to be replaced soon-ish by the simulation v3. This behavior is in line with what's been designed for the v3 (warnings instead of errors).


--- 


It triggers https://github.com/OpenRailAssociation/osrd/issues/5778 in a regression test (which was a known bug for a long time and is unrelated). https://github.com/OpenRailAssociation/osrd/pull/7529 should be merged first for the CI to pass. 