### PR TITLE
front: refacto stops table

### DIFF
--- a/front/src/modules/timesStops/TimeInput.tsx
+++ b/front/src/modules/timesStops/TimeInput.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
-import type { CellComponent, CellProps, Column } from 'react-datasheet-grid/dist/types';
+import type { CellProps } from 'react-datasheet-grid/dist/types';
 
-const TimeComponent = ({
+const TimeInput = ({
   focus,
   rowData,
   active,
@@ -51,15 +51,6 @@ const TimeComponent = ({
   );
 };
 
-TimeComponent.displayName = 'TimeComponent';
+TimeInput.displayName = 'TimeInput';
 
-const timeColumn: Partial<Column<string | null | undefined, string, string>> = {
-  component: TimeComponent as CellComponent<string | null | undefined, string>,
-  deleteValue: () => null,
-  copyValue: ({ rowData }) => rowData ?? null,
-  pasteValue: ({ value }) => value,
-  minWidth: 170,
-  isCellEmpty: ({ rowData }) => !rowData,
-};
-
-export default timeColumn;
+export default TimeInput;

--- a/front/src/modules/timesStops/TimeStopsColumns.tsx
+++ b/front/src/modules/timesStops/TimeStopsColumns.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+
+import cx from 'classnames';
+import { keyColumn, type Column, checkboxColumn, createTextColumn } from 'react-datasheet-grid';
+import type { CellComponent } from 'react-datasheet-grid/dist/types';
+import { useTranslation } from 'react-i18next';
+
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import { marginRegExValidation } from 'utils/physics';
+
+import TimeInput from './TimeInput';
+import type { PathWaypointColumn } from './types';
+
+const timeColumn: Partial<Column<string | null | undefined, string, string>> = {
+  component: TimeInput as CellComponent<string | null | undefined, string>,
+  deleteValue: () => null,
+  copyValue: ({ rowData }) => rowData ?? null,
+  pasteValue: ({ value }) => value,
+  minWidth: 170,
+  isCellEmpty: ({ rowData }) => !rowData,
+};
+
+export const useInputColumns = (pathProperties: ManageTrainSchedulePathProperties) => {
+  const { t } = useTranslation('timesStops');
+  const columns = useMemo<Column<PathWaypointColumn>[]>(
+    () => [
+      {
+        ...keyColumn('name', createTextColumn()),
+        title: t('name'),
+        disabled: true,
+      },
+      {
+        ...keyColumn('ch', createTextColumn()),
+        title: 'Ch',
+        disabled: true,
+        grow: 0.1,
+      },
+      {
+        ...keyColumn('arrival', timeColumn),
+        title: t('arrivalTime'),
+
+        // We should not be able to edit the arrival time of the origin
+        disabled: ({ rowIndex }) => rowIndex === 0,
+        grow: 0.6,
+      },
+      {
+        ...keyColumn(
+          'stopFor',
+          createTextColumn({
+            continuousUpdates: false,
+            alignRight: true,
+          })
+        ),
+        title: `${t('stopTime')}`,
+        grow: 0.6,
+      },
+      {
+        ...keyColumn('onStopSignal', checkboxColumn as Partial<Column<boolean | undefined>>),
+        title: t('receptionOnClosedSignal'),
+
+        // We should not be able to edit the reception on close signal if stopFor is not filled
+        // except for the destination
+        grow: 0.6,
+        disabled: ({ rowData, rowIndex }) =>
+          rowIndex !== pathProperties.allWaypoints?.length - 1 && !rowData.stopFor,
+      },
+      {
+        ...keyColumn(
+          'theoreticalMargin',
+          createTextColumn({
+            continuousUpdates: false,
+            alignRight: true,
+            placeholder: t('theoreticalMarginPlaceholder'),
+            formatBlurredInput: (value) => {
+              if (!value || value === 'none') return '';
+              if (!marginRegExValidation.test(value)) {
+                return `${value}${t('theoreticalMarginPlaceholder')}`;
+              }
+              return value;
+            },
+          })
+        ),
+        cellClassName: ({ rowData }) => cx({ invalidCell: !rowData.isMarginValid }),
+        title: t('theoreticalMargin'),
+        disabled: ({ rowIndex }) => rowIndex === pathProperties.allWaypoints.length - 1,
+      },
+    ],
+    [t, pathProperties.allWaypoints.length]
+  );
+  return columns;
+};
+
+export default timeColumn;

--- a/front/src/modules/timesStops/consts.ts
+++ b/front/src/modules/timesStops/consts.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const marginRegExValidation = /^\d+(\.\d+)?%$|^\d+(\.\d+)?min\/100km$/;

--- a/front/src/modules/timesStops/utils.ts
+++ b/front/src/modules/timesStops/utils.ts
@@ -2,8 +2,8 @@ import type { TFunction } from 'i18next';
 
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { PathStep } from 'reducers/osrdconf/types';
+import { marginRegExValidation } from 'utils/physics';
 
-import { marginRegExValidation } from './consts';
 import type { PathWaypointColumn } from './types';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/front/src/utils/physics.ts
+++ b/front/src/utils/physics.ts
@@ -24,3 +24,5 @@ export function msToKmh(v: number) {
 export function mToKmOneDecimal(m: number) {
   return Math.round(m / 100) / 10;
 }
+
+export const marginRegExValidation = /^\d+(\.\d+)?%$|^\d+(\.\d+)?min\/100km$/;


### PR DESCRIPTION
Pure refacto, no change in behavior

- moved table columns to a separate file, with the use of `cx` for classes
- keyColumn doesn’t need type params, types is inferred from the type of the array `Column<PathWaypointColumn>[]`
- some simplifications