### PR TITLE
core: remove `loadIfMissing`, always load infras

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -32,7 +32,6 @@ public enum ErrorType {
     InfraLoadingInvalidStatusException("infra_loading:invalid_status", "Status doesn’t exist", ErrorCause.INTERNAL),
     InfraInvalidStatusWhileWaitingStable(
             "infra_loading:invalid_status_waiting_stable", "invalid status after waitUntilStable", ErrorCause.INTERNAL),
-    InfraNotLoadedException("infra:not_loaded", "Infra not loaded", ErrorCause.USER, false),
     InfraInvalidVersionException("infra:invalid_version", "Invalid infra version", ErrorCause.USER),
     PathfindingGenericError("no_path_found", "No path could be found", ErrorCause.USER),
     PathfindingGaugeError("no_path_found:gauge", "No path could be found with compatible Gauge", ErrorCause.USER),

--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -23,7 +23,6 @@ public class InfraManager extends APIClient {
 
     private final ConcurrentHashMap<String, InfraCacheEntry> infraCache = new ConcurrentHashMap<>();
     private final SignalingSimulator signalingSimulator = makeSignalingSimulator();
-    private final boolean loadIfMissing;
 
     public void forEach(BiConsumer<String, InfraCacheEntry> action) {
         infraCache.forEach(action);
@@ -88,9 +87,8 @@ public class InfraManager extends APIClient {
         }
     }
 
-    public InfraManager(String baseUrl, String authorizationToken, OkHttpClient httpClient, boolean loadIfMissing) {
+    public InfraManager(String baseUrl, String authorizationToken, OkHttpClient httpClient) {
         super(baseUrl, authorizationToken, httpClient);
-        this.loadIfMissing = loadIfMissing;
     }
 
     @ExcludeFromGeneratedCodeCoverage
@@ -197,10 +195,8 @@ public class InfraManager extends APIClient {
         try {
             var cacheEntry = infraCache.get(infraId);
             if (cacheEntry == null || !cacheEntry.status.isStable) {
-                if (loadIfMissing) {
-                    // download the infra for tests
-                    return load(infraId, expectedVersion, diagnosticRecorder);
-                } else throw new OSRDError(ErrorType.InfraNotLoadedException);
+                // download the infra
+                return load(infraId, expectedVersion, diagnosticRecorder);
             }
             var obsoleteVersion = expectedVersion != null && !expectedVersion.equals(cacheEntry.version);
             if (obsoleteVersion) {

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -68,7 +68,7 @@ public final class ApiServerCommand implements CliCommand {
         var editoastUrl = getEditoastUrl();
         var httpClient =
                 new OkHttpClient.Builder().readTimeout(120, TimeUnit.SECONDS).build();
-        var infraManager = new InfraManager(editoastUrl, editoastAuthorization, httpClient, false);
+        var infraManager = new InfraManager(editoastUrl, editoastAuthorization, httpClient);
         var electricalProfileSetManager =
                 new ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient);
 

--- a/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
@@ -59,7 +59,7 @@ public class ApiTest {
     /** Setup infra handler mock */
     @BeforeEach
     public void setUp() throws IOException {
-        infraManager = new InfraManager("http://test.com/", "", mockHttpClient(".*/infra/(.*)/railjson.*"), true);
+        infraManager = new InfraManager("http://test.com/", "", mockHttpClient(".*/infra/(.*)/railjson.*"));
         electricalProfileSetManager = new ElectricalProfileSetManager(
                 "http://test.com/", "", mockHttpClient(".*/electrical_profile_set/(.*)/"));
     }


### PR DESCRIPTION
This cause issues with caching, inconveniences when running core locally, and the osrdyne refactor makes it irrelevant anyway