### PR TITLE
Add codegen filter to ModelV2

### DIFF
--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -1,6 +1,7 @@
 mod args;
 mod codegen;
 mod config;
+mod crud;
 mod identifier;
 mod parsing;
 mod utils;
@@ -93,6 +94,7 @@ fn test_construction() {
         #[model(table = editoast_models::tables::osrd_infra_document)]
         #[model(row(type_name = "DocumentRow", derive(Debug)))]
         #[model(changeset(type_name = "DocumentChangeset", public, derive(Debug)))] // fields are public
+        #[model(gen(ops = crud, batch_ops = crud, list))]
         struct Document {
             #[model(column = "id", preferred, primary)]
             id_: i64,

--- a/editoast/editoast_derive/src/modelv2/args.rs
+++ b/editoast/editoast_derive/src/modelv2/args.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::manual_unwrap_or_default)]
 
-use super::RawIdentifier;
+use super::{crud::Crud, RawIdentifier};
 use darling::{
     ast,
     util::{self, PathList},
@@ -22,12 +22,24 @@ pub(super) struct ModelArgs {
     pub(super) changeset: GeneratedTypeArgs,
     #[darling(multiple, rename = "identifier")]
     pub(super) identifiers: Vec<RawIdentifier>,
+    #[darling(rename = "gen")]
+    pub(super) impl_plan: ImplPlan,
     #[darling(default)]
     pub(super) preferred: Option<RawIdentifier>,
     #[darling(default)]
     pub(super) batch_chunk_size_limit: Option<usize>,
 
     pub(super) data: ast::Data<util::Ignored, ModelFieldArgs>,
+}
+
+#[derive(Debug, PartialEq, Eq, FromMeta)]
+pub(super) struct ImplPlan {
+    #[darling(default)]
+    pub(super) ops: Crud,
+    #[darling(default)]
+    pub(super) batch_ops: Crud,
+    #[darling(default)]
+    pub(super) list: bool,
 }
 
 #[derive(FromMeta, Default, Debug, PartialEq)]

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -6,7 +6,7 @@ use std::{
 use syn::parse_quote;
 
 use super::{
-    args::GeneratedTypeArgs,
+    args::{GeneratedTypeArgs, ImplPlan},
     identifier::{Identifier, RawIdentifier},
 };
 
@@ -22,6 +22,7 @@ pub(crate) struct ModelConfig {
     pub(crate) identifiers: HashSet<Identifier>, // identifiers ⊆ fields
     pub(crate) preferred_identifier: Identifier, // preferred_identifier ∈ identifiers
     pub(crate) primary_identifier: Identifier,   // primary_identifier ∈ identifiers
+    pub(crate) impl_plan: ImplPlan,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/editoast/editoast_derive/src/modelv2/crud.rs
+++ b/editoast/editoast_derive/src/modelv2/crud.rs
@@ -1,0 +1,117 @@
+use darling::FromMeta;
+use syn::Expr;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Crud {
+    pub(super) create: bool,
+    pub(super) read: bool,
+    pub(super) update: bool,
+    pub(super) delete: bool,
+}
+
+impl FromMeta for Crud {
+    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
+        match expr {
+            Expr::Path(path) => {
+                let s = path
+                    .path
+                    .segments
+                    .first()
+                    .expect("a valid path has at least one segment")
+                    .ident
+                    .to_string()
+                    .to_lowercase();
+                if let Some(find) = s.chars().find(|c| !"crud".contains(*c)) {
+                    return Err(darling::Error::unknown_value(&find.to_string()).with_span(path));
+                }
+                Ok(Self {
+                    create: s.contains('c'),
+                    read: s.contains('r'),
+                    update: s.contains('u'),
+                    delete: s.contains('d'),
+                })
+            }
+            _ => Err(darling::Error::unexpected_expr_type(expr)),
+        }
+        .map_err(|e| e.with_span(expr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use quote::quote;
+
+    use super::*;
+
+    fn parse(tokens: proc_macro2::TokenStream) -> Option<Crud> {
+        let sym: syn::Attribute = syn::parse_quote!(#[ignore = #tokens]);
+        FromMeta::from_meta(&sym.meta).ok()
+    }
+
+    #[test]
+    fn full() {
+        assert_eq!(
+            parse(quote! { crud }).unwrap(),
+            Crud {
+                create: true,
+                read: true,
+                update: true,
+                delete: true,
+            }
+        );
+    }
+
+    #[test]
+    fn some() {
+        assert_eq!(
+            parse(quote! { rd }).unwrap(),
+            Crud {
+                create: false,
+                read: true,
+                update: false,
+                delete: true,
+            }
+        );
+    }
+
+    #[test]
+    fn one() {
+        assert_eq!(
+            parse(quote! { c }).unwrap(),
+            Crud {
+                create: true,
+                read: false,
+                update: false,
+                delete: false,
+            }
+        );
+        assert_eq!(
+            parse(quote! { r }).unwrap(),
+            Crud {
+                create: false,
+                read: true,
+                update: false,
+                delete: false,
+            }
+        );
+    }
+
+    #[test]
+    fn duplicates() {
+        assert_eq!(
+            parse(quote! { ccrd }).unwrap(),
+            Crud {
+                create: true,
+                read: true,
+                update: false,
+                delete: true,
+            }
+        );
+    }
+
+    #[test]
+    fn invalid() {
+        assert!(parse(quote! { crod }).is_none());
+    }
+}

--- a/editoast/src/modelsv2/documents.rs
+++ b/editoast/src/modelsv2/documents.rs
@@ -6,6 +6,7 @@ use editoast_derive::ModelV2;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = editoast_models::tables::document)]
+#[model(gen(ops = crd))]
 pub struct Document {
     pub id: i64,
     pub content_type: String,

--- a/editoast/src/modelsv2/electrical_profiles.rs
+++ b/editoast/src/modelsv2/electrical_profiles.rs
@@ -13,6 +13,7 @@ use editoast_schemas::infra::ElectricalProfileSetData;
 #[derive(Clone, Debug, Serialize, Deserialize, ModelV2, ToSchema)]
 #[model(table = editoast_models::tables::electrical_profile_set)]
 #[model(changeset(derive(Deserialize)))]
+#[model(gen(ops = crd))]
 pub struct ElectricalProfileSet {
     pub id: i64,
     pub name: String,

--- a/editoast/src/modelsv2/infra.rs
+++ b/editoast/src/modelsv2/infra.rs
@@ -58,6 +58,7 @@ pub const DEFAULT_INFRA_VERSION: &str = "0";
 
 #[derive(Debug, Clone, Derivative, Serialize, Deserialize, ModelV2, utoipa::ToSchema)]
 #[model(table = editoast_models::tables::infra)]
+#[model(gen(ops = crud, batch_ops = r, list))]
 #[derivative(Default)]
 pub struct Infra {
     pub id: i64,

--- a/editoast/src/modelsv2/infra_objects.rs
+++ b/editoast/src/modelsv2/infra_objects.rs
@@ -41,6 +41,7 @@ macro_rules! infra_model {
         #[derive(Debug, Clone, Default, Serialize, Deserialize, ModelV2)]
         #[model(table = $table)]
         #[model(preferred = (infra_id, obj_id))]
+        #[model(gen(ops = crud, batch_ops = crud, list))]
         pub struct $name {
             pub id: i64,
             pub obj_id: String,

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -57,6 +57,7 @@ mod tests {
 
     #[derive(Debug, Default, Clone, ModelV2, PartialEq, Eq)]
     #[model(table = editoast_models::tables::document)]
+    #[model(gen(ops = crud, batch_ops = crud, list))]
     struct Document {
         id: i64,
         content_type: String,
@@ -164,6 +165,7 @@ mod tests {
 
         #[derive(Debug, Clone, ModelV2)]
         #[model(table = editoast_models::tables::document)]
+        #[model(gen(ops = r, batch_ops = c))]
         struct Document {
             id: i64,
             content_type: String,

--- a/editoast/src/modelsv2/projects.rs
+++ b/editoast/src/modelsv2/projects.rs
@@ -20,6 +20,7 @@ editoast_common::schemas! {
 
 #[derive(Clone, Debug, Serialize, Deserialize, ModelV2, ToSchema, PartialEq)]
 #[model(table = editoast_models::tables::project)]
+#[model(gen(ops = crud, list))]
 pub struct Project {
     pub id: i64,
     pub name: String,

--- a/editoast/src/modelsv2/rolling_stock_image.rs
+++ b/editoast/src/modelsv2/rolling_stock_image.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize, ModelV2)]
 #[model(table = editoast_models::tables::rolling_stock_separate_image)]
+#[model(gen(ops = c))]
 pub struct RollingStockSeparatedImageModel {
     pub id: i64,
     pub order: i32,

--- a/editoast/src/modelsv2/rolling_stock_livery.rs
+++ b/editoast/src/modelsv2/rolling_stock_livery.rs
@@ -21,9 +21,10 @@ use serde::Deserialize;
 /// /!\ Its compound image is not deleted by cascade if the livery is removed.
 ///
 #[derive(Debug, Clone, Derivative, ModelV2)]
+#[cfg_attr(test, derive(Deserialize))]
 #[derivative(Default)]
 #[model(table = editoast_models::tables::rolling_stock_livery)]
-#[cfg_attr(test, derive(Deserialize))]
+#[model(gen(ops = crd, list))]
 pub struct RollingStockLiveryModel {
     pub id: i64,
     pub name: String,

--- a/editoast/src/modelsv2/rolling_stock_model.rs
+++ b/editoast/src/modelsv2/rolling_stock_model.rs
@@ -34,6 +34,7 @@ editoast_common::schemas! {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, ModelV2, ToSchema)]
 #[model(table = editoast_models::tables::rolling_stock)]
+#[model(gen(ops = crud, batch_ops = r, list))]
 #[model(changeset(derive(Validate), public))]
 #[schema(as = RollingStock)]
 pub struct RollingStockModel {

--- a/editoast/src/modelsv2/scenario.rs
+++ b/editoast/src/modelsv2/scenario.rs
@@ -14,6 +14,7 @@ use editoast_models::DbConnection;
 #[derive(Debug, Clone, ModelV2, Deserialize, Serialize, ToSchema)]
 #[schema(as = ScenarioV2)]
 #[model(table = editoast_models::tables::scenario_v2)]
+#[model(gen(ops = crud, list))]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Scenario {
     pub id: i64,

--- a/editoast/src/modelsv2/stdcm_search_environment.rs
+++ b/editoast/src/modelsv2/stdcm_search_environment.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, ModelV2, ToSchema, Serialize)]
 #[model(table = editoast_models::tables::stdcm_search_environment)]
+#[model(gen(ops = crd, list))]
 #[cfg_attr(test, derive(Deserialize, PartialEq), model(changeset(derive(Clone))))]
 pub struct StdcmSearchEnvironment {
     pub id: i64,

--- a/editoast/src/modelsv2/study.rs
+++ b/editoast/src/modelsv2/study.rs
@@ -15,6 +15,7 @@ use editoast_models::DbConnection;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelV2, ToSchema)]
 #[model(table = editoast_models::tables::study)]
+#[model(gen(ops = crud, list))]
 pub struct Study {
     pub id: i64,
     pub name: String,

--- a/editoast/src/modelsv2/train_schedule.rs
+++ b/editoast/src/modelsv2/train_schedule.rs
@@ -11,6 +11,7 @@ use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = editoast_models::tables::train_schedule_v2)]
+#[model(gen(ops = crud, batch_ops = crd, list))]
 pub struct TrainSchedule {
     pub id: i64,
     pub train_name: String,

--- a/editoast/src/modelsv2/work_schedules.rs
+++ b/editoast/src/modelsv2/work_schedules.rs
@@ -9,6 +9,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Clone, ModelV2)]
 #[model(table = editoast_models::tables::work_schedule_group)]
+#[model(gen(ops = crd, batch_ops = c, list))]
 pub struct WorkScheduleGroup {
     pub id: i64,
     pub creation_date: NaiveDateTime,
@@ -25,6 +26,7 @@ pub enum WorkScheduleType {
 
 #[derive(Debug, Default, Clone, ModelV2)]
 #[model(table = editoast_models::tables::work_schedule)]
+#[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {
     pub id: i64,
     pub start_date_time: NaiveDateTime,

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -15,13 +15,10 @@ use utoipa::ToSchema;
 
 use crate::error::InternalError;
 use crate::error::Result;
+use crate::modelsv2::prelude::*;
 use crate::modelsv2::work_schedules::WorkSchedule;
 use crate::modelsv2::work_schedules::WorkScheduleGroup;
 use crate::modelsv2::work_schedules::WorkScheduleType;
-use crate::modelsv2::Changeset;
-use crate::modelsv2::Create;
-use crate::modelsv2::CreateBatch;
-use crate::modelsv2::Model;
 use crate::views::AuthorizationError;
 use crate::views::AuthorizerExt;
 use crate::AppState;
@@ -187,7 +184,6 @@ pub mod test {
     use std::ops::DerefMut;
 
     use super::*;
-    use crate::modelsv2::prelude::*;
     use crate::views::test_app::TestAppBuilder;
 
     #[rstest]


### PR DESCRIPTION
Adds an option to parametrize which implementation ModelV2 has to generate. This is required to support single PK field models (such as `Timetable`).

No impact on compilation times.

refs #8111 