### PR TITLE
core: delay departure time in stdcm to make the train pass closer to first planned step arrival time

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
@@ -30,4 +30,12 @@ data class PlannedTimingData(
             else -> timeDiff
         }
     }
+
+    /**
+     * Get time difference between the time at which the train passes through the node and the
+     * planned time at which it should have arrived at the node.
+     */
+    fun getTimeDiff(time: Double): Double {
+        return time - this.arrivalTime.seconds
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -106,16 +106,17 @@ data class STDCMNode(
         // ------------[-----|-----------|----------------|----------]------------
         //               currentTime            currentTimeWithMaxDelay
         if (plannedTimingData != null) {
-            val timeDiff =
-                getRealTime(currentTotalAddedDelay) - plannedTimingData.arrivalTime.seconds
+            val realTime = getRealTime(currentTotalAddedDelay)
+            val timeDiff = plannedTimingData.getTimeDiff(realTime)
             val relativeTimeDiff = plannedTimingData.getBeforeOrAfterRelativeTimeDiff(timeDiff)
             // If time diff is positive, adding delay won't decrease relative time diff: return
             // relativeTimeDiff
             if (timeDiff >= 0) return relativeTimeDiff
 
+            val maxTime = getRealTime(currentMaximumDelay)
             val maxTimeDiff =
                 min(
-                    getRealTime(currentMaximumDelay) - plannedTimingData.arrivalTime.seconds,
+                    plannedTimingData.getTimeDiff(maxTime),
                     plannedTimingData.arrivalTimeToleranceAfter.seconds
                 )
             val relativeMaxTimeDiff =
@@ -134,7 +135,7 @@ data class STDCMNode(
      * Takes into account the real current departure time shift to return the real current time at
      * which the train arrives at this node.
      */
-    private fun getRealTime(currentTotalAddedDelay: Double): Double {
+    fun getRealTime(currentTotalAddedDelay: Double): Double {
         assert(currentTotalAddedDelay >= totalPrevAddedDelay)
         return time + (currentTotalAddedDelay - totalPrevAddedDelay)
     }


### PR DESCRIPTION
Fixes #7690.

Once an stdcm solution is found, evaluate the different planned steps: the first planned step where the train arrives before planned arrival time, delay departure time as much as possible to make it pass through planned step at the closest time to planned arrival time.