### PR TITLE
front, editoast, core: homogeneize the plural form for path_item_positions

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
@@ -24,7 +24,7 @@ class PathfindingBlockSuccess(
     val length: Length<Path>,
 
     /** Offsets of the waypoints given as input */
-    @Json(name = "path_items_positions") val pathItemPositions: List<Offset<Path>>
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<Path>>
 ) : PathfindingBlockResponse
 
 class NotFoundInBlocks(

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8496,7 +8496,7 @@ components:
       - routes
       - track_section_ranges
       - length
-      - path_items_positions
+      - path_item_positions
       properties:
         blocks:
           type: array
@@ -8510,7 +8510,7 @@ components:
           format: int64
           description: Length of the path in mm
           minimum: 0
-        path_items_positions:
+        path_item_positions:
           type: array
           items:
             type: integer

--- a/editoast/src/core/v2/pathfinding.rs
+++ b/editoast/src/core/v2/pathfinding.rs
@@ -104,7 +104,7 @@ pub struct PathfindingResultSuccess {
     pub length: u64,
     /// The path offset in mm of each path item given as input of the pathfinding
     /// The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm
-    pub path_items_positions: Vec<u64>,
+    pub path_item_positions: Vec<u64>,
 }
 
 /// An oriented range on a track section.

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -377,12 +377,12 @@ pub async fn train_simulation_batch(
     for (index, (pathfinding, train_schedule)) in
         pathfinding_results.iter().zip(train_schedules).enumerate()
     {
-        let (path, path_items_positions) = match pathfinding {
+        let (path, path_item_positions) = match pathfinding {
             PathfindingResult::Success(PathfindingResultSuccess {
                 blocks,
                 routes,
                 track_section_ranges,
-                path_items_positions,
+                path_item_positions,
                 ..
             }) => (
                 SimulationPath {
@@ -390,7 +390,7 @@ pub async fn train_simulation_batch(
                     routes: routes.clone(),
                     track_section_ranges: track_section_ranges.clone(),
                 },
-                path_items_positions,
+                path_item_positions,
             ),
             _ => {
                 simulation_results[index] = SimulationResponse::PathfindingFailed {
@@ -406,7 +406,7 @@ pub async fn train_simulation_batch(
         let simulation_request = build_simulation_request(
             infra,
             train_schedule,
-            path_items_positions,
+            path_item_positions,
             path,
             rolling_stock,
             timetable,
@@ -462,18 +462,18 @@ pub async fn train_simulation_batch(
 fn build_simulation_request(
     infra: &Infra,
     train_schedule: &TrainSchedule,
-    path_items_position: &[u64],
+    path_item_positions: &[u64],
     path: SimulationPath,
     rolling_stock: RollingStockModel,
     timetable: Timetable,
 ) -> SimulationRequest {
-    assert_eq!(path_items_position.len(), train_schedule.path.len());
+    assert_eq!(path_item_positions.len(), train_schedule.path.len());
     // Project path items to path offset
     let path_items_to_position: HashMap<_, _> = train_schedule
         .path
         .iter()
         .map(|p| &p.id)
-        .zip(path_items_position.iter().copied())
+        .zip(path_item_positions.iter().copied())
         .collect();
 
     let schedule = train_schedule

--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -85,7 +85,7 @@ const useSetupItineraryForTrainUpdate = (
               await postPathProperties(pathPropertiesParams).unwrap();
 
             if (electrifications && geometry && operational_points) {
-              const stepsCoordinates = pathfindingResult.path_items_positions.map((position) =>
+              const stepsCoordinates = pathfindingResult.path_item_positions.map((position) =>
                 getPointCoordinates(geometry, pathfindingResult.length, position)
               );
               const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
@@ -122,7 +122,7 @@ const useSetupItineraryForTrainUpdate = (
                   ch,
                   kp,
                   name,
-                  positionOnPath: pathfindingResult.path_items_positions[i],
+                  positionOnPath: pathfindingResult.path_item_positions[i],
                   arrival: arrival
                     ? addDurationToIsoDate(trainSchedule.start_time, arrival).substring(11, 19)
                     : arrival,

--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -101,7 +101,7 @@ const useStdcmResults = (
       if (geometry && operational_points && electrifications) {
         const pathStepsWihPosition = compact(pathSteps).map((step, i) => ({
           ...step,
-          positionOnPath: path.path_items_positions[i],
+          positionOnPath: path.path_item_positions[i],
         }));
 
         const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3448,7 +3448,7 @@ export type PathfindingResultSuccess = {
   length: number;
   /** The path offset in mm of each path item given as input of the pathfinding
     The first value is always `0` (beginning of the path) and the last one is always equal to the `length` of the path in mm */
-  path_items_positions: number[];
+  path_item_positions: number[];
   /** Path description as route ids */
   routes: string[];
   /** Path description as track ranges */

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPathV2.tsx
@@ -237,7 +237,7 @@ const TypeAndPathV2 = ({ setPathProperties }: PathfindingProps) => {
                 ch: op.ch,
                 kp: correspondingOp.kp,
                 coordinates: correspondingOp.coordinates,
-                positionOnPath: pathfindingResult.path_items_positions[i],
+                positionOnPath: pathfindingResult.path_item_positions[i],
                 stopFor: i === opList.length - 1 ? '0' : undefined,
               };
             });

--- a/front/src/modules/pathfinding/hook/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hook/usePathfinding.ts
@@ -245,7 +245,7 @@ export const usePathfindingV2 = (
 
                 return {
                   ...step,
-                  positionOnPath: pathfindingResult.path_items_positions[i],
+                  positionOnPath: pathfindingResult.path_item_positions[i],
                   stopFor,
                   ...(correspondingOp && {
                     kp: correspondingOp.kp,

--- a/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
+++ b/front/src/modules/powerRestriction/helpers/formatPowerRestrictionRangesWithHandled.ts
@@ -18,7 +18,7 @@ import { mToMm, mmToM } from 'utils/physics';
 export const formatPowerRestrictionRanges = (
   powerRestrictions: NonNullable<TrainScheduleBase['power_restrictions']>,
   path: TrainScheduleBase['path'],
-  stepsPathPositions: PathfindingResultSuccess['path_items_positions']
+  stepsPathPositions: PathfindingResultSuccess['path_item_positions']
 ): Omit<SimulationPowerRestrictionRange, 'handled'>[] =>
   compact(
     powerRestrictions.map((powerRestriction) => {
@@ -98,7 +98,7 @@ const formatPowerRestrictionRangesWithHandled = ({
     const powerRestrictionsRanges = formatPowerRestrictionRanges(
       selectedTrainSchedule.power_restrictions,
       selectedTrainSchedule.path,
-      pathfindingResult.path_items_positions
+      pathfindingResult.path_item_positions
     );
     const powerRestrictionsWithHandled = addHandledToPowerRestrictions(
       powerRestrictionsRanges,


### PR DESCRIPTION
Just because we started to have a various range of opinions about how to write that, let's make it one way everywhere.