### PR TITLE
editoast: refactor infra tests part 5

### DIFF
--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -130,12 +130,12 @@ mod tests {
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
 
-        let req = TestRequest::post()
+        let request = TestRequest::post()
             .uri(format!("/infra/{}/objects/TrackSection", empty_infra.id).as_str())
             .set_json(["invalid_id"])
             .to_request();
-        let response = call_service(&app.service, req).await;
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 
     #[rstest]

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -263,7 +263,6 @@ async fn get_routes_nodes(
 mod tests {
     use actix_http::StatusCode;
     use actix_web::test::call_service;
-    use actix_web::test::read_body_json;
     use actix_web::test::TestRequest;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -463,9 +462,9 @@ mod tests {
         let request = TestRequest::get()
             .uri(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/bs_stop").as_str())
             .to_request();
-        let response = call_service(&app.service, request).await;
-        assert_eq!(response.status(), StatusCode::OK);
-        let routes: RoutesResponse = read_body_json(response).await;
+
+        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+
         assert_eq!(
             routes,
             RoutesResponse {
@@ -479,9 +478,9 @@ mod tests {
         let request = TestRequest::get()
             .uri(format!("/infra/{empty_infra_id}/routes/{waypoint_type}/detector_001").as_str())
             .to_request();
-        let response = call_service(&app.service, request).await;
-        assert_eq!(response.status(), StatusCode::OK);
-        let routes: RoutesResponse = read_body_json(response).await;
+
+        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+
         assert_eq!(
             routes,
             RoutesResponse {
@@ -507,9 +506,9 @@ mod tests {
                 .as_str(),
             )
             .to_request();
-        let response = call_service(&app.service, request).await;
-        assert_eq!(response.status(), StatusCode::OK);
-        let routes: RoutesResponse = read_body_json(response).await;
+
+        let routes: RoutesResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
+
         assert_eq!(
             routes,
             RoutesResponse {


### PR DESCRIPTION
Part of #6980

`create_mini_infra` is a temporary infra, and will be replaced by `small_infra `once `Infra::persist` is refactored.