### PR TITLE
front:timestops: fix operational point removal

### DIFF
--- a/front/src/modules/timesStops/utils.ts
+++ b/front/src/modules/timesStops/utils.ts
@@ -28,7 +28,8 @@ export const formatSuggestedViasToRowVias = (
   }
   return formattedOps.map((op, i) => {
     const pathStep = pathSteps.find((step) => matchPathStepAndOp(step, op));
-    const { arrival, onStopSignal, name, stopFor, theoreticalMargin } = pathStep || op;
+    const { name } = pathStep || op;
+    const { arrival, onStopSignal, stopFor, theoreticalMargin } = pathStep || {};
 
     const isMarginValid = theoreticalMargin ? marginRegExValidation.test(theoreticalMargin) : true;
 


### PR DESCRIPTION
When an operational point in the timestops table was removed from via, it was removed from the store but not updated in the op list

close #8079 