### PR TITLE
front: remove pathSteps property from TimesStopsOutput

### DIFF
--- a/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/SimulationResultsV2.tsx
@@ -3,14 +3,12 @@ import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
 import { Manchette as SpaceTimeChartWithManchette } from '@osrd-project/ui-manchette';
 import cx from 'classnames';
-import { compact } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Rnd } from 'react-rnd';
 
 import type { SimulationResults, TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { getScaleDomainFromValuesV2 } from 'modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues';
 import SimulationResultsMapV2 from 'modules/simulationResult/components/SimulationResultsMapV2';
 import SpaceCurvesSlopesV2 from 'modules/simulationResult/components/SpaceCurvesSlopes/SpaceCurvesSlopesV2';
@@ -57,8 +55,6 @@ const SimulationResultsV2 = ({
   timetableTrainNb,
 }: SimulationResultsV2Props) => {
   const { t } = useTranslation('simulation');
-  const { getPathSteps } = useOsrdConfSelectors();
-  const pathSteps = useSelector(getPathSteps);
   const dispatch = useAppDispatch();
   // TIMELINE DISABLED // const { chart } = useSelector(getOsrdSimulation);
   const isUpdating = useSelector(getIsUpdating);
@@ -231,7 +227,6 @@ const SimulationResultsV2 = ({
               pathProperties={pathProperties}
               operationalPoints={operationalPoints.finalOutput}
               selectedTrainSchedule={selectedTrainSchedule}
-              pathSteps={compact(pathSteps)}
               pathLength={pathLength}
               dataIsLoading={formattedOpPointsLoading}
             />

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -9,7 +9,6 @@ import type {
 import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders/Loader';
 import type { OperationalPointWithTimeAndSpeed } from 'modules/trainschedule/components/DriverTrainScheduleV2/types';
-import type { PathStep } from 'reducers/osrdconf/types';
 import { convertIsoUtcToLocalTime } from 'utils/date';
 import { NO_BREAK_SPACE } from 'utils/strings';
 
@@ -22,7 +21,6 @@ type TimesStopsOutputProps = {
   pathProperties: PathPropertiesFormatted;
   operationalPoints: OperationalPointWithTimeAndSpeed[];
   selectedTrainSchedule: TrainScheduleResult;
-  pathSteps: PathStep[];
   pathLength?: number;
   dataIsLoading: boolean;
 };
@@ -32,7 +30,6 @@ const TimesStopsOutput = ({
   pathProperties,
   operationalPoints,
   selectedTrainSchedule,
-  pathSteps,
   pathLength,
   dataIsLoading,
 }: TimesStopsOutputProps) => {
@@ -54,7 +51,6 @@ const TimesStopsOutput = ({
   return (
     <TimesStops
       allWaypoints={enrichedOperationalPoints}
-      pathSteps={pathSteps}
       startTime={startTime}
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_ }) => {


### PR DESCRIPTION
The pathSteps property is unused for the output table: https://github.com/OpenRailAssociation/osrd/blob/87418f172380fc2f187f8fd84b9f0d95ee1e8d88/front/src/modules/timesStops/helpers/utils.ts#L55

It's coming from the store, so it's left with whatever waypoints the last edited train got saved with.

Instead, the TimesStopsOutput component expects allWaypoints with arrival, onStopSignal, stopFor and theoreticalMargin already filled in.