### PR TITLE
front: use noreferrer for external license links

### DIFF
--- a/front/src/common/ReleaseInformations/LicenseAttributions.tsx
+++ b/front/src/common/ReleaseInformations/LicenseAttributions.tsx
@@ -35,7 +35,7 @@ const LicenseAttributions = () => {
     .map((licence) => ({ ...licence, name: licence.name.replace('@', '') }))
     .sort((a, b) => a.name.localeCompare(b.name))
     .map(({ name, version, copyright, publisher, url, licenses }) => (
-      <a key={name} href={url}>
+      <a key={name} href={url} rel="noreferrer">
         <h3 className="d-flex mr-1 mb-0">
           {name}
           <small className="d-flex align-items-center ml-2">


### PR DESCRIPTION
When clicking a link to an external website, the Web browser might send the URL of the OSRD webapp in the external HTTP request. The URL might contain potentially sensitive information such as a private/internal domain name or URL parameters. Make the Web browser always omit this information by using rel="noreferrer".

No need for noopener here like #7828 did, because the link is opened in the same window (we aren't using target="_blank").