### PR TITLE
core: stdcmv2: fix "time per distance" unit when parsing request

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -188,7 +188,7 @@ private fun parseSteps(infra: FullInfra, pathItems: List<STDCMPathItem>): List<S
 private fun parseMarginValue(margin: MarginValue): AllowanceValue? {
     return when (margin) {
         is MarginValue.MinPer100Km -> {
-            TimePerDistance(margin.value * 100)
+            TimePerDistance(margin.value)
         }
         is MarginValue.Percentage -> {
             Percentage(margin.percentage)


### PR DESCRIPTION
That `* 100` was not actually needed here