### PR TITLE
core: increase precision of envelope times from ms to us

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -32,7 +32,7 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
     private final double minSpeed;
 
     /**
-     * The time from the start of the envelope to envelope part transitions, in milliseconds. Only
+     * The time from the start of the envelope to envelope part transitions, in microseconds. Only
      * read using getTotalTimes.
      */
     private long[] cumulativeTimesCache = null;
@@ -185,17 +185,17 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
     }
 
     /** Computes the time required to get to a given point of the envelope */
-    public long interpolateTotalTimeMS(double position) {
+    public long interpolateTotalTimeUS(double position) {
         assert continuous : "interpolating times on a non continuous envelope is a risky business";
         var envelopePartIndex = findLeft(position);
         assert envelopePartIndex >= 0 : "Trying to interpolate time outside of the envelope";
         var envelopePart = get(envelopePartIndex);
-        return getCumulativeTimeMS(envelopePartIndex) + envelopePart.interpolateTotalTimeMS(position);
+        return getCumulativeTimeUS(envelopePartIndex) + envelopePart.interpolateTotalTimeUS(position);
     }
 
     /** Computes the time required to get to a given point of the envelope */
     public double interpolateTotalTime(double position) {
-        return ((double) interpolateTotalTimeMS(position)) / 1000;
+        return ((double) interpolateTotalTimeUS(position)) / 1_000_000;
     }
 
     /**
@@ -204,7 +204,7 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
      */
     public double interpolateTotalTimeClamp(double position) {
         position = Math.min(getEndPos(), Math.max(0, position));
-        return ((double) interpolateTotalTimeMS(position)) / 1000;
+        return ((double) interpolateTotalTimeUS(position)) / 1_000_000;
     }
 
     // endregion
@@ -212,7 +212,7 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
     // region CACHING
 
     /** This method must be private as it returns an array */
-    private long[] getCumulativeTimesMS() {
+    private long[] getCumulativeTimesUS() {
         if (cumulativeTimesCache != null) return cumulativeTimesCache;
 
         var timesToPartTransitions = new long[parts.length + 1];
@@ -220,22 +220,22 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
 
         long totalTime = 0;
         for (int i = 0; i < parts.length; i++) {
-            totalTime += parts[i].getTotalTimeMS();
+            totalTime += parts[i].getTotalTimeUS();
             timesToPartTransitions[i + 1] = totalTime;
         }
         cumulativeTimesCache = timesToPartTransitions;
         return timesToPartTransitions;
     }
 
-    /** Returns the total time of the envelope, in milliseconds */
-    public long getTotalTimeMS() {
-        var timesToPartTransitions = getCumulativeTimesMS();
+    /** Returns the total time of the envelope, in microseconds */
+    public long getTotalTimeUS() {
+        var timesToPartTransitions = getCumulativeTimesUS();
         return timesToPartTransitions[timesToPartTransitions.length - 1];
     }
 
     /** Returns the total time of the envelope */
     public double getTotalTime() {
-        return ((double) getTotalTimeMS()) / 1000;
+        return ((double) getTotalTimeUS()) / 1_000_000;
     }
 
     /** Returns the time between two positions of the envelope */
@@ -245,13 +245,13 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
 
     /**
      * Returns the total time required to get from the start of the envelope to the start of an
-     * envelope part, in milliseconds
+     * envelope part, in microseconds
      *
      * @param transitionIndex either an envelope part index, of the number of parts to get the total
      *     time
      */
-    public long getCumulativeTimeMS(int transitionIndex) {
-        return getCumulativeTimesMS()[transitionIndex];
+    public long getCumulativeTimeUS(int transitionIndex) {
+        return getCumulativeTimesUS()[transitionIndex];
     }
 
     // endregion

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeConcat.java
@@ -54,8 +54,8 @@ public class EnvelopeConcat implements EnvelopeInterpolate {
     }
 
     @Override
-    public long interpolateTotalTimeMS(double position) {
-        return (long) (interpolateTotalTime(position) * 1000);
+    public long interpolateTotalTimeUS(double position) {
+        return (long) (interpolateTotalTime(position) * 1_000_000);
     }
 
     @Override

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeDebug.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeDebug.java
@@ -26,9 +26,9 @@ public class EnvelopeDebug {
             var positions = part.clonePositions();
             var times = new double[part.pointCount()];
             for (int pointIndex = 0; pointIndex < part.pointCount(); pointIndex++)
-                times[pointIndex] = startTime + part.getTotalTimeMS(pointIndex) / 1000.;
+                times[pointIndex] = startTime + part.getTotalTimeUS(pointIndex) / 1_000_000.;
             plotArrays(plot, lineName, times, positions);
-            startTime += part.getTotalTimeMS() / 1000.;
+            startTime += part.getTotalTimeUS() / 1_000_000.;
         }
     }
 

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/EnvelopeTimeInterpolate.java
@@ -7,8 +7,8 @@ public interface EnvelopeTimeInterpolate {
     /** Computes the time required to get to a given point of the envelope */
     double interpolateTotalTime(double position);
 
-    /** Computes the time required to get to a given point of the envelope in ms */
-    long interpolateTotalTimeMS(double position);
+    /** Computes the time required to get to a given point of the envelope in microseconds */
+    long interpolateTotalTimeUS(double position);
 
     /**
      * Computes the time required to get to a given point of the envelope, clamping the position to

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeConcatTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeConcatTest.java
@@ -21,7 +21,7 @@ public class EnvelopeConcatTest {
                 in -> in.interpolateTotalTime(0),
                 in -> in.interpolateTotalTime(1),
                 in -> in.interpolateTotalTime(2),
-                in -> (double) in.interpolateTotalTimeMS(1.5),
+                in -> in.interpolateTotalTimeUS(1.5) / 1_000.,
                 in -> in.interpolateTotalTimeClamp(-1),
                 in -> in.interpolateTotalTimeClamp(0.5),
                 EnvelopeTimeInterpolate::getBeginPos,

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopePartTest.java
@@ -89,8 +89,8 @@ class EnvelopePartTest {
             switch (i) {
                 case 0:
                     expectedEnvelopePartEnergy = PhysicsRollingStock.getMaxEffort(1, testEffortCurveMap.get(0.))
-                            * envelopePart.getTotalTimeMS()
-                            / 1000;
+                            * envelopePart.getTotalTimeUS()
+                            / 1_000_000;
                     break;
                 case 1:
                     Assertions.assertEquals(envelopePart.getMinSpeed(), envelopePart.getMaxSpeed());

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Duration.kt
@@ -41,6 +41,8 @@ value class Duration(val milliseconds: Long) : Comparable<Duration> {
 
 val Double.seconds: Duration
     get() = Duration(Math.round(this * 1000))
+val Long.microseconds: Duration
+    get() = Duration(this / 1000)
 val Int.seconds: Duration
     get() = Duration(this.toLong() * 1000)
 

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
@@ -28,8 +28,8 @@ public class EnvelopeStopWrapper implements EnvelopeInterpolate {
         return stopTime + envelope.interpolateTotalTime(position);
     }
 
-    public long interpolateTotalTimeMS(double position) {
-        return (long) (this.interpolateTotalTime(position) * 1000);
+    public long interpolateTotalTimeUS(double position) {
+        return (long) (this.interpolateTotalTime(position) * 1_000_000);
     }
 
     @Override

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -517,7 +517,8 @@ fun zoneOccupationChangeEvents(
             // Compute occupation change event
             if (currentOffset.distance > envelope.endPos.meters) break
             val entryOffset = Offset.max(Offset.zero(), currentOffset)
-            val entryTime = TimeDelta(envelope.interpolateTotalTimeMS(entryOffset.distance.meters))
+            val entryTime =
+                envelope.interpolateTotalTimeUS(entryOffset.distance.meters).microseconds
             val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
             zoneOccupationChangeEvents.add(
                 ZoneOccupationChangeEvent(entryTime, entryOffset, zoneCount, true, blockIdx, zone)
@@ -530,7 +531,7 @@ fun zoneOccupationChangeEvents(
             val exitOffset = Offset.max(Offset.zero(), currentOffset + trainLength.meters)
             if (exitOffset.distance <= envelope.endPos.meters) {
                 val exitTime =
-                    TimeDelta(envelope.interpolateTotalTimeMS(exitOffset.distance.meters))
+                    envelope.interpolateTotalTimeUS(exitOffset.distance.meters).microseconds
                 zoneOccupationChangeEvents.add(
                     ZoneOccupationChangeEvent(
                         exitTime,


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/7612

Follow-up of https://github.com/OpenRailAssociation/osrd/pull/7432

I hoped that we only needed us precision inside individual parts, but that isn't actually the case. This PR replaces all milliseconds for microseconds in all envelope APIs.

We'll need to be careful when defining units in the upcoming simulation rewrite, ms are not precise enough.