### PR TITLE
editoast: speed up infra deletion

### DIFF
--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -822,7 +822,11 @@ pub mod tests {
 
     #[rstest]
     async fn infra_delete() {
-        let app = TestAppBuilder::default_app();
+        let pool = DbConnectionPoolV2::for_tests_no_transaction();
+        let app = TestAppBuilder::new()
+            .db_pool(pool)
+            .core_client(CoreClient::default())
+            .build();
         let db_pool = app.db_pool();
         let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -408,7 +408,7 @@ async fn delete(
     infra_caches: Data<CHashMap<i64, InfraCache>>,
 ) -> Result<HttpResponse> {
     let infra_id = infra.infra_id;
-    if Infra::delete_static(db_pool.get().await?.deref_mut(), infra_id).await? {
+    if Infra::fast_delete_static(db_pool.get().await?.deref_mut(), infra_id).await? {
         infra_caches.remove(&infra_id);
         Ok(HttpResponse::NoContent().finish())
     } else {


### PR DESCRIPTION
## What is done

Add a special sql query to delete an infra.
We disable some trigers to avoid unnecessary computation.

> [!IMPORTANT]
> **Benchmark**
> - Before: ~20min
> - After: 3s

close #7499
close #6064

> [!NOTE]
> This PR is inspired by @younesschrifi one: https://github.com/OpenRailAssociation/osrd/pull/6138

## Further improvement

Performance can still be improved. Here is an analysis of the postgres deletion request:

```
 Delete on infra  (cost=0.00..1.06 rows=0 width=0) (actual time=0.429..0.429 rows=0 loops=1)
   Buffers: shared hit=51 read=5 dirtied=1
   ->  Seq Scan on infra  (cost=0.00..1.06 rows=1 width=6) (actual time=0.017..0.017 rows=1 loops=1)
         Filter: (id = 17)
         Rows Removed by Filter: 5
         Buffers: shared read=1
 Planning:
   Buffers: shared hit=18 read=1
 Planning Time: 0.156 ms
 Trigger for constraint infra_layer_buffer_stop_infra_id_fkey on infra: time=2.643 calls=1
 Trigger for constraint infra_layer_catenary_infra_id_fkey on infra: time=67.370 calls=1
 Trigger for constraint infra_layer_detector_infra_id_fkey on infra: time=37.975 calls=1
 Trigger for constraint infra_layer_error_infra_id_fkey on infra: time=441.329 calls=1
 Trigger for constraint infra_layer_lpv_panel_infra_id_fkey on infra: time=5.204 calls=1
 Trigger for constraint infra_layer_neutral_section_infra_id_fkey on infra: time=0.829 calls=1
 Trigger for constraint infra_layer_neutral_sign_infra_id_fkey on infra: time=2.111 calls=1
 Trigger for constraint infra_layer_operational_point_infra_id_fkey on infra: time=20.585 calls=1
 Trigger for constraint infra_layer_signal_infra_id_fkey on infra: time=42.884 calls=1
 Trigger for constraint infra_layer_speed_section_infra_id_fkey on infra: time=1248.030 calls=1
 Trigger for constraint infra_layer_switch_infra_id_fkey on infra: time=21.089 calls=1
 Trigger for constraint infra_layer_track_section_infra_id_fkey on infra: time=98.207 calls=1
 Trigger for constraint infra_object_buffer_stop_infra_id_fkey on infra: time=3.624 calls=1
 Trigger for constraint infra_object_catenary_infra_id_fkey on infra: time=5.830 calls=1
 Trigger for constraint infra_object_detector_infra_id_fkey on infra: time=66.833 calls=1
 Trigger for constraint infra_object_neutral_section_infra_id_fkey on infra: time=3.684 calls=1
 Trigger for constraint infra_object_operational_point_infra_id_fkey on infra: time=26.726 calls=1
 Trigger for constraint infra_object_route_infra_id_fkey on infra: time=105.788 calls=1
 Trigger for constraint infra_object_signal_infra_id_fkey on infra: time=83.908 calls=1
 Trigger for constraint infra_object_speed_section_infra_id_fkey on infra: time=177.233 calls=1
 Trigger for constraint infra_object_switch_infra_id_fkey on infra: time=41.302 calls=1
 Trigger for constraint infra_object_switch_type_infra_id_fkey on infra: time=0.541 calls=1
 Trigger for constraint infra_object_track_section_infra_id_fkey on infra: time=67.852 calls=1
 Trigger for constraint pathfinding_fkey on infra: time=0.721 calls=1
 Trigger for constraint scenario_infra_id_fkey on infra: time=0.827 calls=1
 Trigger for constraint scenario_v2_infra_id_fkey on infra: time=0.560 calls=1
 Trigger for constraint search_operational_point_id_fkey on infra_object_operational_point: time=171.220 calls=8945
 Trigger for constraint search_signal_id_fkey on infra_object_signal: time=540.928 calls=31880
 Execution Time: 3288.413 ms
```

Note how the trigger `search_signal_id_fkey` takes 500ms. We could add a foreign key constraint on `infra_id` to the `search_signal` table.