### PR TITLE
front: drop PathItem type

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 
 import {
   osrdEditoastApi,
+  type PathItemLocation,
   type PostV2InfraByInfraIdPathPropertiesApiArg,
   type PostV2InfraByInfraIdPathfindingBlocksApiArg,
 } from 'common/api/osrdEditoastApi';
@@ -15,7 +16,7 @@ import { adjustConfWithTrainToModifyV2 } from 'modules/trainschedule/components/
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { setFailure } from 'reducers/main';
 import type { OperationalStudiesConfSliceActions } from 'reducers/osrdconf/operationalStudiesConf';
-import type { PathItem, PathStep } from 'reducers/osrdconf/types';
+import type { PathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { addDurationToIsoDate } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
@@ -56,7 +57,7 @@ const useSetupItineraryForTrainUpdate = (
           pathfindingInputV2: {
             path_items: trainSchedule.path.map((item) =>
               omit(item, ['id', 'deleted'])
-            ) as PathItem[],
+            ) as PathItemLocation[],
             rolling_stock_is_thermal: isThermal(rollingStock.effort_curves.modes),
             rolling_stock_loading_gauge: rollingStock.loading_gauge,
             rolling_stock_supported_electrifications: getSupportedElectrification(

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -3,16 +3,15 @@ import type { Feature, Position } from 'geojson';
 import type { PowerRestrictionRange, PointOnMap } from 'applications/operationalStudies/consts';
 import type { PowerRestrictionV2 } from 'applications/operationalStudies/types';
 import type {
-  RollingStockComfortType,
-  PathResponse,
   AllowanceValue,
-  Distribution,
-  PathfindingInputV2,
   Comfort,
+  Distribution,
+  PathItemLocation,
+  PathResponse,
+  RollingStockComfortType,
 } from 'common/api/osrdEditoastApi';
 import type { AllowanceForm } from 'modules/trainschedule/components/ManageTrainSchedule/Allowances/types';
 import type { InfraState } from 'reducers/infra';
-import type { ArrayElement } from 'utils/types';
 
 export interface OsrdConfState extends InfraState {
   constraintDistribution: Distribution;
@@ -69,9 +68,7 @@ export interface OsrdStdcmConfState extends OsrdConfState {
   standardStdcmAllowance?: StandardAllowance;
 }
 
-export type PathItem = ArrayElement<PathfindingInputV2['path_items']>;
-
-export type PathStep = PathItem & {
+export type PathStep = PathItemLocation & {
   id: string;
   /** Metadata given to mark a point as wishing to be deleted by the user.
         It's useful for soft deleting the point (waiting to fix / remove all references)


### PR DESCRIPTION
Since #8073 we have a proper auto-generated PathItemLocation type from the OpenAPI schema. Use that instead of our own type.