### PR TITLE
"Fix" stack overflows for large batch operations

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -237,6 +237,10 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// * `#[model(preferred = PREFERRED)]`: just like `#[model(preferred)]` for fields, but at the struct level.
 ///     Compound identifier syntax is supported. This option can be specified only once, including at field level.
 ///     It is NOT NECESSARY to also specify `#[model(identifier = PREFERRED)]`.
+/// * `#[model(batch_chunk_size_limit = usize)]` (default: [modelv2::DEFAULT_BATCH_CHUNK_SIZE_LIMIT]): there seem to be a bug from either diesel or libpq that causes
+///     a stack overflow for large batch chunk sizes. Until a better solution is found, this option allows to limit the
+///     size of each chunk on a per-model basis. Increasing this value could lead to stack overflows, decreasing it
+///     might degrade the performance of batch operations.
 ///
 /// ### Field-level options
 ///

--- a/editoast/editoast_derive/src/modelv2.rs
+++ b/editoast/editoast_derive/src/modelv2.rs
@@ -15,6 +15,9 @@ use args::ModelArgs;
 use config::*;
 use identifier::RawIdentifier;
 
+// completely pulled from the hat, seems to work for 16Gb machines
+pub(super) const DEFAULT_BATCH_CHUNK_SIZE_LIMIT: usize = 2048;
+
 pub fn model(input: &DeriveInput) -> Result<TokenStream> {
     let model_name = &input.ident;
     let model_vis = &input.vis;

--- a/editoast/editoast_derive/src/modelv2/args.rs
+++ b/editoast/editoast_derive/src/modelv2/args.rs
@@ -24,6 +24,9 @@ pub(super) struct ModelArgs {
     pub(super) identifiers: Vec<RawIdentifier>,
     #[darling(default)]
     pub(super) preferred: Option<RawIdentifier>,
+    #[darling(default)]
+    pub(super) batch_chunk_size_limit: Option<usize>,
+
     pub(super) data: ast::Data<util::Ignored, ModelFieldArgs>,
 }
 

--- a/editoast/editoast_derive/src/modelv2/codegen.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen.rs
@@ -317,6 +317,7 @@ impl ModelConfig {
             model: self.model.clone(),
             table_name: self.table_name(),
             table_mod: self.table.clone(),
+            chunk_size_limit: self.batch_chunk_size_limit,
             row: self.row.ident(),
             changeset: self.changeset.ident(),
             field_count: self.changeset_fields().count(),
@@ -330,6 +331,7 @@ impl ModelConfig {
                 model: self.model.clone(),
                 table_name: self.table_name(),
                 table_mod: self.table.clone(),
+                chunk_size_limit: self.batch_chunk_size_limit,
                 row: self.row.ident(),
                 changeset: self.changeset.ident(),
                 identifier: identifier.clone(),
@@ -345,6 +347,7 @@ impl ModelConfig {
                 model: self.model.clone(),
                 table_name: self.table_name(),
                 table_mod: self.table.clone(),
+                chunk_size_limit: self.batch_chunk_size_limit,
                 row: self.row.ident(),
                 identifier: identifier.clone(),
             })
@@ -358,6 +361,7 @@ impl ModelConfig {
                 model: self.model.clone(),
                 table_name: self.table_name(),
                 table_mod: self.table.clone(),
+                chunk_size_limit: self.batch_chunk_size_limit,
                 row: self.row.ident(),
                 changeset: self.changeset.ident(),
                 identifier: identifier.clone(),
@@ -373,6 +377,7 @@ impl ModelConfig {
                 model: self.model.clone(),
                 table_name: self.table_name(),
                 table_mod: self.table.clone(),
+                chunk_size_limit: self.batch_chunk_size_limit,
                 identifier: identifier.clone(),
             })
             .collect()

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -5,6 +5,7 @@ pub(crate) struct CreateBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) chunk_size_limit: usize,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
     pub(super) field_count: usize,
@@ -16,6 +17,7 @@ impl ToTokens for CreateBatchImpl {
             model,
             table_name,
             table_mod,
+            chunk_size_limit,
             row,
             changeset,
             field_count,
@@ -42,6 +44,7 @@ impl ToTokens for CreateBatchImpl {
                     let values = values.into_iter().collect::<Vec<_>>();
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
+                        #chunk_size_limit,
                         values,
                         C::default(),
                         chunk => {

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -7,6 +7,7 @@ pub(crate) struct CreateBatchWithKeyImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) chunk_size_limit: usize,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
     pub(super) field_count: usize,
@@ -19,6 +20,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
             model,
             table_name,
             table_mod,
+            chunk_size_limit,
             row,
             changeset,
             field_count,
@@ -48,6 +50,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     let values = values.into_iter().collect::<Vec<_>>();
                     Ok(crate::chunked_for_libpq! {
                         #field_count,
+                        #chunk_size_limit,
                         values,
                         C::default(),
                         chunk => {

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -7,6 +7,7 @@ pub(crate) struct DeleteBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) chunk_size_limit: usize,
     pub(super) identifier: Identifier,
 }
 
@@ -16,6 +17,7 @@ impl ToTokens for DeleteBatchImpl {
             model,
             table_name,
             table_mod,
+            chunk_size_limit,
             identifier,
         } = self;
         let ty = identifier.get_type();
@@ -40,6 +42,7 @@ impl ToTokens for DeleteBatchImpl {
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     let counts = crate::chunked_for_libpq! {
                         #params_per_row,
+                        #chunk_size_limit,
                         ids,
                         chunk => {
                             let mut query = diesel::delete(dsl::#table_name).into_boxed();

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -7,6 +7,7 @@ pub(crate) struct RetrieveBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) chunk_size_limit: usize,
     pub(super) row: syn::Ident,
     pub(super) identifier: Identifier,
 }
@@ -17,6 +18,7 @@ impl ToTokens for RetrieveBatchImpl {
             model,
             table_name,
             table_mod,
+            chunk_size_limit,
             row,
             identifier,
         } = self;
@@ -48,6 +50,7 @@ impl ToTokens for RetrieveBatchImpl {
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
                         #params_per_row,
+                        #chunk_size_limit,
                         ids,
                         C::default(),
                         chunk => {
@@ -85,6 +88,7 @@ impl ToTokens for RetrieveBatchImpl {
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
                         #params_per_row,
+                        #chunk_size_limit,
                         ids,
                         C::default(),
                         chunk => {

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -7,6 +7,7 @@ pub(crate) struct UpdateBatchImpl {
     pub(super) model: syn::Ident,
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
+    pub(super) chunk_size_limit: usize,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
     pub(super) identifier: Identifier,
@@ -19,6 +20,7 @@ impl ToTokens for UpdateBatchImpl {
             model,
             table_name,
             table_mod,
+            chunk_size_limit,
             row,
             identifier,
             changeset,
@@ -55,6 +57,7 @@ impl ToTokens for UpdateBatchImpl {
                         // FIXME: that count is correct for each row, but the maximum buffer size
                         // should be libpq's max MINUS the size of the changeset
                         #params_per_row,
+                        #chunk_size_limit,
                         ids,
                         C::default(),
                         chunk => {
@@ -95,6 +98,7 @@ impl ToTokens for UpdateBatchImpl {
                         // FIXME: that count is correct for each row, but the maximum buffer size
                         // should be libpq's max MINUS the size of the changeset
                         #params_per_row,
+                        #chunk_size_limit,
                         ids,
                         C::default(),
                         chunk => {

--- a/editoast/editoast_derive/src/modelv2/config.rs
+++ b/editoast/editoast_derive/src/modelv2/config.rs
@@ -15,6 +15,7 @@ pub(crate) struct ModelConfig {
     pub(crate) model: syn::Ident,
     pub(crate) visibility: syn::Visibility,
     pub(crate) table: syn::Path,
+    pub(crate) batch_chunk_size_limit: usize,
     pub(crate) fields: Fields,
     pub(crate) row: GeneratedTypeArgs,
     pub(crate) changeset: GeneratedTypeArgs,

--- a/editoast/editoast_derive/src/modelv2/parsing.rs
+++ b/editoast/editoast_derive/src/modelv2/parsing.rs
@@ -6,7 +6,7 @@ use proc_macro2::Span;
 use super::{
     args::{GeneratedTypeArgs, ModelArgs, ModelFieldArgs},
     identifier::{Identifier, RawIdentifier},
-    FieldTransformation, Fields, ModelConfig, ModelField,
+    FieldTransformation, Fields, ModelConfig, ModelField, DEFAULT_BATCH_CHUNK_SIZE_LIMIT,
 };
 
 impl ModelConfig {
@@ -118,6 +118,9 @@ impl ModelConfig {
             model: model_name,
             visibility,
             table: options.table,
+            batch_chunk_size_limit: options
+                .batch_chunk_size_limit
+                .unwrap_or(DEFAULT_BATCH_CHUNK_SIZE_LIMIT),
             fields,
             row,
             changeset,

--- a/editoast/src/modelsv2/prelude/mod.rs
+++ b/editoast/src/modelsv2/prelude/mod.rs
@@ -122,13 +122,13 @@ impl<M, T, Column> ModelField<M, T, Column> {
 #[macro_export]
 macro_rules! chunked_for_libpq {
     // Collects every chunk result into a vec
-    ($parameters_per_row:expr, $values:expr, $chunk:ident => $query:tt) => {{
+    ($parameters_per_row:expr, $limit:literal, $values:expr, $chunk:ident => $query:tt) => {{
         const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
         // We need to divide further because of AsyncPgConnection, maybe it is related to connection pipelining
         const ASYNC_SUBDIVISION: usize = 2_usize;
         const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
         let mut result = Vec::new();
-        let chunks = $values.chunks(CHUNK_SIZE);
+        let chunks = $values.chunks(CHUNK_SIZE.min($limit));
         for $chunk in chunks {
             let chunk_result = $query;
             result.push(chunk_result);
@@ -136,13 +136,13 @@ macro_rules! chunked_for_libpq {
         result
     }};
     // Extends the result structure with every chunked query result
-    ($parameters_per_row:expr, $values:expr, $result:expr, $chunk:ident => $query:tt) => {{
+    ($parameters_per_row:expr, $limit:literal, $values:expr, $result:expr, $chunk:ident => $query:tt) => {{
         const LIBPQ_MAX_PARAMETERS: usize = 2_usize.pow(16) - 1;
         // We need to divide further because of AsyncPgConnection, maybe it is related to connection pipelining
         const ASYNC_SUBDIVISION: usize = 2_usize;
         const CHUNK_SIZE: usize = LIBPQ_MAX_PARAMETERS / ASYNC_SUBDIVISION / $parameters_per_row;
         let mut result = $result;
-        let chunks = $values.chunks(CHUNK_SIZE);
+        let chunks = $values.chunks(CHUNK_SIZE.min($limit));
         for $chunk in chunks {
             let chunk_result = $query;
             result.extend(chunk_result);


### PR DESCRIPTION
Closes #8090

TW: hacks like this should be illegal, but here we are.

The stack overflow problem occurs in `OperationalPointModel::retrieve_batch_unchecked` when the list of IDs is large enough.

1. The problem likely happens either in `diesel` or in `libpq` since everything is fine before attempting to execute the query.
2. My first thought was that the `OrFilter` objects (produced by the `.or_filter()` expression method, cf. `retrieve_batch_impl.rs`) were nested beyond control that their recursive flattening would break the stack.
3. Replacing the `.or_filter()`s by a single `.filter()` with nested `.or()`s would have the same effect, so I didn't try that.
4. Using a raw boxed `sql_query` should have helped since the bindings are stored in a `Vec` internally. It didn't. (*)
5. Even a fully (unsafe) single raw SQL query made with `format!` and no bindings stack overflows. (*) So now I doubt that `diesel` is the problem, but googling `libpq stack overflow` isn't very helpful...
6. Copy pasting the query in a DBeaver (which I believe uses `libpq`, to double check) works.

(*) https://gist.github.com/leovalais/301ff4ae0117b0e644c76dd6850f8dac

If I had the time I'd do the following:

* try to reproduce the query using `libpq` directly,
* or try to reproduce the query with `diesel` and a MySQL backend (or anything but Postgres)
* if both of these were to work fine, I'd just burn my PC and become a beekeeper

I can't spend the rest of my sprint on this bug and this "fix" seems to work (even if it degrades the performance significantly, sorry 😞). If someone else with some time wants to pick it up from here, I'd be glad to help though.