### PR TITLE
front: fix wrong stop displayed in driver train schedules

### DIFF
--- a/front/src/modules/trainschedule/components/DriverTrainScheduleV2/utils.ts
+++ b/front/src/modules/trainschedule/components/DriverTrainScheduleV2/utils.ts
@@ -232,7 +232,10 @@ export const formatOperationalPoints = async (
     // Get duration
     let stepDuration = 0;
     const correspondingStep = train.path.find(
-      (step) => 'uic' in step && step.uic === op.extensions?.identifier?.uic
+      (step) =>
+        'uic' in step &&
+        step.uic === op.extensions?.identifier?.uic &&
+        step.secondary_code === op.extensions.sncf?.ch
     );
     if (correspondingStep) {
       const correspondingSchedule = train.schedule?.find(


### PR DESCRIPTION
Creating a train was adding the proper number of stops, but we checked only the corresponding uic to display them in the driver train schedule instead of checking the ch code as well

close #7805 