### PR TITLE
ci: pin rust version for 'editoast' and 'gateway'

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -1,7 +1,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.67-rust-latest AS chef
+FROM lukemathwalker/cargo-chef:0.1.67-rust-1.79.0 AS chef
 WORKDIR /editoast
 
 #######################

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.67-rust-latest AS chef
+FROM lukemathwalker/cargo-chef:0.1.67-rust-1.79.0 AS chef
 WORKDIR /gateway
 
 #######################


### PR DESCRIPTION
`grcov` doesn't compile anymore on `rust@1.80.0` (see https://github.com/mozilla/grcov/pull/1191).