### PR TITLE
front: output table does not display schedule for op via

### DIFF
--- a/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
@@ -49,7 +49,7 @@ const SimulationResultsV2 = ({
     selectedTrainPowerRestrictions,
     trainSimulation,
     pathProperties,
-    pathLength,
+    path,
   },
   timetableTrainNb,
 }: SimulationResultsV2Props) => {
@@ -214,7 +214,7 @@ const SimulationResultsV2 = ({
               pathProperties={pathProperties}
               operationalPoints={operationalPoints.finalOutput}
               selectedTrainSchedule={selectedTrainSchedule}
-              pathLength={pathLength}
+              path={path}
               dataIsLoading={formattedOpPointsLoading}
             />
           </div>

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -6,7 +6,7 @@ import type {
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { PathfindingResultSuccess, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders/Loader';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
 import { convertIsoUtcToLocalTime } from 'utils/date';
@@ -21,7 +21,7 @@ type TimesStopsOutputProps = {
   pathProperties: PathPropertiesFormatted;
   operationalPoints: OperationalPointWithTimeAndSpeed[];
   selectedTrainSchedule: TrainScheduleResult;
-  pathLength?: number;
+  path?: PathfindingResultSuccess;
   dataIsLoading: boolean;
 };
 
@@ -30,7 +30,7 @@ const TimesStopsOutput = ({
   pathProperties,
   operationalPoints,
   selectedTrainSchedule,
-  pathLength,
+  path,
   dataIsLoading,
 }: TimesStopsOutputProps) => {
   const startTime = convertIsoUtcToLocalTime(selectedTrainSchedule.start_time);
@@ -39,7 +39,7 @@ const TimesStopsOutput = ({
     pathProperties,
     operationalPoints,
     selectedTrainSchedule,
-    pathLength
+    path
   );
   if (dataIsLoading) {
     return (

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -6,7 +6,7 @@ import type {
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
-import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { PathfindingResultSuccess, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
@@ -23,20 +23,28 @@ function useOutputTableData(
   pathProperties: PathPropertiesFormatted,
   operationalPoints: OperationalPointWithTimeAndSpeed[],
   selectedTrainSchedule: TrainScheduleResult,
-  pathLength?: number
+  path?: PathfindingResultSuccess
 ) {
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrainSchedule.schedule, 'at');
   const suggestedOperationalPoints: SuggestedOP[] = useMemo(
     () =>
-      pathLength
+      path?.length
         ? formatSuggestedOperationalPoints(
             pathProperties.operationalPoints,
             pathProperties.geometry,
-            pathLength
+            path.length
           )
         : [],
     [pathProperties.operationalPoints, pathProperties.geometry]
   );
+
+  const pathStepsWithPositionOnPath = useMemo(() => {
+    if (!path || !selectedTrainSchedule) return [];
+    return selectedTrainSchedule.path.map((pathStep, index) => ({
+      ...pathStep,
+      positionOnPath: path.path_item_positions[index],
+    }));
+  }, [path, selectedTrainSchedule]);
 
   const pathStepsWithOpPointIndices = useMemo(
     () =>
@@ -65,51 +73,61 @@ function useOutputTableData(
     (opPoint) => `${opPoint.name}-${opPoint.ch}`
   );
 
-  const outputTableData = useMemo(
-    () =>
-      suggestedOperationalPoints.map((sugOpPoint, sugOpIndex) => {
-        const opPoint = operationPointsByNameCh[`${sugOpPoint.name}-${sugOpPoint.ch}`];
-        if (!opPoint) {
-          return sugOpPoint;
-        }
-        const nextOpPoint = findNextScheduledOpPoint(
-          operationalPoints,
-          pathStepsWithOpPointIndices,
-          sugOpIndex
-        );
-        const pathStepKey = `${sugOpPoint.uic}-${sugOpPoint.ch}`;
+  const outputTableData = useMemo(() => {
+    const pathStepRows = pathStepsWithPositionOnPath.map((pathStep) => {
+      const schedule = scheduleByAt[pathStep.id];
+      const scheduleData = computeScheduleData(schedule, selectedTrainSchedule.start_time);
+      return { ...pathStep, ...formatScheduleData(scheduleData) };
+    });
 
-        if (pathStepKey in pathStepsByUic) {
-          const pathStepId = pathStepsByUic[pathStepKey].id || '';
-          const schedule = scheduleByAt[pathStepId];
-          const scheduleData = computeScheduleData(schedule, selectedTrainSchedule.start_time);
-          const formattedScheduleData = formatScheduleData(scheduleData);
-          const marginsData = nextOpPoint
-            ? computeMargins(
-                simulatedTrain,
-                opPoint,
-                nextOpPoint,
-                selectedTrainSchedule,
-                pathStepId
-              )
-            : null;
-          const calculatedArrival = checkAndFormatCalculatedArrival(scheduleData, opPoint.time);
+    const suggestedOpRows = suggestedOperationalPoints.map((sugOpPoint, sugOpIndex) => {
+      const opPoint = operationPointsByNameCh[`${sugOpPoint.name}-${sugOpPoint.ch}`];
+      if (!opPoint) {
+        return sugOpPoint;
+      }
+      const nextOpPoint = findNextScheduledOpPoint(
+        operationalPoints,
+        pathStepsWithOpPointIndices,
+        sugOpIndex
+      );
+      const pathStepKey = `${sugOpPoint.uic}-${sugOpPoint.ch}`;
 
-          return {
-            ...sugOpPoint,
-            ...formattedScheduleData,
-            onStopSignal: schedule?.on_stop_signal || '',
-            calculatedArrival,
-            calculatedDeparture:
-              opPoint.duration > 0 ? secToHoursString(opPoint.time + opPoint.duration, true) : '',
-            ...marginsData,
-          } as SuggestedOP;
-        }
+      if (pathStepKey in pathStepsByUic) {
+        const pathStepId = pathStepsByUic[pathStepKey].id || '';
+        const schedule = scheduleByAt[pathStepId];
+        const scheduleData = computeScheduleData(schedule, selectedTrainSchedule.start_time);
+        const formattedScheduleData = formatScheduleData(scheduleData);
+        const marginsData = nextOpPoint
+          ? computeMargins(simulatedTrain, opPoint, nextOpPoint, selectedTrainSchedule, pathStepId)
+          : null;
+        const calculatedArrival = checkAndFormatCalculatedArrival(scheduleData, opPoint.time);
+        return {
+          ...sugOpPoint,
+          ...formattedScheduleData,
+          onStopSignal: schedule?.on_stop_signal || '',
+          calculatedArrival,
+          calculatedDeparture:
+            opPoint.duration > 0 ? secToHoursString(opPoint.time + opPoint.duration, true) : '',
+          ...marginsData,
+        } as SuggestedOP;
+      }
 
-        return { ...sugOpPoint, calculatedArrival: secToHoursString(opPoint.time, true) };
-      }),
-    [simulatedTrain, pathProperties, operationalPoints, selectedTrainSchedule, pathLength]
-  );
+      return { ...sugOpPoint, calculatedArrival: secToHoursString(opPoint.time, true) };
+    });
+
+    return suggestedOpRows.map((sugOpPoint) => {
+      const matchingPathStep = pathStepRows.find(
+        (pathStepRow) => sugOpPoint.positionOnPath === pathStepRow.positionOnPath
+      );
+      if (matchingPathStep) {
+        return {
+          ...sugOpPoint,
+          ...matchingPathStep,
+        };
+      }
+      return sugOpPoint;
+    });
+  }, [simulatedTrain, pathProperties, operationalPoints, selectedTrainSchedule, path]);
   return outputTableData;
 }
 export default useOutputTableData;


### PR DESCRIPTION
closes #8453

Because of the condition `if (pathStepKey in pathStepsByUic && nextOpPoint)` (l95 in `useOutputData`), the schedules of the pathSteps whose location was not a uic were ignored.

Now, we handle the pathSteps first, then the suggestedOp, and finally we merge them using the positionOnPath.