### PR TITLE
front: collapse scenario description

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -116,7 +116,7 @@
       }
       .scenario-details-description {
         overflow: auto;
-        height: 4rem;
+        max-height: 4rem;
         font-size: 0.9rem;
         white-space: break-spaces;
       }


### PR DESCRIPTION
If the scenario description is empty, or shorter than 4 lines, collapse it instead of eating up screen real estate.

https://github.com/OpenRailAssociation/osrd/pull/8028 made this possible.