### PR TITLE
ci: fix duplicate osrdyne artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: steps.bake-metadata.outputs.output_method == 'artifact' && contains(matrix.targets, 'osrdyne-test')
         with:
-          name: osrdyne
+          name: osrdyne-test
           path: osrd-osrdyne-test.tar
 
   check_generated_railjson_sync:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -877,6 +877,12 @@ jobs:
         with:
           name: front-nginx
           path: .
+      - name: Download built osrdyne image
+        if: needs.build.outputs.output_method == 'artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: osrdyne
+          path: .
       - name: Load built images
         if: needs.build.outputs.output_method == 'artifact'
         run: |
@@ -885,6 +891,7 @@ jobs:
           docker load --input ./osrd-core.tar
           docker load --input ./osrd-gateway-standalone.tar
           docker load --input ./osrd-front-nginx.tar
+          docker load --input ./osrd-osrdyne.tar
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python


### PR DESCRIPTION
See [1] for an example failure. Other jobs downloading the artifact are using the name "osrdyne-test" already.

This PR is made from my personal fork to make sure it fixes the issue.

[1]: https://github.com/OpenRailAssociation/osrd/actions/runs/10581208012/job/29414058355?pr=8594