### PR TITLE
core: stdcm: extract min time from heuristic

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -49,7 +49,7 @@ class STDCMHeuristicBuilder(
     /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
     @WithSpan(value = "Initializing STDCM heuristic", kind = SpanKind.SERVER)
     @Trace(operationName = "Initializing STDCM heuristic")
-    fun build(): STDCMAStarHeuristic {
+    fun build(): Pair<STDCMAStarHeuristic, Double> {
         logger.info("Start building STDCM heuristic...")
         // One map per number of reached pathfinding step
         // maps[n][block] = min time it takes to go from the start of the block to the destination,
@@ -86,7 +86,7 @@ class STDCMHeuristicBuilder(
             } ?: Double.POSITIVE_INFINITY
         logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
 
-        return res@{ edge, offset, nPassedSteps ->
+        val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedSteps ->
             if (nPassedSteps >= steps.size - 1) return@res 0.0
             val lookahead = edge.infraExplorer.getLookahead()
             val currentBlock = edge.block
@@ -121,6 +121,7 @@ class STDCMHeuristicBuilder(
 
             return@res remainingTime
         }
+        return Pair(heuristic, bestTravelTime)
     }
 
     /** Describes a pending block, ready to be added to the cached blocks. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -101,7 +101,8 @@ data class STDCMEdge(
                 stopDuration,
                 firstStopAfterIndex.plannedTimingData,
                 previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(this, locationOnEdge, newWaypointIndex)
+                timeSinceDeparture,
+                graph.remainingTimeEstimator.invoke(this, locationOnEdge, newWaypointIndex),
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.FixedTime
 import fr.sncf.osrd.graph.Graph
+import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
@@ -51,16 +52,9 @@ class STDCMGraph(
     // min 4 minutes between two edges, determined empirically
     private val visitedNodes = VisitedNodes(4 * 60.0)
 
-    // Initialize the A* heuristic
-    val remainingTimeEstimator =
-        STDCMHeuristicBuilder(
-                fullInfra.blockInfra,
-                fullInfra.rawInfra,
-                steps,
-                maxRunTime,
-                rollingStock
-            )
-            .build()
+    // A* heuristic
+    val remainingTimeEstimator: STDCMAStarHeuristic
+    val bestPossibleTime: Double
 
     /** Constructor */
     init {
@@ -74,6 +68,17 @@ class STDCMGraph(
         assert(standardAllowance !is FixedTime) {
             "Standard allowance cannot be a flat time for STDCM trains"
         }
+        val heuristicBuilderResult =
+            STDCMHeuristicBuilder(
+                    fullInfra.blockInfra,
+                    fullInfra.rawInfra,
+                    steps,
+                    maxRunTime,
+                    rollingStock
+                )
+                .build()
+        remainingTimeEstimator = heuristicBuilderResult.first
+        bestPossibleTime = heuristicBuilderResult.second
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -38,7 +38,7 @@ data class STDCMNode(
     // departure time.
     val timeSinceDeparture: Double,
     // Estimation of the min time it takes to reach the end from this node
-    var remainingTimeEstimation: Double = 0.0,
+    var remainingTimeEstimation: Double,
 ) : Comparable<STDCMNode> {
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -221,7 +221,8 @@ class STDCMPathfinding(
                         firstStep.duration,
                         firstStep.plannedTimingData,
                         null,
-                        0.0
+                        0.0,
+                        graph.bestPossibleTime
                     )
                 res.add(node)
             }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -73,6 +73,7 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
+                .first
 
         assertEquals(
             400.0 - 50.0,
@@ -152,6 +153,7 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
+                .first
 
         for (i in 1 until blocks.size) {
             val lookahead = mutableListOf<BlockId>()
@@ -226,6 +228,7 @@ class STDCMHeuristicTests {
                 null,
                 null,
                 null,
+                0.0,
                 0.0
             )
         val defaultEdge =


### PR DESCRIPTION
This lets us remove the default "remaining time" value from nodes. Which happens to fix a small bug: because of the default value, a parameter was for the wrong variable (in stdcm edge)
