### PR TITLE
front: fix simulations still displayed if no train in timetable

### DIFF
--- a/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
@@ -166,18 +166,7 @@ const ScenarioV2 = () => {
         setTrainSpaceTimeData
       );
     }
-  }, [timetable, infra]);
-
-  useEffect(() => {
-    if (timetable && infra?.state === 'CACHED' && trainIdUsedForProjection && infraId) {
-      getSpaceTimeChartData(
-        timetable.train_ids,
-        trainIdUsedForProjection,
-        infraId,
-        setTrainSpaceTimeData
-      );
-    }
-  }, [trainIdUsedForProjection]);
+  }, [timetable, trainIdUsedForProjection, infra]);
 
   useEffect(() => {
     if (!projectId || !studyId || !scenarioId) {
@@ -306,6 +295,7 @@ const ScenarioV2 = () => {
                     selectedTrainId={selectedTrainId}
                     conflicts={conflicts}
                     setTrainResultsToFetch={setTrainResultsToFetch}
+                    setSpaceTimeData={setTrainSpaceTimeData}
                   />
                 )}
               </div>

--- a/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
@@ -102,7 +102,7 @@ const SimulationResultsV2 = ({
     }
   }, [trainSimulation]);
 
-  if (!trainSimulation) return null;
+  if (!trainSimulation || spaceTimeData.length === 0) return null;
 
   if (trainSimulation.status !== 'success' && !isUpdating) return null;
 

--- a/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
+++ b/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
@@ -118,8 +118,5 @@ export const getSpaceTimeChartData = async (
     } finally {
       store.dispatch(updateIsUpdating(false));
     }
-  } else {
-    store.dispatch(updateSelectedTrainId(undefined));
-    store.dispatch(updateTrainIdUsedForProjection(undefined));
   }
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChartV2.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/SpaceTimeChartV2.tsx
@@ -161,7 +161,6 @@ const SpaceTimeChartV2 = (props: SpaceTimeChartV2Props) => {
 
   const redrawChart = () => {
     if (trainSimulations && trainIdUsedForProjection) {
-      // combination of trains data from projectpathtrainresults et simulationresponse ?
       const trainsToDraw = trainSimulations.map((train) => createTrainV2(train));
 
       const newDrawnedChart = drawAllTrainsV2(

--- a/front/src/modules/trainschedule/components/TimetableV2/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/TimetableV2/TimetableToolbar.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { BiSelectMultiple } from 'react-icons/bi';
 import { useSelector } from 'react-redux';
 
+import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
@@ -29,6 +30,8 @@ type TimetableToolbarProps = {
   setSelectedTrainIds: (selectedTrainIds: number[]) => void;
   multiSelectOn: boolean;
   setMultiSelectOn: (multiSelectOn: boolean) => void;
+  setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
+  setSpaceTimeData: React.Dispatch<React.SetStateAction<TrainSpaceTimeData[]>>;
 };
 
 const TimetableToolbar = ({
@@ -39,6 +42,8 @@ const TimetableToolbar = ({
   setSelectedTrainIds,
   multiSelectOn,
   setMultiSelectOn,
+  setTrainResultsToFetch,
+  setSpaceTimeData,
 }: TimetableToolbarProps) => {
   const { t } = useTranslation(['operationalStudies/scenario', 'common/itemTypes']);
   const dispatch = useAppDispatch();
@@ -91,6 +96,8 @@ const TimetableToolbar = ({
     await deleteTrainSchedules({ body: { ids: selectedTrainIds } })
       .unwrap()
       .then(() => {
+        setTrainResultsToFetch([]); // We don't want to fetch space time data again
+        setSpaceTimeData((prev) => prev.filter((train) => !selectedTrainIds.includes(train.id)));
         dispatch(
           setSuccess({
             title: t('timetable.trainsSelectionDeletedCount', { count: trainsCount }),

--- a/front/src/modules/trainschedule/components/TimetableV2/TimetableTrainCardV2.tsx
+++ b/front/src/modules/trainschedule/components/TimetableV2/TimetableTrainCardV2.tsx
@@ -9,6 +9,7 @@ import { MdAvTimer, MdContentCopy } from 'react-icons/md';
 import nextId from 'react-id-generator';
 
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
+import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import invalidInfra from 'assets/pictures/components/missing_tracks.svg';
 import invalidRollingStock from 'assets/pictures/components/missing_train.svg';
 import { enhancedEditoastApi } from 'common/api/enhancedEditoastApi';
@@ -41,6 +42,7 @@ type TimetableTrainCardProps = {
   handleSelectTrain: (trainId: number) => void;
   setDisplayTrainScheduleManagement: (arg0: string) => void;
   setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
+  setSpaceTimeData: React.Dispatch<React.SetStateAction<TrainSpaceTimeData[]>>;
 };
 
 const TimetableTrainCardV2 = ({
@@ -55,6 +57,7 @@ const TimetableTrainCardV2 = ({
   setDisplayTrainScheduleManagement,
   handleSelectTrain,
   setTrainResultsToFetch,
+  setSpaceTimeData,
 }: TimetableTrainCardProps) => {
   const { t } = useTranslation(['operationalStudies/scenario']);
   const dispatch = useAppDispatch();
@@ -86,7 +89,8 @@ const TimetableTrainCardV2 = ({
     deleteTrainSchedule({ body: { ids: [train.id] } })
       .unwrap()
       .then(() => {
-        setTrainResultsToFetch(undefined);
+        setTrainResultsToFetch([]); // We don't want to fetch space time data again
+        setSpaceTimeData((prev) => prev.filter((trainData) => trainData.id !== train.id));
         dispatch(
           setSuccess({
             title: t('timetable.trainDeleted', { name: train.trainName }),
@@ -142,6 +146,12 @@ const TimetableTrainCardV2 = ({
         dispatch(setFailure(castErrorToFailure(e)));
       }
     }
+  };
+
+  const selectPathProjection = async () => {
+    // We want to refetch all train space time data
+    setTrainResultsToFetch(undefined);
+    dispatch(updateTrainIdUsedForProjection(train.id));
   };
 
   const getInvalidIcon = (invalidReason: InvalidReason) => {
@@ -248,7 +258,7 @@ const TimetableTrainCardV2 = ({
             type="button"
             aria-label={t('timetable.choosePath')}
             title={t('timetable.choosePath')}
-            onClick={() => dispatch(updateTrainIdUsedForProjection(train.id))}
+            onClick={selectPathProjection}
           >
             <GiPathDistance />
           </button>

--- a/front/src/modules/trainschedule/components/TimetableV2/TimetableV2.tsx
+++ b/front/src/modules/trainschedule/components/TimetableV2/TimetableV2.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
+import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import type { ConflictV2, InfraState } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
 import ConflictsListV2 from 'modules/conflict/components/ConflictsListV2';
@@ -28,6 +29,7 @@ type TimetableV2Props = {
   selectedTrainId?: number;
   conflicts?: ConflictV2[];
   setTrainResultsToFetch: (trainScheduleIds?: number[]) => void;
+  setSpaceTimeData: React.Dispatch<React.SetStateAction<TrainSpaceTimeData[]>>;
 };
 
 const TimetableV2 = ({
@@ -38,6 +40,7 @@ const TimetableV2 = ({
   selectedTrainId,
   conflicts,
   setTrainResultsToFetch,
+  setSpaceTimeData,
 }: TimetableV2Props) => {
   const { t } = useTranslation(['operationalStudies/scenario', 'common/itemTypes']);
 
@@ -140,6 +143,8 @@ const TimetableV2 = ({
         setSelectedTrainIds={setSelectedTrainIds}
         multiSelectOn={multiselectOn}
         setMultiSelectOn={setMultiselectOn}
+        setTrainResultsToFetch={setTrainResultsToFetch}
+        setSpaceTimeData={setSpaceTimeData}
       />
 
       <div
@@ -165,6 +170,7 @@ const TimetableV2 = ({
               }
               setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
               setTrainResultsToFetch={setTrainResultsToFetch}
+              setSpaceTimeData={setSpaceTimeData}
             />
           ))}
       </div>


### PR DESCRIPTION
close #7588 

seems to have fixed #7590 as well

This PR : 
- fix both related bugs
- remove the else condition in `getSpaceTimeChartData` so we can properly benefit to the "not fetching train space time data" feature when deleting one or several trains and `setTrainResultsToFetch([])`
- refacto the way to change the path projection > allows to remove one useEffect in `ScenarioV2`