### PR TITLE
front: fix rolling stock text filter not updated on reset

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/SearchRollingStock.tsx
@@ -34,6 +34,7 @@ const SearchRollingStock = ({
         <InputSNCF
           id="searchfilter"
           type="text"
+          value={filters.text}
           onChange={(e) => searchMateriel(e.target.value)}
           placeholder={t('translation:common.search')}
           noMargin


### PR DESCRIPTION
duplicateRollingStock() calls resetFilters(), which resets RollingStockFilters.text to "". However that change is not reflected in the UI. Fix this by syncing the input value with our state.

Closes: https://github.com/OpenRailAssociation/osrd/issues/6074