### PR TITLE
editor: improves switch types cache handling

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SwitchList.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SwitchList.tsx
@@ -64,7 +64,7 @@ const SwitchList: React.FC<SwitchListProps> = ({
               <span className="align-self-end">{`${t('Editor.obj-types.Switch')} ${swId}`}</span>
             </div>
             <div className="d-flex ml-4">
-              {switchPositionsByType[type].map((optPosition, posIndex) => {
+              {switchPositionsByType[type]?.map((optPosition, posIndex) => {
                 const isPositionNull = optPosition === 'Any';
                 const isButtonIncompatible =
                   Object.keys(selectedSwitches).length > 1 &&


### PR DESCRIPTION
This commit fixes #7946.

Details:
- Adds a `?` to handle case where switch types have not been loaded yet in SwitchList.tsx
- Adds a very simple cache to `useSwitchTypes` to avoid reloading switch types any time a new component mounts with that hook