### PR TITLE
core: fix node relative time diff calculation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -116,7 +116,10 @@ data class STDCMEdge(
         while (currentEdge != null) {
             val previousPlannedNode = currentEdge.previousNode
             if (previousPlannedNode.plannedTimingData != null) {
-                return previousPlannedNode.getRelativeTimeDiff(totalDepartureTimeShift)
+                return previousPlannedNode.getRelativeTimeDiff(
+                    totalDepartureTimeShift,
+                    maximumAddedDelayAfter
+                )
             }
             currentEdge = previousPlannedNode.previousEdge
         }


### PR DESCRIPTION
Relative time diff calculation should return the lowest possible relative time diff in the interval made of the possible times at which the train can pass through the node. I.e. it should return 0 if it is possible to add delay for the train to pass at the planned arrival time.

Unit tests are already done in `STDCMPathfindingTests`.