### PR TITLE
Fix simulation_summary being called too often

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -50,7 +50,7 @@ const useStdcmResults = (
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postV2InfraByInfraIdPathProperties.useMutation();
   const [projectTrainSchedules] =
-    osrdEditoastApi.endpoints.postV2TrainScheduleProjectPath.useMutation();
+    osrdEditoastApi.endpoints.postV2TrainScheduleProjectPath.useLazyQuery();
 
   const { data: otherSelectedTrainSchedule } =
     osrdEditoastApi.endpoints.getV2TrainScheduleById.useQuery(
@@ -176,7 +176,7 @@ const useStdcmResults = (
         stdcmResponse.rollingStock.length
       );
     }
-  }, [stdcmResponse]);
+  }, [stdcmResponse, infraId, timetable, projectTrainSchedules]);
 
   if (!infraId || !stdcmResponse || !selectedTrainSchedule) return null;
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -925,7 +925,7 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['timetablev2', 'train_schedulev2'],
       }),
-      postV2TrainScheduleProjectPath: build.mutation<
+      postV2TrainScheduleProjectPath: build.query<
         PostV2TrainScheduleProjectPathApiResponse,
         PostV2TrainScheduleProjectPathApiArg
       >({
@@ -934,7 +934,7 @@ const injectedRtkApi = api
           method: 'POST',
           body: queryArg.projectPathForm,
         }),
-        invalidatesTags: ['train_schedulev2'],
+        providesTags: ['train_schedulev2'],
       }),
       postV2TrainScheduleSimulationSummary: build.query<
         PostV2TrainScheduleSimulationSummaryApiResponse,

--- a/front/src/config/openapi-editoast-config.ts
+++ b/front/src/config/openapi-editoast-config.ts
@@ -10,7 +10,11 @@ const config: ConfigFile = {
   tag: true,
   endpointOverrides: [
     {
-      pattern: ['postV2TrainSchedule', 'postV2TrainScheduleSimulationSummary'],
+      pattern: [
+        'postV2TrainSchedule',
+        'postV2TrainScheduleSimulationSummary',
+        'postV2TrainScheduleProjectPath',
+      ],
       type: 'query',
     },
   ],


### PR DESCRIPTION
- removing `train_schedulev2` tag from `postV2TrainScheduleProjectPath` and making the endpoint a query (codegen made it a mutation by defaut as it is a POST) 
- keeping `train_schedulev2` `postV2TrainScheduleSimulationSummary` => the endpoint should but called again if one train is updated (more refinement to come #8010 ). It should not if a train is created/removed, but we can handle that manually with `trainResultToFetch` logic

closes #7989