### PR TITLE
Bye actix

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -3,298 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags 2.6.0",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-cors"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
-dependencies = [
- "actix-utils",
- "actix-web",
- "derive_more",
- "futures-util",
- "log",
- "once_cell",
- "smallvec 1.13.2",
-]
-
-[[package]]
-name = "actix-files"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0773d59061dedb49a8aed04c67291b9d8cf2fe0b60130a381aab53c6dd86e9be"
-dependencies = [
- "actix-http",
- "actix-service",
- "actix-utils",
- "actix-web",
- "bitflags 2.6.0",
- "bytes",
- "derive_more",
- "futures-core",
- "http-range",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "v_htmlescape",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "ahash",
- "base64 0.22.1",
- "bitflags 2.6.0",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more",
- "encoding_rs",
- "flate2",
- "futures-core",
- "h2",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.8.5",
- "sha1",
- "smallvec 1.13.2",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "actix-multipart"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5118a26dee7e34e894f7e85aa0ee5080ae4c18bf03c0e30d49a80e418f00a53"
-dependencies = [
- "actix-multipart-derive",
- "actix-utils",
- "actix-web",
- "derive_more",
- "futures-core",
- "futures-util",
- "httparse",
- "local-waker",
- "log",
- "memchr",
- "mime",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_plain",
- "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "actix-multipart-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11eb847f49a700678ea2fa73daeb3208061afa2b9d1a8527c03390f4c4a1c6b"
-dependencies = [
- "darling",
- "parse-size",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02303ce8d4e8be5b855af6cf3c3a08f3eff26880faad82bab679c22d3650cb5"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio 0.8.11",
- "socket2 0.5.7",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
-dependencies = [
- "futures-core",
- "paste",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-tls"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac453898d866cdbecdbc2334fe1738c747b4eba14a677261f2b768ba05329389"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.1.0",
- "impl-more",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "ahash",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec 1.13.2",
- "socket2 0.5.7",
- "time",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "actix-web-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923b53a2a54dd0b6fb3e737a036b497321b693d16c120806ba4009478f06109b"
-dependencies = [
- "actix-http",
- "actix-web",
- "awc",
- "futures-util",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "serde",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,21 +44,6 @@ name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
 
 [[package]]
 name = "android-tzdata"
@@ -654,6 +347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,51 +382,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "awc"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b67e44fb95d1dc9467e3930383e115f9b4ed60ca689db41409284e967a12d"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "derive_more",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "itoa",
  "matchit",
  "memchr",
@@ -736,10 +403,46 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -752,11 +455,113 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum 0.7.5",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "axum-test"
+version = "15.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd2b6c11bc5e65ec121543c5049b7e07be9e7b5a515df79d01f74a72c6a15f0"
+dependencies = [
+ "anyhow",
+ "auto-future",
+ "axum 0.7.5",
+ "bytes",
+ "cookie",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec 1.13.2",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164dc5772777b14dbd4e3d5c0b8fb4c2f34cfde658337d89b166c50d32a81aff"
+dependencies = [
+ "axum 0.7.5",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -833,27 +638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "built"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,15 +672,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "bytestring"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
-dependencies = [
- "bytes",
-]
 
 [[package]]
 name = "c_vec"
@@ -984,7 +759,7 @@ version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.72",
@@ -1042,18 +817,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "percent-encoding",
  "time",
  "version_check",
 ]
@@ -1247,19 +1015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "diesel"
 version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,14 +1098,12 @@ dependencies = [
 name = "editoast"
 version = "0.1.0"
 dependencies = [
- "actix-cors",
- "actix-files",
- "actix-http",
- "actix-multipart",
- "actix-web",
- "actix-web-opentelemetry",
  "async-std",
  "async-trait",
+ "axum 0.7.5",
+ "axum-extra",
+ "axum-test",
+ "axum-tracing-opentelemetry",
  "chashmap",
  "chrono",
  "clap",
@@ -1369,10 +1122,12 @@ dependencies = [
  "futures 0.3.30",
  "futures-util",
  "geos",
+ "headers",
  "image",
  "inventory",
  "itertools 0.13.0",
  "json-patch",
+ "mime",
  "mvt",
  "opentelemetry",
  "opentelemetry-datadog",
@@ -1387,6 +1142,7 @@ dependencies = [
  "rand 0.8.5",
  "rangemap",
  "redis",
+ "regex",
  "reqwest",
  "rstest",
  "serde",
@@ -1400,6 +1156,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1987,6 +1746,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,10 +1836,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range"
-version = "0.1.5"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -2076,7 +1882,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2089,12 +1895,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec 1.13.2",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.29",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2107,10 +1933,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2190,12 +2036,6 @@ name = "imgref"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
-
-[[package]]
-name = "impl-more"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "indexmap"
@@ -2376,12 +2216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,23 +2261,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2554,18 +2371,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
@@ -2574,6 +2379,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -3039,12 +2861,6 @@ dependencies = [
  "smallvec 1.13.2",
  "windows-targets 0.52.5",
 ]
-
-[[package]]
-name = "parse-size"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "paste"
@@ -3649,12 +3465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,8 +3495,8 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3700,7 +3510,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3710,6 +3520,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9838134a2bfaa8e1f40738fcc972ac799de6e0e06b5157acb95fc2b05a0ea283"
+dependencies = [
+ "lazy_static",
+ "thiserror",
 ]
 
 [[package]]
@@ -3765,6 +3585,22 @@ dependencies = [
  "rustc_version",
  "syn 2.0.72",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand 0.8.5",
+ "thiserror",
 ]
 
 [[package]]
@@ -3943,11 +3779,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_plain"
-version = "1.0.2"
+name = "serde_path_to_error"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3957,7 +3794,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
- "actix-web",
+ "axum 0.7.5",
  "futures 0.3.30",
  "percent-encoding",
  "serde",
@@ -4058,15 +3895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4199,7 +4027,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4241,6 +4069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,7 +4102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck",
+ "heck 0.5.0",
  "pkg-config",
  "toml",
  "version-compare",
@@ -4388,10 +4222,8 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.1",
- "parking_lot 0.12.3",
+ "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -4499,6 +4331,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4543,13 +4376,13 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4577,6 +4410,23 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4654,6 +4504,18 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065f4c337874edb2ba504cb1e487b3bb4f1533a5bb6fcdf72da1575564814c"
+dependencies = [
+ "http 1.1.0",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -4767,7 +4629,6 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "regex",
  "syn 2.0.72",
  "uuid",
 ]
@@ -4792,12 +4653,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "v_htmlescape"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
 
 [[package]]
 name = "validator"
@@ -5202,34 +5057,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -55,23 +55,21 @@ serde_json = "1.0.120"
 strum = { version = "0.26.3", features = ["derive"] }
 tempfile = "3.10.1"
 thiserror = "1.0.63"
-tokio = { version = "1.39.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.39.1", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.11"
 tracing = { version = "0.1.40", features = ["log"] }
 url = { version = "2.5.2", features = ["serde"] }
-utoipa = { version = "4.2.3", features = ["actix_extras", "chrono", "uuid"] }
+utoipa = { version = "4.2.3", features = ["chrono", "uuid"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [dependencies]
 # For batch dependency updates, see editoast/README.md
 
-actix-cors = "0.7.0"
-actix-files = "0.6.6"
-actix-http = "3.8.0"
-actix-multipart = "0.7.2"
-actix-web = "4.8.0"
-actix-web-opentelemetry = { version = "0.18.0", features = ["awc"] }
 async-trait = "0.1.81"
+axum = { version = "0.7.5", features = ["multipart"] }
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
+axum-test = "15.3.0"
+axum-tracing-opentelemetry = "0.19.0"
 chashmap = "2.2.2"
 chrono.workspace = true
 clap = { version = "4.5.10", features = ["derive", "env"] }
@@ -90,10 +88,12 @@ enumset = "1.1.5"
 futures.workspace = true
 futures-util.workspace = true
 geos.workspace = true
+headers = "0.4.0"
 image = "0.25.2"
 inventory = "0.3"
 itertools.workspace = true
 json-patch = { version = "2.0.0", features = ["utoipa"] }
+mime = "0.3.17"
 mvt.workspace = true
 opentelemetry = "0.23.0"
 opentelemetry-datadog = { version = "0.11.0", features = ["reqwest-client"] }
@@ -112,18 +112,27 @@ redis = { version = "0.25.4", features = [
   "tokio-comp",
   "tokio-native-tls-comp",
 ] }
+regex = "1.10.5"
 # 0.12.0 to 0.12.4 have weird timeout issues https://github.com/seanmonstar/reqwest/issues/2283
 # This bug was introduced between 0.12.0 and 0.12.3.
 reqwest = { version = "0.11.27", features = ["json"] }
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
-serde_qs = { version = "0.13.0", features = ["actix4"] }
+serde_qs = { version = "0.13.0", features = ["axum"] }
 serde_yaml = "0.9.34"
 sha1 = "0.10"
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util = { version = "0.7.11", features = ["io", "tracing"] }
+tower = "0.4.13"
+tower-http = { version = "0.5.2", features = [
+  "cors",
+  "limit",
+  "normalize-path",
+  "trace",
+] }
 tracing.workspace = true
 tracing-opentelemetry = "0.24.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
@@ -134,6 +143,7 @@ validator = { version = "0.18.1", features = ["derive"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
+axum = { version = "0.7.5", features = ["macros", "multipart"] }
 editoast_models = { workspace = true, features = ["testing"] }
 pretty_assertions = "1.4.0"
 rstest.workspace = true

--- a/editoast/editoast_derive/src/error.rs
+++ b/editoast/editoast_derive/src/error.rs
@@ -55,7 +55,7 @@ pub fn expand_editoast_error(input: &DeriveInput) -> Result<TokenStream> {
         #error_definitions
 
         impl crate::error::EditoastError for #name {
-            fn get_status(&self) -> actix_web::http::StatusCode {
+            fn get_status(&self) -> axum::http::StatusCode {
                 #get_statuses
             }
 
@@ -167,9 +167,9 @@ fn expand_get_statuses(variants: &[ParsedVariant], default_status: u16) -> Resul
 
     let statuses = variants.iter().map(|variant| {
         let Some(status) = variant.params.status.as_ref() else {
-            return quote! { actix_web::http::StatusCode::from_u16(#default_status).unwrap() };
+            return quote! { axum::http::StatusCode::from_u16(#default_status).unwrap() };
         };
-        quote! { actix_web::http::StatusCode::try_from(#status).expect("EditoastError: invalid status expression") }
+        quote! { axum::http::StatusCode::try_from(#status).expect("EditoastError: invalid status expression") }
     });
 
     Ok(quote! {

--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -59,13 +59,13 @@ pub fn error(input: TokenStream) -> TokenStream {
 /// ## Available implementations
 ///
 /// - **retrieve** (enable `Retrieve` trait)
-///   - `retrieve(Data<DbPool>, i64) -> Result<Option<Self>>`
+///   - `retrieve(State<DbPool>, i64) -> Result<Option<Self>>`
 ///   - `retrieve_conn(&mut PgConnection, i64) -> Result<Option<Self>>`
 /// - **create** (enable `Create` trait)
-///   - `create(self, Data<DbPool>) -> Result<Self>`
+///   - `create(self, State<DbPool>) -> Result<Self>`
 ///   - `create_conn(self, &mut PgConnection) -> Result<Self>`
 /// - **delete** (enable `Delete` trait)
-///   - `delete(Data<DbPool>, i64) -> Result<bool>`
+///   - `delete(State<DbPool>, i64) -> Result<bool>`
 ///   - `delete_conn(&mut PgConnection, i64) -> Result<bool>`
 ///
 /// ## Requirements

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7,7 +7,7 @@ info:
     url: https://www.gnu.org/licenses/lgpl-3.0.html
   version: 0.1.0
 paths:
-  /documents/:
+  /documents:
     post:
       tags:
       - documents
@@ -81,7 +81,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /electrical_profile_set/:
+  /electrical_profile_set:
     get:
       tags:
       - electrical_profiles
@@ -118,7 +118,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ElectricalProfileSet'
-  /electrical_profile_set/{electrical_profile_set_id}/:
+  /electrical_profile_set/{electrical_profile_set_id}:
     get:
       tags:
       - electrical_profiles
@@ -163,7 +163,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /electrical_profile_set/{electrical_profile_set_id}/level_order/:
+  /electrical_profile_set/{electrical_profile_set_id}/level_order:
     get:
       tags:
       - electrical_profiles
@@ -208,7 +208,7 @@ paths:
             text/plain:
               schema:
                 type: string
-  /infra/:
+  /infra:
     get:
       tags:
       - infra
@@ -374,7 +374,7 @@ paths:
               - 2500.5V
         '404':
           description: The infra was not found
-  /infra/{infra_id}/:
+  /infra/{infra_id}:
     get:
       tags:
       - infra
@@ -522,7 +522,7 @@ paths:
                   type: array
                   items:
                     type: string
-  /infra/{infra_id}/auto_fixes/:
+  /infra/{infra_id}/auto_fixes:
     get:
       tags:
       - infra
@@ -650,7 +650,7 @@ paths:
                         properties:
                           information:
                             $ref: '#/components/schemas/InfraError'
-  /infra/{infra_id}/lines/{line_code}/bbox/:
+  /infra/{infra_id}/lines/{line_code}/bbox:
     get:
       tags:
       - infra
@@ -752,7 +752,7 @@ paths:
           description: Duplicate object ids provided
         '404':
           description: Object ID or infra ID invalid
-  /infra/{infra_id}/pathfinding/:
+  /infra/{infra_id}/pathfinding:
     post:
       tags:
       - infra
@@ -1092,7 +1092,7 @@ paths:
               - 2500.5V
         '404':
           description: The infra was not found
-  /layers/layer/{layer_slug}/mvt/{view_slug}/:
+  /layers/layer/{layer_slug}/mvt/{view_slug}:
     get:
       tags:
       - layers
@@ -1160,7 +1160,7 @@ paths:
                     - http://localhost:7070/tile/track_sections/geo/{z}/{x}/{y}/?infra=1
                   type:
                     type: string
-  /layers/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}/:
+  /layers/tile/{layer_slug}/{view_slug}/{z}/{x}/{y}:
     get:
       tags:
       - layers
@@ -1211,7 +1211,7 @@ paths:
               schema:
                 type: string
                 format: binary
-  /light_rolling_stock/:
+  /light_rolling_stock:
     get:
       tags:
       - rolling_stock
@@ -1241,7 +1241,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResponseOfLightRollingStockWithLiveries'
-  /light_rolling_stock/name/{rolling_stock_name}/:
+  /light_rolling_stock/name/{rolling_stock_name}:
     get:
       tags:
       - rolling_stock
@@ -1259,7 +1259,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LightRollingStockWithLiveries'
-  /light_rolling_stock/{rolling_stock_id}/:
+  /light_rolling_stock/{rolling_stock_id}:
     get:
       tags:
       - rolling_stock
@@ -1278,7 +1278,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LightRollingStockWithLiveries'
-  /pathfinding/:
+  /pathfinding:
     post:
       tags:
       - pathfinding
@@ -1296,7 +1296,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PathResponse'
-  /pathfinding/{pathfinding_id}/:
+  /pathfinding/{pathfinding_id}:
     get:
       tags:
       - pathfinding
@@ -1408,7 +1408,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ElectrificationsOnPathResponse'
-  /projects/:
+  /projects:
     get:
       tags:
       - projects
@@ -1469,7 +1469,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectWithStudies'
-  /projects/{project_id}/:
+  /projects/{project_id}:
     get:
       tags:
       - projects
@@ -1548,7 +1548,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /projects/{project_id}/studies/:
+  /projects/{project_id}/studies:
     get:
       tags:
       - studies
@@ -1623,7 +1623,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StudyResponse'
-  /projects/{project_id}/studies/{study_id}/:
+  /projects/{project_id}/studies/{study_id}:
     get:
       tags:
       - studies
@@ -1720,7 +1720,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /projects/{project_id}/studies/{study_id}/scenarios/:
+  /projects/{project_id}/studies/{study_id}/scenarios:
     get:
       tags:
       - scenarios
@@ -1799,7 +1799,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioResponse'
-  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/:
+  /projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}:
     get:
       tags:
       - scenarios
@@ -1913,7 +1913,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /rolling_stock/:
+  /rolling_stock:
     post:
       tags:
       - rolling_stock
@@ -1937,7 +1937,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RollingStock'
-  /rolling_stock/name/{rolling_stock_name}/:
+  /rolling_stock/name/{rolling_stock_name}:
     get:
       tags:
       - rolling_stock
@@ -1955,7 +1955,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RollingStockWithLiveries'
-  /rolling_stock/power_restrictions/:
+  /rolling_stock/power_restrictions:
     get:
       tags:
       - rolling_stock
@@ -1969,7 +1969,7 @@ paths:
                 type: array
                 items:
                   type: string
-  /rolling_stock/{rolling_stock_id}/:
+  /rolling_stock/{rolling_stock_id}:
     get:
       tags:
       - rolling_stock
@@ -2040,7 +2040,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RollingStockWithLiveries'
-  /rolling_stock/{rolling_stock_id}/livery/:
+  /rolling_stock/{rolling_stock_id}/livery:
     post:
       tags:
       - rolling_stock
@@ -2068,7 +2068,7 @@ paths:
                 $ref: '#/components/schemas/RollingStockLivery'
         '404':
           description: The requested rolling stock was not found
-  /rolling_stock/{rolling_stock_id}/locked/:
+  /rolling_stock/{rolling_stock_id}/locked:
     patch:
       tags:
       - rolling_stock
@@ -2171,7 +2171,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SearchResultItem'
-  /single_simulation/:
+  /single_simulation:
     post:
       summary: Runs a simulation with a single train, does not write anything to the database
       requestBody:
@@ -2187,7 +2187,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SingleSimulationResponse'
-  /speed_limit_tags/:
+  /speed_limit_tags:
     get:
       tags:
       - speed_limit_tags
@@ -2243,7 +2243,7 @@ paths:
           description: Atlas image of config
         '404':
           description: Signaling system not found
-  /stdcm/:
+  /stdcm:
     post:
       tags:
       - stdcm
@@ -2338,7 +2338,7 @@ paths:
                     $ref: '#/components/schemas/PathfindingPayload'
                   simulation:
                     $ref: '#/components/schemas/SimulationReport'
-  /timetable/{id}/:
+  /timetable/{id}:
     get:
       tags:
       - timetable
@@ -2376,7 +2376,6 @@ paths:
           format: int64
           minimum: 0
       requestBody:
-        description: ''
         content:
           application/json:
             schema:
@@ -2417,7 +2416,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Conflict'
-  /train_schedule/:
+  /train_schedule:
     delete:
       tags:
       - train_schedule
@@ -2526,7 +2525,7 @@ paths:
                 items:
                   type: integer
                   format: int64
-  /train_schedule/{id}/:
+  /train_schedule/{id}:
     get:
       tags:
       - train_schedule
@@ -2589,7 +2588,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimulationReport'
-  /v2/infra/{infra_id}/path_properties/:
+  /v2/infra/{infra_id}/path_properties:
     post:
       tags:
       - pathfindingv2
@@ -2623,7 +2622,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PathProperties'
-  /v2/infra/{infra_id}/pathfinding/blocks/:
+  /v2/infra/{infra_id}/pathfinding/blocks:
     post:
       tags:
       - pathfindingv2
@@ -2649,7 +2648,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PathfindingResult'
-  /v2/projects/{project_id}/studies/{study_id}/scenarios/:
+  /v2/projects/{project_id}/studies/{study_id}/scenarios:
     get:
       tags:
       - scenariosv2
@@ -2739,7 +2738,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScenarioResponseV2'
-  /v2/projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}/:
+  /v2/projects/{project_id}/studies/{study_id}/scenarios/{scenario_id}:
     get:
       tags:
       - scenariosv2
@@ -2853,7 +2852,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InternalError'
-  /v2/timetable/:
+  /v2/timetable:
     get:
       tags:
       - timetablev2
@@ -2911,7 +2910,7 @@ paths:
                 $ref: '#/components/schemas/TimetableResult'
         '404':
           description: Timetable not found
-  /v2/timetable/{id}/:
+  /v2/timetable/{id}:
     get:
       tags:
       - timetablev2
@@ -2946,7 +2945,6 @@ paths:
           type: integer
           format: int64
       requestBody:
-        description: ''
         content:
           application/json:
             schema:
@@ -3006,7 +3004,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ConflictV2'
-  /v2/timetable/{id}/stdcm/:
+  /v2/timetable/{id}/stdcm:
     post:
       tags:
       - stdcm
@@ -3170,7 +3168,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TrainScheduleResult'
-  /v2/train_schedule/:
+  /v2/train_schedule:
     post:
       tags:
       - train_schedulev2
@@ -3281,7 +3279,7 @@ paths:
                 type: object
                 additionalProperties:
                   $ref: '#/components/schemas/SimulationSummaryResult'
-  /v2/train_schedule/{id}/:
+  /v2/train_schedule/{id}:
     get:
       tags:
       - train_schedulev2
@@ -3327,7 +3325,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrainScheduleResult'
-  /v2/train_schedule/{id}/path/:
+  /v2/train_schedule/{id}/path:
     get:
       tags:
       - train_schedulev2
@@ -3400,7 +3398,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Version'
-  /work_schedules/:
+  /work_schedules:
     post:
       tags:
       - work_schedules
@@ -4402,6 +4400,7 @@ components:
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotCreateCompoundImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotReadImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorKeyNotFound'
+      - $ref: '#/components/schemas/EditoastRollingStockErrorLiveryMultipartError'
       - $ref: '#/components/schemas/EditoastRollingStockErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastRollingStockErrorRollingStockIsLocked'
       - $ref: '#/components/schemas/EditoastRollingStockErrorRollingStockIsUsed'
@@ -5347,6 +5346,25 @@ components:
           type: string
           enum:
           - editoast:rollingstocks:KeyNotFound
+    EditoastRollingStockErrorLiveryMultipartError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:rollingstocks:LiveryMultipartError
     EditoastRollingStockErrorNameAlreadyUsed:
       type: object
       required:

--- a/editoast/src/core/mocking.rs
+++ b/editoast/src/core/mocking.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use actix_http::StatusCode;
+use axum::http::StatusCode;
 use reqwest::Body;
 use serde::Serialize;
 

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::marker::PhantomData;
 
-use actix_http::StatusCode;
 use async_trait::async_trait;
+use axum::http::StatusCode;
 use colored::ColoredString;
 use colored::Colorize;
 use editoast_derive::EditoastError;
@@ -112,7 +112,7 @@ impl CoreClient {
     ) -> Result<R::Response> {
         let method_s = colored_method(&method);
         debug!(
-            target: "editoast::coreclient", 
+            target: "editoast::coreclient",
             body = body.and_then(|b| serde_json::to_string_pretty(b).ok()).unwrap_or_default(),
             "Request content");
         match self {
@@ -403,7 +403,7 @@ impl From<reqwest::Error> for CoreError {
 
 #[cfg(test)]
 mod test {
-    use actix_http::StatusCode;
+    use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use reqwest::Method;
     use serde_derive::Serialize;

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -119,7 +119,7 @@ struct ErrorWithHash {
 impl From<InfraError> for ErrorWithHash {
     fn from(error: InfraError) -> Self {
         let mut hasher = Sha1::new();
-        hasher.update(&serde_json::to_vec(&error).unwrap());
+        hasher.update(serde_json::to_vec(&error).unwrap());
         let hash = hasher.finalize();
         let hash: ErrorHash = format!("{:x}", hash);
         ErrorWithHash { error, hash }

--- a/editoast/src/views/operational_studies.rs
+++ b/editoast/src/views/operational_studies.rs
@@ -19,6 +19,7 @@ pub enum Ordering {
 }
 
 #[derive(Debug, Clone, serde::Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct OperationalStudiesOrderingParam {
     #[serde(default)]
     pub ordering: Ordering,

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -170,6 +170,7 @@ pub struct PaginatedResponse<T> {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct PaginationQueryParam {
     #[serde(default = "default_page")]
     #[param(minimum = 1, default = 1)]

--- a/editoast/src/views/pathfinding/electrical_profiles.rs
+++ b/editoast/src/views/pathfinding/electrical_profiles.rs
@@ -3,12 +3,12 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::ops::DerefMut;
 
-use actix_web::get;
-use actix_web::web::Data;
-use actix_web::web::Json;
-use actix_web::web::Path;
-use actix_web::web::Query;
+use axum::extract::Json;
+use axum::extract::Path;
+use axum::extract::Query;
+use axum::extract::State;
 use editoast_common::rangemap_utils::RangedValue;
+use editoast_models::DbConnectionPoolV2;
 use rangemap::RangeMap;
 use serde::Deserialize;
 use serde::Serialize;
@@ -26,11 +26,10 @@ use crate::views::pathfinding::path_rangemap::make_path_range_map;
 use crate::views::pathfinding::path_rangemap::TrackMap;
 use crate::views::pathfinding::PathfindingError;
 use crate::views::pathfinding::PathfindingIdParam;
-use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::ElectricalProfileSetData;
 
 crate::routes! {
-    electrical_profiles_on_path
+    "/electrical_profiles" => electrical_profiles_on_path,
 }
 
 editoast_common::schemas! {
@@ -73,6 +72,7 @@ fn map_electrical_profiles(
 }
 
 #[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 struct ProfilesOnPathQuery {
     rolling_stock_id: i64,
     electrical_profile_set_id: i64,
@@ -87,20 +87,19 @@ struct ProfilesOnPathResponse {
 }
 
 #[utoipa::path(
+    get, path = "",
     tag = "electrical_profiles",
     params(PathfindingIdParam, ProfilesOnPathQuery),
     responses(
         (status = 200, body = ProfilesOnPathResponse),
     )
 )]
-#[get("/electrical_profiles")]
 /// Retrieve the electrical profiles along a path, as seen by the rolling stock specified
 async fn electrical_profiles_on_path(
-    params: Path<PathfindingIdParam>,
-    request: Query<ProfilesOnPathQuery>,
-    db_pool: Data<DbConnectionPoolV2>,
+    Path(params): Path<PathfindingIdParam>,
+    Query(request): Query<ProfilesOnPathQuery>,
+    State(db_pool): State<DbConnectionPoolV2>,
 ) -> Result<Json<ProfilesOnPathResponse>> {
-    let db_pool = db_pool.into_inner();
     let pathfinding_id = params.pathfinding_id;
     let pathfinding =
         match Pathfinding::retrieve_conn(db_pool.get().await?.deref_mut(), pathfinding_id).await? {
@@ -139,173 +138,8 @@ async fn electrical_profiles_on_path(
 }
 
 #[cfg(test)]
-mod tests {
-    use actix_http::StatusCode;
-    use actix_web::test::TestRequest;
-    use editoast_common::range_map;
-    use rstest::rstest;
-    use std::ops::DerefMut;
-
-    use super::*;
-    use crate::modelsv2::fixtures::create_empty_infra;
-    use crate::modelsv2::fixtures::create_fast_rolling_stock;
-    use crate::modelsv2::fixtures::create_simple_pathfinding_v1;
-    use crate::modelsv2::prelude::*;
-    use crate::views::test_app::TestAppBuilder;
-    use editoast_models::DbConnection;
-    use editoast_schemas::infra::ElectricalProfile;
-    use editoast_schemas::infra::TrackRange;
-
-    async fn electrical_profile_set(conn: &mut DbConnection) -> ElectricalProfileSet {
-        let ep_data = ElectricalProfileSetData {
-            levels: vec![
-                ElectricalProfile {
-                    value: "A".into(),
-                    power_class: "1".into(),
-                    track_ranges: vec![
-                        TrackRange::new("track_1", 0.0, 10.0),
-                        TrackRange::new("track_2", 5.0, 10.0),
-                    ],
-                },
-                ElectricalProfile {
-                    value: "B".into(),
-                    power_class: "1".into(),
-                    track_ranges: vec![
-                        TrackRange::new("track_2", 0.0, 5.0),
-                        TrackRange::new("track_4", 0.0, 5.0),
-                        TrackRange::new("track_5", 5.0, 10.0),
-                    ],
-                },
-                ElectricalProfile {
-                    value: "B".into(),
-                    power_class: "1".into(),
-                    track_ranges: vec![TrackRange::new("track_4", 5.0, 10.0)],
-                },
-                ElectricalProfile {
-                    value: "C".into(),
-                    power_class: "1".into(),
-                    track_ranges: vec![TrackRange::new("track_3", 0.0, 10.0)],
-                },
-                ElectricalProfile {
-                    value: "A".into(),
-                    power_class: "2".into(),
-                    track_ranges: vec![
-                        TrackRange::new("track_1", 0.0, 10.0),
-                        TrackRange::new("track_3", 0.0, 10.0),
-                    ],
-                },
-                ElectricalProfile {
-                    value: "B".into(),
-                    power_class: "2".into(),
-                    track_ranges: vec![
-                        TrackRange::new("track_2", 0.0, 10.0),
-                        TrackRange::new("track_4", 0.0, 10.0),
-                    ],
-                },
-            ],
-            level_order: Default::default(),
-        };
-
-        let electrical_profile_set = ElectricalProfileSet::changeset()
-            .name("Small_ep_test".into())
-            .data(ep_data);
-
-        electrical_profile_set
-            .create(conn)
-            .await
-            .expect("Failed to create electrical profile set")
-    }
-
-    #[rstest]
-    async fn test_map_electrical_profiles() {
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let ep_data = electrical_profile_set(db_pool.get_ok().deref_mut())
-            .await
-            .data;
-        let track_sections: HashSet<_> =
-            vec!["track_1", "track_2", "track_3", "track_4", "track_5"]
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect();
-
-        let (maps_by_track, warnings) =
-            map_electrical_profiles(ep_data, "1".into(), track_sections);
-
-        assert_eq!(warnings.len(), 0);
-
-        let expected_maps_by_track: TrackMap<String> = [
-            ("track_1".into(), range_map!(0.0, 10.0 => "A")),
-            (
-                "track_2".into(),
-                range_map!(0.0, 5.0 => "B", 5.0, 10.0 => "A"),
-            ),
-            ("track_3".into(), range_map!(0.0, 10.0 => "C")),
-            ("track_4".into(), range_map!(0.0, 10.0 => "B")),
-            ("track_5".into(), range_map!(5.0, 10.0 => "B")),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-
-        assert_eq!(maps_by_track, expected_maps_by_track);
-    }
-
-    #[rstest]
-    async fn test_view_electrical_profiles_on_path() {
-        // GIVEN
-        let app = TestAppBuilder::default_app();
-        let db_pool = app.db_pool();
-        let ep_set = electrical_profile_set(db_pool.get_ok().deref_mut()).await;
-        let rolling_stock = create_fast_rolling_stock(
-            db_pool.get_ok().deref_mut(),
-            "fast_rolling_stock_test_view_electrical_profiles_on_path",
-        )
-        .await;
-        let infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
-        let pathfinding =
-            create_simple_pathfinding_v1(db_pool.get_ok().deref_mut(), infra.id).await;
-
-        let request = TestRequest::get()
-            .uri(&format!("/pathfinding/{}/electrical_profiles/?electrical_profile_set_id={}&rolling_stock_id={}", 
-            pathfinding.id, ep_set.id, rolling_stock.id)
-            )
-            .to_request();
-
-        // WHEN
-        let response: ProfilesOnPathResponse =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
-
-        // THEN
-        assert!(response.warnings.is_empty());
-        assert_eq!(
-            response.electrical_profile_ranges,
-            vec![
-                RangedValue {
-                    begin: 0.0,
-                    end: 15.0,
-                    value: "A".into()
-                },
-                RangedValue {
-                    begin: 15.0,
-                    end: 20.0,
-                    value: "B".into()
-                },
-                RangedValue {
-                    begin: 20.0,
-                    end: 30.0,
-                    value: "C".into()
-                },
-                RangedValue {
-                    begin: 30.0,
-                    end: 40.0,
-                    value: "B".into()
-                },
-                RangedValue {
-                    begin: 45.0,
-                    end: 48.0,
-                    value: "B".into()
-                },
-            ]
-        );
-    }
+pub mod tests {
+    // There used to be tests here. They were removed because this TSV1 module will be removed soon.
+    // These tests were using actix's test API, but we switched to axum, so they were removed instead
+    // of being ported.
 }

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -1,9 +1,11 @@
-use actix_files::NamedFile;
-use actix_web::get;
-use actix_web::web::Json;
-use actix_web::web::Path;
+use axum::body::Body;
+use axum::extract::Json;
+use axum::extract::Path;
+use axum::http::header;
+use axum::response::IntoResponse;
 use editoast_derive::EditoastError;
 use thiserror::Error;
+use tokio_util::io::ReaderStream;
 
 use crate::client::get_dynamic_assets_path;
 use crate::error::Result;
@@ -11,8 +13,8 @@ use crate::generated_data::sprite_config::SpriteConfig;
 
 crate::routes! {
     "/sprites" => {
-        sprites,
-        signaling_systems,
+        "/{signaling_system}/{file_name}" => sprites,
+        "/signaling_systems" => signaling_systems,
     },
 }
 
@@ -29,12 +31,12 @@ enum SpriteErrors {
 
 /// This endpoint returns the list of supported signaling systems
 #[utoipa::path(
+    get, path = "",
     tag = "sprites",
     responses(
         (status = 200, description = "List of supported signaling systems", body = Vec<String>, example = json!(["BAL", "TVM300"])),
     ),
 )]
-#[get("/signaling_systems")]
 async fn signaling_systems() -> Result<Json<Vec<String>>> {
     let sprite_configs = SpriteConfig::load();
     let signaling_systems = sprite_configs.keys().cloned().collect();
@@ -43,6 +45,7 @@ async fn signaling_systems() -> Result<Json<Vec<String>>> {
 
 /// This endpoint is used by map libre to retrieve the atlas of each signaling system
 #[utoipa::path(
+    get, path = "",
     tag = "sprites",
     params(
         ("signaling_system" = String, Path, description = "Signaling system name"),
@@ -53,17 +56,89 @@ async fn signaling_systems() -> Result<Json<Vec<String>>> {
         (status = 404, description = "Signaling system not found"),
     ),
 )]
-#[get("/{signaling_system}/{file_name:[-_ @0-9A-Za-z]+\\.(json|png|svg)}")]
-async fn sprites(path: Path<(String, String)>) -> Result<NamedFile> {
-    let (signaling_system, file_name) = path.into_inner();
+async fn sprites(
+    Path((signaling_system, file_name)): Path<(String, String)>,
+) -> Result<impl IntoResponse> {
     let sprite_configs = SpriteConfig::load();
     if !sprite_configs.contains_key(&signaling_system) {
         return Err(SpriteErrors::UnknownSignalingSystem { signaling_system }.into());
     }
     let path =
         get_dynamic_assets_path().join(format!("signal_sprites/{signaling_system}/{file_name}"));
+
     if !path.is_file() {
         return Err(SpriteErrors::FileNotFound { file: file_name }.into());
     }
-    Ok(NamedFile::open(path).unwrap().use_last_modified(false))
+    let file = match tokio::fs::File::open(&path).await {
+        Ok(file) => file,
+        Err(err) => {
+            tracing::error!(path = %path.display(), error = %err, "cannot open existing atlas file");
+            panic!("Cannot open existing sprite: {}", path.display());
+        }
+    };
+
+    let stream = ReaderStream::new(file);
+    let body = Body::from_stream(stream);
+
+    let content_type = match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .expect("all files have an extension")
+    {
+        "json" => headers::ContentType::json(),
+        "png" => headers::ContentType::png(),
+        "svg" => mime::IMAGE_SVG.into(),
+        _ => unreachable!(),
+    };
+
+    let content_disposition = format!("inline; filename=\"{}\"", file_name);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, content_type.to_string()),
+            (header::CONTENT_DISPOSITION, content_disposition),
+        ],
+        body,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::views::test_app::TestAppBuilder;
+
+    use super::*;
+    use axum::http::StatusCode;
+    use rstest::rstest;
+
+    #[rstest]
+    async fn test_signaling_systems() {
+        let app = TestAppBuilder::default_app();
+        let request = app.get("/sprites/signaling_systems");
+        let response: Vec<String> = app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        assert!(response.contains(&"BAL".to_string()));
+        assert!(response.contains(&"BAPR".to_string()));
+        assert!(response.contains(&"TVM300".to_string()));
+        assert!(response.contains(&"TVM430".to_string()));
+    }
+
+    #[rstest]
+    async fn test_sprites() {
+        let app = TestAppBuilder::default_app();
+        let request = app.get("/sprites/TVM300/REP%20TGV.svg");
+        let response = app.fetch(request).assert_status(StatusCode::OK);
+        assert_eq!("image/svg+xml", response.content_type());
+        let response = response.bytes();
+        let expected =
+            std::fs::read(get_dynamic_assets_path().join("signal_sprites/TVM300/REP TGV.svg"))
+                .unwrap();
+        assert_eq!(response, expected);
+    }
+
+    #[rstest]
+    async fn test_sprites_not_found() {
+        let app = TestAppBuilder::default_app();
+        let request = app.get("/sprites/TVM300/NOT_A_THING.svg");
+        app.fetch(request).assert_status(StatusCode::NOT_FOUND);
+    }
 }

--- a/editoast/src/views/v2/mod.rs
+++ b/editoast/src/views/v2/mod.rs
@@ -4,10 +4,10 @@ pub mod timetable;
 pub mod train_schedule;
 
 crate::routes! {
-            train_schedule::routes(),
-            timetable::routes(),
-            path::routes(),
-            scenario::routes(),
+    &train_schedule,
+    &timetable,
+    &path,
+    &scenario,
 }
 
 editoast_common::schemas! {

--- a/editoast/src/views/v2/path.rs
+++ b/editoast/src/views/v2/path.rs
@@ -15,8 +15,8 @@ use crate::modelsv2::Infra;
 use editoast_models::DbConnection;
 
 crate::routes! {
-    properties::routes(),
-    pathfinding::routes(),
+    &properties,
+    &pathfinding,
 }
 
 editoast_common::schemas! {

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -119,6 +119,7 @@
       "CannotReadImage": "Impossible to read the separated image",
       "NameAlreadyUsed": "Name '{{name}}' already used",
       "KeyNotFound": "Rolling stock '{{rolling_stock_key.key}}' could not be found",
+      "LiveryMultipartError": "Invalid multipart request while uploading livery",
       "RollingStockIsLocked": "RollingStock '{{rolling_stock_id}}' is locked",
       "RollingStockIsUsed": "RollingStock '{{rolling_stock_id}}' is used"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -119,6 +119,7 @@
       "CannotReadImage": "Impossible de lire l'image",
       "NameAlreadyUsed": "Un matériel roulant avec le nom '{{name}}' existe déjà",
       "KeyNotFound": "Matériel roulant '{{rolling_stock_key.key}}' non trouvé",
+      "LiveryMultipartError": "Requête multipart invalide pour upload de livrée",
       "RollingStockIsLocked": "Matériel roulant '{{rolling_stock_id}}' est verrouillé",
       "RollingStockIsUsed": "Matériel roulant '{{rolling_stock_id}}' est occupé"
     },

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -32,7 +32,7 @@ const injectedRtkApi = api
     endpoints: (build) => ({
       postDocuments: build.mutation<PostDocumentsApiResponse, PostDocumentsApiArg>({
         query: (queryArg) => ({
-          url: `/documents/`,
+          url: `/documents`,
           method: 'POST',
           body: queryArg.body,
           headers: { content_type: queryArg.contentType },
@@ -57,7 +57,7 @@ const injectedRtkApi = api
         GetElectricalProfileSetApiResponse,
         GetElectricalProfileSetApiArg
       >({
-        query: () => ({ url: `/electrical_profile_set/` }),
+        query: () => ({ url: `/electrical_profile_set` }),
         providesTags: ['electrical_profiles'],
       }),
       postElectricalProfileSet: build.mutation<
@@ -65,7 +65,7 @@ const injectedRtkApi = api
         PostElectricalProfileSetApiArg
       >({
         query: (queryArg) => ({
-          url: `/electrical_profile_set/`,
+          url: `/electrical_profile_set`,
           method: 'POST',
           body: queryArg.electricalProfileSetData,
           params: { name: queryArg.name },
@@ -77,7 +77,7 @@ const injectedRtkApi = api
         GetElectricalProfileSetByElectricalProfileSetIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}/`,
+          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}`,
         }),
         providesTags: ['electrical_profiles'],
       }),
@@ -86,7 +86,7 @@ const injectedRtkApi = api
         DeleteElectricalProfileSetByElectricalProfileSetIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}/`,
+          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}`,
           method: 'DELETE',
         }),
         invalidatesTags: ['electrical_profiles'],
@@ -96,7 +96,7 @@ const injectedRtkApi = api
         GetElectricalProfileSetByElectricalProfileSetIdLevelOrderApiArg
       >({
         query: (queryArg) => ({
-          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}/level_order/`,
+          url: `/electrical_profile_set/${queryArg.electricalProfileSetId}/level_order`,
         }),
         providesTags: ['electrical_profiles'],
       }),
@@ -105,13 +105,13 @@ const injectedRtkApi = api
       }),
       getInfra: build.query<GetInfraApiResponse, GetInfraApiArg>({
         query: (queryArg) => ({
-          url: `/infra/`,
+          url: `/infra`,
           params: { page: queryArg.page, page_size: queryArg.pageSize },
         }),
         providesTags: ['infra'],
       }),
       postInfra: build.mutation<PostInfraApiResponse, PostInfraApiArg>({
-        query: (queryArg) => ({ url: `/infra/`, method: 'POST', body: queryArg.body }),
+        query: (queryArg) => ({ url: `/infra`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['infra'],
       }),
       postInfraRailjson: build.mutation<PostInfraRailjsonApiResponse, PostInfraRailjsonApiArg>({
@@ -136,12 +136,12 @@ const injectedRtkApi = api
         providesTags: ['infra', 'rolling_stock'],
       }),
       getInfraByInfraId: build.query<GetInfraByInfraIdApiResponse, GetInfraByInfraIdApiArg>({
-        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/` }),
+        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}` }),
         providesTags: ['infra'],
       }),
       postInfraByInfraId: build.mutation<PostInfraByInfraIdApiResponse, PostInfraByInfraIdApiArg>({
         query: (queryArg) => ({
-          url: `/infra/${queryArg.infraId}/`,
+          url: `/infra/${queryArg.infraId}`,
           method: 'POST',
           body: queryArg.body,
         }),
@@ -149,7 +149,7 @@ const injectedRtkApi = api
       }),
       putInfraByInfraId: build.mutation<PutInfraByInfraIdApiResponse, PutInfraByInfraIdApiArg>({
         query: (queryArg) => ({
-          url: `/infra/${queryArg.infraId}/`,
+          url: `/infra/${queryArg.infraId}`,
           method: 'PUT',
           body: queryArg.body,
         }),
@@ -159,7 +159,7 @@ const injectedRtkApi = api
         DeleteInfraByInfraIdApiResponse,
         DeleteInfraByInfraIdApiArg
       >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/`, method: 'DELETE' }),
+        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}`, method: 'DELETE' }),
         invalidatesTags: ['infra'],
       }),
       getInfraByInfraIdAttachedAndTrackId: build.query<
@@ -173,7 +173,7 @@ const injectedRtkApi = api
         GetInfraByInfraIdAutoFixesApiResponse,
         GetInfraByInfraIdAutoFixesApiArg
       >({
-        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/auto_fixes/` }),
+        query: (queryArg) => ({ url: `/infra/${queryArg.infraId}/auto_fixes` }),
         providesTags: ['infra'],
       }),
       postInfraByInfraIdClone: build.mutation<
@@ -208,7 +208,7 @@ const injectedRtkApi = api
         GetInfraByInfraIdLinesAndLineCodeBboxApiArg
       >({
         query: (queryArg) => ({
-          url: `/infra/${queryArg.infraId}/lines/${queryArg.lineCode}/bbox/`,
+          url: `/infra/${queryArg.infraId}/lines/${queryArg.lineCode}/bbox`,
         }),
         providesTags: ['infra'],
       }),
@@ -242,7 +242,7 @@ const injectedRtkApi = api
         PostInfraByInfraIdPathfindingApiArg
       >({
         query: (queryArg) => ({
-          url: `/infra/${queryArg.infraId}/pathfinding/`,
+          url: `/infra/${queryArg.infraId}/pathfinding`,
           method: 'POST',
           body: queryArg.pathfindingInput,
           params: { number: queryArg.number },
@@ -333,7 +333,7 @@ const injectedRtkApi = api
         GetLayersLayerByLayerSlugMvtAndViewSlugApiArg
       >({
         query: (queryArg) => ({
-          url: `/layers/layer/${queryArg.layerSlug}/mvt/${queryArg.viewSlug}/`,
+          url: `/layers/layer/${queryArg.layerSlug}/mvt/${queryArg.viewSlug}`,
           params: { infra: queryArg.infra },
         }),
         providesTags: ['layers'],
@@ -343,7 +343,7 @@ const injectedRtkApi = api
         GetLayersTileByLayerSlugAndViewSlugZXYApiArg
       >({
         query: (queryArg) => ({
-          url: `/layers/tile/${queryArg.layerSlug}/${queryArg.viewSlug}/${queryArg.z}/${queryArg.x}/${queryArg.y}/`,
+          url: `/layers/tile/${queryArg.layerSlug}/${queryArg.viewSlug}/${queryArg.z}/${queryArg.x}/${queryArg.y}`,
           params: { infra: queryArg.infra },
         }),
         providesTags: ['layers'],
@@ -353,7 +353,7 @@ const injectedRtkApi = api
         GetLightRollingStockApiArg
       >({
         query: (queryArg) => ({
-          url: `/light_rolling_stock/`,
+          url: `/light_rolling_stock`,
           params: { page: queryArg.page, page_size: queryArg.pageSize },
         }),
         providesTags: ['rolling_stock'],
@@ -362,19 +362,19 @@ const injectedRtkApi = api
         GetLightRollingStockNameByRollingStockNameApiResponse,
         GetLightRollingStockNameByRollingStockNameApiArg
       >({
-        query: (queryArg) => ({ url: `/light_rolling_stock/name/${queryArg.rollingStockName}/` }),
+        query: (queryArg) => ({ url: `/light_rolling_stock/name/${queryArg.rollingStockName}` }),
         providesTags: ['rolling_stock'],
       }),
       getLightRollingStockByRollingStockId: build.query<
         GetLightRollingStockByRollingStockIdApiResponse,
         GetLightRollingStockByRollingStockIdApiArg
       >({
-        query: (queryArg) => ({ url: `/light_rolling_stock/${queryArg.rollingStockId}/` }),
+        query: (queryArg) => ({ url: `/light_rolling_stock/${queryArg.rollingStockId}` }),
         providesTags: ['rolling_stock'],
       }),
       postPathfinding: build.mutation<PostPathfindingApiResponse, PostPathfindingApiArg>({
         query: (queryArg) => ({
-          url: `/pathfinding/`,
+          url: `/pathfinding`,
           method: 'POST',
           body: queryArg.pathfindingRequest,
         }),
@@ -384,7 +384,7 @@ const injectedRtkApi = api
         GetPathfindingByPathfindingIdApiResponse,
         GetPathfindingByPathfindingIdApiArg
       >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}/` }),
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}` }),
         providesTags: ['pathfinding'],
       }),
       putPathfindingByPathfindingId: build.mutation<
@@ -392,7 +392,7 @@ const injectedRtkApi = api
         PutPathfindingByPathfindingIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/pathfinding/${queryArg.pathfindingId}/`,
+          url: `/pathfinding/${queryArg.pathfindingId}`,
           method: 'PUT',
           body: queryArg.pathfindingRequest,
         }),
@@ -402,7 +402,7 @@ const injectedRtkApi = api
         DeletePathfindingByPathfindingIdApiResponse,
         DeletePathfindingByPathfindingIdApiArg
       >({
-        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}/`, method: 'DELETE' }),
+        query: (queryArg) => ({ url: `/pathfinding/${queryArg.pathfindingId}`, method: 'DELETE' }),
         invalidatesTags: ['pathfinding'],
       }),
       getPathfindingByPathfindingIdElectricalProfiles: build.query<
@@ -427,7 +427,7 @@ const injectedRtkApi = api
       }),
       getProjects: build.query<GetProjectsApiResponse, GetProjectsApiArg>({
         query: (queryArg) => ({
-          url: `/projects/`,
+          url: `/projects`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -438,7 +438,7 @@ const injectedRtkApi = api
       }),
       postProjects: build.mutation<PostProjectsApiResponse, PostProjectsApiArg>({
         query: (queryArg) => ({
-          url: `/projects/`,
+          url: `/projects`,
           method: 'POST',
           body: queryArg.projectCreateForm,
         }),
@@ -448,14 +448,14 @@ const injectedRtkApi = api
         GetProjectsByProjectIdApiResponse,
         GetProjectsByProjectIdApiArg
       >({
-        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}/` }),
+        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}` }),
         providesTags: ['projects'],
       }),
       deleteProjectsByProjectId: build.mutation<
         DeleteProjectsByProjectIdApiResponse,
         DeleteProjectsByProjectIdApiArg
       >({
-        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}/`, method: 'DELETE' }),
+        query: (queryArg) => ({ url: `/projects/${queryArg.projectId}`, method: 'DELETE' }),
         invalidatesTags: ['projects'],
       }),
       patchProjectsByProjectId: build.mutation<
@@ -463,7 +463,7 @@ const injectedRtkApi = api
         PatchProjectsByProjectIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/`,
+          url: `/projects/${queryArg.projectId}`,
           method: 'PATCH',
           body: queryArg.projectPatchForm,
         }),
@@ -474,7 +474,7 @@ const injectedRtkApi = api
         GetProjectsByProjectIdStudiesApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/`,
+          url: `/projects/${queryArg.projectId}/studies`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -488,7 +488,7 @@ const injectedRtkApi = api
         PostProjectsByProjectIdStudiesApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/`,
+          url: `/projects/${queryArg.projectId}/studies`,
           method: 'POST',
           body: queryArg.studyCreateForm,
         }),
@@ -499,7 +499,7 @@ const injectedRtkApi = api
         GetProjectsByProjectIdStudiesAndStudyIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
         }),
         providesTags: ['studies'],
       }),
@@ -508,7 +508,7 @@ const injectedRtkApi = api
         DeleteProjectsByProjectIdStudiesAndStudyIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
           method: 'DELETE',
         }),
         invalidatesTags: ['studies'],
@@ -518,7 +518,7 @@ const injectedRtkApi = api
         PatchProjectsByProjectIdStudiesAndStudyIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}`,
           method: 'PATCH',
           body: queryArg.studyPatchForm,
         }),
@@ -529,7 +529,7 @@ const injectedRtkApi = api
         GetProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -543,7 +543,7 @@ const injectedRtkApi = api
         PostProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
           method: 'POST',
           body: queryArg.scenarioCreateForm,
         }),
@@ -554,7 +554,7 @@ const injectedRtkApi = api
         GetProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
         }),
         providesTags: ['scenarios'],
       }),
@@ -563,7 +563,7 @@ const injectedRtkApi = api
         DeleteProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
           method: 'DELETE',
         }),
         invalidatesTags: ['scenarios'],
@@ -573,7 +573,7 @@ const injectedRtkApi = api
         PatchProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
           method: 'PATCH',
           body: queryArg.scenarioPatchForm,
         }),
@@ -581,7 +581,7 @@ const injectedRtkApi = api
       }),
       postRollingStock: build.mutation<PostRollingStockApiResponse, PostRollingStockApiArg>({
         query: (queryArg) => ({
-          url: `/rolling_stock/`,
+          url: `/rolling_stock`,
           method: 'POST',
           body: queryArg.rollingStockForm,
           params: { locked: queryArg.locked },
@@ -592,21 +592,21 @@ const injectedRtkApi = api
         GetRollingStockNameByRollingStockNameApiResponse,
         GetRollingStockNameByRollingStockNameApiArg
       >({
-        query: (queryArg) => ({ url: `/rolling_stock/name/${queryArg.rollingStockName}/` }),
+        query: (queryArg) => ({ url: `/rolling_stock/name/${queryArg.rollingStockName}` }),
         providesTags: ['rolling_stock'],
       }),
       getRollingStockPowerRestrictions: build.query<
         GetRollingStockPowerRestrictionsApiResponse,
         GetRollingStockPowerRestrictionsApiArg
       >({
-        query: () => ({ url: `/rolling_stock/power_restrictions/` }),
+        query: () => ({ url: `/rolling_stock/power_restrictions` }),
         providesTags: ['rolling_stock'],
       }),
       getRollingStockByRollingStockId: build.query<
         GetRollingStockByRollingStockIdApiResponse,
         GetRollingStockByRollingStockIdApiArg
       >({
-        query: (queryArg) => ({ url: `/rolling_stock/${queryArg.rollingStockId}/` }),
+        query: (queryArg) => ({ url: `/rolling_stock/${queryArg.rollingStockId}` }),
         providesTags: ['rolling_stock'],
       }),
       deleteRollingStockByRollingStockId: build.mutation<
@@ -614,7 +614,7 @@ const injectedRtkApi = api
         DeleteRollingStockByRollingStockIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.rollingStockId}/`,
+          url: `/rolling_stock/${queryArg.rollingStockId}`,
           method: 'DELETE',
           params: { force: queryArg.force },
         }),
@@ -625,7 +625,7 @@ const injectedRtkApi = api
         PatchRollingStockByRollingStockIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.rollingStockId}/`,
+          url: `/rolling_stock/${queryArg.rollingStockId}`,
           method: 'PATCH',
           body: queryArg.rollingStockForm,
         }),
@@ -636,7 +636,7 @@ const injectedRtkApi = api
         PostRollingStockByRollingStockIdLiveryApiArg
       >({
         query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.rollingStockId}/livery/`,
+          url: `/rolling_stock/${queryArg.rollingStockId}/livery`,
           method: 'POST',
           body: queryArg.rollingStockLiveryCreateForm,
         }),
@@ -647,7 +647,7 @@ const injectedRtkApi = api
         PatchRollingStockByRollingStockIdLockedApiArg
       >({
         query: (queryArg) => ({
-          url: `/rolling_stock/${queryArg.rollingStockId}/locked/`,
+          url: `/rolling_stock/${queryArg.rollingStockId}/locked`,
           method: 'PATCH',
           body: queryArg.rollingStockLockedUpdateForm,
         }),
@@ -667,13 +667,13 @@ const injectedRtkApi = api
         PostSingleSimulationApiArg
       >({
         query: (queryArg) => ({
-          url: `/single_simulation/`,
+          url: `/single_simulation`,
           method: 'POST',
           body: queryArg.singleSimulationRequest,
         }),
       }),
       getSpeedLimitTags: build.query<GetSpeedLimitTagsApiResponse, GetSpeedLimitTagsApiArg>({
-        query: () => ({ url: `/speed_limit_tags/` }),
+        query: () => ({ url: `/speed_limit_tags` }),
         providesTags: ['speed_limit_tags'],
       }),
       getSpritesSignalingSystems: build.query<
@@ -691,16 +691,16 @@ const injectedRtkApi = api
         providesTags: ['sprites'],
       }),
       postStdcm: build.mutation<PostStdcmApiResponse, PostStdcmApiArg>({
-        query: (queryArg) => ({ url: `/stdcm/`, method: 'POST', body: queryArg.body }),
+        query: (queryArg) => ({ url: `/stdcm`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['stdcm'],
       }),
       getTimetableById: build.query<GetTimetableByIdApiResponse, GetTimetableByIdApiArg>({
-        query: (queryArg) => ({ url: `/timetable/${queryArg.id}/` }),
+        query: (queryArg) => ({ url: `/timetable/${queryArg.id}` }),
         providesTags: ['timetable'],
       }),
       postTimetableById: build.mutation<PostTimetableByIdApiResponse, PostTimetableByIdApiArg>({
         query: (queryArg) => ({
-          url: `/timetable/${queryArg.id}/`,
+          url: `/timetable/${queryArg.id}`,
           method: 'POST',
           body: queryArg.body,
         }),
@@ -717,11 +717,11 @@ const injectedRtkApi = api
         DeleteTrainScheduleApiResponse,
         DeleteTrainScheduleApiArg
       >({
-        query: (queryArg) => ({ url: `/train_schedule/`, method: 'DELETE', body: queryArg.body }),
+        query: (queryArg) => ({ url: `/train_schedule`, method: 'DELETE', body: queryArg.body }),
         invalidatesTags: ['train_schedule', 'timetable'],
       }),
       patchTrainSchedule: build.mutation<PatchTrainScheduleApiResponse, PatchTrainScheduleApiArg>({
-        query: (queryArg) => ({ url: `/train_schedule/`, method: 'PATCH', body: queryArg.body }),
+        query: (queryArg) => ({ url: `/train_schedule`, method: 'PATCH', body: queryArg.body }),
         invalidatesTags: ['train_schedule', 'timetable'],
       }),
       postTrainScheduleResults: build.mutation<
@@ -750,14 +750,14 @@ const injectedRtkApi = api
         GetTrainScheduleByIdApiResponse,
         GetTrainScheduleByIdApiArg
       >({
-        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/` }),
+        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}` }),
         providesTags: ['train_schedule'],
       }),
       deleteTrainScheduleById: build.mutation<
         DeleteTrainScheduleByIdApiResponse,
         DeleteTrainScheduleByIdApiArg
       >({
-        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}/`, method: 'DELETE' }),
+        query: (queryArg) => ({ url: `/train_schedule/${queryArg.id}`, method: 'DELETE' }),
         invalidatesTags: ['train_schedule', 'timetable'],
       }),
       getTrainScheduleByIdResult: build.query<
@@ -775,7 +775,7 @@ const injectedRtkApi = api
         PostV2InfraByInfraIdPathPropertiesApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/infra/${queryArg.infraId}/path_properties/`,
+          url: `/v2/infra/${queryArg.infraId}/path_properties`,
           method: 'POST',
           body: queryArg.pathPropertiesInput,
           params: { props: queryArg.props },
@@ -787,7 +787,7 @@ const injectedRtkApi = api
         PostV2InfraByInfraIdPathfindingBlocksApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/infra/${queryArg.infraId}/pathfinding/blocks/`,
+          url: `/v2/infra/${queryArg.infraId}/pathfinding/blocks`,
           method: 'POST',
           body: queryArg.pathfindingInputV2,
         }),
@@ -798,7 +798,7 @@ const injectedRtkApi = api
         GetV2ProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
+          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
           params: {
             page: queryArg.page,
             page_size: queryArg.pageSize,
@@ -812,7 +812,7 @@ const injectedRtkApi = api
         PostV2ProjectsByProjectIdStudiesAndStudyIdScenariosApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/`,
+          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios`,
           method: 'POST',
           body: queryArg.scenarioCreateFormV2,
         }),
@@ -823,7 +823,7 @@ const injectedRtkApi = api
         GetV2ProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
         }),
         providesTags: ['scenariosv2'],
       }),
@@ -832,7 +832,7 @@ const injectedRtkApi = api
         DeleteV2ProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
           method: 'DELETE',
         }),
         invalidatesTags: ['scenariosv2'],
@@ -842,7 +842,7 @@ const injectedRtkApi = api
         PatchV2ProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}/`,
+          url: `/v2/projects/${queryArg.projectId}/studies/${queryArg.studyId}/scenarios/${queryArg.scenarioId}`,
           method: 'PATCH',
           body: queryArg.scenarioPatchFormV2,
         }),
@@ -850,26 +850,26 @@ const injectedRtkApi = api
       }),
       getV2Timetable: build.query<GetV2TimetableApiResponse, GetV2TimetableApiArg>({
         query: (queryArg) => ({
-          url: `/v2/timetable/`,
+          url: `/v2/timetable`,
           params: { page: queryArg.page, page_size: queryArg.pageSize },
         }),
         providesTags: ['timetablev2'],
       }),
       postV2Timetable: build.mutation<PostV2TimetableApiResponse, PostV2TimetableApiArg>({
         query: (queryArg) => ({
-          url: `/v2/timetable/`,
+          url: `/v2/timetable`,
           method: 'POST',
           body: queryArg.timetableForm,
         }),
         invalidatesTags: ['timetablev2'],
       }),
       getV2TimetableById: build.query<GetV2TimetableByIdApiResponse, GetV2TimetableByIdApiArg>({
-        query: (queryArg) => ({ url: `/v2/timetable/${queryArg.id}/` }),
+        query: (queryArg) => ({ url: `/v2/timetable/${queryArg.id}` }),
         providesTags: ['timetablev2'],
       }),
       putV2TimetableById: build.mutation<PutV2TimetableByIdApiResponse, PutV2TimetableByIdApiArg>({
         query: (queryArg) => ({
-          url: `/v2/timetable/${queryArg.id}/`,
+          url: `/v2/timetable/${queryArg.id}`,
           method: 'PUT',
           body: queryArg.timetableForm,
         }),
@@ -879,7 +879,7 @@ const injectedRtkApi = api
         DeleteV2TimetableByIdApiResponse,
         DeleteV2TimetableByIdApiArg
       >({
-        query: (queryArg) => ({ url: `/v2/timetable/${queryArg.id}/`, method: 'DELETE' }),
+        query: (queryArg) => ({ url: `/v2/timetable/${queryArg.id}`, method: 'DELETE' }),
         invalidatesTags: ['timetablev2'],
       }),
       getV2TimetableByIdConflicts: build.query<
@@ -897,7 +897,7 @@ const injectedRtkApi = api
         PostV2TimetableByIdStdcmApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/timetable/${queryArg.id}/stdcm/`,
+          url: `/v2/timetable/${queryArg.id}/stdcm`,
           method: 'POST',
           body: queryArg.body,
           params: { infra: queryArg.infra },
@@ -916,18 +916,14 @@ const injectedRtkApi = api
         invalidatesTags: ['timetablev2', 'train_schedulev2'],
       }),
       postV2TrainSchedule: build.query<PostV2TrainScheduleApiResponse, PostV2TrainScheduleApiArg>({
-        query: (queryArg) => ({ url: `/v2/train_schedule/`, method: 'POST', body: queryArg.body }),
+        query: (queryArg) => ({ url: `/v2/train_schedule`, method: 'POST', body: queryArg.body }),
         providesTags: ['train_schedulev2'],
       }),
       deleteV2TrainSchedule: build.mutation<
         DeleteV2TrainScheduleApiResponse,
         DeleteV2TrainScheduleApiArg
       >({
-        query: (queryArg) => ({
-          url: `/v2/train_schedule/`,
-          method: 'DELETE',
-          body: queryArg.body,
-        }),
+        query: (queryArg) => ({ url: `/v2/train_schedule`, method: 'DELETE', body: queryArg.body }),
         invalidatesTags: ['timetablev2', 'train_schedulev2'],
       }),
       postV2TrainScheduleProjectPath: build.query<
@@ -956,7 +952,7 @@ const injectedRtkApi = api
         GetV2TrainScheduleByIdApiResponse,
         GetV2TrainScheduleByIdApiArg
       >({
-        query: (queryArg) => ({ url: `/v2/train_schedule/${queryArg.id}/` }),
+        query: (queryArg) => ({ url: `/v2/train_schedule/${queryArg.id}` }),
         providesTags: ['train_schedulev2'],
       }),
       putV2TrainScheduleById: build.mutation<
@@ -964,7 +960,7 @@ const injectedRtkApi = api
         PutV2TrainScheduleByIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/train_schedule/${queryArg.id}/`,
+          url: `/v2/train_schedule/${queryArg.id}`,
           method: 'PUT',
           body: queryArg.trainScheduleForm,
         }),
@@ -975,7 +971,7 @@ const injectedRtkApi = api
         GetV2TrainScheduleByIdPathApiArg
       >({
         query: (queryArg) => ({
-          url: `/v2/train_schedule/${queryArg.id}/path/`,
+          url: `/v2/train_schedule/${queryArg.id}/path`,
           params: { infra_id: queryArg.infraId },
         }),
         providesTags: ['train_schedulev2', 'pathfindingv2'],
@@ -998,7 +994,7 @@ const injectedRtkApi = api
       }),
       postWorkSchedules: build.mutation<PostWorkSchedulesApiResponse, PostWorkSchedulesApiArg>({
         query: (queryArg) => ({
-          url: `/work_schedules/`,
+          url: `/work_schedules`,
           method: 'POST',
           body: queryArg.workScheduleCreateForm,
         }),

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -73,9 +73,9 @@ def test_editoast_bulk_delete(west_to_south_east_simulations: Sequence[int]):
         f"{EDITOAST_URL}train_schedule/results/",
         json={"path_id": None, "train_ids": west_to_south_east_simulations[0]},
     )
-    assert r.status_code == 400
+    assert r.status_code == 422
     r = requests.post(
         f"{EDITOAST_URL}train_schedule/results/",
         json={"path_id": None, "train_ids": west_to_south_east_simulations[1]},
     )
-    assert r.status_code == 400
+    assert r.status_code == 422


### PR DESCRIPTION
![5yvReCm](https://github.com/user-attachments/assets/d4949f3e-0a1b-43af-a357-643bd8c3b985)

# To verify

- [x] The app works 🙃 
    * liveries import
    * timetable import 
- [x] Telemetry works
- [x] The deleted tests can indeed be removed

> [!NOTE]
> Commits are overly split to ease the review, but will be squashed together before merging ofc.

### Main motivation

* the actix execution model was a little strange: it created one thread per worker and each of these threads had a monothread async runtime
* axum's API is more user-friendly and better documented
* actix tends to redefine its entire stack, whereas axum tends to work with other popular libs (hyper, tower, etc.).
* axum is maintained by the tokio team, so we can expect good integration (same for tracing).