### PR TITLE
front: send track offset in mm in stdcm request

### DIFF
--- a/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
@@ -12,6 +12,7 @@ import type { InfraState } from 'reducers/infra';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
 import { dateTimeToIso } from 'utils/date';
+import { mToMm } from 'utils/physics';
 import { ISO8601Duration2sec, sec2ms, time2sec } from 'utils/timeManipulation';
 
 import createMargin from './createMargin';
@@ -128,6 +129,7 @@ export const checkStdcmConf = (
       const {
         id,
         arrival,
+        deleted,
         locked,
         stopFor,
         positionOnPath,
@@ -141,10 +143,19 @@ export const checkStdcmConf = (
         ...stepLocation
       } = step;
 
-      const secondary_code = 'trigram' in stepLocation || 'uic' in stepLocation ? ch : undefined;
+      const duration = stopFor ? sec2ms(ISO8601Duration2sec(stopFor) || Number(stopFor)) : 0;
 
+      if ('track' in stepLocation) {
+        return {
+          duration,
+          location: { track: stepLocation.track, offset: mToMm(stepLocation.offset) },
+        };
+      }
+
+      const secondary_code = 'trigram' in stepLocation || 'uic' in stepLocation ? ch : undefined;
       return {
-        duration: stopFor ? sec2ms(ISO8601Duration2sec(stopFor) || Number(stopFor)) : 0,
+        duration,
+        // TODO DROP V1: we should store the offset in mm in the store
         location: { ...stepLocation, secondary_code },
       };
     }),

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
@@ -5,7 +5,7 @@ import type { Dispatch } from 'redux';
 import type { ValidConfig } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { setFailure } from 'reducers/main';
 import type { OsrdConfState } from 'reducers/osrdconf/types';
-import { kmhToMs } from 'utils/physics';
+import { kmhToMs, mToMm } from 'utils/physics';
 
 import formatMargin from './formatMargin';
 import formatSchedule from './formatSchedule';
@@ -147,9 +147,17 @@ const checkCurrentConfig = (
         kp,
         onStopSignal,
         theoreticalMargin,
-        ...path
+        ...stepLocation
       } = step;
-      return { ...path, secondary_code: ch };
+
+      if ('track' in stepLocation) {
+        return {
+          ...stepLocation,
+          // TODO drop V1: we should store the offset in mm in the store
+          offset: mToMm(stepLocation.offset),
+        };
+      }
+      return { ...stepLocation, secondary_code: ch };
     }),
 
     margins: formatMargin(compact(pathSteps)),


### PR DESCRIPTION
closes #7646
closes #7955
closes #8026 

When adding/updating a train or launching a stdcm request, the track offsets were sent in meters instead of mm.