### PR TITLE
editoast: implement Authorizer creation middleware

### DIFF
--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -78,7 +78,7 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 use validator::ValidationErrorsKind;
 use views::infra::InfraApiError;
 use views::search::SearchConfigFinder;
-use views::Roles;
+use views::{authorizer_middleware, Roles};
 
 /// The mode editoast is running in
 ///
@@ -430,6 +430,10 @@ async fn runserver(
     // Configure the axum router
     let router: Router<()> = axum::Router::<AppState>::new()
         .merge(views::router())
+        .route_layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            authorizer_middleware,
+        ))
         .layer(OtelInResponseLayer)
         .layer(OtelAxumLayer::default())
         .layer(request_payload_limit)

--- a/editoast/src/tests/test_role_config.toml
+++ b/editoast/src/tests/test_role_config.toml
@@ -1,5 +1,2 @@
-name = "Test role configuration"
-version = "0.1"
-
-[application_roles.operational_studies]
+[roles.operational_studies]
 implies = ["operational_studies_write"]

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -23,7 +23,7 @@ use crate::{
 use axum_test::TestRequest;
 use axum_test::TestServer;
 
-use super::Roles;
+use super::{authorizer_middleware, Roles};
 
 /// A builder interface for [TestApp]
 ///
@@ -144,6 +144,10 @@ impl TestAppBuilder {
         // Configure the axum router
         let router: Router<()> = axum::Router::<AppState>::new()
             .merge(crate::views::router())
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                authorizer_middleware,
+            ))
             .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())
             .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
Half of the axum server is in `main.rs` and the rest in `views/mod.rs`. We'll need to homogenize that.

We removed the lazy role fetching and caching as this would require internal mutability since the `Authorizer` now lives in an `Arc`. Instead, we now fetch the roles when the `Authorizer` is initialized.

Closes #8276 