### PR TITLE
front: fix stdcmv2 ui

### DIFF
--- a/front/src/applications/stdcmV2/components/StdcmHeader.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmHeader.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import { useOsrdConfSelectors } from 'common/osrdContext';
+import ScenarioExplorer from 'modules/scenario/components/ScenarioExplorer';
 
 const StdcmHeader = () => {
   const { t } = useTranslation('stdcm');
+  const { getProjectID, getScenarioID, getStudyID } = useOsrdConfSelectors();
+  const studyID = useSelector(getStudyID);
+  const projectID = useSelector(getProjectID);
+  const scenarioID = useSelector(getScenarioID);
   return (
     <div className="stdcm-v2-header">
-      <span className="stdcm-v2-header__title">ST DCM</span>
+      <span className="stdcm-v2-header__title col-3 pl-5">ST DCM</span>
       <span className="stdcm-v2-header__notification" id="notification">
         {t('notificationTitle')}
         {/* <a href="#notification">Plus d’informations</a> */}
       </span>
+      <div className="w-25 pr-4">
+        <ScenarioExplorer
+          globalProjectId={projectID}
+          globalStudyId={studyID}
+          globalScenarioId={scenarioID}
+          displayImgProject={false}
+        />
+      </div>
     </div>
   );
 };

--- a/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
+++ b/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import STDCM_REQUEST_STATUS from 'applications/stdcm/consts';
 import useStdcm from 'applications/stdcm/hooks/useStdcm';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
