### PR TITLE
front: allow to edit invalid trains without rolling stock name

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -237,32 +237,34 @@ const useSetupItineraryForTrainUpdate = (
         return;
       }
       const trainSchedule = await getTrainScheduleById({ id: trainIdToEdit }).unwrap();
-      if (!trainSchedule.rolling_stock_name) {
-        return;
-      }
 
-      let itinerary = null;
-      try {
-        const rollingStock = await getRollingStockByName({
-          rollingStockName: trainSchedule.rolling_stock_name,
-        }).unwrap();
-        itinerary = await computeItineraryForTrainUpdate(trainSchedule, rollingStock);
-        const { pathSteps, pathProperties } = itinerary || {};
+      let rollingStock: RollingStockWithLiveries | null = null;
+      let pathSteps: (PathStep | null)[] | undefined;
 
-        adjustConfWithTrainToModifyV2(
-          trainSchedule,
-          pathSteps || computeBasePathSteps(trainSchedule),
-          rollingStock.id,
-          dispatch,
-          usingElectricalProfiles,
-          osrdActions
-        );
-        if (pathProperties) {
-          setPathProperties(pathProperties);
+      if (trainSchedule.rolling_stock_name) {
+        try {
+          rollingStock = await getRollingStockByName({
+            rollingStockName: trainSchedule.rolling_stock_name,
+          }).unwrap();
+          const itinerary = await computeItineraryForTrainUpdate(trainSchedule, rollingStock);
+          pathSteps = itinerary?.pathSteps;
+
+          if (itinerary?.pathProperties) {
+            setPathProperties(itinerary.pathProperties);
+          }
+        } catch (e) {
+          dispatch(setFailure(castErrorToFailure(e)));
         }
-      } catch (e) {
-        dispatch(setFailure(castErrorToFailure(e)));
       }
+
+      adjustConfWithTrainToModifyV2(
+        trainSchedule,
+        pathSteps || computeBasePathSteps(trainSchedule),
+        rollingStock?.id,
+        dispatch,
+        usingElectricalProfiles,
+        osrdActions
+      );
     };
 
     setupItineraryForTrainUpdate();


### PR DESCRIPTION
The user couldn't see the configuration of an invalid train without rolling stock name because of an early return.

closes #8530 