### PR TITLE
front: upgrade NGE to forked v2.7.2

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -83,7 +83,7 @@
     "lodash": "^4.17.21",
     "maplibre-gl": "^4.0.0",
     "match-sorter": "^6.3.3",
-    "netzgrafik-frontend": "^2.7.0",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.b5ca2e546ba2695c5a999c8e150775230b4152ce",
     "openapi-typescript-codegen": "^0.27.0",
     "party-js": "^2.2.0",
     "prop-types": "^15.8.1",

--- a/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
@@ -16,7 +16,7 @@ interface NGEElement extends HTMLElement {
 
 const frameSrc = `
 <!DOCTYPE html>
-<html class="sbb-lean">
+<html class="sbb-lean sbb-light">
   <head>
     <base href="/netzgrafik-frontend/">
     <link rel="stylesheet" href="${ngeStyles}"></link>

--- a/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/MacroEditor/NGE.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 /* eslint-disable import/extensions, import/no-unresolved */
-import ngeMain from 'netzgrafik-frontend/dist/netzgrafik-frontend/main.js?url';
-import ngePolyfills from 'netzgrafik-frontend/dist/netzgrafik-frontend/polyfills.js?url';
-import ngeRuntime from 'netzgrafik-frontend/dist/netzgrafik-frontend/runtime.js?url';
-import ngeStyles from 'netzgrafik-frontend/dist/netzgrafik-frontend/styles.css?url';
-import ngeVendor from 'netzgrafik-frontend/dist/netzgrafik-frontend/vendor.js?url';
+import ngeMain from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/main.js?url';
+import ngePolyfills from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/polyfills.js?url';
+import ngeRuntime from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/runtime.js?url';
+import ngeStyles from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/styles.css?url';
+import ngeVendor from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/vendor.js?url';
 /* eslint-enable import/extensions, import/no-unresolved */
 
 import type { NetzgrafikDto } from './types';

--- a/front/src/applications/operationalStudies/components/MacroEditor/import.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/import.ts
@@ -85,7 +85,7 @@ const DEFAULT_DTO: NetzgrafikDto = {
 };
 
 const DEFAULT_TIME_LOCK: TimeLock = {
-  time: 0,
+  time: null,
   consecutiveTime: null,
   lock: false,
   warning: null,

--- a/front/src/applications/operationalStudies/components/MacroEditor/types.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/types.ts
@@ -58,7 +58,7 @@ export type Trainrun = {
 };
 
 export type TimeLock = {
-  time: number;
+  time: number | null;
   consecutiveTime: number | null;
   lock: boolean;
   warning: null;

--- a/front/vite.config.mts
+++ b/front/vite.config.mts
@@ -10,7 +10,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 const require = createRequire(import.meta.url);
 const ngeBase = path.dirname(
-  require.resolve('netzgrafik-frontend/dist/netzgrafik-frontend/index.html')
+  require.resolve('@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/index.html')
 );
 
 // https://vitejs.dev/config/

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2072,6 +2072,11 @@
     openapi-typescript "^5.4.1"
     yargs "^17.7.2"
 
+"@osrd-project/netzgrafik-frontend@0.0.0-snapshot.b5ca2e546ba2695c5a999c8e150775230b4152ce":
+  version "0.0.0-snapshot.b5ca2e546ba2695c5a999c8e150775230b4152ce"
+  resolved "https://registry.yarnpkg.com/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.b5ca2e546ba2695c5a999c8e150775230b4152ce.tgz#ec4bcfa99abd602641fc20916699c2783dff28d5"
+  integrity sha512-BUGtCdSqpWtmTV5yO2FriLYGyK+Q89dNWxidoqAZws8v03X2k1yr+DrUar/UuOqZuh4MH6qMF8/Y/wj3ak855A==
+
 "@osrd-project/ui-core@^0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@osrd-project/ui-core/-/ui-core-0.0.30.tgz#ea3d89bc47f2f1de57200b4bd2333d6beb231dfb"
@@ -11283,11 +11288,6 @@ neo-async@^2.5.0, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-netzgrafik-frontend@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/netzgrafik-frontend/-/netzgrafik-frontend-2.7.0.tgz#adcae00ed509686321ebced3a917cdc58a2f2e00"
-  integrity sha512-/xB47rVt6pm2wmtJQiRX97JXCyKvvEl9VZTrJMavx9zDjAjH/kz89jRM3HPAFoAgKFFnXaPC8WKlqmablE0h5A==
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
We maintain a fork of NGE with some custom patches: https://github.com/osrd-project/netzgrafik-editor-frontend/tree/standalone

Our fork includes patches that aren't yet ready to be upstreamed, or cannot be upstreamed at all. For instance, hiding the return travel for trains (making them one-way) will require a much larger refactoring to be supported upstream. Some features like saved filters could in theory be supported but as-is will be lost on page reload.

Unfortunately this means we're back to the @osrd-project namespace for now.