### PR TITLE
front: enable source maps in production

### DIFF
--- a/front/vite.config.mts
+++ b/front/vite.config.mts
@@ -48,6 +48,7 @@ export default defineConfig(({ mode }) => {
     ],
     build: {
       outDir: 'build',
+      sourcemap: true,
     },
     server: {
       open: false,


### PR DESCRIPTION
Source maps are separate .map files which contain debug information and allows user agents to display a proper stack trace on crash.

vite's defaults are tuned for enterprise™ proprietary© code: source map files contain function and variable names thus they are Super Secret and shouldn't get exposed. We are an open-source project so we don't need to hide anything.

This patch should make it easier to debug crashes in production.