-import ScenarioExplorer from 'modules/scenario/components/ScenarioExplorer';
 import { Map } from 'modules/trainschedule/components/ManageTrainSchedule';
 import type { StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
 import { useAppDispatch } from 'store';
@@ -21,9 +20,7 @@ import StdcmLoader from '../components/StdcmLoader';
 import StdcmOrigin from '../components/StdcmOrigin';
 
 const StdcmViewV2 = () => {
-  const { getProjectID, getScenarioID, getStudyID } = useOsrdConfSelectors();
-  const studyID = useSelector(getStudyID);
-  const projectID = useSelector(getProjectID);
+  const { getScenarioID } = useOsrdConfSelectors();
   const scenarioID = useSelector(getScenarioID);
   const { launchStdcmRequest, cancelStdcmRequest, currentStdcmRequestStatus } = useStdcm();
   const isPending = currentStdcmRequestStatus === STDCM_REQUEST_STATUS.pending;
@@ -49,46 +46,35 @@ const StdcmViewV2 = () => {
   return (
     <div className="stdcm-v2">
       <StdcmHeader />
-      <div className="stdcm-v2__body">
-        <div className="stdcm-v2-simulation-settings">
-          <div>
-            <div className="mb-4">
-              <ScenarioExplorer
-                globalProjectId={projectID}
-                globalStudyId={studyID}
-                globalScenarioId={scenarioID}
-              />
+      {scenarioID && (
+        <div className="stdcm-v2__body">
+          <div className="stdcm-v2-simulation-settings">
+            <div className="stdcm-v2-consist-container">
+              <StdcmConsist disabled={isPending} />
             </div>
-            {scenarioID && <StdcmConsist disabled={isPending} />}
-          </div>
-          {scenarioID && (
-            <>
-              <div className="stdcm-v2__separator" />
-              <div className="stdcm-v2-simulation-itinirary">
-                {/* //TODO: rename StdcmDefaultCard */}
-                {/* <StdcmDefaultCard text="Indiquer le sillon antérieur" Icon={<ArrowUp size="lg" />} /> */}
-                <StdcmOrigin disabled={isPending} />
-                {/* <StdcmDefaultCard text="Ajouter un passage" Icon={<Location size="lg" />} /> */}
-                <StdcmDestination disabled={isPending} />
-                {/* <StdcmDefaultCard text="Indiquer le sillon postérieur" Icon={<ArrowDown size="lg" />} /> */}
+            <div className="stdcm-v2__separator" />
+            <div className="stdcm-v2-simulation-itinerary">
+              {/* //TODO: rename StdcmDefaultCard */}
+              {/* <StdcmDefaultCard text="Indiquer le sillon antérieur" Icon={<ArrowUp size="lg" />} /> */}
+              <StdcmOrigin disabled={isPending} />
+              {/* <StdcmDefaultCard text="Ajouter un passage" Icon={<Location size="lg" />} /> */}
+              <StdcmDestination disabled={isPending} />
+              {/* <StdcmDefaultCard text="Indiquer le sillon postérieur" Icon={<ArrowDown size="lg" />} /> */}
+              <div className="stdcm-v2-launch-request">
                 <Button
                   label={t('simulation.getSimulation')}
                   onClick={() => launchStdcmRequest()}
                 />
-                {isPending && (
-                  <StdcmLoader cancelStdcmRequest={cancelStdcmRequest} ref={loaderRef} />
-                )}
               </div>
-            </>
-          )}
-        </div>
-        {scenarioID && (
-          <div className="osrd-config-item-container osrd-config-item-container-map stdcm-v2-map">
-            <Map />
+              {isPending && <StdcmLoader cancelStdcmRequest={cancelStdcmRequest} ref={loaderRef} />}
+            </div>
           </div>
-        )}
-        <div />
-      </div>
+          <div className="osrd-config-item-container osrd-config-item-container-map stdcm-v2-map">
+            <Map hideAttribution />
+          </div>
+          <div />
+        </div>
+      )}
     </div>
   );
 };

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { MdTrain } from 'react-icons/md';
 import { useSelector } from 'react-redux';
@@ -22,7 +23,8 @@ const ScenarioExplorer = ({
   globalProjectId,
   globalStudyId,
   globalScenarioId,
-}: ScenarioExplorerProps) => {
+  displayImgProject = true,
+}: ScenarioExplorerProps & { displayImgProject?: boolean }) => {
   const { t } = useTranslation('common/scenarioExplorer');
   const dispatch = useAppDispatch();
   const { openModal } = useModal();
@@ -136,12 +138,17 @@ const ScenarioExplorer = ({
     >
       {globalProjectId && projectDetails && studyDetails && scenario ? (
         <div className="scenario-explorator-card-head">
-          {imageUrl && (
+          {displayImgProject && imageUrl && (
             <div className="scenario-explorator-card-head-img">
               <img src={imageUrl} alt="Project logo" />
             </div>
           )}
-          <div className={`scenario-explorator-card-head-content ${imageUrl ? '' : 'no-image'}`}>
+          <div
+            className={cx('scenario-explorator-card-head-content', {
+              'no-image': !imageUrl,
+              'ml-0': !displayImgProject,
+            })}
+          >
             <div className="scenario-explorator-card-head-content-item">
               <img src={projectIcon} alt="project icon" />
               <span className="scenario-explorator-card-head-legend">{t('projectLegend')}</span>

--- a/front/src/modules/scenario/styles/_scenarioExplorer.scss
+++ b/front/src/modules/scenario/styles/_scenarioExplorer.scss
@@ -16,11 +16,12 @@
     font-size: 1.5rem;
   }
   .scenario-explorator-card-head {
+    height: 6.75rem;
     .scenario-explorator-card-head-img {
       position: absolute;
       overflow: hidden;
       border-radius: 4px;
-      height: 6.75rem;
+      height: inherit;
       width: 6rem;
       img {
         display: flex;
@@ -34,18 +35,18 @@
     }
     .scenario-explorator-card-head-content {
       margin-left: 6.5rem;
-      height: 4.5rem;
       font-weight: 500;
+      height: 100%;
       .scenario-explorator-card-head-content-item {
         display: flex;
         align-items: center;
         margin-bottom: 0.25rem;
-        height: 1.5rem;
+        height: 22%;
         img {
           border-radius: 4px 0 0 4px;
           background-color: var(--coolgray3);
           padding: 0.25rem;
-          height: 1.5rem;
+          height: 100%;
         }
         div {
           display: flex;

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
@@ -56,9 +56,10 @@ import ItineraryMarkersV2 from './ManageTrainScheduleMap/ItineraryMarkersV2';
 type MapProps = {
   pathProperties?: ManageTrainSchedulePathProperties;
   setMapCanvas?: (mapCanvas: string) => void;
+  hideAttribution?: boolean;
 };
 
-const Map = ({ pathProperties, setMapCanvas }: MapProps) => {
+const Map = ({ pathProperties, setMapCanvas, hideAttribution = false }: MapProps) => {
   const mapBlankStyle = useMapBlankStyle();
 
   const infraID = useInfraID();
@@ -244,7 +245,9 @@ const Map = ({ pathProperties, setMapCanvas }: MapProps) => {
         id="map-container"
       >
         <VirtualLayers />
-        <AttributionControl position="bottom-right" customAttribution={CUSTOM_ATTRIBUTION} />
+        {!hideAttribution && (
+          <AttributionControl position="bottom-right" customAttribution={CUSTOM_ATTRIBUTION} />
+        )}
         <ScaleControl maxWidth={100} unit="metric" style={scaleControlStyle} />
 
         <Background

--- a/front/src/styles/scss/applications/stdcmV2/_consist.scss
+++ b/front/src/styles/scss/applications/stdcmV2/_consist.scss
@@ -1,6 +1,11 @@
+.stdcm-v2-consist-container {
+  width: 20.125rem;
+}
+
 .stdcm-v2-consist-img {
     overflow: hidden;
       img {
+        transform: scaleX(-1);
         max-width: 100%;
         height: 1.25rem;
       }

--- a/front/src/styles/scss/applications/stdcmV2/_header.scss
+++ b/front/src/styles/scss/applications/stdcmV2/_header.scss
@@ -3,12 +3,12 @@
     background-color: rgba(255, 255, 255, 1);
     height: 120px;
     position: relative;
+    display: flex ;
+    align-items: center;
+    justify-content: space-between;
 
     .stdcm-v2-header__title {
-        position: absolute;
-        left: 56px;
-        top: 50%;
-        transform: translateY(-50%);
+        max-height: 3rem;
         color: rgba(0, 0, 0, 1);
         font-size: 32px;
         font-weight: 600;
@@ -19,10 +19,7 @@
     }
 
     .stdcm-v2-header__notification {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
+        max-height: 3rem;
         border-radius: 2px;
         border: 4px solid rgba(112, 193, 229, 1);
         background-color: rgba(230, 247, 255, 1);
@@ -32,7 +29,6 @@
         font-weight: 600;
         font-style: SemiBold;
         letter-spacing: 0px;
-        text-align: left;
         line-height: 24px;
 
         a {
@@ -43,6 +39,19 @@
             letter-spacing: 0px;
             text-align: left;
             line-height: 24px;
+        }
+    }
+
+    .scenario-explorator-card {
+        height: 7rem;
+        margin-bottom: 0;
+
+        &-noscenario {
+            font-size: 1.2rem;
+        }
+
+        &-head-img, &-head {
+            height: 6rem;
         }
     }
 }

--- a/front/src/styles/scss/applications/stdcmV2/_home.scss
+++ b/front/src/styles/scss/applications/stdcmV2/_home.scss
@@ -2,24 +2,30 @@
     .stdcm-v2__body {
         padding: 32px;
         background-color: rgb(239, 243, 245);
-        display: grid;
-        grid-template-columns: 2fr 1fr;
-        gap: 32px;
+        display: flex;
     
         .stdcm-v2-simulation-settings {
-            display: grid;
-            grid-template-columns: 1fr auto 1.5fr;
-            grid-column-gap: 13px;
+            display: flex;
+            gap: 13px;
             .stdcm-v2__separator {
                 border-radius: 4px;
                 background-color: rgba(0, 0, 0, 0.05);
                 width: 6px;
                 height: 280px;
+                margin: 12px 0;
             }
-            .stdcm-v2-simulation-itinirary {
+            .stdcm-v2-simulation-itinerary {
                 display: flex;
                 flex-direction: column;
                 gap: 32px;
+                width: 450px;
+
+                /*TODO Waiting to fix the button in ui-core...*/
+                .stdcm-v2-launch-request > button {
+                    justify-content: center;
+                    width: 100%;
+                    font-weight: 500;
+                }
             }
         }
 
@@ -27,6 +33,11 @@
             border-radius: 8px;
             border: 1px solid rgba(255, 255, 255, 1);
             box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.75) inset, 0px 0px 0px 1px rgba(0, 0, 0, 0.25) inset;
+            height: auto;
+            min-height: 540px;
+            margin-left: 0.85rem;
+            width: 100%;
+            height: calc(100vh - 64px);
         }
     }
 


### PR DESCRIPTION
![image](https://github.com/OpenRailAssociation/osrd/assets/103027832/215aaf05-cb4d-40fb-b23e-e28687130509)


Small UI changes for the new stdcm interface:
- Add margin on "stdcm-v2__separator" class (between the "consist" and the "origin" sections).
- Hide attributions at the bottom of the map.
- Move the scenario explorer on the top right of the page.
- Center the text on the launch button.
- Hide the project image.

![image](https://github.com/OpenRailAssociation/osrd/assets/103027832/fab29b6b-f821-48fe-a1a5-038f6abf89c4)

