### PR TITLE
docker: port is an integer

### DIFF
--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -23,7 +23,7 @@ services:
     network_mode: host
     environment:
       PSQL_HOST: "localhost"
-      EDITOAST_PORT: "8090"
+      EDITOAST_PORT: 8090
       OSRD_BACKEND_URL: "http://localhost:8080"
       REDIS_URL: "redis://localhost"
       DATABASE_URL: "postgres://osrd:password@localhost:5432/osrd"


### PR DESCRIPTION
Since `docker-compose.host.yml` is used to override values of `docker-compose.yml`, and `EDITOAST_PORT` is defined as an integer in the latter, tools like `podman` will refuse to merge the 2 files since the value of `EDITOAST_PORT` is a different type.

```
ValueError: can't merge value of EDITOAST_PORT of type <class 'int'> and <class 'str'>
```