### PR TITLE
github: fix bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -52,7 +52,7 @@ body:
         - Custom (Docker compose)
         - Custom (Using K8s Helm Chart)
         - Other
-      default: Recette (SNCF)
+      default: 2
 
   - type: dropdown
     id: Browser
@@ -66,7 +66,7 @@ body:
         - Safari
         - Opera
         - Other
-      default: Firefox
+      default: 0
 
   - type: input
     id: osrdVersion


### PR DESCRIPTION
GitHub complains with "default must be of type Integer".

Fixes: 83f8fb54d73e ("template: remove dropdown values and add default values")