### PR TITLE
editoast: refactor the remaining tests

### DIFF
--- a/editoast/src/models/pathfinding.rs
+++ b/editoast/src/models/pathfinding.rs
@@ -239,79 +239,12 @@ impl Identifiable for Pathfinding {
 
 #[cfg(test)]
 pub mod tests {
-    use std::sync::Arc;
-
     use super::*;
-    use crate::fixtures::tests::TestFixture;
-    use crate::models::Create;
-    use editoast_models::DbConnectionPool;
-
-    pub fn simple_pathfinding(infra_id: i64) -> Pathfinding {
-        //    T1       T2        T3       T4      T5
-        // |------> < ------| |------> |------> |------>
-        let route_paths = vec![
-            RoutePath {
-                route: "route_1".into(),
-                track_ranges: vec![
-                    DirectionalTrackRange::new("track_1", 0.0, 10.0, Direction::StartToStop),
-                    DirectionalTrackRange::new("track_2", 7.0, 10.0, Direction::StopToStart),
-                    DirectionalTrackRange::new("track_2", 7.0, 7.0, Direction::StartToStop),
-                ],
-                signaling_type: "BAL3".into(),
-            },
-            RoutePath {
-                route: "route_2".into(),
-                track_ranges: vec![DirectionalTrackRange::new(
-                    "track_2",
-                    3.0,
-                    7.0,
-                    Direction::StopToStart,
-                )],
-                signaling_type: "BAL3".into(),
-            },
-            RoutePath {
-                route: "route_3".into(),
-                track_ranges: vec![
-                    DirectionalTrackRange::new("track_2", 0.0, 3.0, Direction::StopToStart),
-                    DirectionalTrackRange::new("track_3", 0.0, 10.0, Direction::StartToStop),
-                    DirectionalTrackRange::new("track_4", 0.0, 2.0, Direction::StartToStop),
-                ],
-                signaling_type: "BAL3".into(),
-            },
-            RoutePath {
-                route: "route_4".into(),
-                track_ranges: vec![
-                    DirectionalTrackRange::new("track_4", 2.0, 10.0, Direction::StartToStop),
-                    DirectionalTrackRange::new("track_5", 0.0, 8.0, Direction::StartToStop),
-                ],
-                signaling_type: "BAL3".into(),
-            },
-        ];
-        Pathfinding {
-            infra_id,
-            payload: diesel_json::Json(PathfindingPayload {
-                route_paths,
-                ..Default::default()
-            }),
-            ..Default::default()
-        }
-    }
-
-    pub async fn simple_pathfinding_fixture(
-        infra_id: i64,
-        db_pool: Arc<DbConnectionPool>,
-    ) -> TestFixture<Pathfinding> {
-        let pathfinding = simple_pathfinding(infra_id);
-        let mut changeset = PathfindingChangeset::from(pathfinding);
-        changeset.id = None;
-        let pathfinding: Pathfinding = changeset.create(db_pool.clone()).await.unwrap().into();
-
-        TestFixture::new(pathfinding, db_pool)
-    }
+    use crate::modelsv2::fixtures::simple_pathfinding_v1;
 
     #[test]
     fn test_path_track_section_ids() {
-        let pathfinding = simple_pathfinding(0);
+        let pathfinding = simple_pathfinding_v1(0);
         let track_section_ids = pathfinding.track_section_ids();
         assert_eq!(
             track_section_ids,
@@ -324,7 +257,7 @@ pub mod tests {
 
     #[test]
     fn test_path_merged_track_ranges() {
-        let pathfinding = simple_pathfinding(0);
+        let pathfinding = simple_pathfinding_v1(0);
         let merged_track_ranges = pathfinding.merged_track_ranges();
         assert_eq!(
             merged_track_ranges,

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -167,16 +167,15 @@ impl Timetable {
     }
 
     /// Get infra_version from timetable
-    pub async fn infra_version_from_timetable(&self, db_pool: Arc<DbConnectionPool>) -> String {
+    pub async fn infra_version_from_timetable(&self, conn: &mut DbConnection) -> String {
         use crate::tables::infra::dsl as infra_dsl;
         use crate::tables::scenario::dsl as scenario_dsl;
         let timetable_id = self.id.unwrap();
-        let mut conn = db_pool.get().await.unwrap();
         scenario_dsl::scenario
             .filter(scenario_dsl::timetable_id.eq(timetable_id))
             .inner_join(infra_dsl::infra)
             .select(infra_dsl::version)
-            .first::<String>(&mut conn)
+            .first::<String>(conn)
             .await
             .expect("could not retrieve the version of the infra of a scenario using its timetable")
     }

--- a/editoast/src/modelsv2/fixtures.rs
+++ b/editoast/src/modelsv2/fixtures.rs
@@ -1,6 +1,8 @@
 use std::io::Cursor;
 
 use chrono::Utc;
+use editoast_schemas::infra::Direction;
+use editoast_schemas::infra::DirectionalTrackRange;
 use editoast_schemas::infra::InfraObject;
 use editoast_schemas::infra::RailJson;
 use editoast_schemas::primitives::OSRDObject;
@@ -8,8 +10,21 @@ use editoast_schemas::train_schedule::TrainScheduleBase;
 use postgis_diesel::types::LineString;
 
 use crate::infra_cache::operation::create::apply_create_operation;
+use crate::models::train_schedule::Mrsp;
+use crate::models::train_schedule::SimulationOutput;
+use crate::models::train_schedule::TrainScheduleValidation;
+use crate::models::Create as _;
 use crate::models::Pathfinding;
 use crate::models::PathfindingChangeset;
+use crate::models::PathfindingPayload;
+use crate::models::ResultPosition;
+use crate::models::ResultStops;
+use crate::models::ResultTrain;
+use crate::models::RoutePath;
+use crate::models::Scenario as ScenarioV1;
+use crate::models::SimulationOutputChangeset;
+use crate::models::Timetable as TimetableV1;
+use crate::models::TrainSchedule as TrainScheduleV1;
 use crate::modelsv2::prelude::*;
 use crate::modelsv2::rolling_stock_livery::RollingStockLiveryModel;
 use crate::modelsv2::timetable::Timetable;
@@ -319,10 +334,163 @@ pub async fn create_pathfinding(conn: &mut DbConnection, infra_id: i64) -> Pathf
         created: Some(Default::default()),
         ..Default::default()
     };
-    use crate::models::Create;
     pathfinding_changeset
         .create_conn(conn)
         .await
         .expect("Failed to create pathfinding")
         .into()
+}
+
+pub fn simple_pathfinding_v1(infra_id: i64) -> Pathfinding {
+    //    T1       T2        T3       T4      T5
+    // |------> < ------| |------> |------> |------>
+    let route_paths = vec![
+        RoutePath {
+            route: "route_1".into(),
+            track_ranges: vec![
+                DirectionalTrackRange::new("track_1", 0.0, 10.0, Direction::StartToStop),
+                DirectionalTrackRange::new("track_2", 7.0, 10.0, Direction::StopToStart),
+                DirectionalTrackRange::new("track_2", 7.0, 7.0, Direction::StartToStop),
+            ],
+            signaling_type: "BAL3".into(),
+        },
+        RoutePath {
+            route: "route_2".into(),
+            track_ranges: vec![DirectionalTrackRange::new(
+                "track_2",
+                3.0,
+                7.0,
+                Direction::StopToStart,
+            )],
+            signaling_type: "BAL3".into(),
+        },
+        RoutePath {
+            route: "route_3".into(),
+            track_ranges: vec![
+                DirectionalTrackRange::new("track_2", 0.0, 3.0, Direction::StopToStart),
+                DirectionalTrackRange::new("track_3", 0.0, 10.0, Direction::StartToStop),
+                DirectionalTrackRange::new("track_4", 0.0, 2.0, Direction::StartToStop),
+            ],
+            signaling_type: "BAL3".into(),
+        },
+        RoutePath {
+            route: "route_4".into(),
+            track_ranges: vec![
+                DirectionalTrackRange::new("track_4", 2.0, 10.0, Direction::StartToStop),
+                DirectionalTrackRange::new("track_5", 0.0, 8.0, Direction::StartToStop),
+            ],
+            signaling_type: "BAL3".into(),
+        },
+    ];
+    Pathfinding {
+        infra_id,
+        payload: diesel_json::Json(PathfindingPayload {
+            route_paths,
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+pub async fn create_simple_pathfinding_v1(conn: &mut DbConnection, infra_id: i64) -> Pathfinding {
+    let pathfinding = simple_pathfinding_v1(infra_id);
+    let mut changeset = PathfindingChangeset::from(pathfinding);
+    changeset.id = None;
+    let pathfinding: Pathfinding = changeset
+        .create_conn(conn)
+        .await
+        .expect("Failed to create pathfinding")
+        .into();
+    pathfinding
+}
+
+pub async fn create_train_schedule_v1(
+    conn: &mut DbConnection,
+    pathfinding_id: i64,
+    timetable_id: i64,
+    rolling_stock_id: i64,
+) -> TrainScheduleV1 {
+    let train_schedule = TrainScheduleV1 {
+        path_id: pathfinding_id,
+        timetable_id,
+        rolling_stock_id,
+        ..serde_json::from_str::<TrainScheduleV1>(include_str!("../tests/train_schedule.json"))
+            .expect("Unable to parse")
+    };
+    train_schedule
+        .create_conn(conn)
+        .await
+        .expect("Failed to create train schedule")
+}
+
+pub async fn create_timetable_v1(conn: &mut DbConnection, name: &str) -> TimetableV1 {
+    let timetable = TimetableV1 {
+        id: None,
+        name: Some(String::from(name)),
+    };
+    timetable
+        .create_conn(conn)
+        .await
+        .expect("Failed to create timetable")
+}
+
+pub async fn create_scenario_v1(
+    conn: &mut DbConnection,
+    name: &str,
+    study_id: i64,
+    timetable_id: i64,
+    infra_id: i64,
+) -> ScenarioV1 {
+    let scenario = ScenarioV1 {
+        name: Some(name.to_string()),
+        study_id: Some(study_id),
+        timetable_id: Some(timetable_id),
+        infra_id: Some(infra_id),
+        creation_date: Some(Utc::now().naive_utc()),
+        ..ScenarioV1::default()
+    };
+    scenario
+        .create_conn(conn)
+        .await
+        .expect("Failed to create scenario")
+}
+
+pub async fn create_simulation_output(
+    conn: &mut DbConnection,
+    train_schedule_id: Option<i64>,
+) -> SimulationOutput {
+    let result_train: ResultTrain = ResultTrain {
+        stops: vec![
+            ResultStops {
+                time: 0.0,
+                duration: 0.0,
+                position: 0.0,
+                ch: None,
+            },
+            ResultStops {
+                time: 110.90135448736316,
+                duration: 1.0,
+                position: 2417.6350658673214,
+                ch: None,
+            },
+        ],
+        head_positions: vec![ResultPosition {
+            time: 0.0,
+            track_section: "TA7".to_string(),
+            offset: 0.0,
+            path_offset: 0.0,
+        }],
+        ..Default::default()
+    };
+
+    let simulation_output = SimulationOutputChangeset {
+        mrsp: Some(diesel_json::Json(Mrsp::default())),
+        base_simulation: Some(diesel_json::Json(result_train)),
+        eco_simulation: Some(None),
+        electrification_ranges: Some(diesel_json::Json(Vec::default())),
+        power_restriction_ranges: Some(diesel_json::Json(Vec::default())),
+        train_schedule_id: Some(train_schedule_id),
+        ..Default::default()
+    };
+    simulation_output.create_conn(conn).await.unwrap().into()
 }

--- a/editoast/src/views/pathfinding/path_rangemap.rs
+++ b/editoast/src/views/pathfinding/path_rangemap.rs
@@ -42,11 +42,11 @@ mod tests {
     use editoast_common::range_map;
 
     use super::*;
-    use crate::models::pathfinding::tests::simple_pathfinding;
+    use crate::modelsv2::fixtures::simple_pathfinding_v1;
 
     #[test]
     fn test_make_path_range_map() {
-        let pathfinding = simple_pathfinding(0);
+        let pathfinding = simple_pathfinding_v1(0);
         let value_maps_by_track: HashMap<String, RangeMap<Float, String>> = [
             ("track_1".into(), range_map!(0.0, 10.0 => "A")),
             (

--- a/editoast/src/views/single_simulation.rs
+++ b/editoast/src/views/single_simulation.rs
@@ -303,7 +303,7 @@ mod tests {
         };
         let request = TestRequest::post()
             .uri("/single_simulation")
-            .set_json(&request_body)
+            .set_json(request_body)
             .to_request();
 
         if let Some(expected_error) = expected_error {
@@ -347,7 +347,7 @@ mod tests {
         });
         let request = TestRequest::post()
             .uri("/single_simulation")
-            .set_json(&request_body)
+            .set_json(request_body)
             .to_request();
 
         // WHEN


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/6980

I've made several commits to make the review easier.
I will fixup the commits once the review is done.
`Pathfinding` still uses `db_pool_v1`, so I added `{function}_v1` to the fixtures to distinguish them from those using `db_pool_v2`.