### PR TITLE
core: stop using default-speed when handling speed-limit tags

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -562,19 +562,7 @@ class RawInfraImpl(
             // TODO: as stated for SpeedSection class, a refactor is required to respect
             //       specifications
             assert(infraTagSpeed == null || speedFromRoute == null) { "checked at parsing" }
-            val allowedSpeed =
-                if (speedFromRoute != null) {
-                    speedFromRoute
-                } else if (infraTagSpeed != null) {
-                    infraTagSpeed
-                } else if (
-                    trainSpeedLimitTagDescriptor?.defaultSpeed != null &&
-                        trainSpeedLimitTagDescriptor.defaultSpeed < speedSection.default
-                ) {
-                    trainSpeedLimitTagDescriptor.defaultSpeed
-                } else {
-                    speedSection.default
-                }
+            val allowedSpeed = speedFromRoute ?: infraTagSpeed ?: speedSection.default
             res.put(entry.lower, entry.upper, allowedSpeed)
         }
         return res

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraImpl.kt
@@ -3,67 +3,13 @@ package fr.sncf.osrd.sim_infra.impl
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Detector
-import fr.sncf.osrd.sim_infra.api.DetectorId
-import fr.sncf.osrd.sim_infra.api.DirDetectorId
-import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
-import fr.sncf.osrd.sim_infra.api.DirTrackSectionId
-import fr.sncf.osrd.sim_infra.api.EndpointTrackSectionId
-import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
-import fr.sncf.osrd.sim_infra.api.LogicalSignal
-import fr.sncf.osrd.sim_infra.api.LogicalSignalId
-import fr.sncf.osrd.sim_infra.api.NeutralSection
-import fr.sncf.osrd.sim_infra.api.OperationalPointPart
-import fr.sncf.osrd.sim_infra.api.OperationalPointPartId
-import fr.sncf.osrd.sim_infra.api.OptDirTrackSectionId
-import fr.sncf.osrd.sim_infra.api.PhysicalSignal
-import fr.sncf.osrd.sim_infra.api.PhysicalSignalId
-import fr.sncf.osrd.sim_infra.api.RawInfra
-import fr.sncf.osrd.sim_infra.api.RawSignalParameters
-import fr.sncf.osrd.sim_infra.api.Route
-import fr.sncf.osrd.sim_infra.api.RouteId
-import fr.sncf.osrd.sim_infra.api.SpeedLimit
-import fr.sncf.osrd.sim_infra.api.TrackChunk
-import fr.sncf.osrd.sim_infra.api.TrackChunkId
-import fr.sncf.osrd.sim_infra.api.TrackNode
-import fr.sncf.osrd.sim_infra.api.TrackNodeConfig
-import fr.sncf.osrd.sim_infra.api.TrackNodeConfigId
-import fr.sncf.osrd.sim_infra.api.TrackNodeId
-import fr.sncf.osrd.sim_infra.api.TrackNodePort
-import fr.sncf.osrd.sim_infra.api.TrackNodePortId
-import fr.sncf.osrd.sim_infra.api.TrackSection
-import fr.sncf.osrd.sim_infra.api.TrackSectionId
-import fr.sncf.osrd.sim_infra.api.Zone
-import fr.sncf.osrd.sim_infra.api.ZoneId
-import fr.sncf.osrd.sim_infra.api.ZonePath
-import fr.sncf.osrd.sim_infra.api.ZonePathId
-import fr.sncf.osrd.sim_infra.api.decreasing
-import fr.sncf.osrd.sim_infra.api.getZonePathZone
-import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.api.toEndpoint
+import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DirectionalMap
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
-import fr.sncf.osrd.utils.indexing.DirStaticIdxList
-import fr.sncf.osrd.utils.indexing.IdxMap
-import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
-import fr.sncf.osrd.utils.indexing.OptStaticIdx
-import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.StaticIdxSortedSet
-import fr.sncf.osrd.utils.indexing.StaticIdxSpace
-import fr.sncf.osrd.utils.indexing.StaticPool
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Length
-import fr.sncf.osrd.utils.units.MutableOffsetArray
-import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.OffsetList
-import fr.sncf.osrd.utils.units.Speed
-import fr.sncf.osrd.utils.units.findSegment
-import fr.sncf.osrd.utils.units.meters
-import fr.sncf.osrd.utils.units.mutableOffsetArrayListOf
+import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.*
 import kotlin.collections.set
 import kotlin.time.Duration
 import mu.KotlinLogging
