### PR TITLE
front: fix app crash when switching too quickly on the times and stops tab

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -39,13 +39,6 @@ const TimesStops = ({
 }: TimesStopsProps) => {
   const isInputTable = tableType === TableType.Input;
   const { t } = useTranslation('timesStops');
-  if (!allWaypoints) {
-    return (
-      <div className="d-flex justify-content-center align-items-center h-100">
-        <p className="pt-1 px-5">{t('noPathLoaded')}</p>
-      </div>
-    );
-  }
 
   const dispatch = useAppDispatch();
   const { upsertViaFromSuggestedOP } = useOsrdConfActions();
@@ -53,17 +46,27 @@ const TimesStops = ({
   const [rows, setRows] = useState<PathWaypointRow[]>([]);
 
   useEffect(() => {
-    const suggestedOPs = formatSuggestedViasToRowVias(
-      allWaypoints,
-      pathSteps,
-      t,
-      startTime,
-      tableType
-    );
-    setRows(suggestedOPs);
+    if (allWaypoints) {
+      const suggestedOPs = formatSuggestedViasToRowVias(
+        allWaypoints,
+        pathSteps,
+        t,
+        startTime,
+        tableType
+      );
+      setRows(suggestedOPs);
+    }
   }, [allWaypoints, pathSteps, startTime]);
 
   const columns = useTimeStopsColumns(tableType, allWaypoints);
+
+  if (!allWaypoints) {
+    return (
+      <div className="d-flex justify-content-center align-items-center h-100">
+        <p className="pt-1 px-5">{t('noPathLoaded')}</p>
+      </div>
+    );
+  }
 
   return (
     <DynamicDataSheetGrid

--- a/front/src/modules/timesStops/hooks/useTimeStopsColumns.ts
+++ b/front/src/modules/timesStops/hooks/useTimeStopsColumns.ts
@@ -23,7 +23,7 @@ const timeColumn: Partial<Column<string | null | undefined, string, string>> = {
 
 const fixedWidth = (width: number) => ({ minWidth: width, maxWidth: width });
 
-export const useTimeStopsColumns = (tableType: TableType, allWaypoints: SuggestedOP[]) => {
+export const useTimeStopsColumns = (tableType: TableType, allWaypoints: SuggestedOP[] = []) => {
   const { t } = useTranslation('timesStops');
   const columns = useMemo<Column<PathWaypointRow>[]>(() => {
     const isOutputTable = tableType === TableType.Output;


### PR DESCRIPTION
closes #8114 
closes #8120

The app crashes because in some cases, the app render more hooks than during the previous render. The early return in TimesStops need to be moved after all the hooks of the file.