### PR TITLE
Fix large uri for batch retrieve train schedules

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3156,20 +3156,25 @@ paths:
                 items:
                   $ref: '#/components/schemas/TrainScheduleResult'
   /v2/train_schedule/:
-    get:
+    post:
       tags:
       - train_schedulev2
       summary: Return a specific train schedule
-      parameters:
-      - name: ids
-        in: query
-        description: Ids of train schedule
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                  uniqueItems: true
         required: true
-        schema:
-          type: array
-          items:
-            type: integer
-            format: int64
       responses:
         '200':
           description: Retrieve a list of train schedule
@@ -3212,29 +3217,11 @@ paths:
         - Returns 200 with a hashmap of train_id to ProjectPathTrainResult
 
         Train schedules that are invalid (pathfinding or simulation failed) are not included in the result
-      parameters:
-      - name: infra
-        in: query
-        description: The infra id
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: ids
-        in: query
-        description: Ids of train schedule
-        required: true
-        schema:
-          type: array
-          items:
-            type: integer
-            format: int64
       requestBody:
-        description: ''
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProjectPathInput'
+              $ref: '#/components/schemas/ProjectPathForm'
         required: true
       responses:
         '200':
@@ -3246,28 +3233,30 @@ paths:
                 additionalProperties:
                   $ref: '#/components/schemas/ProjectPathTrainResult'
   /v2/train_schedule/simulation_summary:
-    get:
+    post:
       tags:
       - train_schedulev2
       summary: Associate each train id with its simulation summary response
       description: 'If the simulation fails, it associates the reason: pathfinding failed or running time failed'
-      parameters:
-      - name: infra
-        in: query
-        description: The infra id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - infra_id
+              - ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: integer
+                    format: int64
+                  uniqueItems: true
+                infra_id:
+                  type: integer
+                  format: int64
         required: true
-        schema:
-          type: integer
-          format: int64
-      - name: ids
-        in: query
-        description: Ids of train schedule
-        required: true
-        schema:
-          type: array
-          items:
-            type: integer
-            format: int64
       responses:
         '200':
           description: Associate each train id with its simulation summary
@@ -3521,17 +3510,6 @@ components:
           maxLength: 255
           minLength: 1
       additionalProperties: false
-    BatchDeletionRequest:
-      type: object
-      required:
-      - ids
-      properties:
-        ids:
-          type: array
-          items:
-            type: integer
-            format: int64
-          uniqueItems: true
     BoundingBox:
       type: array
       items:
@@ -4376,7 +4354,6 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorUnsimulatedTrainSchedule'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorBatchTrainScheduleNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
-      - $ref: '#/components/schemas/EditoastTrainScheduleErrorInvalidQueryParams'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
       - $ref: '#/components/schemas/EditoastTypeCheckErrorArgMissing'
       - $ref: '#/components/schemas/EditoastTypeCheckErrorArgTypeMismatch'
@@ -6167,30 +6144,6 @@ components:
           type: string
           enum:
           - editoast:train_schedule_v2:InfraNotFound
-    EditoastTrainScheduleErrorInvalidQueryParams:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - message
-          properties:
-            message:
-              type: string
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 400
-        type:
-          type: string
-          enum:
-          - editoast:train_schedule_v2:InvalidQueryParams
     EditoastTrainScheduleErrorNoSimulation:
       type: object
       required:
@@ -9115,36 +9068,52 @@ components:
           allOf:
           - $ref: '#/components/schemas/Tags'
           nullable: true
-    ProjectPathInput:
+    ProjectPathForm:
       type: object
-      description: Project path input is described by a list of routes and a list of track range
       required:
-      - track_section_ranges
-      - routes
-      - blocks
+      - infra_id
+      - ids
+      - path
       properties:
-        blocks:
+        ids:
           type: array
           items:
-            type: string
-            maxLength: 255
-            minLength: 1
-          description: Path description as block ids
-          minItems: 1
-        routes:
-          type: array
-          items:
-            type: string
-            maxLength: 255
-            minLength: 1
-          description: List of route ids
-          minItems: 1
-        track_section_ranges:
-          type: array
-          items:
-            $ref: '#/components/schemas/TrackRange'
-          description: List of track ranges
-          minItems: 1
+            type: integer
+            format: int64
+          uniqueItems: true
+        infra_id:
+          type: integer
+          format: int64
+        path:
+          type: object
+          description: Project path input is described by a list of routes and a list of track range
+          required:
+          - track_section_ranges
+          - routes
+          - blocks
+          properties:
+            blocks:
+              type: array
+              items:
+                type: string
+                maxLength: 255
+                minLength: 1
+              description: Path description as block ids
+              minItems: 1
+            routes:
+              type: array
+              items:
+                type: string
+                maxLength: 255
+                minLength: 1
+              description: List of route ids
+              minItems: 1
+            track_section_ranges:
+              type: array
+              items:
+                $ref: '#/components/schemas/TrackRange'
+              description: List of track ranges
+              minItems: 1
     ProjectPathTrainResult:
       allOf:
       - type: object

