### PR TITLE
Disable `/search` `dry` parameter in non-debug builds & harmonize endpoint results

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8337,7 +8337,10 @@ components:
       properties:
         dry:
           type: boolean
-          description: Whether to return the SQL query instead of executing it
+          description: |-
+            Whether to return the SQL query instead of executing it
+
+            Only available in debug builds.
         object:
           type: string
           description: The object kind to query - run `editoast search list` to get all possible values

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2514,7 +2514,9 @@ export type SearchResultItem =
   | SearchResultItemScenario;
 export type SearchQuery = boolean | number | number | string | (SearchQuery | null)[];
 export type SearchPayload = {
-  /** Whether to return the SQL query instead of executing it */
+  /** Whether to return the SQL query instead of executing it
+    
+    Only available in debug builds. */
   dry?: boolean;
   /** The object kind to query - run `editoast search list` to get all possible values */
   object: string;


### PR DESCRIPTION
The `dry` parameter is useful for debugging the query being generated by the search expression. It's not necessary in production. Moreover we spotted during the `axum` migration that the `/search` endpoint sometimes returns json (search results) or text (`dry`). This PR harmonizes that.