### PR TITLE
core: stdcm: remove list of heuristics + related simplifications

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -79,10 +79,12 @@ data class STDCMEdge(
                 null,
                 null,
                 timeSinceDeparture,
+                graph.remainingTimeEstimator.invoke(this, null, newWaypointIndex),
             )
         } else {
             // New edge on the same block, after a stop
             val stopDuration = graph.getFirstStopAfterIndex(waypointIndex)!!.duration!!
+            val locationOnEdge = envelopeStartOffset + length.distance
             STDCMNode(
                 totalTime + timeStart + stopDuration,
                 endSpeed,
@@ -93,7 +95,7 @@ data class STDCMEdge(
                 newWaypointIndex,
                 envelopeStartOffset + length.distance,
                 stopDuration,
-                timeSinceDeparture,
+                graph.remainingTimeEstimator.invoke(this, locationOnEdge, newWaypointIndex)
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.FixedTime
 import fr.sncf.osrd.graph.Graph
 import fr.sncf.osrd.stdcm.STDCMStep
+import fr.sncf.osrd.stdcm.makeSTDCMHeuristic
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
@@ -49,6 +50,16 @@ class STDCMGraph(
 
     // min 4 minutes between two edges, determined empirically
     private val visitedNodes = VisitedNodes(4 * 60.0)
+
+    // Initialize the A* heuristic
+    val remainingTimeEstimator =
+        makeSTDCMHeuristic(
+            fullInfra.blockInfra,
+            fullInfra.rawInfra,
+            steps,
+            maxRunTime,
+            rollingStock
+        )
 
     /** Constructor */
     init {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -6,11 +6,10 @@ import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMStep
-import fr.sncf.osrd.stdcm.apply
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
-import fr.sncf.osrd.stdcm.makeSTDCMHeuristics
+import fr.sncf.osrd.stdcm.makeSTDCMHeuristic
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
@@ -66,40 +65,39 @@ class STDCMHeuristicTests {
                 ),
             )
 
-        val heuristics =
-            makeSTDCMHeuristics(
+        val heuristic =
+            makeSTDCMHeuristic(
                 infra,
                 infra,
                 steps,
                 Double.POSITIVE_INFINITY,
                 SimpleRollingStock.STANDARD_TRAIN,
             )
-        assertEquals(4, heuristics.size)
 
         assertEquals(
             400.0 - 50.0,
-            getLocationRemainingTime(infra, blocks[0], 50.meters, 0, heuristics)
+            getLocationRemainingTime(infra, blocks[0], 50.meters, 0, heuristic)
         )
         assertEquals(
             400.0 - 85.0,
-            getLocationRemainingTime(infra, blocks[0], 85.meters, 0, heuristics)
+            getLocationRemainingTime(infra, blocks[0], 85.meters, 0, heuristic)
         )
         assertEquals(
             400.0 - 100.0 - 25.0,
-            getLocationRemainingTime(infra, blocks[1], 25.meters, 1, heuristics)
+            getLocationRemainingTime(infra, blocks[1], 25.meters, 1, heuristic)
         )
         assertEquals(
             400.0 - 100.0 - 75.0,
-            getLocationRemainingTime(infra, blocks[1], 75.meters, 2, heuristics)
+            getLocationRemainingTime(infra, blocks[1], 75.meters, 2, heuristic)
         )
         assertEquals(
             400.0 - 200.0,
-            getLocationRemainingTime(infra, blocks[2], 0.meters, 3, heuristics)
+            getLocationRemainingTime(infra, blocks[2], 0.meters, 3, heuristic)
         )
-        assertEquals(0.0, getLocationRemainingTime(infra, blocks[3], null, 3, heuristics))
+        assertEquals(0.0, getLocationRemainingTime(infra, blocks[3], null, 3, heuristic))
         assertEquals(
             Double.POSITIVE_INFINITY,
-            getLocationRemainingTime(infra, blocks[3], 0.meters, 0, heuristics)
+            getLocationRemainingTime(infra, blocks[3], 0.meters, 0, heuristic)
         )
     }
 
@@ -112,7 +110,7 @@ class STDCMHeuristicTests {
         block: BlockId,
         nodeOffsetOnEdge: Distance?,
         nbPassedSteps: Int,
-        heuristics: List<STDCMAStarHeuristic<STDCMNode>>
+        heuristic: STDCMAStarHeuristic<STDCMNode>
     ): Double {
         val explorer =
             initInfraExplorerWithEnvelope(
@@ -143,6 +141,6 @@ class STDCMHeuristicTests {
         if (nodeOffsetOnEdge != null) locationOnEdge = Offset(nodeOffsetOnEdge)
         val node =
             STDCMNode(0.0, 0.0, explorer, 0.0, 0.0, defaultEdge, 0, locationOnEdge, null, 0.0)
-        return heuristics.apply(node, nbPassedSteps)
+        return heuristic.invoke(node, nbPassedSteps)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -2,12 +2,10 @@ package fr.sncf.osrd.stdcm.preprocessing
 
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
-import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
-import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.makeSTDCMHeuristic
 import fr.sncf.osrd.utils.DummyInfra
@@ -110,7 +108,7 @@ class STDCMHeuristicTests {
         block: BlockId,
         nodeOffsetOnEdge: Distance?,
         nbPassedSteps: Int,
-        heuristic: STDCMAStarHeuristic<STDCMNode>
+        heuristic: STDCMAStarHeuristic
     ): Double {
         val explorer =
             initInfraExplorerWithEnvelope(
@@ -137,10 +135,6 @@ class STDCMHeuristicTests {
                 Length(0.meters),
                 0.0
             )
-        var locationOnEdge: Offset<Block>? = null
-        if (nodeOffsetOnEdge != null) locationOnEdge = Offset(nodeOffsetOnEdge)
-        val node =
-            STDCMNode(0.0, 0.0, explorer, 0.0, 0.0, defaultEdge, 0, locationOnEdge, null, 0.0)
-        return heuristic.invoke(node, nbPassedSteps)
+        return heuristic.invoke(defaultEdge, nodeOffsetOnEdge?.let { Offset(it) }, nbPassedSteps)
     }
 }


### PR DESCRIPTION
I started this while rebasing https://github.com/OpenRailAssociation/osrd/pull/7844 but it ended up being a fair amount of changes, it feels like this deserves its own PR

I started as removing the list of heuristic and using a single function instead (it's simpler).

Then I figured out `node.remainingTimeEstimation` doesn't have to be optional (or with a default value) anymore with this change, if we just move the place where it's computed