### PR TITLE
front: fix times and stops table

### DIFF
--- a/front/src/applications/operationalStudies/hooks.ts
+++ b/front/src/applications/operationalStudies/hooks.ts
@@ -113,13 +113,13 @@ export const useSetupItineraryForTrainUpdate = (
                 pathfindingResult.length
               );
 
-              const allVias = upsertViasInOPs(suggestedOperationalPoints, formatedPathSteps);
+              const allWaypoints = upsertViasInOPs(suggestedOperationalPoints, formatedPathSteps);
 
               setPathProperties({
                 electrifications,
                 geometry,
                 suggestedOperationalPoints,
-                allVias,
+                allWaypoints,
                 length: pathfindingResult.length,
               });
 

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -86,8 +86,8 @@ export type ManageTrainSchedulePathProperties = {
   electrifications: NonNullable<PathProperties['electrifications']>;
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
-  /** Operational points along the path and vias added by clicking on map */
-  allVias: SuggestedOP[];
+  /** Operational points along the path (including origin and destination) and vias added by clicking on map */
+  allWaypoints: SuggestedOP[];
   length: number;
 };
 

--- a/front/src/applications/operationalStudies/views/v2/ManageTrainScheduleV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ManageTrainScheduleV2.tsx
@@ -25,12 +25,13 @@ import { formatKmValue } from 'utils/strings';
 
 const ManageTrainScheduleV2 = () => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const { getOriginV2, getDestinationV2, getPathSteps, getConstraintDistribution } =
+  const { getOriginV2, getDestinationV2, getPathSteps, getConstraintDistribution, getStartTime } =
     useOsrdConfSelectors();
   const origin = useSelector(getOriginV2);
   const destination = useSelector(getDestinationV2);
   const pathSteps = useSelector(getPathSteps);
   const constraintDistribution = useSelector(getConstraintDistribution);
+  const startTime = useSelector(getStartTime);
 
   const [pathProperties, setPathProperties] = useState<ManageTrainSchedulePathProperties>();
 
@@ -42,13 +43,13 @@ const ManageTrainScheduleV2 = () => {
 
   useEffect(() => {
     if (pathProperties) {
-      const allVias = upsertViasInOPs(
+      const allWaypoints = upsertViasInOPs(
         pathProperties.suggestedOperationalPoints,
         compact(pathSteps)
       );
       setPathProperties({
         ...pathProperties,
-        allVias,
+        allWaypoints,
       });
     }
   }, [pathSteps]);
@@ -123,7 +124,14 @@ const ManageTrainScheduleV2 = () => {
       </div>
     ),
     label: t('tabs.timesStops'),
-    content: <TimesStops pathProperties={pathProperties} pathSteps={pathSteps} />,
+    // If pathProperties is defined we know that pathSteps won't have any null values
+    content: (
+      <TimesStops
+        pathProperties={pathProperties}
+        pathSteps={compact(pathSteps)}
+        startTime={startTime}
+      />
+    ),
   };
 
   const tabSimulationSettings = {

--- a/front/src/applications/stdcm/views/StdcmViewV1.tsx
+++ b/front/src/applications/stdcm/views/StdcmViewV1.tsx
@@ -72,7 +72,7 @@ const StdcmViewV1 = () => {
           electrifications,
           geometry,
           suggestedOperationalPoints: updatedSuggestedOPs,
-          allVias: updatedSuggestedOPs,
+          allWaypoints: updatedSuggestedOPs,
           length: path.length,
         });
       }

--- a/front/src/modules/pathfinding/components/Itinerary/ItineraryV2.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/ItineraryV2.tsx
@@ -112,7 +112,7 @@ const ItineraryV2 = ({
               className="col my-1 text-white btn bg-info btn-sm"
               type="button"
               onClick={() =>
-                openModal(<ModalSuggestedVias suggestedVias={pathProperties.allVias} />)
+                openModal(<ModalSuggestedVias suggestedVias={pathProperties.allWaypoints} />)
               }
             >
               <span className="mr-1">{t('addVias')}</span>

--- a/front/src/modules/pathfinding/components/Pathfinding/PathfindingV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/PathfindingV2.tsx
@@ -323,13 +323,13 @@ const Pathfinding = ({ pathProperties, setPathProperties }: PathfindingProps) =>
               });
               dispatch(updatePathSteps(updatedPathSteps));
 
-              const allVias = upsertViasInOPs(suggestedOperationalPoints, updatedPathSteps);
+              const allWaypoints = upsertViasInOPs(suggestedOperationalPoints, updatedPathSteps);
 
               setPathProperties({
                 electrifications,
                 geometry,
                 suggestedOperationalPoints,
-                allVias,
+                allWaypoints,
                 length: pathfindingResult.length,
               });
 

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
@@ -220,7 +220,7 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
               electrifications,
               geometry,
               suggestedOperationalPoints,
