### PR TITLE
editoast: stdcm: make max_run_time optional, computed if missing

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -244,6 +244,7 @@ fun makeSimpleReportTrain(
             return@rdp abs(point.speed - projSpeed) * speedScaling +
                 abs(point.time - projTime) * timeScaling
         }
+    assert(simplified.isNotEmpty()) { "simulation result shouldn't be empty" }
 
     val scheduledPointsHonored = isScheduledPointsHonored(schedule, envelopeStopWrapper)
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6881,10 +6881,10 @@ components:
           minimum: 0
           type: integer
         maximum_run_time:
-          default: 2592000
           description: Specifies how long the total run time can be in milliseconds
           format: int64
           minimum: 0
+          nullable: true
           type: integer
         rolling_stock_id:
           format: int64
@@ -12438,10 +12438,10 @@ paths:
                   minimum: 0
                   type: integer
                 maximum_run_time:
-                  default: 2592000
                   description: Specifies how long the total run time can be in milliseconds
                   format: int64
                   minimum: 0
+                  nullable: true
                   type: integer
                 rolling_stock_id:
                   format: int64
@@ -12512,6 +12512,17 @@ paths:
                       - path_not_found
                       type: string
                   required:
+                  - status
+                  type: object
+                - properties:
+                    error:
+                      $ref: '#/components/schemas/SimulationResponse'
+                    status:
+                      enum:
+                      - preprocessing_simulation_error
+                      type: string
+                  required:
+                  - error
                   - status
                   type: object
           description: The simulation result

--- a/editoast/src/core/v2/stdcm.rs
+++ b/editoast/src/core/v2/stdcm.rs
@@ -109,6 +109,9 @@ pub enum STDCMResponse {
         departure_time: DateTime<Utc>,
     },
     PathNotFound,
+    PreprocessingSimulationError {
+        error: SimulationResponse,
+    },
 }
 
 impl AsCoreRequest<Json<STDCMResponse>> for STDCMRequest {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1739,6 +1739,10 @@ export type PostV2TimetableByIdStdcmApiResponse =
     }
   | {
       status: 'path_not_found';
+    }
+  | {
+      error: SimulationResponse;
+      status: 'preprocessing_simulation_error';
     };
 export type PostV2TimetableByIdStdcmApiArg = {
   /** The infra id */
@@ -1752,7 +1756,7 @@ export type PostV2TimetableByIdStdcmApiArg = {
     /** By how long we can shift the departure time in milliseconds */
     maximum_departure_delay?: number;
     /** Specifies how long the total run time can be in milliseconds */
-    maximum_run_time?: number;
+    maximum_run_time?: number | null;
     rolling_stock_id: number;
     /** Train categories for speed limits */
     speed_limit_tags?: string | null;


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/7695

For more context: the reason we want to do this in editoast and not in core is because it will let us pre-filter resource uses, the ones in the actual stdcm request from editoast to core

API change summary:

* max_run_time is optional
* editoast stdcm endpoint may return simulation or pathfinding errors, if the preprocessing failed