### PR TITLE
Rvs/front power restrictions v2

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -129,10 +129,11 @@
     "electrification": "Electrification",
     "inconsistent_one": "The interval below has inconsistencies. The default speed effort curve will be used for this.",
     "inconsistent_other": "The intervals below contain inconsistencies. The default speed effort curves will be used for these.",
-    "powerRestrictionInvalidCombination": "- {{powerRestrictionCode}} is incompatible with electrification {{electrification}} of the path between {{begin}}m and {{end}}m",
+    "marginsAndPowerRestrictionsReset": "Margins and power restrictions have been reset.",
     "missingPowerRestriction": "- Missing power restriction between {{begin}}m and {{end}}m.",
     "modeNotHandled": "- No power restriction should be given between {{begin}}m and {{end}}m since the electrification mode {{electrification}} is not handled.",
     "pathfindingChange": "Pathfinding changed",
-    "marginsAndPowerRestrictionsReset": "Margins and power restrictions have been reset."
+    "powerRestrictionInvalidCombination": "- {{powerRestrictionCode}} is incompatible with electrification {{electrification}} of the path between {{begin}}m and {{end}}m",
+    "powerRestrictionsReset": "Power restrictions have been reset."
   }
 }

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -130,10 +130,11 @@
     "electrification": "Électrification",
     "inconsistent_one": "Un intervalle comporte des incohérences. La courbe effort vitesse par défaut sera utilisée pour celui-ci.",
     "inconsistent_other": "Plusieurs intervalles comportent des incohérences. Les courbes effort vitesse par défaut seront utilisées pour ceux-ci.",
-    "powerRestrictionInvalidCombination": "- Code {{powerRestrictionCode}} incompatible avec l'électrification à {{electrification}} de l'itinéraire entre {{begin}}m et {{end}}m. ",
+    "marginsAndPowerRestrictionsReset": "Les marges et les restrictions de puissance ont été réinitialisées.",
     "missingPowerRestriction": "- Restriction de puissance manquante entre {{begin}}m et {{end}}m.",
     "modeNotHandled": "- Aucune restriction de puissance ne devrait être renseignée entre {{begin}}m and {{end}}m comme le matériel roulant ne supporte pas l'électrification {{electrification}}.",
     "pathfindingChange": "Changement de chemin",
-    "marginsAndPowerRestrictionsReset": "Les marges et les restrictions de puissance ont été réinitialisées."
+    "powerRestrictionInvalidCombination": "- Code {{powerRestrictionCode}} incompatible avec l'électrification à {{electrification}} de l'itinéraire entre {{begin}}m et {{end}}m.",
+    "powerRestrictionsReset": "Les restrictions de puissance ont été réinitialisées."
   }
 }

--- a/front/src/applications/operationalStudies/hooks.ts
+++ b/front/src/applications/operationalStudies/hooks.ts
@@ -109,6 +109,7 @@ export const useSetupItineraryForTrainUpdate = (
                 suggestedOperationalPoints,
                 allWaypoints,
                 length: pathfindingResult.length,
+                trackSectionRanges: pathfindingResult.track_section_ranges,
               });
 
               adjustConfWithTrainToModifyV2(

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -1,10 +1,14 @@
 import type {
   PathProperties,
   PathResponse,
+  PathfindingResultSuccess,
   ProjectPathTrainResult,
+  RangedValue,
   SimulationResponse,
+  TrainScheduleBase,
 } from 'common/api/osrdEditoastApi';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
+import type { ArrayElement } from 'utils/types';
 
 export interface Destination {
   uic: number;
@@ -89,6 +93,7 @@ export type ManageTrainSchedulePathProperties = {
   /** Operational points along the path (including origin and destination) and vias added by clicking on map */
   allWaypoints: SuggestedOP[];
   length: number;
+  trackSectionRanges: NonNullable<PathfindingResultSuccess['track_section_ranges']>;
 };
 
 /**
@@ -106,6 +111,7 @@ export type PositionData<T extends 'gradient' | 'radius'> = {
   position: number;
 };
 
+/** Start and stop are in meters */
 export type ElectrificationRangeV2 = {
   electrificationUsage: ElectrificationUsageV2;
   start: number;
@@ -143,15 +149,21 @@ export type ElectricalProfileValue = Extract<
   { status: 'success' }
 >['electrical_profiles']['values'][number];
 
-/**
- * Electrifications start and stop are in meters
- */
+/** Electrifications start and stop are in meters */
 export type PathPropertiesFormatted = {
   electrifications: ElectrificationRangeV2[];
   curves: PositionData<'radius'>[];
   slopes: PositionData<'gradient'>[];
   operationalPoints: NonNullable<PathProperties['operational_points']>;
   geometry: NonNullable<PathProperties['geometry']>;
+  voltages: RangedValue[];
 };
 
+export type PowerRestrictionV2 = ArrayElement<TrainScheduleBase['power_restrictions']>;
+
 export type SimulationResponseSuccess = Extract<SimulationResponse, { status: 'success' }>;
+
+export type ElectrificationVoltage = {
+  type: string;
+  voltage?: string;
+};

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -1,6 +1,7 @@
 import { omit } from 'lodash';
 
 import type { PathProperties, ProjectPathTrainResult } from 'common/api/osrdEditoastApi';
+import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { convertUTCDateToLocalDate, isoDateToMs } from 'utils/date';
 import { mmToM } from 'utils/physics';
 import { ms2sec } from 'utils/timeManipulation';
@@ -183,12 +184,18 @@ export const preparePathPropertiesData = (
     electricalProfilesRanges
   );
 
+  const voltageRanges = getPathVoltages(
+    electrifications as NonNullable<PathProperties['electrifications']>,
+    pathLength
+  );
+
   return {
     electrifications: electrificationRanges,
     curves: formattedCurves,
     slopes: formattedSlopes,
     operationalPoints: operational_points as NonNullable<PathProperties['operational_points']>,
     geometry: geometry as NonNullable<PathProperties['geometry']>,
+    voltages: voltageRanges,
   };
 };
 

--- a/front/src/applications/operationalStudies/views/v2/ManageTrainScheduleV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ManageTrainScheduleV2.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { compact } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -13,10 +13,13 @@ import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector';
 import Tabs from 'common/Tabs';
 import ItineraryV2 from 'modules/pathfinding/components/Itinerary/ItineraryV2';
+import getPathVoltages from 'modules/pathfinding/helpers/getPathVoltages';
 import { upsertViasInOPs } from 'modules/pathfinding/utils';
+import PowerRestrictionsSelectorV2 from 'modules/powerRestriction/components/PowerRestrictionsSelectorV2';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import { RollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
+import { isElectric } from 'modules/rollingStock/helpers/electric';
 import TimesStops from 'modules/timesStops/TimesStops';
 import { Map } from 'modules/trainschedule/components/ManageTrainSchedule';
 import SimulationSettings from 'modules/trainschedule/components/ManageTrainSchedule/SimulationSettings';
@@ -52,16 +55,12 @@ const ManageTrainScheduleV2 = () => {
         allWaypoints,
       });
     }
-  }, [pathSteps]);
+  }, []);
 
-  // TODO TS2 : test this hook in simulation results issue
-  // useSetupItineraryForTrainUpdate(setPathProperties);
-
-  // const { data: pathWithElectrifications = { electrification_ranges: [] as RangedValue[] } } =
-  //   osrdEditoastApi.endpoints.getPathfindingByPathfindingIdElectrifications.useQuery(
-  //     { pathfindingId: pathFindingID as number },
-  //     { skip: !pathFindingID }
-  //   );
+  const voltageRanges = useMemo(
+    () => getPathVoltages(pathProperties?.electrifications, pathProperties?.length),
+    [pathProperties]
+  );
 
   const tabRollingStock = {
     id: 'rollingstock',
@@ -151,13 +150,14 @@ const ManageTrainScheduleV2 = () => {
           dispatchUpdateSpeedLimitByTag={dispatchUpdateSpeedLimitByTag}
           constraintDistribution={constraintDistribution}
         />
-        {/* {rollingStock && isElectric(rollingStock.effort_curves.modes) && (
+        {rollingStock && isElectric(rollingStock.effort_curves.modes) && pathProperties && (
           <PowerRestrictionsSelectorV2
             rollingStockModes={rollingStock.effort_curves.modes}
             rollingStockPowerRestrictions={rollingStock.power_restrictions}
-            pathElectrificationRanges={pathWithElectrifications.electrification_ranges}
+            voltageRanges={voltageRanges}
+            pathProperties={pathProperties}
           />
-        )} */}
+        )}
       </div>
     ),
   };

--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -121,6 +121,7 @@ const useStdcmResults = (
           suggestedOperationalPoints: updatedSuggestedOPs,
           allWaypoints: updatedSuggestedOPs,
           length: path.length,
+          trackSectionRanges: path.track_section_ranges,
         });
       }
     };

--- a/front/src/applications/stdcmV2/components/StdcmVias.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmVias.tsx
@@ -30,7 +30,7 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
 
   const updatePathStepsList = (pathStep: PathStep | null, index: number) => {
     const newPathSteps = replaceElementAtIndex(pathSteps, index, pathStep);
-    dispatch(updatePathSteps(newPathSteps));
+    dispatch(updatePathSteps({ pathSteps: newPathSteps }));
   };
 
   const updatePathStepStopTime = (stopTime: string, index: number) => {
@@ -95,7 +95,7 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
         Icon={<Location size="lg" variant="base" />}
         onClick={() => {
           const newPathSteps = addElementAtIndex(pathSteps, pathSteps.length - 1, null);
-          dispatch(updatePathSteps(newPathSteps));
+          dispatch(updatePathSteps({ pathSteps: newPathSteps }));
         }}
       />
     </div>

--- a/front/src/common/IntervalsDataViz/IntervalItem.tsx
+++ b/front/src/common/IntervalsDataViz/IntervalItem.tsx
@@ -46,6 +46,7 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
   segment,
   setDraginStartAt,
   setResizing,
+  disableDrag = true,
 }: IntervalItemProps<T>) => {
   let valueText = '';
   if (field && segment[field]) {
@@ -161,15 +162,20 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
       {/* Create a div for the resize */}
       {data[segment.index] && segment.end === data[segment.index].end && (
         <div
-          title="Resize"
-          aria-label="Resize"
-          className={cx('resize', resizing && resizing.index === segment.index && 'selected')}
+          title={!disableDrag ? 'Resize' : 'Interval boundary'}
+          aria-label={!disableDrag ? 'Resize' : 'Interval boundary'}
+          className={cx('resize', {
+            selected: resizing && resizing.index === segment.index,
+            disabled: disableDrag,
+          })}
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
           }}
           onMouseDown={(e) => {
-            setResizing({ index: segment.index, startAt: e.clientX, startPosition: segment.end });
+            if (!disableDrag) {
+              setResizing({ index: segment.index, startAt: e.clientX, startPosition: segment.end });
+            }
             e.stopPropagation();
             e.preventDefault();
           }}

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -84,6 +84,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
   onDragX,
   onResize,
   onCreate,
+  disableDrag,
 }: LinearMetadataDatavizProps<T>) => {
   // Html ref of the div wrapper
   const wrapper = useRef<HTMLDivElement | null>(null);
@@ -412,6 +413,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
             segment={segment}
             setDraginStartAt={setDraginStartAt}
             setResizing={setResizing}
+            disableDrag={disableDrag}
           />
         ))}
       </div>

