### PR TITLE
core: fallback for speed limit tags

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -68,10 +68,13 @@ opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrum
 opentracing-util = { module = 'io.opentracing:opentracing-util', version = '0.33.0' }
 dd-trace-api = { module = 'com.datadoghq:dd-trace-api', version = '1.31.2' }
 
+kaml = { module = 'com.charleskorn.kaml:kaml', version = '0.59.0' } # Apache 2.0
+
 [plugins]
 # kotlin
 ksp = { id = 'com.google.devtools.ksp', version.ref = 'ksp' }
 kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
+kotlin-serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', version.ref = 'kotlin' }
 
 # java
 spotbugs = { id = 'com.github.spotbugs', version = '6.0.9' }

--- a/core/kt-osrd-rjs-parser/build.gradle
+++ b/core/kt-osrd-rjs-parser/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     id 'jacoco'
 }
@@ -30,6 +31,9 @@ dependencies {
 
     // Use JUnit Jupiter API for testing.
     testImplementation libs.junit.jupiter.api
+
+    // YAML
+    implementation libs.kaml
 }
 
 // to get KSP generated-stuff to be recognised

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -1,11 +1,16 @@
 package fr.sncf.osrd
 
+import com.charleskorn.kaml.Yaml
 import com.google.common.primitives.Doubles
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeEndpoint
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
-import fr.sncf.osrd.railjson.schema.infra.*
+import fr.sncf.osrd.railjson.schema.infra.RJSInfra
+import fr.sncf.osrd.railjson.schema.infra.RJSRoute
+import fr.sncf.osrd.railjson.schema.infra.RJSSwitch
+import fr.sncf.osrd.railjson.schema.infra.RJSSwitchType
+import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSRouteWaypoint
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSElectrification
@@ -15,28 +20,70 @@ import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSpeedSection
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Detector
+import fr.sncf.osrd.sim_infra.api.DetectorId
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.api.DirTrackSectionId
+import fr.sncf.osrd.sim_infra.api.EndpointTrackSectionId
+import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
+import fr.sncf.osrd.sim_infra.api.LoadingGaugeType
+import fr.sncf.osrd.sim_infra.api.NeutralSection
+import fr.sncf.osrd.sim_infra.api.RawInfra
+import fr.sncf.osrd.sim_infra.api.RawSignalParameters
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackNodeConfig
+import fr.sncf.osrd.sim_infra.api.TrackNodeConfigId
+import fr.sncf.osrd.sim_infra.api.TrackNodeId
+import fr.sncf.osrd.sim_infra.api.TrackNodePort
+import fr.sncf.osrd.sim_infra.api.TrackNodePortId
+import fr.sncf.osrd.sim_infra.api.TrackSection
+import fr.sncf.osrd.sim_infra.api.ZoneId
+import fr.sncf.osrd.sim_infra.api.decreasing
+import fr.sncf.osrd.sim_infra.api.increasing
 import fr.sncf.osrd.sim_infra.impl.BuildRouteError
 import fr.sncf.osrd.sim_infra.impl.MissingNodeConfig
 import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
 import fr.sncf.osrd.sim_infra.impl.ReachedNodeDeadEnd
 import fr.sncf.osrd.sim_infra.impl.ReachedTrackDeadEnd
+import fr.sncf.osrd.sim_infra.impl.SpeedLimitTagDescriptor
 import fr.sncf.osrd.sim_infra.impl.SpeedSection
 import fr.sncf.osrd.sim_infra.impl.TrackChunkDescriptor
 import fr.sncf.osrd.sim_infra.impl.TrackNodeConfigDescriptor
 import fr.sncf.osrd.sim_infra.impl.route
-import fr.sncf.osrd.utils.*
+import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.Direction.DECREASING
 import fr.sncf.osrd.utils.Direction.INCREASING
