### PR TITLE
front: fix nge node position calculation

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -189,8 +189,8 @@ const convertGeoCoords = (nodes: Node[]) => {
   const padding = 0.1;
 
   return nodes.map((node) => {
-    const normalizedX = (node.positionX - minX) / width;
-    const normalizedY = 1 - (node.positionY - minY) / height;
+    const normalizedX = (node.positionX - minX) / (width || 1);
+    const normalizedY = 1 - (node.positionY - minY) / (height || 1);
     const paddedX = normalizedX * (1 - 2 * padding) + padding;
     const paddedY = normalizedY * (1 - 2 * padding) + padding;
     return {


### PR DESCRIPTION
Fix NGE node position when dividing width or height by 0