### PR TITLE
actions: use artifacts instead of registry for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       stable_tags: ${{ steps.bake-metadata.outputs.stable_tags }}
       stable_version: ${{ steps.bake-metadata.outputs.stable_version }}
+      output_method: ${{ steps.bake-metadata.outputs.output_method }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,7 +73,7 @@ jobs:
 
           for i in $(seq 1 3); do
             echo "::group::Try $i"
-            if docker buildx bake $BAKEFILE $METADATA --push 2>&1 | tee docker-build.log; then
+            if docker buildx bake $BAKEFILE $METADATA 2>&1 | tee docker-build.log; then
               echo "::endgroup::"
               exit 0
             fi
@@ -90,6 +91,67 @@ jobs:
           done
           echo "All retries failed, exiting."
           exit 1
+
+      - name: Upload front-build artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: front-build
+          path: osrd-front-build.tar
+      - name: Upload core-build artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: core-build
+          path: osrd-core-build.tar
+      - name: Upload editoast-test artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: editoast-test
+          path: osrd-editoast-test.tar
+      - name: Upload editoast artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: editoast
+          path: osrd-editoast.tar
+      - name: Upload gateway-test artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: gateway-test
+          path: osrd-gateway-test.tar
+      - name: Upload front-tests artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: front-tests
+          path: osrd-front-tests.tar
+      - name: Upload front artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: front
+          path: osrd-front.tar
+      - name: Upload core artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: core
+          path: osrd-core.tar
+      - name: Upload gateway-standalone artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: gateway-standalone
+          path: osrd-gateway-standalone.tar
+      - name: Upload front-nginx artifact
+        uses: actions/upload-artifact@v4
+        if: steps.bake-metadata.outputs.output_method == 'artifact'
+        with:
+          name: front-nginx
+          path: osrd-front-nginx.tar
 
   check_generated_railjson_sync:
     runs-on: ubuntu-latest
@@ -332,6 +394,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download built images
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-build
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-front-build.tar
+          docker image ls -a
+
       - name: Generate rtk bindings
         run: >
           docker run --rm --net=host -v $PWD/output:/app/tests/unit
@@ -352,6 +427,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download built images
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: core-build
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-core-build.tar
 
       - name: Execute tests within container
         run: |
@@ -418,6 +505,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download built front-build image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-build
+          path: .
+      - name: Download built editoast-test image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: editoast-test
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-front-build.tar
+          docker load --input ./osrd-editoast-test.tar
+
       - name: Check for i18n missing keys
         run: |
           docker run --name=front-i18n-checker --net=host \
@@ -461,6 +567,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download built images
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: editoast-test
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-editoast-test.tar
+
       - name: Documentation check
         run: |
           docker run --name=editoast-doc --net=host -v $PWD/output:/output \
@@ -496,6 +614,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download built editoast image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: editoast
+          path: .
+      - name: Download built front-build image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-build
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-editoast.tar
+          docker load --input ./osrd-front-build.tar
+
       - name: Generate OpenAPI
         run: |
           docker run --name=editoast-test --net=host -v $PWD/output:/output \
@@ -521,6 +658,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download built images
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: gateway-test
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-gateway-test.tar
 
       - name: Execute tests within container
         run: |
@@ -572,6 +721,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download built images
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-build
+          path: .
+
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-front-build.tar
+
       - name: Execute tests within container
         run: |
           docker run --name=front-test --net=host -v $PWD/output:/app/tests/unit \
@@ -599,6 +760,44 @@ jobs:
       # https://www.jameskerr.blog/posts/sharing-steps-in-github-action-workflows/
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Download built front-tests image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-tests
+          path: .
+      - name: Download built editoast image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: editoast
+          path: .
+      - name: Download built core image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: core
+          path: .
+      - name: Download built gateway-standalone image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: gateway-standalone
+          path: .
+      - name: Download built front-nginx image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: front-nginx
+          path: .
+      - name: Load built images
+        if: needs.build.outputs.output_method == 'artifact'
+        run: |
+          docker load --input ./osrd-front-tests.tar
+          docker load --input ./osrd-editoast.tar
+          docker load --input ./osrd-core.tar
+          docker load --input ./osrd-gateway-standalone.tar
+          docker load --input ./osrd-front-nginx.tar
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python
@@ -618,7 +817,7 @@ jobs:
           export OSRD_FRONT_MODE=nginx
           export TAG='${{ needs.build.outputs.stable_version }}'
           services='editoast core front gateway'
-          docker compose pull $services
+          docker compose pull --policy missing $services
           docker compose up --no-build -d $services jaeger
         env:
           DOCKER_BUILDKIT: 1


### PR DESCRIPTION
In #7549 we tried to fix CI for external contributors by using the fork repo registry instead of the base repo registry. Unfortunately GITHUB_TOKEN cannot be used to write to the fork repo registry, it only has read access to the base repo registry.

Instead, use artifacts to pass around built Docker images.

Based on https://github.com/OpenRailAssociation/osrd/pull/7554 (but doesn't attempt to re-arrange the actions workflow).

There is quite a lot of boilerplate due to uploading/downloading/loading individual images. We could reduce that boilerplate by always uploading/downloading all images (at the cost of more time spent downloading stuff we won't use), or introducing a re-usable step in a separate yaml file.