### PR TITLE
osrd-schemas: tidy type hints

### DIFF
--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osrd_schemas"
-version = "0.8.12"
+version = "0.8.13"
 description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 


### PR DESCRIPTION
I removed NewType ([as documented by pydantic](https://docs.pydantic.dev/2.6/concepts/types/#named-type-aliases)).
This allows instantiating the classes with `id="example"` without Pylance yielding an error. 
I could have used a `TypeAliasType` but then that would have changed the json schema: it would no longer inline the constraints. This could be desirable, in another PR.

I corrected/added type hints, to fix all errors Pylance would otherwise yield.

I removed the direct calls to `Identifier` because they were unnecessary for constraint checking (and caused Pylance to yield an error).