### PR TITLE
More OpenApi annotations for /infra endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9327,15 +9327,20 @@ paths:
       tags:
       - infra
     post:
+      description: The infra may be edited by batch later via the `POST /infra/ID` or `POST /infra/ID/railjson` endpoints.
       requestBody:
         content:
           application/json:
             schema:
+              additionalProperties: false
               properties:
                 name:
+                  description: The name to give to the new infra
                   type: string
+              required:
+              - name
               type: object
-        description: Name of the infra to create
+        required: true
       responses:
         '201':
           content:
@@ -9343,7 +9348,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Infra'
           description: The created infra
-      summary: Create an infra
+      summary: Creates an empty infra
       tags:
       - infra
   /infra/railjson/:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9393,30 +9393,43 @@ paths:
   /infra/refresh/:
     post:
       parameters:
-      - description: A list of infra ID
+      - in: query
+        name: force
+        required: false
+        schema:
+          type: boolean
+      - description: |-
+          A comma-separated list of infra IDs to refresh
+
+          If not provided, all available infras will be refreshed.
         in: query
         name: infras
+        required: false
         schema:
-          default: []
           items:
+            format: int64
+            minimum: 0
             type: integer
           type: array
-      - description: Force the refresh of the layers
-        in: query
-        name: force
-        schema:
-          default: false
-          type: boolean
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  type: integer
-                type: array
-          description: A list thats contains the ID of the infras that were refreshed*
-      summary: Refresh the layers
+                properties:
+                  infra_refreshed:
+                    description: The list of infras that were refreshed successfully
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                required:
+                - infra_refreshed
+                type: object
+          description: ''
+        '404':
+          description: Invalid infra ID query parameters
+      summary: Refresh infra generated geographic layers
       tags:
       - infra
   /infra/voltages/:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -120,36 +120,6 @@ paths:
                     items:
                       $ref: "#/components/schemas/InfraError"
 
-  /infra/refresh/:
-    post:
-      tags:
-        - infra
-      summary: Refresh the layers
-      parameters:
-        - in: query
-          name: infras
-          schema:
-            type: array
-            items:
-              type: integer
-            default: []
-          description: A list of infra ID
-        - in: query
-          name: force
-          schema:
-            type: boolean
-            default: false
-          description: Force the refresh of the layers
-      responses:
-        200:
-          description: A list thats contains the ID of the infras that were refreshed*
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: integer
-
   /infra/{id}/objects/{object_type}/:
     post:
       tags:

--- a/editoast/openapi_legacy.yaml
+++ b/editoast/openapi_legacy.yaml
@@ -21,28 +21,6 @@ tags:
     description: Train Schedule
 
 paths:
-  /infra/:
-    post:
-      tags:
-        - infra
-      summary: Create an infra
-      requestBody:
-        description: Name of the infra to create
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-      responses:
-        201:
-          description: The created infra
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Infra"
-
   /infra/{id}/:
     post:
       tags:

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -126,7 +126,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/infra/refresh/`,
           method: 'POST',
-          params: { infras: queryArg.infras, force: queryArg.force },
+          params: { force: queryArg.force, infras: queryArg.infras },
         }),
         invalidatesTags: ['infra'],
       }),
@@ -1073,13 +1073,16 @@ export type PostInfraRailjsonApiArg = {
   generateData?: boolean;
   railJson: RailJson;
 };
-export type PostInfraRefreshApiResponse =
-  /** status 200 A list thats contains the ID of the infras that were refreshed* */ number[];
+export type PostInfraRefreshApiResponse = /** status 200  */ {
+  /** The list of infras that were refreshed successfully */
+  infra_refreshed: number[];
+};
 export type PostInfraRefreshApiArg = {
-  /** A list of infra ID */
-  infras?: number[];
-  /** Force the refresh of the layers */
   force?: boolean;
+  /** A comma-separated list of infra IDs to refresh
+    
+    If not provided, all available infras will be refreshed. */
+  infras?: number[];
 };
 export type GetInfraVoltagesApiResponse = /** status 200 Voltages list */ string[];
 export type GetInfraVoltagesApiArg = void;

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -1058,9 +1058,9 @@ export type GetInfraApiArg = {
 };
 export type PostInfraApiResponse = /** status 201 The created infra */ Infra;
 export type PostInfraApiArg = {
-  /** Name of the infra to create */
   body: {
-    name?: string;
+    /** The name to give to the new infra */
+    name: string;
   };
 };
 export type PostInfraRailjsonApiResponse = /** status 201 The imported infra id */ {


### PR DESCRIPTION
> [!IMPORTANT]
> Deletes the `GET /infra/cache_status` endpoint since the front-end doesn't use it (it wasn't even included in the openapi_legacy).
> I hardly imagine that other editoast consumers use it, especially since it's not documented.