### PR TITLE
editorconfig: add initial config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{tsx,ts,js,scss,json,toml,yml,yaml,nix}]
+indent_size = 2
+
+[*.{rs,kt,java,sql,py,sh}]
+indent_size = 4


### PR DESCRIPTION
[EditorConfig][1] defines a configuration file format to set basic code style preferences. The preferences are picked up automatically by many text editors by default.

[1]: https://editorconfig.org/