### PR TITLE
core: stdcm: fix postprocessing with scheduled times

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -333,7 +333,7 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
         Envelope res = null;
         OSRDError lastError = null;
         var search = new DoubleBinarySearch(initialLowBound, initialHighBound, targetTime, tolerance, true);
-        for (int i = 1; i < 21 && !search.complete(); i++) {
+        for (int i = 1; i < 30 && !search.complete(); i++) {
             var input = search.getInput();
             try {
                 res = computeIteration(envelopeSection, context, input, imposedBeginSpeed, imposedEndSpeed);


### PR DESCRIPTION
We assumed that `edges.last.totalDepartureTimeShift` were equal to `startTime + actualDepartureTime`, which is now wrong with scheduled point.

But since we now also have start time = 0, we can simplify a lot of things, which also fixes it. 