### PR TITLE
front: set timezone for test

### DIFF
--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig(({ mode }) => {
     },
     test: {
       globals: true,
+      globalSetup: './vitest.global-setup.ts',
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
       environment: 'happy-dom',
       coverage: {

--- a/front/vitest.global-setup.ts
+++ b/front/vitest.global-setup.ts
@@ -1,0 +1,3 @@
+export const setup = () => {
+  process.env.TZ = 'UTC';
+};


### PR DESCRIPTION
Tests are failing locally because I'm not in the UTC timezone. So tests are plateform dependent, which is bad.
This commit sets the timezone when runnning vitest.