### PR TITLE
front: don't debounce NGE node events

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -83,7 +83,7 @@
     "lodash": "^4.17.21",
     "maplibre-gl": "^4.0.0",
     "match-sorter": "^6.3.3",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.d8b7083bd0d2c21a7922f80a8bb60c2197afb005",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.1f2fe60f93abd5fafa86e67aacbcc6eeae7dc0b5",
     "openapi-typescript-codegen": "^0.27.0",
     "party-js": "^2.2.0",
     "prop-types": "^15.8.1",

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -1,5 +1,3 @@
-import { debounce } from 'lodash';
-
 import { osrdEditoastApi, type TrainScheduleBase } from 'common/api/osrdEditoastApi';
 import type { AppDispatch } from 'store';
 
@@ -126,10 +124,10 @@ const handleTrainrunOperation = async ({
   }
 };
 
-const handleUpdateNode = debounce((timeTableId: number, node: Node) => {
+const handleUpdateNode = (timeTableId: number, node: Node) => {
   const { betriebspunktName: trigram, positionX, positionY } = node;
   nodeStore.set(timeTableId, { trigram, positionX, positionY });
-}, 2000);
+};
 
 const handleNodeOperation = ({
   type,

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2072,10 +2072,10 @@
     openapi-typescript "^5.4.1"
     yargs "^17.7.2"
 
-"@osrd-project/netzgrafik-frontend@0.0.0-snapshot.d8b7083bd0d2c21a7922f80a8bb60c2197afb005":
-  version "0.0.0-snapshot.d8b7083bd0d2c21a7922f80a8bb60c2197afb005"
-  resolved "https://registry.yarnpkg.com/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.d8b7083bd0d2c21a7922f80a8bb60c2197afb005.tgz#8e13fdbb2b98f5c514257a3bfd689a13e0370922"
-  integrity sha512-WRcom1DSfD2IEoducDcohtZKL1CnOuZHolljNwRsvrezfYn1YxiPoUVYpy7NGIVmAi6+leImdVAaY8EMUtnMsA==
+"@osrd-project/netzgrafik-frontend@0.0.0-snapshot.1f2fe60f93abd5fafa86e67aacbcc6eeae7dc0b5":
+  version "0.0.0-snapshot.1f2fe60f93abd5fafa86e67aacbcc6eeae7dc0b5"
+  resolved "https://registry.yarnpkg.com/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.1f2fe60f93abd5fafa86e67aacbcc6eeae7dc0b5.tgz#9ca8f5c4c0c16b6478fa98116c99aca78d2c119e"
+  integrity sha512-5HpHe2TLrNQ6vIpfZu5GDsv0nJlF1Nzf4HRWitWahWIFGfypbm6nCXZoDPNrZD9SQjchK782UfMf8OuHDVaijg==
 
 "@osrd-project/ui-core@^0.0.35":
   version "0.0.35"


### PR DESCRIPTION
The current approach doesn't work when editing two nodes in succession: edit node A and before 2s elapse edit node B. The debounce will only invoke the callback for node B, dropping changes for node A. Moreover, switching to the micro tab will not immediately reflect changes.

Instead, [NGE has been patched][1] to only trigger the node update event once the input field is unfocused.

[1]: https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/248