### PR TITLE
front: fix dropped ch when running pathfinding

### DIFF
--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -85,6 +85,7 @@ export const getPathfindingQuery = ({
       }
       return {
         trigram: step.trigram,
+        secondary_code: step.ch,
       };
     });
 


### PR DESCRIPTION
The ch was taken into account for UICs but not for trigrams.