@@ -654,7 +600,7 @@ class RawInfraImpl(
                 val fallbackSpeed =
                     speedSection.speedByTrainTag[fallbackTagId]
                         // TODO remove once long names are unused and move method to
-                        // SpeedLimitTagDescriptor
+                        //   SpeedLimitTagDescriptor
                         ?: speedSection.speedByTrainTag[speedLimitTagPool[fallbackTagId]?.name]
 
                 if (fallbackSpeed != null) {

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -9,20 +9,12 @@ import fr.sncf.osrd.railjson.schema.geom.RJSLineString
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPoint
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPointExtensions
 import fr.sncf.osrd.railjson.schema.infra.RJSOperationalPointSncfExtension
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSApplicableDirectionsTrackRange
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSCurve
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSElectrification
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSLoadingGaugeLimit
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSOperationalPointPart
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSOperationalPointPartExtensions
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSOperationalPointPartSncfExtension
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSlope
-import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSpeedSection
+import fr.sncf.osrd.railjson.schema.infra.trackranges.*
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.train.TestTrains.MAX_SPEED
 import fr.sncf.osrd.utils.Direction
-import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.pathFromTracks
@@ -75,10 +67,10 @@ class PathPropertiesTests {
         val slopes = path.getSlopes()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 500.meters, 10.0),
-                DistanceRangeMap.RangeMapEntry(500.meters, 1_500.meters, 15.0),
-                DistanceRangeMap.RangeMapEntry(1_500.meters, 2_500.meters, .0),
-                DistanceRangeMap.RangeMapEntry(2_500.meters, 3_000.meters, -5.0),
+                RangeMapEntry(0.meters, 500.meters, 10.0),
+                RangeMapEntry(500.meters, 1_500.meters, 15.0),
+                RangeMapEntry(1_500.meters, 2_500.meters, .0),
+                RangeMapEntry(2_500.meters, 3_000.meters, -5.0),
             ),
             slopes.asList()
         )
@@ -94,8 +86,8 @@ class PathPropertiesTests {
         val slopesBackward = pathBackward.getSlopes()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 1_000.meters, .0),
-                DistanceRangeMap.RangeMapEntry(1_000.meters, 2_000.meters, -15.0),
+                RangeMapEntry(0.meters, 1_000.meters, .0),
+                RangeMapEntry(1_000.meters, 2_000.meters, -15.0),
             ),
             slopesBackward.asList()
         )
@@ -226,8 +218,8 @@ class PathPropertiesTests {
         val slopesBackward = pathBackward.getCurves()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 500.meters, -10_000.0),
-                DistanceRangeMap.RangeMapEntry(500.meters, 1_000.meters, -5_000.0),
+                RangeMapEntry(0.meters, 500.meters, -10_000.0),
+                RangeMapEntry(500.meters, 1_000.meters, -5_000.0),
             ),
             slopesBackward.asList()
         )
@@ -266,8 +258,8 @@ class PathPropertiesTests {
         val slopesBackward = pathBackward.getGradients()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 500.meters, -15.0),
-                DistanceRangeMap.RangeMapEntry(500.meters, 1_000.meters, -5.0 + 800.0 / 5_000.0),
+                RangeMapEntry(0.meters, 500.meters, -15.0),
+                RangeMapEntry(500.meters, 1_000.meters, -5.0 + 800.0 / 5_000.0),
             ),
             slopesBackward.asList()
         )
