### PR TITLE
core: stdcm: avoid a NaN in allowance ratio

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -15,6 +15,8 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.PriorityQueue
 import kotlin.math.max
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * This file implements the A* heuristic used by STDCM.
@@ -29,6 +31,7 @@ import kotlin.math.max
  * It could eventually be improved further by using lookahead or route data, but this adds a fair
  * amount of complexity to the implementation.
  */
+val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
 
 /** Describes a pending block, ready to be added to the cached blocks. */
 private data class PendingBlock(
@@ -51,6 +54,7 @@ fun makeSTDCMHeuristics(
     rollingStock: PhysicsRollingStock,
     maxDepartureDelay: Double,
 ): List<AStarHeuristic<STDCMEdge, STDCMEdge>> {
+    logger.info("Start building STDCM heuristic...")
     // One map per number of reached pathfinding step
     val maps = mutableListOf<MutableMap<BlockId, Double>>()
     for (i in 0 until steps.size - 1) maps.add(mutableMapOf())
@@ -93,6 +97,10 @@ fun makeSTDCMHeuristics(
             return@add Double.POSITIVE_INFINITY
         }
     }
+    val bestTravelTime =
+        steps.first().locations.minOfOrNull { maps.first()[it.edge] ?: Double.POSITIVE_INFINITY }
+            ?: Double.POSITIVE_INFINITY
+    logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
     return res
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import java.lang.Double.isNaN
 import java.util.*
 
 data class STDCMEdge(
@@ -46,6 +47,10 @@ data class STDCMEdge(
     var weight: Double? = null // Weight (total distance from start + estimation to end) of the edge
 ) : Comparable<STDCMEdge> {
     val block = infraExplorer.getCurrentBlock()
+
+    init {
+        assert(!isNaN(timeStart)) { "STDCM edge starts at NaN time" }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other.javaClass != STDCMEdge::class.java) return false

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -69,11 +69,13 @@ class STDCMGraph(
      * allowance.
      */
     fun getStandardAllowanceSpeedRatio(envelope: Envelope): Double {
-        if (standardAllowance == null) return 1.0
+        if (standardAllowance == null || envelope.endPos == 0.0) return 1.0
         val runTime = envelope.totalTime
         val distance = envelope.totalDistance
         val allowanceRatio = standardAllowance.getAllowanceRatio(runTime, distance)
-        return 1 / (1 + allowanceRatio)
+        val res = 1 / (1 + allowanceRatio)
+        assert(!isNaN(res) && isFinite(res))
+        return res
     }
 
     override fun getEdgeEnd(edge: STDCMEdge): STDCMNode {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -11,6 +11,10 @@ import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.utils.units.meters
+import java.lang.Double.isFinite
+import java.lang.Double.isNaN
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding
@@ -41,6 +45,7 @@ class STDCMGraph(
     val backtrackingManager: BacktrackingManager
     val tag: String?
     val standardAllowance: AllowanceValue?
+    val logger: Logger = LoggerFactory.getLogger("STDCM")
 
     // min 4 minutes between two edges, determined empirically
     private val visitedNodes = VisitedNodes(4 * 60.0)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -120,7 +120,12 @@ class STDCMPathfinding(
                 stops,
                 listOf(constraints)
             )
-        val path = findPathImpl() ?: return null
+        val path = findPathImpl()
+        if (path == null) {
+            graph.logger.info("Failed to find a path")
+            return null
+        }
+        graph.logger.info("Path found")
 
         return STDCMPostProcessing(graph)
             .makeResult(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -120,6 +120,7 @@ fun simulateBlock(
         MaxEffortEnvelope.from(context, initialSpeed, maxSpeedEnvelope)
     } catch (e: OSRDError) {
         // The train can't reach its destination, for example because of high slopes
+        logger.info("STDCM Simulation failed (ignoring this possible path): ${e.message}")
         null
     }
 }


### PR DESCRIPTION
Fix a bug where we would fail to find a path for no apparent reason.

Add a few NaN checking assert, as well as some basic logging (in a separate commit)