### PR TITLE
front: fix infinite scrolling in editor error list modal

### DIFF
--- a/front/src/applications/editor/components/InfraErrors/InfraErrorsList.tsx
+++ b/front/src/applications/editor/components/InfraErrors/InfraErrorsList.tsx
@@ -158,29 +158,27 @@ const InfraErrorsList: React.FC<InfraErrorsListProps> = ({ infraID, onErrorClick
           scrollableTarget="errors-list-container"
           next={() => fetch(infraID, next ?? 1, filterLevel, filterType ?? undefined)}
         >
-          {errors && (
-            <ul className="list-group">
-              {errors.map((item, index) => (
-                <li key={uniqueId()} className="list-group-item management-item">
-                  <InfraErrorBox error={item} index={index + 1}>
-                    {EDITOAST_TYPES.includes(item.obj_type as EditoastType) && (
-                      <button
-                        className="dropdown-item"
-                        type="button"
-                        aria-label={t('Editor.infra-errors.list.goto-error')}
-                        title={t('Editor.infra-errors.list.goto-error')}
-                        onClick={() => {
-                          onErrorClick(infraID, item);
-                        }}
-                      >
-                        <FaDiamondTurnRight size={30} />
-                      </button>
-                    )}
-                  </InfraErrorBox>
-                </li>
-              ))}
-            </ul>
-          )}
+          <ul className="list-group">
+            {errors.map((item, index) => (
+              <li key={uniqueId()} className="list-group-item management-item">
+                <InfraErrorBox error={item} index={index + 1}>
+                  {EDITOAST_TYPES.includes(item.obj_type as EditoastType) && (
+                    <button
+                      className="dropdown-item"
+                      type="button"
+                      aria-label={t('Editor.infra-errors.list.goto-error')}
+                      title={t('Editor.infra-errors.list.goto-error')}
+                      onClick={() => {
+                        onErrorClick(infraID, item);
+                      }}
+                    >
+                      <FaDiamondTurnRight size={30} />
+                    </button>
+                  )}
+                </InfraErrorBox>
+              </li>
+            ))}
+          </ul>
         </InfiniteScroll>
       </div>
     </div>

--- a/front/src/styles/scss/applications/editor/_editor.scss
+++ b/front/src/styles/scss/applications/editor/_editor.scss
@@ -200,14 +200,14 @@
       min-height: 100px;
     }
   }
+}
 
-  .editor-infra-errors-list {
-    .error-count {
-      height: 1.5rem;
-    }
-    #errors-list-container {
-      height: 60vh;
-      overflow: auto;
-    }
+.editor-infra-errors-list {
+  .error-count {
+    height: 1.5rem;
+  }
+  #errors-list-container {
+    height: 60vh;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
The modal is not inserted under the .editor-root element. As a
result, the `overflow: auto` rule wasn't applied to the
#errors-list-container element and `<InfiniteScroll>` was not
catching scroll events.

(A small cleanup is also included as a second commit.)

Closes: https://github.com/OpenRailAssociation/osrd/issues/7711