### PR TITLE
core: handle TODO introduced while refactoring infra load

### DIFF
--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -468,12 +468,6 @@ fun parseNeutralRanges(
                 }
 
                 chunkDirNeutralSections.put(dirChunkLower, dirChunkUpper, incomingNeutralSection)
-
-                // TODO: remove this priority given to announcement.
-                // Only added to match the former import process, but no functional need exists
-                if (!isAnnouncement) {
-                    chunkDirNeutralSections.putMany(previousDirNeutralSections.asList())
-                }
             }
         builder.applyFunctionToTrackSectionChunksBetween(
             trackRange.trackSectionID,
@@ -506,8 +500,6 @@ fun mergeIntoSpeedSections(
 
 fun parseSpeedSection(rjsSpeedSection: RJSSpeedSection): SpeedSection {
     var defaultLimit = rjsSpeedSection.speedLimit.metersPerSecond
-    // TODO: this makes 0 sense, and was only added to match the previous implementation.
-    //   it needs to be burned to the ground
     val routeLimits =
         if (rjsSpeedSection.onRoutes != null) {
             val res = rjsSpeedSection.onRoutes.associateWith { defaultLimit }
@@ -801,7 +793,10 @@ fun parseRJSInfra(rjsInfra: RJSInfra): RawInfra {
                     props
                 )
             if (partId == null) {
-                // TODO warning
+                // TODO: link warning to specific request (through response or tracing)
+                logger.warn(
+                    "Invalid Part on track $trackSectionName for Operational Point $operationalPointId"
+                )
             }
         }
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -475,7 +475,7 @@ class RawInfraBuilder {
 
         return trackChunkPool.add(
             TrackChunkDescriptor(
-                // TODO: The track ID will be filled later, track is not initialized yet
+                // TrackSection ID will be filled later, track is not initialized yet
                 StaticIdx(0u),
                 offset,
                 length,


### PR DESCRIPTION
Mainly on behavior introduced only to match previous load (and ease comparison).
As for the TODO on SpeedLimit, an issue has been created: https://github.com/OpenRailAssociation/osrd/issues/7794.

Fixes part of #7056 