### PR TITLE
readme: import all rolling stocks from test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To compile and run the application with an example infrastructure:
 docker compose up -d --build
 
 ./scripts/load-railjson-infra.sh small_infra tests/data/infras/small_infra/infra.json
-./scripts/load-railjson-rolling-stock.sh tests/data/rolling_stocks/fast_rolling_stock.json
+./scripts/load-railjson-rolling-stock.sh tests/data/rolling_stocks/*.json
 
 # open the web app
 xdg-open http://localhost:4000/

--- a/scripts/load-railjson-rolling-stock.sh
+++ b/scripts/load-railjson-rolling-stock.sh
@@ -8,8 +8,13 @@
 
 set -e
 
-rolling_stock_path="${1:?missing path to RailJSON rolling stock}"
+if [ "$#" = 0 ]; then
+	echo "Missing path to RailJSON rolling stock"
+	exit 1
+fi
 
-echo "Loading example rolling stock"
-docker cp "${rolling_stock_path}" osrd-editoast:tmp/stock.json
-docker exec osrd-editoast editoast import-rolling-stock //tmp/stock.json
+echo "Loading $# example rolling stock(s)"
+for rolling_stock_path in "$@"; do
+	docker cp "${rolling_stock_path}" osrd-editoast:tmp/stock.json
+	docker exec osrd-editoast editoast import-rolling-stock //tmp/stock.json
+done


### PR DESCRIPTION
By default, only a single rolling stock is imported. It's nice to
also import other rolling stocks (e.g. an electric one) to have
more options to play with.