### PR TITLE
editoast: train-simulation: return SimulationFailed on 500 from core

### DIFF
--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -385,7 +385,15 @@ pub async fn train_simulation(
     }
 
     // Compute simulation from core
-    let result = simulation_request.fetch(core.as_ref()).await?;
+    let result = simulation_request.fetch(core.as_ref()).await;
+
+    let result = match result {
+        Ok(result) => result,
+        Err(core_error) if core_error.status.is_server_error() => {
+            SimulationResponse::SimulationFailed { core_error }
+        }
+        err => return err,
+    };
 
     // Cache the simulation response
     redis_conn


### PR DESCRIPTION
When `core.fetch` returns an Error made from a 500 from core, `train_simulation` returns `Ok(SimulationResponse::SimulationFailed)` rather than an `Error`.

This allows to still be able to call `train_schedule/simulation_summary` when one of the trains leads to an error in core (an assert error for example).

I left other error status codes fail because they'll likely be transient, what do you think ?