### PR TITLE
core: choose arrivalAt/departureFrom in envelope interpolation

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
@@ -5,16 +5,27 @@ import java.util.List;
 public interface EnvelopeTimeInterpolate {
 
     /** Computes the time required to get to a given point of the envelope */
-    double interpolateTotalTime(double position);
+    double interpolateArrivalAt(double position);
+
+    /** Computes last time when the train is at a given point of the envelope (including stop duration if at stop) */
+    double interpolateDepartureFrom(double position);
 
     /** Computes the time required to get to a given point of the envelope in microseconds */
-    long interpolateTotalTimeUS(double position);
+    long interpolateArrivalAtUS(double position);
+
+    /** Computes last time when the train is at a given point of the envelope (including stop duration if at stop) in microseconds */
+    long interpolateDepartureFromUS(double position);
 
     /**
      * Computes the time required to get to a given point of the envelope, clamping the position to
      * [0, envelope length] first
      */
-    double interpolateTotalTimeClamp(double position);
+    double interpolateArrivalAtClamp(double position);
+
+    /**
+     * Computes last time when the train is at a given point of the envelope (including stop duration if at stop), clamping the position to [0, envelope length] first
+     */
+    double interpolateDepartureFromClamp(double position);
 
     /** Returns the start position of the envelope */
     double getBeginPos();

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeConcatTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeConcatTest.java
@@ -18,12 +18,12 @@ public class EnvelopeConcatTest {
         // List of functions to call, they should return the same result for the envelope and the
         // concatenated version
         var functions = List.<Function<EnvelopeTimeInterpolate, Double>>of(
-                in -> in.interpolateTotalTime(0),
-                in -> in.interpolateTotalTime(1),
-                in -> in.interpolateTotalTime(2),
-                in -> in.interpolateTotalTimeUS(1.5) / 1_000.,
-                in -> in.interpolateTotalTimeClamp(-1),
-                in -> in.interpolateTotalTimeClamp(0.5),
+                in -> in.interpolateDepartureFrom(0),
+                in -> in.interpolateDepartureFrom(1),
+                in -> in.interpolateDepartureFrom(2),
+                in -> in.interpolateDepartureFromUS(1.5) / 1_000.,
+                in -> in.interpolateDepartureFromClamp(-1),
+                in -> in.interpolateDepartureFromClamp(0.5),
                 EnvelopeTimeInterpolate::getBeginPos,
                 EnvelopeTimeInterpolate::getEndPos,
                 EnvelopeTimeInterpolate::getTotalTime);
@@ -46,7 +46,8 @@ public class EnvelopeConcatTest {
         final var secondEnvelopeTime = envelopes.get(1).getTotalTime();
 
         assertEquals(
-                firstEnvelopeTime + envelopes.get(1).interpolateTotalTime(1), concatenated.interpolateTotalTime(3));
+                firstEnvelopeTime + envelopes.get(1).interpolateDepartureFrom(1),
+                concatenated.interpolateDepartureFrom(3));
         assertEquals(0, concatenated.getBeginPos());
         assertEquals(4, concatenated.getEndPos());
         assertEquals(firstEnvelopeTime + secondEnvelopeTime, concatenated.getTotalTime());

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeTest.java
@@ -55,18 +55,18 @@ public class EnvelopeTest {
     }
 
     @Test
-    void testInterpolateTime() {
+    void testInterpolateDepartureFrom() {
         var partA = EnvelopeTestUtils.generateTimes(new double[] {0, 2}, new double[] {1, 1});
         var partB = EnvelopeTestUtils.generateTimes(new double[] {2, 4}, new double[] {1, 1});
         var envelope = Envelope.make(partA, partB);
 
         assertEquals(1, partA.interpolateTotalTime(1));
 
-        assertEquals(1, envelope.interpolateTotalTime(1));
-        assertEquals(2, envelope.interpolateTotalTime(2));
-        assertEquals(2, envelope.interpolateTotalTime(2));
-        assertEquals(3, envelope.interpolateTotalTime(3));
-        assertEquals(3.5, envelope.interpolateTotalTime(3.5));
-        assertEquals(4, envelope.interpolateTotalTime(4));
+        assertEquals(1, envelope.interpolateDepartureFrom(1));
+        assertEquals(2, envelope.interpolateDepartureFrom(2));
+        assertEquals(2, envelope.interpolateDepartureFrom(2));
+        assertEquals(3, envelope.interpolateDepartureFrom(3));
+        assertEquals(3.5, envelope.interpolateDepartureFrom(3.5));
+        assertEquals(4, envelope.interpolateDepartureFrom(4));
     }
 }

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceRangesTests.java
@@ -175,16 +175,19 @@ public class AllowanceRangesTests {
 
         // Check that we lose as much time as specified
         assertEquals(
-                maxEffortEnvelope.interpolateTotalTime(rangesTransitions[1]) + value1.time,
-                marecoEnvelope.interpolateTotalTime(rangesTransitions[1]),
+                maxEffortEnvelope.interpolateDepartureFrom(rangesTransitions[1]) + value1.time,
+                marecoEnvelope.interpolateDepartureFrom(rangesTransitions[1]),
                 testContext.timeStep);
         assertEquals(
-                maxEffortEnvelope.interpolateTotalTime(rangesTransitions[2]) + value1.time + value2.time,
-                marecoEnvelope.interpolateTotalTime(rangesTransitions[2]),
+                maxEffortEnvelope.interpolateDepartureFrom(rangesTransitions[2]) + value1.time + value2.time,
+                marecoEnvelope.interpolateDepartureFrom(rangesTransitions[2]),
                 testContext.timeStep);
         assertEquals(
-                maxEffortEnvelope.interpolateTotalTime(rangesTransitions[3]) + value1.time + value2.time + value3.time,
-                marecoEnvelope.interpolateTotalTime(rangesTransitions[3]),
+                maxEffortEnvelope.interpolateDepartureFrom(rangesTransitions[3])
+                        + value1.time
+                        + value2.time
+                        + value3.time,
+                marecoEnvelope.interpolateDepartureFrom(rangesTransitions[3]),
                 testContext.timeStep);
         assertEquals(
                 maxEffortEnvelope.getTotalTime() + value1.time + value2.time + value3.time,

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope_sim/AllowanceTests.java
@@ -183,11 +183,11 @@ public class AllowanceTests {
         var endPos = allowance.endPos;
         var allowanceEnvelope = allowance.apply(base, context);
 
-        var timeBeginPointBase = base.interpolateTotalTime(beginPos);
-        var timeEndPointBase = base.interpolateTotalTime(endPos);
+        var timeBeginPointBase = base.interpolateDepartureFrom(beginPos);
+        var timeEndPointBase = base.interpolateDepartureFrom(endPos);
 
-        var timeBeginPoint = allowanceEnvelope.interpolateTotalTime(beginPos);
-        var timeEndPoint = allowanceEnvelope.interpolateTotalTime(endPos);
+        var timeBeginPoint = allowanceEnvelope.interpolateDepartureFrom(beginPos);
+        var timeEndPoint = allowanceEnvelope.interpolateDepartureFrom(endPos);
         var expectedTimeEndPoint = timeEndPointBase + allowance.getAddedTime(base);
 
         // make sure begin has the same time before and after margin, and that end is offset by the

--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -38,12 +38,12 @@ class IncrementalRequirementEnvelopeAdapter(
         if (stopOffset.distance.meters > endPos) {
             return Double.POSITIVE_INFINITY
         }
-        // stop duration is included in interpolateTotalTime()
+        // stop duration is included in interpolateDepartureFrom()
         var pastStop = (stopOffset.distance).meters
         if (pastStop > endPos) {
             pastStop = endPos
         }
-        return envelopeWithStops.interpolateTotalTime(pastStop)
+        return envelopeWithStops.interpolateDepartureFrom(pastStop)
     }
 
     override fun arrivalTimeInRange(
@@ -54,7 +54,7 @@ class IncrementalRequirementEnvelopeAdapter(
         // if the head of the train enters the zone at some point, use that
         val begin = pathBeginOff.distance.meters
         if (begin >= 0.0 && begin <= envelopeWithStops.endPos)
-            return envelopeWithStops.interpolateTotalTime(begin)
+            return envelopeWithStops.interpolateArrivalAt(begin)
 
         val end = pathEndOff.distance.meters
 
@@ -75,7 +75,7 @@ class IncrementalRequirementEnvelopeAdapter(
 
         val criticalPoint = end + rollingStock.length
         if (criticalPoint >= 0.0 && criticalPoint <= envelopeWithStops.endPos)
-            return envelopeWithStops.interpolateTotalTime(criticalPoint)
+            return envelopeWithStops.interpolateDepartureFrom(criticalPoint)
 
         return Double.POSITIVE_INFINITY
     }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -172,7 +172,7 @@ public class StandaloneSim {
         double lostTime = 0.;
         for (var schedulePoint : scheduledPoints) {
             var rangeEndPos = schedulePoint.pathOffset;
-            double excessTime = schedulePoint.time - maxEffortEnvelope.interpolateTotalTime(rangeEndPos) - lostTime;
+            double excessTime = schedulePoint.time - maxEffortEnvelope.interpolateArrivalAt(rangeEndPos) - lostTime;
             if (excessTime < 0) {
                 // TODO: Raise a warning
                 continue;

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -61,7 +61,7 @@ fun runScheduleMetadataExtractor(
     // Compute stops
     val stops = ArrayList<ResultStops>()
     for (stop in legacyStops) {
-        val stopTime = envelopeWithStops.interpolateTotalTime(stop.position) - stop.duration
+        val stopTime = envelopeWithStops.interpolateArrivalAt(stop.position)
         stops.add(ResultStops(stopTime, stop.position, stop.duration))
     }
 
@@ -106,7 +106,7 @@ fun runScheduleMetadataExtractor(
                 rawInfra.getPhysicalSignalName(
                     loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
                 )!!,
-                envelopeWithStops.interpolateTotalTime(sightOffset.distance.meters).seconds,
+                envelopeWithStops.interpolateArrivalAt(sightOffset.distance.meters).seconds,
                 sightOffset,
                 "VL" // TODO: find out the real state
             )
@@ -194,8 +194,7 @@ fun isScheduledPointsHonored(
 ): Boolean {
     for (e in schedule) {
         if (e.arrival == null) continue
-        var computed = envelopeStopWrapper.interpolateTotalTime(e.pathOffset.distance.meters)
-        if (e.stopFor != null) computed -= e.stopFor.seconds
+        val computed = envelopeStopWrapper.interpolateArrivalAt(e.pathOffset.distance.meters)
         val expected = e.arrival.seconds
         // Check that the expected arrival time and the simulated one match ~1s
         if ((computed - expected).absoluteValue > 1.0) {

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -202,7 +202,7 @@ fun buildFinalEnvelope(
     scheduledPoints: List<SimulationScheduleItem>
 ): Envelope {
     fun getEnvelopeTimeAt(offset: Offset<TravelledPath>): Double {
-        return provisionalEnvelope.interpolateTotalTimeClamp(offset.distance.meters)
+        return provisionalEnvelope.interpolateDepartureFromClamp(offset.distance.meters)
     }
     var prevFixedPointOffset = Offset<TravelledPath>(0.meters)
     var prevFixedPointDepartureTime = 0.0
@@ -288,8 +288,8 @@ fun distributeAllowance(
         envelope: Envelope = provisionalEnvelope
     ): Double {
         assert(from < to)
-        val start = envelope.interpolateTotalTimeClamp(from.distance.meters)
-        val end = envelope.interpolateTotalTimeClamp(to.distance.meters)
+        val start = envelope.interpolateDepartureFromClamp(from.distance.meters)
+        val end = envelope.interpolateDepartureFromClamp(to.distance.meters)
         return end - start
     }
     val rangeEnds = margins.boundaries.filter { it > startOffset && it < endOffset }.toMutableList()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -341,8 +341,8 @@ private fun makeAllowanceRanges(
     val res = ArrayList<AllowanceRange>()
     for (point in fixedPoints) {
         val baseTime =
-            envelope.interpolateTotalTimeClamp(point.offset.distance.meters) -
-                envelope.interpolateTotalTimeClamp(transition)
+            envelope.interpolateArrivalAtClamp(point.offset.distance.meters) -
+                envelope.interpolateDepartureFromClamp(transition)
         val pointArrivalTime = transitionTime + baseTime
         val neededDelay = max(0.0, point.time - pointArrivalTime - prevAddedTime)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -32,7 +32,7 @@ import fr.sncf.osrd.utils.units.Offset
  *
  * Note: the first envelope doesn't necessarily cover the first block in its entirety, while path
  * offsets start at offset=0 on the first block. There are two ways to properly handle time at path
- * offsets: either using `explorer.interpolateTimeClamp`, or by converting the offsets into
+ * offsets: either using `explorer.interpolateDepartureFromClamp`, or by converting the offsets into
  * `Offset<TravelledPath>` using the underlying incremental path.
  */
 interface InfraExplorerWithEnvelope : InfraExplorer {
@@ -44,10 +44,10 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun addEnvelope(envelope: EnvelopeInterpolate): InfraExplorerWithEnvelope
 
     /**
-     * Calls `InterpolateTotalTimeClamp` on the underlying envelope, taking the travelled path
+     * Calls `InterpolateDepartureFromClamp` on the underlying envelope, taking the travelled path
      * offset into account.
      */
-    fun interpolateTimeClamp(pathOffset: Offset<Path>): Double
+    fun interpolateDepartureFromClamp(pathOffset: Offset<Path>): Double
 
     /** Returns the spacing requirements since the last update */
     fun getSpacingRequirements(): List<ResultTrain.SpacingRequirement>

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -62,9 +62,9 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun interpolateTimeClamp(pathOffset: Offset<Path>): Double {
+    override fun interpolateDepartureFromClamp(pathOffset: Offset<Path>): Double {
         return getFullEnvelope()
-            .interpolateTotalTimeClamp(
+            .interpolateDepartureFromClamp(
                 getIncrementalPath().toTravelledPath(pathOffset).distance.meters
             )
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -35,8 +35,8 @@ data class BlockAvailability(
         val spacingRequirements =
             if (needFullRequirements) infraExplorer.getFullSpacingRequirements()
             else infraExplorer.getSpacingRequirements()
-        val pathStartTime = startTime - infraExplorer.interpolateTimeClamp(startOffset)
-        val endTime = infraExplorer.interpolateTimeClamp(endOffset) + pathStartTime
+        val pathStartTime = startTime - infraExplorer.interpolateDepartureFromClamp(startOffset)
+        val endTime = infraExplorer.interpolateDepartureFromClamp(endOffset) + pathStartTime
 
         // Modify the spacing requirements to adjust for the start time,
         // and filter out the ones that are outside the relevant time range
@@ -90,7 +90,7 @@ data class BlockAvailability(
         var value = 0.0
         while (i++ < 20 && !search.complete()) {
             value = search.input
-            search.feedback(envelope.interpolateTotalTimeClamp(search.input))
+            search.feedback(envelope.interpolateDepartureFromClamp(search.input))
         }
         return Offset(Distance.fromMeters(value))
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -110,15 +110,17 @@ class StandaloneSimulationTest {
             listOf(
                 SimulationScheduleItem(
                     thirdDistance,
-                    maxEffortEnvelope.interpolateTotalTime(thirdDistance.distance.meters).seconds +
-                        60.seconds,
+                    maxEffortEnvelope
+                        .interpolateDepartureFrom(thirdDistance.distance.meters)
+                        .seconds + 60.seconds,
                     null,
                     false
                 ),
                 SimulationScheduleItem(
                     halfDistance,
-                    maxEffortEnvelope.interpolateTotalTime(halfDistance.distance.meters).seconds +
-                        120.seconds,
+                    maxEffortEnvelope
+                        .interpolateDepartureFrom(halfDistance.distance.meters)
+                        .seconds + 120.seconds,
                     15.seconds,
                     true
                 ),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -37,7 +37,7 @@ class DepartureTimeShiftTests {
                 .run()!!
         val secondBlockEntryTime =
             (res.departureTime +
-                res.envelope.interpolateTotalTime(infra.getBlockLength(firstBlock).distance.meters))
+                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).distance.meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
         occupancyTest(res, occupancyGraph)
     }
@@ -70,7 +70,7 @@ class DepartureTimeShiftTests {
                 .run()!!
         val secondBlockEntryTime =
             (res.departureTime +
-                res.envelope.interpolateTotalTime(infra.getBlockLength(firstBlock).distance.meters))
+                res.envelope.interpolateArrivalAt(infra.getBlockLength(firstBlock).distance.meters))
         Assertions.assertTrue(secondBlockEntryTime >= 3600)
         occupancyTest(res, occupancyGraph)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -137,12 +137,12 @@ fun occupancyTest(
         for ((timeStart, timeEnd, distanceStart, distanceEnd) in blockOccupancies) {
             val enterTime =
                 res.departureTime +
-                    envelopeWrapper.interpolateTotalTimeClamp(
+                    envelopeWrapper.interpolateArrivalAtClamp(
                         (startBlockPosition + distanceStart).meters
                     )
             val exitTime =
                 res.departureTime +
-                    envelopeWrapper.interpolateTotalTimeClamp(
+                    envelopeWrapper.interpolateDepartureFromClamp(
                         (startBlockPosition + distanceEnd).meters
                     )
             Assertions.assertTrue(

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StandardAllowanceTests.kt
@@ -103,7 +103,7 @@ class StandardAllowanceTests {
         Assertions.assertNotNull(res.withAllowance!!)
         val secondBlockEntryTime =
             (res.withAllowance.departureTime +
-                res.withAllowance.envelope.interpolateTotalTime(
+                res.withAllowance.envelope.interpolateArrivalAt(
                     infra.getBlockLength(firstBlock).distance.meters
                 ))
         Assertions.assertTrue(secondBlockEntryTime >= 3600 - TIME_STEP)
@@ -137,7 +137,7 @@ class StandardAllowanceTests {
         Assertions.assertNotNull(res.withAllowance!!)
         val timeEnterOccupiedSection =
             (res.withAllowance.departureTime +
-                res.withAllowance.envelope.interpolateTotalTime(5000.0))
+                res.withAllowance.envelope.interpolateArrivalAt(5000.0))
         Assertions.assertEquals(3600.0, timeEnterOccupiedSection, 3 * TIME_STEP)
         occupancyTest(res.withAllowance, occupancyGraph, 2 * TIME_STEP)
         checkAllowanceResult(res, allowance)
@@ -185,7 +185,7 @@ class StandardAllowanceTests {
                 .setStandardAllowance(allowance)
                 .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateTotalTime(11000.0))
+        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(11000.0))
         Assertions.assertEquals(
             1000.0,
             thirdBlockEntryTime,
@@ -234,7 +234,7 @@ class StandardAllowanceTests {
                 .setStandardAllowance(allowance)
                 .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateTotalTime(10001.0))
+        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(10001.0))
         Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)
     }
 
@@ -360,7 +360,7 @@ class StandardAllowanceTests {
                 .setStandardAllowance(allowance)
                 .run()!!
         occupancyTest(res, occupancyGraph, TIME_STEP)
-        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateTotalTime(11000.0))
+        val thirdBlockEntryTime = (res.departureTime + res.envelope.interpolateArrivalAt(11000.0))
         // 2 allowances + the extra safety TIME_STEP added when avoiding conflicts gives us 3 *
         // TIME_STEP
         Assertions.assertEquals(1000.0, thirdBlockEntryTime, 3 * TIME_STEP)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeTests.kt
@@ -200,7 +200,7 @@ class InfraExplorerWithEnvelopeTests {
 
     /**
      * Test that the envelope bounds are equal, then iterate by an arbitrary step length to test for
-     * interpolateTotalTime equality.
+     * interpolateDepartureFrom/ArrivalAt equality (respectively with/without stop duration).
      */
     private fun testEnvelopeTimeEquality(expected: Envelope, actual: EnvelopeTimeInterpolate) {
         assertTrue { arePositionsEqual(expected.beginPos, actual.beginPos) }
@@ -209,8 +209,14 @@ class InfraExplorerWithEnvelopeTests {
         while (position < expected.endPos) {
             assertTrue(
                 areTimesEqual(
-                    expected.interpolateTotalTime(position),
-                    actual.interpolateTotalTime(position),
+                    expected.interpolateDepartureFrom(position),
+                    actual.interpolateDepartureFrom(position),
+                )
+            )
+            assertTrue(
+                areTimesEqual(
+                    expected.interpolateArrivalAt(position),
+                    actual.interpolateArrivalAt(position),
                 )
             )
             position += 1.0

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
@@ -117,7 +117,7 @@ class DummyBlockAvailability(
     ): BlockAvailabilityInterface.Availability {
         val resourceUses = generateResourcesForPath(infraExplorer, startOffset, endOffset)
         // startTime refers to the time at startOffset, we need to offset it
-        val pathStartTime = startTime - infraExplorer.interpolateTimeClamp(startOffset)
+        val pathStartTime = startTime - infraExplorer.interpolateDepartureFromClamp(startOffset)
         val unavailability =
             findMinimumDelay(infraExplorer, resourceUses, pathStartTime, startOffset)
         return unavailability ?: findMaximumDelay(infraExplorer, resourceUses, pathStartTime)
@@ -244,8 +244,8 @@ class DummyBlockAvailability(
         if (startOffset.distance > blockExitOffset || endOffset.distance < blockEnterOffset)
             return null
 
-        val enterTime = explorer.interpolateTimeClamp(Offset(blockEnterOffset))
-        val exitTime = explorer.interpolateTimeClamp(Offset(blockExitOffset))
+        val enterTime = explorer.interpolateDepartureFromClamp(Offset(blockEnterOffset))
+        val exitTime = explorer.interpolateDepartureFromClamp(Offset(blockExitOffset))
         return TimeInterval(enterTime, exitTime)
     }
 


### PR DESCRIPTION
`interpolateTotalTime()` is removed, in favor of one of:
* `interpolateDepartureFrom()` (which was the previous behavior)
* `interpolateArrivalAt()`

also:
* little cleanup on clamp

TODO:
- [x] check if calls to arrival/departure are correct now that it's clarified
- [x] see if allowance should fully ignore stops (which probably requires more work)

Follow-up on https://github.com/OpenRailAssociation/osrd/pull/7322#discussion_r1622406776