### PR TITLE
docker: use dev profile instead of release for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,8 @@ services:
       additional_contexts:
         test_data: tests/data
         static_assets: assets
+      args:
+        CARGO_PROFILE: dev
     restart: unless-stopped
     ports: ["8090:80"]
     environment:
@@ -128,6 +130,7 @@ services:
       dockerfile: Dockerfile
       args:
         OSRD_GIT_DESCRIBE: ${OSRD_GIT_DESCRIBE}
+        CARGO_PROFILE: dev
     volumes:
       - "./docker/gateway.dev.simple.toml:/gateway.toml"
     restart: unless-stopped
@@ -145,6 +148,8 @@ services:
     build:
       context: osrdyne
       dockerfile: Dockerfile
+      args:
+        CARGO_PROFILE: dev
     restart: unless-stopped
     ports: ["4242:4242"]
     environment:

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -45,13 +45,14 @@ FROM base_builder AS run_builder
 COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+ARG CARGO_PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/editoast/target \
-    cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/editoast/target \
-    cargo install --locked --path .
+    cargo install --profile ${CARGO_PROFILE} --locked --path .
 
 ###############
 # Running env #

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -18,13 +18,14 @@ RUN cargo chef prepare --recipe-path recipe.json
 ######################
 FROM chef as run_builder
 COPY --from=planner /gateway/recipe.json recipe.json
+ARG CARGO_PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/gateway/target \
-    cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/gateway/target \
-    cargo install --locked --path .
+    cargo install --profile ${CARGO_PROFILE} --locked --path .
 
 ######################
 # Testing env: build #

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -18,13 +18,14 @@ RUN cargo chef prepare --recipe-path recipe.json
 ######################
 FROM chef as run_builder
 COPY --from=planner /osrdyne/recipe.json recipe.json
+ARG CARGO_PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/osrdyne/target \
-    cargo chef cook --release --recipe-path recipe.json
+    cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/osrdyne/target \
-    cargo install --locked --path .
+    cargo install --profile ${CARGO_PROFILE} --locked --path .
 
 ######################
 # Testing env: build #


### PR DESCRIPTION
docker-compose is used for development. Use the "dev" profile instead of "release" to speed up builds.