### PR TITLE
editoast: silence dependency_on_unit_never_type_fallback

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -15,6 +15,9 @@ members = [
   "osm_to_railjson",
 ]
 
+[workspace.lints.rust]
+dependency_on_unit_never_type_fallback = "allow" # this is caused by tracing, we can't do anything about it
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
@@ -153,3 +156,6 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 serial_test = "3.1.1"
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/editoast_authz/Cargo.toml
+++ b/editoast/editoast_authz/Cargo.toml
@@ -17,3 +17,6 @@ tracing.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/editoast_common/Cargo.toml
+++ b/editoast/editoast_common/Cargo.toml
@@ -13,3 +13,6 @@ serde_derive.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 utoipa.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -19,3 +19,6 @@ proc-macro = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+
+[lints]
+workspace = true

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -24,3 +24,6 @@ url.workspace = true
 [dev-dependencies]
 # The feature 'testing' is needed for all of the doc-tests
 editoast_models = { path = "./", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -18,3 +18,6 @@ strum.workspace = true
 thiserror.workspace = true
 utoipa.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/editoast_search/Cargo.toml
+++ b/editoast/editoast_search/Cargo.toml
@@ -11,3 +11,6 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 utoipa.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/osm_to_railjson/Cargo.toml
+++ b/editoast/osm_to_railjson/Cargo.toml
@@ -16,3 +16,6 @@ tracing.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true


### PR DESCRIPTION
This warning only occurs on nightly, as a results of using the `tracing::instrument` macro. We can't really do anything about it, so we should stop polluting our compiler output.