### PR TITLE
editoast: move PathItemLocation to its own openapi type

### DIFF
--- a/editoast/editoast_schemas/src/train_schedule/path_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/path_item.rs
@@ -24,7 +24,6 @@ pub struct PathItem {
     #[serde(default)]
     pub deleted: bool,
     #[serde(flatten)]
-    #[schema(inline)]
     pub location: PathItemLocation,
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7801,41 +7801,7 @@ components:
       description: JSON Patch single patch operation
     PathItem:
       allOf:
-      - oneOf:
-        - $ref: '#/components/schemas/TrackOffset'
-        - type: object
-          required:
-          - operational_point
-          properties:
-            operational_point:
-              type: string
-              maxLength: 255
-              minLength: 1
-        - type: object
-          required:
-          - trigram
-          properties:
-            secondary_code:
-              type: string
-              description: An optional secondary code to identify a more specific location
-              nullable: true
-            trigram:
-              type: string
-              minLength: 1
-        - type: object
-          required:
-          - uic
-          properties:
-            secondary_code:
-              type: string
-              description: An optional secondary code to identify a more specific location
-              nullable: true
-            uic:
-              type: integer
-              format: int32
-              description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
-              minimum: 0
-        description: The location of a path waypoint
+      - $ref: '#/components/schemas/PathItemLocation'
       - type: object
         required:
         - id
@@ -8133,41 +8099,7 @@ components:
         path_items:
           type: array
           items:
-            oneOf:
-            - $ref: '#/components/schemas/TrackOffset'
-            - type: object
-              required:
-              - operational_point
-              properties:
-                operational_point:
-                  type: string
-                  maxLength: 255
-                  minLength: 1
-            - type: object
-              required:
-              - trigram
-              properties:
-                secondary_code:
-                  type: string
-                  description: An optional secondary code to identify a more specific location
-                  nullable: true
-                trigram:
-                  type: string
-                  minLength: 1
-            - type: object
-              required:
-              - uic
-              properties:
-                secondary_code:
-                  type: string
-                  description: An optional secondary code to identify a more specific location
-                  nullable: true
-                uic:
-                  type: integer
-                  format: int32
-                  description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
-                  minimum: 0
-            description: The location of a path waypoint
+            $ref: '#/components/schemas/PathItemLocation'
           description: List of waypoints given to the pathfinding
         rolling_stock_is_thermal:
           type: boolean
@@ -8479,41 +8411,7 @@ components:
             type: integer
             minimum: 0
           path_item:
-            oneOf:
-            - $ref: '#/components/schemas/TrackOffset'
-            - type: object
-              required:
-              - operational_point
-              properties:
-                operational_point:
-                  type: string
-                  maxLength: 255
-                  minLength: 1
-            - type: object
-              required:
-              - trigram
-              properties:
-                secondary_code:
-                  type: string
-                  description: An optional secondary code to identify a more specific location
-                  nullable: true
-                trigram:
-                  type: string
-                  minLength: 1
-            - type: object
-              required:
-              - uic
-              properties:
-                secondary_code:
-                  type: string
-                  description: An optional secondary code to identify a more specific location
-                  nullable: true
-                uic:
-                  type: integer
-                  format: int32
-                  description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
-                  minimum: 0
-            description: The location of a path waypoint
+            $ref: '#/components/schemas/PathItemLocation'
           status:
             type: string
             enum:
@@ -11962,41 +11860,7 @@ components:
           type: array
           items:
             allOf:
-            - oneOf:
-              - $ref: '#/components/schemas/TrackOffset'
-              - type: object
-                required:
-                - operational_point
-                properties:
-                  operational_point:
-                    type: string
-                    maxLength: 255
-                    minLength: 1
-              - type: object
-                required:
-                - trigram
-                properties:
-                  secondary_code:
-                    type: string
-                    description: An optional secondary code to identify a more specific location
-                    nullable: true
-                  trigram:
-                    type: string
-                    minLength: 1
-              - type: object
-                required:
-                - uic
-                properties:
-                  secondary_code:
-                    type: string
-                    description: An optional secondary code to identify a more specific location
-                    nullable: true
-                  uic:
-                    type: integer
-                    format: int32
-                    description: The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point
-                    minimum: 0
-              description: The location of a path waypoint
+            - $ref: '#/components/schemas/PathItemLocation'
             - type: object
               required:
               - id

--- a/editoast/src/core/v2/pathfinding.rs
+++ b/editoast/src/core/v2/pathfinding.rs
@@ -77,7 +77,6 @@ pub enum PathfindingResult {
     },
     InvalidPathItem {
         index: usize,
-        #[schema(inline)]
         path_item: PathItemLocation,
     },
     NotEnoughPathItems,

--- a/editoast/src/views/v2/path/pathfinding.rs
+++ b/editoast/src/views/v2/path/pathfinding.rs
@@ -56,7 +56,6 @@ struct PathfindingInput {
     /// List of supported signaling systems
     rolling_stock_supported_signaling_systems: Vec<String>,
     /// List of waypoints given to the pathfinding
-    #[schema(inline)]
     path_items: Vec<PathItemLocation>,
 }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3453,6 +3453,22 @@ export type PathfindingResultSuccess = {
   /** Path description as track ranges */
   track_section_ranges: TrackRange[];
 };
+export type PathItemLocation =
+  | TrackOffset
+  | {
+      operational_point: string;
+    }
+  | {
+      /** An optional secondary code to identify a more specific location */
+      secondary_code?: string | null;
+      trigram: string;
+    }
+  | {
+      /** An optional secondary code to identify a more specific location */
+      secondary_code?: string | null;
+      /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
+      uic: number;
+    };
 export type PathfindingResult =
   | (PathfindingResultSuccess & {
       status: 'success';
@@ -3496,23 +3512,7 @@ export type PathfindingResult =
     }
   | {
       index: number;
-      /** The location of a path waypoint */
-      path_item:
-        | TrackOffset
-        | {
-            operational_point: string;
-          }
-        | {
-            /** An optional secondary code to identify a more specific location */
-            secondary_code?: string | null;
-            trigram: string;
-          }
-        | {
-            /** An optional secondary code to identify a more specific location */
-            secondary_code?: string | null;
-            /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
-            uic: number;
-          };
+      path_item: PathItemLocation;
       status: 'invalid_path_item';
     }
   | {
@@ -3528,23 +3528,7 @@ export type PathfindingResult =
     };
 export type PathfindingInputV2 = {
   /** List of waypoints given to the pathfinding */
-  path_items: (
-    | TrackOffset
-    | {
-        operational_point: string;
-      }
-    | {
-        /** An optional secondary code to identify a more specific location */
-        secondary_code?: string | null;
-        trigram: string;
-      }
-    | {
-        /** An optional secondary code to identify a more specific location */
-        secondary_code?: string | null;
-        /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
-        uic: number;
-      }
-  )[];
+  path_items: PathItemLocation[];
   /** Can the rolling stock run on non-electrified tracks */
   rolling_stock_is_thermal: boolean;
   rolling_stock_loading_gauge: LoadingGaugeType;
@@ -3666,22 +3650,6 @@ export type SimulationResponse =
       status: 'simulation_failed';
     };
 export type Comfort = 'STANDARD' | 'AIR_CONDITIONING' | 'HEATING';
-export type PathItemLocation =
-  | TrackOffset
-  | {
-      operational_point: string;
-    }
-  | {
-      /** An optional secondary code to identify a more specific location */
-      secondary_code?: string | null;
-      trigram: string;
-    }
-  | {
-      /** An optional secondary code to identify a more specific location */
-      secondary_code?: string | null;
-      /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
-      uic: number;
-    };
 export type StepTimingData = {
   /** Time at which the train should arrive at the location */
   arrival_time: string;
@@ -3711,23 +3679,7 @@ export type TrainScheduleBase = {
   options?: {
     use_electrical_profiles?: boolean;
   };
-  path: ((
-    | TrackOffset
-    | {
-        operational_point: string;
-      }
-    | {
-        /** An optional secondary code to identify a more specific location */
-        secondary_code?: string | null;
-        trigram: string;
-      }
-    | {
-        /** An optional secondary code to identify a more specific location */
-        secondary_code?: string | null;
-        /** The [UIC](https://en.wikipedia.org/wiki/List_of_UIC_country_codes) code of an operational point */
-        uic: number;
-      }
-  ) & {
+  path: (PathItemLocation & {
     /** Metadata given to mark a point as wishing to be deleted by the user.
         It's useful for soft deleting the point (waiting to fix / remove all references)
         If true, the train schedule is consider as invalid and must be edited */


### PR DESCRIPTION
Removes unnecessary inline annotation.

close #8062