### PR TITLE
front: ignore errors for route entry/exit in getAdditionalEntities()

### DIFF
--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -327,31 +327,21 @@ const EntitySumUp: FC<
     const fetchEntities = async () => {
       setState({ type: 'loading' });
 
-      if (entity) {
-        const additionalEntities = await getAdditionalEntities(infraID as number, entity, dispatch);
-        setState({
-          type: 'ready',
-          entity,
-          additionalEntities,
-        });
-      } else {
-        const fetchedEntity = await getEntity(
+      if (!entity) {
+        entity = await getEntity(
           infraID as number,
           id as string,
           objType as EditoastType,
           dispatch
         );
-        const additionalEntities = await getAdditionalEntities(
-          infraID as number,
-          fetchedEntity,
-          dispatch
-        );
-        setState({
-          type: 'ready',
-          entity: fetchedEntity,
-          additionalEntities,
-        });
       }
+
+      const additionalEntities = await getAdditionalEntities(infraID as number, entity, dispatch);
+      setState({
+        type: 'ready',
+        entity,
+        additionalEntities,
+      });
     };
 
     fetchEntities();

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -320,32 +320,34 @@ const EntitySumUp: FC<
   >({ type: 'idle' });
 
   useEffect(() => {
-    if (state.type === 'idle') {
-      setState({ type: 'loading' });
+    if (state.type !== 'idle') {
+      return;
+    }
 
-      if (entity) {
-        getAdditionalEntities(infraID as number, entity, dispatch).then((additionalEntities) => {
-          setState({
-            type: 'ready',
-            entity,
-            additionalEntities,
-          });
+    setState({ type: 'loading' });
+
+    if (entity) {
+      getAdditionalEntities(infraID as number, entity, dispatch).then((additionalEntities) => {
+        setState({
+          type: 'ready',
+          entity,
+          additionalEntities,
         });
-      } else {
-        getEntity(infraID as number, id as string, objType as EditoastType, dispatch).then(
-          (fetchedEntity) => {
-            getAdditionalEntities(infraID as number, fetchedEntity, dispatch).then(
-              (additionalEntities) => {
-                setState({
-                  type: 'ready',
-                  entity: fetchedEntity,
-                  additionalEntities,
-                });
-              }
-            );
-          }
-        );
-      }
+      });
+    } else {
+      getEntity(infraID as number, id as string, objType as EditoastType, dispatch).then(
+        (fetchedEntity) => {
+          getAdditionalEntities(infraID as number, fetchedEntity, dispatch).then(
+            (additionalEntities) => {
+              setState({
+                type: 'ready',
+                entity: fetchedEntity,
+                additionalEntities,
+              });
+            }
+          );
+        }
+      );
     }
   }, [entity, id, objType, infraID, state.type]);
 

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -84,19 +84,28 @@ async function getAdditionalEntities(
     }
     case 'Route': {
       const route = entity as RouteEntity;
-      const entryPoint = await getEntity(
-        infra,
-        route.properties.entry_point.id,
-        route.properties.entry_point.type,
-        dispatch
-      );
-      const exitPoint = await getEntity(
-        infra,
-        route.properties.exit_point.id,
-        route.properties.exit_point.type,
-        dispatch
-      );
-      return { entryPoint, exitPoint };
+      const results: Record<string, EditorEntity> = {};
+      try {
+        results.entryPoint = await getEntity(
+          infra,
+          route.properties.entry_point.id,
+          route.properties.entry_point.type,
+          dispatch
+        );
+      } catch (e) {
+        // ignore error
+      }
+      try {
+        results.exitPoint = await getEntity(
+          infra,
+          route.properties.exit_point.id,
+          route.properties.exit_point.type,
+          dispatch
+        );
+      } catch (e) {
+        // ignore error
+      }
+      return results;
     }
     default:
       return {};

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -324,31 +324,37 @@ const EntitySumUp: FC<
       return;
     }
 
-    setState({ type: 'loading' });
+    const fetchEntities = async () => {
+      setState({ type: 'loading' });
 
-    if (entity) {
-      getAdditionalEntities(infraID as number, entity, dispatch).then((additionalEntities) => {
+      if (entity) {
+        const additionalEntities = await getAdditionalEntities(infraID as number, entity, dispatch);
         setState({
           type: 'ready',
           entity,
           additionalEntities,
         });
-      });
-    } else {
-      getEntity(infraID as number, id as string, objType as EditoastType, dispatch).then(
-        (fetchedEntity) => {
-          getAdditionalEntities(infraID as number, fetchedEntity, dispatch).then(
-            (additionalEntities) => {
-              setState({
-                type: 'ready',
-                entity: fetchedEntity,
-                additionalEntities,
-              });
-            }
-          );
-        }
-      );
-    }
+      } else {
+        const fetchedEntity = await getEntity(
+          infraID as number,
+          id as string,
+          objType as EditoastType,
+          dispatch
+        );
+        const additionalEntities = await getAdditionalEntities(
+          infraID as number,
+          fetchedEntity,
+          dispatch
+        );
+        setState({
+          type: 'ready',
+          entity: fetchedEntity,
+          additionalEntities,
+        });
+      }
+    };
+
+    fetchEntities();
   }, [entity, id, objType, infraID, state.type]);
 
   if (state.type === 'loading' || state.type === 'idle') return <LoaderFill displayDelay={500} />;


### PR DESCRIPTION
_See individual commits._

Also contains a collection of totally gratuitous cleanups.

Closes: https://github.com/OpenRailAssociation/osrd/issues/8304