### PR TITLE
ci: add telemetry and push to Honeycomb on our CI

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -1,0 +1,23 @@
+name: Export workflow to Honeycomb
+
+on:
+  workflow_run:
+    workflows:
+      # The name of the workflow(s) that triggers the export
+      - "build"
+    types: [completed]
+
+jobs:
+  otel-export-honeycomb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Export workflow to Honeycomb
+        uses: corentinmusard/otel-cicd-action@v1
+        with:
+          otlpEndpoint: grpc://api.honeycomb.io:443/
+          # Example value for HONEYCOMB_OTLP_HEADERS:
+          # x-honeycomb-team=YOUR_API_KEY,x-honeycomb-dataset=YOUR_DATASET
+          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
# Goal

Let's set up some telemetry on our CI to evaluate the time to build and test. I'm also hoping to track down the time it takes to build `editoast` and find which solution works when we try to reduce the build time.

I'm aware that we don't make a full `editoast` build most of the time, because we're heavily relying on caching Docker layers. It's true, and I don't yet know how we'll deal with this, but the setup of this solution is easy enough to get some first numbers and iterate from there (maybe the `release` build will give us the hints we need?).

I'm also aware that we don't have detailed information about one step of the workflow. For example, it might be interesting to have more detailed information about what time it takes to compile each `crate`, how long it takes to the linker. Again, let's start somewhere. I'm happy to drop this solution if we end up with something better later.

# Notes about the PR

`workflow_run` even only works on the default branch. Therefore, I tested with the following configuration, just to evaluate the Github action, and the connection with HoneyComb.

```yaml
name: Export workflow to Honeycomb

on:
  push:
    branches:
      - "wsl/ci/ci-telemetry"

jobs:
  otel-export-honeycomb:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Export workflow to Honeycomb
        uses: corentinmusard/otel-cicd-action@v1
        with:
          otlpEndpoint: grpc://api.honeycomb.io:443/
          # Example value for HONEYCOMB_OTLP_HEADERS:
          # x-honeycomb-team=YOUR_API_KEY,x-honeycomb-dataset=YOUR_DATASET
          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
          githubToken: ${{ secrets.GITHUB_TOKEN }}
          runId: ${{ github.run_id }}
```

It does work and we can see the following on HoneyComb.

![image](https://github.com/user-attachments/assets/cb1d04ab-d197-4455-a172-3539a4a6c7bb)

Note that I don't care if we use HoneyComb or anything else. It just happened there was a HoneyComb example in the documentation of `corentinmusard/otel-cicd-action` and I already had a HoneyComb account so it was the fastest to set up and experiment for me.

Thank you @Khoyo for the help setting up `secrets.HONEYCOMB_OTLP_HEADERS`.