### PR TITLE
Fix infra clone handle search tables

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10597,7 +10597,10 @@ components:
       description: A search result item that depends on the query's `object`
     SearchResultItemOperationalPoint:
       type: object
-      description: A search result item for a query with `object = "operationalpoint"`
+      description: |-
+        A search result item for a query with `object = "operationalpoint"`
+
+        **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
       required:
       - obj_id
       - infra_id
@@ -10729,7 +10732,10 @@ components:
           minimum: 0
     SearchResultItemSignal:
       type: object
-      description: A search result item for a query with `object = "signal"`
+      description: |-
+        A search result item for a query with `object = "signal"`
+
+        **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
       required:
       - infra_id
       - label
@@ -10810,7 +10816,10 @@ components:
             type: string
     SearchResultItemTrack:
       type: object
-      description: A search result item for a query with `object = "track"`
+      description: |-
+        A search result item for a query with `object = "track"`
+
+        **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
       required:
       - infra_id
       - line_name

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -593,7 +593,7 @@ async fn clone_infra(
     let new_name = infra_args
         .new_name
         .unwrap_or_else(|| format!("{} (clone)", infra.name));
-    let cloned_infra = infra.clone(db_pool, new_name).await?;
+    let cloned_infra = infra.clone(conn, new_name).await?;
     println!(
         "✅ Infra {} (ID: {}) was successfully cloned",
         cloned_infra.name.bold(),

--- a/editoast/src/modelsv2/infra_objects.rs
+++ b/editoast/src/modelsv2/infra_objects.rs
@@ -205,6 +205,7 @@ infra_model!(
 infra_model!(
     NeutralSectionModel,
     infra_object_neutral_section,
+    infra_layer_neutral_section,
     editoast_schemas::infra::NeutralSection
 );
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -338,7 +338,7 @@ async fn clone(
         infra_id: params.infra_id,
     })
     .await?;
-    let cloned_infra = infra.clone(db_pool.into_inner(), name).await?;
+    let cloned_infra = infra.clone(conn, name).await?;
     Ok(Json(cloned_infra.id))
 }
 

--- a/editoast/src/views/search/objects.rs
+++ b/editoast/src/views/search/objects.rs
@@ -26,6 +26,8 @@ use editoast_common::geometry::GeoJsonPoint;
 )]
 #[allow(unused)]
 /// A search result item for a query with `object = "track"`
+///
+/// **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
 pub(super) struct SearchResultItemTrack {
     #[search(sql = "search_track.infra_id")]
     infra_id: i64,
@@ -83,6 +85,8 @@ pub(super) struct SearchResultItemTrack {
 )]
 #[allow(unused)]
 /// A search result item for a query with `object = "operationalpoint"`
+///
+/// **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
 pub(super) struct SearchResultItemOperationalPoint {
     #[search(sql = "OP.obj_id")]
     obj_id: String,
@@ -166,6 +170,8 @@ pub(super) struct SearchResultItemOperationalPointTrackSections {
 )]
 #[allow(unused)]
 /// A search result item for a query with `object = "signal"`
+///
+/// **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::modelsv2::infra::Infra::clone]
 pub(super) struct SearchResultItemSignal {
     #[search(sql = "sig.infra_id")]
     infra_id: i64,

--- a/front/scripts/generate-types.sh
+++ b/front/scripts/generate-types.sh
@@ -4,10 +4,10 @@ if [ $? -ne 0 ]; then
     echo "npx @rtk-query/codegen-openapi src/config/openapi-editoast-config.ts command failed. Exit the script"
     exit 1
 fi
-eslint --fix src/common/api/generatedEditoastApi.ts --no-ignore
+yarn eslint --fix src/common/api/generatedEditoastApi.ts --no-ignore
 npx @rtk-query/codegen-openapi src/config/openapi-gateway-config.ts
 if [ $? -ne 0 ]; then
     echo "npx @rtk-query/codegen-openapi src/config/openapi-gateway-config.ts command failed. Exit the script"
     exit 1
 fi
-eslint --fix src/common/api/osrdGatewayApi.ts --no-ignore
+yarn eslint --fix src/common/api/osrdGatewayApi.ts --no-ignore


### PR DESCRIPTION
# What is done

- The clone operation is done in an sql transaction (close #6716)
- We disable search triggers and fill the tables manually
  - Fix: Can't search in a cloned infra
- Clone the `layer_neutral_section` (fix #7663)
- Clone the `layer_neutral_sign`
- Clone the `layer_psl_sign`

> [!IMPORTANT]
> We have a minor drawback. While an infra is cloned we take a full lock on track, signal and op tables.
> This temporarily blocks several types of operation.

# Profiling

> [!NOTE]
> Time wasted duplicating forgotten layers is regained by deactivating triggers.

### Before

**TOTAL**: 19s

- Clone `infra_object_track_section` in 2002ms
- Clone `infra_layer_track_section` in 900ms
- Clone `infra_object_signal` in 2490ms
- Clone `infra_layer_signal` in 409ms
- Clone `infra_object_speed_section` in 810ms
- Clone `infra_layer_speed_section` in 6319ms
- Clone `infra_object_detector` in 474ms
- Clone `infra_layer_detector` in 566ms
- Clone `infra_object_neutral_section` in 14ms
- Clone `infra_object_switch` in 260ms
- Clone `infra_layer_switch` in 321ms
- Clone `infra_object_extended_switch_type` in 0ms
- Clone `infra_object_buffer_stop` in 22ms
- Clone `infra_layer_buffer_stop` in 26ms
- Clone `infra_object_route` in 545ms
- Clone `infra_object_operational_point` in 896ms
- Clone `infra_layer_operational_point` in 281ms
- Clone `infra_object_electrification` in 24ms
- Clone `infra_layer_electrification` in 402ms
- Clone `errors` in 2753ms

### After

**TOTAL**: 19s

- Clone `infra_object_track_section` in 786ms 🚀
- Clone `infra_layer_track_section` in 877ms
- Clone `infra_object_signal` in 329ms 🚀
- Clone `infra_layer_signal` in 418ms
- Clone `infra_object_speed_section` in 1054ms
- Clone `infra_layer_speed_section` in 6596ms ⚠️ (We should try to reduce the number of speed sections)
- Clone `infra_object_detector` in 444ms
- Clone `infra_layer_detector` in 560ms
- Clone `infra_object_neutral_section` in 14ms
- Clone `infra_object_switch` in 230ms
- Clone `infra_layer_switch` in 303ms
- Clone `infra_object_extended_switch_type` in 0ms
- Clone `infra_object_buffer_stop` in 22ms
- Clone `infra_layer_buffer_stop` in 26ms
- Clone `infra_object_route` in 512ms
- Clone `infra_object_operational_point` in 90ms
- Clone `infra_layer_operational_point` in 276ms 🚀
- Clone `infra_object_electrification` in 24ms
- Clone `infra_layer_electrification` in 378ms
- Clone `errors` in 2647ms

New:
- Clone `search_signal` in 1707ms 🐢
- Clone `search_track` in 10ms
- Clone `search_operational_point` in 314ms 🐢
- Clone `infra_layer_neutral_section` in 15ms
- Clone `infra_layer_psl_sign` in 174ms
- Clone `infra_layer_neutral_sign` in 52ms
