### PR TITLE
front: drop trainIdsToFetch state

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -38,7 +38,6 @@ const useLazyLoadTrains = ({ infraId, path, trainSchedules }: UseLazyLoadTrainsP
   const [trainScheduleSummariesById, setTrainScheduleSummariesById] = useState<
     Map<number, TrainScheduleWithDetails>
   >(new Map());
-  const [trainIdsToProject, setTrainIdsToProject] = useState<number[]>([]);
   const [allTrainsLoaded, setAllTrainsLoaded] = useState(false);
 
   const [postTrainScheduleSimulationSummary] =
@@ -47,13 +46,11 @@ const useLazyLoadTrains = ({ infraId, path, trainSchedules }: UseLazyLoadTrainsP
   const { data: { results: rollingStocks } = { results: [] } } =
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({ pageSize: 1000 });
 
-  const { projectedTrainsById, setProjectedTrainsById } = useLazyProjectTrains({
+  const { projectedTrainsById, setProjectedTrainsById, projectTrains } = useLazyProjectTrains({
     infraId,
-    trainIdsToProject,
     path,
     trainSchedules,
     moreTrainsToCome: !allTrainsLoaded,
-    setTrainIdsToProject,
   });
 
   const loadTrains = async (_trainSchedules: TrainScheduleResult[]) => {
@@ -77,7 +74,7 @@ const useLazyLoadTrains = ({ infraId, path, trainSchedules }: UseLazyLoadTrainsP
       }).unwrap();
 
       // launch the projection of the trains
-      setTrainIdsToProject((prev) => [...prev, ...packageToFetch]);
+      projectTrains(packageToFetch);
 
       // format the summaries to display them in the timetable
       const newFormattedSummaries = formatTrainScheduleSummaries(

--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-import { useEffect, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -20,10 +20,8 @@ const BATCH_SIZE = 10;
 
 type UseLazyLoadTrainsProps = {
   infraId?: number;
-  trainIdsToFetch?: number[];
   path?: PathfindingResultSuccess;
   trainSchedules?: TrainScheduleResult[];
-  setTrainIdsToFetch: Dispatch<SetStateAction<number[] | undefined>>;
 };
 
 /**
@@ -33,13 +31,7 @@ type UseLazyLoadTrainsProps = {
  * This optimizes the performance of the application and allow us to display the trains as
  * soon as they are ready.
  */
-const useLazyLoadTrains = ({
-  infraId,
-  trainIdsToFetch,
-  path,
-  trainSchedules,
-  setTrainIdsToFetch,
-}: UseLazyLoadTrainsProps) => {
+const useLazyLoadTrains = ({ infraId, path, trainSchedules }: UseLazyLoadTrainsProps) => {
   const { getElectricalProfileSetId } = useOsrdConfSelectors();
   const electricalProfileSetId = useSelector(getElectricalProfileSetId);
 
@@ -66,65 +58,62 @@ const useLazyLoadTrains = ({
     setTrainIdsToProject,
   });
 
-  // gradually fetch the simulation of the trains
-  useEffect(() => {
-    const getTrainScheduleSummaries = async (_infraId: number, _trainToFetchIds: number[]) => {
-      setAllTrainsLoaded(false);
-
-      for (let i = 0; i < _trainToFetchIds.length; i += BATCH_SIZE) {
-        const packageToFetch = getBatchPackage(i, _trainToFetchIds, BATCH_SIZE);
-
-        const rawSummaries = await postTrainScheduleSimulationSummary({
-          body: {
-            infra_id: _infraId,
-            ids: packageToFetch,
-            electrical_profile_set_id: electricalProfileSetId,
-          },
-        }).unwrap();
-
-        // the two rtk-query calls postV2TrainSchedule & postV2TrainScheduleSimulationSummary
-        // do not happen during the same react cycle.
-        // if we update a train, one is going to re-fetch first and the 2 are out of sync during a few cycles.
-        // these cycles do not make sense to render.
-        const outOfSync = [...trainSchedulesById.values()].some((trainShedule) => {
-          const summary = rawSummaries[trainShedule.id];
-          if (summary?.status === 'success') {
-            return trainShedule.path.length !== summary.path_item_times_final.length;
-          }
-          return false;
-        });
-
-        if (!outOfSync) {
-          // launch the projection of the trains
-          setTrainIdsToProject((prev) => [...prev, ...packageToFetch]);
-
-          // format the summaries to display them in the timetable
-          const newFormattedSummaries = formatTrainScheduleSummaries(
-            packageToFetch,
-            rawSummaries,
-            trainSchedulesById,
-            rollingStocks
-          );
-
-          // as formattedSummaries is a dictionary, we replace the previous values with the new ones
-          setTrainScheduleSummariesById((prev) => concatMap(prev, newFormattedSummaries));
-        }
-      }
-
-      setTrainIdsToFetch([]);
-      setAllTrainsLoaded(true);
-    };
-
-    if (infraId && trainIdsToFetch && trainIdsToFetch.length > 0) {
-      getTrainScheduleSummaries(infraId, trainIdsToFetch);
+  const loadTrainIds = async (trainIds: number[]) => {
+    if (!infraId) {
+      return;
     }
-  }, [infraId, trainIdsToFetch]);
+
+    setAllTrainsLoaded(false);
+
+    for (let i = 0; i < trainIds.length; i += BATCH_SIZE) {
+      const packageToFetch = getBatchPackage(i, trainIds, BATCH_SIZE);
+
+      const rawSummaries = await postTrainScheduleSimulationSummary({
+        body: {
+          infra_id: infraId,
+          ids: packageToFetch,
+          electrical_profile_set_id: electricalProfileSetId,
+        },
+      }).unwrap();
+
+      // the two rtk-query calls postV2TrainSchedule & postV2TrainScheduleSimulationSummary
+      // do not happen during the same react cycle.
+      // if we update a train, one is going to re-fetch first and the 2 are out of sync during a few cycles.
+      // these cycles do not make sense to render.
+      const outOfSync = [...trainSchedulesById.values()].some((trainShedule) => {
+        const summary = rawSummaries[trainShedule.id];
+        if (summary?.status === 'success') {
+          return trainShedule.path.length !== summary.path_item_times_final.length;
+        }
+        return false;
+      });
+
+      if (!outOfSync) {
+        // launch the projection of the trains
+        setTrainIdsToProject((prev) => [...prev, ...packageToFetch]);
+
+        // format the summaries to display them in the timetable
+        const newFormattedSummaries = formatTrainScheduleSummaries(
+          packageToFetch,
+          rawSummaries,
+          trainSchedulesById,
+          rollingStocks
+        );
+
+        // as formattedSummaries is a dictionary, we replace the previous values with the new ones
+        setTrainScheduleSummariesById((prev) => concatMap(prev, newFormattedSummaries));
+      }
+    }
+
+    setAllTrainsLoaded(true);
+  };
 
   return {
     trainScheduleSummariesById,
     projectedTrainsById,
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
+    loadTrainIds,
   };
 };
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -27,7 +27,6 @@ const useScenarioData = () => {
   const selectedTrainId = useSelector(getSelectedTrainId);
 
   const [trainSchedules, setTrainSchedules] = useState<TrainScheduleResult[]>();
-  const [trainIdsToFetch, setTrainIdsToFetch] = useState<number[]>();
 
   const scenario = useScenario();
 
@@ -74,10 +73,9 @@ const useScenarioData = () => {
     projectedTrainsById,
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
+    loadTrainIds,
   } = useLazyLoadTrains({
     infraId: scenario?.infra_id,
-    trainIdsToFetch,
-    setTrainIdsToFetch,
     path: projectionPath?.status === 'success' ? projectionPath : undefined,
     trainSchedules,
   });
@@ -110,7 +108,7 @@ const useScenarioData = () => {
   useEffect(() => {
     if (trainSchedules && infra?.state === 'CACHED' && trainScheduleSummaries.length === 0) {
       const trainIds = trainSchedules.map((trainSchedule) => trainSchedule.id);
-      setTrainIdsToFetch(trainIds);
+      loadTrainIds(trainIds);
     }
   }, [trainSchedules, infra?.state]);
 
@@ -153,7 +151,7 @@ const useScenarioData = () => {
       });
 
       const sortedTrainSchedulesToUpsert = sortBy(trainSchedulesToUpsert, 'start_time');
-      setTrainIdsToFetch(sortedTrainSchedulesToUpsert.map((trainSchedule) => trainSchedule.id));
+      loadTrainIds(sortedTrainSchedulesToUpsert.map((trainSchedule) => trainSchedule.id));
     },
     [trainSchedules]
   );

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -73,7 +73,7 @@ const useScenarioData = () => {
     projectedTrainsById,
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
-    loadTrainIds,
+    loadTrains,
   } = useLazyLoadTrains({
     infraId: scenario?.infra_id,
     path: projectionPath?.status === 'success' ? projectionPath : undefined,
@@ -107,8 +107,7 @@ const useScenarioData = () => {
   // first load of the trainScheduleSummaries
   useEffect(() => {
     if (trainSchedules && infra?.state === 'CACHED' && trainScheduleSummaries.length === 0) {
-      const trainIds = trainSchedules.map((trainSchedule) => trainSchedule.id);
-      loadTrainIds(trainIds);
+      loadTrains(trainSchedules);
     }
   }, [trainSchedules, infra?.state]);
 
@@ -151,7 +150,7 @@ const useScenarioData = () => {
       });
 
       const sortedTrainSchedulesToUpsert = sortBy(trainSchedulesToUpsert, 'start_time');
-      loadTrainIds(sortedTrainSchedulesToUpsert.map((trainSchedule) => trainSchedule.id));
+      loadTrains(sortedTrainSchedulesToUpsert);
     },
     [trainSchedules]
   );

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -16,7 +16,6 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmV2SuccessResponse) => {
   const timetableId = useSelector(getTimetableID);
 
   const [spaceTimeData, setSpaceTimeData] = useState<TrainSpaceTimeData[]>([]);
-  const [trainIdsToProject, setTrainIdsToProject] = useState<number[]>([]);
 
   const { data: timetable } = osrdEditoastApi.endpoints.getTimetableById.useQuery(
     { id: timetableId! },
@@ -43,10 +42,8 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmV2SuccessResponse) => {
 
   const { projectedTrainsById: projectedTimetableTrainsById } = useLazyProjectTrains({
     infraId,
-    trainIdsToProject,
     path: stdcmResponse?.path,
     trainSchedules,
-    setTrainIdsToProject,
   });
 
   useEffect(() => {

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-import { useEffect, useState, type Dispatch, type SetStateAction, useMemo, useRef } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -21,11 +21,9 @@ const BATCH_SIZE = 10;
 
 type useLazyLoadTrainsProp = {
   infraId?: number;
-  trainIdsToProject: number[];
   path?: PathfindingResultSuccess;
   trainSchedules?: TrainScheduleResult[];
   moreTrainsToCome?: boolean;
-  setTrainIdsToProject: Dispatch<SetStateAction<number[]>>;
 };
 
 /**
@@ -37,15 +35,15 @@ type useLazyLoadTrainsProp = {
  */
 const useLazyProjectTrains = ({
   infraId,
-  trainIdsToProject,
   path,
   trainSchedules,
   moreTrainsToCome = false,
-  setTrainIdsToProject,
 }: useLazyLoadTrainsProp) => {
   const dispatch = useAppDispatch();
   const { getElectricalProfileSetId } = useOsrdConfSelectors();
   const electricalProfileSetId = useSelector(getElectricalProfileSetId);
+
+  const [trainIdsToProject, setTrainIdsToProject] = useState<number[]>([]);
 
   const [projectedTrainsById, setProjectedTrainsById] = useState<Map<number, TrainSpaceTimeData>>(
     new Map()
@@ -126,9 +124,14 @@ const useLazyProjectTrains = ({
     }
   }, [path]);
 
+  const projectTrains = (trainIds: number[]) => {
+    setTrainIdsToProject((prev) => [...prev, ...trainIds]);
+  };
+
   return {
     projectedTrainsById,
     setProjectedTrainsById,
+    projectTrains,
   };
 };
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -93,7 +93,7 @@ const useLazyProjectTrains = ({
 
       for (let i = 0; i < shouldProjectIds.length; i += BATCH_SIZE) {
         // If projection parameters have changed, bail out
-        if (projectionSeqNum.current !== seqNum) break;
+        if (projectionSeqNum.current !== seqNum) return;
 
         const packageToProject = getBatchPackage(i, shouldProjectIds, BATCH_SIZE);
         try {
@@ -103,25 +103,16 @@ const useLazyProjectTrains = ({
           dispatch(setFailure(castErrorToFailure(e)));
         }
       }
+
+      requestedProjectedTrainIds.current = new Set();
+      setTrainIdsToProject([]);
     };
 
-    if (infraId && path) {
+    if (infraId && path && trainIdsToProject.length > 0) {
       projectionSeqNum.current += 1;
       projectTrains(projectionSeqNum.current, path, trainIdsToProject);
     }
   }, [trainIdsToProject]);
-
-  useEffect(() => {
-    // reset the state when all the trains have been projected
-    if (
-      !moreTrainsToCome &&
-      trainIdsToProject.length > 0 &&
-      requestedProjectedTrainIds.current.size === trainIdsToProject.length
-    ) {
-      setTrainIdsToProject([]);
-      requestedProjectedTrainIds.current = new Set();
-    }
-  }, [moreTrainsToCome, projectedTrainsById]);
 
   useEffect(() => {
     if (!moreTrainsToCome && trainSchedules && path) {

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -77,14 +77,9 @@ const useLazyProjectTrains = ({
         },
       }).unwrap();
 
-      setProjectedTrainsById((prevTrains) => {
-        const newProjectedTrains = upsertNewProjectedTrains(
-          prevTrains,
-          rawProjectedTrains,
-          trainSchedulesById
-        );
-        return newProjectedTrains;
-      });
+      setProjectedTrainsById((prevTrains) =>
+        upsertNewProjectedTrains(prevTrains, rawProjectedTrains, trainSchedulesById)
+      );
     };
 
     const projectTrains = async (


### PR DESCRIPTION
We don't actually need a state here: all setTrainIdsToFetch() calls were overwriting any previously stored value.

The state makes the whole thing harder to reason about, because a state update will (asynchronously) invoke any useEffect() that depends on that state, so it's harder to figure out what exact side effects will be caused by setting the state. A simple callback is easier to follow.

No behavior change intended.