### PR TITLE
editoast: use default value for missing SignalSncfExtension::side

### DIFF
--- a/editoast/editoast_schemas/src/infra/signal.rs
+++ b/editoast/editoast_schemas/src/infra/signal.rs
@@ -70,6 +70,7 @@ pub struct SignalExtensions {
 #[serde(deny_unknown_fields)]
 pub struct SignalSncfExtension {
     pub label: String,
+    #[serde(default)]
     pub side: Side,
     pub kp: String,
 }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7558,7 +7558,6 @@ components:
                     $ref: '#/components/schemas/Side'
                 required:
                 - label
-                - side
                 - kp
                 type: object
               nullable: true

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -2051,7 +2051,7 @@ export type Signal = {
     sncf?: {
       kp: string;
       label: string;
-      side: Side;
+      side?: Side;
     } | null;
   };
   id: string;


### PR DESCRIPTION
The JSON Schema has this field marked as optional. Instead of rejecting requests which don't include the field, fill the field with the default value.

This still isn't enough to fix the original bug, because the form doesn't reflect the correct default (shows "LEFT" instead of "CENTER" initially, even if the field is undefined). But I believe it's still worth fixing editoast.

References: https://github.com/OpenRailAssociation/osrd/issues/7445