### PR TITLE
front: make ch check more robust in updatePathStepsFromOperationalPoints()

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -94,14 +94,14 @@ export function updatePathStepsFromOperationalPoints(
           return condition && suggestedOp.ch === step.ch;
         }
         // When importing train from open data or from files, secondary_code might not always exist
-        if ('secondary_code' in step) {
+        if (step.secondary_code) {
           return condition && suggestedOp.ch === step.secondary_code;
         }
         return condition;
       }
       if ('trigram' in step) {
         const condition = suggestedOp.trigram === step.trigram;
-        if ('secondary_code' in step) {
+        if (step.secondary_code) {
           return condition && suggestedOp.ch === step.secondary_code;
         }
       }


### PR DESCRIPTION
The PathItemLocation type definition allows for null secondary_code such as:

    { uic: 42, secondary_code: null }

and this is equivalent to:

    { uic: 42 }

Make the logic more future-proof by checking whether the property is truthy instead of checking if step has a secondary_code property.