### PR TITLE
core: stdcm: add link to website documentation in the code

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -28,6 +28,12 @@ data class Result(
     val waypoints: List<EdgeLocation>
 )
 
+/**
+ * Find a path for a new train that exclusively uses tracks at times when they're available.
+ *
+ * For a detailed explanation of how this module works, there is some general documentation on the
+ * OSRD website: https://osrd.fr/en/docs/reference/design-docs/stdcm/
+ */
 fun findPath(
     fullInfra: FullInfra,
     rollingStock: RollingStock,


### PR DESCRIPTION
The website doc really helps but it's easy to miss, it should be referenced in the code