### PR TITLE
chore: remove debug info in dev builds

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -164,3 +164,10 @@ tempfile.workspace = true
 
 [lints]
 workspace = true
+
+[profile.dev]
+debug = "limited"
+
+[profile.dev-for-debug]
+inherits = "dev"
+debug = "full"

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -41,6 +41,19 @@ To avoid thread conflicts while accessing the database, use serial_test
 cargo test -- --test-threads=4
 ```
 
+# Debugging
+
+:warning: For improving compilation time and therefore the developer experience, the project
+choose to strip out debug information by default, resulting in [about 20%
+shorter compilation time](https://github.com/OpenRailAssociation/osrd/pull/8579).
+
+If you need to debug the project, you might want to activate the `dev-for-debug` profile
+which will build with debug information.
+
+```
+cargo build --profile dev-for-debug
+```
+
 ## Useful tools
 
 Here a list of components to help you in your development (see CI jobs if necessary):


### PR DESCRIPTION
First, most of the time, we do not debug our binaries: debug information is useless, until we need it for debugging. But it affects our compile time significantly (and that is more frequent than debugging).

Therefore, I propose to remove the debug information by default, and those who needs to debug the binary, can always turn it on again when needed. Removing debug information is configured with `debug` option https://doc.rust-lang.org/cargo/reference/profiles.html#debug.

A small benchmark for total build time,
using [`hyperfine`](https://github.com/sharkdp/hyperfine), shows a 21% improvement in compile times.

```
❯ hyperfine \
    --parameter-list branch 'dev,wsl/editoast/chore/no-debug-info' \
    --prepare 'git switch {branch} && cargo clean' \
    'cargo build --workspace'

Benchmark 1: cargo build --workspace (branch = dev)
  Time (mean ± σ):     246.746 s ±  7.407 s    [User: 1196.443 s, System: 60.608 s]
  Range (min … max):   227.791 s … 256.083 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: cargo build --workspace (branch = wsl/editoast/chore/no-debug-info)
  Time (mean ± σ):     203.227 s ±  1.618 s    [User: 939.154 s, System: 51.359 s]
  Range (min … max):   201.509 s … 206.476 s    10 runs

Summary
  cargo build --workspace (branch = wsl/editoast/chore/no-debug-info) ran
    1.21 ± 0.04 times faster than cargo build --workspace (branch = dev)
```