### PR TITLE
Move electrical profile set id from timetable to scenario

### DIFF
--- a/editoast/migrations/2024-07-15-150521_move_electrical_profile_set_id/down.sql
+++ b/editoast/migrations/2024-07-15-150521_move_electrical_profile_set_id/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE timetable_v2 ADD electrical_profile_set_id int8 NULL REFERENCES electrical_profile_set(id) ON DELETE CASCADE;
+
+UPDATE timetable_v2
+SET electrical_profile_set_id = scenario_v2.electrical_profile_set_id
+FROM scenario_v2
+WHERE scenario_v2.timetable_id = timetable_v2.id;
+
+ALTER TABLE scenario_v2 DROP COLUMN electrical_profile_set_id;

--- a/editoast/migrations/2024-07-15-150521_move_electrical_profile_set_id/up.sql
+++ b/editoast/migrations/2024-07-15-150521_move_electrical_profile_set_id/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE scenario_v2 ADD electrical_profile_set_id int8 NULL REFERENCES electrical_profile_set(id) ON DELETE CASCADE;
+
+UPDATE scenario_v2
+SET electrical_profile_set_id = timetable_v2.electrical_profile_set_id
+FROM timetable_v2
+WHERE scenario_v2.timetable_id = timetable_v2.id;
+
+ALTER TABLE timetable_v2 DROP COLUMN electrical_profile_set_id;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2010,7 +2010,7 @@ paths:
           format: int64
       - name: force
         in: query
-        description: force the deletion even if it’s used
+        description: force the deletion even if it's used
         required: false
         schema:
           type: boolean
@@ -2862,54 +2862,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/InternalError'
   /v2/timetable:
-    get:
-      tags:
-      - timetablev2
-      summary: Retrieve paginated timetables
-      parameters:
-      - name: page
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 1
-          minimum: 1
-      - name: page_size
-        in: query
-        required: false
-        schema:
-          type: integer
-          format: int64
-          default: 25
-          nullable: true
-          minimum: 1
-      responses:
-        '200':
-          description: List timetables
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/PaginationStats'
-                - type: object
-                  required:
-                  - results
-                  properties:
-                    results:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/TimetableResult'
     post:
       tags:
       - timetablev2
       summary: Create a timetable
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TimetableForm'
-        required: true
       responses:
         '200':
           description: Timetable with train schedules ids
@@ -2932,33 +2888,6 @@ paths:
         schema:
           type: integer
           format: int64
-      responses:
-        '200':
-          description: Timetable with train schedules ids
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TimetableDetailedResult'
-        '404':
-          description: Timetable not found
-    put:
-      tags:
-      - timetablev2
-      summary: Update a specific timetable
-      parameters:
-      - name: id
-        in: path
-        description: A timetable ID
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TimetableForm'
-        required: true
       responses:
         '200':
           description: Timetable with train schedules ids
@@ -3004,6 +2933,13 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: electrical_profile_set_id
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          nullable: true
       responses:
         '200':
           description: List of conflict
@@ -3269,6 +3205,10 @@ paths:
               - infra_id
               - ids
               properties:
+                electrical_profile_set_id:
+                  type: integer
+                  format: int64
+                  nullable: true
                 ids:
                   type: array
                   items:
@@ -3379,6 +3319,12 @@ paths:
       - name: infra_id
         in: query
         required: true
+        schema:
+          type: integer
+          format: int64
+      - name: electrical_profile_set_id
+        in: query
+        required: false
         schema:
           type: integer
           format: int64
@@ -3751,7 +3697,7 @@ components:
       properties:
         force:
           type: boolean
-          description: force the deletion even if it’s used
+          description: force the deletion even if it's used
     Detector:
       type: object
       required:
@@ -6293,6 +6239,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ElectricalProfile'
+    ElectricalProfileSetIdQueryParam:
+      type: object
+      properties:
+        electrical_profile_set_id:
+          type: integer
+          format: int64
+          nullable: true
     Electrification:
       type: object
       required:
@@ -8700,6 +8653,10 @@ components:
       - ids
       - path
       properties:
+        electrical_profile_set_id:
+          type: integer
+          format: int64
+          nullable: true
         ids:
           type: array
           items:
@@ -9915,6 +9872,10 @@ components:
       properties:
         description:
           type: string
+        electrical_profile_set_id:
+          type: integer
+          format: int64
+          nullable: true
         infra_id:
           type: integer
           format: int64
@@ -9946,6 +9907,10 @@ components:
       properties:
         description:
           type: string
+          nullable: true
+        electrical_profile_set_id:
+          type: integer
+          format: int64
           nullable: true
         infra_id:
           type: integer
@@ -10022,6 +9987,9 @@ components:
           format: date-time
         description:
           type: string
+        electrical_profile_set_id:
+          type: integer
+          format: int64
         id:
           type: integer
           format: int64
@@ -11406,37 +11374,20 @@ components:
         name:
           type: string
     TimetableDetailedResult:
-      allOf:
-      - type: object
-        description: Creation form for a Timetable
-        required:
-        - id
-        properties:
-          electrical_profile_set_id:
-            type: integer
-            format: int64
-            nullable: true
-          id:
-            type: integer
-            format: int64
-      - type: object
-        required:
-        - train_ids
-        properties:
-          train_ids:
-            type: array
-            items:
-              type: integer
-              format: int64
-      description: Creation form for a Timetable
-    TimetableForm:
       type: object
-      description: Creation form for a Timetable
+      description: Creation result for a Timetable
+      required:
+      - timetable_id
+      - train_ids
       properties:
-        electrical_profile_set_id:
+        timetable_id:
           type: integer
           format: int64
-          nullable: true
+        train_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
     TimetableImportError:
       oneOf:
       - type: object
@@ -11595,15 +11546,11 @@ components:
           example: '7015'
     TimetableResult:
       type: object
-      description: Creation form for a Timetable
+      description: Creation result for a Timetable
       required:
-      - id
+      - timetable_id
       properties:
-        electrical_profile_set_id:
-          type: integer
-          format: int64
-          nullable: true
-        id:
+        timetable_id:
           type: integer
           format: int64
     TimetableWithSchedulesDetails:

