### PR TITLE
editoast: mark sprites as cacheable

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -2258,6 +2258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
+
+[[package]]
 name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,10 +5163,18 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -138,6 +138,7 @@ tokio-util = { version = "0.7.11", features = ["io", "tracing"] }
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = [
   "cors",
+  "fs",
   "limit",
   "normalize-path",
   "trace",


### PR DESCRIPTION
Same goal as #8514 but for sprites.

Since the data comes from the filesystem, we can just use ServeFile instead of hand-rolling our own logic. We get Last-Modified for free (allows user agents to cache requests).