### PR TITLE
editoast: make core pathfinding/simulation errors non-fatal

### DIFF
--- a/editoast/src/views/v2/path/pathfinding.rs
+++ b/editoast/src/views/v2/path/pathfinding.rs
@@ -177,7 +177,12 @@ async fn pathfinding_blocks_batch(
     let computed_paths: Vec<_> = futures::future::join_all(futures)
         .await
         .into_iter()
-        .collect::<Result<_>>()?;
+        .map(|res| match res {
+            Ok(pathfinding_result) => pathfinding_result,
+            // TODO: only make HTTP status code errors non-fatal
+            Err(core_error) => PathfindingResult::PathfindingFailed { core_error },
+        })
+        .collect();
 
     for (index, computed_path) in computed_paths.into_iter().enumerate() {
         let path_index = pathfinding_requests_index[index];


### PR DESCRIPTION
core may throw an HTTP error when a pathfinding or simulation fails, e.g. when a track offset is past the end of a track. In that case, don't fail the whole batch, only fail a single pathfinding/simulation result.