### PR TITLE
front: implement macro editor OP import

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 /* eslint-disable import/extensions, import/no-unresolved */
 import ngeMain from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/en/main.js?url';
@@ -7,6 +7,12 @@ import ngeRuntime from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-fronte
 import ngeStyles from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/en/styles.css?url';
 import ngeVendor from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/en/vendor.js?url';
 /* eslint-enable import/extensions, import/no-unresolved */
+
+import type { NetzgrafikDto } from './types';
+
+interface NGEElement extends HTMLElement {
+  netzgrafikDto: NetzgrafikDto;
+}
 
 const frameSrc = `
 <!DOCTYPE html>
@@ -22,29 +28,24 @@ const frameSrc = `
 </html>
 `;
 
-const NGE = () => {
+const NGE = ({ dto }: { dto?: NetzgrafikDto }) => {
   const frameRef = useRef<HTMLIFrameElement>(null);
 
+  const [ngeRootElement, setNgeRootElement] = useState<NGEElement | null>(null);
   useEffect(() => {
     const frame = frameRef.current!;
 
     const handleFrameLoad = () => {
       frame.removeEventListener('load', handleFrameLoad);
 
-      const ngeRoot = frame.contentDocument!.createElement('sbb-root');
+      const ngeRoot = frame.contentDocument!.createElement('sbb-root') as NGEElement;
       frame.contentDocument!.body.appendChild(ngeRoot);
+      setNgeRootElement(ngeRoot);
 
       // listens to create, update and delete operations
       // ngeRoot.addEventListener('operation', (event: Event) => {
       //   console.log('Operation received', (event as CustomEvent).detail);
       // });
-
-      // get netzgrafik model from NGE
-      // let netzgrafikDto = ngeRoot.netzgrafikDto;
-
-      // // set new netzgrafik model with new nodes
-      // netzgrafikDto.nodes = testNodesDto;
-      // ngeRoot.netzgrafikDto = netzgrafikDto;
     };
 
     frame.addEventListener('load', handleFrameLoad);
@@ -53,6 +54,12 @@ const NGE = () => {
       frame.removeEventListener('load', handleFrameLoad);
     };
   }, []);
+
+  useEffect(() => {
+    if (ngeRootElement && dto) {
+      ngeRootElement.netzgrafikDto = dto;
+    }
+  }, [dto, ngeRootElement]);
 
   return <iframe ref={frameRef} srcDoc={frameSrc} title="NGE" className="nge-iframe-container" />;
 };

--- a/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
@@ -36,8 +36,6 @@ const NGE = ({ dto }: { dto?: NetzgrafikDto }) => {
     const frame = frameRef.current!;
 
     const handleFrameLoad = () => {
-      frame.removeEventListener('load', handleFrameLoad);
-
       const ngeRoot = frame.contentDocument!.createElement('sbb-root') as NGEElement;
       frame.contentDocument!.body.appendChild(ngeRoot);
       setNgeRootElement(ngeRoot);

--- a/front/src/applications/operationalStudies/components/MacroEditor/import.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/import.ts
@@ -1,0 +1,245 @@
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import type {
+  SearchResultItemOperationalPoint,
+  SearchPayload,
+  SearchQuery,
+  TrainScheduleResult,
+} from 'common/api/osrdEditoastApi';
+import type { AppDispatch } from 'store';
+
+import type { Node, NetzgrafikDto } from './types';
+
+// TODO: make this optional in NGE since it's SBB-specific
+const TRAINRUN_CATEGORY_HALTEZEITEN = {
+  HaltezeitIPV: { haltezeit: 0, no_halt: false },
+  HaltezeitA: { haltezeit: 0, no_halt: false },
+  HaltezeitB: { haltezeit: 0, no_halt: false },
+  HaltezeitC: { haltezeit: 0, no_halt: false },
+  HaltezeitD: { haltezeit: 0, no_halt: false },
+  HaltezeitUncategorized: { haltezeit: 0, no_halt: false },
+};
+
+const DEFAULT_DTO: NetzgrafikDto = {
+  nodes: [],
+  trainrunSections: [],
+  trainruns: [],
+  resources: [],
+  metadata: {
+    netzgrafikColors: [],
+    trainrunCategories: [],
+    trainrunFrequencies: [],
+    trainrunTimeCategories: [],
+  },
+  freeFloatingTexts: [],
+  labels: [],
+  labelGroups: [],
+  filterData: {
+    filterSettings: [],
+  },
+};
+
+/**
+ * Build a search query to fetch all operational points from their UICs,
+ * trigrams and IDs.
+ */
+const buildOpQuery = (
+  infraId: number,
+  trainSchedules: TrainScheduleResult[]
+): SearchPayload | null => {
+  const pathItems = trainSchedules.map((schedule) => schedule.path).flat();
+  const pathItemQueries = [];
+  const pathItemSet = new Set<string>();
+  // eslint-disable-next-line no-restricted-syntax
+  for (const item of pathItems) {
+    let query: SearchQuery;
+    if ('uic' in item) {
+      query = ['=', ['uic'], item.uic];
+      if (item.secondary_code) {
+        query = ['and', query, ['=', ['ch'], item.secondary_code]];
+      }
+    } else if ('trigram' in item) {
+      query = ['=', ['trigram'], item.trigram];
+      if (item.secondary_code) {
+        query = ['and', query, ['=', ['ch'], item.secondary_code]];
+      }
+    } else if ('operational_point' in item) {
+      query = ['=', ['obj_id'], item.operational_point];
+    } else {
+      // eslint-disable-next-line no-continue
+      continue; // track offset, handled by creating an empty node
+    }
+
+    // Avoid including the same query twice in the search payload
+    const key = JSON.stringify(query);
+    if (pathItemSet.has(key)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    pathItemSet.add(key);
+    pathItemQueries.push(query);
+  }
+
+  if (pathItemQueries.length === 0) {
+    return null;
+  }
+
+  return {
+    object: 'operationalpoint',
+    query: ['and', ['=', ['infra_id'], infraId], ['or', ...pathItemQueries]],
+  };
+};
+
+/**
+ * Execute the search payload and collect all result pages.
+ */
+const executeSearch = async (
+  searchPayload: SearchPayload,
+  dispatch: AppDispatch
+): Promise<SearchResultItemOperationalPoint[]> => {
+  const pageSize = 100;
+  let done = false;
+  const searchResults: SearchResultItemOperationalPoint[] = [];
+  for (let page = 1; !done; page += 1) {
+    const searchPromise = dispatch(
+      osrdEditoastApi.endpoints.postSearch.initiate({
+        page,
+        pageSize,
+        searchPayload,
+      })
+    );
+    // eslint-disable-next-line no-await-in-loop
+    const results = (await searchPromise.unwrap()) as SearchResultItemOperationalPoint[];
+    searchResults.push(...results);
+    done = results.length < pageSize;
+  }
+  return searchResults;
+};
+
+/**
+ * Convert geographic coordinates (latitude/longitude) into screen coordinates
+ * (pixels).
+ */
+const convertGeoCoords = (nodes: Node[]) => {
+  const xCoords = nodes.map((node) => node.positionX);
+  const yCoords = nodes.map((node) => node.positionY);
+  const minX = Math.min(...xCoords);
+  const minY = Math.min(...yCoords);
+  const maxX = Math.max(...xCoords);
+  const maxY = Math.max(...yCoords);
+  const width = maxX - minX;
+  const height = maxY - minY;
+  // TODO: grab NGE component size
+  const scaleX = 800;
+  const scaleY = 500;
+  const padding = 0.1;
+
+  return nodes.map((node) => {
+    const normalizedX = (node.positionX - minX) / width;
+    const normalizedY = 1 - (node.positionY - minY) / height;
+    const paddedX = normalizedX * (1 - 2 * padding) + padding;
+    const paddedY = normalizedY * (1 - 2 * padding) + padding;
+    return {
+      ...node,
+      positionX: scaleX * paddedX,
+      positionY: scaleY * paddedY,
+    };
+  });
+};
+
+const importTimetable = async (
+  infraId: number,
+  timetableId: number,
+  dispatch: AppDispatch
+): Promise<NetzgrafikDto> => {
+  const timetablePromise = dispatch(
+    osrdEditoastApi.endpoints.getV2TimetableById.initiate({ id: timetableId })
+  );
+  const { train_ids } = await timetablePromise.unwrap();
+
+  const trainSchedulesPromise = dispatch(
+    osrdEditoastApi.endpoints.postV2TrainSchedule.initiate({
+      body: { ids: train_ids },
+    })
+  );
+  const trainSchedules = await trainSchedulesPromise.unwrap();
+
+  const searchPayload = buildOpQuery(infraId, trainSchedules);
+  const searchResults = searchPayload ? await executeSearch(searchPayload, dispatch) : [];
+
+  const resource = {
+    id: 1,
+    capacity: trainSchedules.length,
+  };
+
+  let nodes: Node[] = [];
+  const nodesById = new Map<string | number, Node>();
+  let nodeId = 0;
+  let nodePositionX = 0;
+  const createNode = ({
+    id,
+    trigram,
+    fullName,
+    positionX,
+    positionY,
+  }: {
+    id?: string | number;
+    trigram?: string;
+    fullName?: string;
+    positionX?: number;
+    positionY?: number;
+  }): Node => {
+    if (id === undefined) {
+      id = nodeId;
+      nodeId += 1;
+    }
+    if (positionX === undefined) {
+      positionX = nodePositionX;
+      nodePositionX += 200;
+    }
+
+    const node = {
+      id: id!,
+      betriebspunktName: trigram || '',
+      fullName: fullName || '',
+      positionX: positionX!,
+      positionY: positionY || 0,
+      ports: [],
+      transitions: [],
+      connections: [],
+      resourceId: resource.id,
+      perronkanten: 10,
+      connectionTime: 0,
+      trainrunCategoryHaltezeiten: TRAINRUN_CATEGORY_HALTEZEITEN,
+      symmetryAxis: 0,
+      warnings: [],
+      labelIds: [],
+    };
+
+    nodes.push(node);
+    nodesById.set(node.id, node);
+
+    return node;
+  };
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const op of searchResults) {
+    createNode({
+      id: op.obj_id,
+      trigram: op.trigram + (op.ch ? `/${op.ch}` : ''),
+      fullName: op.name,
+      positionX: op.geographic.coordinates[0],
+      positionY: op.geographic.coordinates[1],
+    });
+  }
+
+  nodes = convertGeoCoords(nodes);
+
+  return {
+    ...DEFAULT_DTO,
+    resources: [resource],
+    nodes,
+  };
+};
+
+export default importTimetable;

--- a/front/src/applications/operationalStudies/components/MacroEditor/import.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/import.ts
@@ -7,7 +7,13 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import type { AppDispatch } from 'store';
 
-import type { Node, NetzgrafikDto } from './types';
+import type {
+  Node,
+  TrainrunCategory,
+  TrainrunFrequency,
+  TrainrunTimeCategory,
+  NetzgrafikDto,
+} from './types';
 
 // TODO: make this optional in NGE since it's SBB-specific
 const TRAINRUN_CATEGORY_HALTEZEITEN = {
@@ -19,16 +25,50 @@ const TRAINRUN_CATEGORY_HALTEZEITEN = {
   HaltezeitUncategorized: { haltezeit: 0, no_halt: false },
 };
 
+const DEFAULT_TRAINRUN_CATEGORY: TrainrunCategory = {
+  id: 1, // In NGE, Trainrun.DEFAULT_TRAINRUN_CATEGORY
+  order: 0,
+  name: 'Default',
+  shortName: '', // TODO: find a better way to hide this in the graph
+  fachCategory: 'HaltezeitUncategorized',
+  colorRef: 'EC',
+  minimalTurnaroundTime: 0,
+  nodeHeadwayStop: 0,
+  nodeHeadwayNonStop: 0,
+  sectionHeadway: 0,
+};
+
+const DEFAULT_TRAINRUN_FREQUENCY: TrainrunFrequency = {
+  id: 3, // In NGE, Trainrun.DEFAULT_TRAINRUN_FREQUENCY
+  order: 0,
+  frequency: 60,
+  offset: 0,
+  name: 'Default',
+  /** Short name, needs to be unique */
+  shortName: 'D',
+  linePatternRef: '60',
+};
+
+const DEFAULT_TRAINRUN_TIME_CATEGORY: TrainrunTimeCategory = {
+  id: 0, // In NGE, Trainrun.DEFAULT_TRAINRUN_TIME_CATEGORY
+  order: 0,
+  name: 'Default',
+  shortName: '7/24',
+  dayTimeInterval: [],
+  weekday: [1, 2, 3, 4, 5, 6, 7],
+  linePatternRef: '7/24',
+};
+
 const DEFAULT_DTO: NetzgrafikDto = {
-  nodes: [],
-  trainrunSections: [],
-  trainruns: [],
   resources: [],
+  nodes: [],
+  trainruns: [],
+  trainrunSections: [],
   metadata: {
     netzgrafikColors: [],
-    trainrunCategories: [],
-    trainrunFrequencies: [],
-    trainrunTimeCategories: [],
+    trainrunCategories: [DEFAULT_TRAINRUN_CATEGORY],
+    trainrunFrequencies: [DEFAULT_TRAINRUN_FREQUENCY],
+    trainrunTimeCategories: [DEFAULT_TRAINRUN_TIME_CATEGORY],
   },
   freeFloatingTexts: [],
   labels: [],
@@ -238,6 +278,12 @@ const importTimetable = async (
   return {
     ...DEFAULT_DTO,
     resources: [resource],
+    metadata: {
+      netzgrafikColors: [],
+      trainrunCategories: [DEFAULT_TRAINRUN_CATEGORY],
+      trainrunFrequencies: [DEFAULT_TRAINRUN_FREQUENCY],
+      trainrunTimeCategories: [DEFAULT_TRAINRUN_TIME_CATEGORY],
+    },
     nodes,
   };
 };

--- a/front/src/applications/operationalStudies/components/MacroEditor/types.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/types.ts
@@ -14,7 +14,7 @@ export type Node = {
   positionX: number;
   positionY: number;
   ports: Port[];
-  transitions: unknown[];
+  transitions: Transition[];
   connections: unknown[];
   resourceId: number;
   /** Number of tracks where train can stop */
@@ -32,6 +32,13 @@ export type Port = {
   positionIndex: number;
   positionAlignment: PortAlignment;
   trainrunSectionId: number;
+};
+
+export type Transition = {
+  id: number;
+  port1Id: number;
+  port2Id: number;
+  isNonStopTransit: boolean;
 };
 
 export enum PortAlignment {

--- a/front/src/applications/operationalStudies/components/MacroEditor/types.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/types.ts
@@ -1,0 +1,95 @@
+// NGE DTO types, see:
+// https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/src/app/data-structures/business.data.structures.ts
+
+export type Haltezeit = {
+  haltezeit: number;
+  no_halt: boolean;
+};
+
+export type Node = {
+  id: number | string; // TODO: in NGE this is a number
+  /** Trigram */
+  betriebspunktName: string;
+  fullName: string;
+  positionX: number;
+  positionY: number;
+  ports: unknown[];
+  transitions: unknown[];
+  connections: unknown[];
+  resourceId: number;
+  /** Number of tracks where train can stop */
+  perronkanten: number;
+  /** Time needed to change train in minutes */
+  connectionTime: number;
+  trainrunCategoryHaltezeiten: { [category: string]: Haltezeit };
+  symmetryAxis: number;
+  warnings: unknown[];
+  labelIds: number[];
+};
+
+export type Trainrun = {
+  id: number;
+  name: string;
+  categoryId: number;
+  frequencyId: number;
+  trainrunTimeCategoryId: number;
+  labelIds: number[];
+};
+
+export type TimeLock = {
+  time: number;
+  consecutiveTime: number;
+  lock: boolean;
+  warning: null;
+  timeFormatter: null;
+};
+
+export type TrainrunSection = {
+  id: number;
+  sourceNodeId: number | string;
+  sourcePortId: number;
+  targetNodeId: number | string;
+  targetPortId: number;
+
+  sourceArrival: TimeLock;
+  sourceDeparture: TimeLock;
+  targetArrival: TimeLock;
+  targetDeparture: TimeLock;
+  travelTime: TimeLock;
+
+  numberOfStops: number;
+
+  trainrunId: number;
+  resourceId: number;
+
+  specificTrainrunSectionFrequencyId: number;
+  path: null;
+  warnings: unknown[];
+};
+
+export type Resource = {
+  id: number;
+  capacity: number;
+};
+
+/**
+ * The DTO contains the entire NGE state.
+ */
+export type NetzgrafikDto = {
+  nodes: Node[];
+  trainrunSections: TrainrunSection[];
+  trainruns: Trainrun[];
+  resources: Resource[];
+  metadata: {
+    netzgrafikColors: unknown[];
+    trainrunCategories: unknown[];
+    trainrunFrequencies: unknown[];
+    trainrunTimeCategories: unknown[];
+  };
+  freeFloatingTexts: unknown[];
+  labels: unknown[];
+  labelGroups: unknown[];
+  filterData: {
+    filterSettings: unknown[];
+  };
+};

--- a/front/src/applications/operationalStudies/components/MacroEditor/types.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/types.ts
@@ -67,6 +67,42 @@ export type TrainrunSection = {
   warnings: unknown[];
 };
 
+export type TrainrunCategory = {
+  id: number;
+  order: number;
+  name: string;
+  /** Short name, needs to be unique */
+  shortName: string;
+  fachCategory: string;
+  colorRef: string;
+  minimalTurnaroundTime: number;
+  nodeHeadwayStop: number;
+  nodeHeadwayNonStop: number;
+  sectionHeadway: number;
+};
+
+export type TrainrunFrequency = {
+  id: number;
+  order: number;
+  frequency: number;
+  offset: number;
+  name: string;
+  /** Short name, needs to be unique */
+  shortName: string;
+  linePatternRef: string;
+};
+
+export type TrainrunTimeCategory = {
+  id: number;
+  order: number;
+  name: string;
+  /** Short name, needs to be unique */
+  shortName: string;
+  dayTimeInterval: unknown[];
+  weekday: number[];
+  linePatternRef: string;
+};
+
 export type Resource = {
   id: number;
   capacity: number;
@@ -82,9 +118,9 @@ export type NetzgrafikDto = {
   resources: Resource[];
   metadata: {
     netzgrafikColors: unknown[];
-    trainrunCategories: unknown[];
-    trainrunFrequencies: unknown[];
-    trainrunTimeCategories: unknown[];
+    trainrunCategories: TrainrunCategory[];
+    trainrunFrequencies: TrainrunFrequency[];
+    trainrunTimeCategories: TrainrunTimeCategory[];
   };
   freeFloatingTexts: unknown[];
   labels: unknown[];

--- a/front/src/applications/operationalStudies/components/MacroEditor/types.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/types.ts
@@ -13,7 +13,7 @@ export type Node = {
   fullName: string;
   positionX: number;
   positionY: number;
-  ports: unknown[];
+  ports: Port[];
   transitions: unknown[];
   connections: unknown[];
   resourceId: number;
@@ -27,6 +27,20 @@ export type Node = {
   labelIds: number[];
 };
 
+export type Port = {
+  id: number;
+  positionIndex: number;
+  positionAlignment: PortAlignment;
+  trainrunSectionId: number;
+};
+
+export enum PortAlignment {
+  Top,
+  Bottom,
+  Left,
+  Right,
+}
+
 export type Trainrun = {
   id: number;
   name: string;
@@ -38,7 +52,7 @@ export type Trainrun = {
 
 export type TimeLock = {
   time: number;
-  consecutiveTime: number;
+  consecutiveTime: number | null;
   lock: boolean;
   warning: null;
   timeFormatter: null;
@@ -51,11 +65,11 @@ export type TrainrunSection = {
   targetNodeId: number | string;
   targetPortId: number;
 
-  sourceArrival: TimeLock;
-  sourceDeparture: TimeLock;
-  targetArrival: TimeLock;
-  targetDeparture: TimeLock;
   travelTime: TimeLock;
+  sourceDeparture: TimeLock;
+  sourceArrival: TimeLock;
+  targetDeparture: TimeLock;
+  targetArrival: TimeLock;
 
   numberOfStops: number;
 
@@ -63,7 +77,10 @@ export type TrainrunSection = {
   resourceId: number;
 
   specificTrainrunSectionFrequencyId: number;
-  path: null;
+  path: {
+    path: unknown[];
+    textPositions: unknown[];
+  };
   warnings: unknown[];
 };
 

--- a/front/src/applications/operationalStudies/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/utils.ts
@@ -2,8 +2,8 @@ import type {
   PathItemLocation,
   SearchResultItemOperationalPoint,
 } from 'common/api/osrdEditoastApi';
+import { ISO8601Duration2sec } from 'utils/timeManipulation';
 
-// eslint-disable-next-line import/prefer-default-export
 export const findOpFromPathItem = (
   pathItem: PathItemLocation,
   searchResults: SearchResultItemOperationalPoint[]
@@ -22,3 +22,6 @@ export const findOpFromPathItem = (
     }
     return false;
   });
+
+export const addDurationToDate = (date: Date, duration: string) =>
+  new Date(date.getTime() + ISO8601Duration2sec(duration) * 1000);

--- a/front/src/applications/operationalStudies/components/MacroEditor/utils.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/utils.ts
@@ -1,0 +1,24 @@
+import type {
+  PathItemLocation,
+  SearchResultItemOperationalPoint,
+} from 'common/api/osrdEditoastApi';
+
+// eslint-disable-next-line import/prefer-default-export
+export const findOpFromPathItem = (
+  pathItem: PathItemLocation,
+  searchResults: SearchResultItemOperationalPoint[]
+) =>
+  searchResults.find((searchResult) => {
+    if ('uic' in pathItem) {
+      return searchResult.uic === pathItem.uic && searchResult.ch === pathItem.secondary_code;
+    }
+    if ('trigram' in pathItem) {
+      return (
+        searchResult.trigram === pathItem.trigram && searchResult.ch === pathItem.secondary_code
+      );
+    }
+    if ('operational_point' in pathItem) {
+      return searchResult.obj_id === pathItem.operational_point;
+    }
+    return false;
+  });

--- a/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
@@ -32,6 +32,8 @@ import { getSpaceTimeChartData, selectProjectionV2 } from './getSimulationResult
 import ImportTrainScheduleV2 from './ImportTrainScheduleV2';
 import ManageTrainScheduleV2 from './ManageTrainScheduleV2';
 import SimulationResultsV2 from './SimulationResultsV2';
+import importTimetableToNGE from '../../components/MacroEditor/import';
+import type { NetzgrafikDto } from '../../components/MacroEditor/types';
 
 type SimulationParams = {
   projectId: string;
@@ -162,6 +164,18 @@ const ScenarioV2 = () => {
     setIsMacro(isMacroMode);
     setCollapsedTimetable(isMacroMode);
   };
+
+  const [ngeDto, setNgeDto] = useState<NetzgrafikDto | undefined>(undefined);
+  useEffect(() => {
+    if (!infraId || !timetableId || !isMacro) {
+      return;
+    }
+    const doImport = async () => {
+      const dto = await importTimetableToNGE(infraId, timetableId, dispatch);
+      setNgeDto(dto);
+    };
+    doImport();
+  }, [infraId, timetableId, isMacro]);
 
   if (!scenario || !infraId || !timetableId || !timetable) return null;
 
@@ -341,7 +355,7 @@ const ScenarioV2 = () => {
                 )}
                 {isMacro ? (
                   <div className={cx(collapsedTimetable ? 'macro-container' : 'h-100')}>
-                    <NGE />
+                    <NGE dto={ngeDto} />
                   </div>
                 ) : (
                   isInfraLoaded &&


### PR DESCRIPTION
_This PR is best reviewed commit-by-commit._

What's in the box?

- Import all waypoints of all trains schedules as NGE nodes (whether we can find corresponding OPs for these in the infra or not, e.g. track offset or trigram which doesn't exist)
- Import all train schedules paths
- Import stop times specified by the user (anything left unspecified is imported as zero for now)

Closes https://github.com/OpenRailAssociation/osrd/issues/7737  
Closes https://github.com/OpenRailAssociation/osrd/issues/7739  
References https://github.com/OpenRailAssociation/osrd/issues/7741  
~~Depends on https://github.com/OpenRailAssociation/osrd/pull/8006 (in other words, please ignore the first few commits, they belong to that other PR)~~

<!--
How to test:

- Open a scenario in OSRD
- In the browser console, right click on the printed array and select "Copy Object"
- In the [`window-get-set` branch](https://github.com/osrd-project/osrd-nge-poc/tree/window-get-set) of osrd-nge-poc, open a browser console and write `SET(`, paste, `)`, enter
-->

TODO:

- [x] Handle non-UIC path items
- [x] Prettify node coords
- [x] Pagination
- [x] The import process should only kick in when the macro tab is selected
- [x] Passthrough UICs/trigrams that we don't find in infra
- [x] Add `secondary_code` suffix to OPs
- [x] Set times based on train schedule

Follow-up work:

- [ ] Check if rtk-query requests need to be unsubscribed
- [ ] Adjust coords for large number of nodes (try with France infra test cases, e.g. Paris-Lyon-Grenoble)