### PR TITLE
front: localize pathfinding errors

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -78,6 +78,16 @@
   "pathfindingMissingParamsSimple": "Missing information for the search",
   "pathfindingNoState": "No route search.",
   "pathfindingStatus": "Pathfinding state",
+  "pathfindingErrors": {
+    "not_found_in_blocks": "Missing block",
+    "not_found_in_routes": "Missing route",
+    "not_found_in_tracks": "Missing track",
+    "incompatible_electrification": "Incompatible electrification",
+    "incompatible_loading_gauge": "Incompatible loading gauge",
+    "incompatible_signaling_system": "Incompatible signaling system",
+    "not_enough_path_items": "Missing parameters for pathfinding: Departure, Arrival, Rolling stock",
+    "pathfinding_failed": "No path found"
+  },
   "powerRestriction": "Power restriction code",
   "powerRestrictionExplanationText": "By default, the simulation will use the nominal power.",
   "powerRestrictionEmptyExplanationText": "The selected rolling stock does not have any power restrictions. You can edit it in the rolling stock editor.",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -78,6 +78,16 @@
   "pathfindingMissingParamsSimple": "Informations manquantes pour la recherche",
   "pathfindingNoState": "Aucune recherche itinéraire.",
   "pathfindingStatus": "Statut recherche d’itinéraire",
+  "pathfindingErrors": {
+    "not_found_in_blocks": "Canton manquant",
+    "not_found_in_routes": "Itinéraire manquant",
+    "not_found_in_tracks": "Voie manquante",
+    "incompatible_electrification": "Électrification incompatible",
+    "incompatible_loading_gauge": "Gabarit incompatible",
+    "incompatible_signaling_system": "Système de signalisation incompatible",
+    "not_enough_path_items": "Éléments manquants pour la recherche : Origine, Destination, Matériel roulant",
+    "pathfinding_failed": "Aucun chemin trouvé"
+  },
   "pleaseWait": "Veuillez patientez…",
   "powerRestriction": "Code de restriction de puissance",
   "powerRestrictionExplanationText": "Si aucune restriction de puissance n'est renseignée sur un intervalle, le calcul de marche sera réalisé en utilisant la puissance nominale.",

--- a/front/src/modules/pathfinding/hook/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hook/usePathfinding.ts
@@ -296,7 +296,10 @@ export const usePathfindingV2 = (
               // * }
             }
           } else {
-            pathfindingDispatch({ type: 'PATHFINDING_ERROR', message: pathfindingResult.status });
+            pathfindingDispatch({
+              type: 'PATHFINDING_ERROR',
+              message: `pathfindingErrors.${pathfindingResult.status}`,
+            });
           }
         } catch (e) {
           if (isObject(e)) {


### PR DESCRIPTION
The list of pathfinding error codes can be found here:

https://github.com/OpenRailAssociation/osrd/blob/9f12cd44573cdb498155484cf8ac42372b06a622/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt#L84

Closes: https://github.com/OpenRailAssociation/osrd/issues/7862