### PR TITLE
docker: fix restart policy type for core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       additional_contexts:
         test_data: tests/data
         static_assets: assets
-    restart: no
+    restart: "no"
     command: "true"
 
   front:


### PR DESCRIPTION
In YAML, "no" is a boolean. This makes podman-compose choke on the docker-compose.yml, because it expects a string:

    Error: running container create option: "False" is not a valid restart policy: invalid argument

Use a string instead, just like wait-healthy already does.