### PR TITLE
front: fix default side value for signals in editor

### DIFF
--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -110,7 +110,7 @@ function getSumUpContent(
   classesOverride: Partial<typeof DEFAULT_CLASSES> | undefined,
   status: string | undefined
 ): JSX.Element {
-  let type = t(`Editor.obj-types.${entity.objType}`);
+  const type = t(`Editor.obj-types.${entity.objType}`);
   let text = '';
   const subtexts: (string | JSX.Element)[] = [];
   const classes = { ...DEFAULT_CLASSES, ...(classesOverride || {}) };
@@ -133,18 +133,10 @@ function getSumUpContent(
       }
       break;
     }
-    // @ts-expect-error: Here we only deal with the installation_type, the rest is handled with BufferStop and Detector.
-    case 'Signal': {
-      const signal = entity as SignalEntity;
-      if (signal.properties.extensions.sncf.installation_type) {
-        type += ` - ${signal.properties.extensions.sncf.installation_type}`;
-      }
-    }
-    // eslint-disable-next-line no-fallthrough
+    case 'Signal':
     case 'BufferStop':
     case 'Detector': {
-      // This cast is OK since both buffer stops and detectors have same
-      // properties:
+      // This cast is OK since signals, buffer stops and detectors have same properties
       const typedEntity = entity as BufferStopEntity;
       const track = typedEntity.properties.track
         ? additionalEntities[typedEntity.properties.track]

--- a/front/src/applications/editor/tools/pointEdition/types.ts
+++ b/front/src/applications/editor/tools/pointEdition/types.ts
@@ -50,10 +50,9 @@ export type SignalEntity = EditorEntity<
     logical_signals?: SignalingSystem[];
     extensions: {
       sncf: {
-        is_in_service?: boolean;
-        is_lightable?: boolean;
-        is_operational?: boolean;
-        installation_type?: string;
+        kp?: string;
+        label?: string;
+        side?: string;
       };
     };
   }

--- a/front/src/applications/editor/tools/pointEdition/utils.ts
+++ b/front/src/applications/editor/tools/pointEdition/utils.ts
@@ -18,7 +18,9 @@ export function getNewSignal(point?: [number, number]): SignalEntity {
     properties: {
       id: NEW_ENTITY_ID,
       extensions: {
-        sncf: {},
+        sncf: {
+          side: 'CENTER',
+        },
       },
     },
     geometry: point


### PR DESCRIPTION
The editor forms are automatically generated by rjsf from the infra JSON Schema. The schema is automatically generated from Python classes by pydantic. The schema contains some unnecessary "allOf" fields (which could just be inlined), and [rjsf chokes on them][1] when handling default values. Unfortunately the "allOf" fields cannot easily be simplified (because of the auto-generation), and rjsf cannot easily be fixed (the logic to handle defaults is quite involved).

As a workaround, manually specify the default for extensions.sncf.side so that the form data always includes this field.

Closes: https://github.com/OpenRailAssociation/osrd/issues/7445

[1]: https://github.com/rjsf-team/react-jsonschema-form/issues/3599

* * *

Let me know if you'd prefer a fix in rjsf instead (would take a tad more time, maybe a few days).