### PR TITLE
core: stdcm: improve heuristic by using lookahead data

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -186,7 +186,6 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
     }
 
     private long interpolateUS(double position, boolean isArrivalAt) {
-        assert continuous : "interpolating times on a non continuous envelope is a risky business";
         var envelopePartIndex = findLeft(position);
         assert envelopePartIndex >= 0 : "Trying to interpolate time outside of the envelope";
         var envelopePart = get(envelopePartIndex);

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -12,11 +12,17 @@ import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import java.util.PriorityQueue
+import java.util.*
 import kotlin.math.max
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+/**
+ * This typealias defines a function that can be used as a heuristic for an A* pathfinding. It takes
+ * an edge, and offset on this edge, and a number of passed steps as input, and returns an
+ * estimation of the remaining time needed to get to the end.
+ */
+typealias STDCMAStarHeuristic = (STDCMEdge, Offset<Block>?, Int) -> Double
 /**
  * This file implements the A* heuristic used by STDCM.
  *
@@ -30,177 +36,133 @@ import org.slf4j.LoggerFactory
  * It could eventually be improved further by using lookahead or route data, but this adds a fair
  * amount of complexity to the implementation.
  */
-val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
+class STDCMHeuristicBuilder(
+    private val blockInfra: BlockInfra,
+    private val rawInfra: RawInfra,
+    private val steps: List<STDCMStep>,
+    private val maxRunningTime: Double,
+    private val rollingStock: PhysicsRollingStock,
+) {
+    private val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
 
-/** Describes a pending block, ready to be added to the cached blocks. */
-private data class PendingBlock(
-    val block: BlockId,
-    val stepIndex: Int, // Number of steps that have been reached
-    val remainingTimeAtBlockStart: Double,
-) : Comparable<PendingBlock> {
-    /** Used to find the lowest remaining time at block start in a priority queue. */
-    override fun compareTo(other: PendingBlock): Int {
-        return remainingTimeAtBlockStart.compareTo(other.remainingTimeAtBlockStart)
-    }
-}
+    /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
+    fun build(): STDCMAStarHeuristic {
+        logger.info("Start building STDCM heuristic...")
+        // One map per number of reached pathfinding step
+        val maps = mutableListOf<MutableMap<BlockId, Double>>()
+        for (i in 0 until steps.size - 1) maps.add(mutableMapOf())
 
-/**
- * This typealias defines a function that can be used as a heuristic for an A* pathfinding. It takes
- * an edge, and offset on this edge, and a number of passed steps as input, and returns an
- * estimation of the remaining time needed to get to the end.
- */
-typealias STDCMAStarHeuristic = (STDCMEdge, Offset<Block>?, Int) -> Double
-
-/** Runs all the pre-processing and initializes the STDCM A* heuristic. */
-fun makeSTDCMHeuristic(
-    blockInfra: BlockInfra,
-    rawInfra: RawInfra,
-    steps: List<STDCMStep>,
-    maxRunningTime: Double,
-    rollingStock: PhysicsRollingStock,
-): STDCMAStarHeuristic {
-    logger.info("Start building STDCM heuristic...")
-    // One map per number of reached pathfinding step
-    val maps = mutableListOf<MutableMap<BlockId, Double>>()
-    for (i in 0 until steps.size - 1) maps.add(mutableMapOf())
-
-    // Build the cached values
-    // We run a kind of Dijkstra, but starting from the end
-    val pendingBlocks = initFirstBlocks(rawInfra, blockInfra, steps, rollingStock)
-    while (true) {
-        val block = pendingBlocks.poll() ?: break
-        val index = max(0, block.stepIndex - 1)
-        if (maps[index].contains(block.block)) {
-            continue
+        // Build the cached values
+        // We run a kind of Dijkstra, but starting from the end
+        val pendingBlocks = initFirstBlocks()
+        while (true) {
+            val block = pendingBlocks.poll() ?: break
+            val index = max(0, block.stepIndex - 1)
+            if (maps[index].contains(block.block)) {
+                continue
+            }
+            maps[index][block.block] = block.remainingTimeAtBlockStart
+            if (block.stepIndex > 0) {
+                pendingBlocks.addAll(getPredecessors(block))
+            }
         }
-        maps[index][block.block] = block.remainingTimeAtBlockStart
-        if (block.stepIndex > 0) {
-            pendingBlocks.addAll(
-                getPredecessors(blockInfra, rawInfra, steps, maxRunningTime, block, rollingStock)
-            )
+        val bestTravelTime =
+            steps.first().locations.minOfOrNull {
+                maps.first()[it.edge] ?: Double.POSITIVE_INFINITY
+            } ?: Double.POSITIVE_INFINITY
+        logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
+
+        // We build one function (`AStarHeuristic`) per number of reached step
+        return res@{ edge, offset, nPassedSteps ->
+            // We need to iterate through the previous maps,
+            // to handle cases where several steps are on the same block
+            for (i in (0..nPassedSteps).reversed()) {
+                val cachedRemainingDistance = maps[i][edge.block] ?: continue
+                val remainingTime = cachedRemainingDistance - getBlockTime(edge.block, offset)
+
+                return@res remainingTime
+            }
+            return@res Double.POSITIVE_INFINITY
         }
     }
 
-    val bestTravelTime =
-        steps.first().locations.minOfOrNull { maps.first()[it.edge] ?: Double.POSITIVE_INFINITY }
-            ?: Double.POSITIVE_INFINITY
-    logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
-
-    return res@{ previousEdge, location, nPassedSteps ->
-        if (nPassedSteps >= maps.size) return@res 0.0
-        // We need to iterate through the previous maps,
-        // to handle cases where several steps are on the same block
-        for (i in (0..nPassedSteps).reversed()) {
-            val cachedRemainingTime = maps[i][previousEdge.block] ?: continue
-            val remainingTime =
-                cachedRemainingTime -
-                    getBlockTime(rawInfra, blockInfra, previousEdge.block, rollingStock, location)
-            return@res remainingTime
+    /** Describes a pending block, ready to be added to the cached blocks. */
+    private data class PendingBlock(
+        val block: BlockId,
+        val stepIndex: Int, // Number of steps that have been reached
+        val remainingTimeAtBlockStart: Double,
+    ) : Comparable<PendingBlock> {
+        /** Used to find the lowest remaining time at block start in a priority queue. */
+        override fun compareTo(other: PendingBlock): Int {
+            return remainingTimeAtBlockStart.compareTo(other.remainingTimeAtBlockStart)
         }
-        return@res Double.POSITIVE_INFINITY
     }
-}
 
-/**
- * Generates all the pending blocks that can lead to the given block, as long as the pending blocks'
- * remaining times stay below `maximumRunningTime`.
- */
-private fun getPredecessors(
-    blockInfra: BlockInfra,
-    rawInfra: RawInfra,
-    steps: List<STDCMStep>,
-    maxRunningTime: Double,
-    pendingBlock: PendingBlock,
-    rollingStock: PhysicsRollingStock,
-): Collection<PendingBlock> {
-    if (pendingBlock.remainingTimeAtBlockStart > maxRunningTime) return emptyList()
-    val detector = blockInfra.getBlockEntry(rawInfra, pendingBlock.block)
-    val blocks = blockInfra.getBlocksEndingAtDetector(detector)
-    val res = mutableListOf<PendingBlock>()
-    for (block in blocks) {
-        val newBlock =
-            makePendingBlock(
-                rawInfra,
-                blockInfra,
-                rollingStock,
-                block,
-                null,
-                steps,
-                pendingBlock.stepIndex,
-                pendingBlock.remainingTimeAtBlockStart
-            )
-        res.add(newBlock)
-    }
-    return res
-}
-
-/** Initialize the priority queue with the blocks that contain the destination. */
-private fun initFirstBlocks(
-    rawInfra: RawInfra,
-    blockInfra: BlockInfra,
-    steps: List<STDCMStep>,
-    rollingStock: PhysicsRollingStock
-): PriorityQueue<PendingBlock> {
-    val res = PriorityQueue<PendingBlock>()
-    val stepCount = steps.size
-    for (wp in steps[stepCount - 1].locations) {
-        res.add(
-            makePendingBlock(
-                rawInfra,
-                blockInfra,
-                rollingStock,
-                wp.edge,
-                wp.offset,
-                steps,
-                stepCount - 1,
-                0.0
-            )
-        )
-    }
-    return res
-}
-
-/** Instantiate one pending block. */
-private fun makePendingBlock(
-    rawInfra: RawInfra,
-    blockInfra: BlockInfra,
-    rollingStock: PhysicsRollingStock,
-    block: StaticIdx<Block>,
-    offset: Offset<Block>?,
-    steps: List<STDCMStep>,
-    currentIndex: Int,
-    remainingTime: Double
-): PendingBlock {
-    var newIndex = currentIndex
-    val actualOffset = offset ?: blockInfra.getBlockLength(block)
-    var remainingTimeWithStops = remainingTime
-    while (newIndex > 0) {
-        val step = steps[newIndex - 1]
-        if (step.locations.none { it.edge == block && it.offset <= actualOffset }) {
-            break
+    /**
+     * Generates all the pending blocks that can lead to the given block, as long as the pending
+     * blocks' remaining times stay below `maximumRunningTime`.
+     */
+    private fun getPredecessors(
+        pendingBlock: PendingBlock,
+    ): Collection<PendingBlock> {
+        if (pendingBlock.remainingTimeAtBlockStart > maxRunningTime) return emptyList()
+        val detector = blockInfra.getBlockEntry(rawInfra, pendingBlock.block)
+        val blocks = blockInfra.getBlocksEndingAtDetector(detector)
+        val res = mutableListOf<PendingBlock>()
+        for (block in blocks) {
+            val newBlock =
+                makePendingBlock(
+                    block,
+                    null,
+                    pendingBlock.stepIndex,
+                    pendingBlock.remainingTimeAtBlockStart
+                )
+            res.add(newBlock)
         }
-        if (step.stop) remainingTimeWithStops += step.duration!!
-        newIndex--
+        return res
     }
-    return PendingBlock(
-        block,
-        newIndex,
-        remainingTimeWithStops + getBlockTime(rawInfra, blockInfra, block, rollingStock, offset)
-    )
-}
 
-/** Returns the time it takes to go through the given block, until `endOffset` if specified. */
-private fun getBlockTime(
-    rawInfra: RawInfra,
-    blockInfra: BlockInfra,
-    block: BlockId,
-    rollingStock: PhysicsRollingStock,
-    endOffset: Offset<Block>?,
-): Double {
-    if (endOffset?.distance == 0.meters) return 0.0
-    val actualLength = endOffset ?: blockInfra.getBlockLength(block)
-    val pathProps =
-        makePathProps(blockInfra, rawInfra, block, endOffset = actualLength, routes = listOf())
-    val mrsp = MRSP.computeMRSP(pathProps, rollingStock, false, null)
-    return mrsp.totalTime
+    /** Initialize the priority queue with the blocks that contain the destination. */
+    private fun initFirstBlocks(): PriorityQueue<PendingBlock> {
+        val res = PriorityQueue<PendingBlock>()
+        val stepCount = steps.size
+        for (wp in steps[stepCount - 1].locations) {
+            res.add(makePendingBlock(wp.edge, wp.offset, stepCount - 1, 0.0))
+        }
+        return res
+    }
+
+    /** Instantiate one pending block. */
+    private fun makePendingBlock(
+        block: StaticIdx<Block>,
+        offset: Offset<Block>?,
+        currentIndex: Int,
+        remainingTime: Double
+    ): PendingBlock {
+        var newIndex = currentIndex
+        val actualOffset = offset ?: blockInfra.getBlockLength(block)
+        var remainingTimeWithStops = remainingTime
+        while (newIndex > 0) {
+            val step = steps[newIndex - 1]
+            if (step.locations.none { it.edge == block && it.offset <= actualOffset }) {
+                break
+            }
+            if (step.stop) remainingTimeWithStops += step.duration!!
+            newIndex--
+        }
+        return PendingBlock(block, newIndex, remainingTimeWithStops + getBlockTime(block, offset))
+    }
+
+    /** Returns the time it takes to go through the given block, until `endOffset` if specified. */
+    private fun getBlockTime(
+        block: BlockId,
+        endOffset: Offset<Block>?,
+    ): Double {
+        if (endOffset?.distance == 0.meters) return 0.0
+        val actualLength = endOffset ?: blockInfra.getBlockLength(block)
+        val pathProps =
+            makePathProps(blockInfra, rawInfra, block, endOffset = actualLength, routes = listOf())
+        val mrsp = MRSP.computeMRSP(pathProps, rollingStock, false, null)
+        return mrsp.totalTime
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -6,8 +6,8 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.FixedTime
 import fr.sncf.osrd.graph.Graph
+import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
-import fr.sncf.osrd.stdcm.makeSTDCMHeuristic
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
@@ -53,13 +53,14 @@ class STDCMGraph(
 
     // Initialize the A* heuristic
     val remainingTimeEstimator =
-        makeSTDCMHeuristic(
-            fullInfra.blockInfra,
-            fullInfra.rawInfra,
-            steps,
-            maxRunTime,
-            rollingStock
-        )
+        STDCMHeuristicBuilder(
+                fullInfra.blockInfra,
+                fullInfra.rawInfra,
+                steps,
+                maxRunTime,
+                rollingStock
+            )
+            .build()
 
     /** Constructor */
     init {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -1,13 +1,17 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.pathfinding.constraints.*
+import fr.sncf.osrd.api.pathfinding.constraints.ConstraintCombiner
+import fr.sncf.osrd.api.pathfinding.constraints.initConstraints
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
-import fr.sncf.osrd.graph.*
+import fr.sncf.osrd.graph.PathfindingConstraint
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.*
+import fr.sncf.osrd.stdcm.STDCMResult
+import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -4,10 +4,10 @@ import fr.sncf.osrd.envelope_sim.SimpleRollingStock
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
+import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
-import fr.sncf.osrd.stdcm.makeSTDCMHeuristic
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
@@ -64,13 +64,14 @@ class STDCMHeuristicTests {
             )
 
         val heuristic =
-            makeSTDCMHeuristic(
-                infra,
-                infra,
-                steps,
-                Double.POSITIVE_INFINITY,
-                SimpleRollingStock.STANDARD_TRAIN,
-            )
+            STDCMHeuristicBuilder(
+                    infra,
+                    infra,
+                    steps,
+                    Double.POSITIVE_INFINITY,
+                    SimpleRollingStock.STANDARD_TRAIN,
+                )
+                .build()
 
         assertEquals(
             400.0 - 50.0,


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/7642

Work in progress: the tests fail, and it will conflict hard with https://github.com/OpenRailAssociation/osrd/pull/7830 once merged (this PR won't be merged first)

1. Small refactor of the heuristic to wrap in in a class
2. Cache the MRSPs
3. Use lookahead data to correctly identify which edges are going the wrong way
4. Improve how we evaluate the number of passed steps (prerequisite for this to work out)

Benchmark results:

![image](https://github.com/OpenRailAssociation/osrd/assets/3882074/6c1d856d-bd07-4062-a8c9-fe5ca5f9bda4)
Average -10% time.

But there's a few requests that used to cause an error and have been fixed, which increase the average response time (that's the +55s in the first max). Ignoring all errors, the average time goes from 3.79 to 2.58s (32% less time). 

![image](https://github.com/OpenRailAssociation/osrd/assets/3882074/f816895d-52f3-4620-b7d8-f79ebbc0d306)