--- a/editoast/src/fixtures.rs
+++ b/editoast/src/fixtures.rs
@@ -364,11 +364,12 @@ pub mod tests {
 
     #[fixture]
     pub async fn timetable_v2(db_pool: Arc<DbConnectionPool>) -> TestFixture<TimetableV2> {
-        TestFixture::create(
-            TimetableV2::changeset().electrical_profile_set_id(None),
+        TestFixture::new(
+            TimetableV2::create(db_pool.get().await.unwrap().deref_mut())
+                .await
+                .expect("Unable to create timetable"),
             db_pool,
         )
-        .await
     }
 
     pub struct ScenarioV2FixtureSet {

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -297,10 +297,7 @@ async fn trains_import(
                 return Err(Box::new(error));
             }
         },
-        None => {
-            let changeset = Timetable::changeset();
-            changeset.create(db_pool.get().await?.deref_mut()).await?
-        }
+        None => Timetable::create(db_pool.get().await?.deref_mut()).await?,
     };
 
     let train_schedules: Vec<TrainScheduleBase> =
@@ -903,9 +900,7 @@ mod tests {
     async fn import_export_timetable_schedule_v2() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
-        let changeset = Timetable::changeset();
-        let timetable = changeset
-            .create(db_pool.get_ok().deref_mut())
+        let timetable = Timetable::create(db_pool.get_ok().deref_mut())
             .await
             .unwrap();
 

--- a/editoast/src/modelsv2/fixtures.rs
+++ b/editoast/src/modelsv2/fixtures.rs
@@ -79,9 +79,7 @@ pub async fn create_study(conn: &mut DbConnection, name: &str, project_id: i64) 
 }
 
 pub async fn create_timetable(conn: &mut DbConnection) -> Timetable {
-    Timetable::changeset()
-        .electrical_profile_set_id(None)
-        .create(conn)
+    Timetable::create(conn)
         .await
         .expect("Failed to create timetable")
 }

--- a/editoast/src/modelsv2/scenario.rs
+++ b/editoast/src/modelsv2/scenario.rs
@@ -26,6 +26,9 @@ pub struct Scenario {
     pub tags: Tags,
     pub timetable_id: i64,
     pub study_id: i64,
+    #[schema(nullable = false)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub electrical_profile_set_id: Option<i64>,
 }
 
 impl Scenario {

--- a/editoast/src/modelsv2/timetable.rs
+++ b/editoast/src/modelsv2/timetable.rs
@@ -1,19 +1,81 @@
+use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
-use diesel::sql_types::Nullable;
-use editoast_derive::ModelV2;
+use diesel_async::RunQueryDsl;
 
 use crate::error::Result;
-use crate::modelsv2::Retrieve;
+use crate::models::Identifiable;
+use crate::modelsv2::{DeleteStatic, Retrieve};
+use crate::tables::timetable_v2::dsl;
+use crate::Exists;
 use editoast_models::DbConnection;
 
-#[derive(Debug, Default, Clone, ModelV2, PartialEq)]
-#[model(table = crate::tables::timetable_v2)]
+#[derive(Debug, Default, Clone, PartialEq, Queryable, Identifiable)]
+#[diesel(table_name = crate::tables::timetable_v2)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 pub struct Timetable {
     pub id: i64,
-    pub electrical_profile_set_id: Option<i64>,
+}
+
+impl Timetable {
+    #[tracing::instrument(name = "model:create<Timetable>", skip_all, err)]
+    pub async fn create(conn: &mut DbConnection) -> Result<Self> {
+        diesel::insert_into(crate::tables::timetable_v2::table)
+            .default_values()
+            .get_result::<Timetable>(conn)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+}
+
+#[async_trait::async_trait]
+impl DeleteStatic<i64> for Timetable {
+    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
+    #[tracing::instrument(name = "model:delete_static<Timetable>", skip_all, ret, err)]
+    async fn delete_static(conn: &mut DbConnection, id: i64) -> Result<bool> {
+        diesel::delete(dsl::timetable_v2.filter(dsl::id.eq(id)))
+            .execute(conn)
+            .await
+            .map(|n| n == 1)
+            .map_err(Into::into)
+    }
+}
+
+#[async_trait::async_trait]
+impl Retrieve<i64> for Timetable {
+    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
+    #[tracing::instrument(name = "model:retrieve<Timetable>", skip_all, err)]
+    async fn retrieve(
+        conn: &mut editoast_models::DbConnection,
+        id: i64,
+    ) -> crate::error::Result<Option<Timetable>> {
+        dsl::timetable_v2
+            .filter(dsl::id.eq(id))
+            .first::<Timetable>(conn)
+            .await
+            .optional()
+            .map_err(Into::into)
+    }
+}
+
+#[async_trait::async_trait]
+impl Exists<i64> for Timetable {
+    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
+    #[tracing::instrument(name = "model:exists<Timetable>", skip_all, ret, err)]
+    async fn exists(conn: &mut DbConnection, id: i64) -> Result<bool> {
+        Self::retrieve(conn, id)
+            .await
+            .map(|r| r.is_some())
+            .map_err(Into::into)
+    }
+}
+
+impl Identifiable<i64> for Timetable {
+    fn get_id(&self) -> i64 {
+        self.id
+    }
 }
 
 /// Should be used to retrieve a timetable with its trains
@@ -21,8 +83,6 @@ pub struct Timetable {
 pub struct TimetableWithTrains {
     #[diesel(sql_type = BigInt)]
     pub id: i64,
-    #[diesel(sql_type = Nullable<BigInt>)]
-    pub electrical_profile_set_id: Option<i64>,
     #[diesel(sql_type = Array<BigInt>)]
     pub train_ids: Vec<i64>,
 }
@@ -30,7 +90,6 @@ pub struct TimetableWithTrains {
 #[async_trait::async_trait]
 impl Retrieve<i64> for TimetableWithTrains {
     async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
-        use diesel_async::RunQueryDsl;
         let result = sql_query(
             "SELECT timetable_v2.*,
         array_remove(array_agg(train_schedule_v2.id), NULL) as train_ids
@@ -54,7 +113,6 @@ impl From<TimetableWithTrains> for Timetable {
     fn from(timetable_with_trains: TimetableWithTrains) -> Self {
         Self {
             id: timetable_with_trains.id,
-            electrical_profile_set_id: timetable_with_trains.electrical_profile_set_id,
         }
     }
 }

--- a/editoast/src/tables.rs
+++ b/editoast/src/tables.rs
@@ -489,6 +489,7 @@ diesel::table! {
         tags -> Array<Nullable<Text>>,
         timetable_id -> Int8,
         study_id -> Int8,
+        electrical_profile_set_id -> Nullable<Int8>,
     }
 }
 
@@ -639,7 +640,6 @@ diesel::table! {
 
     timetable_v2 (id) {
         id -> Int8,
-        electrical_profile_set_id -> Nullable<Int8>,
     }
 }
 
@@ -758,6 +758,7 @@ diesel::joinable!(scenario -> electrical_profile_set (electrical_profile_set_id)
 diesel::joinable!(scenario -> infra (infra_id));
 diesel::joinable!(scenario -> study (study_id));
 diesel::joinable!(scenario -> timetable (timetable_id));
+diesel::joinable!(scenario_v2 -> electrical_profile_set (electrical_profile_set_id));
 diesel::joinable!(scenario_v2 -> infra (infra_id));
 diesel::joinable!(scenario_v2 -> study (study_id));
 diesel::joinable!(scenario_v2 -> timetable_v2 (timetable_id));
@@ -768,7 +769,6 @@ diesel::joinable!(search_signal -> infra_object_signal (id));
 diesel::joinable!(search_study -> study (id));
 diesel::joinable!(simulation_output -> train_schedule (train_schedule_id));
 diesel::joinable!(study -> project (project_id));
-diesel::joinable!(timetable_v2 -> electrical_profile_set (electrical_profile_set_id));
 diesel::joinable!(train_schedule -> pathfinding (path_id));
 diesel::joinable!(train_schedule -> rolling_stock (rolling_stock_id));
 diesel::joinable!(train_schedule -> timetable (timetable_id));

--- a/editoast/src/views/rolling_stocks/mod.rs
+++ b/editoast/src/views/rolling_stocks/mod.rs
@@ -350,7 +350,7 @@ async fn update(
 #[derive(Deserialize, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
 struct DeleteRollingStockQueryParams {
-    /// force the deletion even if it’s used
+    /// force the deletion even if it's used
     #[serde(default)]
     force: bool,
 }

--- a/editoast/src/views/v2/scenario.rs
+++ b/editoast/src/views/v2/scenario.rs
@@ -78,6 +78,7 @@ struct ScenarioCreateForm {
     pub timetable_id: i64,
     #[serde(default)]
     pub tags: Tags,
+    pub electrical_profile_set_id: Option<i64>,
 }
 
 impl From<ScenarioCreateForm> for Changeset<Scenario> {
@@ -90,6 +91,7 @@ impl From<ScenarioCreateForm> for Changeset<Scenario> {
             .infra_id(scenario.infra_id)
             .timetable_id(scenario.timetable_id)
             .tags(scenario.tags)
+            .electrical_profile_set_id(scenario.electrical_profile_set_id)
     }
 }
 
@@ -297,6 +299,7 @@ struct ScenarioPatchForm {
     pub description: Option<String>,
     pub tags: Option<Tags>,
     pub infra_id: Option<i64>,
+    pub electrical_profile_set_id: Option<Option<i64>>,
 }
 
 impl From<ScenarioPatchForm> for <Scenario as crate::modelsv2::Model>::Changeset {
@@ -306,6 +309,7 @@ impl From<ScenarioPatchForm> for <Scenario as crate::modelsv2::Model>::Changeset
             .flat_description(scenario.description)
             .flat_tags(scenario.tags)
             .flat_infra_id(scenario.infra_id)
+            .flat_electrical_profile_set_id(scenario.electrical_profile_set_id)
             .last_modification(Utc::now().naive_utc())
     }
 }

--- a/editoast/src/views/v2/timetable/stdcm.rs
+++ b/editoast/src/views/v2/timetable/stdcm.rs
@@ -190,6 +190,7 @@ async fn stdcm(
         core_client.clone(),
         &trains,
         &infra,
+        None,
     )
     .await?;
 
@@ -414,6 +415,7 @@ async fn get_maximum_run_time(
         core_client,
         train_schedule,
         infra,
+        None,
     )
     .await?;
 

--- a/editoast/src/views/v2/train_schedule/projection.rs
+++ b/editoast/src/views/v2/train_schedule/projection.rs
@@ -53,6 +53,7 @@ crate::routes! {
 #[derive(Debug, Deserialize, ToSchema)]
 struct ProjectPathForm {
     infra_id: i64,
+    electrical_profile_set_id: Option<i64>,
     ids: HashSet<i64>,
     #[schema(inline)]
     path: ProjectPathInput,
@@ -132,6 +133,7 @@ async fn project_path(
         infra_id,
         ids: train_ids,
         path,
+        electrical_profile_set_id,
     } = data;
     let ProjectPathInput {
         track_section_ranges: path_track_ranges,
@@ -169,6 +171,7 @@ async fn project_path(
         core_client.clone(),
         &trains,
         &infra,
+        electrical_profile_set_id,
     )
     .await?;
 

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
+import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
 import { getSelectedTrainId } from 'reducers/osrdsimulation/selectors';
 
@@ -10,6 +10,8 @@ import { getSelectedTrainId } from 'reducers/osrdsimulation/selectors';
  */
 const useSimulationResults = () => {
   const infraId = useInfraID();
+  const { getElectricalProfileSetId } = useOsrdConfSelectors();
+  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
   const { data: selectedTrainSchedule } = osrdEditoastApi.endpoints.getV2TrainScheduleById.useQuery(
@@ -30,7 +32,7 @@ const useSimulationResults = () => {
 
   const { data: trainSimulation } =
     osrdEditoastApi.endpoints.getV2TrainScheduleByIdSimulation.useQuery(
-      { id: selectedTrainId as number, infraId: infraId as number },
+      { id: selectedTrainId as number, infraId: infraId as number, electricalProfileSetId },
       { skip: !selectedTrainId || !infraId }
     );
 

--- a/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { Pencil, Eye, EyeClosed, ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
+import { ChevronLeft, ChevronRight, Eye, EyeClosed, Pencil } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { GiElectric } from 'react-icons/gi';
@@ -25,7 +25,7 @@ import TimetableManageTrainScheduleV2 from 'modules/trainschedule/components/Man
 import TimetableV2 from 'modules/trainschedule/components/TimetableV2/TimetableV2';
 import type { RootState } from 'reducers';
 import { updateTrainIdUsedForProjection } from 'reducers/osrdsimulation/actions';
-import { getTrainIdUsedForProjection, getSelectedTrainId } from 'reducers/osrdsimulation/selectors';
+import { getSelectedTrainId, getTrainIdUsedForProjection } from 'reducers/osrdsimulation/selectors';
 import { useAppDispatch } from 'store';
 
 import { getSpaceTimeChartData, selectProjectionV2 } from './getSimulationResultsV2';
@@ -96,12 +96,13 @@ const ScenarioV2 = () => {
     if (isScenarioError && errorScenario) throw errorScenario;
   }, [isScenarioError, errorScenario]);
 
-  const { updateInfraID, updateTimetableID } = useOsrdConfActions();
+  const { updateInfraID, updateTimetableID, updateElectricalProfileSetId } = useOsrdConfActions();
 
   useEffect(() => {
     if (scenario) {
       dispatch(updateTimetableID(scenario.timetable_id));
       dispatch(updateInfraID(scenario.infra_id));
+      dispatch(updateElectricalProfileSetId(scenario.electrical_profile_set_id));
     }
   }, [scenario]);
 
@@ -113,8 +114,12 @@ const ScenarioV2 = () => {
   );
 
   const { data: conflicts } = osrdEditoastApi.endpoints.getV2TimetableByIdConflicts.useQuery(
-    { id: timetable?.id as number, infraId: infraId! },
-    { skip: !timetable || !infraId }
+    {
+      id: scenario?.timetable_id as number,
+      infraId: scenario?.infra_id as number,
+      electricalProfileSetId: scenario?.electrical_profile_set_id,
+    },
+    { skip: !scenario }
   );
 
   useEffect(() => {
@@ -131,7 +136,8 @@ const ScenarioV2 = () => {
         trainResultsToFetch ?? timetable.train_ids,
         trainIdUsedForProjection,
         infraId,
-        setTrainSpaceTimeData
+        setTrainSpaceTimeData,
+        scenario?.electrical_profile_set_id ?? undefined
       );
     }
   }, [timetable, trainIdUsedForProjection, infra]);
@@ -146,6 +152,7 @@ const ScenarioV2 = () => {
     () => () => {
       dispatch(updateTimetableID(undefined));
       dispatch(updateInfraID(undefined));
+      dispatch(updateElectricalProfileSetId(undefined));
       dispatch(updateTrainIdUsedForProjection(undefined));
     },
     []
@@ -228,8 +235,8 @@ const ScenarioV2 = () => {
                           <span className="mr-2">
                             <GiElectric />
                           </span>
-                          {timetable.electrical_profile_set_id
-                            ? timetable.electrical_profile_set_id
+                          {scenario.electrical_profile_set_id
+                            ? scenario.electrical_profile_set_id
                             : t('noElectricalProfileSet')}
                         </div>
                       </div>
@@ -324,8 +331,8 @@ const ScenarioV2 = () => {
                         <span className="mr-1">
                           <GiElectric />
                         </span>
-                        {timetable.electrical_profile_set_id
-                          ? timetable.electrical_profile_set_id
+                        {scenario.electrical_profile_set_id
+                          ? scenario.electrical_profile_set_id
                           : t('noElectricalProfileSet')}
                       </div>
                     </div>

--- a/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
+++ b/front/src/applications/operationalStudies/views/v2/getSimulationResultsV2.ts
@@ -4,8 +4,8 @@ import i18n from 'i18n';
 import { setFailure } from 'reducers/main';
 import {
   updateIsUpdating,
-  updateTrainIdUsedForProjection,
   updateSelectedTrainId,
+  updateTrainIdUsedForProjection,
 } from 'reducers/osrdsimulation/actions';
 import { store } from 'store';
 import { replaceElementAtIndex } from 'utils/array';
@@ -45,7 +45,8 @@ export const getSpaceTimeChartData = async (
   trainSchedulesIDs: number[],
   trainIdUsedForProjection: number,
   infraId: number,
-  setSpaceTimeData: React.Dispatch<React.SetStateAction<TrainSpaceTimeData[]>>
+  setSpaceTimeData: React.Dispatch<React.SetStateAction<TrainSpaceTimeData[]>>,
+  electricalProfileSetId?: number
 ) => {
   if (trainSchedulesIDs.length > 0) {
     store.dispatch(updateIsUpdating(true));
@@ -71,6 +72,7 @@ export const getSpaceTimeChartData = async (
                 infra_id: infraId,
                 ids: trainSchedulesIDs,
                 path: { blocks, routes, track_section_ranges },
+                electrical_profile_set_id: electricalProfileSetId,
               },
             })
           )

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -848,32 +848,13 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['scenariosv2'],
       }),
-      getV2Timetable: build.query<GetV2TimetableApiResponse, GetV2TimetableApiArg>({
-        query: (queryArg) => ({
-          url: `/v2/timetable`,
-          params: { page: queryArg.page, page_size: queryArg.pageSize },
-        }),
-        providesTags: ['timetablev2'],
-      }),
       postV2Timetable: build.mutation<PostV2TimetableApiResponse, PostV2TimetableApiArg>({
-        query: (queryArg) => ({
-          url: `/v2/timetable`,
-          method: 'POST',
-          body: queryArg.timetableForm,
-        }),
+        query: () => ({ url: `/v2/timetable`, method: 'POST' }),
         invalidatesTags: ['timetablev2'],
       }),
       getV2TimetableById: build.query<GetV2TimetableByIdApiResponse, GetV2TimetableByIdApiArg>({
         query: (queryArg) => ({ url: `/v2/timetable/${queryArg.id}` }),
         providesTags: ['timetablev2'],
-      }),
-      putV2TimetableById: build.mutation<PutV2TimetableByIdApiResponse, PutV2TimetableByIdApiArg>({
-        query: (queryArg) => ({
-          url: `/v2/timetable/${queryArg.id}`,
-          method: 'PUT',
-          body: queryArg.timetableForm,
-        }),
-        invalidatesTags: ['timetablev2'],
       }),
       deleteV2TimetableById: build.mutation<
         DeleteV2TimetableByIdApiResponse,
@@ -888,7 +869,10 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: `/v2/timetable/${queryArg.id}/conflicts`,
-          params: { infra_id: queryArg.infraId },
+          params: {
+            infra_id: queryArg.infraId,
+            electrical_profile_set_id: queryArg.electricalProfileSetId,
+          },
         }),
         providesTags: ['timetablev2'],
       }),
@@ -982,7 +966,10 @@ const injectedRtkApi = api
       >({
         query: (queryArg) => ({
           url: `/v2/train_schedule/${queryArg.id}/simulation`,
-          params: { infra_id: queryArg.infraId },
+          params: {
+            infra_id: queryArg.infraId,
+            electrical_profile_set_id: queryArg.electricalProfileSetId,
+          },
         }),
         providesTags: ['train_schedulev2'],
       }),
@@ -1491,7 +1478,7 @@ export type DeleteRollingStockByRollingStockIdApiResponse =
   /** status 204 The rolling stock was deleted successfully */ void;
 export type DeleteRollingStockByRollingStockIdApiArg = {
   rollingStockId: number;
-  /** force the deletion even if it’s used */
+  /** force the deletion even if it's used */
   force?: boolean;
 };
 export type PatchRollingStockByRollingStockIdApiResponse =
@@ -1695,30 +1682,14 @@ export type PatchV2ProjectsByProjectIdStudiesAndStudyIdScenariosScenarioIdApiArg
   scenarioId: number;
   scenarioPatchFormV2: ScenarioPatchFormV2;
 };
-export type GetV2TimetableApiResponse = /** status 200 List timetables */ PaginationStats & {
-  results: TimetableResult[];
-};
-export type GetV2TimetableApiArg = {
-  page?: number;
-  pageSize?: number | null;
-};
 export type PostV2TimetableApiResponse =
   /** status 200 Timetable with train schedules ids */ TimetableResult;
-export type PostV2TimetableApiArg = {
-  timetableForm: TimetableForm;
-};
+export type PostV2TimetableApiArg = void;
 export type GetV2TimetableByIdApiResponse =
   /** status 200 Timetable with train schedules ids */ TimetableDetailedResult;
 export type GetV2TimetableByIdApiArg = {
   /** A timetable ID */
   id: number;
-};
-export type PutV2TimetableByIdApiResponse =
-  /** status 200 Timetable with train schedules ids */ TimetableDetailedResult;
-export type PutV2TimetableByIdApiArg = {
-  /** A timetable ID */
-  id: number;
-  timetableForm: TimetableForm;
 };
 export type DeleteV2TimetableByIdApiResponse = unknown;
 export type DeleteV2TimetableByIdApiArg = {
@@ -1731,6 +1702,7 @@ export type GetV2TimetableByIdConflictsApiArg = {
   /** A timetable ID */
   id: number;
   infraId: number;
+  electricalProfileSetId?: number | null;
 };
 export type PostV2TimetableByIdStdcmApiResponse = /** status 201 The simulation result */
   | {
@@ -1810,6 +1782,7 @@ export type PostV2TrainScheduleSimulationSummaryApiResponse =
   };
 export type PostV2TrainScheduleSimulationSummaryApiArg = {
   body: {
+    electrical_profile_set_id?: number | null;
     ids: number[];
     infra_id: number;
   };
@@ -1839,6 +1812,7 @@ export type GetV2TrainScheduleByIdSimulationApiArg = {
   /** A train schedule ID */
   id: number;
   infraId: number;
+  electricalProfileSetId?: number;
 };
 export type GetVersionApiResponse = /** status 200 Return the service version */ Version;
 export type GetVersionApiArg = void;
@@ -3537,6 +3511,7 @@ export type ScenarioWithDetails = Scenario & {
 export type ScenarioV2 = {
   creation_date: string;
   description: string;
+  electrical_profile_set_id?: number;
   id: number;
   infra_id: number;
   last_modification: string;
@@ -3553,6 +3528,7 @@ export type ScenarioResponseV2 = ScenarioV2 & {
 };
 export type ScenarioCreateFormV2 = {
   description?: string;
+  electrical_profile_set_id?: number | null;
   infra_id: number;
   name: string;
   tags?: Tags;
@@ -3560,21 +3536,16 @@ export type ScenarioCreateFormV2 = {
 };
 export type ScenarioPatchFormV2 = {
   description?: string | null;
+  electrical_profile_set_id?: number | null;
   infra_id?: number | null;
   name?: string | null;
   tags?: Tags | null;
 };
 export type TimetableResult = {
-  electrical_profile_set_id?: number | null;
-  id: number;
-};
-export type TimetableForm = {
-  electrical_profile_set_id?: number | null;
+  timetable_id: number;
 };
 export type TimetableDetailedResult = {
-  electrical_profile_set_id?: number | null;
-  id: number;
-} & {
+  timetable_id: number;
   train_ids: number[];
 };
 export type ConflictV2 = {
@@ -3738,6 +3709,7 @@ export type ProjectPathTrainResult = {
   rolling_stock_length: number;
 };
 export type ProjectPathForm = {
+  electrical_profile_set_id?: number | null;
   ids: number[];
   infra_id: number;
   /** Project path input is described by a list of routes and a list of track range */

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -160,10 +160,7 @@ export default function AddOrEditScenarioModal({
       setDisplayErrors(true);
     } else if (projectId && studyId && currentScenario && currentScenario.name) {
       const ids = { projectId, studyId };
-      const timetable = await postTimetableV2({
-        timetableForm: { electrical_profile_set_id: currentScenario.electrical_profile_set_id },
-      }).unwrap();
-
+      const timetable = await postTimetableV2().unwrap();
       postScenarioV2({
         ...ids,
         scenarioCreateFormV2: {
@@ -171,7 +168,8 @@ export default function AddOrEditScenarioModal({
           infra_id: currentScenario.infra_id,
           name: currentScenario.name,
           tags: currentScenario.tags || [],
-          timetable_id: timetable.id,
+          timetable_id: timetable.timetable_id,
+          electrical_profile_set_id: currentScenario.electrical_profile_set_id,
         },
       })
         .unwrap()

--- a/front/src/modules/scenario/components/ScenarioCard.tsx
+++ b/front/src/modules/scenario/components/ScenarioCard.tsx
@@ -14,12 +14,12 @@ import { updateSelectedProjection } from 'reducers/osrdsimulation/actions';
 import { useAppDispatch } from 'store';
 import { dateTimeFormatting } from 'utils/date';
 
-type StudyCardProps = {
+type ScenarioCardProps = {
   setFilterChips: (filterChips: string) => void;
   scenario: ScenarioWithCountTrains;
 };
 
-export default function StudyCard({ setFilterChips, scenario }: StudyCardProps) {
+export default function ScenarioCard({ setFilterChips, scenario }: ScenarioCardProps) {
   const { t } = useTranslation('operationalStudies/study');
   const navigate = useNavigate();
   const dispatch = useAppDispatch();

--- a/front/src/modules/trainschedule/components/TimetableV2/hooks.ts
+++ b/front/src/modules/trainschedule/components/TimetableV2/hooks.ts
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 
 import dayjs from 'dayjs';
 import { uniq } from 'lodash';
+import { useSelector } from 'react-redux';
 
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { SimulationSummaryResult, TrainScheduleResult } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
-import { isoDateToMs, formatToIsoDate } from 'utils/date';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
+import { formatToIsoDate, isoDateToMs } from 'utils/date';
 import { jouleToKwh } from 'utils/physics';
 import { formatKmValue } from 'utils/strings';
 import { ISO8601Duration2sec } from 'utils/timeManipulation';
@@ -34,6 +35,8 @@ const useTrainSchedulesDetails = (
   selectedTags: Set<string | null>
 ) => {
   const infraId = useInfraID();
+  const { getElectricalProfileSetId } = useOsrdConfSelectors();
+  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
 
   const [uniqueTags, setUniqueTags] = useState<string[]>([]);
 
@@ -43,6 +46,7 @@ const useTrainSchedulesDetails = (
         body: {
           infra_id: infraId as number,
           ids: trainIds,
+          electrical_profile_set_id: electricalProfileSetId,
         },
       },
       {

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
@@ -168,6 +168,20 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
     expect(state.timetableID).toBe(newTimetableID);
   });
 
+  it('should handle updateElectricalProfileSetId with number', () => {
+    const newElectricalProfileSetId = 1;
+    defaultStore.dispatch(slice.actions.updateElectricalProfileSetId(newElectricalProfileSetId));
+    const state = defaultStore.getState()[slice.name];
+    expect(state.electricalProfileSetId).toBe(newElectricalProfileSetId);
+  });
+
+  it('should handle updateElectricalProfileSetId with undefined', () => {
+    const newElectricalProfileSetId = undefined;
+    defaultStore.dispatch(slice.actions.updateElectricalProfileSetId(newElectricalProfileSetId));
+    const state = defaultStore.getState()[slice.name];
+    expect(state.electricalProfileSetId).toBe(undefined);
+  });
+
   it('should handle updateRollingStockID', () => {
     const newRollingStockID = 1;
     defaultStore.dispatch(slice.actions.updateRollingStockID(newRollingStockID));

--- a/front/src/reducers/osrdconf/osrdConfCommon/index.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/index.ts
@@ -35,6 +35,7 @@ export const defaultCommonConf: OsrdConfState = {
   scenarioID: undefined,
   pathfindingID: undefined,
   timetableID: undefined,
+  electricalProfileSetId: undefined,
   rollingStockID: undefined,
   rollingStockComfort: 'STANDARD' as const,
   powerRestrictionRanges: [],
@@ -79,6 +80,7 @@ interface CommonConfReducers<S extends OsrdConfState> extends InfraStateReducers
   ['updateScenarioID']: CaseReducer<S, PayloadAction<S['scenarioID']>>;
   ['updatePathfindingID']: CaseReducer<S, PayloadAction<S['pathfindingID']>>;
   ['updateTimetableID']: CaseReducer<S, PayloadAction<S['timetableID']>>;
+  ['updateElectricalProfileSetId']: CaseReducer<S, PayloadAction<S['electricalProfileSetId']>>;
   ['updateRollingStockID']: CaseReducer<S, PayloadAction<S['rollingStockID']>>;
   ['updateRollingStockComfort']: CaseReducer<S, PayloadAction<S['rollingStockComfort']>>;
   ['updateSpeedLimitByTag']: CaseReducer<S, PayloadAction<S['speedLimitByTag'] | null>>;
@@ -180,6 +182,12 @@ export function buildCommonConfReducers<S extends OsrdConfState>(): CommonConfRe
     },
     updateTimetableID(state: Draft<S>, action: PayloadAction<S['timetableID']>) {
       state.timetableID = action.payload;
+    },
+    updateElectricalProfileSetId(
+      state: Draft<S>,
+      action: PayloadAction<S['electricalProfileSetId']>
+    ) {
+      state.electricalProfileSetId = action.payload;
     },
     updateRollingStockID(state: Draft<S>, action: PayloadAction<S['rollingStockID']>) {
       state.rollingStockID = action.payload;

--- a/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
@@ -40,6 +40,7 @@ const buildCommonConfSelectors = <ConfState extends OsrdConfState>(
     getScenarioID: makeOsrdConfSelector('scenarioID'),
     getPathfindingID: makeOsrdConfSelector('pathfindingID'),
     getTimetableID: makeOsrdConfSelector('timetableID'),
+    getElectricalProfileSetId: makeOsrdConfSelector('electricalProfileSetId'),
     getRollingStockID: makeOsrdConfSelector('rollingStockID'),
     getRollingStockComfort: makeOsrdConfSelector('rollingStockComfort'),
     getSpeedLimitByTag: makeOsrdConfSelector('speedLimitByTag'),

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -1,6 +1,6 @@
 import type { Feature, Position } from 'geojson';
 
-import type { PowerRestrictionRange, PointOnMap } from 'applications/operationalStudies/consts';
+import type { PointOnMap, PowerRestrictionRange } from 'applications/operationalStudies/consts';
 import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
 import type {
   AllowanceValue,
@@ -28,6 +28,7 @@ export interface OsrdConfState extends InfraState {
   scenarioID?: number;
   pathfindingID?: number;
   timetableID?: number;
+  electricalProfileSetId?: number;
   rollingStockID?: number;
   speedLimitByTag?: string;
   // TODO: update the call to the api, to rename the fields begin & end -> begin_position & end_position

--- a/front/tests/004-scenario-management.spec.ts
+++ b/front/tests/004-scenario-management.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { Infra, Project, Scenario, Study, Timetable } from 'common/api/osrdEditoastApi';
+import type { Infra, Project, Scenario, Study, TimetableResult } from 'common/api/osrdEditoastApi';
 
 import scenarioData from './assets/operationStudies/scenario.json';
 import CommonPage from './pages/common-page-model';
@@ -13,7 +13,7 @@ let smallInfra: Infra;
 let project: Project;
 let study: Study;
 let scenario: Scenario;
-let timetable: Timetable;
+let timetableResult: TimetableResult;
 
 test.beforeAll(async () => {
   smallInfra = (await getInfra()) as Infra;
@@ -22,15 +22,14 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async () => {
-  timetable = await postApiRequest(`/api/v2/timetable/`, {
-    electrical_profile_set_id: null,
-  });
+  timetableResult = await postApiRequest(`/api/v2/timetable/`);
   scenario = await postApiRequest(`/api/v2/projects/${project.id}/studies/${study.id}/scenarios`, {
     ...scenarioData,
     name: `${scenarioData.name} ${uuidv4()}`,
     study_id: study.id,
     infra_id: smallInfra.id,
-    timetable_id: timetable.id,
+    timetable_id: timetableResult.timetable_id,
+    electrical_profile_set_id: null,
   });
 });
 

--- a/front/tests/005-operational-studies.spec.ts
+++ b/front/tests/005-operational-studies.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
@@ -7,21 +7,21 @@ import type {
   RollingStock,
   Scenario,
   Study,
-  Timetable,
+  TimetableResult,
 } from 'common/api/osrdEditoastApi';
 
 import scenarioData from './assets/operationStudies/scenario.json';
 import HomePage from './pages/home-page-model';
 import RollingStockSelectorPage from './pages/rollingstock-selector-page';
 import ScenarioPage from './pages/scenario-page-model';
-import { getProject, getStudy, getRollingStock, postApiRequest, getInfra } from './utils/index';
+import { getInfra, getProject, getRollingStock, getStudy, postApiRequest } from './utils/index';
 
 let smallInfra: Infra;
 let project: Project;
 let study: Study;
 let scenario: Scenario;
 let rollingStock: RollingStock;
-let timetable: Timetable;
+let timetableResult: TimetableResult;
 
 test.beforeAll(async () => {
   smallInfra = (await getInfra()) as Infra;
@@ -31,15 +31,14 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async () => {
-  timetable = await postApiRequest(`/api/v2/timetable/`, {
-    electrical_profile_set_id: null,
-  });
+  timetableResult = await postApiRequest(`/api/v2/timetable/`);
   scenario = await postApiRequest(`/api/v2/projects/${project.id}/studies/${study.id}/scenarios`, {
     ...scenarioData,
     name: `${scenarioData.name} ${uuidv4()}`,
     study_id: study.id,
     infra_id: smallInfra.id,
-    timetable_id: timetable.id,
+    timetable_id: timetableResult.timetable_id,
+    electrical_profile_set_id: null,
   });
 });
 

--- a/front/tests/007-op-rollingstock-tab.spec.ts
+++ b/front/tests/007-op-rollingstock-tab.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import type {
@@ -7,21 +7,21 @@ import type {
   RollingStock,
   Scenario,
   Study,
-  Timetable,
+  TimetableResult,
 } from 'common/api/osrdEditoastApi';
 
 import scenarioData from './assets/operationStudies/scenario.json';
 import OperationalStudiesPage from './pages/operational-studies-page-model';
 import RollingStockSelectorPage from './pages/rollingstock-selector-page';
 import ScenarioPage from './pages/scenario-page-model';
-import { getProject, getStudy, getRollingStock, postApiRequest, getInfra } from './utils/index';
+import { getInfra, getProject, getRollingStock, getStudy, postApiRequest } from './utils/index';
 
 let smallInfra: Infra;
 let project: Project;
 let study: Study;
 let scenario: Scenario;
 let rollingStock: RollingStock;
-let timetable: Timetable;
+let timetableResult: TimetableResult;
 
 const dualModeRollingStockName = 'dual-mode_rollingstock_test_e2e';
 const electricRollingStockName = 'rollingstock_1500_25000_test_e2e';
@@ -33,15 +33,13 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async () => {
-  timetable = await postApiRequest(`/api/v2/timetable/`, {
-    electrical_profile_set_id: null,
-  });
+  timetableResult = await postApiRequest(`/api/v2/timetable/`);
   scenario = await postApiRequest(`/api/v2/projects/${project.id}/studies/${study.id}/scenarios/`, {
     ...scenarioData,
     name: `${scenarioData.name} ${uuidv4()}`,
     study_id: study.id,
     infra_id: smallInfra.id,
-    timetable_id: timetable.id,
+    timetable_id: timetableResult.timetable_id,
   });
 });
 

--- a/front/tests/010-op-route-tab.spec.ts
+++ b/front/tests/010-op-route-tab.spec.ts
@@ -1,19 +1,19 @@
 import { test } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { Infra, Project, Scenario, Study, Timetable } from 'common/api/osrdEditoastApi';
+import type { Infra, Project, Scenario, Study, TimetableResult } from 'common/api/osrdEditoastApi';
 
 import scenarioData from './assets/operationStudies/scenario.json';
 import HomePage from './pages/home-page-model';
 import OperationalStudiesPage from './pages/operational-studies-page-model';
 import ScenarioPage from './pages/scenario-page-model';
-import { getProject, getStudy, postApiRequest, getInfra } from './utils/index';
+import { getInfra, getProject, getStudy, postApiRequest } from './utils/index';
 
 let smallInfra: Infra;
 let project: Project;
 let study: Study;
 let scenario: Scenario;
-let timetable: Timetable;
+let timetableResult: TimetableResult;
 let selectedLanguage: string;
 
 const electricRollingStockName = 'rollingstock_1500_25000_test_e2e';
@@ -25,15 +25,13 @@ test.beforeAll(async () => {
 });
 
 test.beforeEach(async ({ page }) => {
-  timetable = await postApiRequest(`/api/v2/timetable/`, {
-    electrical_profile_set_id: null,
-  });
+  timetableResult = await postApiRequest(`/api/v2/timetable/`);
   scenario = await postApiRequest(`/api/v2/projects/${project.id}/studies/${study.id}/scenarios/`, {
     ...scenarioData,
     name: `${scenarioData.name} ${uuidv4()}`,
     study_id: study.id,
     infra_id: smallInfra.id,
-    timetable_id: timetable.id,
+    timetable_id: timetableResult.timetable_id,
   });
 
   // Navigate to the home page and set up the required settings

--- a/front/tests/global-setup.ts
+++ b/front/tests/global-setup.ts
@@ -61,16 +61,15 @@ async function createDataForTests() {
     budget: 1234567890,
   } as StudyCreateForm);
 
-  const timetable = await postApiRequest(`/api/v2/timetable/`, {
-    electrical_profile_set_id: null,
-  });
+  const timetableResult = await postApiRequest(`/api/v2/timetable/`);
 
   await postApiRequest(`/api/v2/projects/${project.id}/studies/${study.id}/scenarios`, {
     ...scenarioData,
     name: `${scenarioData.name} ${uuidv4()}`,
     study_id: study.id,
     infra_id: smallInfra.id,
-    timetable_id: timetable.id,
+    timetable_id: timetableResult.timetable_id,
+    electrical_profile_set_id: null,
   });
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional
+from typing import Dict, Iterable, Iterator, List, Optional
 
 import pytest
 import requests
@@ -10,7 +10,6 @@ from tests.path import Path as TrainPath
 from tests.scenario import Scenario
 from tests.services import EDITOAST_URL
 from tests.test_e2e import FAST_ROLLING_STOCK_JSON_PATH, TestRollingStock
-from tests.timetable_v2 import TimetableV2
 from tests.utils.timetable import create_scenario, create_scenario_v2
 
 
@@ -127,7 +126,7 @@ def create_fast_rolling_stocks(test_rolling_stocks: Optional[List[TestRollingSto
 
 
 @pytest.fixture
-def fast_rolling_stocks(request: Any) -> Iterator[Iterable[int]]:
+def fast_rolling_stocks(request: pytest.FixtureRequest) -> Iterator[Iterable[int]]:
     ids = create_fast_rolling_stocks(request.node.get_closest_marker("names_and_metadata").args[0])
     yield ids
     for id in ids:
@@ -242,13 +241,8 @@ def west_to_south_east_simulations(
 
 
 @pytest.fixture
-def timetable_v2() -> TimetableV2:
-    timetable_payload = {}
-    r = requests.post(
-        f"{EDITOAST_URL}v2/timetable/",
-        json=timetable_payload,
-    )
-    if r.status_code // 100 != 2:
-        err = f"Error creating timetable {r.status_code}: {r.content}, payload={json.dumps(timetable_payload)}"
-        raise RuntimeError(err)
-    return TimetableV2(**r.json())
+def timetable_v2_id() -> int:
+    r = requests.post(f"{EDITOAST_URL}v2/timetable/")
+    if not r.ok:
+        raise RuntimeError(f"Error creating timetable {r.status_code}: {r.content}")
+    return r.json()["timetable_id"]

--- a/tests/tests/test_timetable_v2.py
+++ b/tests/tests/test_timetable_v2.py
@@ -3,18 +3,15 @@ import requests
 
 from .infra import Infra
 from .services import EDITOAST_URL
-from .timetable_v2 import TimetableV2
 
 
 def test_get_timetable_v2(
-    timetable_v2: TimetableV2,
+    timetable_v2_id: int,
 ):
-    timetable_id = timetable_v2.id
-
-    response = requests.get(f"{EDITOAST_URL}/v2/timetable/{timetable_id}/")
+    response = requests.get(f"{EDITOAST_URL}/v2/timetable/{timetable_v2_id}/")
     assert response.status_code == 200
     json = response.json()
-    assert "id" in json
+    assert "timetable_id" in json
     assert "train_ids" in json
 
 
@@ -23,7 +20,7 @@ def test_get_timetable_v2(
 )
 def test_conflicts(
     small_infra: Infra,
-    timetable_v2: TimetableV2,
+    timetable_v2_id: int,
     fast_rolling_stock: int,
     on_stop_signal: bool,
     expected_conflict_types: set[str],
@@ -58,7 +55,7 @@ def test_conflicts(
         }
     ]
     response = requests.post(
-        f"{EDITOAST_URL}/v2/timetable/{timetable_v2.id}/train_schedule", json=train_schedule_payload
+        f"{EDITOAST_URL}/v2/timetable/{timetable_v2_id}/train_schedule", json=train_schedule_payload
     )
     train_schedule_payload = [
         {
@@ -87,9 +84,9 @@ def test_conflicts(
         }
     ]
     response = requests.post(
-        f"{EDITOAST_URL}/v2/timetable/{timetable_v2.id}/train_schedule", json=train_schedule_payload
+        f"{EDITOAST_URL}/v2/timetable/{timetable_v2_id}/train_schedule", json=train_schedule_payload
     )
-    response = requests.get(f"{EDITOAST_URL}/v2/timetable/{timetable_v2.id}/conflicts/?infra_id={small_infra.id}")
+    response = requests.get(f"{EDITOAST_URL}/v2/timetable/{timetable_v2_id}/conflicts/?infra_id={small_infra.id}")
     assert response.status_code == 200
     actual_conflicts = {conflict["conflict_type"] for conflict in response.json()}
     assert actual_conflicts == expected_conflict_types
@@ -97,7 +94,7 @@ def test_conflicts(
 
 def test_scheduled_points_with_incompatible_margins(
     small_infra: Infra,
-    timetable_v2: TimetableV2,
+    timetable_v2_id: int,
     fast_rolling_stock: int,
 ):
     requests.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
@@ -130,7 +127,7 @@ def test_scheduled_points_with_incompatible_margins(
         }
     ]
     response = requests.post(
-        f"{EDITOAST_URL}/v2/timetable/{timetable_v2.id}/train_schedule", json=train_schedule_payload
+        f"{EDITOAST_URL}/v2/timetable/{timetable_v2_id}/train_schedule", json=train_schedule_payload
     )
     response.raise_for_status()
     train_id = response.json()[0]["id"]

--- a/tests/tests/timetable_v2.py
+++ b/tests/tests/timetable_v2.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-from typing import Optional
-
-
-@dataclass(frozen=True)
-class TimetableV2:
-    id: int
-    electrical_profile_set_id: Optional[int] = None
-    train_ids: Optional[list[int]] = None

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -27,11 +27,11 @@ def create_scenario(editoast_url, infra_id, project_id, op_study_id) -> Tuple[in
 
 def create_scenario_v2(editoast_url: str, infra_id: int, project_id: int, op_study_id: int) -> Tuple[int, int]:
     # Create the timetable
-    r = requests.post(editoast_url + "v2/timetable/", json={})
+    r = requests.post(editoast_url + "v2/timetable/")
     if r.status_code // 100 != 2:
         err = f"Error creating timetable {r.status_code}: {r.content}"
         raise RuntimeError(err)
-    timetable_id = r.json()["id"]
+    timetable_id = r.json()["timetable_id"]
 
     # Create the scenario
     scenario_payload = {
@@ -43,5 +43,4 @@ def create_scenario_v2(editoast_url: str, infra_id: int, project_id: int, op_stu
         editoast_url + f"v2/projects/{project_id}/studies/{op_study_id}/scenarios/", json=scenario_payload
     )
     r.raise_for_status()
-    timetable_id = r.json()["timetable_id"]
     return r.json()["id"], timetable_id


### PR DESCRIPTION
> [!Warning]
> For editoast please review only the first commit

The timetable model gets a ton of changes in editoast because the `ModelV2` derive does not handle struct with only primary keys.
Indeed, the derive creates a `TimetableV2Changeset` struct, with no fields, and a struct with no field can not derive `AsChangeset` and `Insertable` from `diesel`.
With @leovalais we checked the following solutions:
* implementing the diesel traits manually on `TimetableV2Changeset`: impossible due to the way they're made
* update the derive so in the case there are only primary keys in the struct, we do not rely on a `TimetableV2Changeset` struct: this would complexify the derive a lot for a single and simple use, we deemed it overkill.
* updating the derive so that you could pick which parts of the CRUD you wish to be automatically derived: most desirable but very havy in resources, should come at some point
* implementing the `ModelV2` traits manually: the solution we selected.

I removed the timetable listing endpoint because it was unused, because the `List` trait required the struct to be a `Model` (which it isn't anymore), and because a list of only ids did not seem very exploitable...