### PR TITLE
core: prevents path from taking the same track section twice

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
@@ -7,7 +7,6 @@ import fr.sncf.osrd.api.api_v2.TrackLocation
 import fr.sncf.osrd.api.pathfinding.constraints.*
 import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
-import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -308,9 +307,9 @@ fun validatePathfindingResponse(
         }
     }
 
-    val dirTracks = HashSet<Pair<String, EdgeDirection>>()
-    for (track in res.trackSectionRanges) dirTracks.add(Pair(track.trackSection, track.direction))
-    if (dirTracks.size != res.trackSectionRanges.size)
+    val trackSet = HashSet<String>()
+    for (track in res.trackSectionRanges) trackSet.add(track.trackSection)
+    if (trackSet.size != res.trackSectionRanges.size)
         throw OSRDError(ErrorType.PathWithRepeatedTracks)
 
     if (res.pathItemPositions.size != req.pathItems.size)


### PR DESCRIPTION
This check was already there but not for opposite direction.

close #7785