### PR TITLE
editoast: revert "make core pathfinding/simulation errors non-fatal"

### DIFF
--- a/editoast/src/views/v2/path/pathfinding.rs
+++ b/editoast/src/views/v2/path/pathfinding.rs
@@ -177,12 +177,7 @@ async fn pathfinding_blocks_batch(
     let computed_paths: Vec<_> = futures::future::join_all(futures)
         .await
         .into_iter()
-        .map(|res| match res {
-            Ok(pathfinding_result) => pathfinding_result,
-            // TODO: only make HTTP status code errors non-fatal
-            Err(core_error) => PathfindingResult::PathfindingFailed { core_error },
-        })
-        .collect();
+        .collect::<Result<_>>()?;
 
     for (index, computed_path) in computed_paths.into_iter().enumerate() {
         let path_index = pathfinding_requests_index[index];

--- a/editoast/src/views/v2/train_schedule.rs
+++ b/editoast/src/views/v2/train_schedule.rs
@@ -460,12 +460,7 @@ pub async fn train_simulation_batch(
     let simulated: Vec<_> = futures::future::join_all(futures)
         .await
         .into_iter()
-        .map(|res| match res {
-            Ok(sim) => sim,
-            // TODO: only make HTTP status code errors non-fatal
-            Err(core_error) => SimulationResponse::SimulationFailed { core_error },
-        })
-        .collect();
+        .collect::<Result<_>>()?;
 
     let mut to_cache = Vec::with_capacity(simulated.len());
     for (&(train_index, _), sim_res) in futures_index_hash.iter().zip(simulated) {


### PR DESCRIPTION
This reverts commit 1ab7fa8635cc861b8bb487ada2309a6691851355.

We consider core 500 errors as unexpected so we don't want to cache the result of this query.

Example:
- Let's say the infra is not loaded but a pathfinding query is performed.
- The "Infra not loaded" error will be transformed as PathfindingResult and cached
- Once the infra is loaded if the same query is performed the cached response is sent (instead of re-computing the pathfinding)