### PR TITLE
 front: reference map when no infra (or not existing) is selected

### DIFF
--- a/front/src/applications/referenceMap/Home.tsx
+++ b/front/src/applications/referenceMap/Home.tsx
@@ -7,13 +7,16 @@ import { Route, Routes } from 'react-router-dom';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { ModalProvider } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import NavBarSNCF from 'common/BootstrapSNCF/NavBarSNCF';
-import { useInfraID } from 'common/osrdContext';
+import { useInfraActions, useInfraID } from 'common/osrdContext';
+import { useAppDispatch } from 'store';
 
 import Map from './Map';
 
 const HomeReferenceMap = () => {
   const { t } = useTranslation(['home/home', 'referenceMap']);
+  const dispatch = useAppDispatch();
 
+  const { updateInfraID } = useInfraActions();
   const infraID = useInfraID();
   const [getInfraByInfraId, { data: infra }] =
     osrdEditoastApi.endpoints.getInfraByInfraId.useLazyQuery({});
@@ -24,9 +27,14 @@ const HomeReferenceMap = () => {
    */
   useEffect(() => {
     if (infraID) {
-      getInfraByInfraId({ infraId: infraID as number });
+      // if the infra in the store is not found, then we set it to undefined
+      getInfraByInfraId({ infraId: infraID as number }).then((resp) => {
+        if (resp.error && 'status' in resp.error && resp.error.status === 404) {
+          dispatch(updateInfraID(undefined));
+        }
+      });
     }
-  }, [infraID, getInfraByInfraId]);
+  }, [infraID, getInfraByInfraId, dispatch]);
 
   return (
     <ModalProvider>

--- a/front/src/common/Map/Layers/BufferStops.tsx
+++ b/front/src/common/Map/Layers/BufferStops.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source, type SymbolLayer } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
@@ -43,7 +44,7 @@ interface BufferStopsProps {
 const BufferStops = ({ layerOrder, infraID }: BufferStopsProps) => {
   const layersSettings = useSelector(getLayersSettings);
 
-  if (!layersSettings.bufferstops) return null;
+  if (!layersSettings.bufferstops || isNil(infraID)) return null;
   return (
     <Source
       id="osrd_bufferstop_geo"

--- a/front/src/common/Map/Layers/Detectors.tsx
+++ b/front/src/common/Map/Layers/Detectors.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source } from 'react-map-gl/maplibre';
 import type { CircleLayer, SymbolLayer } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
@@ -68,7 +69,7 @@ const Detectors = ({ colors, layerOrder, infraID }: DetectorsProps) => {
   const layerPoint = getDetectorsLayerProps({ colors, sourceTable: 'detectors' });
   const layerName = getDetectorsNameLayerProps({ colors, sourceTable: 'detectors' });
 
-  if (!layersSettings.detectors) return null;
+  if (!layersSettings.detectors || isNil(infraID)) return null;
   return (
     <Source
       id="osrd_detectors_geo"

--- a/front/src/common/Map/Layers/Electrifications.tsx
+++ b/front/src/common/Map/Layers/Electrifications.tsx
@@ -133,27 +133,25 @@ export default function Electrifications({ colors, layerOrder, infraID }: Electr
     sourceTable: 'electrifications',
   });
 
-  if (layersSettings.electrifications) {
-    return (
-      <Source
-        id="electrifications_geo"
-        type="vector"
-        url={`${MAP_URL}/layer/electrifications/mvt/geo/?infra=${infraID}`}
-      >
-        <OrderedLayer
-          {...electrificationsParams}
-          // beforeId={`chartis/tracks-geo/main`}
-          id="chartis/electrifications/geo"
-          layerOrder={layerOrder}
-        />
-        <OrderedLayer
-          {...electrificationsTextParams}
-          // beforeId={`chartis/tracks-geo/main`}
-          id="chartis/electrifications_names/geo"
-          layerOrder={layerOrder}
-        />
-      </Source>
-    );
-  }
-  return null;
+  if (!layersSettings.electrifications || isNil(infraID)) return null;
+  return (
+    <Source
+      id="electrifications_geo"
+      type="vector"
+      url={`${MAP_URL}/layer/electrifications/mvt/geo/?infra=${infraID}`}
+    >
+      <OrderedLayer
+        {...electrificationsParams}
+        // beforeId={`chartis/tracks-geo/main`}
+        id="chartis/electrifications/geo"
+        layerOrder={layerOrder}
+      />
+      <OrderedLayer
+        {...electrificationsTextParams}
+        // beforeId={`chartis/tracks-geo/main`}
+        id="chartis/electrifications_names/geo"
+        layerOrder={layerOrder}
+      />
+    </Source>
+  );
 }

--- a/front/src/common/Map/Layers/LineSearchLayer.tsx
+++ b/front/src/common/Map/Layers/LineSearchLayer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
@@ -14,14 +15,13 @@ interface TracksGeographicProps {
 
 const LineSearchLayer = ({ layerOrder, infraID }: TracksGeographicProps) => {
   const { lineSearchCode } = useSelector(getMap);
-  const infraVersion = infraID !== undefined ? `?infra=${infraID}` : null;
 
-  if (!infraVersion) return null;
+  if (isNil(infraID)) return null;
   return (
     <Source
       id="searchTrack-geo"
       type="vector"
-      url={`${MAP_URL}/layer/track_sections/mvt/geo/${infraVersion}`}
+      url={`${MAP_URL}/layer/track_sections/mvt/geo/?infra=${infraID}`}
       source-layer={MAP_TRACK_SOURCES.geographic}
     >
       {lineSearchCode && (

--- a/front/src/common/Map/Layers/OperationalPoints.tsx
+++ b/front/src/common/Map/Layers/OperationalPoints.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
@@ -116,6 +117,7 @@ export default function OperationalPoints({ colors, layerOrder, infraID }: Props
     },
   };
 
+  if (isNil(infraID)) return null;
   return (
     <Source
       id="osrd_operational_point_geo"

--- a/front/src/common/Map/Layers/Routes.tsx
+++ b/front/src/common/Map/Layers/Routes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source } from 'react-map-gl/maplibre';
 import type { CircleLayer, LineLayer, SymbolLayer } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
@@ -96,7 +97,7 @@ export default function Routes({ colors, layerOrder, infraID }: RoutesProps) {
   const pointProps = getRoutesPointLayerProps({ colors, sourceTable: 'routes' });
   const textProps = getRoutesTextLayerProps({ colors, sourceTable: 'routes' });
 
-  if (!layersSettings.routes) return null;
+  if (!layersSettings.routes || isNil(infraID)) return null;
   return (
     <Source
       id="osrd_routes_geo"

--- a/front/src/common/Map/Layers/Signals.tsx
+++ b/front/src/common/Map/Layers/Signals.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source, type MapRef } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
@@ -36,7 +37,7 @@ const Signals = ({ colors, sourceTable, layerOrder, infraID }: PlatformProps) =>
     minzoom: 12,
   };
 
-  if (!layersSettings.signals) return null;
+  if (!layersSettings.signals || isNil(infraID)) return null;
   return (
     <Source
       promoteId="id"

--- a/front/src/common/Map/Layers/SpeedLimits.tsx
+++ b/front/src/common/Map/Layers/SpeedLimits.tsx
@@ -198,31 +198,28 @@ export default function SpeedLimits({ colors, layerOrder, infraID }: SpeedLimits
     filter,
   };
 
-  if (layersSettings.speedlimits) {
-    return (
-      <Source
-        id="osrd_speed_limit_geo"
-        type="vector"
-        url={`${MAP_URL}/layer/speed_sections/mvt/geo/?infra=${infraID}`}
-      >
-        <OrderedLayer
-          {...lineProps}
-          id="chartis/osrd_speed_limit_colors/geo"
-          layerOrder={layerOrder}
-        />
-        <OrderedLayer
-          {...pointProps}
-          id="chartis/osrd_speed_limit_points/geo"
-          layerOrder={layerOrder}
-        />
-        <OrderedLayer
-          {...textProps}
-          id="chartis/osrd_speed_limit_value/geo"
-          layerOrder={layerOrder}
-        />
-      </Source>
-    );
-  }
-
-  return null;
+  if (!layersSettings.speedlimits || isNil(infraID)) return null;
+  return (
+    <Source
+      id="osrd_speed_limit_geo"
+      type="vector"
+      url={`${MAP_URL}/layer/speed_sections/mvt/geo/?infra=${infraID}`}
+    >
+      <OrderedLayer
+        {...lineProps}
+        id="chartis/osrd_speed_limit_colors/geo"
+        layerOrder={layerOrder}
+      />
+      <OrderedLayer
+        {...pointProps}
+        id="chartis/osrd_speed_limit_points/geo"
+        layerOrder={layerOrder}
+      />
+      <OrderedLayer
+        {...textProps}
+        id="chartis/osrd_speed_limit_value/geo"
+        layerOrder={layerOrder}
+      />
+    </Source>
+  );
 }

--- a/front/src/common/Map/Layers/Switches.tsx
+++ b/front/src/common/Map/Layers/Switches.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source } from 'react-map-gl/maplibre';
 import type { SymbolLayer, CircleLayer } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
@@ -69,7 +70,7 @@ const Switches = ({ colors, layerOrder, infraID }: SwitchesProps) => {
   const layerPoint = getSwitchesLayerProps({ colors, sourceTable: 'switches' });
   const layerName = getSwitchesNameLayerProps({ colors, sourceTable: 'switches' });
 
-  if (!layersSettings.switches) return null;
+  if (!layersSettings.switches || isNil(infraID)) return null;
   return (
     <Source
       id="osrd_switches_geo"

--- a/front/src/common/Map/Layers/TracksGeographic.tsx
+++ b/front/src/common/Map/Layers/TracksGeographic.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { Source } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
@@ -18,13 +19,13 @@ interface TracksGeographicProps {
 
 function TracksGeographic({ colors, layerOrder, infraID }: TracksGeographicProps) {
   const { showIGNBDORTHO, showIGNSCAN25 } = useSelector(getMap);
-  const infraVersion = infraID !== undefined ? `?infra=${infraID}` : null;
 
+  if (isNil(infraID)) return null;
   return (
     <Source
       id="tracksGeographic"
       type="vector"
-      url={`${MAP_URL}/layer/track_sections/mvt/geo/${infraVersion}`}
+      url={`${MAP_URL}/layer/track_sections/mvt/geo/?infra=${infraID}`}
       source-layer={MAP_TRACK_SOURCES.geographic}
     >
       <OrderedLayer

--- a/front/src/common/Map/Layers/extensions/SNCF/NeutralSectionSigns.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/NeutralSectionSigns.tsx
@@ -79,6 +79,8 @@ export default function NeutralSectionSigns(props: NeutralSectionSignsProps) {
     isSignalisation: true,
     sourceTable: 'neutral_signs',
   });
+
+  if (isNil(infraID)) return null;
   return (
     <Source
       id="osrd_sncf_neutral_signs_geo"

--- a/front/src/common/Map/Layers/extensions/SNCF/NeutralSections.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/NeutralSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { isNil } from 'lodash';
 import { type LayerProps, Source } from 'react-map-gl/maplibre';
 
 import { MAP_URL } from 'common/Map/const';
@@ -36,6 +37,7 @@ export default ({ colors, layerOrder, infraID }: NeutralSectionsProps) => {
     },
   };
 
+  if (isNil(infraID)) return null;
   return (
     <>
       <Source

--- a/front/src/common/Map/Layers/extensions/SNCF/PSL.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/PSL.tsx
@@ -185,35 +185,33 @@ const SNCF_PSL = ({ colors, layerOrder, infraID }: SNCF_PSLProps) => {
     filter: speedSectionFilter,
   };
 
-  if (layersSettings.sncf_psl) {
-    return (
-      <>
-        <Source
-          id="osrd_sncf_psl_geo"
-          type="vector"
-          url={`${MAP_URL}/layer/psl/mvt/geo/?infra=${infraID}`}
-        >
-          <OrderedLayer
-            {...speedValueParams}
-            id="chartis/osrd_sncf_psl_value/geo"
-            layerOrder={layerOrder}
-          />
-          <OrderedLayer
-            {...speedLineBGParams}
-            id="chartis/osrd_sncf_psl_colors_bg/geo"
-            layerOrder={layerOrder}
-          />
-          <OrderedLayer
-            {...speedLineParams}
-            id="chartis/osrd_sncf_psl_colors/geo"
-            layerOrder={layerOrder}
-          />
-        </Source>
-        <SNCF_PSL_Signs colors={colors} layerOrder={layerOrder} />
-      </>
-    );
-  }
-  return null;
+  if (!layersSettings.sncf_psl || isNil(infraID)) return null;
+  return (
+    <>
+      <Source
+        id="osrd_sncf_psl_geo"
+        type="vector"
+        url={`${MAP_URL}/layer/psl/mvt/geo/?infra=${infraID}`}
+      >
+        <OrderedLayer
+          {...speedValueParams}
+          id="chartis/osrd_sncf_psl_value/geo"
+          layerOrder={layerOrder}
+        />
+        <OrderedLayer
+          {...speedLineBGParams}
+          id="chartis/osrd_sncf_psl_colors_bg/geo"
+          layerOrder={layerOrder}
+        />
+        <OrderedLayer
+          {...speedLineParams}
+          id="chartis/osrd_sncf_psl_colors/geo"
+          layerOrder={layerOrder}
+        />
+      </Source>
+      <SNCF_PSL_Signs colors={colors} layerOrder={layerOrder} />
+    </>
+  );
 };
 
 export default SNCF_PSL;

--- a/front/src/common/Map/Layers/extensions/SNCF/PSLSigns.tsx
+++ b/front/src/common/Map/Layers/extensions/SNCF/PSLSigns.tsx
@@ -91,6 +91,7 @@ export default function SNCF_PSL_Signs(props: SNCF_PSL_SignsProps) {
     sourceTable: 'psl_signs',
   });
 
+  if (isNil(infraID)) return null;
   return (
     <Source
       id="osrd_sncf_psl_signs_geo"

--- a/front/src/modules/infra/components/InfraSelector/InfraSelector.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelector.tsx
@@ -1,12 +1,4 @@
-import React, { useEffect } from 'react';
-
-import { useTranslation } from 'react-i18next';
-
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
-import { setFailure } from 'reducers/main';
-import { useAppDispatch } from 'store';
-import { castErrorToFailure } from 'utils/error';
+import React from 'react';
 
 import InfraSelectorModal from './InfraSelectorModal';
 
@@ -14,30 +6,8 @@ type InfraSelectorProps = {
   isInEditor?: boolean;
 };
 
-const InfraSelector = ({ isInEditor }: InfraSelectorProps) => {
-  const dispatch = useAppDispatch();
-  const infraID = useInfraID();
-  const [getInfraByInfraId] = osrdEditoastApi.endpoints.getInfraByInfraId.useLazyQuery({});
-  const { t } = useTranslation(['infraManagement']);
-
-  const getInfra = async (infraId: number) => {
-    getInfraByInfraId({ infraId })
-      .unwrap()
-      .catch((e) =>
-        dispatch(
-          setFailure(castErrorToFailure(e, { name: t('errorMessages.unableToRetrieveInfra') }))
-        )
-      );
-  };
-
-  useEffect(() => {
-    if (infraID !== undefined) {
-      getInfra(infraID);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [infraID]);
-
-  return <InfraSelectorModal isInEditor={isInEditor} />;
-};
+const InfraSelector = ({ isInEditor }: InfraSelectorProps) => (
+  <InfraSelectorModal isInEditor={isInEditor} />
+);
 
 export default InfraSelector;


### PR DESCRIPTION
 Fix #6541

 - map layers : don't display them if the infra is undefined (avoid 404)
 - InfraSelector : remove the code that check that the current infra exist (not it's role and if the infra doesn't exist display an error toast)
 - map reference: if the current infra doesn't exist, then we set it as undefined in the state. It avoid to have "no selected infra" in the header whereas in reality we have one in the store