### PR TITLE
core: stdcm: log memory use along the search

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -4,6 +4,11 @@ import fr.sncf.osrd.api.pathfinding.makePathProps
 import fr.sncf.osrd.stdcm.graph.STDCMGraph
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.logger
+import fr.sncf.osrd.utils.units.Duration
+import fr.sncf.osrd.utils.units.seconds
+import java.time.Duration.*
+import java.time.Instant
+import kotlin.math.pow
 
 /**
  * This class is used to log some elements during the graph traversal. It logs a small number of
@@ -11,25 +16,45 @@ import fr.sncf.osrd.stdcm.graph.logger
  */
 data class ProgressLogger(
     val graph: STDCMGraph,
-    val nSteps: Int = 10,
+    val nStepsProgress: Int = 10,
+    val memoryReportTimeInterval: Duration = 10.seconds,
 ) {
-    private val thresholdDistance = 1.0 / nSteps.toDouble()
+    private val thresholdDistance = 1.0 / nStepsProgress.toDouble()
     private var nSamplesReached = 1 // Avoids first node
+    private var seenSteps = 0
+    private var nextMemoryReport = Instant.now() + ofMillis(memoryReportTimeInterval.milliseconds)
 
     /** Process one node, logging it if it reaches a new threshold */
     fun processNode(node: STDCMNode) {
+        seenSteps++
         val progress =
             (graph.bestPossibleTime - node.remainingTimeEstimation) / graph.bestPossibleTime
-        if (progress < thresholdDistance * nSamplesReached) return
-        val block = node.infraExplorer.getCurrentBlock()
-        val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]
-        val str =
-            "node sample $nSamplesReached/$nSteps: " +
-                "time=${node.time.toInt()}s, " +
-                "since departure=${node.timeSinceDeparture.toInt()}s, " +
-                "best remaining time=${node.remainingTimeEstimation.toInt()}s, " +
-                "loc=$geo"
-        logger.info(str)
-        while (progress >= thresholdDistance * nSamplesReached) nSamplesReached++
+        if (progress >= thresholdDistance * nSamplesReached) {
+            val block = node.infraExplorer.getCurrentBlock()
+            val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]
+            val str =
+                "node sample for progress $nSamplesReached/$nStepsProgress: " +
+                    "time=${node.time.toInt()}s, " +
+                    "since departure=${node.timeSinceDeparture.toInt()}s, " +
+                    "best remaining time=${node.remainingTimeEstimation.toInt()}s, " +
+                    "loc=$geo, " +
+                    "#visited nodes=$seenSteps"
+            logger.info(str)
+            while (progress >= thresholdDistance * nSamplesReached) nSamplesReached++
+        }
+
+        if (Instant.now() >= nextMemoryReport) {
+            nextMemoryReport += ofMillis(memoryReportTimeInterval.milliseconds)
+            val rt = Runtime.getRuntime()
+            val max = rt.maxMemory()
+            val free = rt.freeMemory()
+            val total = rt.totalMemory()
+            val used = total - free
+            val mb = 2.0.pow(20.0)
+            val str =
+                "node #$seenSteps, memory tracing: " +
+                    "used ${(used / mb).toInt()} / ${(max / mb).toInt()} MB"
+            logger.info(str)
+        }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -120,7 +120,7 @@ class STDCMPathfinding(
             logger.info("Failed to find a path")
             return null
         }
-        logger.info("Path found, start preprocessing")
+        logger.info("Path found, start postprocessing")
 
         val res =
             STDCMPostProcessing(graph)


### PR DESCRIPTION
We now log memory usage every `x` seconds during stdcm search. This would help troubleshoot performance issues, including ones that may be caused by the gc. 