### PR TITLE
front: fix text wrapping in speed space chart settings

### DIFF
--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceSettings.tsx
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceSettings.tsx
@@ -84,6 +84,7 @@ const SpeedSpaceSettings = ({
         onChange={() => toggleSetting(settingKey)}
         type="checkbox"
         disabled={disabled}
+        containerClassName="small"
       />
     ),
     [t, toggleSetting]
@@ -91,7 +92,7 @@ const SpeedSpaceSettings = ({
 
   return (
     <div
-      className={cx('showSettings', { 'ml-5': showSettings })}
+      className={cx('showSettings', { 'mx-2': showSettings })}
       style={showSettings ? { width: 'auto' } : { width: 0 }}
     >
       <div className="h2 d-flex align-items-center">{t('speedSpaceSettings.display')}</div>

--- a/front/src/modules/simulationResult/styles/_speedSpaceChart.scss
+++ b/front/src/modules/simulationResult/styles/_speedSpaceChart.scss
@@ -5,7 +5,6 @@
   position: relative;
 
   .showSettingsButton {
-    position: absolute;
     border: none;
     background: none;
     cursor: pointer;
@@ -16,6 +15,7 @@
   .showSettings {
     overflow: hidden;
     transition: 0.3s;
+    white-space: nowrap;
   }
 
   .btn-rotate {


### PR DESCRIPTION
Add `white-space: nowrap` to prevent the text from spilling on multiple lines. Drop the `position: absolute` on the button to toggle settings, it's better to just rely on flexbox instead and avoid hardcoding a margin-left on the the settings form.

While at it, slightly reduce the font size for the checkbox labels (purely cosmetic and subjective change, let me know if you want me to drop it).

Closes: https://github.com/OpenRailAssociation/osrd/issues/7589

![out](https://github.com/OpenRailAssociation/osrd/assets/506932/24addea8-fabf-47ae-b6ea-5aaf16c1ab22)