--- a/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
+++ b/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
@@ -59,7 +59,7 @@ export const getSpaceTimeChartData = async (
       );
 
       const { data: trainSchedules } = await store.dispatch(
-        osrdEditoastApi.endpoints.getV2TrainSchedule.initiate({ ids: trainSchedulesIDs })
+        osrdEditoastApi.endpoints.postV2TrainSchedule.initiate({ body: { ids: trainSchedulesIDs } })
       );
 
       if (pathfindingResult && pathfindingResult.status === 'success' && trainSchedules) {
@@ -67,9 +67,11 @@ export const getSpaceTimeChartData = async (
         const projectPathTrainResult = await store
           .dispatch(
             osrdEditoastApi.endpoints.postV2TrainScheduleProjectPath.initiate({
-              infra: infraId,
-              ids: trainSchedulesIDs,
-              projectPathInput: { blocks, routes, track_section_ranges },
+              projectPathForm: {
+                infra_id: infraId,
+                ids: trainSchedulesIDs,
+                path: { blocks, routes, track_section_ranges },
+              },
             })
           )
           .unwrap();

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -910,12 +910,9 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['timetablev2', 'train_schedulev2'],
       }),
-      postV2TrainSchedule: build.mutation<
-        PostV2TrainScheduleApiResponse,
-        PostV2TrainScheduleApiArg
-      >({
+      postV2TrainSchedule: build.query<PostV2TrainScheduleApiResponse, PostV2TrainScheduleApiArg>({
         query: (queryArg) => ({ url: `/v2/train_schedule/`, method: 'POST', body: queryArg.body }),
-        invalidatesTags: ['train_schedulev2'],
+        providesTags: ['train_schedulev2'],
       }),
       deleteV2TrainSchedule: build.mutation<
         DeleteV2TrainScheduleApiResponse,
@@ -939,7 +936,7 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['train_schedulev2'],
       }),
-      postV2TrainScheduleSimulationSummary: build.mutation<
+      postV2TrainScheduleSimulationSummary: build.query<
         PostV2TrainScheduleSimulationSummaryApiResponse,
         PostV2TrainScheduleSimulationSummaryApiArg
       >({
@@ -948,7 +945,7 @@ const injectedRtkApi = api
           method: 'POST',
           body: queryArg.body,
         }),
-        invalidatesTags: ['train_schedulev2'],
+        providesTags: ['train_schedulev2'],
       }),
       getV2TrainScheduleById: build.query<
         GetV2TrainScheduleByIdApiResponse,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -910,9 +910,12 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['timetablev2', 'train_schedulev2'],
       }),