-import fr.sncf.osrd.utils.indexing.*
-import fr.sncf.osrd.utils.units.*
+import fr.sncf.osrd.utils.DirectionalMap
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.DistanceRangeMapImpl
+import fr.sncf.osrd.utils.Endpoint
+import fr.sncf.osrd.utils.UnionFind
+import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.indexing.DirStaticIdx
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArraySet
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticPool
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Speed
+import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.metersPerSecond
+import fr.sncf.osrd.utils.units.mutableOffsetArrayListOf
+import java.io.IOException
 import java.util.*
 import kotlin.collections.set
 import kotlin.math.abs
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import mu.KotlinLogging
 
 val logger = KotlinLogging.logger {}
+private const val SPEED_LIMIT_TAGS_RESOURCE_PATH = "speed_limit_tags.yml"
 
 private fun parseLineString(rjsLineString: RJSLineString?): LineString? {
     if (rjsLineString == null) return null
@@ -717,6 +764,41 @@ fun EdgeEndpoint.toEndpoint(): Endpoint {
     return if (this == EdgeEndpoint.BEGIN) Endpoint.START else Endpoint.END
 }
 
+@Serializable
+data class YamlSpeedLimitTagDescriptor(
+    val name: String,
+    @SerialName("fallback_list") val fallbackList: List<String>,
+    @SerialName("default_speed") val defaultSpeed: Double?,
+)
+
+fun parseSpeedLimitTags(builder: RawInfraBuilder) {
+    val resourceURL =
+        {}.javaClass.classLoader.getResource(SPEED_LIMIT_TAGS_RESOURCE_PATH)
+            ?: throw IOException(
+                "can't find speedLimitTags resource $SPEED_LIMIT_TAGS_RESOURCE_PATH"
+            )
+    val speedLimitTagDescriptors =
+        Yaml.default.decodeFromString(
+            MapSerializer(String.serializer(), YamlSpeedLimitTagDescriptor.serializer()),
+            resourceURL.readText(),
+        )
+
+    for ((tagCode, tagDescriptor) in speedLimitTagDescriptors.entries) {
+        val defaultSpeed =
+            if (tagDescriptor.defaultSpeed != null)
+                Speed.fromMetersPerSecond(tagDescriptor.defaultSpeed)
+            else null
+        builder.speedLimitTag(
+            SpeedLimitTagDescriptor(
+                tagCode,
+                tagDescriptor.name,
+                tagDescriptor.fallbackList,
+                defaultSpeed
+            )
+        )
+    }
+}
+
 fun parseRJSInfra(rjsInfra: RJSInfra): RawInfra {
     val builder = RawInfraBuilder()
 
@@ -820,6 +902,8 @@ fun parseRJSInfra(rjsInfra: RJSInfra): RawInfra {
     for (rjsSignal in rjsInfra.signals) {
         parseSignal(builder, rjsSignal)
     }
+
+    parseSpeedLimitTags(builder)
 
     return builder.build()
 }

--- a/core/kt-osrd-rjs-parser/src/main/resources/speed_limit_tags.yml
+++ b/core/kt-osrd-rjs-parser/src/main/resources/speed_limit_tags.yml
@@ -1,0 +1,224 @@
+V200:
+  name: Voyageurs - V200
+  fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+R200:
+  name: Voyageurs - Trains réversibles V200
+  fallback_list: [V200, V160, V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+AR200:
+  name: Voyageurs - AR200
+  fallback_list: [V200, V160, V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+V160:
+  name: Voyageurs - V160
+  fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+R160:
+  name: Voyageurs - Trains réversibles V160
+  fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+AR160:
+  name: Voyageurs - AR160
+  fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+V140:
+  name: Voyageurs - V140
+  fallback_list: [V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+R140:
+  name: Voyageurs - Trains réversibles V140
+  fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+AR140:
+  name: Voyageurs - AR140
+  fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+V120:
+  name: Voyageurs - V120
+  fallback_list: [ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+R120:
+  name: Voyageurs - Trains réversibles V120
+  fallback_list: [V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+AR120:
+  name: Voyageurs - AR120
+  fallback_list: [V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+MVGV:
+  name: Messagerie - MVGV
+  fallback_list: [MV160, ME140, ME120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+MV160:
+  name: Messagerie - MV160
+  fallback_list: [ME140, ME120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+ME140:
+  name: Messagerie - ME140
+  fallback_list: [ME120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+ME120:
+  name: Messagerie - ME120
+  fallback_list: [ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+ME100:
+  name: Messagerie - ME100
+  fallback_list: [MA100, MA90, MA80]
+  default_speed: 8.333333
+
+HLP:
+  name: Divers - Haut le pied
+  fallback_list: [ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+MA100:
+  name: Marchandise - MA100
+  fallback_list: [MA90, MA80]
+  default_speed: 8.333333
+
+MA90:
+  name: Marchandise - MA90
+  fallback_list: [MA80]
+  default_speed: 8.333333
+
+MA80:
+  name: Marchandise - MA80
+  fallback_list: []
+  default_speed: 8.333333
+
+E32C:
+  name: Voyageurs - Automoteurs - E32C
+  fallback_list: [E30C, E20C, E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E30C:
+  name: Voyageurs - Automoteurs - E30C
+  fallback_list: [E20C, E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E20C:
+  name: Voyageurs - Automoteurs - E20C
+  fallback_list: [E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E20N:
+  name: Voyageurs - Automoteurs - E20N
+  fallback_list: [V200, E16N, V160, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E16C:
+  name: Voyageurs - Automoteurs - E16C
+  fallback_list: [E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E16N:
+  name: Voyageurs - Automoteurs - E16N
+  fallback_list: [V160, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14F:
+  name: Voyageurs - Automoteurs - E14F
+  fallback_list: [E14R, E14Q, E14P, E14C, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14C:
+  name: Voyageurs - Automoteurs - E14C
+  fallback_list: [E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14R:
+  name: Voyageurs - Automoteurs - E14R
+  fallback_list: [E14Q, E14P, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14Q:
+  name: Voyageurs - Automoteurs - E14Q
+  fallback_list: [E14P, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14P:
+  name: Voyageurs - Automoteurs - E14P
+  fallback_list: [E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E14N:
+  name: Voyageurs - Automoteurs - E14N
+  fallback_list: [V140, E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E12C:
+  name: Voyageurs - Automoteurs - E12C
+  fallback_list: [E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E12Q:
+  name: Voyageurs - Automoteurs - E12Q
+  fallback_list: [E12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E12N:
+  name: Voyageurs - Automoteurs - E12N
+  fallback_list: [V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+E10C:
+  name: Voyageurs - Automoteurs - E10C
+  fallback_list: [ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+T16C:
+  name: Voyageurs - Autorails - T16C
+  fallback_list: [V160, T14C, T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+T14C:
+  name: Voyageurs - Autorails - T14C
+  fallback_list: [T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+T14N:
+  name: Voyageurs - Autorails - T14N
+  fallback_list: [V140, T12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+T12C:
+  name: Voyageurs - Autorails - T12C
+  fallback_list: [T12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+T12N:
+  name: Voyageurs - Autorails - T12N
+  fallback_list: [V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+B16C:
+  name: Voyageurs - BIMA - B16C
+  fallback_list: [T16C, V160, T14C, T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
+  default_speed: 8.333333
+
+TM:
+  name: Divers - Train de machines
+  fallback_list: [MA90, MA80]
+  default_speed: 8.333333
+
+EVO:
+  name: Divers - Evolution
+  fallback_list: [MA80]
+  default_speed: 8.333333

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -187,6 +187,7 @@ class RawInfraBuilder {
     private val zonePathMap = mutableMapOf<ZonePathSpec, ZonePathId>()
     private val operationalPointPartPool =
         StaticPool<OperationalPointPart, OperationalPointPartDescriptor>()
+    private val speedLimitTagPool = mutableMapOf<String, SpeedLimitTagDescriptor>()
 
     private val trackSectionNameToIdxMap = mutableMapOf<String, TrackSectionId>()
     private val routeNameToIdxMap = mutableMapOf<String, RouteId>()
@@ -433,6 +434,10 @@ class RawInfraBuilder {
         return physicalSignalPool.add(builder.build())
     }
 
+    fun speedLimitTag(tagDescriptor: SpeedLimitTagDescriptor) {
+        speedLimitTagPool[tagDescriptor.id] = tagDescriptor
+    }
+
     fun trackSection(name: String, chunks: StaticIdxList<TrackChunk>): TrackSectionId {
         val chunkBoundaryToDetector = MutableList<DetectorId?>(chunks.size + 1) { null }
         val detectors = mutableStaticIdxArrayListOf<Detector>()
@@ -568,6 +573,7 @@ class RawInfraBuilder {
             zonePathPool,
             zonePathMap,
             operationalPointPartPool,
+            speedLimitTagPool,
             makeTrackNameMap(),
             makeRouteNameMap(),
             makeDetEntryToRouteMap(),

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/units/Speed.kt
@@ -9,7 +9,7 @@ value class Speed(val millimetersPerSecond: ULong) : Comparable<Speed> {
 
     override fun toString(): String {
         val metersPerSecond = millimetersPerSecond / multiplier.toUInt()
-        val decimal = metersPerSecond % multiplier.toUInt()
+        val decimal = millimetersPerSecond % multiplier.toUInt()
         if (decimal == 0UL) return String.format("%sm/s", metersPerSecond)
         else return String.format("%s.%sm/s", metersPerSecond, decimal)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -9,14 +9,24 @@ import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfi
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingStock
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.SignalingSystem
+import fr.sncf.osrd.sim_infra.api.TrackChunk
+import fr.sncf.osrd.sim_infra.api.TrackLocation
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.sim_infra.impl.buildChunkPath
 import fr.sncf.osrd.sim_infra.impl.getOffsetOfTrackLocationOnChunks
 import fr.sncf.osrd.sim_infra.utils.BlockPathElement
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
 import fr.sncf.osrd.sim_infra.utils.toList
-import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.moshi.MoshiUtils
 import fr.sncf.osrd.utils.units.Offset
 import java.io.File
@@ -75,9 +85,8 @@ object Helpers {
 
     @Throws(IOException::class, URISyntaxException::class)
     private fun <T> deserializeResource(adapter: JsonAdapter<T>, resourcePath: String): T {
-        val loader = Helpers::class.java.getClassLoader()
         val resourceURL =
-            loader.getResource(resourcePath)
+            {}.javaClass.classLoader.getResource(resourcePath)
                 ?: throw IOException("can't find resource $resourcePath")
         return MoshiUtils.deserialize(adapter, Paths.get(resourceURL.toURI()))
     }
@@ -85,8 +94,7 @@ object Helpers {
     /** Given a resource path find the full path (works cross-platform) */
     @JvmStatic
     fun getResourcePath(resourcePath: String?): Path {
-        val classLoader = Helpers::class.java.getClassLoader()
-        val url = classLoader.getResource(resourcePath)!!
+        val url = {}.javaClass.classLoader.getResource(resourcePath)!!
         return try {
             File(url.toURI()).toPath()
         } catch (e: URISyntaxException) {


### PR DESCRIPTION
Only handling the speed for now, no work on output, warnings and logs.
Extra-code to handle long-names currently used on speedLimitTag (both in infra or in requested simu).

also: little fix on `Speed.toString()`

Test:
- ✅ hand-tested locally that fallback works (for long-names) on small-infra: adding a speed section on `Messagerie - ME100` somewhere else than South-East(to be able to select it), then using that speedLimitTag on a train to trigger fallback to MA100 on South-East.

Fix #7715 