### PR TITLE
front: fix wrong origin via position on path

### DIFF
--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
@@ -224,17 +224,24 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
               allVias: suggestedOperationalPoints,
               length: pathfindingResult.length,
             });
-          }
 
-          const pathSteps: PathStep[] = opList.map((op, i) => ({
-            id: nextId(),
-            uic: op.uic,
-            name: op.name,
-            ch: op.ch,
-            coordinates: op.geographic.coordinates,
-            positionOnPath: pathfindingResult.path_items_positions[i],
-          }));
-          dispatch(updatePathSteps(pathSteps));
+            const pathSteps: PathStep[] = opList.map((op, i) => {
+              // We know we will find one because the operational points returned by pathproperties depend on the op searched
+              const correspondingOp = suggestedOperationalPoints.find(
+                (formattedOP) => formattedOP.uic === op.uic && formattedOP.ch === op.ch
+              ) as SuggestedOP;
+              return {
+                id: nextId(),
+                uic: op.uic,
+                name: op.name,
+                ch: op.ch,
+                kp: correspondingOp.kp,
+                coordinates: correspondingOp.coordinates,
+                positionOnPath: pathfindingResult.path_items_positions[i],
+              };
+            });
+            dispatch(updatePathSteps(pathSteps));
+          }
         }
         // TODO TS2 : test errors display after core / editoast connexion for pathProperties
       } catch (e) {


### PR DESCRIPTION
close #7618 

This PR : 
- fix the related bugs
- add kp property to the store's pathsteps to have one property allowing to distinguish them when they have same uic and ch codes. This enables the vias added by clicking on map to be properly displayed as vias on the modal suggested vias.