-              allVias: suggestedOperationalPoints,
+              allWaypoints: suggestedOperationalPoints,
               length: pathfindingResult.length,
             });
 

--- a/front/src/modules/timesStops/TimeColumnComponent.tsx
+++ b/front/src/modules/timesStops/TimeColumnComponent.tsx
@@ -19,6 +19,13 @@ const TimeComponent = ({
     }
   }, [active]);
 
+  // Allow us to update the field when the change comes from outside of the input
+  // In this use case, we use it when the user updates the start time to update
+  // the arrival time for the origin which should match the departure time
+  useEffect(() => {
+    setTempTimeValue(rowData);
+  }, [rowData]);
+
   return (
     <input
       className="dsg-input"

--- a/front/src/modules/timesStops/consts.ts
+++ b/front/src/modules/timesStops/consts.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const marginRegExValidation = /^\d+(\.\d+)?%$|^\d+(\.\d+)?min\/100km$/;

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,0 +1,5 @@
+import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
+
+export type PathWaypointColumn = SuggestedOP & {
+  isMarginValid: boolean;
+};

--- a/front/src/modules/timesStops/utils.ts
+++ b/front/src/modules/timesStops/utils.ts
@@ -1,0 +1,35 @@
+import type { TFunction } from 'i18next';
+
+import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
+import type { PathStep } from 'reducers/osrdconf/types';
+
+import { marginRegExValidation } from './consts';
+import type { PathWaypointColumn } from './types';
+
+// eslint-disable-next-line import/prefer-default-export
+export const formatSuggestedViasToRowVias = (
+  operationalPoints: SuggestedOP[],
+  pathSteps: PathStep[],
+  t: TFunction<'timesStops', undefined>,
+  startTime?: string
+): PathWaypointColumn[] => {
+  let formattedOps = [...operationalPoints];
+  const origin = pathSteps[0] as PathStep;
+  if ('uic' in origin && 'ch' in origin) {
+    const originIndexInOps = operationalPoints.findIndex(
+      (op) => op.uic === origin.uic && op.ch === origin.ch && op.name === origin.name
+    );
+    // If the origin is in the ops and isn't the first operational point, we need to move it to the first position
+    if (originIndexInOps !== (-1 || 0)) {
+      formattedOps = formattedOps.toSpliced(originIndexInOps, 1);
+      formattedOps.unshift(operationalPoints[originIndexInOps]);
+    }
+  }
+  return formattedOps.map((op, i) => ({
+    ...op,
+    name: op.name || t('waypoint', { id: op.opId }),
+    isMarginValid: op.theoreticalMargin ? marginRegExValidation.test(op.theoreticalMargin) : true,
+    onStopSignal: op.onStopSignal || false,
+    arrival: i === 0 ? startTime?.substring(11, 19) : op.arrival,
+  }));
+};

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
@@ -223,7 +223,7 @@ export default function commonConfBuilder() {
         ],
       },
       suggestedOperationalPoints: [],
-      allVias: [],
+      allWaypoints: [],
       length: 1169926000,
     }),
   };

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
@@ -797,7 +797,7 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
       expect(state.pathSteps).toEqual([brest, rennes, insertedVia, paris, strasbourg]);
     });
 
-    it('should update an existing via if it comes from the "times and step" table and has been added by slecting it on the map', () => {
+    it('should update an existing via if it comes from the "times and step" table and has been added by selecting it on the map', () => {
       const pathSteps = [brest, rennes, lemans, paris, strasbourg];
       const store = createStore(slice, {
         pathSteps,
@@ -813,7 +813,7 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
       };
 
       const updatedVia: PathStep = {
-        id: 'id2', // nextId() second increments after the one l.764
+        id: 'lemans',
         positionOnPath: 200,
         track: '60ca8dda-6667-11e3-81ff-01f464e0362d',
         offset: 426.443,


### PR DESCRIPTION
close #7598 
close #7586 
deal with one issue in #7585 
deal with issues/enhancements listed in a comment in #7586.

What the PR changes/fix : 
- fix 7598. The issue came from the fact that, with some paths, there could be multiple operational points at position 0. As we used the position on path to find which op to update when changing something in the table, it could result to this issue.
- fix 7586. The issue came from the same thing as above and also the fact that the code wasn't built to update origin or destination in the time and stops table.
- origin is always the first op in the list even if there is multiple ops with position 0
- the arrival time field for the origin is synced with the departure time of the train and can't be updated in the table
- all origin's fields are updatable (except arrival time)
- all destination's fields are updatable except margins
- origin and destination don't have the "remove via" button anymore at the end of the row
- when we change a constraint from an operational point, its id doesn't change anymore