### PR TITLE
front: stdcm result table, round times to the closest minute

### DIFF
--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -83,7 +83,7 @@ function getTimeAtPosition(
 ): string {
   const index = trainPositions.findIndex((pos) => pos >= trainPosition);
   const timeInMillis = trainTimes[index];
-  const timeInMinutes = Math.floor(timeInMillis / 60000);
+  const timeInMinutes = Math.round(timeInMillis / 60000);
   return addMinutesToTime(trainDepartureHour, trainDepartureMinute, timeInMinutes);
 }
 


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/8502

All the times in the table were just floored down to the minute. We need round to the closest minute