### PR TITLE
front: localize missing editoast pathfinding error codes

### DIFF
--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -86,6 +86,8 @@
     "incompatible_loading_gauge": "Incompatible loading gauge",
     "incompatible_signaling_system": "Incompatible signaling system",
     "not_enough_path_items": "Missing parameters for pathfinding: Departure, Arrival, Rolling stock",
+    "invalid_path_item": "Waypoint not found",
+    "rolling_stock_not_found": "Rolling stock not found",
     "pathfinding_failed": "No path found"
   },
   "powerRestriction": "Power restriction code",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -86,6 +86,8 @@
     "incompatible_loading_gauge": "Gabarit incompatible",
     "incompatible_signaling_system": "Système de signalisation incompatible",
     "not_enough_path_items": "Éléments manquants pour la recherche : Origine, Destination, Matériel roulant",
+    "invalid_path_item": "Point de passage non trouvé",
+    "rolling_stock_not_found": "Matériel roulant non trouvé",
     "pathfinding_failed": "Aucun chemin trouvé"
   },
   "pleaseWait": "Veuillez patientez…",


### PR DESCRIPTION
In #7883, core pathfinding errors have been localized. But I missed a few error codes that are generated by editoast instead of core: "invalid_path_item" and "rolling_stock_not_found". Localize these as well.

The editoast errors are defined here:
https://github.com/OpenRailAssociation/osrd/blob/769de63a18d74b6239b85dd2094ae713b56de2c1/editoast/src/core/v2/pathfinding.rs#L40