### PR TITLE
core: logging cleanup and extra stdcm info

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -225,7 +225,6 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
         for (var rangeIndex : rangeOrder) {
             try {
                 var range = ranges.get(rangeIndex);
-                logger.debug("computing range n°{}", rangeIndex + 1);
                 var envelopeRange = Envelope.make(envelopeRegion.slice(range.beginPos, range.endPos));
                 var imposedBeginSpeed = imposedTransitionSpeeds[rangeIndex];
                 var imposedEndSpeed = imposedTransitionSpeeds[rangeIndex + 1];
@@ -305,7 +304,6 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
             var imposedBeginSpeed = sectionBeginPos == rangeBeginPos ? imposedRangeBeginSpeed : NaN;
             var imposedEndSpeed = sectionEndPos == rangeEndPos ? imposedRangeEndSpeed : NaN;
 
-            logger.debug("  computing section n°{}", i + 1);
             var distributedTolerance = tolerance * sectionRatio;
             var allowanceSection = computeAllowanceSection(
                     section, context, targetTime, imposedBeginSpeed, imposedEndSpeed, distributedTolerance);
@@ -335,17 +333,14 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
         Envelope res = null;
         OSRDError lastError = null;
         var search = new DoubleBinarySearch(initialLowBound, initialHighBound, targetTime, tolerance, true);
-        logger.debug("  target time = {}", targetTime);
         for (int i = 1; i < 21 && !search.complete(); i++) {
             var input = search.getInput();
-            logger.debug("    starting attempt {}", i);
             try {
                 res = computeIteration(envelopeSection, context, input, imposedBeginSpeed, imposedEndSpeed);
                 var regionTime = res.getTotalTime();
-                logger.debug("    envelope time {}", regionTime);
                 search.feedback(regionTime);
             } catch (OSRDError allowanceError) {
-                logger.debug("    couldn't build an envelope ({})", allowanceError);
+                logger.debug("    couldn't build an envelope ({})", allowanceError.toString());
                 lastError = allowanceError;
                 if (allowanceError.osrdErrorType.equals(ErrorType.AllowanceConvergenceTooMuchTime))
                     // Can't go slow enough to even build a valid envelope: we need to go faster

--- a/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/Point.java
+++ b/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/Point.java
@@ -25,6 +25,6 @@ public record Point(
 
     @Override
     public String toString() {
-        return String.format("{x=%f, y=%f}", x, y);
+        return String.format("{lat=%f, lon=%f}", y, x);
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -29,6 +29,7 @@ import fr.sncf.osrd.stdcm.PlannedTimingData
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.findPath
+import fr.sncf.osrd.stdcm.graph.logger
 import fr.sncf.osrd.stdcm.preprocessing.implementation.makeBlockAvailability
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
@@ -59,6 +60,9 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
             val request =
                 stdcmRequestAdapter.fromJson(body)
                     ?: return RsWithStatus(RsText("missing request body"), 400)
+            logger.info(
+                "Request received: start=${request.startTime}, max duration=${request.maximumRunTime}"
+            )
 
             // parse input data
             val infra = infraManager.getInfra(request.infra, request.expectedVersion, recorder)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -1,0 +1,35 @@
+package fr.sncf.osrd.stdcm
+
+import fr.sncf.osrd.api.pathfinding.makePathProps
+import fr.sncf.osrd.stdcm.graph.STDCMGraph
+import fr.sncf.osrd.stdcm.graph.STDCMNode
+import fr.sncf.osrd.stdcm.graph.logger
+
+/**
+ * This class is used to log some elements during the graph traversal. It logs a small number of
+ * nodes, at most the specified number. Nodes are logged as they get closer to the destination.
+ */
+data class ProgressLogger(
+    val graph: STDCMGraph,
+    val nSteps: Int = 10,
+) {
+    private val thresholdDistance = 1.0 / nSteps.toDouble()
+    private var nSamplesReached = 1 // Avoids first node
+
+    /** Process one node, logging it if it reaches a new threshold */
+    fun processNode(node: STDCMNode) {
+        val progress =
+            (graph.bestPossibleTime - node.remainingTimeEstimation) / graph.bestPossibleTime
+        if (progress < thresholdDistance * nSamplesReached) return
+        val block = node.infraExplorer.getCurrentBlock()
+        val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]
+        val str =
+            "node sample $nSamplesReached/$nSteps: " +
+                "time=${node.time.toInt()}s, " +
+                "since departure=${node.timeSinceDeparture.toInt()}s, " +
+                "best remaining time=${node.remainingTimeEstimation.toInt()}s, " +
+                "loc=$geo"
+        logger.info(str)
+        while (progress >= thresholdDistance * nSamplesReached) nSamplesReached++
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -84,7 +84,9 @@ class STDCMHeuristicBuilder(
             steps.first().locations.minOfOrNull {
                 remainingTimeEstimations.first()[it.edge] ?: Double.POSITIVE_INFINITY
             } ?: Double.POSITIVE_INFINITY
-        logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
+        logger.info(
+            "STDCM heuristic built, best theoretical travel time = ${bestTravelTime.toInt()} seconds"
+        )
 
         val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedSteps ->
             if (nPassedSteps >= steps.size - 1) return@res 0.0

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -49,7 +49,7 @@ class STDCMHeuristicBuilder(
     /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
     @WithSpan(value = "Initializing STDCM heuristic", kind = SpanKind.SERVER)
     @Trace(operationName = "Initializing STDCM heuristic")
-    fun build(): STDCMAStarHeuristic {
+    fun build(): Pair<STDCMAStarHeuristic, Double> {
         logger.info("Start building STDCM heuristic...")
         // One map per number of reached pathfinding step
         // maps[n][block] = min time it takes to go from the start of the block to the destination,
@@ -86,7 +86,7 @@ class STDCMHeuristicBuilder(
             } ?: Double.POSITIVE_INFINITY
         logger.info("STDCM heuristic built, best theoretical travel time = $bestTravelTime seconds")
 
-        return res@{ edge, offset, nPassedSteps ->
+        val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedSteps ->
             if (nPassedSteps >= steps.size - 1) return@res 0.0
             val lookahead = edge.infraExplorer.getLookahead()
             val currentBlock = edge.block
@@ -121,6 +121,7 @@ class STDCMHeuristicBuilder(
 
             return@res remainingTime
         }
+        return Pair(heuristic, bestTravelTime)
     }
 
     /** Describes a pending block, ready to be added to the cached blocks. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -23,12 +23,8 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import java.util.*
 import kotlin.math.max
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 object STDCMStandardAllowance
-
-val logger: Logger = LoggerFactory.getLogger(STDCMStandardAllowance::class.java)
 
 private data class FixedTimePoint(
     val time: Double,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -101,7 +101,8 @@ data class STDCMEdge(
                 stopDuration,
                 firstStopAfterIndex.plannedTimingData,
                 previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(this, locationOnEdge, newWaypointIndex)
+                timeSinceDeparture,
+                graph.remainingTimeEstimator.invoke(this, locationOnEdge, newWaypointIndex),
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.FixedTime
 import fr.sncf.osrd.graph.Graph
+import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
@@ -51,16 +52,9 @@ class STDCMGraph(
     // min 4 minutes between two edges, determined empirically
     private val visitedNodes = VisitedNodes(4 * 60.0)
 
-    // Initialize the A* heuristic
-    val remainingTimeEstimator =
-        STDCMHeuristicBuilder(
-                fullInfra.blockInfra,
-                fullInfra.rawInfra,
-                steps,
-                maxRunTime,
-                rollingStock
-            )
-            .build()
+    // A* heuristic
+    val remainingTimeEstimator: STDCMAStarHeuristic
+    val bestPossibleTime: Double
 
     /** Constructor */
     init {
@@ -74,6 +68,17 @@ class STDCMGraph(
         assert(standardAllowance !is FixedTime) {
             "Standard allowance cannot be a flat time for STDCM trains"
         }
+        val heuristicBuilderResult =
+            STDCMHeuristicBuilder(
+                    fullInfra.blockInfra,
+                    fullInfra.rawInfra,
+                    steps,
+                    maxRunTime,
+                    rollingStock
+                )
+                .build()
+        remainingTimeEstimator = heuristicBuilderResult.first
+        bestPossibleTime = heuristicBuilderResult.second
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -15,8 +15,6 @@ import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 /**
  * This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding
@@ -47,7 +45,6 @@ class STDCMGraph(
     val backtrackingManager: BacktrackingManager
     val tag: String?
     val standardAllowance: AllowanceValue?
-    val logger: Logger = LoggerFactory.getLogger("STDCM")
 
     // min 4 minutes between two edges, determined empirically
     private val visitedNodes = VisitedNodes(4 * 60.0)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -38,7 +38,7 @@ data class STDCMNode(
     // departure time.
     val timeSinceDeparture: Double,
     // Estimation of the min time it takes to reach the end from this node
-    var remainingTimeEstimation: Double = 0.0,
+    var remainingTimeEstimation: Double,
 ) : Comparable<STDCMNode> {
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -221,7 +221,8 @@ class STDCMPathfinding(
                         firstStep.duration,
                         firstStep.plannedTimingData,
                         null,
-                        0.0
+                        0.0,
+                        graph.bestPossibleTime
                     )
                 res.add(node)
             }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -73,6 +73,7 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
+                .first
 
         assertEquals(
             400.0 - 50.0,
@@ -152,6 +153,7 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
+                .first
 
         for (i in 1 until blocks.size) {
             val lookahead = mutableListOf<BlockId>()
@@ -226,6 +228,7 @@ class STDCMHeuristicTests {
                 null,
                 null,
                 null,
+                0.0,
                 0.0
             )
         val defaultEdge =


### PR DESCRIPTION
Require https://github.com/OpenRailAssociation/osrd/pull/8204 (first commit)

There's two main change:

1. General logging cleanup: remove allowance info (not used since allowances are stable), fix some formatting
2. Log a small amount of stdcm nodes along the search

The node logging helps with debugging, we can follow along when the computations are too long.

Sample of how the logs look like (one success and one failure): 

```
[16:39:01,737] [INFO]                  [STDCM] Request received: start=2024-01-19T08:00Z, max duration=43200s
[16:39:01,738] [INFO]         [STDCMHeuristic] Start building STDCM heuristic...
[16:39:02,388] [INFO]         [STDCMHeuristic] STDCM heuristic built, best theoretical travel time = 19229 seconds
[16:39:02,491] [INFO]                  [STDCM] node sample 1/10: time=3317s, since departure=3216s, best remaining time=17276s, loc={lat=48.452942, lon=2.723136}
[16:39:02,590] [INFO]                  [STDCM] node sample 2/10: time=6263s, since departure=6163s, best remaining time=15312s, loc={lat=48.242771, lon=3.246910}
[16:39:02,598] [INFO]                  [STDCM] node sample 3/10: time=8618s, since departure=8518s, best remaining time=13441s, loc={lat=47.957088, lon=3.455668}
[16:39:02,697] [INFO]                  [STDCM] node sample 4/10: time=14203s, since departure=14102s, best remaining time=11482s, loc={lat=47.010632, lon=3.097832}
[16:39:02,729] [INFO]                  [STDCM] node sample 5/10: time=16671s, since departure=16570s, best remaining time=9537s, loc={lat=46.726170, lon=3.174625}
[16:39:03,206] [INFO]                  [STDCM] node sample 6/10: time=19344s, since departure=19244s, best remaining time=7688s, loc={lat=47.181107, lon=4.974491}
[16:39:03,225] [INFO]                  [STDCM] node sample 7/10: time=21635s, since departure=21534s, best remaining time=5625s, loc={lat=46.551398, lon=3.345790}
[16:39:03,527] [INFO]                  [STDCM] node sample 8/10: time=24052s, since departure=23952s, best remaining time=3774s, loc={lat=46.463643, lon=4.891152}
[16:39:03,668] [INFO]                  [STDCM] node sample 9/10: time=26382s, since departure=26282s, best remaining time=1921s, loc={lat=46.110876, lon=4.728671}
[16:39:03,800] [INFO]                  [STDCM] node sample 10/10: time=28721s, since departure=28621s, best remaining time=0s, loc={lat=45.768396, lon=4.860437}
[16:39:03,803] [INFO]                  [STDCM] Path found, start preprocessing
[16:39:03,992] [INFO]                  [STDCM] departure time = 100s, total travel time = 28622s
[16:39:04,097] [INFO]                [TkSlf4j] [POST http://localhost:8080/v2/stdcm] returned "HTTP/1.1 200 OK" in 2363 ms
[16:39:05,785] [INFO]                [TkSlf4j] [POST http://localhost:8080/v2/signal_projection] returned "HTTP/1.1 200 OK" in 4 ms
[16:39:23,292] [INFO]                  [STDCM] Request received: start=2024-01-19T08:00Z, max duration=43200s
[16:39:23,293] [INFO]         [STDCMHeuristic] Start building STDCM heuristic...
[16:39:23,684] [INFO]         [STDCMHeuristic] STDCM heuristic built, best theoretical travel time = 32914 seconds
[16:39:23,761] [INFO]                  [STDCM] node sample 1/10: time=5533s, since departure=5432s, best remaining time=29569s, loc={lat=48.321296, lon=3.138675}
[16:39:23,810] [INFO]                  [STDCM] node sample 2/10: time=12811s, since departure=12710s, best remaining time=26308s, loc={lat=47.259742, lon=2.996603}
[16:39:23,841] [INFO]                  [STDCM] node sample 3/10: time=16944s, since departure=16844s, best remaining time=23025s, loc={lat=46.690242, lon=3.215255}
[16:39:24,172] [INFO]                  [STDCM] node sample 4/10: time=21635s, since departure=21534s, best remaining time=19328s, loc={lat=46.551398, lon=3.345790}
[16:39:24,543] [INFO]                  [STDCM] node sample 5/10: time=25436s, since departure=25335s, best remaining time=16399s, loc={lat=46.251778, lon=4.785882}
[16:39:24,797] [INFO]                  [STDCM] node sample 6/10: time=29430s, since departure=29329s, best remaining time=13104s, loc={lat=45.662555, lon=4.851573}
[16:39:27,494] [INFO]                  [STDCM] node sample 7/10: time=33358s, since departure=33257s, best remaining time=9855s, loc={lat=45.113731, lon=4.825372}
[16:39:27,559] [INFO]                  [STDCM] Failed to find a path
[16:39:27,560] [INFO]                [TkSlf4j] [POST http://localhost:8080/v2/stdcm] returned "HTTP/1.1 200 OK" in 4270 ms
```