### PR TITLE
core, editoast, front: stop using speed-limit tags' long names

### DIFF
--- a/assets/static_resources/speed_limit_tags.yml
+++ b/assets/static_resources/speed_limit_tags.yml
@@ -1,224 +1,134 @@
 V200:
-  name: Voyageurs - V200
   fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 R200:
-  name: Voyageurs - Trains réversibles V200
   fallback_list: [V200, V160, V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 AR200:
-  name: Voyageurs - AR200
   fallback_list: [V200, V160, V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 V160:
-  name: Voyageurs - V160
   fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 R160:
-  name: Voyageurs - Trains réversibles V160
   fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 AR160:
-  name: Voyageurs - AR160
   fallback_list: [V160, V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 V140:
-  name: Voyageurs - V140
   fallback_list: [V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 R140:
-  name: Voyageurs - Trains réversibles V140
   fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 AR140:
-  name: Voyageurs - AR140
   fallback_list: [V140, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 V120:
-  name: Voyageurs - V120
   fallback_list: [ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 R120:
-  name: Voyageurs - Trains réversibles V120
   fallback_list: [V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 AR120:
-  name: Voyageurs - AR120
   fallback_list: [V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 MVGV:
-  name: Messagerie - MVGV
   fallback_list: [MV160, ME140, ME120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 MV160:
-  name: Messagerie - MV160
   fallback_list: [ME140, ME120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 ME140:
-  name: Messagerie - ME140
   fallback_list: [ME120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 ME120:
-  name: Messagerie - ME120
   fallback_list: [ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 ME100:
-  name: Messagerie - ME100
   fallback_list: [MA100, MA90, MA80]
-  default_speed: 8.333333
 
 HLP:
-  name: Divers - Haut le pied
   fallback_list: [ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 MA100:
-  name: Marchandise - MA100
   fallback_list: [MA90, MA80]
-  default_speed: 8.333333
 
 MA90:
-  name: Marchandise - MA90
   fallback_list: [MA80]
-  default_speed: 8.333333
 
 MA80:
-  name: Marchandise - MA80
   fallback_list: []
-  default_speed: 8.333333
 
 E32C:
-  name: Voyageurs - Automoteurs - E32C
   fallback_list: [E30C, E20C, E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E30C:
-  name: Voyageurs - Automoteurs - E30C
   fallback_list: [E20C, E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E20C:
-  name: Voyageurs - Automoteurs - E20C
   fallback_list: [E20N, V200, E16C, E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E20N:
-  name: Voyageurs - Automoteurs - E20N
   fallback_list: [V200, E16N, V160, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E16C:
-  name: Voyageurs - Automoteurs - E16C
   fallback_list: [E16N, V160, E14C, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E16N:
-  name: Voyageurs - Automoteurs - E16N
   fallback_list: [V160, E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14F:
-  name: Voyageurs - Automoteurs - E14F
   fallback_list: [E14R, E14Q, E14P, E14C, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14C:
-  name: Voyageurs - Automoteurs - E14C
   fallback_list: [E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14R:
-  name: Voyageurs - Automoteurs - E14R
   fallback_list: [E14Q, E14P, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14Q:
-  name: Voyageurs - Automoteurs - E14Q
   fallback_list: [E14P, E14N, V140, E12Q, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14P:
-  name: Voyageurs - Automoteurs - E14P
   fallback_list: [E14N, V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E14N:
-  name: Voyageurs - Automoteurs - E14N
   fallback_list: [V140, E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E12C:
-  name: Voyageurs - Automoteurs - E12C
   fallback_list: [E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E12Q:
-  name: Voyageurs - Automoteurs - E12Q
   fallback_list: [E12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E12N:
-  name: Voyageurs - Automoteurs - E12N
   fallback_list: [V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 E10C:
-  name: Voyageurs - Automoteurs - E10C
   fallback_list: [ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 T16C:
-  name: Voyageurs - Autorails - T16C
   fallback_list: [V160, T14C, T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 T14C:
-  name: Voyageurs - Autorails - T14C
   fallback_list: [T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 T14N:
-  name: Voyageurs - Autorails - T14N
   fallback_list: [V140, T12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 T12C:
-  name: Voyageurs - Autorails - T12C
   fallback_list: [T12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 T12N:
-  name: Voyageurs - Autorails - T12N
   fallback_list: [V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 B16C:
-  name: Voyageurs - BIMA - B16C
   fallback_list: [T16C, V160, T14C, T14N, V140, T12C, T12N, V120, ME100, MA100, MA90, MA80]
-  default_speed: 8.333333
 
 TM:
-  name: Divers - Train de machines
   fallback_list: [MA90, MA80]
-  default_speed: 8.333333
 
 EVO:
-  name: Divers - Evolution
   fallback_list: [MA80]
-  default_speed: 8.333333

--- a/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
+++ b/core/kt-osrd-rjs-parser/src/main/kotlin/fr/sncf/osrd/RawInfraRJSParser.kt
@@ -6,11 +6,7 @@ import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeEndpoint
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
-import fr.sncf.osrd.railjson.schema.infra.RJSInfra
-import fr.sncf.osrd.railjson.schema.infra.RJSRoute
-import fr.sncf.osrd.railjson.schema.infra.RJSSwitch
-import fr.sncf.osrd.railjson.schema.infra.RJSSwitchType
-import fr.sncf.osrd.railjson.schema.infra.RJSTrackSection
+import fr.sncf.osrd.railjson.schema.infra.*
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSRouteWaypoint
 import fr.sncf.osrd.railjson.schema.infra.trackobjects.RJSSignal
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSElectrification
@@ -20,57 +16,13 @@ import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSSpeedSection
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Detector
-import fr.sncf.osrd.sim_infra.api.DetectorId
-import fr.sncf.osrd.sim_infra.api.DirDetectorId
-import fr.sncf.osrd.sim_infra.api.DirTrackSectionId
-import fr.sncf.osrd.sim_infra.api.EndpointTrackSectionId
-import fr.sncf.osrd.sim_infra.api.LoadingGaugeConstraint
-import fr.sncf.osrd.sim_infra.api.LoadingGaugeType
-import fr.sncf.osrd.sim_infra.api.NeutralSection
-import fr.sncf.osrd.sim_infra.api.RawInfra
-import fr.sncf.osrd.sim_infra.api.RawSignalParameters
-import fr.sncf.osrd.sim_infra.api.TrackChunk
-import fr.sncf.osrd.sim_infra.api.TrackNodeConfig
-import fr.sncf.osrd.sim_infra.api.TrackNodeConfigId
-import fr.sncf.osrd.sim_infra.api.TrackNodeId
-import fr.sncf.osrd.sim_infra.api.TrackNodePort
-import fr.sncf.osrd.sim_infra.api.TrackNodePortId
-import fr.sncf.osrd.sim_infra.api.TrackSection
-import fr.sncf.osrd.sim_infra.api.ZoneId
-import fr.sncf.osrd.sim_infra.api.decreasing
-import fr.sncf.osrd.sim_infra.api.increasing
-import fr.sncf.osrd.sim_infra.impl.BuildRouteError
-import fr.sncf.osrd.sim_infra.impl.MissingNodeConfig
-import fr.sncf.osrd.sim_infra.impl.RawInfraBuilder
-import fr.sncf.osrd.sim_infra.impl.ReachedNodeDeadEnd
-import fr.sncf.osrd.sim_infra.impl.ReachedTrackDeadEnd
-import fr.sncf.osrd.sim_infra.impl.SpeedLimitTagDescriptor
-import fr.sncf.osrd.sim_infra.impl.SpeedSection
-import fr.sncf.osrd.sim_infra.impl.TrackChunkDescriptor
-import fr.sncf.osrd.sim_infra.impl.TrackNodeConfigDescriptor
-import fr.sncf.osrd.sim_infra.impl.route
-import fr.sncf.osrd.utils.Direction
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.impl.*
+import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.Direction.DECREASING
 import fr.sncf.osrd.utils.Direction.INCREASING
-import fr.sncf.osrd.utils.DirectionalMap
-import fr.sncf.osrd.utils.DistanceRangeMap
-import fr.sncf.osrd.utils.DistanceRangeMapImpl
-import fr.sncf.osrd.utils.Endpoint
-import fr.sncf.osrd.utils.UnionFind
-import fr.sncf.osrd.utils.distanceRangeMapOf
-import fr.sncf.osrd.utils.indexing.DirStaticIdx
-import fr.sncf.osrd.utils.indexing.MutableStaticIdxArraySet
-import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticPool
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArraySetOf
-import fr.sncf.osrd.utils.units.Distance
-import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.Speed
-import fr.sncf.osrd.utils.units.meters
-import fr.sncf.osrd.utils.units.metersPerSecond
-import fr.sncf.osrd.utils.units.mutableOffsetArrayListOf
+import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.units.*
 import java.io.IOException
 import java.util.*
 import kotlin.collections.set
@@ -766,9 +718,7 @@ fun EdgeEndpoint.toEndpoint(): Endpoint {
 
 @Serializable
 data class YamlSpeedLimitTagDescriptor(
-    val name: String,
     @SerialName("fallback_list") val fallbackList: List<String>,
-    @SerialName("default_speed") val defaultSpeed: Double?,
 )
 
 fun parseSpeedLimitTags(builder: RawInfraBuilder) {
@@ -784,16 +734,10 @@ fun parseSpeedLimitTags(builder: RawInfraBuilder) {
         )
 
     for ((tagCode, tagDescriptor) in speedLimitTagDescriptors.entries) {
-        val defaultSpeed =
-            if (tagDescriptor.defaultSpeed != null)
-                Speed.fromMetersPerSecond(tagDescriptor.defaultSpeed)
-            else null
         builder.speedLimitTag(
+            tagCode,
             SpeedLimitTagDescriptor(
-                tagCode,
-                tagDescriptor.name,
                 tagDescriptor.fallbackList,
-                defaultSpeed
             )
         )
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/RawInfraBuilder.kt
@@ -434,8 +434,8 @@ class RawInfraBuilder {
         return physicalSignalPool.add(builder.build())
     }
 
-    fun speedLimitTag(tagDescriptor: SpeedLimitTagDescriptor) {
-        speedLimitTagPool[tagDescriptor.id] = tagDescriptor
+    fun speedLimitTag(tagId: String, tagDescriptor: SpeedLimitTagDescriptor) {
+        speedLimitTagPool[tagId] = tagDescriptor
     }
 
     fun trackSection(name: String, chunks: StaticIdxList<TrackChunk>): TrackSectionId {

--- a/editoast/src/generated_data/speed_limit_tags_config.rs
+++ b/editoast/src/generated_data/speed_limit_tags_config.rs
@@ -9,10 +9,8 @@ type SpeedLimitTagsConfig = HashMap<String, SpeedLimitTag>;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SpeedLimitTag {
-    pub name: String,
     #[serde(default)]
     pub fallback_list: Vec<String>,
-    pub default_speed: f64,
 }
 
 impl SpeedLimitTagIds {

--- a/front/src/applications/stdcm/components/SimulationReportSheet.tsx
+++ b/front/src/applications/stdcm/components/SimulationReportSheet.tsx
@@ -8,7 +8,7 @@ import { formatDateToString, formatDay } from 'utils/date';
 
 import styles from './SimulationReportStyleSheet';
 import type { SimulationReportSheetProps } from '../types';
-import { extractSpeedLimit, getStopDurationTime } from '../utils/formatSimulationReportSheet';
+import { getStopDurationTime } from '../utils/formatSimulationReportSheet';
 
 const SimulationReportSheet = ({
   stdcmData,
@@ -82,9 +82,7 @@ const SimulationReportSheet = ({
             <View style={styles.convoyAndRoute.convoyInfo}>
               <View style={styles.convoyAndRoute.convoyInfoBox1}>
                 <Text style={styles.convoyAndRoute.convoyInfoTitles}>{t('speedLimitByTag')}</Text>
-                <Text style={styles.convoyAndRoute.convoyInfoData}>
-                  {(speedLimitByTag && extractSpeedLimit(speedLimitByTag)) || '-'}
-                </Text>
+                <Text style={styles.convoyAndRoute.convoyInfoData}>{speedLimitByTag || '-'}</Text>
                 <Text style={styles.convoyAndRoute.convoyInfoTitles}>{t('towedMaterial')}</Text>
                 <Text style={styles.convoyAndRoute.convoyInfoData}>-</Text>
                 <Text style={styles.convoyAndRoute.convoyInfoTitles}>{t('maxSpeed')}</Text>

--- a/front/src/applications/stdcm/utils/__tests__/simulationReportSheet.spec.ts
+++ b/front/src/applications/stdcm/utils/__tests__/simulationReportSheet.spec.ts
@@ -1,7 +1,6 @@
 import {
   generateCodeNumber,
   getStopDurationTime,
-  extractSpeedLimit,
   computeStopDepartureTime,
   addMinutesToTime,
   getStopDurationBetweenTwoPositions,
@@ -18,15 +17,6 @@ describe('getStopDurationTime', () => {
   it('should return correct time format', () => {
     expect(getStopDurationTime(30)).toBe('30 sec');
     expect(getStopDurationTime(120)).toBe('2 min');
-  });
-});
-
-describe('extractSpeedLimit', () => {
-  it('should extract the speed limit correctly', () => {
-    const speedLimitByTag1 = 'Voyageurs 100 - MA100';
-    const speedLimitByTag2 = 'Voyageurs';
-    expect(extractSpeedLimit(speedLimitByTag1)).toBe('MA100');
-    expect(extractSpeedLimit(speedLimitByTag2)).toBe('Voyageurs');
   });
 });
 

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -29,11 +29,6 @@ export function getStopDurationTime(sec: number) {
   return `${time.getUTCMinutes()} min`;
 }
 
-export function extractSpeedLimit(speedLimitByTag: string): string {
-  const parts = speedLimitByTag.split(' - ');
-  return parts[parts.length - 1];
-}
-
 function secondsToTimeString(duration: number): string {
   const minutes = Math.floor(duration / 60);
   const seconds = duration % 60;

--- a/front/src/modules/trainschedule/components/Timetable/consts.ts
+++ b/front/src/modules/trainschedule/components/Timetable/consts.ts
@@ -1,7 +1,6 @@
 import type { InvalidReason } from './types';
 
 export const specialCodeDictionary: { [key: string]: string } = {
-  'Divers - Haut le pied': 'HLP',
   '': 'NO CODE',
 };
 

--- a/front/tests/005-operational-studies.spec.ts
+++ b/front/tests/005-operational-studies.spec.ts
@@ -99,12 +99,8 @@ test.describe('Testing if all mandatory elements simulation configuration are lo
     await expect(scenarioPage.getSpeedLimitSelector).toBeVisible();
     await scenarioPage.getSpeedLimitSelector.click();
     await scenarioPage.getSpeedLimitSelector.locator('input').fill('32');
-    await scenarioPage.getSpeedLimitSelector
-      .getByRole('button', { name: 'Voyageurs - Automoteurs - E32C' })
-      .click();
-    expect(await scenarioPage.getSpeedLimitSelector.textContent()).toMatch(
-      /Voyageurs - Automoteurs - E32C/i
-    );
+    await scenarioPage.getSpeedLimitSelector.getByRole('button', { name: 'E32C' }).click();
+    expect(await scenarioPage.getSpeedLimitSelector.textContent()).toMatch(/E32C/i);
 
     // ***************** Test Add Train Schedule *****************
     await scenarioPage.addTrainSchedule();

--- a/front/tests/assets/trainSchedule/train_schedules.json
+++ b/front/tests/assets/trainSchedule/train_schedules.json
@@ -67,7 +67,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Divers - Haut le pied",
+    "speed_limit_tag": "HLP",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": false }
   },
@@ -85,7 +85,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [{ "from": "id7838", "to": "id7839", "value": "C1" }],
     "options": { "use_electrical_profiles": true }
   },
@@ -118,7 +118,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   },
@@ -144,7 +144,7 @@
     "initial_speed": 16.666666666666668,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   },
@@ -235,7 +235,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   },
@@ -296,7 +296,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Divers - Haut le pied",
+    "speed_limit_tag": "HLP",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": false }
   },
@@ -322,7 +322,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   },
@@ -349,7 +349,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Divers - Haut le pied",
+    "speed_limit_tag": "HLP",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   },
@@ -427,7 +427,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Voyageurs - Automoteurs - E32C",
+    "speed_limit_tag": "E32C",
     "power_restrictions": [{ "from": "id933", "to": "id884", "value": "C1" }],
     "options": { "use_electrical_profiles": true }
   },
@@ -517,7 +517,7 @@
     "initial_speed": 33.333333333333336,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [{ "from": "id353", "to": "id339", "value": "C2" }],
     "options": { "use_electrical_profiles": true }
   },
@@ -559,7 +559,7 @@
     "initial_speed": 0,
     "comfort": "STANDARD",
     "constraint_distribution": "MARECO",
-    "speed_limit_tag": "Marchandise - MA100",
+    "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true }
   }

--- a/tests/data/infras/small_infra/infra.json
+++ b/tests/data/infras/small_infra/infra.json
@@ -2927,7 +2927,7 @@
             "id": "speed_section.0",
             "speed_limit": 83.33333333333333,
             "speed_limit_by_tag": {
-                "Divers - Haut le pied": 69.44444444444444
+                "HLP": 69.44444444444444
             },
             "track_ranges": [
                 {
@@ -3123,7 +3123,7 @@
             "id": "speed_section.1",
             "speed_limit": 39.44444444444444,
             "speed_limit_by_tag": {
-                "Voyageurs - Automoteurs - E32C": 27.77777777777778
+                "E32C": 27.77777777777778
             },
             "track_ranges": [
                 {
@@ -3145,7 +3145,7 @@
             "id": "speed_section.2",
             "speed_limit": 31.11111111111111,
             "speed_limit_by_tag": {
-                "Marchandise - MA100": 22.22222222222222
+                "MA100": 22.22222222222222
             },
             "track_ranges": [
                 {

--- a/tests/infra-scripts/small_infra.py
+++ b/tests/infra-scripts/small_infra.py
@@ -576,16 +576,16 @@ south_east.add_part(th1, 4400)
 # ================================
 #  Speed sections
 # ================================
-speed_0 = builder.add_speed_section(300 / 3.6, speed_limit_by_tag={"Divers - Haut le pied": 250 / 3.6})
+speed_0 = builder.add_speed_section(300 / 3.6, speed_limit_by_tag={"HLP": 250 / 3.6})
 for track_section in builder.infra.track_sections:
     speed_0.add_track_range(track_section, 0, track_section.length, ApplicableDirection.BOTH)
 
 
-speed_1 = builder.add_speed_section(142 / 3.6, speed_limit_by_tag={"Voyageurs - Automoteurs - E32C": 100 / 3.6})
+speed_1 = builder.add_speed_section(142 / 3.6, speed_limit_by_tag={"E32C": 100 / 3.6})
 speed_1.add_track_range(th0, 500, 1000, ApplicableDirection.BOTH)
 speed_1.add_track_range(th1, 0, 4000, ApplicableDirection.BOTH)
 
-speed_2 = builder.add_speed_section(112 / 3.6, speed_limit_by_tag={"Marchandise - MA100": 80 / 3.6})
+speed_2 = builder.add_speed_section(112 / 3.6, speed_limit_by_tag={"MA100": 80 / 3.6})
 speed_2.add_track_range(th1, 3500, 4400, ApplicableDirection.BOTH)
 
 # ================================


### PR DESCRIPTION
* stop fallback on long-names (core)
* remove short-id extractors (front)
* adapt examples and small_infra

also remove default-speed, as it is unused

Resolves #7977 
🔍 ~This PR can be reviewed, but not merged~ 👇 

TODO:
- [x] Create a new dump beforehand and test it, then share it