--- a/front/src/common/IntervalsDataViz/style.scss
+++ b/front/src/common/IntervalsDataViz/style.scss
@@ -174,7 +174,7 @@ $resize-width: 3px;
             }
 
             &.with-data {
-                z-index: 2;
+              z-index: 2;
             }
 
             &.highlighted {
@@ -195,14 +195,14 @@ $resize-width: 3px;
               background-color: $color;
               text-align: center;
               white-space: nowrap;
-              overflow-y:hidden;
+              overflow-y: hidden;
               span {
-                color:#fff;
+                color: #fff;
                 display: block;
                 font-size: 0.6em;
                 // trick to hide the value if the div is too small
                 // https://medium.com/swlh/hiding-an-element-when-there-is-no-enough-space-thanos-snap-technique-8a11e31267c0
-                max-height: max(0px, calc((100% - 12px)*999));
+                max-height: max(0px, calc((100% - 12px) * 999));
                 overflow: hidden;
               }
             }
@@ -214,8 +214,8 @@ $resize-width: 3px;
               z-index: 2;
               background-color: #fff;
 
-              &:hover,
-              &.selected {
+              &:not(.disabled):hover,
+              &:not(.disabled).selected {
                 background-color: #000;
                 cursor: col-resize;
               }
@@ -280,7 +280,7 @@ $resize-width: 3px;
         .scale {
           display: flex;
           justify-content: space-between;
-          span{
+          span {
             font-size: 0.6em;
             overflow: hidden;
             align-self: end;
@@ -335,10 +335,10 @@ $resize-width: 3px;
               height: 50px;
               text-align: center;
 
-              &:before{
-                content: "";
+              &:before {
+                content: '';
                 position: absolute;
-                top: -.2em;
+                top: -0.2em;
                 width: 1px;
                 height: 0.4em;
                 background-color: black;
@@ -355,7 +355,6 @@ $resize-width: 3px;
                 top: 0.75em;
               }
             }
-
           }
         }
       }
@@ -372,7 +371,8 @@ $resize-width: 3px;
       z-index: 999;
 
       .linear-metadata-tooltip {
-        .header, .footer {
+        .header,
+        .footer {
           display: flex;
           flex-direction: row;
           justify-content: space-between;
@@ -396,7 +396,6 @@ $resize-width: 3px;
       padding: 1em;
 
       .header {
-
         .btn-toolbar {
           width: 100%;
           display: flex;

--- a/front/src/common/IntervalsDataViz/types.ts
+++ b/front/src/common/IntervalsDataViz/types.ts
@@ -95,6 +95,8 @@ export interface IntervalItemBaseProps<T> {
    * stringValues: each interval has just a category ref, not a continuous value
    */
   options?: { resizingScale?: boolean; fullHeightItem?: boolean; showValues?: boolean };
+
+  disableDrag?: boolean;
 }
 
 export interface OperationalPoint {

--- a/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorCommonForm.tsx
@@ -6,13 +6,15 @@ import DebouncedNumberInputSNCF from 'common/BootstrapSNCF/FormSNCF/DebouncedNum
 import { fixLinearMetadataItems, resizeSegment } from 'common/IntervalsDataViz/data';
 import { notEmpty } from 'common/IntervalsDataViz/utils';
 
+import type { IntervalsEditorProps } from './IntervalsEditor';
 import type { IntervalItem } from './types';
 
 type IntervalsEditorFormProps = {
   data: IntervalItem[];
   interval: IntervalItem;
   selectedIntervalIndex: number;
-  setData: (newData: IntervalItem[]) => void;
+  setData: (newData: IntervalItem[], selectedIntervalIndex?: number) => void;
+  onInputChange?: IntervalsEditorProps['onResizeFromInput'];
   setSelectedIntervalIndex: (selectedIntervalIndex: number) => void;
   totalLength: number;
   defaultValue: string | number;
@@ -26,10 +28,11 @@ const IntervalsEditorCommonForm = ({
   setSelectedIntervalIndex,
   totalLength,
   defaultValue,
+  onInputChange,
 }: IntervalsEditorFormProps) => {
   const { t } = useTranslation('common/common');
 
-  const [begin, setBegin] = useState<number>(Math.round(interval.begin));
+  const [begin, setBegin] = useState(Math.round(interval.begin));
   const [end, setEnd] = useState(Math.round(interval.end));
 
   useEffect(() => {
@@ -39,6 +42,7 @@ const IntervalsEditorCommonForm = ({
 
   const resizeSegmentByInput = (newPosition: number, context: 'begin' | 'end') => {
     const gap = newPosition - interval[context];
+
     // use absolute value to manage cases where the position is not rounded
     // ex: begin = 1200.68 and newPosition = 1200 (because input is rounded)
     if (Math.abs(gap) > 1) {
@@ -53,7 +57,11 @@ const IntervalsEditorCommonForm = ({
         fieldName: 'value',
         defaultValue,
       });
-      setData(fixedResults);
+      if (onInputChange) {
+        onInputChange(selectedIntervalIndex, context, newPosition);
+      } else {
+        setData(fixedResults, selectedIntervalIndex);
+      }
 
       // update the selected interval if needed
       // corner case: if we create a new empty first segment

--- a/front/src/common/IntervalsEditor/IntervalsEditorSelectForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorSelectForm.tsx
@@ -10,7 +10,7 @@ type IntervalsEditorSelectFormProps = {
   data: IntervalItem[];
   interval: IntervalItem;
   selectedIntervalIndex: number;
-  setData: (newData: IntervalItem[]) => void;
+  setData: (newData: IntervalItem[], selectedIntervalIndex?: number) => void;
   selectOptions: string[];
 };
 
@@ -31,7 +31,7 @@ const IntervalsEditorSelectForm = ({
           const result = cloneDeep(data);
           if (result[selectedIntervalIndex]) {
             result[selectedIntervalIndex].value = newValue;
-            setData(result);
+            setData(result, selectedIntervalIndex);
           }
         }
       }}

--- a/front/src/common/IntervalsEditor/IntervalsEditorToolButtons.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorToolButtons.tsx
@@ -76,13 +76,15 @@ const ToolButtons = ({ selectedTool, toolsConfig, toggleSelectedTool }: ToolButt
             toggleSelectedTool={toggleSelectedTool}
           />
         )}
-        <ToolButton
-          selectedTool={selectedTool}
-          tool={INTERVALS_EDITOR_TOOLS.MERGE_TOOL}
-          title={t('actions.merge')}
-          icon={<BiArrowFromLeft />}
-          toggleSelectedTool={toggleSelectedTool}
-        />
+        {toolsConfig.mergeTool && (
+          <ToolButton
+            selectedTool={selectedTool}
+            tool={INTERVALS_EDITOR_TOOLS.MERGE_TOOL}
+            title={t('actions.merge')}
+            icon={<BiArrowFromLeft />}
+            toggleSelectedTool={toggleSelectedTool}
+          />
+        )}
         {toolsConfig.deleteTool && (
           <ToolButton
             selectedTool={selectedTool}

--- a/front/src/common/IntervalsEditor/types.ts
+++ b/front/src/common/IntervalsEditor/types.ts
@@ -26,6 +26,7 @@ export type IntervalsEditorTool =
 export type IntervalsEditorToolsConfig = {
   cutTool?: boolean;
   deleteTool?: boolean;
+  mergeTool?: boolean;
   translateTool?: boolean;
   addTool?: boolean;
 };

--- a/front/src/modules/pathfinding/components/Itinerary/ItineraryV2.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/ItineraryV2.tsx
@@ -59,12 +59,12 @@ const ItineraryV2 = ({
 
   const inverseOD = () => {
     const revertedPathSteps = [...pathSteps].reverse();
-    dispatch(updatePathSteps(revertedPathSteps));
+    dispatch(updatePathSteps({ pathSteps: revertedPathSteps, resetPowerRestrictions: true }));
   };
 
   const resetPathfinding = () => {
     setPathProperties(undefined);
-    dispatch(updatePathSteps([null, null]));
+    dispatch(updatePathSteps({ pathSteps: [null, null], resetPowerRestrictions: true }));
   };
 
   useEffect(() => {

--- a/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
@@ -37,12 +37,12 @@ const ModalSuggestedVias = ({ suggestedVias }: ModalSuggestedViasProps) => {
   const removeViaFromPath = (op: SuggestedOP) => {
     const updatedPathSteps = [...pathSteps];
     dispatch(
-      updatePathSteps(
-        compact(updatedPathSteps).filter(
+      updatePathSteps({
+        pathSteps: compact(updatedPathSteps).filter(
           (step) =>
             ('uic' in step && step.uic !== op.uic) || ('track' in step && step.track !== op.track)
-        )
-      )
+        ),
+      })
     );
   };
 

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
@@ -222,6 +222,7 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
               suggestedOperationalPoints,
               allWaypoints: suggestedOperationalPoints,
               length: pathfindingResult.length,
+              trackSectionRanges: pathfindingResult.track_section_ranges,
             });
 
             const pathSteps: PathStep[] = opList.map((op, i) => {
@@ -240,7 +241,7 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
                 stopFor: i === opList.length - 1 ? '0' : undefined,
               };
             });
-            dispatch(updatePathSteps(pathSteps));
+            dispatch(updatePathSteps({ pathSteps, resetPowerRestrictions: true }));
           }
         }
         // TODO TS2 : test errors display after core / editoast connexion for pathProperties

--- a/front/src/modules/pathfinding/helpers/__tests__/getPathVoltages.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/getPathVoltages.spec.ts
@@ -1,0 +1,137 @@
+import type { PathProperties } from 'common/api/generatedEditoastApi';
+
+import getPathVoltages from '../getPathVoltages';
+
+const pathLength = 10;
+
+describe('getPathVoltages', () => {
+  it('should return 1 range if 1500V - neutral - 1500V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [4, 6],
+      values: [
+        { type: 'electrification', voltage: '1500V' },
+        { type: 'neutral_section', lower_pantograph: true },
+        { type: 'electrification', voltage: '1500V' },
+      ],
+    };
+
+    const expectedResult = [{ begin: 0, end: 10, value: '1500V' }];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 3 ranges if 1500V - neutral - 25000V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [4, 6],
+      values: [
+        { type: 'electrification', voltage: '1500V' },
+        { type: 'neutral_section', lower_pantograph: true },
+        { type: 'electrification', voltage: '25000V' },
+      ],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 4, value: '1500V' },
+      { begin: 4, end: 6, value: '' },
+      { begin: 6, end: 10, value: '25000V' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 3 ranges if 1500V - non electrified - 25000V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [4, 6],
+      values: [
+        { type: 'electrification', voltage: '1500V' },
+        { type: 'non_electrified' },
+        { type: 'electrification', voltage: '25000V' },
+      ],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 4, value: '1500V' },
+      { begin: 4, end: 6, value: '' },
+      { begin: 6, end: 10, value: '25000V' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 3 ranges if 1500V - non electrified - 1500V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [4, 6],
+      values: [
+        { type: 'electrification', voltage: '1500V' },
+        { type: 'non_electrified' },
+        { type: 'electrification', voltage: '1500V' },
+      ],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 4, value: '1500V' },
+      { begin: 4, end: 6, value: '' },
+      { begin: 6, end: 10, value: '1500V' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 2 ranges if non electrified - 1500V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [5],
+      values: [{ type: 'non_electrified' }, { type: 'electrification', voltage: '1500V' }],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 5, value: '' },
+      { begin: 5, end: 10, value: '1500V' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 2 ranges if neutral - non electrified - 1500V', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [2, 5],
+      values: [
+        { type: 'neutral_section', lower_pantograph: true },
+        { type: 'non_electrified' },
+        { type: 'electrification', voltage: '1500V' },
+      ],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 5, value: '' },
+      { begin: 5, end: 10, value: '1500V' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should return 3 ranges if non electrified - 1500V - neutral', () => {
+    const electrifications: NonNullable<PathProperties['electrifications']> = {
+      boundaries: [2, 8],
+      values: [
+        { type: 'non_electrified' },
+        { type: 'electrification', voltage: '1500V' },
+        { type: 'neutral_section', lower_pantograph: true },
+      ],
+    };
+
+    const expectedResult = [
+      { begin: 0, end: 2, value: '' },
+      { begin: 2, end: 8, value: '1500V' },
+      { begin: 8, end: 10, value: '' },
+    ];
+
+    const result = getPathVoltages(electrifications, pathLength);
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/front/src/modules/pathfinding/helpers/getPathVoltages.ts
+++ b/front/src/modules/pathfinding/helpers/getPathVoltages.ts
@@ -1,0 +1,79 @@
+import type { ElectrificationVoltage } from 'applications/operationalStudies/types';
+import type { PathProperties, RangedValue } from 'common/api/osrdEditoastApi';
+
+const isElectrification = (
+  value: ElectrificationVoltage
+): value is { type: 'electrification'; voltage: string } => value.type === 'electrification';
+
+const isNeutralSection = (
+  value: ElectrificationVoltage
+): value is {
+  lower_pantograph: boolean;
+  type: 'neutral_section';
+} => value.type === 'neutral_section';
+
+const isNonElectrified = (value: ElectrificationVoltage): value is { type: 'non_electrified' } =>
+  value.type === 'non_electrified';
+
+/**
+ * Given electrifications on path, return the list of voltages on the path ranges
+ *
+ * Filter the neutral sections and group the ranges
+ */
+const getPathVoltages = (
+  electrifications?: NonNullable<PathProperties['electrifications']>,
+  pathLength?: number
+): RangedValue[] => {
+  if (!electrifications || !pathLength) return [];
+
+  const boundaries = [...electrifications.boundaries, pathLength];
+  const ranges: RangedValue[] = [];
+  let start = 0;
+  let currentVoltage: string = '';
+
+  electrifications.values.forEach((electrification, index) => {
+    if (isNonElectrified(electrification)) {
+      if (currentVoltage) {
+        // non electrified range, we add the previous range which has a voltage
+        ranges.push({ begin: start, end: boundaries[index - 1], value: currentVoltage });
+        currentVoltage = '';
+        start = boundaries[index - 1] || 0;
+      }
+    } else if (isElectrification(electrification)) {
+      if (!currentVoltage) {
+        // electrified range, we add the previous range without electrification
+        if (index > 0) ranges.push({ begin: start, end: boundaries[index - 1], value: '' });
+        start = boundaries[index - 1] || 0;
+      } else if (electrification.voltage !== currentVoltage) {
+        // electrified range, we add the previous range which has a different voltage
+        ranges.push({ begin: start, end: boundaries[index], value: currentVoltage });
+        start = boundaries[index];
+      }
+      currentVoltage = electrification.voltage;
+    } else if (isNeutralSection(electrification)) {
+      const nextElectrification = electrifications.values[index + 1];
+      if (
+        currentVoltage &&
+        (!nextElectrification ||
+          !isElectrification(nextElectrification) ||
+          nextElectrification.voltage !== currentVoltage)
+      ) {
+        // neutral range, we add the previous range with electrification if:
+        // - there is no next range
+        // - the next range is an electrification and the voltage is not the same than on the previous one
+        ranges.push({ begin: start, end: boundaries[index - 1], value: currentVoltage });
+        currentVoltage = '';
+        start = boundaries[index - 1];
+      }
+    }
+
+    if (index === electrifications.values.length - 1) {
+      // we add the last range
+      ranges.push({ begin: start, end: pathLength, value: currentVoltage });
+    }
+  });
+
+  return ranges;
+};
+
+export default getPathVoltages;

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -56,6 +56,7 @@ export const getPathfindingQuery = ({
       if ('track' in step) {
         return {
           track: step.track,
+          // TODO: step offset should be in mm in the store /!\
           // pathfinding blocks endpoint requires offsets in mm
           offset: step.offset * 1000,
         };

--- a/front/src/modules/powerRestriction/components/PowerRestrictionsSelectorV2.tsx
+++ b/front/src/modules/powerRestriction/components/PowerRestrictionsSelectorV2.tsx
@@ -1,137 +1,52 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 
 import { Alert } from '@osrd-project/ui-icons';
-import { isEmpty, last } from 'lodash';
+import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
-import type { PowerRestrictionRange } from 'applications/operationalStudies/consts';
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
 import icon from 'assets/pictures/components/power_restrictions.svg';
 import type { RangedValue, RollingStock } from 'common/api/osrdEditoastApi';
 import IntervalsEditor from 'common/IntervalsEditor/IntervalsEditor';
 import { INTERVAL_TYPES } from 'common/IntervalsEditor/types';
-import type { IntervalItem } from 'common/IntervalsEditor/types';
-import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
-import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
-import displayPowerRestrictionIntervals from 'modules/powerRestriction/helpers/displayPowerRestrictionIntervals';
-import {
-  countWarnings,
-  getPowerRestrictionsWarnings,
-} from 'modules/powerRestriction/helpers/powerRestrictionWarnings';
-import { useAppDispatch } from 'store';
+import { mmToM } from 'utils/physics';
 
-/** Arbitrairy default segment length (1km) */
-const DEFAULT_SEGMENT_LENGTH = 1000;
+import { NO_POWER_RESTRICTION } from '../consts';
+import usePowerRestrictionSelector from '../hooks/usePowerRestrictionSelectorData';
 
-interface PowerRestrictionsSelectorProps {
-  pathElectrificationRanges: RangedValue[];
-  rollingStockPowerRestrictions: RollingStock['power_restrictions'];
+type PowerRestrictionsSelectorProps = {
+  voltageRanges: RangedValue[];
   rollingStockModes: RollingStock['effort_curves']['modes'];
-}
+  rollingStockPowerRestrictions: RollingStock['power_restrictions'];
+  pathProperties: ManageTrainSchedulePathProperties;
+};
 
 const PowerRestrictionsSelectorV2 = ({
-  pathElectrificationRanges,
+  voltageRanges,
   rollingStockModes,
   rollingStockPowerRestrictions,
+  pathProperties,
 }: PowerRestrictionsSelectorProps) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const dispatch = useAppDispatch();
-  const { getPowerRestrictionRanges } = useOsrdConfSelectors();
-  const { updatePowerRestrictionRanges } = useOsrdConfActions();
-  const powerRestrictionRanges = useSelector(getPowerRestrictionRanges);
 
-  const pathLength = useMemo(() => {
-    const lastPathSegment = last(pathElectrificationRanges);
-    return lastPathSegment ? lastPathSegment.end : DEFAULT_SEGMENT_LENGTH;
-  }, [pathElectrificationRanges]);
-
-  /** Compute the list of points where the electrification changes on path to give them to the intervals editor as operationalPoints */
-  const electrificationChangePoints = useMemo(() => {
-    const specialPoints = [
-      ...pathElectrificationRanges.map((electrificationRange) => ({
-        position: electrificationRange.end,
-      })),
-    ];
-    specialPoints.pop();
-    return specialPoints;
-  }, [pathElectrificationRanges]);
-
-  /** Format the electrification ranges to display them on the interval editor */
-  const formattedPathElectrificationRanges = useMemo(
-    () =>
-      pathElectrificationRanges.map((electrificationRange) => ({
-        begin: electrificationRange.begin,
-        end: electrificationRange.end,
-        value: `${electrificationRange.value}`,
-      })),
-    [pathElectrificationRanges]
+  const {
+    ranges,
+    compatibleVoltageRanges,
+    electrificationChangePoints,
+    pathLength, // in meters
+    powerRestrictionOptions,
+    warnings,
+    warningsNb,
+    resizeSegments,
+    deletePowerRestrictionRange,
+    cutPowerRestrictionRange,
+    editPowerRestrictionRanges,
+  } = usePowerRestrictionSelector(
+    voltageRanges,
+    rollingStockPowerRestrictions,
+    rollingStockModes,
+    pathProperties
   );
-
-  /** Set up the powerRestrictionRanges with the electrificationChangePoints */
-  useEffect(() => {
-    if (
-      isEmpty(powerRestrictionRanges) ||
-      (powerRestrictionRanges.length === 1 &&
-        powerRestrictionRanges[0].value === NO_POWER_RESTRICTION)
-    ) {
-      if (!isEmpty(pathElectrificationRanges)) {
-        const initialPowerRestrictionRanges = pathElectrificationRanges.map((pathSegment) => ({
-          begin: pathSegment.begin,
-          end: pathSegment.end,
-          value: NO_POWER_RESTRICTION,
-        }));
-        dispatch(updatePowerRestrictionRanges(initialPowerRestrictionRanges));
-      } else {
-        dispatch(
-          updatePowerRestrictionRanges([
-            {
-              begin: 0,
-              end: pathLength,
-              value: NO_POWER_RESTRICTION,
-            },
-          ])
-        );
-      }
-    }
-  }, [pathElectrificationRanges]);
-
-  /** List of options of the rollingStock's power restrictions + option noPowerRestriction */
-  const powerRestrictionOptions = useMemo(
-    () => [NO_POWER_RESTRICTION, ...Object.keys(rollingStockPowerRestrictions)],
-    [rollingStockPowerRestrictions]
-  );
-
-  const editPowerRestrictionRanges = (newPowerRestrictionRanges: IntervalItem[]) => {
-    dispatch(updatePowerRestrictionRanges(newPowerRestrictionRanges as PowerRestrictionRange[]));
-  };
-
-  /** Check the compatibility between the powerRestrictionRanges and the electrifications */
-  const powerRestrictionsWarnings = useMemo(
-    () =>
-      !isEmpty(rollingStockPowerRestrictions) &&
-      !isEmpty(pathElectrificationRanges) &&
-      !isEmpty(powerRestrictionRanges)
-        ? getPowerRestrictionsWarnings(
-            powerRestrictionRanges,
-            pathElectrificationRanges,
-            rollingStockModes
-          )
-        : undefined,
-    [powerRestrictionRanges]
-  );
-
-  const totalPowerRestrictionWarnings = useMemo(
-    () => countWarnings(powerRestrictionsWarnings),
-    [powerRestrictionsWarnings]
-  );
-
-  useEffect(() => {
-    const formattedPowerRestrictionRanges = displayPowerRestrictionIntervals(
-      formattedPathElectrificationRanges,
-      powerRestrictionRanges
-    );
-    dispatch(updatePowerRestrictionRanges(formattedPowerRestrictionRanges));
-  }, [formattedPathElectrificationRanges]);
 
   return (
     <div className="osrd-config-item mb-2">
@@ -141,59 +56,71 @@ const PowerRestrictionsSelectorV2 = ({
         {!isEmpty(rollingStockPowerRestrictions) ? (
           <>
             <p className="mb-1 mt-1">{t('powerRestrictionExplanationText')}</p>
-            {powerRestrictionsWarnings && totalPowerRestrictionWarnings > 0 && (
+            {warningsNb > 0 && (
               <div className="border border-warning rounded p-3 my-3">
                 <div className="d-flex align-items-center mb-2">
                   <div className="d-flex align-items-center text-warning">
                     <Alert />
                   </div>
                   <span className="ml-2">
-                    {t('warningMessages.inconsistent', { count: totalPowerRestrictionWarnings })}
+                    {t('warningMessages.inconsistent', { count: warningsNb })}
                   </span>
                 </div>
                 <div className="d-flex flex-column">
-                  {powerRestrictionsWarnings.modeNotSupportedWarnings.map(
-                    ({ begin, end, electrification }) => (
+                  {warnings &&
+                    warnings.modeNotSupportedWarnings.map(({ begin, end, electrification }) => (
                       <span key={`not-handled-mode-${begin}-${end}`}>
-                        {t('warningMessages.modeNotHandled', { begin, end, electrification })}
-                      </span>
-                    )
-                  )}
-                  {Object.values(powerRestrictionsWarnings.invalidCombinationWarnings).map(
-                    ({ powerRestrictionCode, electrification, begin, end }) => (
-                      <span key={`${powerRestrictionCode}-${begin}-${end}`}>
-                        {t('warningMessages.powerRestrictionInvalidCombination', {
-                          powerRestrictionCode,
+                        {t('warningMessages.modeNotHandled', {
+                          begin: mmToM(begin),
+                          end: mmToM(end),
                           electrification,
-                          begin,
-                          end,
                         })}
                       </span>
-                    )
-                  )}
-                  {powerRestrictionsWarnings.missingPowerRestrictionWarnings.map(
-                    ({ begin, end }) => (
+                    ))}
+
+                  {warnings &&
+                    Object.values(warnings.invalidCombinationWarnings).map(
+                      ({ powerRestrictionCode, electrification, begin, end }) => (
+                        <span key={`${powerRestrictionCode}-${begin}-${end}`}>
+                          {t('warningMessages.powerRestrictionInvalidCombination', {
+                            powerRestrictionCode,
+                            electrification,
+                            begin: mmToM(begin),
+                            end: mmToM(end),
+                          })}
+                        </span>
+                      )
+                    )}
+                  {warnings &&
+                    warnings.missingPowerRestrictionWarnings.map(({ begin, end }) => (
                       <span key={`missing-power-restriction-${begin}-${end}`}>
                         {t('warningMessages.missingPowerRestriction', {
-                          begin,
-                          end,
+                          begin: mmToM(begin),
+                          end: mmToM(end),
                         })}
                       </span>
-                    )
-                  )}
+                    ))}
                 </div>
               </div>
             )}
             <IntervalsEditor
-              additionalData={formattedPathElectrificationRanges}
+              additionalData={compatibleVoltageRanges}
               intervalType={INTERVAL_TYPES.SELECT}
-              data={powerRestrictionRanges}
+              data={ranges}
               defaultValue={NO_POWER_RESTRICTION}
               emptyValue={NO_POWER_RESTRICTION}
               operationalPoints={electrificationChangePoints}
               selectOptions={powerRestrictionOptions}
               setData={editPowerRestrictionRanges}
+              onCut={cutPowerRestrictionRange}
+              onDelete={deletePowerRestrictionRange}
               totalLength={pathLength}
+              toolsConfig={{
+                cutTool: true,
+                deleteTool: true,
+              }}
+              disableDrag
+              onResizeFromInput={resizeSegments}
             />
           </>
         ) : (

--- a/front/src/modules/powerRestriction/helpers/__tests__/formatPowerRestrionRangesWithHandle.spec.ts
+++ b/front/src/modules/powerRestriction/helpers/__tests__/formatPowerRestrionRangesWithHandle.spec.ts
@@ -1,6 +1,6 @@
 import {
   effortCurves,
-  electrificationRangesForPowerRestrictions,
+  voltageRangesForPowerRestrictions,
   formattedPowerRestrictionRanges,
   powerRestriction,
   powerRestrictionRanges,
@@ -25,7 +25,7 @@ describe('addHandledToPowerRestrictions', () => {
   it('should properly format power restrictions ranges with handled property', () => {
     const result = addHandledToPowerRestrictions(
       powerRestrictionRanges,
-      electrificationRangesForPowerRestrictions,
+      voltageRangesForPowerRestrictions,
       effortCurves
     );
 

--- a/front/src/modules/powerRestriction/helpers/__tests__/sampleData.ts
+++ b/front/src/modules/powerRestriction/helpers/__tests__/sampleData.ts
@@ -1,4 +1,3 @@
-import type { ElectrificationRangeV2 } from 'applications/operationalStudies/types';
 import type {
   EffortCurves,
   RangedValue,
@@ -471,37 +470,21 @@ export const powerRestrictionRanges: Omit<SimulationPowerRestrictionRange, 'hand
   },
 ];
 
-export const electrificationRangesForPowerRestrictions: ElectrificationRangeV2[] = [
+export const voltageRangesForPowerRestrictions: RangedValue[] = [
   {
-    start: 0,
-    stop: 2,
-    electrificationUsage: {
-      type: 'electrification',
-      voltage: '1500V',
-      electrical_profile_type: 'profile',
-      profile: 'O',
-      handled: true,
-    },
+    begin: 0,
+    end: 2000,
+    value: '1500V',
   },
   {
-    start: 2,
-    stop: 3,
-    electrificationUsage: {
-      lower_pantograph: true,
-      type: 'neutral_section',
-      electrical_profile_type: 'no_profile',
-    },
+    begin: 2000,
+    end: 3000,
+    value: '',
   },
   {
-    start: 3,
-    stop: 4,
-    electrificationUsage: {
-      type: 'electrification',
-      voltage: '25000V',
-      electrical_profile_type: 'profile',
-      profile: '25000V',
-      handled: true,
-    },
+    begin: 3000,
+    end: 4000,
+    value: '25000V',
   },
 ];
 

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -1,0 +1,135 @@
+import nextId from 'react-id-generator';
+
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import type { TrackRange } from 'common/api/osrdEditoastApi';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import type { PathStep } from 'reducers/osrdconf/types';
+import { getPointCoordinates } from 'utils/geometry';
+import { mToKm, mToMm } from 'utils/physics';
+
+import { NO_POWER_RESTRICTION } from '../consts';
+
+const findTrackSectionIndex = (position: number, tracksLengthCumulativeSums: number[]) => {
+  for (let i = 0; i < tracksLengthCumulativeSums.length; i += 1) {
+    if (position <= tracksLengthCumulativeSums[i]) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const findTrackSection = (
+  position: number, // in mm
+  tracksLengthCumulativeSums: number[],
+  pathProperties: ManageTrainSchedulePathProperties
+) => {
+  const index = findTrackSectionIndex(position, tracksLengthCumulativeSums);
+  return index !== -1 ? pathProperties.trackSectionRanges[index] : null;
+};
+
+const calculateOffset = (
+  trackSectionRange: TrackRange,
+  position: number, // in mm
+  tracksLengthCumulativeSums: number[] // in meters
+) => {
+  const index = findTrackSectionIndex(position, tracksLengthCumulativeSums);
+  const inferiorSum = tracksLengthCumulativeSums[index];
+  return trackSectionRange.direction === 'START_TO_STOP'
+    ? inferiorSum - position
+    : position - inferiorSum;
+};
+
+const createPathStep = (
+  positionOnPathInM: number, // in meters
+  tracksLengthCumulativeSums: number[],
+  pathProperties: ManageTrainSchedulePathProperties,
+  pathSteps: PathStep[]
+): PathStep | undefined => {
+  const positionOnPath = mToMm(positionOnPathInM);
+  if (
+    positionOnPath === 0 ||
+    new Set(pathSteps.map((step) => step?.positionOnPath)).has(positionOnPath)
+  )
+    return undefined;
+
+  const trackSectionRange = findTrackSection(
+    positionOnPath,
+    tracksLengthCumulativeSums,
+    pathProperties
+  );
+  if (!trackSectionRange) return undefined;
+
+  const offset = calculateOffset(trackSectionRange, positionOnPath, tracksLengthCumulativeSums);
+
+  const coordinates = getPointCoordinates(
+    pathProperties.geometry,
+    pathProperties.length,
+    positionOnPath
+  );
+
+  return {
+    id: nextId(),
+    positionOnPath,
+    coordinates,
+    track: trackSectionRange.track_section,
+    offset: mToKm(offset),
+  };
+};
+
+export const createCutAtPathStep = (
+  cutAtPositionInM: number,
+  pathProperties: ManageTrainSchedulePathProperties,
+  rangesData: IntervalItem[],
+  cutPositions: number[],
+  tracksLengthCumulativeSums: number[],
+  setCutPositions: (newCutPosition: number[]) => void
+): PathStep | null => {
+  const intervalCut = rangesData.find(
+    (interval) => interval.begin <= cutAtPositionInM && interval.end >= cutAtPositionInM
+  );
+
+  if (!intervalCut || intervalCut.value === NO_POWER_RESTRICTION) {
+    const newCutPositions = !cutPositions.length
+      ? [cutAtPositionInM]
+      : cutPositions.flatMap((position, index) => {
+          if (position > cutAtPositionInM) {
+            return [cutAtPositionInM, position];
+          }
+          if (index === cutPositions.length - 1) {
+            return [position, cutAtPositionInM];
+          }
+          return [position];
+        });
+    setCutPositions(newCutPositions);
+    return null;
+  }
+
+  const cutAtPosition = mToMm(cutAtPositionInM);
+  const trackSectionRangeAtCut = findTrackSection(
+    cutAtPosition,
+    tracksLengthCumulativeSums,
+    pathProperties
+  );
+
+  if (!trackSectionRangeAtCut) return null;
+
+  const offsetAtCut = calculateOffset(
+    trackSectionRangeAtCut,
+    cutAtPosition,
+    tracksLengthCumulativeSums
+  );
+  const coordinatesAtCut = getPointCoordinates(
+    pathProperties.geometry,
+    pathProperties.length,
+    cutAtPosition
+  );
+  return {
+    id: nextId(),
+    positionOnPath: cutAtPosition,
+    coordinates: coordinatesAtCut,
+    track: trackSectionRangeAtCut.track_section,
+    offset: offsetAtCut,
+  };
+};
+
+export default createPathStep;

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictions.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictions.ts
@@ -1,0 +1,93 @@
+import { isEmpty, keyBy, sortBy } from 'lodash';
+
+import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import type { PathStep } from 'reducers/osrdconf/types';
+import { mmToM } from 'utils/physics';
+
+const addNoPowerRestrictions = (
+  acc: IntervalItem[],
+  from: number,
+  to: number,
+  changePoints: number[]
+): void => {
+  if (changePoints.length === 0) {
+    acc.push({ begin: from, end: to, value: 'NO_POWER_RESTRICTION' });
+    return;
+  }
+
+  changePoints.forEach((changePoint, idx) => {
+    if (idx === 0) {
+      acc.push({ begin: from, end: changePoint, value: 'NO_POWER_RESTRICTION' });
+    }
+    acc.push({
+      begin: changePoint,
+      end: idx === changePoints.length - 1 ? to : changePoints[idx + 1],
+      value: 'NO_POWER_RESTRICTION',
+    });
+  });
+};
+
+const appendFinalNoPowerRestriction = (
+  ranges: IntervalItem[],
+  pathLength: number,
+  electrificationChangePoints: number[]
+): void => {
+  const lastEnd = ranges.length ? ranges[ranges.length - 1].end : 0;
+  if (lastEnd < pathLength) {
+    const finalChangePoints = electrificationChangePoints.filter((cp) => cp > lastEnd);
+    if (finalChangePoints.length > 0) {
+      addNoPowerRestrictions(ranges, lastEnd, pathLength, finalChangePoints);
+    } else {
+      ranges.push({ begin: lastEnd, end: pathLength, value: 'NO_POWER_RESTRICTION' });
+    }
+  }
+};
+
+const reducePowerRestrictions =
+  (pathStepById: Record<string, PathStep>, electrificationChangePoints: number[]) =>
+  (acc: IntervalItem[], restriction: PowerRestrictionV2, index: number): IntervalItem[] => {
+    const fromPathStep = pathStepById[restriction.from];
+    const toPathStep = pathStepById[restriction.to];
+    const from =
+      fromPathStep?.positionOnPath !== undefined ? mmToM(fromPathStep?.positionOnPath) : undefined;
+    const to = toPathStep?.positionOnPath ? mmToM(toPathStep?.positionOnPath) : undefined;
+    const prevEnd = isEmpty(acc) ? 0 : acc[acc.length - 1].end;
+
+    if (from !== undefined && to !== undefined) {
+      if (index === 0 || from > prevEnd) {
+        const gapChangePoints = electrificationChangePoints.filter(
+          (cp) => cp > prevEnd && cp < from
+        );
+        if (gapChangePoints.length > 0) {
+          addNoPowerRestrictions(acc, prevEnd, from, gapChangePoints);
+        } else {
+          acc.push({ begin: prevEnd, end: from, value: 'NO_POWER_RESTRICTION' });
+        }
+      }
+      acc.push({ begin: from, end: to, value: restriction.value });
+    }
+    return acc;
+  };
+
+const formatPowerRestrictions = (
+  powerRestrictionRanges: PowerRestrictionV2[],
+  changePoints: number[],
+  pathSteps: PathStep[],
+  pathLength: number
+): IntervalItem[] => {
+  const pathStepById = keyBy(pathSteps, 'id');
+  const electrificationChangePoints = sortBy(changePoints, (position) => position);
+  const formattedPowerRestrictionRanges = powerRestrictionRanges.reduce(
+    reducePowerRestrictions(pathStepById, electrificationChangePoints),
+    [] as IntervalItem[]
+  );
+  appendFinalNoPowerRestriction(
+    formattedPowerRestrictionRanges,
+    pathLength,
+    electrificationChangePoints
+  );
+  return formattedPowerRestrictionRanges;
+};
+
+export default formatPowerRestrictions;

--- a/front/src/modules/powerRestriction/helpers/getRestrictionsToResize.ts
+++ b/front/src/modules/powerRestriction/helpers/getRestrictionsToResize.ts
@@ -1,0 +1,103 @@
+import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import type { PathStep } from 'reducers/osrdconf/types';
+
+import { getPathStep } from './utils';
+import { NO_POWER_RESTRICTION } from '../consts';
+
+const getPowerRestrictionFromRange = (
+  pathSteps: PathStep[],
+  powerRestrictionRanges: PowerRestrictionV2[],
+  rangeData: IntervalItem
+): PowerRestrictionV2 | null => {
+  const fromPathStep = getPathStep(pathSteps, rangeData.begin);
+  const toPathStep = getPathStep(pathSteps, rangeData.end);
+
+  if (!fromPathStep || !toPathStep) return null;
+
+  const powerRestrictionRange = powerRestrictionRanges.find(
+    (restriction) => restriction.from === fromPathStep.id && restriction.to === toPathStep.id
+  );
+  return powerRestrictionRange || null;
+};
+
+/**
+ * Given the new position of the modified extremity, return the powerRestrictions to update
+ */
+const getPowerRestrictionsToUpdate = (
+  pathSteps: PathStep[],
+  powerRestrictionRanges: PowerRestrictionV2[],
+  ranges: IntervalItem[],
+  position: number,
+  selectedRangeIndex: number
+) => {
+  const selectedRange = ranges[selectedRangeIndex];
+  const selectedRestriction = getPowerRestrictionFromRange(
+    pathSteps,
+    powerRestrictionRanges,
+    selectedRange
+  );
+  if (!selectedRestriction) return null;
+
+  const otherRangeIndex = ranges.findIndex(
+    (range) => range.begin <= position && position <= range.end
+  );
+
+  const otherRange = otherRangeIndex !== selectedRangeIndex ? ranges[otherRangeIndex] : undefined;
+
+  if (!otherRange || otherRange.value === NO_POWER_RESTRICTION)
+    return { selectedRange, selectedRestriction };
+
+  const otherRestriction = getPowerRestrictionFromRange(
+    pathSteps,
+    powerRestrictionRanges,
+    otherRange
+  );
+  return { selectedRange, selectedRestriction, otherRange, otherRestriction };
+};
+
+const getRestrictionsToResize = (
+  ranges: IntervalItem[],
+  selectedRangeIndex: number,
+  context: 'begin' | 'end',
+  newPosition: number,
+  pathSteps: PathStep[],
+  powerRestrictionRanges: PowerRestrictionV2[]
+) => {
+  const result = getPowerRestrictionsToUpdate(
+    pathSteps,
+    powerRestrictionRanges,
+    ranges,
+    newPosition,
+    selectedRangeIndex
+  );
+  if (!result) return null;
+
+  const { selectedRange, selectedRestriction, otherRange, otherRestriction } = result;
+
+  let firstRestriction: PowerRestrictionV2 | undefined;
+  let secondRestriction: PowerRestrictionV2 | undefined;
+  if (context === 'begin') {
+    // default hypothesis: the begin was decremented
+    firstRestriction = otherRestriction || undefined;
+    secondRestriction = selectedRestriction;
+
+    if (otherRange && otherRestriction && otherRange.begin > selectedRange.begin) {
+      firstRestriction = selectedRestriction;
+      secondRestriction = otherRestriction;
+    }
+  } else {
+    // default hypothesis: the end was incremented
+    firstRestriction = selectedRestriction;
+    secondRestriction = otherRestriction || undefined;
+
+    if (otherRange && otherRestriction && otherRange.begin < selectedRange.begin) {
+      firstRestriction = otherRestriction;
+      secondRestriction = selectedRestriction;
+    }
+  }
+
+  return { firstRestriction, secondRestriction };
+};
+
+export default getRestrictionsToResize;

--- a/front/src/modules/powerRestriction/helpers/utils.ts
+++ b/front/src/modules/powerRestriction/helpers/utils.ts
@@ -1,0 +1,44 @@
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import type { PathStep } from 'reducers/osrdconf/types';
+import { mToMm } from 'utils/physics';
+
+import createPathStep from './createPathStep';
+
+/** Get pathStep located at the given position on path (in meters), if it exists. */
+export const getPathStep = (pathSteps: PathStep[], positionInM: number) =>
+  pathSteps.find((step) => step.positionOnPath === mToMm(positionInM));
+
+export const getOrCreatePathStepAtPosition = (
+  positionOnPathInM: number,
+  pathSteps: PathStep[],
+  tracksLengthCumulativeSums: number[],
+  pathProperties: ManageTrainSchedulePathProperties
+) => {
+  const pathStep = getPathStep(pathSteps, positionOnPathInM);
+  if (pathStep) {
+    return pathStep;
+  }
+  return createPathStep(positionOnPathInM, tracksLengthCumulativeSums, pathProperties, pathSteps);
+};
+
+export const extractPathStepsFromRange = (
+  range: IntervalItem,
+  pathSteps: PathStep[],
+  tracksLengthCumulativeSums: number[],
+  pathProperties: ManageTrainSchedulePathProperties
+) => {
+  const from = getOrCreatePathStepAtPosition(
+    range.begin,
+    pathSteps,
+    tracksLengthCumulativeSums,
+    pathProperties
+  );
+  const to = getOrCreatePathStepAtPosition(
+    range.end,
+    pathSteps,
+    tracksLengthCumulativeSums,
+    pathProperties
+  );
+  return { from, to };
+};

--- a/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
+++ b/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
@@ -1,0 +1,167 @@
+import { useMemo } from 'react';
+
+import type {
+  ManageTrainSchedulePathProperties,
+  PowerRestrictionV2,
+} from 'applications/operationalStudies/types';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import { useOsrdConfActions } from 'common/osrdContext';
+import { createCutAtPathStep } from 'modules/powerRestriction/helpers/createPathStep';
+import type { OperationalStudiesConfSliceActions } from 'reducers/osrdconf/operationalStudiesConf';
+import type { PathStep } from 'reducers/osrdconf/types';
+import { useAppDispatch } from 'store';
+
+import { NO_POWER_RESTRICTION } from '../consts';
+import getRestrictionsToResize from '../helpers/getRestrictionsToResize';
+import {
+  extractPathStepsFromRange,
+  getOrCreatePathStepAtPosition,
+  getPathStep,
+} from '../helpers/utils';
+
+type UsePowerRestrictionSelectorBehavioursArgs = {
+  ranges: IntervalItem[];
+  cutPositions: number[];
+  pathProperties: ManageTrainSchedulePathProperties;
+  pathSteps: PathStep[];
+  powerRestrictionRanges: PowerRestrictionV2[];
+  setCutPositions: (newCutPosition: number[]) => void;
+};
+
+const usePowerRestrictionSelectorBehaviours = ({
+  cutPositions,
+  pathProperties,
+  pathSteps,
+  powerRestrictionRanges,
+  ranges,
+  setCutPositions,
+}: UsePowerRestrictionSelectorBehavioursArgs) => {
+  const dispatch = useAppDispatch();
+
+  const {
+    upsertPowerRestrictionRangesV2,
+    cutPowerRestrictionRangesV2,
+    deletePowerRestrictionRangesV2,
+    resizeSegmentEndInput,
+    resizeSegmentBeginInput,
+  } = useOsrdConfActions() as OperationalStudiesConfSliceActions;
+
+  /** Cumulative sums of the trackSections' length on path (in meters) */
+  const tracksLengthCumulativeSums = useMemo(
+    () =>
+      pathProperties.trackSectionRanges.reduce((acc, range, index) => {
+        const rangeLength = range.end - range.begin;
+        if (index === 0) {
+          acc.push(rangeLength);
+        } else {
+          acc.push(acc[acc.length - 1] + rangeLength);
+        }
+        return acc;
+      }, [] as number[]),
+    [pathProperties.trackSectionRanges]
+  );
+
+  const editPowerRestrictionRanges = (
+    newPowerRestrictionRanges: IntervalItem[],
+    selectedIntervalIndex?: number
+  ) => {
+    if (selectedIntervalIndex === undefined) return;
+
+    const newRange = newPowerRestrictionRanges[selectedIntervalIndex];
+    const { from, to } = extractPathStepsFromRange(
+      newRange,
+      pathSteps,
+      tracksLengthCumulativeSums,
+      pathProperties
+    );
+
+    if (from && to) {
+      if (newRange.value !== NO_POWER_RESTRICTION) {
+        dispatch(
+          upsertPowerRestrictionRangesV2({
+            from,
+            to,
+            code: newRange.value.toString(),
+          })
+        );
+      } else {
+        dispatch(deletePowerRestrictionRangesV2({ from, to }));
+      }
+    }
+  };
+
+  const cutPowerRestrictionRange = (cutAtPositionInM: number) => {
+    const cutAt = createCutAtPathStep(
+      cutAtPositionInM,
+      pathProperties,
+      ranges,
+      cutPositions,
+      tracksLengthCumulativeSums,
+      setCutPositions
+    );
+    if (cutAt) {
+      dispatch(cutPowerRestrictionRangesV2({ cutAt }));
+    }
+  };
+
+  const deletePowerRestrictionRange = (from: number, to: number) => {
+    const fromPathStep = getPathStep(pathSteps, from);
+    const toPathStep = getPathStep(pathSteps, to);
+
+    if (fromPathStep && toPathStep) {
+      dispatch(deletePowerRestrictionRangesV2({ from: fromPathStep, to: toPathStep }));
+    }
+  };
+
+  const resizeSegments = (
+    selectedRangeIndex: number,
+    context: 'begin' | 'end',
+    newPosition: number
+  ) => {
+    const result = getRestrictionsToResize(
+      ranges,
+      selectedRangeIndex,
+      context,
+      newPosition,
+      pathSteps,
+      powerRestrictionRanges
+    );
+    if (!result) return;
+    const { firstRestriction, secondRestriction } = result;
+
+    const newPathStep = getOrCreatePathStepAtPosition(
+      newPosition,
+      pathSteps,
+      tracksLengthCumulativeSums,
+      pathProperties
+    );
+    if (!newPathStep) return;
+
+    if (context === 'begin') {
+      if (secondRestriction)
+        dispatch(
+          resizeSegmentBeginInput({
+            firstRestriction,
+            secondRestriction,
+            newFromPathStep: newPathStep,
+          })
+        );
+    } else if (firstRestriction)
+      dispatch(
+        resizeSegmentEndInput({
+          firstRestriction,
+          secondRestriction,
+          newEndPathStep: newPathStep,
+        })
+      );
+  };
+
+  return {
+    resizeSegments,
+    deletePowerRestrictionRange,
+    cutPowerRestrictionRange,
+    editPowerRestrictionRanges,
+  };
+};
+
+export default usePowerRestrictionSelectorBehaviours;

--- a/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorData.ts
+++ b/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorData.ts
@@ -1,0 +1,109 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { compact } from 'lodash';
+import { useSelector } from 'react-redux';
+
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import type { RangedValue, RollingStock } from 'common/api/osrdEditoastApi';
+import type { IntervalItem } from 'common/IntervalsEditor/types';
+import { useOsrdConfSelectors } from 'common/osrdContext';
+import { mmToM } from 'utils/physics';
+
+import usePowerRestrictionSelectorBehaviours from './usePowerRestrictionSelectorBehaviours';
+import { NO_POWER_RESTRICTION } from '../consts';
+import formatPowerRestrictions from '../helpers/formatPowerRestrictions';
+import getPowerRestrictionsWarningsData from '../helpers/powerRestrictionWarnings';
+
+const usePowerRestrictionSelector = (
+  voltageRanges: RangedValue[],
+  rollingStockPowerRestrictions: RollingStock['power_restrictions'],
+  rollingStockModes: RollingStock['effort_curves']['modes'],
+  pathProperties: ManageTrainSchedulePathProperties
+) => {
+  const { getPowerRestrictionV2, getPathSteps } = useOsrdConfSelectors();
+  const powerRestrictionRanges = useSelector(getPowerRestrictionV2);
+  const pathSteps = compact(useSelector(getPathSteps));
+
+  const [cutPositions, setCutPositions] = useState<number[]>([]); // in meters
+  const [ranges, setRanges] = useState<IntervalItem[]>([]);
+
+  const electrificationChangePoints = useMemo(() => {
+    const specialPoints = voltageRanges.map((range) => ({
+      position: mmToM(range.end),
+    }));
+    specialPoints.pop();
+    return specialPoints;
+  }, [voltageRanges]);
+
+  const powerRestrictionOptions = useMemo(
+    () => [NO_POWER_RESTRICTION, ...Object.keys(rollingStockPowerRestrictions)],
+    [rollingStockPowerRestrictions]
+  );
+
+  const compatibleVoltageRanges = useMemo(() => {
+    const handledModes = Object.keys(rollingStockModes);
+    return voltageRanges.map(({ begin, end, value: mode }) => ({
+      begin,
+      end,
+      value: handledModes.includes(mode) ? mode : '',
+    }));
+  }, [voltageRanges]);
+
+  const {
+    resizeSegments,
+    deletePowerRestrictionRange,
+    cutPowerRestrictionRange,
+    editPowerRestrictionRanges,
+  } = usePowerRestrictionSelectorBehaviours({
+    cutPositions,
+    pathProperties,
+    pathSteps,
+    powerRestrictionRanges,
+    ranges,
+    setCutPositions,
+  });
+
+  const { warnings, warningsNb } = useMemo(
+    () =>
+      getPowerRestrictionsWarningsData({
+        pathSteps,
+        rollingStockPowerRestrictions,
+        pathElectrificationRanges: voltageRanges,
+        rollingStockModes,
+        powerRestrictionRanges,
+      }),
+    [
+      pathSteps,
+      rollingStockPowerRestrictions,
+      voltageRanges,
+      rollingStockModes,
+      powerRestrictionRanges,
+    ]
+  );
+
+  useEffect(() => {
+    const newRanges = formatPowerRestrictions(
+      powerRestrictionRanges,
+      [...electrificationChangePoints.map(({ position }) => position), ...cutPositions],
+      compact(pathSteps),
+      mmToM(pathProperties.length)
+    );
+    setRanges(newRanges);
+  }, [electrificationChangePoints, cutPositions, powerRestrictionRanges]);
+
+  return {
+    ranges,
+    compatibleVoltageRanges,
+    electrificationChangePoints,
+    pathLength: mmToM(pathProperties.length),
+    powerRestrictionOptions,
+    warnings,
+    warningsNb,
+    resizeSegments,
+    deletePowerRestrictionRange,
+    cutPowerRestrictionRange,
+    editPowerRestrictionRanges,
+  };
+};
+
+export default usePowerRestrictionSelector;

--- a/front/src/modules/simulationResult/components/ChartHelpers/drawPowerRestriction.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/drawPowerRestriction.ts
@@ -84,7 +84,7 @@ const drawPowerRestriction = (
     }
   };
 
-  if (!isIncompatible && isRestriction) drawZone.call(addTextZone);
+  drawZone.call(addTextZone);
 
   // create pop-up when hovering rect-profile
   drawZone

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/utils.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/utils.ts
@@ -157,7 +157,7 @@ export const createPowerRestrictionSegment = (
   // figure out if the power restriction is incompatible or missing`
   const isRestriction = powerRestrictionRange.handled;
   const isIncompatiblePowerRestriction = !!powerRestrictionRange.code;
-  const isStriped = !!powerRestrictionRange.code;
+  const isStriped = !powerRestrictionRange.code || !powerRestrictionRange.handled;
 
   const segment: PowerRestrictionSegment = {
     position_start: powerRestrictionRange.start,

--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -94,7 +94,7 @@ const TimesStops = ({ pathProperties, pathSteps = [], startTime }: TimesStopsPro
     });
     const updatedPathSteps = removeElementAtIndex(pathSteps, index);
 
-    dispatch(updatePathSteps(updatedPathSteps));
+    dispatch(updatePathSteps({ pathSteps: updatedPathSteps }));
   };
 
   return (

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify.ts
@@ -145,7 +145,7 @@ export function adjustConfWithTrainToModifyV2(
   dispatch(updateRollingStockID(rollingStockId));
   dispatch(updateName(train_name));
   dispatch(updateDepartureTime(start_time));
-  dispatch(updatePathSteps(pathSteps));
+  dispatch(updatePathSteps({ pathSteps, resetPowerRestrictions: true }));
   dispatch(updateInitialSpeed(initial_speed ? msToKmh(initial_speed) : 0));
 
   if (options?.use_electrical_profiles === usingElectricalProfiles)

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
@@ -31,6 +31,7 @@ const checkCurrentConfig = (
     initialSpeed,
     usingElectricalProfiles,
     rollingStockComfortV2,
+    powerRestrictionV2,
     startTime,
   } = osrdconf;
   let error = false;
@@ -153,9 +154,7 @@ const checkCurrentConfig = (
 
     margins: formatMargin(compact(pathSteps)),
     schedule: formatSchedule(compact(pathSteps), startTime),
-
-    // TODO TS2 : adapt this for power restrictions issue
-    // powerRestrictions: formatPowerRestrictions(pathSteps)
+    powerRestrictions: powerRestrictionV2,
     firstStartTime: startTime,
     speedLimitByTag,
   };

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatTrainSchedulePayload.ts
@@ -18,6 +18,7 @@ export default function formatTrainSchedulePayload(
     usingElectricalProfiles,
     rollingStockComfort,
     margins,
+    powerRestrictions,
   } = validConfig;
 
   return {
@@ -30,10 +31,8 @@ export default function formatTrainSchedulePayload(
       use_electrical_profiles: usingElectricalProfiles,
     },
     path,
-    // TODO TS2 : handle power restrictions
-    // power_restrictions: validConfig.powerRestrictions,
+    power_restrictions: powerRestrictions,
     rolling_stock_name: rollingStockName,
-    // TODO TS2 : handle handle margins
     schedule: validConfig.schedule,
     speed_limit_tag: speedLimitByTag,
     start_time: startTime,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/types.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/types.ts
@@ -53,10 +53,9 @@ export type ValidConfig = {
   initialSpeed: number;
   usingElectricalProfiles: boolean;
   path: TrainScheduleBase['path'];
-  // TODO TS2 : adapt this for times and stops / power restrictions issues
   margins: TrainScheduleBase['margins'];
   schedule: TrainScheduleBase['schedule'];
-  // powerRestrictions: TrainScheduleBase['power_restrictions']
+  powerRestrictions?: TrainScheduleBase['power_restrictions'];
   firstStartTime: string;
   speedLimitByTag?: string;
 };

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -3,6 +3,8 @@ import { createSlice } from '@reduxjs/toolkit';
 import { defaultCommonConf, buildCommonConfReducers } from 'reducers/osrdconf/osrdConfCommon';
 import type { OsrdConfState } from 'reducers/osrdconf/types';
 
+import { builPowerRestrictionReducer } from './powerRestrictionReducer';
+
 export type OperationalStudiesConfState = OsrdConfState;
 
 export const operationalStudiesConfSlice = createSlice({
@@ -10,6 +12,7 @@ export const operationalStudiesConfSlice = createSlice({
   initialState: defaultCommonConf,
   reducers: {
     ...buildCommonConfReducers<OperationalStudiesConfState>(),
+    ...builPowerRestrictionReducer<OperationalStudiesConfState>(),
   },
 });
 

--- a/front/src/reducers/osrdconf/operationalStudiesConf/powerRestrictionReducer.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/powerRestrictionReducer.ts
@@ -1,0 +1,242 @@
+import type { CaseReducer, PayloadAction } from '@reduxjs/toolkit';
+import type { Draft } from 'immer';
+import { compact, isEqual, keyBy, sortBy } from 'lodash';
+
+import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
+import { NO_POWER_RESTRICTION } from 'modules/powerRestriction/consts';
+import type { OsrdConfState, PathStep } from 'reducers/osrdconf/types';
+import { addElementAtIndex } from 'utils/array';
+
+import { addPathStep, cleanPathSteps, isRangeCovered, updateRestrictions } from './utils';
+
+export type PowerRestrictionReducer<S extends OsrdConfState> = {
+  ['upsertPowerRestrictionRangesV2']: CaseReducer<
+    S,
+    PayloadAction<{ from: PathStep; to: PathStep; code: string }>
+  >;
+  ['cutPowerRestrictionRangesV2']: CaseReducer<S, PayloadAction<{ cutAt: PathStep }>>;
+  ['deletePowerRestrictionRangesV2']: CaseReducer<
+    S,
+    PayloadAction<{ from: PathStep; to: PathStep }>
+  >;
+  ['resizeSegmentEndInput']: CaseReducer<
+    S,
+    PayloadAction<{
+      firstRestriction: PowerRestrictionV2;
+      secondRestriction?: PowerRestrictionV2;
+      newEndPathStep: PathStep;
+    }>
+  >;
+  ['resizeSegmentBeginInput']: CaseReducer<
+    S,
+    PayloadAction<{
+      firstRestriction?: PowerRestrictionV2;
+      secondRestriction: PowerRestrictionV2;
+      newFromPathStep: PathStep;
+    }>
+  >;
+  ['resetPowerRestrictionRangesV2']: CaseReducer<S>;
+};
+
+export function builPowerRestrictionReducer<S extends OsrdConfState>(): PowerRestrictionReducer<S> {
+  return {
+    upsertPowerRestrictionRangesV2(
+      state: Draft<S>,
+      action: PayloadAction<{ from: PathStep; to: PathStep; code: string }>
+    ) {
+      const { from, to, code } = action.payload;
+      let newPathSteps = compact(state.pathSteps);
+      let newPowerRestrictionRangesV2 = state.powerRestrictionV2.filter(
+        (restriction) => restriction.from !== from.id && restriction.to !== to.id
+      );
+
+      // add new pathSteps
+      newPathSteps = addPathStep(newPathSteps, from);
+      newPathSteps = addPathStep(newPathSteps, to);
+
+      const newPathStepsById = keyBy(newPathSteps, 'id');
+
+      // update power restriction ranges
+      if (code !== NO_POWER_RESTRICTION) {
+        newPowerRestrictionRangesV2.push({ from: from.id, to: to.id, value: code });
+        newPowerRestrictionRangesV2 = sortBy(
+          newPowerRestrictionRangesV2,
+          (range) => newPathStepsById[range.from]?.positionOnPath
+        );
+      }
+
+      state.pathSteps = newPathSteps;
+      state.powerRestrictionV2 = newPowerRestrictionRangesV2;
+    },
+
+    cutPowerRestrictionRangesV2(state: Draft<S>, action: PayloadAction<{ cutAt: PathStep }>) {
+      const { cutAt } = action.payload;
+      let newPathSteps = [...state.pathSteps];
+
+      const pathIds = compact(state.pathSteps).map((step) => step.id);
+
+      if (!pathIds.includes(cutAt.id)) {
+        const cutAtIndex = newPathSteps.findIndex(
+          (step) => step?.positionOnPath && step.positionOnPath > cutAt.positionOnPath!
+        );
+
+        if (cutAtIndex === -1) return;
+
+        // add the new pathStep at the right index
+        newPathSteps = addElementAtIndex(newPathSteps, cutAtIndex, cutAt);
+
+        const prevStep = newPathSteps[cutAtIndex - 1];
+        const nextStep = newPathSteps[cutAtIndex + 1];
+
+        if (!prevStep || !nextStep) {
+          console.error('cutPowerRestrictionRangesV2: prevStep or nextStep is undefined');
+        } else {
+          // update the power restriction ranges by splitting 1 range into 2
+          const newPowerRestrictionRangesV2 = state.powerRestrictionV2.reduce(
+            (acc, powerRestriction) => {
+              if (powerRestriction.from === prevStep.id) {
+                acc.push({
+                  ...powerRestriction,
+                  to: cutAt.id,
+                });
+                acc.push({
+                  ...powerRestriction,
+                  from: cutAt.id,
+                  to: nextStep.id,
+                });
+              } else {
+                acc.push(powerRestriction);
+              }
+              return acc;
+            },
+            [] as PowerRestrictionV2[]
+          );
+
+          state.pathSteps = newPathSteps;
+          state.powerRestrictionV2 = newPowerRestrictionRangesV2;
+        }
+      }
+    },
+
+    deletePowerRestrictionRangesV2(
+      state: Draft<S>,
+      action: PayloadAction<{ from: PathStep; to: PathStep }>
+    ) {
+      const { from, to } = action.payload;
+
+      const newPowerRestrictionRanges = state.powerRestrictionV2.filter(
+        (restriction) => restriction.from !== from.id && restriction.to !== to.id
+      );
+
+      const newPathSteps = [...state.pathSteps] as PathStep[];
+      state.pathSteps = cleanPathSteps(newPathSteps, newPowerRestrictionRanges);
+      state.powerRestrictionV2 = newPowerRestrictionRanges;
+    },
+
+    resizeSegmentBeginInput(
+      state: Draft<S>,
+      action: PayloadAction<{
+        firstRestriction?: PowerRestrictionV2;
+        secondRestriction: PowerRestrictionV2;
+        newFromPathStep: PathStep;
+      }>
+    ) {
+      const { firstRestriction, secondRestriction, newFromPathStep } = action.payload;
+
+      // pathSteps should not be undefined or have null values
+      if (state.pathSteps && !state.pathSteps.some((pathStep) => !pathStep)) {
+        let newPathSteps = [...state.pathSteps] as PathStep[];
+        let newPowerRestrictionRanges = state.powerRestrictionV2.filter(
+          (restriction) =>
+            !isEqual(restriction, firstRestriction) || !isEqual(restriction, secondRestriction)
+        );
+
+        // find the covered ranges
+        const pathStepEnd = newPathSteps.find((pathStep) => pathStep.id === secondRestriction.to);
+        const coveredRanges = pathStepEnd
+          ? newPowerRestrictionRanges.filter((restriction) =>
+              isRangeCovered(
+                newPathSteps,
+                restriction,
+                newFromPathStep.positionOnPath,
+                pathStepEnd.positionOnPath
+              )
+            )
+          : [];
+
+        // add the new pathStep
+        newPathSteps = addPathStep(newPathSteps, newFromPathStep);
+
+        // update the power restriction ranges
+        newPowerRestrictionRanges = updateRestrictions(
+          newPowerRestrictionRanges,
+          firstRestriction,
+          secondRestriction,
+          newFromPathStep.id,
+          coveredRanges
+        );
+
+        // clean pathSteps
+        newPathSteps = cleanPathSteps(newPathSteps, newPowerRestrictionRanges);
+
+        state.pathSteps = newPathSteps;
+        state.powerRestrictionV2 = newPowerRestrictionRanges;
+      }
+    },
+    resizeSegmentEndInput(
+      state: Draft<S>,
+      action: PayloadAction<{
+        firstRestriction: PowerRestrictionV2;
+        secondRestriction?: PowerRestrictionV2;
+        newEndPathStep: PathStep;
+      }>
+    ) {
+      const { firstRestriction, secondRestriction, newEndPathStep } = action.payload;
+
+      // pathSteps should not be undefined or have null values
+      if (state.pathSteps && !state.pathSteps.some((pathStep) => !pathStep)) {
+        let newPathSteps = [...state.pathSteps] as PathStep[];
+        let newPowerRestrictionRanges = state.powerRestrictionV2.filter(
+          (restriction) =>
+            !isEqual(restriction, firstRestriction) || !isEqual(restriction, secondRestriction)
+        );
+        const pathStepBegin = newPathSteps.find(
+          (pathStep) => pathStep.id === firstRestriction.from
+        );
+
+        // find the covered ranges
+        const coveredRanges = pathStepBegin
+          ? newPowerRestrictionRanges.filter((restriction) =>
+              isRangeCovered(
+                newPathSteps,
+                restriction,
+                pathStepBegin.positionOnPath,
+                newEndPathStep.positionOnPath
+              )
+            )
+          : [];
+
+        // add the new pathStep
+        newPathSteps = addPathStep(newPathSteps, newEndPathStep);
+
+        // update the power restriction ranges
+        newPowerRestrictionRanges = updateRestrictions(
+          newPowerRestrictionRanges,
+          firstRestriction,
+          secondRestriction,
+          newEndPathStep.id,
+          coveredRanges
+        );
+
+        // clean pathSteps
+        newPathSteps = cleanPathSteps(newPathSteps, newPowerRestrictionRanges);
+
+        state.pathSteps = newPathSteps;
+        state.powerRestrictionV2 = newPowerRestrictionRanges;
+      }
+    },
+    resetPowerRestrictionRangesV2(state: Draft<S>) {
+      state.powerRestrictionV2 = [];
+    },
+  };
+}

--- a/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
@@ -1,0 +1,110 @@
+import { compact } from 'lodash';
+
+import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
+import { addElementAtIndex } from 'utils/array';
+
+import type { PathStep } from '../types';
+
+/**
+ * Check if a pathStep can be removed.
+ *
+ * It cannot be removed if it is used in at least one power restriction range, if it is locked or has an arrival time,
+ * a stop duration or a margin.
+ */
+export const canRemovePathStep = (
+  pathStep: PathStep,
+  powerRestrictionRanges: PowerRestrictionV2[]
+) => {
+  const pathStepIsUsed = powerRestrictionRanges.some(
+    (restriction) => restriction.from === pathStep.id || restriction.to === pathStep.id
+  );
+  return (
+    !pathStepIsUsed &&
+    !pathStep.locked &&
+    !pathStep.arrival &&
+    !pathStep.stopFor &&
+    !pathStep.theoreticalMargin
+  );
+};
+
+/** Remove some restrictions and update the first and second restrictions with the new path step */
+export const updateRestrictions = (
+  restrictions: PowerRestrictionV2[],
+  firstRestriction: PowerRestrictionV2 | undefined,
+  secondRestriction: PowerRestrictionV2 | undefined,
+  newPathStepId: string,
+  restrictionsToRemove: PowerRestrictionV2[] = []
+): PowerRestrictionV2[] =>
+  compact(
+    restrictions.map((restriction) => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const restrictionToRemove of restrictionsToRemove) {
+        if (
+          restriction.from === restrictionToRemove.from &&
+          restriction.to === restrictionToRemove.to
+        ) {
+          return undefined;
+        }
+      }
+
+      if (restriction.to === firstRestriction?.to) {
+        return { ...restriction, to: newPathStepId };
+      }
+      if (restriction.from === secondRestriction?.from) {
+        return { ...restriction, from: newPathStepId };
+      }
+      return restriction;
+    })
+  );
+
+export const isRangeCovered = (
+  pathSteps: PathStep[],
+  powerRestrictionRange: PowerRestrictionV2,
+  positionMin: number | undefined,
+  positionMax: number | undefined
+): boolean => {
+  const pathStepFrom = pathSteps.find((pathStep) => pathStep.id === powerRestrictionRange.from);
+  const pathStepTo = pathSteps.find((pathStep) => pathStep.id === powerRestrictionRange.to);
+
+  if (
+    pathStepFrom?.positionOnPath === undefined ||
+    pathStepTo?.positionOnPath === undefined ||
+    positionMin === undefined ||
+    positionMax === undefined
+  ) {
+    return false;
+  }
+
+  return positionMin < pathStepFrom.positionOnPath && pathStepTo.positionOnPath < positionMax;
+};
+
+export const addPathStep = (pathSteps: PathStep[], newPathStep: PathStep): PathStep[] => {
+  const newPathStepExists = pathSteps.some((pathStep) => pathStep.id === newPathStep.id);
+  if (!newPathStepExists) {
+    const index = pathSteps.findIndex(
+      (step) => step.positionOnPath && step.positionOnPath > newPathStep.positionOnPath!
+    );
+    return addElementAtIndex(pathSteps, index, newPathStep);
+  }
+
+  return pathSteps;
+};
+
+/** Remove the unused path steps */
+export const cleanPathSteps = (
+  pathSteps: PathStep[],
+  powerRestrictions: PowerRestrictionV2[]
+): PathStep[] =>
+  pathSteps.reduce((acc, pathStep, index) => {
+    if (index === 0 || index === pathSteps.length - 1) {
+      acc.push(pathStep);
+      return acc;
+    }
+
+    if (canRemovePathStep(pathStep, powerRestrictions)) {
+      return acc;
+    }
+
+    acc.push(pathStep);
+    return acc;
+  }, [] as PathStep[]);

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
@@ -225,6 +225,7 @@ export default function commonConfBuilder() {
       suggestedOperationalPoints: [],
       allWaypoints: [],
       length: 1169926000,
+      trackSectionRanges: [],
     }),
   };
 }

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
@@ -625,7 +625,7 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
 
   it('should handle updatePathSteps', () => {
     const pathSteps = testDataBuilder.buildPathSteps();
-    defaultStore.dispatch(slice.actions.updatePathSteps(pathSteps));
+    defaultStore.dispatch(slice.actions.updatePathSteps({ pathSteps }));
     const state = defaultStore.getState()[slice.name];
     expect(state.pathSteps).toEqual(pathSteps);
   });

--- a/front/src/reducers/osrdconf/osrdConfCommon/index.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/index.ts
@@ -38,6 +38,7 @@ export const defaultCommonConf: OsrdConfState = {
   rollingStockID: undefined,
   rollingStockComfort: 'STANDARD' as const,
   powerRestrictionRanges: [],
+  powerRestrictionV2: [],
   speedLimitByTag: undefined,
   origin: undefined,
   initialSpeed: 0,
@@ -113,7 +114,10 @@ interface CommonConfReducers<S extends OsrdConfState> extends InfraStateReducers
   ['updatePowerRestrictionRanges']: CaseReducer<S, PayloadAction<S['powerRestrictionRanges']>>;
   ['updateTrainScheduleIDsToModify']: CaseReducer<S, PayloadAction<S['trainScheduleIDsToModify']>>;
   ['updateFeatureInfoClick']: CaseReducer<S, PayloadAction<S['featureInfoClick']>>;
-  ['updatePathSteps']: CaseReducer<S, PayloadAction<S['pathSteps']>>;
+  ['updatePathSteps']: CaseReducer<
+    S,
+    PayloadAction<{ pathSteps: S['pathSteps']; resetPowerRestrictions?: boolean }>
+  >;
   ['updateOriginV2']: CaseReducer<S, PayloadAction<ArrayElement<S['pathSteps']>>>;
   ['updateDestinationV2']: CaseReducer<S, PayloadAction<ArrayElement<S['pathSteps']>>>;
   ['deleteItineraryV2']: CaseReducer<S>;
@@ -348,8 +352,14 @@ export function buildCommonConfReducers<S extends OsrdConfState>(): CommonConfRe
       const feature = omit(action.payload.feature, ['_vectorTileFeature']);
       state.featureInfoClick = { ...action.payload, feature };
     },
-    updatePathSteps(state: Draft<S>, action: PayloadAction<S['pathSteps']>) {
-      state.pathSteps = action.payload;
+    updatePathSteps(
+      state: Draft<S>,
+      action: PayloadAction<{ pathSteps: S['pathSteps']; resetPowerRestrictions?: boolean }>
+    ) {
+      state.pathSteps = action.payload.pathSteps;
+      if (action.payload.resetPowerRestrictions) {
+        state.powerRestrictionV2 = [];
+      }
     },
     updateOriginV2(state: Draft<S>, action: PayloadAction<ArrayElement<S['pathSteps']>>) {
       state.pathSteps = replaceElementAtIndex(state.pathSteps, 0, action.payload);

--- a/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
@@ -60,6 +60,7 @@ const buildCommonConfSelectors = <ConfState extends OsrdConfState>(
     getGridMarginBefore: makeOsrdConfSelector('gridMarginBefore'),
     getGridMarginAfter: makeOsrdConfSelector('gridMarginAfter'),
     getPowerRestrictionRanges: makeOsrdConfSelector('powerRestrictionRanges'),
+    getPowerRestrictionV2: makeOsrdConfSelector('powerRestrictionV2'),
     getTrainScheduleIDsToModify: makeOsrdConfSelector('trainScheduleIDsToModify'),
     getFeatureInfoClick: makeOsrdConfSelector('featureInfoClick'),
     getPathSteps,

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -1,6 +1,7 @@
 import type { Feature, Position } from 'geojson';
 
 import type { PowerRestrictionRange, PointOnMap } from 'applications/operationalStudies/consts';
+import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
 import type {
   RollingStockComfortType,
   PathResponse,
@@ -31,6 +32,7 @@ export interface OsrdConfState extends InfraState {
   speedLimitByTag?: string;
   // TODO: update the call to the api, to rename the fields begin & end -> begin_position & end_position
   powerRestrictionRanges: PowerRestrictionRange[];
+  powerRestrictionV2: PowerRestrictionV2[];
   origin?: PointOnMap;
   initialSpeed?: number;
   // TODO TS2 : remove this property from store when drop v1

--- a/front/src/utils/physics.ts
+++ b/front/src/utils/physics.ts
@@ -21,6 +21,11 @@ export function mmToM(length: number) {
   return length / 1000;
 }
 
+/** Convert meters to millimeters */
+export function mToMm(length: number) {
+  return length * 1000;
+}
+
 /** Convert km/h to m/s */
 export function kmhToMs(v: number) {
   return Math.abs(v / 3.6);


### PR DESCRIPTION
closes #7025 

What does the power restriction selector do : 
- Detects the change of electrification on a path
- creates intervals with the electrification change points values

The user can : 
- Cut intervals manually (cut tool, or with the inputs)
- Select power restrictions in intervals

Once a power restriction has been selected on an interval : 
- Two pathSteps are created. One where the power restriction begins, and one at the end (calculated with the position on Path)