### PR TITLE
docker: fix SIGTERM not received by editoast

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,9 +105,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - |
-        diesel migration run
-        editoast runserver
+      - "diesel migration run && exec editoast runserver"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
       start_period: 4s


### PR DESCRIPTION
For some reason it seems like SIGTERM is not properly sent to editoast when bringing down the cluster. I see the following in my logs after a timeout:

    WARN[0010] StopSignal SIGTERM failed to stop container osrd-editoast in 10 seconds, resorting to SIGKILL

It seems like sh is the cause of the issue somehow. Use "exec" to replace the sh process and fix the Unix signal issues.

With this patch, the shutdown is instantaneous and I now see the following in the logs:

    [editoast]     |   2024-06-20T12:37:41.520662Z  INFO actix_server::server: SIGINT received; starting forced shutdown

(Maybe this is all specific to my Podman-based setup? I still think it's worth fixing.)

While at it, use "&&" to abort startup if the diesel migration fails.