-      getV2TrainSchedule: build.query<GetV2TrainScheduleApiResponse, GetV2TrainScheduleApiArg>({
-        query: (queryArg) => ({ url: `/v2/train_schedule/`, params: { ids: queryArg.ids } }),
-        providesTags: ['train_schedulev2'],
+      postV2TrainSchedule: build.mutation<
+        PostV2TrainScheduleApiResponse,
+        PostV2TrainScheduleApiArg
+      >({
+        query: (queryArg) => ({ url: `/v2/train_schedule/`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['train_schedulev2'],
       }),
       deleteV2TrainSchedule: build.mutation<
         DeleteV2TrainScheduleApiResponse,
@@ -932,20 +935,20 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/v2/train_schedule/project_path`,
           method: 'POST',
-          body: queryArg.projectPathInput,
-          params: { infra: queryArg.infra, ids: queryArg.ids },
+          body: queryArg.projectPathForm,
         }),
         invalidatesTags: ['train_schedulev2'],
       }),
-      getV2TrainScheduleSimulationSummary: build.query<
-        GetV2TrainScheduleSimulationSummaryApiResponse,
-        GetV2TrainScheduleSimulationSummaryApiArg
+      postV2TrainScheduleSimulationSummary: build.mutation<
+        PostV2TrainScheduleSimulationSummaryApiResponse,
+        PostV2TrainScheduleSimulationSummaryApiArg
       >({
         query: (queryArg) => ({
           url: `/v2/train_schedule/simulation_summary`,
-          params: { infra: queryArg.infra, ids: queryArg.ids },
+          method: 'POST',
+          body: queryArg.body,
         }),
-        providesTags: ['train_schedulev2'],
+        invalidatesTags: ['train_schedulev2'],
       }),
       getV2TrainScheduleById: build.query<
         GetV2TrainScheduleByIdApiResponse,
@@ -1781,11 +1784,12 @@ export type PostV2TimetableByIdTrainScheduleApiArg = {
   id: number;
   body: TrainScheduleBase[];
 };
-export type GetV2TrainScheduleApiResponse =
+export type PostV2TrainScheduleApiResponse =
   /** status 200 Retrieve a list of train schedule */ TrainScheduleResult[];
-export type GetV2TrainScheduleApiArg = {
-  /** Ids of train schedule */
-  ids: number[];
+export type PostV2TrainScheduleApiArg = {
+  body: {
+    ids: number[];
+  };
 };
 export type DeleteV2TrainScheduleApiResponse = unknown;
 export type DeleteV2TrainScheduleApiArg = {
@@ -1797,21 +1801,17 @@ export type PostV2TrainScheduleProjectPathApiResponse = /** status 200 Project P
   [key: string]: ProjectPathTrainResult;
 };
 export type PostV2TrainScheduleProjectPathApiArg = {
-  /** The infra id */
-  infra: number;
-  /** Ids of train schedule */
-  ids: number[];
-  projectPathInput: ProjectPathInput;
+  projectPathForm: ProjectPathForm;
 };
-export type GetV2TrainScheduleSimulationSummaryApiResponse =
+export type PostV2TrainScheduleSimulationSummaryApiResponse =
   /** status 200 Associate each train id with its simulation summary */ {
     [key: string]: SimulationSummaryResult;
   };
-export type GetV2TrainScheduleSimulationSummaryApiArg = {
-  /** The infra id */
-  infra: number;
-  /** Ids of train schedule */
-  ids: number[];
+export type PostV2TrainScheduleSimulationSummaryApiArg = {
+  body: {
+    ids: number[];
+    infra_id: number;
+  };
 };
 export type GetV2TrainScheduleByIdApiResponse =
   /** status 200 The train schedule */ TrainScheduleResult;
@@ -3799,13 +3799,18 @@ export type ProjectPathTrainResult = {
   /** Rolling stock length in mm */
   rolling_stock_length: number;
 };
-export type ProjectPathInput = {
-  /** Path description as block ids */
-  blocks: string[];
-  /** List of route ids */
-  routes: string[];
-  /** List of track ranges */
-  track_section_ranges: TrackRange[];
+export type ProjectPathForm = {
+  ids: number[];
+  infra_id: number;
+  /** Project path input is described by a list of routes and a list of track range */
+  path: {
+    /** Path description as block ids */
+    blocks: string[];
+    /** List of route ids */
+    routes: string[];
+    /** List of track ranges */
+    track_section_ranges: TrackRange[];
+  };
 };
 export type SimulationSummaryResult =
   | {

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -38,34 +38,6 @@ const osrdEditoastApi = generatedEditoastApi.enhanceEndpoints({
         body: queryArg.pathPropertiesInput,
       }),
     },
-    getV2TrainScheduleSimulationSummary: {
-      query: (queryArg) => ({
-        // We currently can't build the url path the way we want with rtk query with the regular endpoint
-        // so we need to do it manually with this function and enhanced endpoint
-        url: `/v2/train_schedule/simulation_summary?infra=${queryArg.infra}&${formatURLWithIds(queryArg.ids)}`,
-        method: 'GET',
-      }),
-    },
-    getV2TrainSchedule: {
-      query: (queryArg) => ({
-        // We currently can't build the url path the way we want with rtk query with the regular endpoint
-        // so we need to do it manually with this function and enhanced endpoint
-        url: `/v2/train_schedule?${formatURLWithIds(queryArg.ids)}`,
-        method: 'GET',
-      }),
-    },
-    postV2TrainScheduleProjectPath: {
-      query: (queryArg) => ({
-        // We currently can't build the url path the way we want with rtk query with the regular endpoint
-        // so we need to do it manually with this function and enhanced endpoint
-        url: `/v2/train_schedule/project_path?infra=${queryArg.infra}&${formatURLWithIds(queryArg.ids)}`,
-        method: 'POST',
-        body: queryArg.projectPathInput,
-      }),
-      // As we always use all get trainschedule v2 endpoints after updating the timetable,
-      // we don't want to invalidate the trainschedulev2 tag here to preven multiple calls
-      invalidatesTags: [],
-    },
     deleteV2TrainSchedule: {
       query: (queryArg) => ({
         url: `/v2/train_schedule/`,
@@ -73,7 +45,7 @@ const osrdEditoastApi = generatedEditoastApi.enhanceEndpoints({
         body: queryArg.body,
       }),
       // As we always use all get trainschedule v2 endpoints after updating the timetable,
-      // we don't want to invalidate the trainschedulev2 tag here to preven multiple calls
+      // we don't want to invalidate the trainschedulev2 tag here to prevent multiple calls
       invalidatesTags: ['timetablev2', 'scenariosv2'],
     },
     postV2TimetableByIdTrainSchedule: {
@@ -83,7 +55,7 @@ const osrdEditoastApi = generatedEditoastApi.enhanceEndpoints({
         body: queryArg.body,
       }),
       // As we always use all get trainschedule v2 endpoints after updating the timetable,
-      // we don't want to invalidate the trainschedulev2 tag here to preven multiple calls
+      // we don't want to invalidate the trainschedulev2 tag here to prevent multiple calls
       invalidatesTags: ['timetablev2', 'scenariosv2'],
     },
     // Invalidate the children count and last update timestamp

--- a/front/src/config/openapi-editoast-config.ts
+++ b/front/src/config/openapi-editoast-config.ts
@@ -8,6 +8,12 @@ const config: ConfigFile = {
   exportName: 'generatedEditoastApi',
   hooks: false,
   tag: true,
+  endpointOverrides: [
+    {
+      pattern: ['postV2TrainSchedule', 'postV2TrainScheduleSimulationSummary'],
+      type: 'query',
+    },
+  ],
 };
 
 export default config;

--- a/front/src/modules/trainschedule/components/TimetableV2/TimetableTrainCardV2.tsx
+++ b/front/src/modules/trainschedule/components/TimetableV2/TimetableTrainCardV2.tsx
@@ -64,7 +64,7 @@ const TimetableTrainCardV2 = ({
 
   const [postTrainSchedule] =
     osrdEditoastApi.endpoints.postV2TimetableByIdTrainSchedule.useMutation();
-  const [getTrainSchedule] = osrdEditoastApi.endpoints.getV2TrainSchedule.useLazyQuery();
+  const [getTrainSchedule] = osrdEditoastApi.endpoints.postV2TrainSchedule.useLazyQuery();
   const [deleteTrainSchedule] = osrdEditoastApi.endpoints.deleteV2TrainSchedule.useMutation();
 
   const changeSelectedTrainId = (trainId: number) => {
@@ -112,7 +112,7 @@ const TimetableTrainCardV2 = ({
     const trainCount = 1;
     const actualTrainCount = 1;
 
-    const trainsResults = await getTrainSchedule({ ids: [train.id] })
+    const trainsResults = await getTrainSchedule({ body: { ids: [train.id] } })
       .unwrap()
       .catch((e) => {
         dispatch(setFailure(castErrorToFailure(e)));

--- a/front/src/modules/trainschedule/components/TimetableV2/hooks.ts
+++ b/front/src/modules/trainschedule/components/TimetableV2/hooks.ts
@@ -36,10 +36,12 @@ const useTrainSchedulesDetails = (
   const [uniqueTags, setUniqueTags] = useState<string[]>([]);
 
   const { currentData: trainSchedulesSummary } =
-    osrdEditoastApi.endpoints.getV2TrainScheduleSimulationSummary.useQuery(
+    osrdEditoastApi.endpoints.postV2TrainScheduleSimulationSummary.useQuery(
       {
-        infra: infraId as number,
-        ids: trainIds,
+        body: {
+          infra_id: infraId as number,
+          ids: trainIds,
+        },
       },
       {
         skip: !infraId || !trainIds.length,
@@ -47,9 +49,11 @@ const useTrainSchedulesDetails = (
       }
     );
 
-  const { currentData: trainSchedules } = osrdEditoastApi.endpoints.getV2TrainSchedule.useQuery(
+  const { currentData: trainSchedules } = osrdEditoastApi.endpoints.postV2TrainSchedule.useQuery(
     {
-      ids: trainIds,
+      body: {
+        ids: trainIds,
+      },
     },
     {
       skip: !trainIds.length,


### PR DESCRIPTION
close #7860

Browser have a URI length limit:

- Microsoft Internet Explorer: 2,083 characters
- Microsoft Edge: 2,083 characters
- Google Chrome: 32,779 characters
- Mozilla Firefox: more than 64,000 characters
- Apple Safari: more than 64,000 characters
- Google Android: 8,192 characters

The idea is to move query parameters to the body of the request.

> [!NOTE]
> This implies moving `GET` endpoint to `POST`.

Which endpoint is involved:

- [x] Get batch train schedules
- [x] Simulation summary
- [x] Project path