### PR TITLE
editoast: refactor infra tests part 7

### DIFF
--- a/editoast/editoast_models/src/db_connection_pool.rs
+++ b/editoast/editoast_models/src/db_connection_pool.rs
@@ -134,6 +134,14 @@ impl DbConnectionPoolV2 {
     /// # }
     /// ```
     ///
+    /// ### Deadlocks
+    ///
+    /// We encountered a deadlock error in our tests,
+    /// especially those using `empty_infra` and `small_infra`.
+    /// Adding `#[serial_test::serial]` solved the issue.
+    /// We tried increasing the deadlock timeout, but that didn't work.
+    /// Using random `infra_id` with rand didn't help either.
+    ///
     /// ## Guidelines
     ///
     /// To prevent these issues, prefer the following patterns:

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -474,7 +474,7 @@ pub mod tests {
         Infra::changeset()
             .name("small_infra".to_owned())
             .last_railjson_version()
-            .persist(railjson, db_pool)
+            .persist(railjson, db_pool.get().await.unwrap().deref_mut())
             .await
             .unwrap()
     }

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -4,6 +4,7 @@ pub mod tests {
     use std::io::Cursor;
     use std::ops::{Deref, DerefMut};
     use std::sync::Arc;
+    use uuid::Uuid;
 
     use editoast_models::create_connection_pool;
     use editoast_models::DbConnection;
@@ -261,8 +262,7 @@ pub mod tests {
         } = scenario_fixture_set().await;
 
         let pathfinding = pathfinding(db_pool()).await;
-        let mut rs_name = "fast_rolling_stock_".to_string();
-        rs_name.push_str(name);
+        let rs_name = format!("fast_rolling_stock_{}_{name}", Uuid::new_v4()).to_string();
         let rolling_stock = named_fast_rolling_stock(&rs_name, db_pool()).await;
         let ts_model = make_train_schedule(
             db_pool(),

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -209,20 +209,21 @@ pub mod tests {
     use rstest::rstest;
     use std::ops::DerefMut;
 
-    use crate::fixtures::tests::db_pool;
     use crate::generated_data::clear_all;
-    use crate::generated_data::refresh_all;
+    use crate::generated_data::refresh_all_v2;
     use crate::generated_data::update_all;
     use crate::modelsv2::fixtures::create_empty_infra;
     use editoast_models::DbConnectionPoolV2;
 
     #[rstest] // Slow test
     async fn refresh_all_test() {
-        let db_pool_v2 = DbConnectionPoolV2::for_tests();
-        let infra = create_empty_infra(db_pool_v2.get_ok().deref_mut()).await;
-        assert!(refresh_all(db_pool(), infra.id, &Default::default())
-            .await
-            .is_ok());
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        assert!(
+            refresh_all_v2(db_pool.into(), infra.id, &Default::default())
+                .await
+                .is_ok()
+        );
     }
 
     #[rstest]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -506,7 +506,7 @@ async fn generate_infra(
         );
         let infra_cache = InfraCache::load(db_pool.get().await?.deref_mut(), &infra).await?;
         if infra
-            .refresh_v2(db_pool.clone(), args.force, &infra_cache)
+            .refresh(db_pool.clone(), args.force, &infra_cache)
             .await?
         {
             build_redis_pool_and_invalidate_all_cache(redis_config.clone(), infra.id).await?;
@@ -641,7 +641,7 @@ async fn import_railjson(
     // Generate only if the was set
     if args.generate {
         let infra_cache = InfraCache::load(db_pool.get().await?.deref_mut(), &infra).await?;
-        infra.refresh_v2(db_pool, true, &infra_cache).await?;
+        infra.refresh(db_pool, true, &infra_cache).await?;
         println!(
             "✅ Infra {infra_name}[{}] generated data refreshed!",
             infra.id

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -630,7 +630,9 @@ async fn import_railjson(
     let railjson: RailJson = serde_json::from_reader(BufReader::new(railjson_file))?;
 
     println!("🍞 Importing infra {infra_name}");
-    let mut infra = infra.persist_v2(railjson, db_pool.clone()).await?;
+    let mut infra = infra
+        .persist(railjson, db_pool.get().await?.deref_mut())
+        .await?;
 
     infra
         .bump_version(db_pool.get().await?.deref_mut())

--- a/editoast/src/modelsv2/fixtures.rs
+++ b/editoast/src/modelsv2/fixtures.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 
 use chrono::Utc;
 use editoast_schemas::infra::InfraObject;
@@ -287,7 +286,7 @@ where
     railjson_object
 }
 
-pub async fn create_small_infra(db_pool: Arc<DbConnectionPoolV2>) -> Infra {
+pub async fn create_small_infra(conn: &mut DbConnection) -> Infra {
     let railjson: RailJson = serde_json::from_str(include_str!(
         "../../../tests/data/infras/small_infra/infra.json"
     ))
@@ -295,7 +294,7 @@ pub async fn create_small_infra(db_pool: Arc<DbConnectionPoolV2>) -> Infra {
     Infra::changeset()
         .name("small_infra".to_owned())
         .last_railjson_version()
-        .persist_v2(railjson, db_pool)
+        .persist(railjson, conn)
         .await
         .unwrap()
 }

--- a/editoast/src/modelsv2/infra.rs
+++ b/editoast/src/modelsv2/infra.rs
@@ -236,6 +236,31 @@ impl Infra {
     /// `force` argument allows us to refresh it in any cases.
     /// This function will update `generated_version` accordingly.
     /// If refreshed you need to call `invalidate_after_refresh` to invalidate layer cache
+    pub async fn refresh_v2(
+        &mut self,
+        db_pool: Arc<DbConnectionPoolV2>,
+        force: bool,
+        infra_cache: &InfraCache,
+    ) -> Result<bool> {
+        // Check if refresh is needed
+        if !force
+            && self.generated_version.is_some()
+            && &self.version == self.generated_version.as_ref().unwrap()
+        {
+            return Ok(false);
+        }
+
+        // TODO: lock self for update
+
+        generated_data::refresh_all_v2(db_pool.clone(), self.id, infra_cache).await?;
+
+        // Update generated infra version
+        self.bump_generated_version(db_pool.get().await?.deref_mut())
+            .await?;
+
+        Ok(true)
+    }
+
     pub async fn refresh(
         &mut self,
         db_pool: Arc<DbConnectionPool>,

--- a/editoast/src/modelsv2/railjson.rs
+++ b/editoast/src/modelsv2/railjson.rs
@@ -1,16 +1,12 @@
-use std::sync::Arc;
-
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::RailJson;
 use editoast_schemas::infra::RAILJSON_VERSION;
 
-use crate::error::InternalError;
 use crate::error::Result;
 use crate::modelsv2::infra_objects::*;
 use crate::modelsv2::prelude::*;
+use diesel_async::AsyncConnection;
 use editoast_models::DbConnection;
-use editoast_models::DbConnectionPool;
-use editoast_models::DbConnectionPoolV2;
 
 #[derive(Debug, thiserror::Error, EditoastError)]
 #[editoast_error(base_id = "railjson")]
@@ -23,26 +19,11 @@ pub enum RailJsonError {
 ///
 /// All objects are attached to a given infra.
 ///
-/// #### `/!\ ATTENTION /!\` On failure this function does NOT rollback the insertions!
 pub async fn persist_railjson(
-    db_pool: Arc<DbConnectionPool>,
+    connection: &mut DbConnection,
     infra_id: i64,
     railjson: RailJson,
 ) -> Result<()> {
-    macro_rules! persist {
-        ($model:ident, $objects:expr) => {
-            async {
-                let conn = &mut db_pool.get().await.map_err(Into::<InternalError>::into)?;
-                let _ = $model::create_batch::<_, Vec<_>>(
-                    conn,
-                    $model::from_infra_schemas(infra_id, $objects),
-                )
-                .await?;
-                Ok(())
-            }
-        };
-    }
-
     let RailJson {
         version,
         track_sections,
@@ -57,6 +38,7 @@ pub async fn persist_railjson(
         extended_switch_types,
         neutral_sections,
     } = railjson;
+
     if version != RAILJSON_VERSION {
         return Err(RailJsonError::UnsupportedVersion {
             actual: version,
@@ -64,20 +46,80 @@ pub async fn persist_railjson(
         }
         .into());
     }
-    futures::try_join!(
-        persist!(TrackSectionModel, track_sections),
-        persist!(BufferStopModel, buffer_stops),
-        persist!(ElectrificationModel, electrifications),
-        persist!(DetectorModel, detectors),
-        persist!(OperationalPointModel, operational_points),
-        persist!(RouteModel, routes),
-        persist!(SignalModel, signals),
-        persist!(SwitchModel, switches),
-        persist!(SpeedSectionModel, speed_sections),
-        persist!(SwitchTypeModel, extended_switch_types),
-        persist!(NeutralSectionModel, neutral_sections),
-    )
-    .map(|_| ())
+
+    connection
+        .transaction(|conn| {
+            Box::pin(async {
+                let _ = TrackSectionModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    TrackSectionModel::from_infra_schemas(infra_id, track_sections),
+                )
+                .await?;
+
+                let _ = BufferStopModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    BufferStopModel::from_infra_schemas(infra_id, buffer_stops),
+                )
+                .await?;
+
+                let _ = ElectrificationModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    ElectrificationModel::from_infra_schemas(infra_id, electrifications),
+                )
+                .await?;
+
+                let _ = DetectorModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    DetectorModel::from_infra_schemas(infra_id, detectors),
+                )
+                .await?;
+
+                let _ = OperationalPointModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    OperationalPointModel::from_infra_schemas(infra_id, operational_points),
+                )
+                .await?;
+
+                let _ = RouteModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    RouteModel::from_infra_schemas(infra_id, routes),
+                )
+                .await?;
+
+                let _ = SignalModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    SignalModel::from_infra_schemas(infra_id, signals),
+                )
+                .await?;
+
+                let _ = SwitchModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    SwitchModel::from_infra_schemas(infra_id, switches),
+                )
+                .await?;
+
+                let _ = SpeedSectionModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    SpeedSectionModel::from_infra_schemas(infra_id, speed_sections),
+                )
+                .await?;
+
+                let _ = SwitchTypeModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    SwitchTypeModel::from_infra_schemas(infra_id, extended_switch_types),
+                )
+                .await?;
+
+                let _ = NeutralSectionModel::create_batch::<_, Vec<_>>(
+                    conn,
+                    NeutralSectionModel::from_infra_schemas(infra_id, neutral_sections),
+                )
+                .await?;
+
+                Ok(())
+            })
+        })
+        .await
 }
 
 pub async fn find_all_schemas<T, C>(conn: &mut DbConnection, infra_id: i64) -> Result<C>
@@ -90,60 +132,4 @@ where
         .into_iter()
         .map(Into::into)
         .collect())
-}
-
-pub async fn persist_railjson_v2(
-    db_pool: Arc<DbConnectionPoolV2>,
-    infra_id: i64,
-    railjson: RailJson,
-) -> Result<()> {
-    macro_rules! persist {
-        ($model:ident, $objects:expr) => {
-            async {
-                let conn = &mut db_pool.get().await.map_err(Into::<InternalError>::into)?;
-                let _ = $model::create_batch::<_, Vec<_>>(
-                    conn,
-                    $model::from_infra_schemas(infra_id, $objects),
-                )
-                .await?;
-                Ok(())
-            }
-        };
-    }
-
-    let RailJson {
-        version,
-        track_sections,
-        buffer_stops,
-        electrifications,
-        detectors,
-        operational_points,
-        routes,
-        signals,
-        switches,
-        speed_sections,
-        extended_switch_types,
-        neutral_sections,
-    } = railjson;
-    if version != RAILJSON_VERSION {
-        return Err(RailJsonError::UnsupportedVersion {
-            actual: version,
-            expected: RAILJSON_VERSION.to_string(),
-        }
-        .into());
-    }
-    futures::try_join!(
-        persist!(TrackSectionModel, track_sections),
-        persist!(BufferStopModel, buffer_stops),
-        persist!(ElectrificationModel, electrifications),
-        persist!(DetectorModel, detectors),
-        persist!(OperationalPointModel, operational_points),
-        persist!(RouteModel, routes),
-        persist!(SignalModel, signals),
-        persist!(SwitchModel, switches),
-        persist!(SpeedSectionModel, speed_sections),
-        persist!(SwitchTypeModel, extended_switch_types),
-        persist!(NeutralSectionModel, neutral_sections),
-    )
-    .map(|_| ())
 }

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -392,7 +392,7 @@ mod tests {
             .await
             .expect("Failed to get infra cache");
         small_infra
-            .refresh_v2(db_pool.clone(), true, &infra_cache)
+            .refresh(db_pool.clone(), true, &infra_cache)
             .await
             .expect("Failed to refresh infra");
 
@@ -418,7 +418,7 @@ mod tests {
             .apply_operations(&vec![CacheOperation::Delete(delete_operation.into())])
             .expect("Failed to apply operations");
         small_infra
-            .refresh_v2(db_pool.clone(), true, &infra_cache)
+            .refresh(db_pool.clone(), true, &infra_cache)
             .await
             .expect("Failed to refresh infra");
 

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -370,7 +370,7 @@ mod tests {
     async fn test_no_fix() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
         let small_infra_id = small_infra.id;
 
         let operations: Vec<Operation> = app
@@ -386,7 +386,7 @@ mod tests {
         // GIVEN
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let mut small_infra = create_small_infra(db_pool.clone()).await;
+        let mut small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
         let small_infra_id = small_infra.id;
         let mut infra_cache = InfraCache::load(db_pool.get_ok().deref_mut(), &small_infra)
             .await
@@ -402,7 +402,6 @@ mod tests {
         assert!(infra_errors_before_all
             .iter()
             .all(|e| matches!(e.sub_type, InfraErrorType::OverlappingSpeedSections { .. })));
-        dbg!(infra_errors_before_all, before_all_count);
 
         // Remove a track
         let delete_operation = DeleteOperation {
@@ -425,7 +424,6 @@ mod tests {
         // Check that some new issues appeared
         let (infra_errors_before_fix, before_fix_count) =
             query_errors(db_pool.get_ok().deref_mut(), &small_infra).await;
-        dbg!(before_fix_count, before_all_count);
         assert!(before_fix_count > before_all_count);
 
         // WHEN
@@ -461,7 +459,7 @@ mod tests {
     async fn test_fix_invalid_ref_route_entry_exit() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
         let small_infra_id = small_infra.id;
         // Remove a buffer stop
         let deletion = Operation::Delete(DeleteOperation {
@@ -694,7 +692,7 @@ mod tests {
     async fn invalid_switch_ports() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
         let small_infra_id = small_infra.id;
 
         let ports = HashMap::from([

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -944,7 +944,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
 
         // Make a call with a bad ID
         let request = TestRequest::post()
@@ -964,7 +964,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
 
         // Make a call with a bad distance
         let request = TestRequest::post()
@@ -984,7 +984,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
 
         // Refresh the infra to get the good number of infra errors
         let req_refresh = TestRequest::post()

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -687,7 +687,7 @@ pub mod tests {
     async fn infra_clone() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
         let small_infra_id = small_infra.id;
         let infra_cache = InfraCache::load(db_pool.get_ok().deref_mut(), &small_infra)
             .await
@@ -884,7 +884,10 @@ pub mod tests {
         assert_eq!(refreshed_infras.infra_refreshed, vec![empty_infra.id]);
     }
 
-    #[rstest] // Slow test
+    #[rstest]
+    // Slow test
+    // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
+    #[serial_test::serial]
     async fn infra_refresh_force() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -159,10 +159,7 @@ async fn refresh(
         let infra_cache =
             InfraCache::get_or_load(db_pool.get().await?.deref_mut(), &infra_caches, &infra)
                 .await?;
-        if infra
-            .refresh_v2(db_pool.clone(), force, &infra_cache)
-            .await?
-        {
+        if infra.refresh(db_pool.clone(), force, &infra_cache).await? {
             infra_refreshed.push(infra.id);
         }
     }
@@ -714,7 +711,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        generated_data::refresh_all_v2(db_pool.clone(), small_infra_id, &infra_cache)
+        generated_data::refresh_all(db_pool.clone(), small_infra_id, &infra_cache)
             .await
             .unwrap();
 

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -176,7 +176,7 @@ async fn post_railjson(
         let infra_cache =
             InfraCache::get_or_load(db_pool.get().await?.deref_mut(), &infra_caches, &infra)
                 .await?;
-        infra.refresh_v2(db_pool, true, &infra_cache).await?;
+        infra.refresh(db_pool, true, &infra_cache).await?;
     }
 
     Ok(Json(PostRailjsonResponse { infra: infra.id }))

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -164,7 +164,7 @@ async fn post_railjson(
     let mut infra = Infra::changeset()
         .name(params.name.clone())
         .last_railjson_version()
-        .persist_v2(railjson, db_pool.clone())
+        .persist(railjson, db_pool.get().await?.deref_mut())
         .await?;
     let infra_id = infra.id;
 
@@ -196,6 +196,7 @@ mod tests {
     use editoast_schemas::infra::SwitchType;
 
     #[rstest]
+    // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     #[serial_test::serial]
     async fn test_get_railjson() {
         let app = TestAppBuilder::default_app();
@@ -221,6 +222,7 @@ mod tests {
     }
 
     #[rstest]
+    // PostgreSQL deadlock can happen in this test, see section `Deadlock` of [DbConnectionPoolV2::get] for more information
     #[serial_test::serial]
     async fn test_post_railjson() {
         let app = TestAppBuilder::default_app();

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -353,7 +353,7 @@ mod tests {
 
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.clone()).await;
+        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
 
         fn compare_result(got: RoutesFromNodesPositions, expected: RoutesFromNodesPositions) {
             let mut got_routes = got.routes;

--- a/editoast/src/views/pathfinding/electrical_profiles.rs
+++ b/editoast/src/views/pathfinding/electrical_profiles.rs
@@ -219,7 +219,6 @@ mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn test_map_electrical_profiles(
         #[future] electrical_profile_set: TestFixture<ElectricalProfileSet>,
     ) {
@@ -253,7 +252,6 @@ mod tests {
     }
 
     #[rstest]
-    #[serial_test::serial]
     async fn test_view_electrical_profiles_on_path(
         db_pool: Arc<DbConnectionPool>,
         #[future] empty_infra: TestFixture<Infra>,


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/6980

It's better to review the PR commit by commit.
I created intermediate functions `{function}_v2` to facilitate the migration, but I deleted everything at the end.

I also refactored `persist_railjson` to use `DbConnection` directly instead of `DbConnectionPool`. Consequently, I removed the macro `persist!` that was in there and `futures::try_join!`, and I added a transaction.