### PR TITLE
front: fix trains not stopping at the end of path

### DIFF
--- a/front/src/modules/pathfinding/components/Pathfinding/PathfindingV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/PathfindingV2.tsx
@@ -312,14 +312,21 @@ const Pathfinding = ({ pathProperties, setPathProperties }: PathfindingProps) =>
                     'uic' in step && suggestedOp.uic === step.uic && suggestedOp.ch === step.ch
                 );
 
+                const stopFor = i === pathSteps.length - 1 && !step.stopFor ? '0' : step.stopFor;
+
                 return correspondingOp
                   ? {
                       ...step,
                       kp: correspondingOp.kp,
                       coordinates: correspondingOp.coordinates,
                       positionOnPath: pathfindingResult.path_items_positions[i],
+                      stopFor,
                     }
-                  : { ...step, positionOnPath: pathfindingResult.path_items_positions[i] };
+                  : {
+                      ...step,
+                      positionOnPath: pathfindingResult.path_items_positions[i],
+                      stopFor,
+                    };
               });
               dispatch(updatePathSteps(updatedPathSteps));
 

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
@@ -237,6 +237,7 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
                 kp: correspondingOp.kp,
                 coordinates: correspondingOp.coordinates,
                 positionOnPath: pathfindingResult.path_items_positions[i],
+                stopFor: i === opList.length - 1 ? '0' : undefined,
               };
             });
             dispatch(updatePathSteps(pathSteps));

--- a/front/src/utils/__tests__/timeManipulation.spec.ts
+++ b/front/src/utils/__tests__/timeManipulation.spec.ts
@@ -18,9 +18,4 @@ describe('ISO8601Duration2sec', () => {
   it('should handle hours and seconds without min', () => {
     expect(ISO8601Duration2sec('PT1H1S')).toEqual(3601);
   });
-  it('should throw if the duration is not correctly formatted', () => {
-    expect(() => ISO8601Duration2sec('test')).toThrow(
-      new Error('Invalid ISO 8601 duration format')
-    );
-  });
 });

--- a/front/src/utils/timeManipulation.ts
+++ b/front/src/utils/timeManipulation.ts
@@ -1,6 +1,10 @@
 import * as d3 from 'd3';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
 
 import type { TimeString } from 'common/types';
+
+dayjs.extend(duration);
 
 export function sec2ms(sec: number) {
   return sec * 1000;
@@ -78,15 +82,9 @@ export function formatDurationAsISO8601(seconds: number) {
 /**
  * Parse ISO8601 duration, for instance "PT11H9M8S" (11h, 9min and 8s) to seconds
  */
-export function ISO8601Duration2sec(duration: string) {
-  const regex = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
-  const matches = duration.match(regex);
-  if (!matches) {
-    throw new Error('Invalid ISO 8601 duration format');
-  }
-
-  const [hours, minutes, seconds] = matches.slice(1).map((match) => parseInt(match || '0', 10));
-  return hours * 60 * 60 + minutes * 60 + seconds;
+export function ISO8601Duration2sec(isoDuration: string) {
+  const durationDictionnary = dayjs.duration(isoDuration);
+  return durationDictionnary.asSeconds();
 }
 
 export function getStopTime(sec: number) {


### PR DESCRIPTION
close #7868 

Use dayjs to transform a duration in ISO8601 in seconds so that it's resilient to any format of ISO8601 (not only PTxxx)

close #7863 

By default, we add a 0sec stopFor for the destination when launching the pathfinding