@@ -385,8 +377,8 @@ class PathPropertiesTests {
         val electrificationForward = path.getElectrification()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 2_500.meters, "1500V"),
-                DistanceRangeMap.RangeMapEntry(2_500.meters, 3_000.meters, "25000V"),
+                RangeMapEntry(0.meters, 2_500.meters, "1500V"),
+                RangeMapEntry(2_500.meters, 3_000.meters, "25000V"),
             ),
             electrificationForward.asList(),
         )
@@ -402,8 +394,8 @@ class PathPropertiesTests {
         val electrificationBackward = pathBackward.getElectrification()
         assertEquals(
             listOf(
-                DistanceRangeMap.RangeMapEntry(0.meters, 500.meters, "25000V"),
-                DistanceRangeMap.RangeMapEntry(500.meters, 2_500.meters, "1500V"),
+                RangeMapEntry(0.meters, 500.meters, "25000V"),
+                RangeMapEntry(500.meters, 2_500.meters, "1500V"),
             ),
             electrificationBackward.asList(),
         )
@@ -475,12 +467,8 @@ class PathPropertiesTests {
         assertThat(speedLimits.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 400.meters, 42.42.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(
-                        400.meters,
-                        1_820.meters,
-                        MAX_SPEED.metersPerSecond
-                    )
+                    RangeMapEntry(0.meters, 400.meters, 42.42.metersPerSecond),
+                    RangeMapEntry(400.meters, 1_820.meters, MAX_SPEED.metersPerSecond)
                 )
             )
     }
