### PR TITLE
front: fix chart pointers and train details

### DIFF
--- a/front/src/applications/operationalStudies/hooks.ts
+++ b/front/src/applications/operationalStudies/hooks.ts
@@ -234,77 +234,79 @@ export const useSimulationResults = () => {
           setFormattedPowerRestrictions(powerRestrictionsWithHandled);
         }
 
-        // Format chart synchronizer data
-        const {
-          baseHeadPositions,
-          baseTailPositions,
-          baseSpeeds,
-          marginSpeeds,
-          ecoHeadPosition,
-          ecoTailPosition,
-          ecoSpeeds,
-        } = trainSimulation.base.positions.reduce(
-          (results, position, index) => {
-            const positionInMeters = mmToM(position);
+        const baseHeadPositions: { time: Date; position: number }[] = [];
+        const baseTailPositions: { time: Date; position: number }[] = [];
+        const baseSpeeds: { time: Date; position: number; speed: number }[] = [];
+        trainSimulation.base.positions.forEach((positionInMM, index) => {
+          const position = mmToM(positionInMM);
 
-            // TODO GET v2 : probably remove this conversion as trains will travel on several days
-            // The chart time axis is set by d3 function *sec2d3datetime* which start the chart at 01/01/1900 00:00:00
-            // As javascript new Date() util takes count of the minutes lost since 1/1/1900 (9min and 21s), we have
-            // to use sec2d3datetime here as well to set the times on the chart
-            const time = sec2d3datetime(
-              isoDateWithTimezoneToSec(selectedTrainSchedule.start_time) +
-                trainSimulation.base.times[index] / 1000
-            );
-
-            if (!time) {
-              return results;
-            }
-
-            results.baseHeadPositions.push({ position: positionInMeters, time });
-            results.baseTailPositions.push({
-              position: positionInMeters - selectedTrainRollingStock.length,
-              time,
-            });
-            results.baseSpeeds.push({
-              position: positionInMeters,
-              time,
-              speed: trainSimulation.base.speeds[index],
-            });
-            results.marginSpeeds.push({
-              position: positionInMeters,
-              time,
-              speed: trainSimulation.final_output.speeds[index],
-            });
-            results.ecoHeadPosition.push({ position, time });
-            results.ecoTailPosition.push({
-              position: positionInMeters - selectedTrainRollingStock.length,
-              time,
-            });
-            results.ecoSpeeds.push({
-              position: positionInMeters,
-              time,
-              speed: trainSimulation.final_output.speeds[index],
-            });
-            return results;
-          },
-          {
-            baseHeadPositions: [] as { time: Date; position: number }[],
-            baseTailPositions: [] as { time: Date; position: number }[],
-            baseSpeeds: [] as { time: Date; position: number; speed: number }[],
-            marginSpeeds: [] as { time: Date; position: number; speed: number }[],
-            ecoHeadPosition: [] as { time: Date; position: number }[],
-            ecoTailPosition: [] as { time: Date; position: number }[],
-            ecoSpeeds: [] as { time: Date; position: number; speed: number }[],
+          // TODO GET v2 : probably remove this conversion as trains will travel on several days
+          // The chart time axis is set by d3 function *sec2d3datetime* which start the chart at 01/01/1900 00:00:00
+          // As javascript new Date() util takes count of the minutes lost since 1/1/1900 (9min and 21s), we have
+          // to use sec2d3datetime here as well to set the times on the chart
+          const time = sec2d3datetime(
+            isoDateWithTimezoneToSec(selectedTrainSchedule.start_time) +
+              trainSimulation.base.times[index] / 1000
+          );
+          if (!time) {
+            return;
           }
-        );
+
+          baseHeadPositions.push({ position, time });
+          baseTailPositions.push({
+            position: position - selectedTrainRollingStock.length,
+            time,
+          });
+          baseSpeeds.push({
+            position,
+            time,
+            speed: trainSimulation.base.speeds[index],
+          });
+        });
+
+        const marginSpeeds: { time: Date; position: number; speed: number }[] = [];
+        const ecoHeadPositions: { time: Date; position: number }[] = [];
+        const ecoTailPositions: { time: Date; position: number }[] = [];
+        const ecoSpeeds: { time: Date; position: number; speed: number }[] = [];
+        trainSimulation.final_output.positions.forEach((positionInMM, index) => {
+          const position = mmToM(positionInMM);
+
+          // TODO GET v2 : probably remove this conversion as trains will travel on several days
+          // The chart time axis is set by d3 function *sec2d3datetime* which start the chart at 01/01/1900 00:00:00
+          // As javascript new Date() util takes count of the minutes lost since 1/1/1900 (9min and 21s), we have
+          // to use sec2d3datetime here as well to set the times on the chart
+          const time = sec2d3datetime(
+            isoDateWithTimezoneToSec(selectedTrainSchedule.start_time) +
+              trainSimulation.final_output.times[index] / 1000
+          );
+          if (!time) {
+            return;
+          }
+
+          marginSpeeds.push({
+            position,
+            time,
+            speed: trainSimulation.final_output.speeds[index],
+          });
+          ecoHeadPositions.push({ position, time });
+          ecoTailPositions.push({
+            position: position - selectedTrainRollingStock.length,
+            time,
+          });
+          ecoSpeeds.push({
+            position,
+            time,
+            speed: trainSimulation.final_output.speeds[index],
+          });
+        });
 
         const formattedChartSynchronizerData: ChartSynchronizerTrainData = {
           headPosition: baseHeadPositions,
           tailPosition: baseTailPositions,
           speed: baseSpeeds,
           margins_speed: marginSpeeds,
-          eco_headPosition: ecoHeadPosition,
-          eco_tailPosition: ecoTailPosition,
+          eco_headPosition: ecoHeadPositions,
+          eco_tailPosition: ecoTailPositions,
           eco_speed: ecoSpeeds,
         };
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/drawTrain.ts
@@ -161,7 +161,7 @@ export default function drawTrain(
         groupID,
         'curveLinear',
         CHART_AXES.SPACE_TIME,
-        'headPosition',
+        'eco_headPosition',
         rotate,
         isSelected
       )
@@ -174,7 +174,7 @@ export default function drawTrain(
         groupID,
         'curveLinear',
         CHART_AXES.SPACE_TIME,
-        'tailPosition',
+        'eco_tailPosition',
         rotate,
         isSelected
       )

--- a/front/src/modules/simulationResult/components/TrainDetailsV2.tsx
+++ b/front/src/modules/simulationResult/components/TrainDetailsV2.tsx
@@ -43,9 +43,10 @@ type TrainDetailsV2Props = {
 };
 
 const TrainDetailsV2 = ({ projectedTrain }: TrainDetailsV2Props) => {
-  const [{ headPosition, tailPosition, speed }, setLocalPositionValues] = useState<
-    PositionsSpeedTimes<Date>
-  >({} as PositionsSpeedTimes<Date>);
+  const [
+    { eco_headPosition: headPosition, eco_tailPosition: tailPosition, eco_speed: speed },
+    setLocalPositionValues,
+  ] = useState<PositionsSpeedTimes<Date>>({} as PositionsSpeedTimes<Date>);
 
   useChartSynchronizerV2(
     (_, positionValues) => {


### PR DESCRIPTION
_See individual commits._

Closes: https://github.com/OpenRailAssociation/osrd/issues/7801

* * *

This has one unfortunate consequence: the space-speed chart now (correctly) displays pointers that are not aligned vertically for a given timestamp. That is, the pointer for the eco curve will lag behind the pointer for the base curve. See below:

![out](https://github.com/OpenRailAssociation/osrd/assets/506932/b593cac5-e2df-4f9c-80d3-b20f020d242a)

I don't see a good way to fix it when hovering the space-time chart... Maybe only show the pointer for eco, not for base?