### PR TITLE
Compute mareco constant speed parts correctly

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/MarecoAllowance.java
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.envelope_sim.allowances;
 
+import static fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope.addAccelerationAndConstantSpeedParts;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.*;
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext;
@@ -74,8 +76,11 @@ public final class MarecoAllowance extends AbstractAllowanceWithRanges {
     protected Envelope computeCore(Envelope coreBase, EnvelopeSimContext context, double v1) {
         double vf = computeVf(v1, context.rollingStock);
 
-        // 1) cap the core base envelope at v1
+        // 1) cap the core base envelope at v1 and check if v1 is physically reachable
         var cappedEnvelope = EnvelopeSpeedCap.from(coreBase, List.of(new MarecoSpeedLimit()), v1);
+        var initialPosition = cappedEnvelope.getBeginPos();
+        var initialSpeed = cappedEnvelope.getBeginSpeed();
+        cappedEnvelope = addAccelerationAndConstantSpeedParts(context, cappedEnvelope, initialPosition, initialSpeed);
 
         // 2) find accelerating slopes on constant speed limit regions
         var coastingOpportunities = new ArrayList<CoastingOpportunity>();

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/pipelines/MaxEffortEnvelope.java
@@ -34,12 +34,13 @@ public class MaxEffortEnvelope {
      * maintain its speed
      */
     public static Envelope addAccelerationAndConstantSpeedParts(
-            EnvelopeSimContext context, Envelope maxSpeedProfile, double initialSpeed) {
+            EnvelopeSimContext context, Envelope maxSpeedProfile, double initialPosition, double initialSpeed) {
         var builder = OverlayEnvelopeBuilder.forward(maxSpeedProfile);
         var cursor = EnvelopeCursor.forward(maxSpeedProfile);
-        var maxSpeed = maxSpeedProfile.interpolateSpeedRightDir(0, 1);
-        if (initialSpeed < maxSpeed) accelerate(context, maxSpeedProfile, initialSpeed, 0, builder, cursor);
-
+        var maxSpeed = maxSpeedProfile.interpolateSpeedRightDir(initialPosition, 1);
+        if (initialSpeed < maxSpeed) {
+            accelerate(context, maxSpeedProfile, initialSpeed, initialPosition, builder, cursor);
+        }
         while (!cursor.hasReachedEnd()) {
             if (cursor.checkPart(MaxEffortEnvelope::maxEffortPlateau)) {
                 var partBuilder = new EnvelopePartBuilder();
@@ -126,7 +127,7 @@ public class MaxEffortEnvelope {
 
     /** Generate a max effort envelope given a max speed envelope */
     public static Envelope from(EnvelopeSimContext context, double initialSpeed, Envelope maxSpeedProfile) {
-        var maxEffortEnvelope = addAccelerationAndConstantSpeedParts(context, maxSpeedProfile, initialSpeed);
+        var maxEffortEnvelope = addAccelerationAndConstantSpeedParts(context, maxSpeedProfile, 0, initialSpeed);
         assert maxEffortEnvelope.continuous : "Discontinuity in max effort envelope";
         assert maxEffortEnvelope.getBeginPos() == 0;
         return maxEffortEnvelope;


### PR DESCRIPTION
Constant speed parts in MARECO were not physically accurate because we were not making a proper computation, just a mathematical cap at v1.
I called the method `addAccelerationAndConstantSpeedParts()` in order to check that v1 is physically reachable.

Closes #7702 