### PR TITLE
readme: add missing copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ Send an email at <contact@osrd.fr>, [open an issue](https://github.com/OpenRailA
   <img src="assets/sponsors/european-union.svg" width="150px" height="150px" alt="European Union"/>
   <img src="assets/sponsors/sncf-reseau.svg" width="150px" height="150px" alt="SNCF Réseau"/>
 </p>
+
+## License
+
+OSRD is licensed under the GNU Lesser General Public License v3.0, see LICENSE.
+
+Copyright © 2022 The OSRD Contributors


### PR DESCRIPTION
It seems like a [copyright notice][1] is missing from the project. The copyright notice has a legal significance in most countries, so it's safer to include it to make it clear that the work is copyrighted.

The copyright is shared by all contributors to the project, reflect that in the legal author.

[1]: https://en.wikipedia.org/wiki/Copyright_notice