### PR TITLE
docker: add override for Docker socket path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       rabbitmq: {condition: service_healthy}
     command: osrdyne
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
       - ./docker/osrdyne.yml:/osrdyne.yml
     build:
       context: osrdyne


### PR DESCRIPTION
Some systems (e.g. podman) have a non-standard socket path. Allow developers to override the default via a .env file.

I've tried using compose.override.yml but it doesn't seem to work.