### PR TITLE
front: fix timestops output using wrong simulation

### DIFF
--- a/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
@@ -203,12 +203,13 @@ const SimulationResultsV2 = ({ collapsedTimetable, spaceTimeData }: SimulationRe
       {selectedTrainSchedule &&
         trainSimulation.status === 'success' &&
         pathProperties &&
+        operationalPoints &&
         infraId && (
           <div className="osrd-simulation-container mb-2">
             <TimesStopsOutput
               simulatedTrain={trainSimulation}
               pathProperties={pathProperties}
-              operationalPoints={operationalPoints}
+              operationalPoints={operationalPoints.finalOutput}
               selectedTrainSchedule={selectedTrainSchedule}
               pathSteps={compact(pathSteps)}
               pathLength={pathLength}
@@ -283,6 +284,7 @@ const SimulationResultsV2 = ({ collapsedTimetable, spaceTimeData }: SimulationRe
         trainSimulation &&
         pathProperties &&
         selectedTrainRollingStock &&
+        operationalPoints &&
         infraId && (
           <div className="osrd-simulation-container mb-2">
             <DriverTrainScheduleV2

--- a/front/src/modules/trainschedule/components/DriverTrainScheduleV2/DriverTrainScheduleV2.tsx
+++ b/front/src/modules/trainschedule/components/DriverTrainScheduleV2/DriverTrainScheduleV2.tsx
@@ -17,7 +17,10 @@ type DriverTrainScheduleV2Props = {
   simulatedTrain: SimulationResponseSuccess;
   pathProperties: PathPropertiesFormatted;
   rollingStock: LightRollingStock;
-  operationalPoints: OperationalPointWithTimeAndSpeed[];
+  operationalPoints: {
+    base: OperationalPointWithTimeAndSpeed[];
+    finalOutput: OperationalPointWithTimeAndSpeed[];
+  };
   formattedOpPointsLoading: boolean;
   baseOrEco: BaseOrEcoType;
   setBaseOrEco: (baseOrEco: BaseOrEcoType) => void;
@@ -38,32 +41,33 @@ const DriverTrainScheduleV2 = ({
     [baseOrEco, simulatedTrain]
   );
 
+  const operationPointsToUse = useMemo(
+    () => (baseOrEco === BaseOrEco.eco ? operationalPoints.finalOutput : operationalPoints.base),
+    [baseOrEco, operationalPoints]
+  );
+
   return (
     <div className="simulation-driver-train-schedule">
-      {operationalPoints.length > 0 && (
-        <>
-          <DriverTrainScheduleHeaderV2
-            simulatedTrain={simulatedTrain}
-            train={train}
-            operationalPoints={operationalPoints}
-            electrificationRanges={pathProperties.electrifications}
-            rollingStock={rollingStock}
-            baseOrEco={baseOrEco}
-            setBaseOrEco={setBaseOrEco}
-          />
-          {formattedOpPointsLoading ? (
-            // Prevent the screen from resizing during loading
-            <div style={{ height: '50vh' }}>
-              <Loader />
-            </div>
-          ) : (
-            <DriverTrainScheduleStopListV2
-              trainRegime={selectedTrainRegime}
-              mrsp={simulatedTrain.mrsp}
-              operationalPoints={operationalPoints}
-            />
-          )}
-        </>
+      <DriverTrainScheduleHeaderV2
+        simulatedTrain={simulatedTrain}
+        train={train}
+        operationalPoints={operationPointsToUse}
+        electrificationRanges={pathProperties.electrifications}
+        rollingStock={rollingStock}
+        baseOrEco={baseOrEco}
+        setBaseOrEco={setBaseOrEco}
+      />
+      {formattedOpPointsLoading ? (
+        // Prevent the screen from resizing during loading
+        <div style={{ height: '50vh' }}>
+          <Loader />
+        </div>
+      ) : (
+        <DriverTrainScheduleStopListV2
+          trainRegime={selectedTrainRegime}
+          mrsp={simulatedTrain.mrsp}
+          operationalPoints={operationPointsToUse}
+        />
       )}
     </div>
   );

--- a/front/src/modules/trainschedule/useFormattedOperationalPoints.ts
+++ b/front/src/modules/trainschedule/useFormattedOperationalPoints.ts
@@ -20,9 +20,10 @@ export const useFormattedOperationalPoints = (
   pathProperties?: PathPropertiesFormatted,
   infraId?: number
 ) => {
-  const [operationalPoints, setOperationalPoints] = useState<OperationalPointWithTimeAndSpeed[]>(
-    []
-  );
+  const [operationalPoints, setOperationalPoints] = useState<{
+    base: OperationalPointWithTimeAndSpeed[];
+    finalOutput: OperationalPointWithTimeAndSpeed[];
+  }>();
   const [loading, setLoading] = useState(false);
   const [baseOrEco, setBaseOrEco] = useState<BaseOrEcoType>(
     train && isEco(train) ? BaseOrEco.eco : BaseOrEco.base
@@ -30,13 +31,11 @@ export const useFormattedOperationalPoints = (
 
   useEffect(() => {
     if (train && simulatedTrain && pathProperties && infraId) {
-      const selectedTrainRegime =
-        baseOrEco === BaseOrEco.eco ? simulatedTrain.final_output : simulatedTrain.base;
       const fetchOperationalPoints = async () => {
         setLoading(true);
         const formattedOperationalPoints = await formatOperationalPoints(
           pathProperties.operationalPoints,
-          selectedTrainRegime,
+          simulatedTrain,
           train,
           infraId
         );
@@ -45,7 +44,7 @@ export const useFormattedOperationalPoints = (
       };
       fetchOperationalPoints();
     }
-  }, [train, simulatedTrain, pathProperties, infraId, baseOrEco]);
+  }, [train, simulatedTrain, pathProperties, infraId]);
 
   return { operationalPoints, loading, baseOrEco, setBaseOrEco };
 };


### PR DESCRIPTION
close #8280 

- fix the bug
- optimize the switch in driver trainSchedule so it doesn't call the endpoint each time we switch (resulting with a small loading)