### PR TITLE
front: fix curves update

### DIFF
--- a/front/src/common/Selector/Selector.tsx
+++ b/front/src/common/Selector/Selector.tsx
@@ -78,7 +78,11 @@ const SelectorItem = <T extends string | null>({
           <button
             type="button"
             tabIndex={0}
-            onClick={() => onItemRemoved(item.id)}
+            onClick={(e) => {
+              // This way, we won't trigger the onClick of the parent div
+              e.stopPropagation();
+              onItemRemoved(item.id);
+            }}
             className="selector-trash-icon"
             aria-label="Delete item"
           >

--- a/front/src/modules/rollingStock/components/RollingStockEditor/CurveParamSelectors.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/CurveParamSelectors.tsx
@@ -192,7 +192,6 @@ const CurveParamSelectors = ({
 
   const removeTractionMode = (mode: string) => {
     if (!effortCurves) return;
-    if (mode === selectedTractionMode) selectedParamsSetter('tractionMode', null);
     const filteredModesList = Object.fromEntries(
       Object.entries(effortCurves).filter(([key]) => key !== mode)
     );
@@ -270,6 +269,7 @@ const CurveParamSelectors = ({
           selectNewItemButtonProps={{
             options: comfortOptions,
             selectNewItem: updateComfortLevelsList,
+            disabled: !selectedTractionMode,
           }}
           dataTestId="comfort-level-selector"
         />

--- a/front/src/modules/rollingStock/components/RollingStockEditor/CurveSpreadsheet.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/CurveSpreadsheet.tsx
@@ -85,7 +85,7 @@ const CurveSpreadsheet = ({
     const filledDataSheet: DataSheetCurve[] = max_efforts.map((effort, index) => ({
       speed: speeds[index] !== null ? Math.round(msToKmh(speeds[index]!)) : null,
       // Effort needs to be displayed in kN
-      effort: effort && effort !== null ? effort / 1000 : null,
+      effort: effort !== null ? effort / 1000 : null,
     }));
 
     // Add an empty line for input only if last line is not already empty
@@ -105,6 +105,7 @@ const CurveSpreadsheet = ({
       const sortedSpreadsheetValues = spreadsheetCurve
         .filter((item) => item.speed !== null || item.effort !== null)
         .sort((a, b) => {
+          if (a.speed === null && b.speed === null) return Number(a.effort) - Number(b.effort);
           if (a.speed === null) return -1;
           if (b.speed === null) return 1;
           return Number(a.speed) - Number(b.speed);

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorCurves.tsx
@@ -79,35 +79,6 @@ const RollingStockEditorCurves = ({
     }
   };
 
-  const { selectedCurveIndex, selectedCurve, selectedTractionModeCurves } = useMemo(() => {
-    if (!selectedTractionMode || !effortCurves || !effortCurves[selectedTractionMode])
-      return { selectedCurveIndex: null, selectedCurve: null, selectedTractionModeCurves: null };
-
-    const isElectric = selectedTractionMode !== THERMAL_TRACTION_IDENTIFIER;
-    const modeCurves = effortCurves[selectedTractionMode].curves.filter(
-      (curve) => curve.cond.comfort === selectedParams.comfortLevel
-    );
-
-    if (isElectric) {
-      const index = modeCurves.findIndex(
-        (curve) =>
-          curve.cond.electrical_profile_level === selectedParams.electricalProfile &&
-          curve.cond.power_restriction_code === selectedParams.powerRestriction
-      );
-      return {
-        selectedCurveIndex: index,
-        selectedCurve: modeCurves[index],
-        selectedTractionModeCurves: modeCurves,
-      };
-    }
-
-    return {
-      selectedCurveIndex: 0,
-      selectedCurve: modeCurves[0],
-      selectedTractionModeCurves: modeCurves,
-    };
-  }, [effortCurves, selectedTractionMode, selectedParams]);
-
   const [hoveredRollingstockParam, setHoveredRollingstockParam] = useState<string | null>();
 
   /** Dict of all the params of the rollingStock */
@@ -155,6 +126,25 @@ const RollingStockEditorCurves = ({
     selectedTractionMode,
     effortCurves,
   ]);
+
+  const { selectedCurveIndex, selectedCurve, selectedTractionModeCurves } = useMemo(() => {
+    if (!selectedTractionMode || !effortCurves)
+      return { selectedCurveIndex: null, selectedCurve: null, selectedTractionModeCurves: null };
+
+    const modeCurves = effortCurves[selectedTractionMode].curves;
+
+    const index = modeCurves.findIndex(
+      (curve) =>
+        curve.cond.comfort === selectedParams.comfortLevel &&
+        curve.cond.electrical_profile_level === selectedParams.electricalProfile &&
+        curve.cond.power_restriction_code === selectedParams.powerRestriction
+    );
+    return {
+      selectedCurveIndex: index,
+      selectedCurve: modeCurves[index],
+      selectedTractionModeCurves: modeCurves,
+    };
+  }, [effortCurves, selectedTractionMode, selectedParams]);
 
   /** List of curves matching the selected comfort, traction mode and electrical profile */
   const curvesToDisplay = useMemo(() => {


### PR DESCRIPTION
Closes #7658 
Closes #7669 

The button for adding a new comfort level is now disabled as long as no traction mode is selected, since it is not possible to add one without it.
![image](https://github.com/OpenRailAssociation/osrd/assets/103027832/6ee013bd-056a-4bff-8ac5-a4575b94c00c)
