### PR TITLE
editoast: use workspace for version and licenses

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "editoast"
-version = "0.1.0"
-edition = "2021"
-license = "LGPL-3.0"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 [workspace]
 members = [
@@ -13,6 +13,11 @@ members = [
   "editoast_schemas",
   "osm_to_railjson",
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "LGPL-3.0"
 
 [workspace.dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/editoast/editoast_common/Cargo.toml
+++ b/editoast/editoast_common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "editoast_common"
-version = "0.1.0"
-edition = "2021"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "editoast_derive"
-version = "0.1.0"
-edition = "2021"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "editoast_models"
-version = "0.1.0"
-edition = "2021"
-license = "LGPL-3.0"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 [features]
 testing = []

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "editoast_schemas"
-version = "0.1.0"
-edition = "2021"
-license = "LGPL-3.0"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 chrono.workspace = true

--- a/editoast/osm_to_railjson/Cargo.toml
+++ b/editoast/osm_to_railjson/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "osm_to_railjson"
-version = "0.1.0"
-edition = "2021"
-license = "LGPL-3.0"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 editoast_schemas.workspace = true


### PR DESCRIPTION
Just a way to add the license and versions everywhere, as a workspace feature, so only in one unique place.