### PR TITLE
actions: adding quotes around commit title in log's checker

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -59,7 +59,7 @@ while IFS= read -r commit_title; do
         # if it's the first error for this commit, print the error header
         if [ -z "$commit_check_failed" ]; then
             printf '%sinvalid commit title:%s ' "$RED" "$RESET"
-            printf '%s%s%s\n' "$BLUE" "$commit_title" "$RESET"
+            printf '%s"%s"%s\n' "$BLUE" "$commit_title" "$RESET"
         fi
 
         printf '   %s- %s%s\n' "$RED" "$check_error" "$RESET"


### PR DESCRIPTION
With quotes around, it's easier to see if you have a whitespace at the start