### PR TITLE
Use tracing's pretty formatter for editoast logs

### DIFF
--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -94,7 +94,10 @@ fn init_tracing(mode: EditoastMode, telemetry_config: &client::TelemetryConfig) 
         // Set the default log level to 'info'
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
-    let fmt_layer = tracing_subscriber::fmt::layer().compact();
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .pretty()
+        .with_file(false)
+        .with_line_number(false);
     let fmt_layer = if mode == EditoastMode::Cli {
         fmt_layer.with_writer(std::io::stderr).boxed()
     } else {


### PR DESCRIPTION
Configures `tracing` formatter to `pretty` to improve log readability. This is especially valuable for multiline log entries. Likewise, the span contexts output is more readable (one line per span instead of joining them using `:` for the `compact` formatter).
