### PR TITLE
editoast: fix std_search_env tests for cases when the table initially contains data

### DIFF
--- a/editoast/src/modelsv2/stdcm_search_environment.rs
+++ b/editoast/src/modelsv2/stdcm_search_environment.rs
@@ -96,6 +96,10 @@ pub mod test {
     #[rstest]
     async fn test_overwrite() {
         let db_pool = DbConnectionPoolV2::for_tests();
+        let initial_env_count =
+            StdcmSearchEnvironment::count(db_pool.get_ok().deref_mut(), Default::default())
+                .await
+                .expect("failed to count STDCM envs");
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
             stdcm_search_env_fixtures(db_pool.get_ok().deref_mut()).await;
 
@@ -124,7 +128,7 @@ pub mod test {
             StdcmSearchEnvironment::count(db_pool.get_ok().deref_mut(), SelectionSettings::new())
                 .await
                 .expect("Failed to count"),
-            1
+            initial_env_count + 1
         );
 
         let _ = changeset_2
@@ -150,6 +154,9 @@ pub mod test {
     #[rstest]
     async fn test_retrieve_latest() {
         let db_pool = DbConnectionPoolV2::for_tests();
+        StdcmSearchEnvironment::delete_all(db_pool.get_ok().deref_mut())
+            .await
+            .expect("failed to delete envs");
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
             stdcm_search_env_fixtures(db_pool.get_ok().deref_mut()).await;
 
@@ -192,8 +199,10 @@ pub mod test {
     #[rstest]
     async fn test_retrieve_latest_empty() {
         let db_pool = DbConnectionPoolV2::for_tests();
+        StdcmSearchEnvironment::delete_all(db_pool.get_ok().deref_mut())
+            .await
+            .expect("failed to delete envs");
         let result = StdcmSearchEnvironment::retrieve_latest(db_pool.get_ok().deref_mut()).await;
-
         assert_eq!(result, None);
     }
 }

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -184,6 +184,9 @@ pub mod test {
         let app = TestAppBuilder::default_app();
 
         let pool = app.db_pool();
+        StdcmSearchEnvironment::delete_all(pool.get_ok().deref_mut())
+            .await
+            .expect("failed to delete envs");
 
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
             stdcm_search_env_fixtures(pool.get_ok().deref_mut()).await;


### PR DESCRIPTION
closes #8574 

> [!NOTE]
> It's fine to delete everything from the table as changes are never committed.