### PR TITLE
core: change ignore electrical profile value in sim v2

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -68,7 +68,7 @@ fun runStandaloneSimulation(
             rollingStock.basePowerClass,
             powerRestrictionsLegacyMap,
             rollingStock.powerRestrictions,
-            useElectricalProfiles
+            !useElectricalProfiles
         )
     val curvesAndConditions = rollingStock.mapTractiveEffortCurves(electrificationMap, comfort)
     val electrificationRanges =


### PR DESCRIPTION
closes #8003