### PR TITLE
core: skip work schedules on track chunks with no routes

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/InterlockingInfra.kt
@@ -32,7 +32,7 @@ interface LocationInfra : TrackNetworkInfra, TrackInfra, TrackProperties {
 
     fun getDetectorName(det: DetectorId): String
 
-    fun getTrackChunkZone(chunk: TrackChunkId): ZoneId
+    fun getTrackChunkZone(chunk: TrackChunkId): ZoneId?
 }
 
 fun LocationInfra.isBufferStop(detector: StaticIdx<Detector>): Boolean {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -605,8 +605,8 @@ class RawInfraImpl(
         return detectorPool[det].names[0]
     }
 
-    override fun getTrackChunkZone(chunk: TrackChunkId): ZoneId {
-        return chunkToZoneMap[chunk]!!
+    override fun getTrackChunkZone(chunk: TrackChunkId): ZoneId? {
+        return chunkToZoneMap[chunk]
     }
 
     override fun getNextTrackSection(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -17,6 +17,10 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.max
 import kotlin.math.min
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+val blockAvailabilityLogger: Logger = LoggerFactory.getLogger("BlockAvailability")
 
 data class BlockAvailability(
     val fullInfra: FullInfra,
@@ -143,6 +147,12 @@ private fun convertWorkSchedules(
                 val chunkEndOffset = chunkStartOffset + infra.getTrackChunkLength(chunk).distance
                 if (chunkStartOffset > range.end || chunkEndOffset < range.begin) continue
                 val zone = infra.getTrackChunkZone(chunk)
+                if (zone == null) {
+                    blockAvailabilityLogger.info(
+                        "Skipping part of work schedule [${entry.startTime}; ${entry.endTime}] because it is on a track not fully covered by routes: $track",
+                    )
+                    continue
+                }
                 res.add(
                     SpacingRequirement(
                         infra.getZoneName(zone),


### PR DESCRIPTION
Fixes #7871.

For more context: in the current infra, there are currently 1265 track sections which are fully not covered by routes (and 9 which are partially covered). As a result, the corresponding 2465 track chunks are not covered by routes, and hence have no zones, which is the root of this bug. There might be a bug in route generation, it is getting looked into. For now, we can just skip the corresponding work schedules (the method isn't used elsewhere).