### PR TITLE
front: fix infinite loop in timestops

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -31,7 +31,7 @@ type TimesStopsProps = {
 
 const TimesStops = ({
   allWaypoints,
-  pathSteps = [],
+  pathSteps,
   startTime,
   tableType,
   cellClassName,
@@ -47,7 +47,7 @@ const TimesStops = ({
   const [rows, setRows] = useState<PathWaypointRow[]>([]);
 
   useEffect(() => {
-    if (allWaypoints) {
+    if (allWaypoints && pathSteps) {
       const suggestedOPs = formatSuggestedViasToRowVias(
         allWaypoints,
         pathSteps,
@@ -114,7 +114,7 @@ const TimesStops = ({
           activeRow:
             rowIndex === 0 ||
             rowIndex === allWaypoints.length - 1 ||
-            isVia(pathSteps, rowData, WITH_KP),
+            isVia(pathSteps || [], rowData, WITH_KP),
         })
       }
       cellClassName={cellClassName}


### PR DESCRIPTION
The useEffect dependency array was using allwaypoints and pathSteps but allwaypoints was already using pathSteps to be computed

fix #8690 