### PR TITLE
Bulk get cached projection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     ports: ["6379:6379"]
     volumes:
       - "redis_data:/data"
-    command: "valkey-server --save 30 1 --loglevel warning"
+      - "./docker/valkey.conf:/etc/valkey.conf"
+    command: "valkey-server /etc/valkey.conf --save 30 1 --loglevel warning"
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       start_period: 4s

--- a/docker/valkey.conf
+++ b/docker/valkey.conf
@@ -1,0 +1,2 @@
+maxmemory-policy allkeys-lru
+maxmemory 1gb


### PR DESCRIPTION
## Description

The idea is to bulk-get the cached projection to limit the number of queries performed to Redis.

## Benchmark

Condition:
- I performed the test when everything was cached.
- It was tested locally
- Timetable size: 823 trains
- Valid trains: 674

The `path_projection` performance doesn't seem to change (1.2s).

Queries performances:
- Before: 1 query took ~0,07ms (times 674 = 47ms)
- Now: 1 bulk query takes ~8ms

I think in production, because of queries overhead the difference will be far more important.


The number of Redis queries is reduced by the number of valid train schedule. (2211 -> 1532 queries).
Next, I will do the same to retrieve the path and simulation from the cache (but this implies code refactoring).

> [!IMPORTANT]
> There is a limitation with this. I didn't find how to set the expiration time of Redis entry with a bulk command. So now the Redis entry expires after 1 week even if they're used recently.