### PR TITLE
Add field `scheduled_points_honored` to the simulatio…

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/EnvelopeStopWrapper.java
@@ -28,6 +28,7 @@ public class EnvelopeStopWrapper implements EnvelopeInterpolate {
         return stopTime + envelope.interpolateTotalTime(position);
     }
 
+    /** Interpolate time in microseconds */
     public long interpolateTotalTimeUS(double position) {
         return (long) (this.interpolateTotalTime(position) * 1_000_000);
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
@@ -44,17 +44,19 @@ class CompleteReportTrain(
     times: List<TimeDelta>, // Times are compared to the departure time
     speeds: List<Double>,
     @Json(name = "energy_consumption") energyConsumption: Double,
+    @Json(name = "scheduled_points_honored") scheduledPointsHonored: Boolean,
     @Json(name = "signal_sightings") val signalSightings: List<SignalSighting>,
     @Json(name = "zone_updates") val zoneUpdates: List<ZoneUpdate>,
     @Json(name = "spacing_requirements") val spacingRequirements: List<SpacingRequirement>,
     @Json(name = "routing_requirements") val routingRequirements: List<RoutingRequirement>
-) : ReportTrain(positions, times, speeds, energyConsumption)
+) : ReportTrain(positions, times, speeds, energyConsumption, scheduledPointsHonored)
 
 open class ReportTrain(
     val positions: List<Offset<TravelledPath>>,
     val times: List<TimeDelta>, // Times are compared to the departure time
     val speeds: List<Double>,
     @Json(name = "energy_consumption") val energyConsumption: Double,
+    @Json(name = "scheduled_points_honored") val scheduledPointsHonored: Boolean,
 )
 
 class SimulationFailed(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -136,7 +136,8 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
                 reportTrain.positions,
                 reportTrain.times,
                 reportTrain.speeds,
-                reportTrain.energyConsumption
+                reportTrain.energyConsumption,
+                reportTrain.scheduledPointsHonored
             )
         val speedLimits = MRSP.computeMRSP(path.trainPath, rollingStock, false, speedLimitTag)
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5751,15 +5751,23 @@ components:
     ReportTrainV2:
       properties:
         energy_consumption:
+          description: Total energy consumption
           format: double
           type: number
         positions:
+          description: |-
+            List of positions of a train
+            Both positions (in mm) and times (in ms) must have the same length
           items:
             format: int64
             minimum: 0
             type: integer
           type: array
+        scheduled_points_honored:
+          description: Whether the train has reached all its scheduled points on time
+          type: boolean
         speeds:
+          description: List of speeds associated to a position
           items:
             format: double
             type: number
@@ -5775,6 +5783,7 @@ components:
       - times
       - speeds
       - energy_consumption
+      - scheduled_points_honored
       type: object
     ResultPosition:
       properties:
@@ -7524,6 +7533,9 @@ components:
             format: int64
             minimum: 0
             type: integer
+          scheduled_points_honored:
+            description: Whether the train has reached all its scheduled points on time
+            type: boolean
           status:
             enum:
             - success
@@ -7537,6 +7549,7 @@ components:
         - length
         - time
         - energy_consumption
+        - scheduled_points_honored
         - status
         type: object
       - properties:

--- a/editoast/src/core/v2/simulation.rs
+++ b/editoast/src/core/v2/simulation.rs
@@ -140,13 +140,16 @@ pub struct SimulationPath {
 #[derive(Deserialize, Serialize, Clone, Debug, ToSchema)]
 #[schema(as = ReportTrainV2)]
 pub struct ReportTrain {
-    // List of positions of a train
-    // Both positions (in mm) and times (in ms) must have the same length
+    /// List of positions of a train
+    /// Both positions (in mm) and times (in ms) must have the same length
     pub positions: Vec<u64>,
     pub times: Vec<u64>,
-    // List of speeds associated to a position
+    /// List of speeds associated to a position
     pub speeds: Vec<f64>,
+    /// Total energy consumption
     pub energy_consumption: f64,
+    /// Whether the train has reached all its scheduled points on time
+    pub scheduled_points_honored: bool,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, ToSchema)]

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -505,6 +505,8 @@ enum SimulationSummaryResult {
         time: u64,
         /// Total energy consumption of a train in kWh
         energy_consumption: f64,
+        /// Whether the train has reached all its scheduled points on time
+        scheduled_points_honored: bool,
     },
     /// Pathfinding not found
     PathfindingNotFound,
@@ -574,6 +576,7 @@ pub async fn simulation_summary(
                     length: *report.positions.last().unwrap(),
                     time: *report.times.last().unwrap(),
                     energy_consumption: report.energy_consumption,
+                    scheduled_points_honored: report.scheduled_points_honored,
                 }
             }
             SimulationResponse::PathfindingFailed { pathfinding_result } => {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -3465,8 +3465,14 @@ export type ConflictV2 = {
   train_ids: number[];
 };
 export type ReportTrainV2 = {
+  /** Total energy consumption */
   energy_consumption: number;
+  /** List of positions of a train
+    Both positions (in mm) and times (in ms) must have the same length */
   positions: number[];
+  /** Whether the train has reached all its scheduled points on time */
+  scheduled_points_honored: boolean;
+  /** List of speeds associated to a position */
   speeds: number[];
   times: number[];
 };
@@ -3646,6 +3652,8 @@ export type SimulationSummaryResult =
       energy_consumption: number;
       /** Length of a path in mm */
       length: number;
+      /** Whether the train has reached all its scheduled points on time */
+      scheduled_points_honored: boolean;
       status: 'success';
       /** Travel time in ms */
       time: number;


### PR DESCRIPTION
Used to detect train schedules that have one or more scheduled points that could not be fulfilled by the simulation.