### PR TITLE
front: change pathfinding track offsets from m to mm

### DIFF
--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -56,7 +56,8 @@ export const getPathfindingQuery = ({
       if ('track' in step) {
         return {
           track: step.track,
-          offset: step.offset,
+          // pathfinding blocks endpoint requires offsets in mm
+          offset: step.offset * 1000,
         };
       }
       if ('operational_point' in step) {


### PR DESCRIPTION
Fix *some* of the problems on https://github.com/OpenRailAssociation/osrd/issues/7585

I'm not sure if I did the change at the right place (I'm not quite familiar with the front-end). It felt simple enough to make a commit, but feel free to dismiss it entirely. 

I don't know yet if similar changes need to be made at other places, we should probably do some general double-checking.