### PR TITLE
editoast: hide 'datadog' and 'opentelemetry' behind feature flags

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -123,7 +123,7 @@ opentelemetry = { version = "0.23.0", default-features = false, features = [
 opentelemetry-datadog = { version = "0.11.0", default-features = false, features = [
   "intern-std",
   "reqwest-client",
-] }
+], optional = true }
 opentelemetry-otlp = { version = "0.16.0", default-features = false, features = [
   "grpc-tonic",
   "trace",
@@ -188,6 +188,9 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 serial_test = "3.1.1"
 tempfile.workspace = true
+
+[features]
+datadog = ["dep:opentelemetry-datadog"]
 
 [lints]
 workspace = true

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -64,7 +64,10 @@ tempfile = "3.12.0"
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.11"
-tracing = { version = "0.1.40", default-features = false, features = ["log"] }
+tracing = { version = "0.1.40", default-features = false, features = [
+  "attributes",
+  "log",
+] }
 url = { version = "2.5.2", features = ["serde"] }
 utoipa = { version = "4.2.3", features = ["chrono", "uuid"] }
 uuid = { version = "1.10.0", features = ["serde", "v4"] }

--- a/editoast/src/client/telemetry_config.rs
+++ b/editoast/src/client/telemetry_config.rs
@@ -22,6 +22,7 @@ pub struct TelemetryConfig {
 pub enum TelemetryKind {
     #[default]
     None,
+    #[cfg(feature = "datadog")]
     Datadog,
     Opentelemetry,
 }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -17,7 +17,7 @@ use crate::modelsv2::Infra;
 use crate::views::OpenApiRoot;
 use axum::extract::FromRef;
 use axum::{Router, ServiceExt};
-use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
+use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use chashmap::CHashMap;
 use clap::Parser;
 use client::{
@@ -431,7 +431,6 @@ async fn runserver(
             app_state.clone(),
             authorizer_middleware,
         ))
-        .layer(OtelInResponseLayer)
         .layer(OtelAxumLayer::default())
         .layer(request_payload_limit)
         .layer(cors)

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use axum::Router;
-use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
+use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use chashmap::CHashMap;
 use editoast_models::db_connection_pool::create_connection_pool;
 use editoast_models::DbConnectionPoolV2;
@@ -148,7 +148,6 @@ impl TestAppBuilder {
                 app_state.clone(),
                 authorizer_middleware,
             ))
-            .layer(OtelInResponseLayer)
             .layer(OtelAxumLayer::default())
             .layer(TraceLayer::new_for_http())
             .with_state(app_state);


### PR DESCRIPTION
The goal is to reduce the default compile time for developers.
Datadog is mostly used in specific deployment, not necessary to run any
test or any useful runtime functionalities unless communicating with
a Datadog agent.

Some summary about the total number of dependencies depending on which
feature is activated:

|   activated features   | number of dependencies |
| ---------------------- | ---------------------- |
|         (None)         |           566          |
|         datadog        |           582          |
|      opentelemetry     |           596          |
| datadog, opentelemetry |           604          |