### PR TITLE
core: stdcm: minor cleanup + bugfix

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -31,13 +31,6 @@ data class STDCMEdge(
     val previousNode: STDCMNode?,
     // Offset of the envelope if it doesn't start at the beginning of the edge
     val envelopeStartOffset: Offset<Block>,
-    // Time at which the train enters the block, discretized by only considering the
-    // minutes.
-    // Used to identify visited edges
-    val minuteTimeStart: Int,
-    // Speed factor used to account for standard allowance
-    // e.g. if we have a 5% standard allowance, this value is 1/1.05.
-    val standardAllowanceSpeedFactor: Double,
     // Index of the last waypoint passed by this train
     val waypointIndex: Int,
     // True if the edge end is a stop

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -8,41 +8,49 @@ import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isNaN
 
 data class STDCMEdge(
-    val infraExplorer:
-        InfraExplorerWithEnvelope, // Instance used to explore the infra, contains the current
+    // Instance used to explore the infra, contains the current
     // underlying edge (block)
-    val infraExplorerWithNewEnvelope: InfraExplorerWithEnvelope, // Includes this edge's envelope
-    val timeStart: Double, // Time at which the train enters the block
-    val maximumAddedDelayAfter:
-        Double, // Maximum delay we can add after this block by delaying the start time without
+    val infraExplorer: InfraExplorerWithEnvelope,
+    // Includes this edge's envelope
+    val infraExplorerWithNewEnvelope: InfraExplorerWithEnvelope,
+    // Time at which the train enters the block
+    val timeStart: Double,
+    // Maximum delay we can add after this block by delaying the start time without
     // causing conflicts
-    val addedDelay:
-        Double, // Delay we needed to add in this block to avoid conflicts (by shifting the
+    val maximumAddedDelayAfter: Double,
+    // Delay we needed to add in this block to avoid conflicts (by shifting the
     // departure time)
-    val timeNextOccupancy:
-        Double, // Time of the next occupancy of the block, used to identify the "opening" used by
+    val addedDelay: Double,
+    // Time of the next occupancy of the block, used to identify the "opening" used by
     // the edge
-    val totalDepartureTimeShift:
-        Double, // Total delay we have added by shifting the departure time since the start of the
+    val timeNextOccupancy: Double,
+    // Total delay we have added by shifting the departure time since the start of the
     // path
-    val previousNode:
-        STDCMNode?, // Node located at the start of this edge, null if this is the first edge
-    val envelopeStartOffset:
-        Offset<Block>, // Offset of the envelope if it doesn't start at the beginning of the edge
-    val minuteTimeStart:
-        Int, // Time at which the train enters the block, discretized by only considering the
+    val totalDepartureTimeShift: Double,
+    // Node located at the start of this edge, null if this is the first edge
+    val previousNode: STDCMNode?,
+    // Offset of the envelope if it doesn't start at the beginning of the edge
+    val envelopeStartOffset: Offset<Block>,
+    // Time at which the train enters the block, discretized by only considering the
     // minutes.
     // Used to identify visited edges
-    val standardAllowanceSpeedFactor: Double, // Speed factor used to account for standard allowance
+    val minuteTimeStart: Int,
+    // Speed factor used to account for standard allowance
     // e.g. if we have a 5% standard allowance, this value is 1/1.05.
-    val waypointIndex: Int, // Index of the last waypoint passed by this train
-    val endAtStop: Boolean, // True if the edge end is a stop
-    val beginSpeed: Double, // Speed at the beginning of the edge
-    val endSpeed: Double, // Speed at the end of the edge
-    val length: Length<STDCMEdge>, // Edge length
-    val totalTime:
-        Double, // How long it takes to go from the beginning to the end of the block, taking the
+    val standardAllowanceSpeedFactor: Double,
+    // Index of the last waypoint passed by this train
+    val waypointIndex: Int,
+    // True if the edge end is a stop
+    val endAtStop: Boolean,
+    // Speed at the beginning of the edge
+    val beginSpeed: Double,
+    // Speed at the end of the edge
+    val endSpeed: Double,
+    // Edge length
+    val length: Length<STDCMEdge>,
+    // How long it takes to go from the beginning to the end of the block, taking the
     // standard allowance into account
+    val totalTime: Double,
 ) {
     val block = infraExplorer.getCurrentBlock()
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -64,6 +64,8 @@ data class STDCMEdge(
             if (!pass) break
             newWaypointIndex++
         }
+        val timeSinceDeparture =
+            totalTime + timeStart - totalDepartureTimeShift - graph.minScheduleTimeStart
         return if (!endAtStop) {
             // We move on to the next block
             STDCMNode(
@@ -75,7 +77,8 @@ data class STDCMEdge(
                 this,
                 newWaypointIndex,
                 null,
-                null
+                null,
+                timeSinceDeparture,
             )
         } else {
             // New edge on the same block, after a stop
@@ -89,7 +92,8 @@ data class STDCMEdge(
                 this,
                 newWaypointIndex,
                 envelopeStartOffset + length.distance,
-                stopDuration
+                stopDuration,
+                timeSinceDeparture,
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -280,8 +280,6 @@ internal constructor(
                 prevAddedDelay + departureTimeShift,
                 prevNode,
                 startOffset,
-                (actualStartTime / 60).toInt(),
-                standardAllowanceSpeedRatio,
                 waypointIndex,
                 endAtStop,
                 envelope!!.beginSpeed,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -31,7 +31,7 @@ class STDCMGraph(
     val timeStep: Double,
     blockAvailability: BlockAvailabilityInterface,
     maxRunTime: Double,
-    minScheduleTimeStart: Double,
+    val minScheduleTimeStart: Double,
     steps: List<STDCMStep>,
     tag: String?,
     standardAllowance: AllowanceValue?

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -24,6 +24,9 @@ data class STDCMNode(
     val locationOnEdge: Offset<Block>?,
     // When the node is a stop, how long the train remains here
     val stopDuration: Double?,
+    // Time since train departure. Accounts for stops and travel time, but not the changes in
+    // departure time.
+    val timeSinceDeparture: Double,
     // Estimation of the min time it takes to reach the end from this node
     var remainingTimeEstimation: Double = 0.0,
 ) : Comparable<STDCMNode> {
@@ -35,8 +38,8 @@ data class STDCMNode(
      * priority queue, from the best path to the worst path. We then explore them in that order.
      */
     override fun compareTo(other: STDCMNode): Int {
-        val runTimeEstimation = getCurrentRunningTime() + remainingTimeEstimation
-        val otherRunTimeEstimation = other.getCurrentRunningTime() + other.remainingTimeEstimation
+        val runTimeEstimation = timeSinceDeparture + remainingTimeEstimation
+        val otherRunTimeEstimation = other.timeSinceDeparture + other.remainingTimeEstimation
         // Firstly, minimize the total run time: highest priority node takes the least time to
         // complete the path
         return if (abs(runTimeEstimation - otherRunTimeEstimation) >= 1e-3)
@@ -57,9 +60,5 @@ data class STDCMNode(
             infraExplorer.getCurrentBlock(),
             waypointIndex
         )
-    }
-
-    fun getCurrentRunningTime(): Double {
-        return time - totalPrevAddedDelay
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -6,22 +6,26 @@ import fr.sncf.osrd.utils.units.Offset
 import kotlin.math.abs
 
 data class STDCMNode(
-    val time: Double, // Time at the transition of the edge
-    val speed: Double, // Speed at the end of the previous edge
-    val infraExplorer: InfraExplorerWithEnvelope, // Instance used to explore the infra
-    val totalPrevAddedDelay:
-        Double, // Sum of all the delays we have added by shifting the departure time
-    val maximumAddedDelay:
-        Double, // Maximum delay we can add by delaying the start time without causing conflicts
-    val previousEdge: STDCMEdge, // Edge that lead to this node
-    val waypointIndex: Int, // Index of the last waypoint passed by the train
-    val locationOnEdge:
-        Offset<
-            Block
-        >?, // Position on a block, if this node isn't on the transition between blocks (stop)
-    val stopDuration: Double?, // When the node is a stop, how long the train remains here
-    var remainingTimeEstimation: Double =
-        0.0, // Estimation of the min time it takes to reach the end from this node
+    // Time at the transition of the edge
+    val time: Double,
+    // Speed at the end of the previous edge
+    val speed: Double,
+    // Instance used to explore the infra
+    val infraExplorer: InfraExplorerWithEnvelope,
+    // Sum of all the delays we have added by shifting the departure time
+    val totalPrevAddedDelay: Double,
+    // Maximum delay we can add by delaying the start time without causing conflicts
+    val maximumAddedDelay: Double,
+    // Edge that lead to this node
+    val previousEdge: STDCMEdge,
+    // Index of the last waypoint passed by the train
+    val waypointIndex: Int,
+    // Position on a block, if this node isn't on the transition between blocks (stop)
+    val locationOnEdge: Offset<Block>?,
+    // When the node is a stop, how long the train remains here
+    val stopDuration: Double?,
+    // Estimation of the min time it takes to reach the end from this node
+    var remainingTimeEstimation: Double = 0.0,
 ) : Comparable<STDCMNode> {
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -150,7 +150,7 @@ class STDCMPathfinding(
             if (Duration.between(start, Instant.now()).toSeconds() >= pathfindingTimeout)
                 throw OSRDError(ErrorType.PathfindingTimeoutError)
             val endNode = queue.poll() ?: return null
-            if (endNode.getCurrentRunningTime() + endNode.remainingTimeEstimation > maxRunTime)
+            if (endNode.timeSinceDeparture + endNode.remainingTimeEstimation > maxRunTime)
                 return null
             if (endNode.waypointIndex >= graph.steps.size - 1) {
                 return buildResult(endNode)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -141,7 +141,8 @@ class STDCMHeuristicTests {
             )
         var locationOnEdge: Offset<Block>? = null
         if (nodeOffsetOnEdge != null) locationOnEdge = Offset(nodeOffsetOnEdge)
-        val node = STDCMNode(0.0, 0.0, explorer, 0.0, 0.0, defaultEdge, 0, locationOnEdge, null)
+        val node =
+            STDCMNode(0.0, 0.0, explorer, 0.0, 0.0, defaultEdge, 0, locationOnEdge, null, 0.0)
         return heuristics.apply(node, nbPassedSteps)
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -133,8 +133,6 @@ class STDCMHeuristicTests {
                 null,
                 Offset(0.meters),
                 0,
-                0.0,
-                0,
                 false,
                 0.0,
                 0.0,


### PR DESCRIPTION
* Fix formatting of edge / node comments. It got weird when going to java to kotlin, then  worse with the auto-formatter
* Remove unused fields in `STDCMEdge`
* Small bugfix on V1 with time since departure