### PR TITLE
front: fix time display, use utc for hour conversion

### DIFF
--- a/front/src/modules/timesStops/helpers/__tests__/formatScheduleData.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/formatScheduleData.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+
+import formatScheduleData from '../formatScheduleData';
+
+describe('formatScheduleData', () => {
+  it('should compute simple arrival time in the correct timezone', () => {
+    const schedule = {
+      at: 'id325',
+      arrival: 'PT3600S',
+      stop_for: 'PT100S',
+      on_stop_signal: false,
+      locked: false,
+    };
+    const startTime = '2024-05-14T00:00:00Z';
+
+    expect(formatScheduleData(schedule, startTime)).toEqual({
+      arrival: '01:00:00',
+      departure: '01:01:40',
+      stopFor: '100',
+    });
+  });
+});

--- a/front/src/utils/timeManipulation.ts
+++ b/front/src/utils/timeManipulation.ts
@@ -97,5 +97,5 @@ export function secToHoursString(sec: number | null, withSeconds = false): TimeS
     return '';
   }
   const format = withSeconds ? '%H:%M:%S' : '%H:%M';
-  return d3.timeFormat(format)(new Date(sec * 1000));
+  return d3.utcFormat(format)(new Date(sec * 1000));
 }


### PR DESCRIPTION
fixes time display, wrong function was used in d3.
partially fixes #8193