### PR TITLE
editoast: stdcm: add arrival time parameters

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/json/UnitJsonAdapters.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/json/UnitJsonAdapters.kt
@@ -75,7 +75,11 @@ class DurationAdapter : JsonAdapter<Duration?>() {
  */
 class DateAdapter : JsonAdapter<ZonedDateTime>() {
     @FromJson
-    override fun fromJson(reader: JsonReader): ZonedDateTime {
+    override fun fromJson(reader: JsonReader): ZonedDateTime? {
+        if (reader.peek() == JsonReader.Token.NULL) {
+            reader.skipValue()
+            return null
+        }
         return ZonedDateTime.parse(reader.nextString())
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
@@ -60,6 +60,13 @@ class STDCMRequestV2(
 class STDCMPathItem(
     val locations: List<TrackLocation>,
     @Json(name = "stop_duration") val stopDuration: Duration?,
+    @Json(name = "step_timing_data") val stepTimingData: StepTimingData?,
+)
+
+data class StepTimingData(
+    @Json(name = "arrival_time") val arrivalTime: ZonedDateTime,
+    @Json(name = "arrival_time_tolerance_before") val arrivalTimeToleranceBefore: Duration,
+    @Json(name = "arrival_time_tolerance_after") val arrivalTimeToleranceAfter: Duration,
 )
 
 class TrackOffset(val track: String, val offset: Offset<TrackSection>)

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3017,7 +3017,6 @@ paths:
               type: object
               description: An STDCM request
               required:
-              - start_time
               - steps
               - rolling_stock_id
               - comfort
@@ -3035,7 +3034,9 @@ paths:
                 maximum_departure_delay:
                   type: integer
                   format: int64
-                  description: By how long we can shift the departure time in milliseconds
+                  description: |-
+                    By how long we can shift the departure time in milliseconds
+                    Deprecated, first step data should be used instead
                   default: 432000
                   minimum: 0
                 maximum_run_time:
@@ -3054,6 +3055,8 @@ paths:
                 start_time:
                   type: string
                   format: date-time
+                  description: Deprecated, first step arrival time should be used instead
+                  nullable: true
                 steps:
                   type: array
                   items:
@@ -8549,6 +8552,10 @@ components:
           minimum: 0
         location:
           $ref: '#/components/schemas/PathItemLocation'
+        timing_data:
+          allOf:
+          - $ref: '#/components/schemas/StepTimingData'
+          nullable: true
     PathfindingOutput:
       type: object
       required:
@@ -10177,7 +10184,6 @@ components:
       type: object
       description: An STDCM request
       required:
-      - start_time
       - steps
       - rolling_stock_id
       - comfort
@@ -10195,7 +10201,9 @@ components:
         maximum_departure_delay:
           type: integer
           format: int64
-          description: By how long we can shift the departure time in milliseconds
+          description: |-
+            By how long we can shift the departure time in milliseconds
+            Deprecated, first step data should be used instead
           default: 432000
           minimum: 0
         maximum_run_time:
@@ -10214,6 +10222,8 @@ components:
         start_time:
           type: string
           format: date-time
+          description: Deprecated, first step arrival time should be used instead
+          nullable: true
         steps:
           type: array
           items:
@@ -11487,6 +11497,27 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RangeAllowance'
+    StepTimingData:
+      type: object
+      required:
+      - arrival_time
+      - arrival_time_tolerance_before
+      - arrival_time_tolerance_after
+      properties:
+        arrival_time:
+          type: string
+          format: date-time
+          description: Time at which the train should arrive at the location
+        arrival_time_tolerance_after:
+          type: integer
+          format: int64
+          description: The train may arrive up to this duration after the expected arrival time
+          minimum: 0
+        arrival_time_tolerance_before:
+          type: integer
+          format: int64
+          description: The train may arrive up to this duration before the expected arrival time
+          minimum: 0
     Study:
       type: object
       required:

--- a/editoast/src/core/v2/stdcm.rs
+++ b/editoast/src/core/v2/stdcm.rs
@@ -64,6 +64,19 @@ pub struct STDCMPathItem {
     pub locations: Vec<TrackOffset>,
     /// Stop duration in milliseconds. None if the train does not stop at this path item.
     pub stop_duration: Option<u64>,
+    /// If specified, describes when the train may arrive at the location
+    pub step_timing_data: Option<STDCMStepTimingData>,
+}
+
+/// Contains the data of a step timing, when it is specified
+#[derive(Debug, Serialize)]
+pub struct STDCMStepTimingData {
+    /// Time the train should arrive at this point
+    pub arrival_time: DateTime<Utc>,
+    /// Tolerance for the arrival time, when it arrives before the expected time, in ms
+    pub arrival_time_tolerance_before: u64,
+    /// Tolerance for the arrival time, when it arrives after the expected time, in ms
+    pub arrival_time_tolerance_after: u64,
 }
 
 /// Lighter description of a work schedule, only contains what's relevant

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1751,14 +1751,16 @@ export type PostV2TimetableByIdStdcmApiArg = {
     comfort: Comfort;
     /** Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km` or `None` */
     margin?: string | null;
-    /** By how long we can shift the departure time in milliseconds */
+    /** By how long we can shift the departure time in milliseconds
+        Deprecated, first step data should be used instead */
     maximum_departure_delay?: number;
     /** Specifies how long the total run time can be in milliseconds */
     maximum_run_time?: number | null;
     rolling_stock_id: number;
     /** Train categories for speed limits */
     speed_limit_tags?: string | null;
-    start_time: string;
+    /** Deprecated, first step arrival time should be used instead */
+    start_time?: string | null;
     steps: PathfindingItem[];
     /** Margin after the train passage in milliseconds
         
@@ -3684,10 +3686,19 @@ export type PathItemLocation =
       /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
       uic: number;
     };
+export type StepTimingData = {
+  /** Time at which the train should arrive at the location */
+  arrival_time: string;
+  /** The train may arrive up to this duration after the expected arrival time */
+  arrival_time_tolerance_after: number;
+  /** The train may arrive up to this duration before the expected arrival time */
+  arrival_time_tolerance_before: number;
+};
 export type PathfindingItem = {
   /** The stop duration in milliseconds, None if the train does not stop. */
   duration?: number | null;
   location: PathItemLocation;
+  timing_data?: StepTimingData | null;
 };
 export type Distribution = 'STANDARD' | 'MARECO';
 export type TrainScheduleBase = {


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/7692 and https://github.com/OpenRailAssociation/osrd/issues/7687

Adds stop time parameters and forwards them from editoast inputs to core. Departure time parameter is now optional.

There's a few other changes on the editoast side to have meaningful values as start/end times despite this change. Eventually we should use them to pre-filter the resource uses (see https://github.com/OpenRailAssociation/osrd/issues/7649). 

There's one API change on which I'm not 100% sure: I've "deprecated" the departure time parameter, assuming the time of the first waypoint should be used instead. We could instead keep it but not let the user set a time for the first waypoint.

Note: the feature is not entirely supported by core yet. When the departure time is set, the behavior won't change. If it's not set, the departure time will be too early and the scheduled points will be ignored, but it won't crash. 