### PR TITLE
core: fix too drastic continuity test on speed envelopes

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/Envelope.java
@@ -5,6 +5,7 @@ import static fr.sncf.osrd.envelope_utils.DoubleUtils.clamp;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import fr.sncf.osrd.envelope.part.EnvelopePart;
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator;
 import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import java.util.ArrayList;
@@ -51,7 +52,8 @@ public final class Envelope implements Iterable<EnvelopePart>, SearchableEnvelop
         for (int i = 0; i < parts.length - 1; i++) {
             if (parts[i].getEndPos() != parts[i + 1].getBeginPos())
                 throw new OSRDError(ErrorType.EnvelopePartsNotContiguous);
-            if (parts[i].getEndSpeed() != parts[i + 1].getBeginSpeed()) continuous = false;
+            if (!TrainPhysicsIntegrator.areSpeedsEqual(parts[i].getEndSpeed(), parts[i + 1].getBeginSpeed()))
+                continuous = false;
         }
 
         // find the minimum and maximum speeds for all envelope parts

--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeBuilderTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeBuilderTest.java
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.envelope;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,25 @@ public class EnvelopeBuilderTest {
         builder.addPart(EnvelopeTestUtils.generateTimes(new double[] {1, 2}, new double[] {20, 30}));
         var env = builder.build();
         assertTrue(env.continuous);
+    }
+
+    @Test
+    public void testEnvelopeBuilderEpsilonSpeedContinuity() {
+        // One example is that allowance can generate rounding errors
+        var builder = new EnvelopeBuilder();
+        builder.addPart(EnvelopeTestUtils.generateTimes(new double[] {0, 1}, new double[] {10, 20}));
+        builder.addPart(EnvelopeTestUtils.generateTimes(new double[] {1, 2}, new double[] {20.0000001, 30}));
+        var env = builder.build();
+        assertTrue(env.continuous);
+    }
+
+    @Test
+    public void testEnvelopeBuilderEpsilonSpeedDiscontinuity() {
+        var builder = new EnvelopeBuilder();
+        builder.addPart(EnvelopeTestUtils.generateTimes(new double[] {0, 1}, new double[] {10, 20}));
+        builder.addPart(EnvelopeTestUtils.generateTimes(new double[] {1, 2}, new double[] {20.001, 30}));
+        var env = builder.build();
+        assertFalse(env.continuous);
     }
 
     @Test


### PR DESCRIPTION
This case can happen after rounding errors when allowance is processed.

fix #7901