### PR TITLE
front: add linter rule to prevent generatedEditoastApi imports

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -81,7 +81,11 @@
     "react/prefer-stateless-function": "off",
     "react/static-property-placement": 0,
     // disable vitest/prefer-to-be because it does not authorize toEqual for the floats
-    "vitest/prefer-to-be": "off"
+    "vitest/prefer-to-be": "off",
+    "no-restricted-imports": ["error", {
+      "name": "common/api/generatedEditoastApi",
+      "message": "Please use common/api/osrdEditoastApi instead"
+    }]
   },
   "settings": {
     "import/resolver": {

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -1,4 +1,4 @@
-import type { SimulationResponse } from 'common/api/generatedEditoastApi';
+import type { SimulationResponse } from 'common/api/osrdEditoastApi';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 
 import type { StdcmResultsOperationalPointsList } from '../types';

--- a/front/src/applications/stdcm/utils/formatStdcmIntoSpaceTimeData.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmIntoSpaceTimeData.ts
@@ -1,4 +1,4 @@
-import type { ProjectPathTrainResult } from 'common/api/generatedEditoastApi';
+import type { ProjectPathTrainResult } from 'common/api/osrdEditoastApi';
 
 import { STDCM_TRAIN_ID } from '../consts';
 import type { StdcmV2SuccessResponse } from '../types';

--- a/front/src/applications/stdcmV2/types.ts
+++ b/front/src/applications/stdcmV2/types.ts
@@ -1,7 +1,7 @@
 import type {
   RollingStockWithLiveries,
   PostV2TimetableByIdStdcmApiResponse,
-} from 'common/api/generatedEditoastApi';
+} from 'common/api/osrdEditoastApi';
 import type { PathStep } from 'reducers/osrdconf/types';
 
 export type StdcmSimulationResult = {

--- a/front/src/modules/pathfinding/helpers/__tests__/getPathVoltages.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/getPathVoltages.spec.ts
@@ -1,4 +1,4 @@
-import type { PathProperties } from 'common/api/generatedEditoastApi';
+import type { PathProperties } from 'common/api/osrdEditoastApi';
 
 import getPathVoltages from '../getPathVoltages';
 

--- a/front/src/modules/simulationResult/components/ChartSynchronizer/utils.ts
+++ b/front/src/modules/simulationResult/components/ChartSynchronizer/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import type { SimulationResponseSuccess } from 'applications/operationalStudies/types';
-import type { RollingStock } from 'common/api/generatedEditoastApi';
+import type { RollingStock } from 'common/api/osrdEditoastApi';
 import { isoDateWithTimezoneToSec } from 'utils/date';
 import { mmToM } from 'utils/physics';
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/formatSpaceTimeData.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/formatSpaceTimeData.ts
@@ -1,5 +1,5 @@
 import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
-import type { ProjectPathTrainResult, TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { ProjectPathTrainResult, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 
 const formatTrainsIntoSpaceTimeData = (
   projectedTrains: Record<string, ProjectPathTrainResult>,

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/helpers.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/helpers.ts
@@ -13,7 +13,7 @@ import type {
   PositionData,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { ReportTrainV2 } from 'common/api/generatedEditoastApi';
+import type { ReportTrainV2 } from 'common/api/osrdEditoastApi';
 import { mmToKm, msToKmh, mToKm } from 'utils/physics';
 
 import { electricalProfilesDesignValues } from './consts';

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -6,7 +6,7 @@ import type {
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders/Loader';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
 import type { PathStep } from 'reducers/osrdconf/types';

--- a/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
@@ -1,5 +1,5 @@
 import type { SimulationResponseSuccess } from 'applications/operationalStudies/types';
-import type { TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
 
 import testData from './computeMargins.json';
 import computeMargins from '../computeMargins';

--- a/front/src/modules/timesStops/helpers/computeMargins.ts
+++ b/front/src/modules/timesStops/helpers/computeMargins.ts
@@ -1,5 +1,5 @@
 import type { SimulationResponseSuccess } from 'applications/operationalStudies/types';
-import type { ReportTrainV2, TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { ReportTrainV2, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
 import { interpolateValue } from 'modules/trainschedule/components/DriverTrainScheduleV2/utils';
 import { mToMm, msToS } from 'utils/physics';

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -6,7 +6,7 @@ import type {
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -1,4 +1,4 @@
-import type { TrainScheduleBase, TrainScheduleResult } from 'common/api/generatedEditoastApi';
+import type { TrainScheduleBase, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { ArrayElement } from 'utils/types';
 

--- a/front/src/modules/trainschedule/components/DriverTrainScheduleV2/DriverTrainScheduleStopListV2.tsx
+++ b/front/src/modules/trainschedule/components/DriverTrainScheduleV2/DriverTrainScheduleStopListV2.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { SimulationResponseSuccess } from 'applications/operationalStudies/types';
-import type { ReportTrainV2 } from 'common/api/generatedEditoastApi';
+import type { ReportTrainV2 } from 'common/api/osrdEditoastApi';
 import type { PositionSpeedTime } from 'reducers/osrdsimulation/types';
 import { mmToM } from 'utils/physics';
 


### PR DESCRIPTION
The generated file is not meant to be used directly: we override a few auto-generated pieces in osrdEditoastApi.ts.

* * *

Alternatively, we could maybe leverage [`allowTypeImports`](https://typescript-eslint.io/rules/no-restricted-imports/#allowtypeimports) to allow type imports and disallow regular imports, since we don't override any type in `osrdEditoastApi.ts`.