### PR TITLE
front: do not modify rolling stock search filter and trim it

### DIFF
--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.tsx
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.tsx
@@ -55,7 +55,7 @@ function rollingStockPassesSearchedStringFilter(
     return true;
   }
   function includesSearchedString(str: string | undefined) {
-    return str && str.toLowerCase().includes(filters.text);
+    return str?.trim().toLowerCase().includes(filters.text.trim().toLowerCase());
   }
   return [
     name,
@@ -142,7 +142,7 @@ export default function useFilterRollingStock() {
     useState<LightRollingStockWithLiveries[]>(allRollingStocks);
 
   const searchRollingStock = (value: string) => {
-    setFilters({ ...filters, text: value.toLowerCase() });
+    setFilters({ ...filters, text: value });
     setSearchIsLoading(true);
   };
 

--- a/front/tests/005-operational-studies.spec.ts
+++ b/front/tests/005-operational-studies.spec.ts
@@ -55,7 +55,8 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
     const rollingstockModal = playwrightRollingstockModalPage.rollingStockSelectorModal;
     await expect(rollingstockModal).toBeVisible();
 
-    await playwrightRollingstockModalPage.searchRollingstock('rollingstock_1500_25000_test_e2e');
+    // Voluntarily add spaces and capital letters so we also test the normalization of the search functionality
+    await playwrightRollingstockModalPage.searchRollingstock(' rollingstock_1500_25000_test_E2E ');
 
     const rollingstockCard = playwrightRollingstockModalPage.getRollingstockCardByTestID(
       `rollingstock-${rollingStock.name}`


### PR DESCRIPTION
When searching for rolling stock, the input does modify what is entered (making it lower case). It is a disturbing user experience to type a capital letter and see a lower case letter being displayed.

Also, if a leading space is typed, the search won't work. We might want to trim the search input before using it.
