### PR TITLE
front: fix slopes and curves wrong display

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -25,8 +25,11 @@ export const getExpectedResultDataNumber = <T extends 'gradient' | 'radius'>(
   [
     { position: 0, [value]: 0 },
     { position: 1, [value]: 1 },
+    { position: 1, [value]: 2 },
     { position: 2, [value]: 2 },
+    { position: 2, [value]: 3 },
     { position: 3, [value]: 3 },
+    { position: 3, [value]: 4 },
     { position: 4, [value]: 4 },
   ] as PositionData<T>[];
 

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -38,7 +38,11 @@ export const transformBoundariesDataToPositionDataArray = <T extends 'gradient' 
         position: mmToM(boundary),
         [value]: boundariesData.values[index],
       } as PositionData<T>;
-      acc.push(newData);
+      const combiningData = {
+        position: mmToM(boundary),
+        [value]: boundariesData.values[index + 1],
+      } as PositionData<T>;
+      acc.push(newData, combiningData);
       return acc;
     },
     [{ position: 0, [value]: 0 }] as PositionData<T>[]


### PR DESCRIPTION
Add an extra point on the chart to match an histogram form (because of the new boundaries/values format returned by the v2 endpoints)

close #7703 