### PR TITLE
core: reduce path requirement to compute spacing resource uses

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -96,7 +96,7 @@ class STDCMGraph(
             visitedNodes.markAsVisited(fingerprint, node.time)
             res.addAll(STDCMEdgeBuilder.fromNode(this, node, explorer).makeAllEdges())
         } else {
-            val extended = extendLookaheadUntil(node.infraExplorer.clone(), 4)
+            val extended = extendLookaheadUntil(node.infraExplorer.clone(), 3)
             for (newPath in extended) {
                 if (newPath.getLookahead().size == 0) continue
                 newPath.moveForward()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -252,7 +252,7 @@ class STDCMPathfinding(
         for (location in locations) {
             val infraExplorers =
                 initInfraExplorerWithEnvelope(fullInfra, location, rollingStock, stops, constraints)
-            val extended = infraExplorers.flatMap { extendLookaheadUntil(it, 4) }
+            val extended = infraExplorers.flatMap { extendLookaheadUntil(it, 3) }
             for (explorer in extended) {
                 val edges =
                     STDCMEdgeBuilder(explorer, graph)

--- a/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
@@ -146,10 +146,10 @@ class SpacingResourceGeneratorTest {
             res.add(iterationResult)
         }
         for (i in res.indices) {
-            // We need at least 4 blocks to find a block that doesn't restrict the signal at the end
+            // We need at least 3 blocks to find a block that doesn't restrict the signal at the end
             // of block 1
             val nBlocks = i + 1
-            val expectedNotEnoughPath = nBlocks < 4
+            val expectedNotEnoughPath = nBlocks < 3
             assertEquals(expectedNotEnoughPath, res[i] is NotEnoughPath)
         }
     }
@@ -281,6 +281,41 @@ class SpacingResourceGeneratorTest {
             assertFalse { requirement.isComplete }
             assertEquals(automaton.callbacks.currentTime, requirement.endTime)
         }
+    }
+
+    @Test
+    fun testRequiredPathLength() {
+        val path = incrementalPathOf(infra.rawInfra, infra.blockInfra)
+        val automaton =
+            SpacingRequirementAutomaton(
+                infra.rawInfra,
+                infra.loadedSignalInfra,
+                infra.blockInfra,
+                infra.signalingSimulator,
+                makeCallbacks(blockLengths[0].distance, false),
+                path
+            )
+        val blocks =
+            mutableStaticIdxArrayListOf(
+                blocks[0],
+                blocks[1],
+                blocks[2],
+            )
+        path.extend(
+            PathFragment(
+                mutableStaticIdxArrayListOf(routes[0]),
+                blocks,
+                stops = listOf(),
+                containsStart = true,
+                containsEnd = false,
+                0.meters,
+                0.meters
+            )
+        )
+        val iterationResult = automaton.processPathUpdate()
+
+        // We should have just enough data to generate resource use
+        assertTrue { iterationResult != NotEnoughPath }
     }
 }
 


### PR DESCRIPTION
We used to require path until it includes a zone that isn't necessary for the train. But we don't need to know which precise block it is, it doesn't need to be included in the path.

Fix https://github.com/OpenRailAssociation/osrd/issues/7788, there's a little more explanation there with a fancy drawing

Change summary: we rely on the `followingZoneState` parameter of `SignalingSimulator.evaluate()` to figure out if a zone affects the signal (if the end of the path has been reached). This lets us peek one zone further than before. 