### PR TITLE
warped-map: fixes extendLine issue

### DIFF
--- a/front/src/common/Map/WarpedMap/core/helpers.ts
+++ b/front/src/common/Map/WarpedMap/core/helpers.ts
@@ -58,7 +58,7 @@ export function getSamples(
  * Given a line and a lengthToAdd, extend the line at its two extremities by lengthToAdd meters.
  */
 export function extendLine(line: Feature<LineString>, lengthToAdd: number): Feature<LineString> {
-  if (lengthToAdd <= 1) throw new Error('lengthToAdd must be a positive');
+  if (lengthToAdd < 0) throw new Error('lengthToAdd must be positive');
 
   const points = line.geometry.coordinates;
   const firstPoint = points[0] as Vec2;


### PR DESCRIPTION
This commit fixes #7964.

The lengthToAdd value is supposed to be positive, and doesn't need to be less than 1 in practice.