### PR TITLE
scripts/cleanup-db: fix command to drop all keys from redis 

### DIFF
--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -57,7 +57,7 @@ docker exec osrd-postgres psql -f //tmp/init.sql > /dev/null
 
 # Clear Redis Cache
 echo "Deleting redis cache..."
-docker exec osrd-redis redis-cli DEL * &> /dev/null || docker volume rm -f osrd_redis_data > /dev/null
+docker exec osrd-redis redis-cli FLUSHALL &> /dev/null || docker volume rm -f osrd_redis_data > /dev/null
 
 echo "Cleanup done!\n"
 echo "You may want to apply migrations if you don't load a backup:"

--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -57,7 +57,7 @@ docker exec osrd-postgres psql -f //tmp/init.sql > /dev/null
 
 # Clear Redis Cache
 echo "Deleting redis cache..."
-docker exec osrd-redis redis-cli FLUSHALL &> /dev/null || docker volume rm -f osrd_redis_data > /dev/null
+docker exec osrd-redis redis-cli FLUSHALL > /dev/null 2>&1 || docker volume rm -f osrd_redis_data > /dev/null
 
 echo "Cleanup done!\n"
 echo "You may want to apply migrations if you don't load a backup:"

--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -57,7 +57,7 @@ docker exec osrd-postgres psql -f //tmp/init.sql > /dev/null
 
 # Clear Redis Cache
 echo "Deleting redis cache..."
-docker exec osrd-redis redis-cli FLUSHALL > /dev/null 2>&1 || docker volume rm -f osrd_redis_data > /dev/null
+docker exec osrd-redis valkey-cli FLUSHALL > /dev/null 2>&1 || docker volume rm -f osrd_redis_data > /dev/null
 
 echo "Cleanup done!\n"
 echo "You may want to apply migrations if you don't load a backup:"


### PR DESCRIPTION
_Also contains two cleanup commits._

`DEL *` doesn't work, it never deletes any key:

    127.0.0.1:6379> DBSIZE
    (integer) 31
    127.0.0.1:6379> DEL *
    (integer) 0
    127.0.0.1:6379> DBSIZE
    (integer) 31

Redis silently ignores any argument which doesn't match any key.
Seems like `DEL` doesn't support wildcards.

Use `FLUSHALL` instead.

Ref https://github.com/OpenRailAssociation/osrd/pull/8087