### PR TITLE
front: retain margin boundaries when set but constant

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatMargin.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatMargin.ts
@@ -13,10 +13,7 @@ const formatMargin = (pathSteps: PathStep[]): Margin | undefined => {
         boundaries.push(step.id);
         values.push('none');
       }
-    }
-
-    // for the other steps, we add the margin if it's different from the previous one
-    else if (step.theoreticalMargin && step.theoreticalMargin !== values[values.length - 1]) {
+    } else if (step.theoreticalMargin) {
       boundaries.push(step.id);
       values.push(step.theoreticalMargin);
     }


### PR DESCRIPTION
If the user sets two consecutive margins at 5%, we need to send two ranges [5%, 5%] to the backend instead of merging them together into a single margin.

Closes: https://github.com/OpenRailAssociation/osrd/issues/8022