### PR TITLE
Remove layer cache duration

### DIFF
--- a/editoast/map_layers.yml
+++ b/editoast/map_layers.yml
@@ -5,7 +5,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: track_section.data
         exclude_fields: [geo]
         joins:
@@ -17,7 +16,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: signal.data - 'logical_signals' || jsonb_build_object('angle', layer.angle_geo, 'signaling_system', layer.signaling_system, 'sprite', layer.sprite)
         joins:
           - inner join infra_object_signal signal on signal.obj_id = layer.obj_id and signal.infra_id = layer.infra_id
@@ -28,7 +26,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: speed_section.data
         joins:
           - inner join infra_object_speed_section speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
@@ -41,7 +38,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: speed_section.data
         joins:
           - inner join infra_object_speed_section speed_section on speed_section.obj_id = layer.obj_id and speed_section.infra_id = layer.infra_id
@@ -54,7 +50,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: switch.data
         joins:
           - inner join infra_object_switch switch on switch.obj_id = layer.obj_id and switch.infra_id = layer.infra_id
@@ -65,7 +60,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: detector.data
         joins:
           - inner join infra_object_detector detector on detector.obj_id = layer.obj_id and detector.infra_id = layer.infra_id
@@ -76,7 +70,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: buffer_stop.data
         joins:
           - inner join infra_object_buffer_stop buffer_stop on buffer_stop.obj_id = layer.obj_id and buffer_stop.infra_id = layer.infra_id
@@ -87,7 +80,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: operational_point.data - 'parts' || jsonb_build_object('kp', layer.kp)
         joins:
           - inner join infra_object_operational_point operational_point on operational_point.obj_id = layer.obj_id and operational_point.infra_id = layer.infra_id
@@ -98,7 +90,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: electrification.data
         joins:
           - inner join infra_object_electrification electrification on electrification.obj_id = layer.obj_id and electrification.infra_id = layer.infra_id
@@ -109,7 +100,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: layer.data || jsonb_build_object('angle', layer.angle_geo)
 
   neutral_signs:
@@ -118,7 +108,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: layer.data - 'value' || jsonb_build_object('angle', layer.angle_geo)
 
   neutral_sections:
@@ -127,7 +116,6 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: neutral_section.data
         joins:
           - inner join infra_object_neutral_section neutral_section on neutral_section.obj_id = layer.obj_id and neutral_section.infra_id = layer.infra_id
@@ -138,5 +126,4 @@ layers:
     views:
       geo:
         on_field: geographic
-        cache_duration: 3600
         data_expr: layer.information

--- a/editoast/src/map/layers.rs
+++ b/editoast/src/map/layers.rs
@@ -18,7 +18,6 @@ pub struct View {
     pub exclude_fields: Vec<String>,
     #[serde(default)]
     pub joins: Vec<JoinExpr>,
-    pub cache_duration: u64,
     #[serde(rename = "where", default)]
     pub where_expr: Vec<String>,
 }

--- a/editoast/src/views/layers/mod.rs
+++ b/editoast/src/views/layers/mod.rs
@@ -198,9 +198,7 @@ async fn cache_and_get_mvt_tile(
     );
 
     let mut redis = redis_client.get_connection().await?;
-    let cached_value: Option<Vec<u8>> = redis
-        .get_ex(&cache_key, redis::Expiry::EX(view.cache_duration as usize))
-        .await?;
+    let cached_value: Option<Vec<u8>> = redis.get(&cache_key).await?;
 
     if let Some(value) = cached_value {
         return Ok(HttpResponse::Ok()
@@ -222,7 +220,7 @@ async fn cache_and_get_mvt_tile(
         .to_bytes()
         .unwrap();
     redis
-        .set_ex(&cache_key, mvt_bytes.clone(), view.cache_duration)
+        .set(&cache_key, mvt_bytes.clone())
         .await
         .unwrap_or_else(|_| panic!("Fail to set value in redis with key {cache_key}"));
     Ok(HttpResponse::Ok()


### PR DESCRIPTION
Since Redis is configured with the lru policy we don't need to handle the expiration time.