### PR TITLE
core: prioritize paths closer to expected passage times

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -153,7 +153,11 @@ public enum ErrorType {
             "speed_section",
             "Speed section definition is nonsensical and cannot be used for simulation",
             ErrorCause.USER),
-    MissingLastSTDCMStop("missing_last_stdcm_stop", "Last step of stdcm request needs to be a stop", ErrorCause.USER);
+    MissingLastSTDCMStop("missing_last_stdcm_stop", "Last step of stdcm request needs to be a stop", ErrorCause.USER),
+    InvalidSTDCMStepWithTimingData(
+            "invalid_stdcm_step_with_timing_data",
+            "An STDCM step with planned timing data must be a stop",
+            ErrorCause.USER);
 
     public final String type;
     public final String message;

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -187,6 +187,9 @@ private fun parseSteps(
     if (pathItems.last().stopDuration == null) {
         throw OSRDError(ErrorType.MissingLastSTDCMStop)
     }
+    if (pathItems.any { it.stopDuration == null && it.stepTimingData != null }) {
+        throw OSRDError(ErrorType.InvalidSTDCMStepWithTimingData)
+    }
     return pathItems
         .map {
             STDCMStep(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.TimeDelta
+import kotlin.math.abs
 
 data class STDCMStep(
     val locations: Collection<PathfindingEdgeLocationId<Block>>,
@@ -16,4 +17,17 @@ data class PlannedTimingData(
     val arrivalTime: TimeDelta,
     val arrivalTimeToleranceBefore: Duration,
     val arrivalTimeToleranceAfter: Duration,
-)
+) {
+    /**
+     * TimeDiff is the time difference between the train's passage and the planned timing data's
+     * arrival time. This method returns the relative time diff, depending on whether the train
+     * passes before or after the planned arrival time.
+     */
+    fun getBeforeOrAfterRelativeTimeDiff(timeDiff: Double): Double {
+        return when {
+            timeDiff < 0 -> abs(timeDiff / arrivalTimeToleranceBefore.seconds)
+            timeDiff > 0 -> timeDiff / arrivalTimeToleranceAfter.seconds
+            else -> timeDiff
+        }
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -20,7 +20,7 @@ class BacktrackingManager(private val graph: STDCMGraph) {
      * the new edge is invalid (for example if it would cause conflicts), returns null.
      */
     fun backtrack(edge: STDCMEdge, envelope: Envelope): STDCMEdge? {
-        if (edge.previousNode == null) {
+        if (edge.previousNode.previousEdge == null) {
             // First edge of the path
             assert(edge.beginSpeed == 0.0)
             return edge
@@ -78,12 +78,11 @@ class BacktrackingManager(private val graph: STDCMGraph) {
                 graph
             )
         val prevNode = old.previousNode
-        return STDCMEdgeBuilder(old.infraExplorer, graph)
+        return STDCMEdgeBuilder(old.infraExplorer, graph, prevNode)
             .setStartTime(old.timeStart - old.addedDelay)
             .setStartOffset(old.envelopeStartOffset)
             .setPrevMaximumAddedDelay(old.maximumAddedDelayAfter + old.addedDelay)
             .setPrevAddedDelay(old.totalDepartureTimeShift - old.addedDelay)
-            .setPrevNode(prevNode)
             .setEnvelope(newEnvelope)
             .setWaypointIndex(old.waypointIndex)
             .findEdgeSameNextOccupancy(old.timeNextOccupancy)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -30,8 +30,8 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
      * Check whether an engineering allowance can be used in this context to be at the expected
      * start time at the node location.
      */
-    fun checkEngineeringAllowance(prevNode: STDCMNode?, expectedStartTime: Double): Boolean {
-        if (prevNode == null)
+    fun checkEngineeringAllowance(prevNode: STDCMNode, expectedStartTime: Double): Boolean {
+        if (prevNode.previousEdge == null)
             return false // The conflict happens on the first block, we can't add delay here
         val affectedEdges =
             findAffectedEdges(prevNode.previousEdge, expectedStartTime - prevNode.time)
@@ -150,13 +150,13 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
                 return ArrayList(res)
             }
             res.addFirst(mutEdge)
-            if (mutEdge.previousNode == null) {
+            if (mutEdge.previousNode.previousEdge == null) {
                 // We've reached the start of the path, this should only happen because of the max
                 // delay parameter
                 return ArrayList(res)
             }
             mutDelayNeeded += mutEdge.addedDelay
-            mutEdge = mutEdge.previousNode!!.previousEdge
+            mutEdge = mutEdge.previousNode.previousEdge!!
         }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -27,8 +27,8 @@ data class STDCMEdge(
     // Total delay we have added by shifting the departure time since the start of the
     // path
     val totalDepartureTimeShift: Double,
-    // Node located at the start of this edge, null if this is the first edge
-    val previousNode: STDCMNode?,
+    // Node located at the start of this edge
+    val previousNode: STDCMNode,
     // Offset of the envelope if it doesn't start at the beginning of the edge
     val envelopeStartOffset: Offset<Block>,
     // Index of the last waypoint passed by this train
@@ -79,7 +79,7 @@ data class STDCMEdge(
                 newWaypointIndex,
                 null,
                 null,
-                graph.steps[newWaypointIndex].plannedTimingData,
+                null,
                 previousPlannedNodeRelativeTimeDiff,
                 timeSinceDeparture,
                 graph.remainingTimeEstimator.invoke(this, null, newWaypointIndex),
@@ -111,12 +111,13 @@ data class STDCMEdge(
      * new total departure time shift into account.
      */
     private fun getPreviousPlannedNodeRelativeTimeDiff(): Double? {
-        var previousPlannedNode = this.previousNode
-        while (previousPlannedNode != null) {
+        var currentEdge: STDCMEdge? = this
+        while (currentEdge != null) {
+            val previousPlannedNode = currentEdge.previousNode
             if (previousPlannedNode.plannedTimingData != null) {
                 return previousPlannedNode.getRelativeTimeDiff(totalDepartureTimeShift)
             }
-            previousPlannedNode = previousPlannedNode.previousEdge.previousNode
+            currentEdge = previousPlannedNode.previousEdge
         }
         return null
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -1,12 +1,16 @@
 package fr.sncf.osrd.stdcm.graph
 
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual
 import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.stdcm.PlannedTimingData
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Offset
-import kotlin.math.abs
+import kotlin.math.min
 
 data class STDCMNode(
-    // Time at the transition of the edge
+    // Time at the transition of the edge. Because of potentially added delay, this isn't the actual
+    // real time at which the train arrives at this node. To get the real time, use getRealTime()
+    // method.
     val time: Double,
     // Speed at the end of the previous edge
     val speed: Double,
@@ -24,6 +28,11 @@ data class STDCMNode(
     val locationOnEdge: Offset<Block>?,
     // When the node is a stop, how long the train remains here
     val stopDuration: Double?,
+    // Planned arrival time at node, with its tolerance
+    val plannedTimingData: PlannedTimingData?,
+    // Previous node with non-null PlannedTimingDelta: time difference between arrival time on node
+    // and planned arrival time, divided by the total duration of the time window
+    val previousPlannedNodeRelativeTimeDiff: Double?,
     // Time since train departure. Accounts for stops and travel time, but not the changes in
     // departure time.
     val timeSinceDeparture: Double,
@@ -32,18 +41,40 @@ data class STDCMNode(
 ) : Comparable<STDCMNode> {
 
     /**
-     * Defines the estimated better path between 2 nodes, in terms of total run time, then departure
-     * time, then number of reached targets. If the result is negative, the current node has a
-     * better path, and should be explored first. This method allows us to order the nodes in a
-     * priority queue, from the best path to the worst path. We then explore them in that order.
+     * Defines the estimated better path between 2 nodes, in the following priority:
+     * - lowest total run time
+     * - closest planned arrival time, taking the tolerance into account, using the current node's
+     *   planned timing data, then the last planned node's timing data
+     * - earliest departure time
+     * - highest number of reached targets
+     *
+     * If the result is negative, the current node has a better path, and should be explored first.
+     * This method allows us to order the nodes in a priority queue, from the best path to the worst
+     * path. We then explore them in that order.
      */
     override fun compareTo(other: STDCMNode): Int {
         val runTimeEstimation = timeSinceDeparture + remainingTimeEstimation
         val otherRunTimeEstimation = other.timeSinceDeparture + other.remainingTimeEstimation
+        val plannedRelativeTimeDiff = getRelativeTimeDiff()
+        val otherPlannedRelativeTimeDiff = other.getRelativeTimeDiff()
         // Firstly, minimize the total run time: highest priority node takes the least time to
         // complete the path
-        return if (abs(runTimeEstimation - otherRunTimeEstimation) >= 1e-3)
+        return if (!areTimesEqual(runTimeEstimation, otherRunTimeEstimation))
             runTimeEstimation.compareTo(otherRunTimeEstimation)
+        // Minimise the difference with the planned arrival times
+        else if (
+            plannedRelativeTimeDiff != null &&
+                otherPlannedRelativeTimeDiff != null &&
+                plannedRelativeTimeDiff != otherPlannedRelativeTimeDiff
+        )
+            (plannedRelativeTimeDiff).compareTo(otherPlannedRelativeTimeDiff)
+        // If not, minimise the difference with the planned arrival times at the last planned node
+        else if (
+            previousPlannedNodeRelativeTimeDiff != null &&
+                other.previousPlannedNodeRelativeTimeDiff != null &&
+                previousPlannedNodeRelativeTimeDiff != other.previousPlannedNodeRelativeTimeDiff
+        )
+            previousPlannedNodeRelativeTimeDiff.compareTo(other.previousPlannedNodeRelativeTimeDiff)
         // If not, take the train which departs first, as it is the closest to the demanded
         // departure time
         else if (time != other.time) time.compareTo(other.time)
@@ -60,5 +91,38 @@ data class STDCMNode(
             infraExplorer.getCurrentBlock(),
             waypointIndex
         )
+    }
+
+    /**
+     * Returns the relative time difference between the real arrival time at node and the planned
+     * arrival time at node, taking into account the tolerance on either side. It takes the lowest
+     * value between the relative time diff at the current time and the relative time diff at the
+     * maximum time at which the train can pass on the node.
+     */
+    fun getRelativeTimeDiff(currentTotalAddedDelay: Double = totalPrevAddedDelay): Double? {
+        if (plannedTimingData != null) {
+            val timeDiff =
+                getRealTime(currentTotalAddedDelay) - plannedTimingData.arrivalTime.seconds
+            val relativeTimeDiff = plannedTimingData.getBeforeOrAfterRelativeTimeDiff(timeDiff)
+            val maxTimeDiff =
+                min(
+                    getRealTime(maximumAddedDelay) - plannedTimingData.arrivalTime.seconds,
+                    plannedTimingData.arrivalTimeToleranceAfter.seconds
+                )
+            val relativeMaxTimeDiff =
+                plannedTimingData.getBeforeOrAfterRelativeTimeDiff(maxTimeDiff)
+            val minRelativeTimeDiff = min(relativeTimeDiff, relativeMaxTimeDiff)
+            return minRelativeTimeDiff
+        }
+        return null
+    }
+
+    /**
+     * Takes into account the real current departure time shift to return the real current time at
+     * which the train arrives at this node.
+     */
+    private fun getRealTime(currentTotalAddedDelay: Double): Double {
+        assert(currentTotalAddedDelay >= totalPrevAddedDelay)
+        return time + (currentTotalAddedDelay - totalPrevAddedDelay)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -20,15 +20,16 @@ data class STDCMNode(
     val totalPrevAddedDelay: Double,
     // Maximum delay we can add by delaying the start time without causing conflicts
     val maximumAddedDelay: Double,
-    // Edge that lead to this node
-    val previousEdge: STDCMEdge,
+    // Edge that lead to this node, null if this is the first node
+    val previousEdge: STDCMEdge?,
     // Index of the last waypoint passed by the train
     val waypointIndex: Int,
     // Position on a block, if this node isn't on the transition between blocks (stop)
     val locationOnEdge: Offset<Block>?,
     // When the node is a stop, how long the train remains here
     val stopDuration: Double?,
-    // Planned arrival time at node, with its tolerance
+    // Planned arrival time at node, with its tolerance. Is null at least when the node is not a
+    // stop
     val plannedTimingData: PlannedTimingData?,
     // Previous node with non-null PlannedTimingDelta: time difference between arrival time on node
     // and planned arrival time, divided by the total duration of the time window

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -4,7 +4,6 @@ import datadog.trace.api.Trace
 import fr.sncf.osrd.api.pathfinding.makeOperationalPoints
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPath
-import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.*
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope
@@ -146,7 +145,12 @@ private fun makeStops(edges: List<STDCMEdge>): List<TrainStop> {
     var offset = 0.meters
     for (edge in edges) {
         val prevNode = edge.previousNode
-        if (prevNode?.stopDuration != null && prevNode.stopDuration >= 0)
+        // Ignore first path node and last node (we aren't checking lastEdge.getEdgeEnd())
+        if (
+            prevNode.previousEdge != null &&
+                prevNode.stopDuration != null &&
+                prevNode.stopDuration >= 0
+        )
             res.add(
                 TrainStop(
                     offset.meters,
@@ -197,7 +201,7 @@ private fun sortAndMergeStopsDuplicates(stops: List<TrainStop>): List<TrainStop>
     val res = ArrayList<TrainStop>()
     var last: TrainStop? = null
     for (stop in sorted) {
-        if (last != null && TrainPhysicsIntegrator.arePositionsEqual(last.position, stop.position))
+        if (last != null && arePositionsEqual(last.position, stop.position))
             last.position = stop.position
         else {
             last = stop

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -61,9 +61,10 @@ class STDCMPathfindingBuilder {
      * intermediate steps
      */
     fun setStartLocations(
-        startLocations: Set<PathfindingEdgeLocationId<Block>>
+        startLocations: Set<PathfindingEdgeLocationId<Block>>,
+        plannedTimingData: PlannedTimingData? = null
     ): STDCMPathfindingBuilder {
-        steps.add(0, STDCMStep(startLocations, 0.0, true))
+        steps.add(0, STDCMStep(startLocations, 0.0, true, plannedTimingData))
         return this
     }
 
@@ -72,9 +73,10 @@ class STDCMPathfindingBuilder {
      * intermediate steps
      */
     fun setEndLocations(
-        endLocations: Set<PathfindingEdgeLocationId<Block>>
+        endLocations: Set<PathfindingEdgeLocationId<Block>>,
+        plannedTimingData: PlannedTimingData? = null
     ): STDCMPathfindingBuilder {
-        steps.add(STDCMStep(endLocations, 0.0, true))
+        steps.add(STDCMStep(endLocations, 0.0, true, plannedTimingData))
         return this
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
@@ -212,6 +213,21 @@ class STDCMHeuristicTests {
                     newExplorer.getLookahead().all { lookahead.contains(it) }
                 }
         }
+        val defaultNode =
+            STDCMNode(
+                0.0,
+                0.0,
+                explorer,
+                0.0,
+                0.0,
+                null,
+                0,
+                Offset(0.meters),
+                null,
+                null,
+                null,
+                0.0
+            )
         val defaultEdge =
             STDCMEdge(
                 explorer,
@@ -221,7 +237,7 @@ class STDCMHeuristicTests {
                 0.0,
                 0.0,
                 0.0,
-                null,
+                defaultNode,
                 Offset(0.meters),
                 0,
                 false,


### PR DESCRIPTION
Fixes #7689.

Highest prio paths remain paths wth the minimum total run time. Afterwards, prioritize paths closer to expected passage times.