@@ -528,14 +516,14 @@ class PathPropertiesTests {
 
         val expectedSpeedLimitsMA100 =
             listOf(
-                DistanceRangeMap.RangeMapEntry(
+                RangeMapEntry(
                     0.meters,
                     100.meters,
                     8.333.metersPerSecond // default speed all known tags
                 ),
-                DistanceRangeMap.RangeMapEntry(100.meters, 1000.meters, 22.222.metersPerSecond),
-                DistanceRangeMap.RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
-                DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                RangeMapEntry(100.meters, 1000.meters, 22.222.metersPerSecond),
+                RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
+                RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
             )
         val speedLimitsMA100 = path.getSpeedLimits("MA100")
         assertThat(speedLimitsMA100.asList()).containsExactlyElementsOf(expectedSpeedLimitsMA100)
@@ -547,10 +535,10 @@ class PathPropertiesTests {
         assertThat(speedLimitsE32C.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 600.meters, 27.778.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(600.meters, 1000.meters, 22.222.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                    RangeMapEntry(0.meters, 600.meters, 27.778.metersPerSecond),
+                    RangeMapEntry(600.meters, 1000.meters, 22.222.metersPerSecond),
+                    RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
+                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
 
@@ -558,14 +546,10 @@ class PathPropertiesTests {
         assertThat(speedLimitsHLP.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(100.meters, 1000.meters, 31.111.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(
-                        1000.meters,
-                        1500.meters,
-                        69.444.metersPerSecond
-                    ),
-                    DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                    RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
+                    RangeMapEntry(100.meters, 1000.meters, 31.111.metersPerSecond),
+                    RangeMapEntry(1000.meters, 1500.meters, 69.444.metersPerSecond),
+                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
 
@@ -573,14 +557,10 @@ class PathPropertiesTests {
         assertThat(speedLimitsNull.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(100.meters, 1000.meters, 31.111.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(
-                        1000.meters,
-                        1500.meters,
-                        83.333.metersPerSecond
-                    ),
-                    DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                    RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
+                    RangeMapEntry(100.meters, 1000.meters, 31.111.metersPerSecond),
+                    RangeMapEntry(1000.meters, 1500.meters, 83.333.metersPerSecond),
+                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
 
@@ -588,8 +568,8 @@ class PathPropertiesTests {
         assertThat(speedLimitsMA90.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                    RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
+                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
 
@@ -597,8 +577,8 @@ class PathPropertiesTests {
         assertThat(speedLimitsMA80.asList())
             .containsExactlyElementsOf(
                 listOf(
-                    DistanceRangeMap.RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
-                    DistanceRangeMap.RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
+                    RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
+                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -512,17 +512,15 @@ class PathPropertiesTests {
         |                     69.444                      |     HLP
         |      27.778       |-----------------------------|     E32C
         |---------|      22.222       |-------------------|     MA100
+
+        Default speed for all known tags (unused currently): 8.333
         */
 
         val expectedSpeedLimitsMA100 =
             listOf(
-                RangeMapEntry(
-                    0.meters,
-                    100.meters,
-                    8.333.metersPerSecond // default speed all known tags
-                ),
+                RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
                 RangeMapEntry(100.meters, 1000.meters, 22.222.metersPerSecond),
-                RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
+                RangeMapEntry(1000.meters, 1500.meters, 83.333.metersPerSecond),
                 RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
             )
         val speedLimitsMA100 = path.getSpeedLimits("MA100")
@@ -537,7 +535,7 @@ class PathPropertiesTests {
                 listOf(
                     RangeMapEntry(0.meters, 600.meters, 27.778.metersPerSecond),
                     RangeMapEntry(600.meters, 1000.meters, 22.222.metersPerSecond),
-                    RangeMapEntry(1000.meters, 1500.meters, 8.333.metersPerSecond),
+                    RangeMapEntry(1000.meters, 1500.meters, 83.333.metersPerSecond),
                     RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
                 )
             )
@@ -564,23 +562,18 @@ class PathPropertiesTests {
                 )
             )
 
-        val speedLimitsMA90 = path.getSpeedLimits("MA90")
-        assertThat(speedLimitsMA90.asList())
-            .containsExactlyElementsOf(
-                listOf(
-                    RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
-                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
-                )
+        val expectedSpeedLimitsMA90 =
+            listOf(
+                RangeMapEntry(0.meters, 100.meters, 39.444.metersPerSecond),
+                RangeMapEntry(100.meters, 1000.meters, 31.111.metersPerSecond),
+                RangeMapEntry(1000.meters, 1500.meters, 83.333.metersPerSecond),
+                RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
             )
+        val speedLimitsMA90 = path.getSpeedLimits("MA90")
+        assertThat(speedLimitsMA90.asList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
 
         val speedLimitsMA80 = path.getSpeedLimits("MA80")
-        assertThat(speedLimitsMA80.asList())
-            .containsExactlyElementsOf(
-                listOf(
-                    RangeMapEntry(0.meters, 1500.meters, 8.333.metersPerSecond),
-                    RangeMapEntry(1500.meters, 1600.meters, 3.0.metersPerSecond)
-                )
-            )
+        assertThat(speedLimitsMA80.asList()).containsExactlyElementsOf(expectedSpeedLimitsMA90)
     }
 
     /** Assert that line strings are equal, with a certain tolerance for double values */


### PR DESCRIPTION
Use only given speed-limit tag + fallback tags.

Adapt tests accordingly

As stated in https://github.com/osrd-project/osrd-confidential/issues/364#issuecomment-2236185634:
The use of given tag + fallback-tags but without (super low) default-speed has the best chances to reach a consensus among different use-cases (circulation mass-imports, STDCM, operational studies).
The use of default-speed creates overly-hard constraints on MRSP when infrastructure data is not perfect (which is the case most of the time) and the issues in infrastructure data should still be visible once showing a warning that a range of the path is not covered by a speed-limit tag in speed-space chart.

To be decided later:

- [x] cleanup default-speed values in config file if no use is planned (in https://github.com/OpenRailAssociation/osrd/issues/7977)
- [x] offer different MRSP policies for speed-limit tag handling if we need to differentiate use-cases (place to track this is undecided) : tracked into a separate issue : https://github.com/osrd-project/osrd-confidential/issues/606