### PR TITLE
editoast: add instrumentation in diesel-async connections

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1110,14 +1110,12 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
@@ -1208,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.6"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -1224,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -1239,11 +1237,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -1262,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.79",
 ]
@@ -1302,6 +1301,20 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "dunce"
@@ -1437,6 +1450,7 @@ dependencies = [
  "futures 0.3.30",
  "futures-util",
  "openssl",
+ "opentelemetry-semantic-conventions",
  "postgis_diesel",
  "postgres-openssl",
  "thiserror",
@@ -3714,12 +3728,6 @@ dependencies = [
  "lazy_static",
  "thiserror",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -27,13 +27,13 @@ license = "LGPL-3.0"
 [workspace.dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
-diesel = { version = "2.1.6", default-features = false, features = [
+diesel = { version = "2.2", default-features = false, features = [
   "chrono",
   "postgres",
   "serde_json",
   "uuid",
 ] }
-diesel-async = { version = "0.4.1", default-features = false, features = [
+diesel-async = { version = "0.5", default-features = false, features = [
   "deadpool",
   "postgres",
 ] }
@@ -53,6 +53,7 @@ hostname = "0.4.0"
 itertools = "0.13.0"
 mvt = "0.9.3"
 openssl = "0.10.66"
+opentelemetry-semantic-conventions = "0.15.0"
 paste = "1.0.15"
 postgis_diesel = { version = "2.3.1", features = ["serde"] }
 postgres-openssl = "0.5.0"
@@ -141,7 +142,7 @@ opentelemetry-otlp = { version = "0.16.0", default-features = false, features = 
   "grpc-tonic",
   "trace",
 ] }
-opentelemetry-semantic-conventions = "0.15.0"
+opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio", "trace"] }
 ordered-float = { version = "4.3.0", features = ["serde"] }
 osm_to_railjson = { path = "./osm_to_railjson" }

--- a/editoast/editoast_derive/src/model/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/count_impl.rs
@@ -9,7 +9,7 @@ pub(crate) struct CountImpl {
 impl ToTokens for CountImpl {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self { model, table_mod } = self;
-        let span_name = format!("model:list<{}>", model);
+        let span_name = format!("model:count<{}>", model);
 
         tokens.extend(quote! {
             #[automatically_derived]

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -14,6 +14,7 @@ editoast_derive.workspace = true
 futures.workspace = true
 futures-util.workspace = true
 openssl.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 postgis_diesel.workspace = true
 postgres-openssl.workspace = true
 thiserror.workspace = true

--- a/editoast/editoast_models/src/db_connection_pool/tracing_instrumentation.rs
+++ b/editoast/editoast_models/src/db_connection_pool/tracing_instrumentation.rs
@@ -1,0 +1,148 @@
+use std::collections::VecDeque;
+
+use diesel::connection::Instrumentation;
+use diesel::connection::InstrumentationEvent;
+use tracing::Span;
+use url::Url;
+
+#[derive(Debug)]
+pub struct TracingInstrumentation {
+    connection_span: Span,
+    query_spans: Option<Span>,
+    transaction_spans: VecDeque<Span>,
+}
+
+impl Default for TracingInstrumentation {
+    fn default() -> Self {
+        Self {
+            connection_span: tracing::Span::none(),
+            query_spans: None,
+            transaction_spans: VecDeque::default(),
+        }
+    }
+}
+
+impl Instrumentation for TracingInstrumentation {
+    fn on_connection_event(&mut self, event: InstrumentationEvent<'_>) {
+        match event {
+            InstrumentationEvent::StartEstablishConnection { url, .. } => {
+                let url = Url::parse(url).unwrap();
+                let span = tracing::trace_span!(
+                    "connection",
+                    // opentelemetry_semantic_conventions::trace::DB_SYSTEM
+                    "db.system" = "postgresql",
+                    // opentelemetry_semantic_conventions::trace::NETWORK_PEER_ADDRESS
+                    "network.peer.address" = tracing::field::display(url.host().unwrap()),
+                    // opentelemetry_semantic_conventions::trace::NETWORK_PEER_PORT
+                    "network.peer.port" = tracing::field::display(url.port().unwrap()),
+                    // opentelemetry_semantic_conventions::trace::ERROR_TYPE
+                    "error.type" = tracing::field::Empty,
+                );
+                {
+                    let _guard = span.enter();
+                    tracing::debug!("establishing a connection");
+                }
+                self.connection_span = span;
+            }
+            InstrumentationEvent::FinishEstablishConnection { error, .. } => {
+                {
+                    let _guard = self.connection_span.enter();
+                    if let Some(error) = error {
+                        self.connection_span.record(
+                            opentelemetry_semantic_conventions::trace::ERROR_TYPE,
+                            tracing::field::debug(error),
+                        );
+                        tracing::warn!("failed to establish a connection");
+                    } else {
+                        tracing::debug!("connection established");
+                    }
+                }
+                self.connection_span = tracing::Span::none();
+            }
+            InstrumentationEvent::StartQuery { query, .. } => {
+                let span = tracing::info_span!(
+                    "query",
+                    // opentelemetry_semantic_conventions::trace::DB_STATEMENT
+                    "db.statement" = tracing::field::display(query),
+                    // opentelemetry_semantic_conventions::trace::ERROR_TYPE
+                    "error.type" = tracing::field::Empty,
+                );
+                {
+                    let _guard = span.enter();
+                    tracing::debug!("starting query");
+                }
+                if let Some(_existing_span) = self.query_spans.take() {
+                    tracing::warn!("a query was already started: are you pipelining queries on the same connection?");
+                }
+                self.query_spans = Some(span);
+            }
+            InstrumentationEvent::CacheQuery { .. } => {
+                tracing::debug!("caching query");
+            }
+            InstrumentationEvent::FinishQuery { query, error, .. } => {
+                let span = self
+                    .query_spans
+                    .take()
+                    .expect("a query has to be started before finishing");
+                let _guard = span.enter();
+                span.record(
+                    opentelemetry_semantic_conventions::trace::DB_STATEMENT,
+                    tracing::field::display(query),
+                );
+                if let Some(error) = error {
+                    span.record(
+                        opentelemetry_semantic_conventions::trace::ERROR_TYPE,
+                        tracing::field::debug(error),
+                    );
+                    tracing::warn!("failed to execute the query");
+                } else {
+                    tracing::debug!("query finished");
+                }
+            }
+            InstrumentationEvent::BeginTransaction { depth, .. } => {
+                let span = tracing::info_span!(
+                    "transaction",
+                    // opentelemetry_semantic_conventions::trace::DB_OPERATION,
+                    "db.operation" = "create_transaction",
+                    "db.transaction.depth" = depth,
+                    // opentelemetry_semantic_conventions::trace::ERROR_TYPE
+                    "error.type" = tracing::field::Empty,
+                );
+                {
+                    let _guard = span.enter();
+                    tracing::debug!("beginning transaction");
+                }
+                self.transaction_spans.push_back(span);
+            }
+            InstrumentationEvent::CommitTransaction { depth, .. } => {
+                debug_assert_eq!(self.transaction_spans.len(), depth.get() as usize);
+                let span = self
+                    .transaction_spans
+                    .pop_back()
+                    .expect("a transaction has necessary began first");
+                let _guard = span.enter();
+                span.record(
+                    opentelemetry_semantic_conventions::trace::DB_OPERATION,
+                    "commit_transaction",
+                );
+                tracing::debug!("committing transaction");
+            }
+            InstrumentationEvent::RollbackTransaction { depth, .. } => {
+                debug_assert_eq!(self.transaction_spans.len(), depth.get() as usize);
+                let span = self
+                    .transaction_spans
+                    .pop_back()
+                    .expect("a transaction has necessary began first");
+                let _guard = span.enter();
+                span.record(
+                    opentelemetry_semantic_conventions::trace::DB_OPERATION,
+                    "rollback_transaction",
+                );
+                tracing::debug!("rollbacking transaction");
+            }
+            _ => {
+                tracing::warn!("unknown instrumentation event, maybe 'InstrumentationEvent' evolved since last time this code was updated?");
+            }
+        }
+    }
+}


### PR DESCRIPTION
New version of `diesel-async` gives us the possibility to instrument different events of a DB connection.

We assume that a connection cannot be used concurrently: it cannot start a new query if another one is not already finished. In theory, it could happen if we're pipelining multiple queries into a single connection (but the current code will panic in that case).

See an example in Jaeger here.

![image](https://github.com/user-attachments/assets/6c4d5a5e-b8cb-4d99-a4dd-c6a38871c388)
