### PR TITLE
core: add error details when infra couldn't be loaded

### DIFF
--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -341,8 +341,7 @@ private fun parseRjsTrackSection(
         for (detector in trackSectionDetectors) {
             val detectorOffset = detector.key
             if (detectorOffset > trackSectionLength || detectorOffset < Offset.zero()) {
-                throw OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
+                throw OSRDError.newInfraError(
                     "Detector out of range at offset $detectorOffset on trackSection ${rjsTrack.id}"
                 )
             }
@@ -562,8 +561,7 @@ fun parseTrackNode(
     }
     val switchType =
         switchTypeMap[rjsNode.switchType]
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
+            ?: throw OSRDError.newInfraError(
                 "Node ${rjsNode.id} references unknown switch-type ${rjsNode.switchType}"
             )
     if (rjsNode.ports.size != switchType.ports.size || portMap.keys != switchType.ports.toSet()) {
@@ -592,16 +590,14 @@ fun parseRoute(builder: RawInfraBuilder, rjsRoute: RJSRoute) {
     // parse the entry / exit detectors
     val routeEntryDetector =
         builder.getDetectorByName(rjsRoute.entryPoint.id.id)
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
+            ?: throw OSRDError.newInfraError(
                 "Route $routeName references unknown entry point ${rjsRoute.entryPoint.id.id}"
             )
     val routeEntryDirection = rjsRoute.entryPointDirection.toDirection()
     val routeEntry: DirDetectorId = DirStaticIdx(routeEntryDetector, routeEntryDirection)
     val routeExit: DetectorId =
         builder.getDetectorByName(rjsRoute.exitPoint.id.id)
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
+            ?: throw OSRDError.newInfraError(
                 "Route $routeName references unknown exit point ${rjsRoute.exitPoint.id.id}"
             )
 
@@ -610,8 +606,7 @@ fun parseRoute(builder: RawInfraBuilder, rjsRoute: RJSRoute) {
     for (rjsDetName in rjsRoute.releaseDetectors) {
         releaseDetectors.add(
             builder.getDetectorByName(rjsDetName)
-                ?: throw OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
+                ?: throw OSRDError.newInfraError(
                     "Route $routeName references unknown release detector $rjsDetName"
                 )
         )
@@ -622,14 +617,12 @@ fun parseRoute(builder: RawInfraBuilder, rjsRoute: RJSRoute) {
     for (rjsRouteNode in rjsRoute.switchesDirections) {
         val node =
             builder.getTrackNodeByName(rjsRouteNode.key)
-                ?: throw OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
+                ?: throw OSRDError.newInfraError(
                     "Route $routeName references unknown track node ${rjsRouteNode.key}"
                 )
         val config =
             builder.getTrackNodeConfigByName(node, rjsRouteNode.value)
-                ?: throw OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
+                ?: throw OSRDError.newInfraError(
                     "Route $routeName references unknown config ${rjsRouteNode.value} for track node ${rjsRouteNode.key}"
                 )
         routeNodes[node] = config
@@ -640,18 +633,11 @@ fun parseRoute(builder: RawInfraBuilder, rjsRoute: RJSRoute) {
     } catch (error: BuildRouteError) {
         throw when (error) {
             is ReachedTrackDeadEnd ->
-                OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
-                    "Impossible to build route: could not reach exit point"
-                )
+                OSRDError.newInfraError("Impossible to build route: could not reach exit point")
             is ReachedNodeDeadEnd ->
-                OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
-                    "Impossible to build route: could not cross node"
-                )
+                OSRDError.newInfraError("Impossible to build route: could not cross node")
             is MissingNodeConfig ->
-                OSRDError.newInfraLoadingError(
-                    ErrorType.InfraHardLoadingError,
+                OSRDError.newInfraError(
                     "Impossible to build route: reached a node not listed on given route"
                 )
         }
@@ -661,8 +647,7 @@ fun parseRoute(builder: RawInfraBuilder, rjsRoute: RJSRoute) {
 fun parseSignal(builder: RawInfraBuilder, rjsSignal: RJSSignal) {
     val trackSectionId =
         builder.getTrackSectionByName(rjsSignal.track)
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
+            ?: throw OSRDError.newInfraError(
                 "Signal ${rjsSignal.id} references unknown track section ${rjsSignal.track}"
             )
     val direction = rjsSignal.direction!!.toDirection()

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.sim_infra.impl
 
 import fr.sncf.osrd.fast_collections.mutableIntArrayListOf
 import fr.sncf.osrd.geom.LineString
-import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.*
@@ -278,17 +277,13 @@ class RawInfraBuilder {
 
     private fun getTrackSectionIdx(name: String): TrackSectionId {
         return trackSectionNameToIdxMap[name]
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
-                "Accessing track-section from unregistered name $name"
-            )
+            ?: throw OSRDError.newInfraError("Accessing track-section from unregistered name $name")
     }
 
     private fun getTrackSectionDistanceSortedChunks(name: String): TreeMap<Distance, TrackChunkId> {
         val trackSectionIdx = getTrackSectionIdx(name)
         return trackSectionDistanceSortedChunkMap[trackSectionIdx]
-            ?: throw OSRDError.newInfraLoadingError(
-                ErrorType.InfraHardLoadingError,
+            ?: throw OSRDError.newInfraError(
                 "Accessing sorted chunks from unregistered track-section idx $trackSectionIdx (name: $name)"
             )
     }

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -28,6 +28,7 @@ public enum ErrorType {
     UnknownError("unknown_error", "An unknown exception was thrown", ErrorCause.INTERNAL),
     InfraSoftLoadingError("infra_loading:soft_error", "soft error while loading new infra", ErrorCause.USER),
     InfraHardLoadingError("infra_loading:hard_error", "hard error while loading new infra", ErrorCause.USER),
+    InfraHardError("infra:hard_error", "hard error while parsing infra", ErrorCause.USER),
     InfraLoadingCacheException("infra_loading:cache_exception", "cached exception", ErrorCause.INTERNAL),
     InfraLoadingInvalidStatusException("infra_loading:invalid_status", "Status doesn’t exist", ErrorCause.INTERNAL),
     InfraInvalidStatusWhileWaitingStable(

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
@@ -126,6 +126,18 @@ public final class OSRDError extends RuntimeException {
     }
 
     /**
+     * Creates a new OSRDError for any kind of unrecoverable infra error
+     *
+     * @param message a short description of what went wrong
+     * @return a new OSRDError instance
+     */
+    public static OSRDError newInfraError(String message) {
+        var error = new OSRDError(ErrorType.InfraHardError);
+        error.context.put("error", message);
+        return error;
+    }
+
+    /**
      * Creates a new OSRDError for an infrastructure loading error.
      *
      * @param errorType the error type
@@ -149,6 +161,7 @@ public final class OSRDError extends RuntimeException {
     public static OSRDError newInfraLoadingError(ErrorType errorType, Object sourceOperation, Throwable e) {
         var error = new OSRDError(errorType, e);
         error.context.put("source_operation", sourceOperation);
+        error.context.put("original_error", e);
         return error;
     }
 


### PR DESCRIPTION
## The current situation

There was a confusion around "hard infra error" types

The original error was used in `InfraManager` and its only content is that the infra couldn't be loaded. "source operation" described at what step it failed. It had no other context.

Then it was also used to describe any infra error. "Source operation" was used with strings instead, with the error message.

The error in `InfraManager` is actually thrown any time something was thrown while loading an infra, which removes any kind of context or explanation.

## Content of this PR

The two use cases have been split. The original use remains as it is.

A new error has been created for generic infra errors. It still lacks details and eventually we should have different errors for each case.

When the original error is thrown because of another exception, the original error is now included in the context.

## Open questions

1. Are "recursive errors" okay? I feel like it's better than nothing as the actual error can be seen in the response, but it's harder to display / translate
2. If not, do we need the `InfraManager` to wrap everything in its own error? It seems to be used to identify "soft error" / "hard error". Could we use another method instead?
3. Do we want to display these errors to the user in the front-end? I feel like we should as it explains infra edition issues, but we're currently very far away from doing this