### PR TITLE
Improve batch pathfinding performances

### DIFF
--- a/editoast/editoast_schemas/src/infra/operational_point.rs
+++ b/editoast/editoast_schemas/src/infra/operational_point.rs
@@ -95,8 +95,8 @@ impl OSRDIdentified for OperationalPoint {
 }
 
 impl OperationalPoint {
-    pub fn track_offset(op: &OperationalPoint) -> Vec<TrackOffset> {
-        op.parts
+    pub fn track_offset(&self) -> Vec<TrackOffset> {
+        self.parts
             .clone()
             .into_iter()
             .map(|el| TrackOffset {

--- a/editoast/src/views/v2/path.rs
+++ b/editoast/src/views/v2/path.rs
@@ -1,3 +1,4 @@
+pub mod path_item_cache;
 pub mod pathfinding;
 pub mod projection;
 mod properties;

--- a/editoast/src/views/v2/path/path_item_cache.rs
+++ b/editoast/src/views/v2/path/path_item_cache.rs
@@ -1,0 +1,256 @@
+use crate::core::v2::pathfinding::PathfindingResult;
+use crate::error::Result;
+use crate::modelsv2::TrackSectionModel;
+use crate::RetrieveBatchUnchecked;
+use editoast_schemas::infra::TrackOffset;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use editoast_models::DbConnection;
+use editoast_schemas::train_schedule::PathItemLocation;
+
+use crate::modelsv2::OperationalPointModel;
+
+type TrackOffsetResult = std::result::Result<Vec<Vec<TrackOffset>>, PathfindingResult>;
+
+/// Gather information about several path items, factorizing db calls.
+pub struct PathItemCache {
+    uic_to_ops: HashMap<i64, Vec<OperationalPointModel>>,
+    trigram_to_ops: HashMap<String, Vec<OperationalPointModel>>,
+    ids_to_ops: HashMap<String, OperationalPointModel>,
+    existing_track_ids: HashSet<String>,
+}
+
+impl PathItemCache {
+    /// Load the path item cache from a list of pathfinding inputs
+    pub async fn load(
+        conn: &mut DbConnection,
+        infra_id: i64,
+        path_items: &[&PathItemLocation],
+    ) -> Result<PathItemCache> {
+        let (trigrams, ops_uic, ops_id) = collect_path_item_ids(path_items);
+        let uic_to_ops = retrieve_op_from_uic(conn, infra_id, &ops_uic).await?;
+        let trigram_to_ops = retrieve_op_from_trigrams(conn, infra_id, &trigrams).await?;
+        let ids_to_ops = retrieve_op_from_ids(conn, infra_id, &ops_id).await?;
+
+        let tracks = path_items.iter().filter_map(|item| match item {
+            PathItemLocation::TrackOffset(TrackOffset { track, .. }) => {
+                Some((infra_id, track.0.clone()))
+            }
+            _ => None,
+        });
+        let tracks = ids_to_ops
+            .values()
+            .chain(trigram_to_ops.values().flatten())
+            .chain(uic_to_ops.values().flatten())
+            .flat_map(|op| &op.parts)
+            .map(|part| (infra_id, part.track.0.clone()))
+            .chain(tracks);
+        let existing_track_ids =
+            TrackSectionModel::retrieve_batch_unchecked::<_, Vec<_>>(conn, tracks)
+                .await?
+                .into_iter()
+                .map(|track| track.obj_id)
+                .collect();
+
+        Ok(PathItemCache {
+            uic_to_ops,
+            trigram_to_ops,
+            ids_to_ops,
+            existing_track_ids,
+        })
+    }
+
+    /// Get the operational points associated with an identifier
+    pub fn get_from_id(&self, id: &str) -> Option<&OperationalPointModel> {
+        self.ids_to_ops.get(id)
+    }
+
+    /// Get the operational points associated with a trigram
+    pub fn get_from_trigram(&self, trigram: &str) -> Option<&Vec<OperationalPointModel>> {
+        self.trigram_to_ops.get(trigram)
+    }
+
+    /// Get the operational points associated with a UIC code
+    pub fn get_from_uic(&self, uic: i64) -> Option<&Vec<OperationalPointModel>> {
+        self.uic_to_ops.get(&uic)
+    }
+
+    /// Check if a track exists
+    pub fn track_exists(&self, track: &str) -> bool {
+        self.existing_track_ids.contains(track)
+    }
+
+    /// Extract locations from path items
+    pub fn extract_location_from_path_items(
+        &self,
+        path_items: &[&PathItemLocation],
+    ) -> TrackOffsetResult {
+        let mut result: Vec<Vec<_>> = Vec::default();
+        for (index, &path_item) in path_items.iter().enumerate() {
+            let track_offsets = match path_item {
+                PathItemLocation::TrackOffset(track_offset) => {
+                    vec![track_offset.clone()]
+                }
+                PathItemLocation::OperationalPointId { operational_point } => {
+                    match self.get_from_id(&operational_point.0) {
+                        Some(op) => op.track_offset(),
+                        None => {
+                            return Err(PathfindingResult::InvalidPathItem {
+                                index,
+                                path_item: path_item.clone(),
+                            });
+                        }
+                    }
+                }
+                PathItemLocation::OperationalPointDescription {
+                    trigram,
+                    secondary_code,
+                } => {
+                    let ops = self
+                        .get_from_trigram(&trigram.0)
+                        .cloned()
+                        .unwrap_or_default();
+                    let ops = secondary_code_filter(secondary_code, ops);
+                    if ops.is_empty() {
+                        return Err(PathfindingResult::InvalidPathItem {
+                            index,
+                            path_item: path_item.clone(),
+                        });
+                    }
+                    track_offsets_from_ops(&ops)
+                }
+                PathItemLocation::OperationalPointUic {
+                    uic,
+                    secondary_code,
+                } => {
+                    let ops = self
+                        .get_from_uic(i64::from(*uic))
+                        .cloned()
+                        .unwrap_or_default();
+                    let ops = secondary_code_filter(secondary_code, ops);
+                    if ops.is_empty() {
+                        return Err(PathfindingResult::InvalidPathItem {
+                            index,
+                            path_item: path_item.clone(),
+                        });
+                    }
+                    track_offsets_from_ops(&ops)
+                }
+            };
+
+            // Check if tracks exist
+            for track_offset in &track_offsets {
+                if !self.track_exists(&track_offset.track.0) {
+                    return Err(PathfindingResult::InvalidPathItem {
+                        index,
+                        path_item: path_item.clone(),
+                    });
+                }
+            }
+
+            result.push(track_offsets);
+        }
+        Ok(result)
+    }
+}
+
+/// Collect the ids of the operational points from the path items
+fn collect_path_item_ids(path_items: &[&PathItemLocation]) -> (Vec<String>, Vec<i64>, Vec<String>) {
+    let mut trigrams: Vec<String> = Vec::new();
+    let mut ops_uic: Vec<i64> = Vec::new();
+    let mut ops_id: Vec<String> = Vec::new();
+
+    for item in path_items {
+        match item {
+            PathItemLocation::OperationalPointDescription { trigram, .. } => {
+                trigrams.push(trigram.clone().0);
+            }
+            PathItemLocation::OperationalPointUic { uic, .. } => {
+                ops_uic.push(i64::from(*uic));
+            }
+            PathItemLocation::OperationalPointId {
+                operational_point, ..
+            } => {
+                ops_id.push(operational_point.clone().0);
+            }
+            _ => {}
+        }
+    }
+    (trigrams, ops_uic, ops_id)
+}
+
+/// Retrieve operational points from operational point uic codes
+async fn retrieve_op_from_uic(
+    conn: &mut DbConnection,
+    infra_id: i64,
+    ops_uic: &[i64],
+) -> Result<HashMap<i64, Vec<OperationalPointModel>>> {
+    let mut uic_to_ops: HashMap<i64, Vec<OperationalPointModel>> = HashMap::new();
+    OperationalPointModel::retrieve_from_uic(conn, infra_id, ops_uic)
+        .await?
+        .into_iter()
+        .for_each(|op| {
+            uic_to_ops
+                .entry(op.extensions.identifier.clone().unwrap().uic)
+                .or_default()
+                .push(op)
+        });
+    Ok(uic_to_ops)
+}
+
+/// Retrieve operational points from operational point trigams
+async fn retrieve_op_from_trigrams(
+    conn: &mut DbConnection,
+    infra_id: i64,
+    trigrams: &[String],
+) -> Result<HashMap<String, Vec<OperationalPointModel>>> {
+    let mut trigrams_to_ops: HashMap<String, Vec<OperationalPointModel>> = HashMap::new();
+    OperationalPointModel::retrieve_from_trigrams(conn, infra_id, trigrams)
+        .await?
+        .into_iter()
+        .for_each(|op| {
+            trigrams_to_ops
+                .entry(op.extensions.sncf.clone().unwrap().trigram)
+                .or_default()
+                .push(op)
+        });
+    Ok(trigrams_to_ops)
+}
+
+/// Retrieve operational points from operational point ids
+async fn retrieve_op_from_ids(
+    conn: &mut DbConnection,
+    infra_id: i64,
+    ops_id: &[String],
+) -> Result<HashMap<String, OperationalPointModel>> {
+    let ops_id = ops_id.iter().map(|obj_id| (infra_id, obj_id.clone()));
+    // a check for missing ids is performed later
+    let ids_to_ops: HashMap<_, _> =
+        OperationalPointModel::retrieve_batch_unchecked::<_, Vec<_>>(conn, ops_id)
+            .await?
+            .into_iter()
+            .map(|op| (op.obj_id.clone(), op))
+            .collect();
+
+    Ok(ids_to_ops)
+}
+
+fn track_offsets_from_ops(ops: &[OperationalPointModel]) -> Vec<TrackOffset> {
+    ops.iter().flat_map(|op| op.track_offset()).collect()
+}
+
+/// Filter operational points by secondary code
+/// If the secondary code is not provided, the original list is returned
+fn secondary_code_filter(
+    secondary_code: &Option<String>,
+    ops: Vec<OperationalPointModel>,
+) -> Vec<OperationalPointModel> {
+    if let Some(secondary_code) = secondary_code {
+        ops.into_iter()
+            .filter(|op| &op.extensions.sncf.as_ref().unwrap().ch == secondary_code)
+            .collect()
+    } else {
+        ops
+    }
+}

--- a/editoast/src/views/v2/path/pathfinding.rs
+++ b/editoast/src/views/v2/path/pathfinding.rs
@@ -8,7 +8,6 @@ use actix_web::post;
 use actix_web::web::Data;
 use actix_web::web::Json;
 use actix_web::web::Path;
-use editoast_schemas::infra::TrackOffset;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::train_schedule::PathItemLocation;
 use serde::Deserialize;
@@ -22,21 +21,15 @@ use crate::core::CoreClient;
 use crate::error::Result;
 use crate::modelsv2::train_schedule::TrainSchedule;
 use crate::modelsv2::Infra;
-use crate::modelsv2::OperationalPointModel;
 use crate::modelsv2::Retrieve;
-use crate::modelsv2::RetrieveBatch;
-use crate::modelsv2::RetrieveBatchUnchecked;
 use crate::modelsv2::RollingStockModel;
-use crate::modelsv2::TrackSectionModel;
 use crate::redis_utils::RedisClient;
 use crate::redis_utils::RedisConnection;
 use crate::views::get_app_version;
+use crate::views::v2::path::path_item_cache::PathItemCache;
 use crate::views::v2::path::PathfindingError;
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
-use editoast_schemas::infra::OperationalPoint;
-
-type TrackOffsetResult = std::result::Result<Vec<Vec<TrackOffset>>, TrackOffsetExtractionError>;
 
 crate::routes! {
     "/v2/infra/{infra_id}/pathfinding/blocks" => {
@@ -140,6 +133,14 @@ async fn pathfinding_blocks_batch(
 
     // Handle miss cache:
     // 1) extract locations from path items
+    let path_items: Vec<_> = pathfinding_results
+        .iter()
+        .zip(pathfinding_inputs)
+        .filter(|(res, _)| res.is_none())
+        .flat_map(|(_, input)| &input.path_items)
+        .collect();
+    let path_item_cache = PathItemCache::load(conn, infra.id, &path_items).await?;
+
     let mut to_cache = vec![];
     let mut pathfinding_requests = vec![];
     let mut pathfinding_requests_index = vec![];
@@ -152,7 +153,7 @@ async fn pathfinding_blocks_batch(
             continue;
         }
 
-        match build_pathfinding_request(pathfinding_input, conn, infra).await? {
+        match build_pathfinding_request(pathfinding_input, infra, &path_item_cache) {
             Ok(pathfinding_request) => {
                 pathfinding_requests.push(pathfinding_request);
                 pathfinding_requests_index.push(index);
@@ -186,27 +187,19 @@ async fn pathfinding_blocks_batch(
     Ok(pathfinding_results.into_iter().flatten().collect())
 }
 
-async fn build_pathfinding_request(
+fn build_pathfinding_request(
     pathfinding_input: &PathfindingInput,
-    conn: &mut DbConnection,
     infra: &Infra,
-) -> Result<std::result::Result<PathfindingRequest, PathfindingResult>> {
-    let path_items = &pathfinding_input.path_items;
+    path_item_cache: &PathItemCache,
+) -> std::result::Result<PathfindingRequest, PathfindingResult> {
+    let path_items: Vec<_> = pathfinding_input.path_items.iter().collect();
     if path_items.len() <= 1 {
-        return Ok(Err(PathfindingResult::NotEnoughPathItems));
+        return Err(PathfindingResult::NotEnoughPathItems);
     }
-    let track_offsets = match extract_location_from_path_items(conn, infra.id, path_items).await? {
-        Ok(track_offsets) => track_offsets,
-        Err(e) => return Ok(Err(e.into())),
-    };
-
-    // Check if tracks exist
-    if let Err(err) = check_tracks_from_path_items(conn, infra.id, &track_offsets).await? {
-        return Ok(Err(err));
-    }
+    let track_offsets = path_item_cache.extract_location_from_path_items(&path_items)?;
 
     // Create the pathfinding request
-    Ok(Ok(PathfindingRequest {
+    Ok(PathfindingRequest {
         infra: infra.id,
         expected_version: infra.version.clone(),
         path_items: track_offsets,
@@ -218,7 +211,7 @@ async fn build_pathfinding_request(
         rolling_stock_supported_signaling_systems: pathfinding_input
             .rolling_stock_supported_signaling_systems
             .clone(),
-    }))
+    })
 }
 
 /// Compute a path given a train schedule and an infrastructure.
@@ -304,193 +297,4 @@ fn path_input_hash(infra: i64, infra_version: &String, path_input: &PathfindingI
     path_input.hash(&mut hasher);
     let hash_path_input = hasher.finish();
     format!("pathfinding_{osrd_version}.{infra}.{infra_version}.{hash_path_input}")
-}
-
-fn collect_path_item_ids(path_items: &[PathItemLocation]) -> (Vec<String>, Vec<i64>, Vec<String>) {
-    let mut trigrams: Vec<String> = Vec::new();
-    let mut ops_uic: Vec<i64> = Vec::new();
-    let mut ops_id: Vec<String> = Vec::new();
-
-    for item in path_items {
-        match item {
-            PathItemLocation::OperationalPointDescription { trigram, .. } => {
-                trigrams.push(trigram.clone().0);
-            }
-            PathItemLocation::OperationalPointUic { uic, .. } => {
-                ops_uic.push(*uic as i64);
-            }
-            PathItemLocation::OperationalPointId {
-                operational_point, ..
-            } => {
-                ops_id.push(operational_point.clone().0);
-            }
-            _ => {}
-        }
-    }
-    (trigrams, ops_uic, ops_id)
-}
-
-async fn retrieve_op_from_locations(
-    conn: &mut DbConnection,
-    infra_id: i64,
-    ops_uic: &[i64],
-    trigrams: &[String],
-    ops_id: &[String],
-) -> Result<(
-    HashMap<i64, Vec<OperationalPointModel>>,
-    HashMap<String, Vec<OperationalPointModel>>,
-    HashMap<String, OperationalPointModel>,
-)> {
-    let mut uic_to_ops: HashMap<i64, Vec<OperationalPointModel>> = HashMap::new();
-    OperationalPointModel::retrieve_from_uic(conn, infra_id, ops_uic)
-        .await?
-        .into_iter()
-        .for_each(|op| {
-            uic_to_ops
-                .entry(op.extensions.identifier.clone().unwrap().uic)
-                .or_default()
-                .push(op)
-        });
-
-    let mut trigrams_to_ops: HashMap<String, Vec<OperationalPointModel>> = HashMap::new();
-    OperationalPointModel::retrieve_from_trigrams(conn, infra_id, trigrams)
-        .await?
-        .into_iter()
-        .for_each(|op| {
-            trigrams_to_ops
-                .entry(op.extensions.sncf.clone().unwrap().trigram)
-                .or_default()
-                .push(op)
-        });
-
-    let ops_id = ops_id.iter().map(|obj_id| (infra_id, obj_id.clone()));
-    // a check for missing ids is performed later
-    let ids_to_ops: HashMap<_, _> =
-        OperationalPointModel::retrieve_batch_unchecked::<_, Vec<_>>(conn, ops_id)
-            .await?
-            .into_iter()
-            .map(|op| (op.obj_id.clone(), op))
-            .collect();
-
-    Ok((uic_to_ops, trigrams_to_ops, ids_to_ops))
-}
-
-/// Error when extracting track offsets from path items
-pub struct TrackOffsetExtractionError {
-    /// The index of the path item that caused the error
-    pub index: usize,
-    /// The path item that caused the error
-    pub path_item: PathItemLocation,
-}
-
-impl From<TrackOffsetExtractionError> for PathfindingResult {
-    fn from(error: TrackOffsetExtractionError) -> Self {
-        PathfindingResult::InvalidPathItem {
-            index: error.index,
-            path_item: error.path_item,
-        }
-    }
-}
-
-/// extract locations from path items
-pub async fn extract_location_from_path_items(
-    conn: &mut DbConnection,
-    infra_id: i64,
-    path_items: &[PathItemLocation],
-) -> Result<TrackOffsetResult> {
-    let (trigrams, ops_uic, ops_id) = collect_path_item_ids(path_items);
-
-    let (uic_to_ops, trigrams_to_ops, ids_to_ops) =
-        retrieve_op_from_locations(conn, infra_id, &ops_uic, &trigrams, &ops_id).await?;
-
-    let mut result: Vec<Vec<_>> = Vec::default();
-    for (index, path_item) in path_items.iter().enumerate() {
-        let track_offsets = match path_item {
-            PathItemLocation::TrackOffset(track_offset) => {
-                vec![TrackOffset {
-                    track: track_offset.track.clone(),
-                    offset: track_offset.offset,
-                }]
-            }
-            PathItemLocation::OperationalPointId { operational_point } => {
-                match ids_to_ops.get(&operational_point.0) {
-                    Some(op) => OperationalPoint::track_offset(op),
-                    None => {
-                        return Ok(Err(TrackOffsetExtractionError {
-                            index,
-                            path_item: path_item.clone(),
-                        }));
-                    }
-                }
-            }
-            PathItemLocation::OperationalPointDescription {
-                trigram,
-                secondary_code,
-            } => {
-                let ops = trigrams_to_ops.get(&trigram.0).cloned().unwrap_or_default();
-                let ops = secondary_code_filter(secondary_code, ops);
-                if ops.is_empty() {
-                    return Ok(Err(TrackOffsetExtractionError {
-                        index,
-                        path_item: path_item.clone(),
-                    }));
-                }
-                track_offsets_from_ops(&ops)
-            }
-            PathItemLocation::OperationalPointUic {
-                uic,
-                secondary_code,
-            } => {
-                let ops = uic_to_ops.get(&(*uic as i64)).cloned().unwrap_or_default();
-                let ops = secondary_code_filter(secondary_code, ops);
-                if ops.is_empty() {
-                    return Ok(Err(TrackOffsetExtractionError {
-                        index,
-                        path_item: path_item.clone(),
-                    }));
-                }
-                track_offsets_from_ops(&ops)
-            }
-        };
-        result.push(track_offsets);
-    }
-    Ok(Ok(result))
-}
-
-async fn check_tracks_from_path_items(
-    conn: &mut DbConnection,
-    infra_id: i64,
-    track_offsets: &[Vec<TrackOffset>],
-) -> Result<std::result::Result<(), PathfindingResult>> {
-    for tracks in track_offsets {
-        let ids = tracks
-            .iter()
-            .map(|track_offset| (infra_id, track_offset.track.0.clone()));
-        let (_, missings): (Vec<_>, _) = TrackSectionModel::retrieve_batch(conn, ids).await?;
-        if !missings.is_empty() {
-            return Ok(Err(PathfindingResult::NotFoundInTracks));
-        }
-    }
-    Ok(Ok(()))
-}
-
-fn track_offsets_from_ops(ops: &[OperationalPointModel]) -> Vec<TrackOffset> {
-    ops.iter()
-        .flat_map(|op| OperationalPoint::track_offset(op.as_ref()))
-        .collect()
-}
-
-/// Filter operational points by secondary code
-/// If the secondary code is not provided, the original list is returned
-fn secondary_code_filter(
-    secondary_code: &Option<String>,
-    ops: Vec<OperationalPointModel>,
-) -> Vec<OperationalPointModel> {
-    if let Some(secondary_code) = secondary_code {
-        ops.into_iter()
-            .filter(|op| &op.extensions.sncf.as_ref().unwrap().ch == secondary_code)
-            .collect()
-    } else {
-        ops
-    }
 }


### PR DESCRIPTION
## Description

This PR tries to improve calls to `simulation_summary` when train schedules are **not cached** to redis.

- Fixing the `--no-cache` option
- Reducing the number of call perform to the database

## Benchmark

- Run `simulation_summary` endpoint on 30 train schedules timetable (all valid)
- `--no-cache` option is enabled

### Before

Time: 1.15s
Number of DB queries: 236 

![begore](https://github.com/user-attachments/assets/a8f31798-c9a9-4dac-9af7-b9fe8f21cc10)

### After

Time: 937ms
Number of DB queries: 5 

![after](https://github.com/user-attachments/assets/1a0e8848-b094-4387-9b0b-4bb47ca56d9b)

