### PR TITLE
core: fix and reintroduce pathfinding heuristic

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -78,9 +78,6 @@ dependencies {
     implementation libs.opentracing.util
     implementation libs.dd.trace.api
 
-    // Geographic computations
-    implementation libs.geodesy
-
     // Use JUnit Jupiter API for testing.
     testImplementation libs.junit.jupiter.api
     testImplementation libs.junit.jupiter.params

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -60,7 +60,6 @@ mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.10.+' } # EPL 2.0
 jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' } # CC Attribution
 spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' } # LGPLv2.1
-geodesy = { module = 'org.gavaghan:geodesy', version = '1.1.+' } # Apache 2.0
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
 opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.6.0' }

--- a/core/osrd-geom/build.gradle
+++ b/core/osrd-geom/build.gradle
@@ -16,9 +16,6 @@ java {
 dependencies {
     // PLEASE ADD AND UPDATE DEPENDENCIES USING libs.versions.toml
 
-    // Geographic computations
-    implementation libs.geodesy
-
     // fast primitive collections
     implementation libs.hppc
 

--- a/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/Point.java
+++ b/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/Point.java
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.geom;
 
-import org.gavaghan.geodesy.*;
+import static java.lang.Math.*;
 
 public record Point(
         // Longitude
@@ -10,15 +10,17 @@ public record Point(
 
     /**
      * Returns the distance between this point and another in meters, assuming x = longitude and y =
-     * latitude
+     * latitude. Uses equirectangular distance approximation (very fast but not 100% accurate)
      */
     public double distanceAsMeters(Point other) {
-        GeodeticCalculator geoCalc = new GeodeticCalculator();
-        Ellipsoid reference = Ellipsoid.WGS84;
-        GlobalPosition thisPosition = new GlobalPosition(y, x, 0.0);
-        GlobalPosition otherPosition = new GlobalPosition(other.y, other.x, 0.0);
-        return geoCalc.calculateGeodeticCurve(reference, thisPosition, otherPosition)
-                .getEllipsoidalDistance();
+        final var earthRadius = 6_378_160;
+        var lon1 = toRadians(x);
+        var lon2 = toRadians(other.x);
+        var lat1 = toRadians(y);
+        var lat2 = toRadians(other.y);
+        var xDiff = (lon1 - lon2) * cos(0.5 * (lat1 + lat2));
+        var yDiff = lat1 - lat2;
+        return earthRadius * sqrt(xDiff * xDiff + yDiff * yDiff);
     }
 
     @Override

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.InfraManager
 import fr.sncf.osrd.api.api_v2.TrackLocation
 import fr.sncf.osrd.api.pathfinding.constraints.*
+import fr.sncf.osrd.api.pathfinding.makeHeuristics
 import fr.sncf.osrd.graph.*
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
@@ -13,6 +14,7 @@ import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder.Companion.DEFAULT_MAX_ROLLING_STOCK_SPEED
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.Length
@@ -89,8 +91,12 @@ fun runPathfinding(
             request.rollingStockSupportedElectrifications,
             request.rollingStockSupportedSignalingSystems,
         )
+
+    // TODO: add the rolling stock global speed limit to the request
+    val heuristics = makeHeuristics(infra, waypoints, DEFAULT_MAX_ROLLING_STOCK_SPEED)
+
     // Compute the paths from the entry waypoint to the exit waypoint
-    return computePaths(infra, waypoints, constraints, listOf(), request.timeout)
+    return computePaths(infra, waypoints, constraints, heuristics, request.timeout)
 }
 
 private fun initConstraintsFromRSProps(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/RemainingDistanceEstimator.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/RemainingDistanceEstimator.kt
@@ -1,0 +1,105 @@
+package fr.sncf.osrd.api.pathfinding
+
+import fr.sncf.osrd.geom.Point
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.BlockInfra
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
+import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.math.min
+
+/**
+ * This is a function object that estimates the remaining distance to the closest target point,
+ * using geo data. It is used as heuristic for A*.
+ */
+class RemainingDistanceEstimator(
+    private val blockInfra: BlockInfra,
+    private val rawInfra: RawSignalingInfra,
+    edgeLocations: Collection<PathfindingEdgeLocationId<Block>>,
+    private val remainingDistance: Distance
+) {
+    private val targets: MutableCollection<Point> = ArrayList()
+
+    init {
+        for (edgeLocation in edgeLocations) {
+            val point =
+                blockOffsetToPoint(blockInfra, rawInfra, edgeLocation.edge, edgeLocation.offset)
+            // Avoid adding duplicate geo points to the target list
+            val isDuplicate = targets.any { point.distanceAsMeters(it) < DISTANCE_THRESHOLD }
+            if (!isDuplicate) targets.add(point)
+        }
+    }
+
+    fun apply(edge: BlockId, offset: Offset<Block>): Distance {
+        var resMeters = Double.POSITIVE_INFINITY
+        val point = blockOffsetToPoint(blockInfra, rawInfra, edge, offset)
+        for (target in targets) resMeters = min(resMeters, point.distanceAsMeters(target))
+
+        return resMeters.meters + remainingDistance
+    }
+
+    companion object {
+        /** Targets closer than this threshold will be merged together */
+        private const val DISTANCE_THRESHOLD = 1.0
+    }
+}
+
+/**
+ * Compute the minimum geo distance between two steps. Expected to be used when instantiating the
+ * heuristic, to estimate the remaining total distance for any step.
+ */
+fun minDistanceBetweenSteps(
+    blockInfra: BlockInfra,
+    rawInfra: RawSignalingInfra,
+    step1: Collection<PathfindingEdgeLocationId<Block>>,
+    step2: Collection<PathfindingEdgeLocationId<Block>>
+): Distance {
+    val step1Points = step1.map { blockOffsetToPoint(blockInfra, rawInfra, it.edge, it.offset) }
+    val step2Points = step2.map { blockOffsetToPoint(blockInfra, rawInfra, it.edge, it.offset) }
+    var res = Double.POSITIVE_INFINITY
+    for (point1 in step1Points) {
+        for (point2 in step2Points) {
+            res = min(res, point1.distanceAsMeters(point2))
+        }
+    }
+
+    return res.meters
+}
+
+/** Converts a block and offset from its start into a geo point */
+private fun blockOffsetToPoint(
+    blockInfra: BlockInfra,
+    rawInfra: RawSignalingInfra,
+    blockIdx: BlockId,
+    pointOffset: Offset<Block>
+): Point {
+    // Ideally, we would just call `makePathProps(blockId).getGeo()` to get geo data for the block.
+    // But that introduces a lot of overhead (building the path and projecting the results),
+    // which results in a net performance loss when using the heuristic.
+    // This implementation is more verbose but quite lightweight.
+    // TODO: maybe investigate where the path overhead is coming from, it may not be normal
+
+    var pathOffset = 0.meters
+    for (chunk in blockInfra.getTrackChunksFromBlock(blockIdx)) {
+        val chunkLength = rawInfra.getTrackChunkLength(chunk.value)
+        if (pathOffset + chunkLength.distance < pointOffset.distance) {
+            pathOffset += chunkLength.distance
+            continue
+        }
+
+        val remainingOffsetOnBlock = pointOffset.distance - pathOffset
+        val chunkOffset =
+            if (chunk.direction == Direction.INCREASING) {
+                remainingOffsetOnBlock
+            } else {
+                chunkLength.distance - remainingOffsetOnBlock
+            }
+        val lineString = rawInfra.getTrackChunkGeom(chunk.value)
+        return lineString.interpolateNormalized(chunkOffset.meters / chunkLength.distance.meters)
+    }
+    throw RuntimeException("Unreachable (block offset outside of block)")
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/CachedBlockMRSPBuilder.kt
@@ -19,8 +19,7 @@ data class CachedBlockMRSPBuilder(
 ) {
     private val mrspCache = mutableMapOf<BlockId, Envelope>()
 
-    // 320km/h as default value (global max speed in France)
-    private val rsMaxSpeed = rollingStock?.maxSpeed ?: (320.0 / 3.6)
+    private val rsMaxSpeed = rollingStock?.maxSpeed ?: DEFAULT_MAX_ROLLING_STOCK_SPEED
     private val rsLength = rollingStock?.length ?: 0.0
 
     /** Returns the speed limits for the given block (cached). */
@@ -40,5 +39,10 @@ data class CachedBlockMRSPBuilder(
         val actualLength = endOffset ?: blockInfra.getBlockLength(block)
         val mrsp = getMRSP(block)
         return mrsp.interpolateArrivalAtClamp(actualLength.distance.meters)
+    }
+
+    companion object {
+        // 320km/h as default value (global max speed in France)
+        const val DEFAULT_MAX_ROLLING_STOCK_SPEED = (320.0 / 3.6)
     }
 }

--- a/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
+++ b/core/src/test/java/fr/sncf/osrd/utils/graph/AStarTests.kt
@@ -1,0 +1,139 @@
+package fr.sncf.osrd.utils.graph
+
+import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator
+import fr.sncf.osrd.geom.Point
+import fr.sncf.osrd.graph.AStarHeuristic
+import fr.sncf.osrd.graph.GraphAdapter
+import fr.sncf.osrd.graph.Pathfinding
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder.Companion.DEFAULT_MAX_ROLLING_STOCK_SPEED
+import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AStarTests {
+    /**
+     * We try to find a path from a point on the center-west of the infra to the east most point.
+     * The path is almost a geographic line, so a good heuristic should help. We run the pathfinding
+     * with and without a heuristic and ensure that we visit more blocks without heuristic.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun lessBlocksVisitedWithHeuristic() {
+
+        /*                     ---------- DUMMY INFRA ----------
+         *                                                               k0
+         *                                                              /
+         *                                                            j0
+         *                                                           /
+         *                                                         i0
+         *                                                        /
+         *                                                   g0-h0
+         *                                                  /
+         *                                       c1-d1-e1-f1
+         *                                      /           \
+         *                             d3-c3-a-b             g1-h1-i1
+         *                            /         \                    \
+         *                          e3           c2                   j1-k1
+         *                         /               \
+         *                       f3                 d2
+         *                                            \
+         *                                             e2
+         *                                               \
+         *                                                f2
+         */
+
+        val dummyInfra = DummyInfra()
+        val fullDummyInfra = dummyInfra.fullInfra()
+
+        val pointsList =
+            hashMapOf(
+                "a" to Point(.0, .0),
+                "b" to Point(1.0, .0),
+                "c1" to Point(2.0, 1.0),
+                "d1" to Point(3.0, 1.0),
+                "e1" to Point(4.0, 1.0),
+                "f1" to Point(5.0, 1.0),
+                "g0" to Point(6.0, 2.0),
+                "h0" to Point(7.0, 2.0),
+                "i0" to Point(8.0, 3.0),
+                "j0" to Point(9.0, 4.0),
+                "k0" to Point(10.0, 6.0),
+                "g1" to Point(6.0, .0),
+                "h1" to Point(7.0, .0),
+                "i1" to Point(8.0, .0),
+                "j1" to Point(9.0, -1.0),
+                "k1" to Point(10.0, -1.0),
+                "c2" to Point(2.0, -1.0),
+                "d2" to Point(3.0, -2.0),
+                "e2" to Point(4.0, -4.0),
+                "f2" to Point(6.0, -5.0),
+                "c3" to Point(-1.0, .0),
+                "d3" to Point(-2.0, .0),
+                "e3" to Point(-3.0, -1.0),
+                "f3" to Point(-4.0, -2.0)
+            )
+
+        dummyInfra.addDetectorGeoPoints(pointsList)
+
+        val routePointsA = listOf("a", "b", "c1", "d1", "e1", "f1", "g0", "h0", "i0", "j0", "k0")
+        val routePointsB = listOf("f1", "g1", "h1", "i1", "j1", "k1")
+        val routePointsC = listOf("b", "c2", "d2", "e2", "f2")
+        val routePointsD = listOf("a", "c3", "d3", "e3", "f3")
+
+        val startBlock = dummyInfra.addBlockChain(routePointsA).first()
+        dummyInfra.addBlockChain(routePointsB)
+        val endBlock = dummyInfra.addBlockChain(routePointsC).last()
+        dummyInfra.addBlockChain(routePointsD)
+
+        // ---------- ----------- ----------
+
+        val origin = mutableSetOf(PathfindingEdgeLocationId(startBlock, Offset(0.meters)))
+        val destination = mutableSetOf(PathfindingEdgeLocationId(endBlock, Offset(100.meters)))
+
+        val remainingDistanceEstimator =
+            RemainingDistanceEstimator(
+                fullDummyInfra.blockInfra,
+                fullDummyInfra.rawInfra,
+                destination,
+                0.meters
+            )
+        val seenWithHeuristic = HashSet<BlockId>()
+        val seenWithoutHeuristic = HashSet<BlockId>()
+        val mrspBuilder =
+            CachedBlockMRSPBuilder(fullDummyInfra.rawInfra, fullDummyInfra.blockInfra, null)
+        Pathfinding(GraphAdapter(fullDummyInfra.blockInfra, fullDummyInfra.rawInfra))
+            .setEdgeToLength { blockId -> fullDummyInfra.blockInfra.getBlockLength(blockId) }
+            .setRangeCost { range ->
+                mrspBuilder.getBlockTime(range.edge, range.end) -
+                    mrspBuilder.getBlockTime(range.edge, range.start)
+            }
+            .setRemainingDistanceEstimator(
+                listOf(
+                    AStarHeuristic { block, offset ->
+                        seenWithHeuristic.add(block)
+                        remainingDistanceEstimator.apply(block, offset).meters /
+                            DEFAULT_MAX_ROLLING_STOCK_SPEED
+                    }
+                )
+            )
+            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
+        Pathfinding(GraphAdapter(fullDummyInfra.blockInfra, fullDummyInfra.rawInfra))
+            .setEdgeToLength { blockId -> fullDummyInfra.blockInfra.getBlockLength(blockId) }
+            .setRemainingDistanceEstimator(
+                listOf(
+                    AStarHeuristic { block, _ ->
+                        seenWithoutHeuristic.add(block)
+                        0.0
+                    }
+                )
+            )
+            .runPathfinding(listOf<Set<PathfindingEdgeLocationId<Block>>>(origin, destination))
+        Assertions.assertTrue(seenWithHeuristic.size < seenWithoutHeuristic.size)
+    }
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -1,0 +1,100 @@
+package fr.sncf.osrd.pathfinding
+
+import com.google.common.collect.Iterables
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.pathfinding.RemainingDistanceEstimator
+import fr.sncf.osrd.api.pathfinding.makePathProps
+import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
+import fr.sncf.osrd.graph.PathfindingEdgeLocationId
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.PathProperties
+import fr.sncf.osrd.utils.Helpers
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RemainingDistanceEstimatorTest {
+    private var smallInfra: FullInfra? = null
+    private var block: BlockId? = null
+    private var path: PathProperties? = null
+
+    @BeforeAll
+    fun setUp() {
+        smallInfra = Helpers.smallInfra
+        block = Helpers.getBlocksOnRoutes(smallInfra!!, listOf("rt.DA2->DA5"))[0]
+        path = makePathProps(smallInfra!!.blockInfra, smallInfra!!.rawInfra, block!!)
+    }
+
+    @ParameterizedTest
+    @MethodSource("testRemainingDistanceEstimatorArgs")
+    fun testRemainingDistanceEstimator(
+        edgeLocations: Collection<PathfindingEdgeLocationId<Block>>,
+        remainingDistance: Distance,
+        expectedDistance: Distance,
+        blockOffset: Offset<Block>
+    ) {
+        val estimator =
+            RemainingDistanceEstimator(
+                smallInfra!!.blockInfra,
+                smallInfra!!.rawInfra,
+                edgeLocations,
+                remainingDistance
+            )
+        Assertions.assertEquals(expectedDistance, estimator.apply(block!!, blockOffset))
+    }
+
+    @SuppressFBWarnings(
+        value = ["UPM_UNCALLED_PRIVATE_METHOD"],
+        justification = "called implicitly by MethodSource"
+    )
+    private fun testRemainingDistanceEstimatorArgs(): Stream<Arguments> {
+        val points = path!!.getGeo().points
+        return Stream.of( // Test same point
+            Arguments.of(
+                listOf(EdgeLocation(block, Offset<Block>(0.meters))),
+                0,
+                0,
+                0
+            ), // Test same point with non-null remaining distance
+            Arguments.of(
+                listOf(EdgeLocation(block, Offset<Block>(0.meters))),
+                10,
+                10,
+                0
+            ), // Test with target at the end of the edge
+            Arguments.of(
+                listOf(EdgeLocation(block, Offset<Path>(path!!.getLength()))),
+                0,
+                fromMeters(points[0].distanceAsMeters(Iterables.getLast(points))).millimeters,
+                0
+            ), // Test multiple targets
+            Arguments.of(
+                listOf(
+                    EdgeLocation(block, Offset(0.meters)),
+                    EdgeLocation(block, Offset<Path>(path!!.getLength()))
+                ),
+                0,
+                0,
+                0
+            ), // Test with an offset on the block
+            Arguments.of(
+                listOf(EdgeLocation(block, Offset<Path>(path!!.getLength()))),
+                0,
+                0,
+                path!!.getLength().millimeters
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/7200

Change summary:

1. Revert the removal of the heuristic
2. Use remaining time instead of remaining distance
3. Use faster maths to compute geographic distance
4. Speed up the "block location -> geo point" method (see comments)
5. Remove old geo computation + external lib dependency


When running the benchmark, average process time per train goes from 40s to 25s. (note: this includes *more* than just the pathfinding). No extra error. 

While tested I compared the old and new distance methods. The new one is less accurate, but it's not off by more than 0.1%. 