### PR TITLE
front: fix localStorage.setItem() in macro node store

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/nodeStore.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/nodeStore.ts
@@ -22,7 +22,8 @@ const loadNodes = () => {
 };
 
 const saveNodes = (nodes: Map<string, Node>) => {
-  localStorage.setItem(NODES_LOCAL_STORAGE_KEY, JSON.stringify(nodes));
+  const entries = [...nodes.entries()];
+  localStorage.setItem(NODES_LOCAL_STORAGE_KEY, JSON.stringify(entries));
 };
 
 const getNodeKey = (timetableId: number, trigram: string) => `${timetableId}:${trigram}`;

--- a/front/src/applications/operationalStudies/components/MacroEditor/nodeStore.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/nodeStore.ts
@@ -14,7 +14,14 @@ const loadNodes = () => {
   let entries = [];
   const rawNodes = localStorage.getItem(NODES_LOCAL_STORAGE_KEY);
   if (rawNodes) {
-    entries = JSON.parse(rawNodes);
+    const parsedNodes = JSON.parse(rawNodes);
+    if (Array.isArray(parsedNodes)) {
+      entries = parsedNodes;
+    } else {
+      console.error(
+        `Error loading nodes from localStorage: expected an array, but received: '${typeof parsedNodes}' type.`
+      );
+    }
   }
 
   nodesCache = new Map(entries);


### PR DESCRIPTION
JSON.stringify() will always return "{}" for a Map. Convert the Map to an array of entries before encoding these to JSON.

Closes: https://github.com/OpenRailAssociation/osrd/issues/8477