### PR TITLE
core: stdcm: rework visited nodes to include time range

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/DebugUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/DebugUtils.kt
@@ -2,6 +2,7 @@ package fr.sncf.osrd.api.api_v2.pathfinding
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.makePathProps
+import java.io.BufferedWriter
 import java.io.File
 
 /**
@@ -25,5 +26,21 @@ fun exportPathGeo(infra: FullInfra, res: PathfindingBlockSuccess) {
             val geo = lineString.interpolateNormalized(item.distance / fullPath.getLength())
             out.println("$i;${geo.x};${geo.y}")
         }
+    }
+}
+
+/** Small utility class to log values in a csv */
+class CSVLogger(filename: String, private val keys: List<String>) {
+    private val writer: BufferedWriter = File(filename).bufferedWriter()
+
+    init {
+        writer.write(keys.joinToString(";") + "\n")
+    }
+
+    /** Log the given entries to the CSV. All keys must appear in the object keys. */
+    fun log(entries: Map<String, Any>) {
+        assert(entries.keys.all { keys.contains(it) })
+        val line = keys.joinToString(separator = ";") { entries.getOrDefault(it, "").toString() }
+        writer.write(line + "\n")
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -15,6 +15,8 @@ import fr.sncf.osrd.train.RollingStock.Comfort
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * This is the class that encodes the STDCM problem as a graph on which we can run our pathfinding
@@ -98,34 +100,72 @@ class STDCMGraph(
 
     override fun getAdjacentEdges(node: STDCMNode): Collection<STDCMEdge> {
         val res = ArrayList<STDCMEdge>()
+        val maxMarginDuration = estimateMaxMarginDuration(node)
+        val baseNodeCost = node.timeSinceDeparture + node.remainingTimeEstimation
+        val visitedNodesParameters =
+            VisitedNodes.Parameters(
+                null,
+                node.time,
+                node.maximumAddedDelay,
+                maxMarginDuration,
+                baseNodeCost
+            )
         if (node.locationOnEdge != null) {
             val explorer = node.infraExplorer.clone()
-            val fingerprint =
+            visitedNodesParameters.fingerprint =
                 VisitedNodes.Fingerprint(
                     explorer.getLastEdgeIdentifier(),
                     node.waypointIndex,
                     node.locationOnEdge.distance
                 )
-            if (visitedNodes.isVisited(fingerprint, node.time)) return listOf()
-            visitedNodes.markAsVisited(fingerprint, node.time)
+            if (visitedNodes.isVisited(visitedNodesParameters)) return listOf()
+            visitedNodes.markAsVisited(visitedNodesParameters)
             res.addAll(STDCMEdgeBuilder.fromNode(this, node, explorer).makeAllEdges())
         } else {
             val extended = extendLookaheadUntil(node.infraExplorer.clone(), 3)
             for (newPath in extended) {
                 if (newPath.getLookahead().size == 0) continue
                 newPath.moveForward()
-                val fingerprint =
+                visitedNodesParameters.fingerprint =
                     VisitedNodes.Fingerprint(
                         newPath.getLastEdgeIdentifier(),
                         node.waypointIndex,
                         0.meters
                     )
-                if (visitedNodes.isVisited(fingerprint, node.time)) return listOf()
-                visitedNodes.markAsVisited(fingerprint, node.time)
+                if (visitedNodes.isVisited(visitedNodesParameters)) return listOf()
+                visitedNodes.markAsVisited(visitedNodesParameters)
                 res.addAll(STDCMEdgeBuilder.fromNode(this, node, newPath).makeAllEdges())
             }
         }
         return res
+    }
+
+    /**
+     * Give a (rough) estimation of how much delay we could add before this node with engineering
+     * margins. Should be on the pessimistic side.
+     */
+    private fun estimateMaxMarginDuration(inputNode: STDCMNode): Double {
+        // We look for the 20km before the node (very rough estimation of a distance that lets the
+        // train slow down to a stop and speed up). We return the max delay that can be added after
+        // the train in all of those edges, on top of maximum start time delay
+        var node = inputNode
+        var remainingDistance = 20_000.meters
+        var maxTime = Double.POSITIVE_INFINITY
+        while (true) {
+            val edge = node.previousEdge ?: return 0.0
+
+            val latestTimeWithMaxShift =
+                edge.timeStart + edge.totalTime + edge.maximumAddedDelayAfter
+
+            // Only consider this specific edge, not the rest of the path
+            val maxDelayAddedOnEdge = max(0.0, edge.timeNextOccupancy - latestTimeWithMaxShift)
+            maxTime = min(maxTime, maxDelayAddedOnEdge)
+
+            remainingDistance -= edge.length.distance
+            if (edge.beginSpeed == 0.0 || remainingDistance <= 0.meters) return maxTime
+
+            node = edge.previousNode
+        }
     }
 
     /** Returns the first step with a stop after the given index, if any. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
@@ -1,50 +1,142 @@
 package fr.sncf.osrd.stdcm.graph
 
+import com.google.common.collect.Comparators.min
+import com.google.common.collect.ImmutableRangeMap
+import com.google.common.collect.ImmutableRangeSet
+import com.google.common.collect.Range
+import com.google.common.collect.RangeMap
+import com.google.common.collect.RangeSet
+import com.google.common.collect.TreeRangeMap
+import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.utils.units.Distance
+import kotlin.Double.Companion.POSITIVE_INFINITY
+import kotlin.math.max
 
 /**
- * This class keeps track of which nodes have already been visited. This is a first filter that
- * isn't meant to replace the checks made by the pathfinding algorithm itself, it just avoids some
- * unnecessary edge instanciation.
+ * This class keeps track of which nodes have already been visited.
  *
- * This class doesn't handle nodes directly, because some edges aren't instantiated from a node.
- *
- * Two nodes are considered "equal" when their `InfraExplorer` instances are equal (which consider
- * the current edge and lookahead), and when their times are close enough. Internally, we have
- * buckets for time frames of (min time distance) length, and we put infra explorer "signatures" in
- * there.
+ * This class doesn't handle nodes instances directly, because the filtering is made on a node with
+ * some extra lookahead data.
  *
  * the `minDelay` value should be roughly *twice* the minimum time delay between two trains. If it's
  * larger than that, we may consider two scenarios as equal when they are separated by a scheduled
  * train. A smaller value would lead to increased computation time.
+ *
+ * There are two steps to determine if a node has been visited. The first is the location: have we
+ * seen this physical place? This is defined by the `Fingerprint` class, and handles the block
+ * location and lookahead. The second is the time: have we been at this location at a time that has
+ * already been covered?
+ *
+ * The time check is where most complexity lies: we often pass by the same places at different
+ * times, but in ways that have been fully covered by previously seen nodes. For each location, we
+ * keep track of two things:
+ * 1. When have we *visited* this place? This considers the ranges that have been covered by
+ *    previously seen nodes, possibly by shifting the departure time
+ * 2. When could we reach this place, including engineering margins? This isn't just a "visited"
+ *    flag as it would increase the path cost, but it can avoid a lot of redundant computations
+ *
+ * When testing for a time range, we only test the range that can be reached by delaying the
+ * departure time. We consider it "already visited" when the whole range is either flagged as
+ * visited, or the new cost value isn't lower than what could be obtained by adding engineering
+ * margins.
  */
 data class VisitedNodes(val minDelay: Double) {
 
+    /** Data class representing a space location. Must be usable as map key. */
     data class Fingerprint(
         val identifier: EdgeIdentifier,
         val waypointIndex: Int,
         val startOffset: Distance
     )
 
-    // We still assume a 24h search space, this may change later on
-    private val buckets =
-        Array<MutableSet<Fingerprint>>((24 * 3600 / minDelay).toInt()) { mutableSetOf() }
+    /** Parameters for either function, having a class avoids repetitions */
+    data class Parameters(
+        var fingerprint: Fingerprint?,
+        val startTime: Double,
+        val duration: Double,
+        val maxMarginDuration: Double,
+        val baseNodeCost: Double,
+    )
+
+    /**
+     * Linear function with slope of 1. Used to represent the cost to reach a given time with margin
+     */
+    data class LinearFunction(private val y0: Double) : Comparable<LinearFunction> {
+        fun apply(x: Double): Double = y0 + x
+
+        override fun compareTo(other: LinearFunction): Int {
+            return y0.compareTo(other.y0)
+        }
+    }
+
+    /**
+     * For each location, the time ranges that have been visited. We know they can always be
+     * ignored.
+     */
+    private val visitedRangesPerLocation = mutableMapOf<Fingerprint, RangeSet<Double>>()
+
+    /**
+     * Time ranges that can be reached by adding margins. This isn't just "visited" as it would add
+     * the margin duration to the cost function. The values represent the estimated cost of a path
+     * that reach any given time of the range.
+     */
+    private val reachableRangesPerLocation =
+        mutableMapOf<Fingerprint, RangeMap<Double, LinearFunction>>()
 
     /** Returns true if the input has already been visited */
-    fun isVisited(fingerprint: Fingerprint, time: Double): Boolean {
-        val bucket = getBucket(time) ?: return false
-        return bucket.contains(fingerprint)
+    fun isVisited(
+        parameters: Parameters,
+    ): Boolean {
+        val alreadyVisitedTimes =
+            visitedRangesPerLocation[parameters.fingerprint!!] ?: ImmutableRangeSet.of()
+        val alreadyReachableRanges =
+            reachableRangesPerLocation[parameters.fingerprint!!]
+                ?: ImmutableRangeMap.of(Range.all<Double>(), LinearFunction(POSITIVE_INFINITY))
+
+        val visitingRange =
+            Range.closed(parameters.startTime, parameters.startTime + parameters.duration)
+
+        // List the ranges that are being explored, outside the previously visited ranges
+        val rangesToCheck = TreeRangeSet.create<Double>()
+        rangesToCheck.add(visitingRange)
+        rangesToCheck.removeAll(alreadyVisitedTimes)
+
+        // then check what's left against the reachable ranges
+        for (range in rangesToCheck.asRanges()) {
+            val alreadyReachableMap = alreadyReachableRanges.subRangeMap(range)
+            for (entry in alreadyReachableMap.asMapOfRanges()) {
+                if (entry.value.apply(entry.key.upperEndpoint()) > parameters.baseNodeCost)
+                    return false
+            }
+        }
+        return true
     }
 
     /** Marks the input as visited */
-    fun markAsVisited(fingerprint: Fingerprint, time: Double) {
-        getBucket(time)?.add(fingerprint)
-    }
+    fun markAsVisited(
+        parameters: Parameters,
+    ) {
+        val visitedTimes =
+            visitedRangesPerLocation.getOrPut(parameters.fingerprint!!) { TreeRangeSet.create() }
 
-    /** Returns the bucket for the given time value */
-    private fun getBucket(time: Double): MutableSet<Fingerprint>? {
-        val index = (time / minDelay).toInt()
-        return if (index < buckets.size) buckets[index] else null
+        // We still enforce a min duration for the visited range to avoid evaluating close trains
+        // separately
+        val endVisitedTime = parameters.startTime + max(parameters.duration, minDelay)
+        val newRange = Range.closed(parameters.startTime, endVisitedTime)
+        visitedTimes.add(newRange)
+
+        if (parameters.maxMarginDuration > 0.0) {
+            val reachableRanges =
+                reachableRangesPerLocation.getOrPut(parameters.fingerprint!!) {
+                    val map = TreeRangeMap.create<Double, LinearFunction>()
+                    map.put(Range.all(), LinearFunction(POSITIVE_INFINITY))
+                    map
+                }
+            val reachableRange =
+                Range.closed(endVisitedTime, endVisitedTime + parameters.maxMarginDuration)
+            val value = LinearFunction(parameters.baseNodeCost - endVisitedTime)
+            reachableRanges.merge(reachableRange, value) { f, g -> min(f, g) }
+        }
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -1,0 +1,95 @@
+package fr.sncf.osrd.stdcm
+
+import fr.sncf.osrd.stdcm.graph.VisitedNodes
+import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class VisitedNodesTests {
+
+    private data class DummyEdgeIdentifier(val int: Int) : EdgeIdentifier
+
+    private val fingerprint =
+        VisitedNodes.Fingerprint(
+            identifier = DummyEdgeIdentifier(1),
+            waypointIndex = 1,
+            startOffset = 0.meters,
+        )
+
+    @Test
+    fun simpleTest() {
+        val visitedNodes = VisitedNodes(0.0)
+
+        val params1 =
+            VisitedNodes.Parameters(
+                fingerprint = fingerprint,
+                startTime = 0.0,
+                duration = 42.0,
+                maxMarginDuration = 0.0,
+                baseNodeCost = 0.0,
+            )
+
+        assertFalse { visitedNodes.isVisited(params1) }
+        visitedNodes.markAsVisited(params1)
+        assertTrue { visitedNodes.isVisited(params1) }
+    }
+
+    @Test
+    fun overlappingTest() {
+        val visitedNodes = VisitedNodes(0.0)
+
+        val params1 =
+            VisitedNodes.Parameters(
+                fingerprint = fingerprint,
+                startTime = 0.0,
+                duration = 42.0,
+                maxMarginDuration = 0.0,
+                baseNodeCost = 0.0,
+            )
+        visitedNodes.markAsVisited(params1)
+        assertTrue { visitedNodes.isVisited(params1.copy(startTime = 20.0, duration = 20.0)) }
+    }
+
+    @Test
+    fun coveredByReachable() {
+        val visitedNodes = VisitedNodes(0.0)
+
+        val params1 =
+            VisitedNodes.Parameters(
+                fingerprint = fingerprint,
+                startTime = 0.0,
+                duration = 100.0,
+                maxMarginDuration = 100.0,
+                baseNodeCost = 0.0,
+            )
+        val params2 = params1.copy(startTime = 120.0, duration = 1.0, baseNodeCost = 15.0)
+        val params3 = params1.copy(startTime = 120.0, duration = 1.0, baseNodeCost = 25.0)
+        // At t=120, it's covered by the first parameters at cost=20
+        visitedNodes.markAsVisited(params1)
+        assertFalse { visitedNodes.isVisited(params2) }
+        assertTrue { visitedNodes.isVisited(params3) }
+    }
+
+    @Test
+    fun intersectionTest() {
+        val visitedNodes = VisitedNodes(0.0)
+
+        val params1 =
+            VisitedNodes.Parameters(
+                fingerprint = fingerprint,
+                startTime = 0.0,
+                duration = 100.0,
+                maxMarginDuration = 100.0,
+                baseNodeCost = 0.0,
+            )
+        // At t=120, it's covered by the first parameters at cost=20
+        val params2 = params1.copy(startTime = 120.0, baseNodeCost = 15.0)
+        // The duration here is longer than the previous test: it's visited from t=120 to t=125
+        // (above the cost function), then unvisited from t=125. Some parts are unvisited => false
+        // is expected
+        visitedNodes.markAsVisited(params1)
+        assertFalse { visitedNodes.isVisited(params2) }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/8268


First commit is unrelated (debugging utils)


### Performances:

On average it barely makes a measurable difference and actually slows things down (by 1%). But std goes down by 25%.

On some extreme cases that caused timeouts (and in practice infinite loops / OOM), it's down to a reasonable time (22s).

No extra error or "path not found" when running the benchmark.

