### PR TITLE
core: stdcm: add opentelemetry spans for large sections

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm
 
+import datadog.trace.api.Trace
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
@@ -11,6 +12,8 @@ import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.util.*
 import kotlin.math.max
 import kotlin.math.min
@@ -44,6 +47,8 @@ class STDCMHeuristicBuilder(
     private val mrspBuilder = CachedBlockMRSPBuilder(rawInfra, blockInfra, rollingStock)
 
     /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
+    @WithSpan(value = "Initializing STDCM heuristic", kind = SpanKind.SERVER)
+    @Trace(operationName = "Initializing STDCM heuristic")
     fun build(): STDCMAStarHeuristic {
         logger.info("Start building STDCM heuristic...")
         // One map per number of reached pathfinding step

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.graph
 
+import datadog.trace.api.Trace
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.constraints.ConstraintCombiner
 import fr.sncf.osrd.api.pathfinding.constraints.initConstraints
@@ -16,6 +17,8 @@ import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.units.Offset
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
 import java.time.Instant
 import java.util.*
@@ -96,6 +99,8 @@ class STDCMPathfinding(
             standardAllowance
         )
 
+    @WithSpan(value = "STDCM pathfinding", kind = SpanKind.SERVER)
+    @Trace(operationName = "STDCM pathfinding")
     fun findPath(): STDCMResult? {
         assert(steps.size >= 2) { "Not enough steps have been set to find a path" }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -1,5 +1,6 @@
 package fr.sncf.osrd.stdcm.graph
 
+import datadog.trace.api.Trace
 import fr.sncf.osrd.api.pathfinding.makeOperationalPoints
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimPath
@@ -22,6 +23,8 @@ import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.units.meters
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.util.*
 
 /**
@@ -33,6 +36,8 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
      * Builds the STDCM result object from the raw pathfinding result. This is the only non-private
      * method of this class, the rest is implementation detail.
      */
+    @WithSpan(value = "STDCM post processing", kind = SpanKind.SERVER)
+    @Trace(operationName = "STDCM post processing")
     fun makeResult(
         infra: RawSignalingInfra,
         path: Result,


### PR DESCRIPTION
Spans are cool


I'm not 100% sure of how I'm doing it, is there something else to do with datadog? I only tested the opentelemetry setup

---


![image](https://github.com/user-attachments/assets/2f77d1c9-f28f-44e2-a1cf-59c2753959bd)

