### PR TITLE
Better encapsulate diesel's connection to ease the split of editoast_models

### DIFF
--- a/editoast/editoast_derive/src/model.rs
+++ b/editoast/editoast_derive/src/model.rs
@@ -84,7 +84,7 @@ fn create_functions(config: &Config) -> TokenStream {
     quote! {
         #[async_trait::async_trait]
         impl crate::models::Create for #model_name {
-            async fn create_conn(self, conn: &mut editoast_models::DbConnection) -> crate::error::Result<Self> {
+            async fn create_conn(self, conn: &mut editoast_models::DieselConnection) -> crate::error::Result<Self> {
                 use #table::table;
                 use diesel_async::RunQueryDsl;
 
@@ -126,7 +126,7 @@ fn retrieve_functions(config: &Config) -> TokenStream {
     quote! {
         #[async_trait::async_trait]
         impl crate::models::Retrieve for #model_name {
-            async fn retrieve_conn(conn: &mut editoast_models::DbConnection, obj_id: i64) -> crate::error::Result<Option<Self>> {
+            async fn retrieve_conn(conn: &mut editoast_models::DieselConnection, obj_id: i64) -> crate::error::Result<Option<Self>> {
                 use #table::table;
                 use #table::dsl;
                 use diesel_async::RunQueryDsl;
@@ -174,7 +174,7 @@ fn delete_functions(config: &Config) -> TokenStream {
     quote! {
         #[async_trait::async_trait]
         impl crate::models::Delete for #model_name {
-            async fn delete_conn(conn: &mut editoast_models::DbConnection, obj_id: i64) -> crate::error::Result<bool> {
+            async fn delete_conn(conn: &mut editoast_models::DieselConnection, obj_id: i64) -> crate::error::Result<bool> {
                 use #table::table;
                 use #table::dsl;
                 use diesel_async::RunQueryDsl;
@@ -207,7 +207,7 @@ fn update_functions(config: &Config) -> TokenStream {
     quote! {
         #[async_trait::async_trait]
         impl crate::models::Update for #model_name {
-            async fn update_conn(self, conn: &mut editoast_models::DbConnection, obj_id: i64) -> crate::error::Result<Option<Self>> {
+            async fn update_conn(self, conn: &mut editoast_models::DieselConnection, obj_id: i64) -> crate::error::Result<Option<Self>> {
                 use #table::table;
 
                 match diesel::update(table.find(obj_id)).set(&self).get_result(conn).await

--- a/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/count_impl.rs
@@ -28,6 +28,7 @@ impl ToTokens for CountImpl {
                     use diesel::QueryDsl;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    use std::ops::DerefMut;
 
                     let mut query = #table_mod::table.select(diesel::dsl::count_star()).into_boxed();
 
@@ -48,7 +49,7 @@ impl ToTokens for CountImpl {
                         }
                     }
 
-                    Ok(query.get_result::<i64>(conn).await? as u64)
+                    Ok(query.get_result::<i64>(conn.write().await.deref_mut()).await? as u64)
                 }
             }
 

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_impl.rs
@@ -38,6 +38,7 @@ impl ToTokens for CreateBatchImpl {
                 ) -> crate::error::Result<C> {
                     use crate::modelsv2::Model;
                     use #table_mod::dsl;
+                    use std::ops::DerefMut;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
@@ -50,7 +51,7 @@ impl ToTokens for CreateBatchImpl {
                         chunk => {
                             diesel::insert_into(dsl::#table_name)
                                 .values(chunk)
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
                                 .await?

--- a/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_batch_with_key_impl.rs
@@ -43,6 +43,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
                 ) -> crate::error::Result<C> {
                     use crate::models::Identifiable;
                     use crate::modelsv2::Model;
+                    use std::ops::DerefMut;
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
@@ -56,7 +57,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
                         chunk => {
                             diesel::insert_into(dsl::#table_name)
                                 .values(chunk)
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| {
                                     s.map_ok(|row| {

--- a/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/create_impl.rs
@@ -28,9 +28,10 @@ impl ToTokens for CreateImpl {
                     conn: &mut editoast_models::DbConnection,
                 ) -> crate::error::Result<#model> {
                     use diesel_async::RunQueryDsl;
+                    use std::ops::DerefMut;
                     diesel::insert_into(#table_mod::table)
                         .values(&self)
-                        .get_result::<#row>(conn)
+                        .get_result::<#row>(conn.write().await.deref_mut())
                         .await
                         .map(Into::into)
                         .map_err(Into::into)

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_batch_impl.rs
@@ -38,6 +38,7 @@ impl ToTokens for DeleteBatchImpl {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
+                    use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     let counts = crate::chunked_for_libpq! {
@@ -49,7 +50,7 @@ impl ToTokens for DeleteBatchImpl {
                             for #id_ident in chunk.into_iter() {
                                 query = query.or_filter(#filters);
                             }
-                            query.execute(conn).await?
+                            query.execute(conn.write().await.deref_mut()).await?
                         }
                     };
                     Ok(counts.into_iter().sum())

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_impl.rs
@@ -28,9 +28,10 @@ impl ToTokens for DeleteImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
+                    use std::ops::DerefMut;
                     let id = self.#primary_key;
                     diesel::delete(#table_mod::table.find(id))
-                        .execute(conn)
+                        .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
                         .map_err(Into::into)

--- a/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/delete_static_impl.rs
@@ -35,10 +35,11 @@ impl ToTokens for DeleteStaticImpl {
                 ) -> crate::error::Result<bool> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
+                    use std::ops::DerefMut;
                     use #table_mod::dsl;
                     tracing::Span::current().record("query_id", tracing::field::debug(#id_ref_ident));
                     diesel::delete(dsl::#table_name.#(filter(#eqs)).*)
-                        .execute(conn)
+                        .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
                         .map_err(Into::into)

--- a/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/exists_impl.rs
@@ -35,10 +35,11 @@ impl ToTokens for ExistsImpl {
                 ) -> crate::error::Result<bool> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
+                    use std::ops::DerefMut;
                     use #table_mod::dsl;
                     tracing::Span::current().record("query_id", tracing::field::debug(#id_ref_ident));
                     diesel::select(diesel::dsl::exists(dsl::#table_name.#(filter(#eqs)).*))
-                        .get_result(conn)
+                        .get_result(conn.write().await.deref_mut())
                         .await
                         .map_err(Into::into)
                 }

--- a/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/list_impl.rs
@@ -34,6 +34,7 @@ impl ToTokens for ListImpl {
                     use diesel::QueryDsl;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    use std::ops::DerefMut;
 
                     let mut query = #table_mod::table.into_boxed();
 
@@ -58,7 +59,7 @@ impl ToTokens for ListImpl {
                     }
 
                     let results: Vec<#model> = query
-                        .load_stream::<#row>(conn)
+                        .load_stream::<#row>(conn.write().await.deref_mut())
                         .await?
                         .map_ok(<#model as crate::modelsv2::prelude::Model>::from_row)
                         .try_collect()

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_batch_impl.rs
@@ -46,6 +46,7 @@ impl ToTokens for RetrieveBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
@@ -62,7 +63,7 @@ impl ToTokens for RetrieveBatchImpl {
                                 query = query.or_filter(#filters);
                             }
                             query
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
                                 .await?
@@ -84,6 +85,7 @@ impl ToTokens for RetrieveBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
@@ -97,7 +99,7 @@ impl ToTokens for RetrieveBatchImpl {
                                 query = query.or_filter(#filters);
                             }
                             query
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| {
                                     s.map_ok(|row| {

--- a/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/retrieve_impl.rs
@@ -38,10 +38,11 @@ impl ToTokens for RetrieveImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
+                    use std::ops::DerefMut;
                     tracing::Span::current().record("query_id", tracing::field::debug(#id_ref_ident));
                     dsl::#table_name
                         .#(filter(#eqs)).*
-                        .first::<#row>(conn)
+                        .first::<#row>(conn.write().await.deref_mut())
                         .await
                         .map(Into::into)
                         .optional()

--- a/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_batch_impl.rs
@@ -51,6 +51,7 @@ impl ToTokens for UpdateBatchImpl {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
+                    use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok(crate::chunked_for_libpq! {
@@ -69,7 +70,7 @@ impl ToTokens for UpdateBatchImpl {
                             diesel::update(dsl::#table_name)
                                 .filter(dsl::#primary_key_column.eq_any(query))
                                 .set(&self)
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
                                 .await?
@@ -89,6 +90,7 @@ impl ToTokens for UpdateBatchImpl {
                     use crate::models::Identifiable;
                     use crate::modelsv2::Model;
                     use #table_mod::dsl;
+                    use std::ops::DerefMut;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use futures_util::stream::TryStreamExt;
@@ -109,7 +111,7 @@ impl ToTokens for UpdateBatchImpl {
                             diesel::update(dsl::#table_name)
                                 .filter(dsl::#primary_key_column.eq_any(query))
                                 .set(&self)
-                                .load_stream::<#row>(conn)
+                                .load_stream::<#row>(conn.write().await.deref_mut())
                                 .await
                                 .map(|s| {
                                     s.map_ok(|row| {

--- a/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/modelv2/codegen/update_impl.rs
@@ -40,11 +40,12 @@ impl ToTokens for UpdateImpl {
                 ) -> crate::error::Result<Option<#model>> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
+                    use std::ops::DerefMut;
                     use #table_mod::dsl;
                     tracing::Span::current().record("query_id", tracing::field::debug(#id_ref_ident));
                     diesel::update(dsl::#table_name.#(filter(#eqs)).*)
                         .set(&self)
-                        .get_result::<#row>(conn)
+                        .get_result::<#row>(conn.write().await.deref_mut())
                         .await
                         .map(Into::into)
                         .optional()

--- a/editoast/editoast_models/src/lib.rs
+++ b/editoast/editoast_models/src/lib.rs
@@ -1,12 +1,14 @@
-use diesel_async::{pooled_connection::deadpool::Pool, AsyncPgConnection};
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::AsyncPgConnection;
 
 pub mod db_connection_pool;
 pub mod tables;
 
+pub use db_connection_pool::DbConnection;
 pub use db_connection_pool::DbConnectionPoolV2;
 
-pub type DbConnection = AsyncPgConnection;
-pub type DbConnectionPool = Pool<DbConnection>;
+type DieselConnection = AsyncPgConnection;
+pub type DbConnectionPool = Pool<DieselConnection>;
 
 /// Generic error type to forward errors from the database
 ///

--- a/editoast/src/generated_data/detector.rs
+++ b/editoast/src/generated_data/detector.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_detector::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_detector::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct DetectorLayer;
 
@@ -28,7 +30,7 @@ impl GeneratedData for DetectorLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_detector_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -49,7 +51,7 @@ impl GeneratedData for DetectorLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(involved_objects.deleted)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -58,7 +60,7 @@ impl GeneratedData for DetectorLayer {
             sql_query(include_str!("sql/insert_update_detector_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/electrification.rs
+++ b/editoast/src/generated_data/electrification.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_electrification::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_electrification::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct ElectrificationLayer;
 
@@ -32,7 +34,7 @@ impl GeneratedData for ElectrificationLayer {
     ) -> Result<()> {
         sql_query(include_str!("sql/generate_electrification_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -59,7 +61,7 @@ impl GeneratedData for ElectrificationLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(objs)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -68,7 +70,7 @@ impl GeneratedData for ElectrificationLayer {
             sql_query(include_str!("sql/insert_electrification_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/neutral_section.rs
+++ b/editoast/src/generated_data/neutral_section.rs
@@ -1,13 +1,15 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 
 use super::GeneratedData;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::DbConnection;
 
 pub struct NeutralSectionLayer;
 
@@ -20,7 +22,7 @@ impl GeneratedData for NeutralSectionLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_neutral_section_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }

--- a/editoast/src/generated_data/neutral_sign.rs
+++ b/editoast/src/generated_data/neutral_sign.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_neutral_sign::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_neutral_sign::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct NeutralSignLayer;
 
@@ -28,7 +30,7 @@ impl GeneratedData for NeutralSignLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_neutral_sign_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -52,7 +54,7 @@ impl GeneratedData for NeutralSignLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(objs)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -61,7 +63,7 @@ impl GeneratedData for NeutralSignLayer {
             sql_query(include_str!("sql/insert_neutral_sign_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/operational_point.rs
+++ b/editoast/src/generated_data/operational_point.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_operational_point::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_operational_point::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct OperationalPointLayer;
 
@@ -28,7 +30,7 @@ impl GeneratedData for OperationalPointLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_operational_point_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -55,7 +57,7 @@ impl GeneratedData for OperationalPointLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(objs)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -64,7 +66,7 @@ impl GeneratedData for OperationalPointLayer {
             sql_query(include_str!("sql/insert_operational_point_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/psl_sign.rs
+++ b/editoast/src/generated_data/psl_sign.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_psl_sign::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_psl_sign::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct PSLSignLayer;
 
@@ -28,7 +30,7 @@ impl GeneratedData for PSLSignLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_psl_sign_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -54,7 +56,7 @@ impl GeneratedData for PSLSignLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(objs)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -63,7 +65,7 @@ impl GeneratedData for PSLSignLayer {
             sql_query(include_str!("sql/insert_psl_sign_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/speed_section.rs
+++ b/editoast/src/generated_data/speed_section.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
@@ -6,6 +8,9 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_speed_section::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +18,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_speed_section::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct SpeedSectionLayer;
 
@@ -28,7 +30,7 @@ impl GeneratedData for SpeedSectionLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_speed_section_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -55,7 +57,7 @@ impl GeneratedData for SpeedSectionLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(objs)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -64,7 +66,7 @@ impl GeneratedData for SpeedSectionLayer {
             sql_query(include_str!("sql/insert_speed_section_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/switch.rs
+++ b/editoast/src/generated_data/switch.rs
@@ -4,14 +4,15 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
+use std::ops::DerefMut;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct SwitchLayer;
 
@@ -24,7 +25,7 @@ impl GeneratedData for SwitchLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_switch_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -46,7 +47,7 @@ impl GeneratedData for SwitchLayer {
             ))
             .bind::<BigInt, _>(infra)
             .bind::<Array<Text>, _>(involved_objects.deleted.into_iter().collect::<Vec<_>>())
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -55,7 +56,7 @@ impl GeneratedData for SwitchLayer {
             sql_query(include_str!("sql/insert_update_switch_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/generated_data/track_section.rs
+++ b/editoast/src/generated_data/track_section.rs
@@ -6,6 +6,10 @@ use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::tables::infra_layer_track_section::dsl;
+use editoast_models::DbConnection;
+use editoast_schemas::primitives::ObjectType;
+use std::ops::DerefMut;
 
 use super::utils::InvolvedObjects;
 use super::GeneratedData;
@@ -13,9 +17,6 @@ use crate::diesel::ExpressionMethods;
 use crate::error::Result;
 use crate::infra_cache::operation::CacheOperation;
 use crate::infra_cache::InfraCache;
-use editoast_models::tables::infra_layer_track_section::dsl;
-use editoast_models::DbConnection;
-use editoast_schemas::primitives::ObjectType;
 
 pub struct TrackSectionLayer;
 
@@ -28,7 +29,7 @@ impl GeneratedData for TrackSectionLayer {
     async fn generate(conn: &mut DbConnection, infra: i64, _cache: &InfraCache) -> Result<()> {
         sql_query(include_str!("sql/generate_track_section_layer.sql"))
             .bind::<BigInt, _>(infra)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -49,7 +50,7 @@ impl GeneratedData for TrackSectionLayer {
                     .filter(dsl::infra_id.eq(infra))
                     .filter(dsl::obj_id.eq_any(involved_objects.deleted)),
             )
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         }
 
@@ -58,7 +59,7 @@ impl GeneratedData for TrackSectionLayer {
             sql_query(include_str!("sql/insert_update_track_section_layer.sql"))
                 .bind::<BigInt, _>(infra)
                 .bind::<Array<Text>, _>(involved_objects.updated.into_iter().collect::<Vec<_>>())
-                .execute(conn)
+                .execute(conn.write().await.deref_mut())
                 .await?;
         }
         Ok(())

--- a/editoast/src/modelsv2/auth.rs
+++ b/editoast/src/modelsv2/auth.rs
@@ -1,7 +1,9 @@
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
+use std::ops::DerefMut;
+use std::sync::Arc;
 
 use diesel::{dsl, prelude::*};
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
+use diesel_async::{scoped_futures::ScopedFutureExt, RunQueryDsl};
 use editoast_authz::{
     authorizer::{StorageDriver, UserInfo},
     roles::{BuiltinRoleSet, RoleConfig},
@@ -39,49 +41,49 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
 
     #[tracing::instrument(skip_all, fields(%user), ret, err)]
     async fn ensure_user(&self, user: &UserInfo) -> Result<i64, Self::Error> {
-        let pool = self.pool.clone();
-        let mut conn = pool.get().await?;
+        self.pool
+            .get()
+            .await?
+            .transaction(|conn| {
+                async move {
+                    let user_id = authn_user::table
+                        .select(authn_user::id)
+                        .filter(authn_user::identity_id.eq(&user.identity))
+                        .first::<i64>(conn.write().await.deref_mut())
+                        .await
+                        .optional()?;
 
-        conn.transaction(|conn| {
-            async {
-                let user_id = authn_user::table
-                    .select(authn_user::id)
-                    .filter(authn_user::identity_id.eq(&user.identity))
-                    .first::<i64>(conn)
-                    .await
-                    .optional()?;
+                    match user_id {
+                        Some(user_id) => {
+                            tracing::debug!("user already exists in db");
+                            Ok(user_id)
+                        }
 
-                match user_id {
-                    Some(user_id) => {
-                        tracing::debug!("user already exists in db");
-                        Ok(user_id)
-                    }
+                        None => {
+                            tracing::info!("registering new user in db");
 
-                    None => {
-                        tracing::info!("registering new user in db");
+                            let id: i64 = dsl::insert_into(authn_subject::table)
+                                .default_values()
+                                .returning(authn_subject::id)
+                                .get_result(&mut conn.clone().write().await)
+                                .await?;
 
-                        let id: i64 = dsl::insert_into(authn_subject::table)
-                            .default_values()
-                            .returning(authn_subject::id)
-                            .get_result(conn)
-                            .await?;
+                            dsl::insert_into(authn_user::table)
+                                .values((
+                                    authn_user::id.eq(id),
+                                    authn_user::identity_id.eq(&user.identity),
+                                    authn_user::name.eq(&user.name),
+                                ))
+                                .execute(conn.write().await.deref_mut())
+                                .await?;
 
-                        dsl::insert_into(authn_user::table)
-                            .values((
-                                authn_user::id.eq(id),
-                                authn_user::identity_id.eq(&user.identity),
-                                authn_user::name.eq(&user.name),
-                            ))
-                            .execute(conn)
-                            .await?;
-
-                        Ok(id)
+                            Ok(id)
+                        }
                     }
                 }
-            }
-            .scope_boxed()
-        })
-        .await
+                .scope_boxed()
+            })
+            .await
     }
 
     #[tracing::instrument(skip_all, fields(%subject_id, %roles_config), ret, err)]
@@ -90,7 +92,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
         subject_id: i64,
         roles_config: &RoleConfig<Self::BuiltinRole>,
     ) -> Result<HashSet<Self::BuiltinRole>, Self::Error> {
-        let mut conn = self.pool.get().await?;
+        let conn = self.pool.get().await?;
 
         let roles = authz_role::table
             .select(authz_role::role)
@@ -99,7 +101,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
             )
             .filter(authz_role::subject.eq(subject_id))
             .or_filter(authz_role::subject.eq(authn_group_membership::group))
-            .load::<String>(&mut conn)
+            .load::<String>(conn.write().await.deref_mut())
             .await?
             .into_iter()
             .map(|role| {
@@ -119,7 +121,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
         roles_config: &RoleConfig<Self::BuiltinRole>,
         roles: HashSet<Self::BuiltinRole>,
     ) -> Result<(), Self::Error> {
-        let mut conn = self.pool.get().await?;
+        let conn = self.pool.get().await?;
 
         dsl::insert_into(authz_role::table)
             .values(
@@ -135,7 +137,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
             )
             .on_conflict((authz_role::subject, authz_role::role))
             .do_nothing()
-            .execute(&mut conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
 
         Ok(())
@@ -148,7 +150,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
         roles_config: &RoleConfig<Self::BuiltinRole>,
         roles: HashSet<Self::BuiltinRole>,
     ) -> Result<HashSet<Self::BuiltinRole>, Self::Error> {
-        let mut conn = self.pool.get().await?;
+        let conn = self.pool.get().await?;
 
         let deleted_roles = dsl::delete(
             authz_role::table
@@ -158,7 +160,7 @@ impl<B: BuiltinRoleSet + Send + Sync> StorageDriver for PgAuthDriver<B> {
                 ),
         )
         .returning(authz_role::role)
-        .load::<String>(&mut conn)
+        .load::<String>(conn.write().await.deref_mut())
         .await?
         .into_iter()
         .map(|role| {

--- a/editoast/src/modelsv2/electrical_profiles.rs
+++ b/editoast/src/modelsv2/electrical_profiles.rs
@@ -1,14 +1,16 @@
+use std::ops::DerefMut;
+
 use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
+use editoast_models::tables::electrical_profile_set;
+use editoast_models::DbConnection;
+use editoast_schemas::infra::ElectricalProfileSetData;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::diesel::QueryDsl;
 use crate::error::Result;
-use editoast_models::tables::electrical_profile_set;
-use editoast_models::DbConnection;
-use editoast_schemas::infra::ElectricalProfileSetData;
 
 #[derive(Clone, Debug, Serialize, Deserialize, ModelV2, ToSchema)]
 #[model(table = editoast_models::tables::electrical_profile_set)]
@@ -24,7 +26,10 @@ pub struct ElectricalProfileSet {
 impl ElectricalProfileSet {
     pub async fn list_light(conn: &mut DbConnection) -> Result<Vec<LightElectricalProfileSet>> {
         use editoast_models::tables::electrical_profile_set::dsl::*;
-        let result = electrical_profile_set.select((id, name)).load(conn).await?;
+        let result = electrical_profile_set
+            .select((id, name))
+            .load(conn.write().await.deref_mut())
+            .await?;
         Ok(result)
     }
 }
@@ -39,7 +44,6 @@ pub struct LightElectricalProfileSet {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::modelsv2::fixtures::create_electrical_profile_set;
@@ -48,10 +52,10 @@ mod tests {
     #[rstest]
     async fn test_list_light() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        let set_1 = create_electrical_profile_set(db_pool.get_ok().deref_mut()).await;
-        let set_2 = create_electrical_profile_set(db_pool.get_ok().deref_mut()).await;
+        let set_1 = create_electrical_profile_set(&mut db_pool.get_ok()).await;
+        let set_2 = create_electrical_profile_set(&mut db_pool.get_ok()).await;
 
-        let list = ElectricalProfileSet::list_light(db_pool.get_ok().deref_mut())
+        let list = ElectricalProfileSet::list_light(&mut db_pool.get_ok())
             .await
             .expect("Failed to list electrical profile sets");
 

--- a/editoast/src/modelsv2/fixtures.rs
+++ b/editoast/src/modelsv2/fixtures.rs
@@ -1,16 +1,20 @@
 use std::io::Cursor;
+use std::ops::DerefMut;
 
 use chrono::Utc;
+use editoast_models::DbConnection;
+use editoast_models::DbConnectionPool;
+use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
 use editoast_schemas::infra::InfraObject;
 use editoast_schemas::infra::RailJson;
 use editoast_schemas::primitives::OSRDObject;
+use editoast_schemas::rolling_stock::RollingStock;
 use editoast_schemas::train_schedule::TrainScheduleBase;
 use postgis_diesel::types::LineString;
 
 use crate::infra_cache::operation::create::apply_create_operation;
-
 use crate::modelsv2::prelude::*;
 use crate::modelsv2::rolling_stock_livery::RollingStockLiveryModel;
 use crate::modelsv2::timetable::Timetable;
@@ -26,9 +30,6 @@ use crate::modelsv2::Tags;
 use crate::views::rolling_stock::form::RollingStockForm;
 use crate::views::train_schedule::TrainScheduleForm;
 use crate::ElectricalProfileSet;
-use editoast_models::DbConnection;
-use editoast_models::DbConnectionPool;
-use editoast_models::DbConnectionPoolV2;
 
 pub fn project_changeset(name: &str) -> Changeset<Project> {
     Project::changeset()
@@ -193,9 +194,6 @@ pub fn rolling_stock_livery_changeset(
     rolling_stock_id: i64,
     compound_image_id: i64,
 ) -> Changeset<RollingStockLiveryModel> {
-    // let rolling_stock = named_fast_rolling_stock(&rs_name, db_pool.clone()).await;
-    // let image = document_example(db_pool.clone()).await;
-
     RollingStockLiveryModel::changeset()
         .name(name.to_string())
         .rolling_stock_id(rolling_stock_id)

--- a/editoast/src/modelsv2/infra/object_queryable.rs
+++ b/editoast/src/modelsv2/infra/object_queryable.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
@@ -6,6 +8,7 @@ use diesel::sql_types::Nullable;
 use diesel::sql_types::Text;
 use diesel::QueryableByName;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use editoast_schemas::primitives::ObjectType;
 use serde::Deserialize;
 use serde::Serialize;
@@ -14,7 +17,6 @@ use super::Infra;
 use crate::error::Result;
 use crate::modelsv2::get_geometry_layer_table;
 use crate::modelsv2::get_table;
-use editoast_models::DbConnection;
 
 editoast_common::schemas! {
     ObjectQueryable,
@@ -66,7 +68,7 @@ impl Infra {
         let objects = sql_query(query)
             .bind::<BigInt, _>(self.id)
             .bind::<Array<Text>, _>(object_ids)
-            .load::<ObjectQueryable>(conn)
+            .load::<ObjectQueryable>(conn.write().await.deref_mut())
             .await?;
         Ok(objects)
     }

--- a/editoast/src/modelsv2/infra/railjson_data.rs
+++ b/editoast/src/modelsv2/infra/railjson_data.rs
@@ -1,13 +1,15 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use editoast_schemas::primitives::ObjectType;
 
 use super::Infra;
 use crate::error::Result;
 use crate::modelsv2::get_table;
-use editoast_models::DbConnection;
 
 #[derive(QueryableByName, Default)]
 pub struct RailJsonData {
@@ -25,7 +27,7 @@ impl Infra {
         let query = format!("SELECT (x.data)::text AS railjson FROM {table_name} x WHERE x.infra_id = $1 ORDER BY x.obj_id");
         let railjson_data = sql_query(query)
             .bind::<BigInt, _>(infra_id)
-            .load::<RailJsonData>(conn)
+            .load::<RailJsonData>(conn.write().await.deref_mut())
             .await?;
         Ok(railjson_data)
     }

--- a/editoast/src/modelsv2/infra/route_from_waypoint_result.rs
+++ b/editoast/src/modelsv2/infra/route_from_waypoint_result.rs
@@ -1,12 +1,14 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Bool;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 
 use super::Infra;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 #[derive(QueryableByName)]
 pub struct RouteFromWaypointResult {
@@ -27,7 +29,7 @@ impl Infra {
             .bind::<BigInt, _>(self.id)
             .bind::<Text, _>(&waypoint_id)
             .bind::<Text, _>(waypoint_type)
-            .load::<RouteFromWaypointResult>(conn)
+            .load::<RouteFromWaypointResult>(conn.write().await.deref_mut())
             .await?;
         Ok(routes)
     }

--- a/editoast/src/modelsv2/infra/speed_limit_tags.rs
+++ b/editoast/src/modelsv2/infra/speed_limit_tags.rs
@@ -1,13 +1,15 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::Infra;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 #[derive(QueryableByName, Debug, Clone, Serialize, Deserialize)]
 pub struct SpeedLimitTags {
@@ -23,7 +25,7 @@ impl Infra {
         let query = include_str!("sql/get_speed_limit_tags.sql");
         let speed_limits_tags = sql_query(query)
             .bind::<BigInt, _>(self.id)
-            .load::<SpeedLimitTags>(conn)
+            .load::<SpeedLimitTags>(conn.write().await.deref_mut())
             .await?;
         Ok(speed_limits_tags)
     }

--- a/editoast/src/modelsv2/infra/split_track_section_with_data.rs
+++ b/editoast/src/modelsv2/infra/split_track_section_with_data.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Double;
@@ -5,13 +7,13 @@ use diesel::sql_types::Jsonb;
 use diesel::sql_types::Text;
 use diesel::OptionalExtension;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use editoast_schemas::infra::TrackSection;
 use editoast_schemas::primitives::Identifier;
 use serde::Deserialize;
 
 use super::Infra;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 #[derive(QueryableByName, Debug, Clone, Deserialize)]
 pub struct SplitTrackSectionWithData {
@@ -37,7 +39,7 @@ impl Infra {
             .bind::<BigInt, _>(self.id)
             .bind::<Text, _>(track.to_string())
             .bind::<Double, _>(distance_fraction)
-            .get_result::<SplitTrackSectionWithData>(conn)
+            .get_result::<SplitTrackSectionWithData>(conn.write().await.deref_mut())
             .await
             .optional()?;
         Ok(result)

--- a/editoast/src/modelsv2/infra/voltage.rs
+++ b/editoast/src/modelsv2/infra/voltage.rs
@@ -1,13 +1,15 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::Infra;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 #[derive(QueryableByName, Debug, Clone, Serialize, Deserialize)]
 pub struct Voltage {
@@ -28,14 +30,16 @@ impl Infra {
         };
         let voltages = sql_query(query)
             .bind::<BigInt, _>(self.id)
-            .load::<Voltage>(conn)
+            .load::<Voltage>(conn.write().await.deref_mut())
             .await?;
         Ok(voltages)
     }
 
     pub async fn get_all_voltages(conn: &mut DbConnection) -> Result<Vec<Voltage>> {
         let query = include_str!("sql/get_all_voltages_and_modes.sql");
-        let voltages = sql_query(query).load::<Voltage>(conn).await?;
+        let voltages = sql_query(query)
+            .load::<Voltage>(conn.write().await.deref_mut())
+            .await?;
         Ok(voltages)
     }
 }

--- a/editoast/src/modelsv2/layers/geo_json_and_data.rs
+++ b/editoast/src/modelsv2/layers/geo_json_and_data.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::Integer;
 use diesel::sql_types::Jsonb;
@@ -40,7 +42,7 @@ impl GeoJsonAndData {
             .bind::<Integer, _>(x as i32)
             .bind::<Integer, _>(y as i32)
             .bind::<Integer, _>(infra as i32)
-            .get_results::<GeoJsonAndData>(conn)
+            .get_results::<GeoJsonAndData>(conn.write().await.deref_mut())
             .await?;
 
         Ok(records)

--- a/editoast/src/modelsv2/mod.rs
+++ b/editoast/src/modelsv2/mod.rs
@@ -45,7 +45,6 @@ editoast_common::schemas! {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::ops::DerefMut;
 
     use editoast_derive::ModelV2;
     use editoast_models::DbConnectionPoolV2;
@@ -74,7 +73,7 @@ mod tests {
                 .data(vec![i])
         });
 
-        let docs = Document::create_batch::<_, Vec<_>>(pool.get_ok().deref_mut(), changesets)
+        let docs = Document::create_batch::<_, Vec<_>>(&mut pool.get_ok(), changesets)
             .await
             .expect("Failed to create documents");
         assert_eq!(docs.len(), 5);
@@ -83,7 +82,7 @@ mod tests {
         ids.push(123456789);
 
         let (docs, missing): (Vec<_>, _) =
-            Document::retrieve_batch(pool.get_ok().deref_mut(), ids.clone())
+            Document::retrieve_batch(&mut pool.get_ok(), ids.clone())
                 .await
                 .unwrap();
 
@@ -105,17 +104,16 @@ mod tests {
         let new_ct = String::from("I like trains");
         let (updated_docs, missing): (Vec<_>, _) = Document::changeset()
             .content_type(new_ct.clone())
-            .update_batch(pool.get_ok().deref_mut(), ids.iter().cloned().take(2))
+            .update_batch(&mut pool.get_ok(), ids.iter().cloned().take(2))
             .await
             .expect("Failed to update documents");
         assert!(missing.is_empty());
         assert!(updated_docs.iter().all(|d| d.content_type == new_ct));
         assert_eq!(updated_docs.len(), 2);
 
-        let (docs, _): (Vec<_>, _) =
-            Document::retrieve_batch(pool.get_ok().deref_mut(), ids.clone())
-                .await
-                .expect("Failed to retrieve documents");
+        let (docs, _): (Vec<_>, _) = Document::retrieve_batch(&mut pool.get_ok(), ids.clone())
+            .await
+            .expect("Failed to retrieve documents");
         assert_eq!(
             docs.iter()
                 .map(|d| d.content_type.clone())
@@ -124,12 +122,12 @@ mod tests {
         );
 
         let not_deleted = ids.remove(0);
-        let count = Document::delete_batch(pool.get_ok().deref_mut(), ids)
+        let count = Document::delete_batch(&mut pool.get_ok(), ids)
             .await
             .expect("Failed to delete documents");
         assert_eq!(count, 4);
 
-        let exists = Document::exists(pool.get_ok().deref_mut(), not_deleted)
+        let exists = Document::exists(&mut pool.get_ok(), not_deleted)
             .await
             .expect("Failed to check if document exists");
 
@@ -175,7 +173,7 @@ mod tests {
 
         let pool = DbConnectionPoolV2::for_tests();
         let docs = Document::create_batch::<_, Vec<_>>(
-            pool.get_ok().deref_mut(),
+            &mut pool.get_ok(),
             [
                 Document::changeset()
                     .content_type(String::from("text/plain"))
@@ -193,7 +191,7 @@ mod tests {
 
         let ids = docs.iter().map(|d| d.id).collect::<Vec<_>>();
         assert_eq!(
-            Document::retrieve(pool.get_ok().deref_mut(), ids[0])
+            Document::retrieve(&mut pool.get_ok(), ids[0])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")
@@ -201,7 +199,7 @@ mod tests {
             Data::Prefixed(0x43)
         );
         assert_eq!(
-            Document::retrieve(pool.get_ok().deref_mut(), ids[1])
+            Document::retrieve(&mut pool.get_ok(), ids[1])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")
@@ -221,22 +219,21 @@ mod tests {
                 .content_type(multiple_ct.to_string())
                 .data(vec![i])
         });
-        let mut documents =
-            Document::create_batch::<_, Vec<_>>(pool.get_ok().deref_mut(), changesets)
-                .await
-                .expect("Failed to create documents batch");
+        let mut documents = Document::create_batch::<_, Vec<_>>(&mut pool.get_ok(), changesets)
+            .await
+            .expect("Failed to create documents batch");
         let unique_doc_idx = 10;
 
         documents[unique_doc_idx]
             .patch()
             .content_type(unique_ct.to_string())
-            .apply(pool.get_ok().deref_mut())
+            .apply(&mut pool.get_ok())
             .await
             .expect("Failed to update document");
 
         // WHEN
         let (list, multiple_count) = Document::list_and_count(
-            pool.get_ok().deref_mut(),
+            &mut pool.get_ok(),
             SelectionSettings::new()
                 .filter(move || Document::CONTENT_TYPE.eq(multiple_ct.to_string()))
                 .order_by(|| Document::ID.desc())
@@ -246,7 +243,7 @@ mod tests {
         .expect("Failed to list documents with multiple content type");
 
         let (past_unique_ct_index, unique_count) = Document::list_and_count(
-            pool.get_ok().deref_mut(),
+            &mut pool.get_ok(),
             SelectionSettings::new()
                 .filter(move || Document::CONTENT_TYPE.eq(unique_ct.to_string()))
                 .offset(15),
@@ -254,7 +251,7 @@ mod tests {
         .await
         .expect("Failed to list documents with unique content type");
         let (with_unique, unique_count_bis) = Document::list_and_count(
-            pool.get_ok().deref_mut(),
+            &mut pool.get_ok(),
             SelectionSettings::new()
                 .filter(move || Document::CONTENT_TYPE.eq(unique_ct.to_string())),
         )

--- a/editoast/src/modelsv2/pagination.rs
+++ b/editoast/src/modelsv2/pagination.rs
@@ -4,6 +4,7 @@ use diesel::sql_types::{BigInt, Untyped};
 use diesel::{QueryResult, QueryableByName};
 use diesel_async::RunQueryDsl;
 use editoast_models::DbConnection;
+use std::ops::DerefMut;
 
 use crate::error::Result;
 
@@ -40,7 +41,9 @@ where
         offset: ((page - 1) * page_size) as i64,
     };
 
-    let results = query.load::<RowWithCount<T>>(conn).await?;
+    let results = query
+        .load::<RowWithCount<T>>(conn.write().await.deref_mut())
+        .await?;
 
     if results.is_empty() {
         return Ok((vec![], 0));

--- a/editoast/src/modelsv2/prelude/create.rs
+++ b/editoast/src/modelsv2/prelude/create.rs
@@ -1,8 +1,9 @@
 use std::fmt::Debug;
 
+use editoast_models::DbConnection;
+
 use crate::error::EditoastError;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 /// Describes how a [Model](super::Model) can be created in the database
 ///

--- a/editoast/src/modelsv2/prelude/delete.rs
+++ b/editoast/src/modelsv2/prelude/delete.rs
@@ -1,6 +1,7 @@
+use editoast_models::DbConnection;
+
 use crate::error::EditoastError;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 /// Describes how a [Model](super::Model) can be deleted from the database
 ///

--- a/editoast/src/modelsv2/prelude/retrieve.rs
+++ b/editoast/src/modelsv2/prelude/retrieve.rs
@@ -1,8 +1,9 @@
 use std::fmt::Debug;
 
+use editoast_models::DbConnection;
+
 use crate::error::EditoastError;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 /// Describes how a [Model](super::Model) can be retrieved from the database
 ///

--- a/editoast/src/modelsv2/prelude/update.rs
+++ b/editoast/src/modelsv2/prelude/update.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
 use diesel::result::Error::NotFound;
+use editoast_models::DbConnection;
 
 use crate::error::EditoastError;
 use crate::error::Result;
 use crate::models::PreferredId;
-use editoast_models::DbConnection;
 
 use super::Model;
 

--- a/editoast/src/modelsv2/projects.rs
+++ b/editoast/src/modelsv2/projects.rs
@@ -120,7 +120,6 @@ impl Project {
 pub mod test {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::modelsv2::fixtures::create_project;
@@ -132,18 +131,17 @@ pub mod test {
     async fn project_creation() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let project_name = "test_project_name";
-        let created_project = create_project(db_pool.get_ok().deref_mut(), project_name).await;
+        let created_project = create_project(&mut db_pool.get_ok(), project_name).await;
         assert_eq!(created_project.name, project_name);
     }
 
     #[rstest]
     async fn project_retrieve() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        let created_project =
-            create_project(db_pool.get_ok().deref_mut(), "test_project_name").await;
+        let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
         // Get a project
-        let project = Project::retrieve(db_pool.get_ok().deref_mut(), created_project.id)
+        let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -154,8 +152,7 @@ pub mod test {
     #[rstest]
     async fn project_update() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        let mut created_project =
-            create_project(db_pool.get_ok().deref_mut(), "test_project_name").await;
+        let mut created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
         let project_name = "update_name";
         let project_budget = Some(1000);
@@ -165,11 +162,11 @@ pub mod test {
             .patch()
             .name(project_name.to_owned())
             .budget(project_budget)
-            .apply(db_pool.get_ok().deref_mut())
+            .apply(&mut db_pool.get_ok())
             .await
             .expect("Failed to update project");
 
-        let project = Project::retrieve(db_pool.get_ok().deref_mut(), created_project.id)
+        let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
             .expect("Project not found");
@@ -181,13 +178,11 @@ pub mod test {
     #[rstest]
     async fn sort_project() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        let _created_project_1 =
-            create_project(db_pool.get_ok().deref_mut(), "test_project_name_1").await;
-        let _created_project_2 =
-            create_project(db_pool.get_ok().deref_mut(), "test_project_name_2").await;
+        let _created_project_1 = create_project(&mut db_pool.get_ok(), "test_project_name_1").await;
+        let _created_project_2 = create_project(&mut db_pool.get_ok(), "test_project_name_2").await;
 
         let projects = Project::list(
-            db_pool.get_ok().deref_mut(),
+            &mut db_pool.get_ok(),
             SelectionSettings::new().order_by(|| Project::NAME.desc()),
         )
         .await

--- a/editoast/src/modelsv2/railjson.rs
+++ b/editoast/src/modelsv2/railjson.rs
@@ -5,7 +5,6 @@ use editoast_schemas::infra::RAILJSON_VERSION;
 use crate::error::Result;
 use crate::modelsv2::infra_objects::*;
 use crate::modelsv2::prelude::*;
-use diesel_async::AsyncConnection;
 use editoast_models::DbConnection;
 
 #[derive(Debug, thiserror::Error, EditoastError)]
@@ -48,70 +47,71 @@ pub async fn persist_railjson(
     }
 
     connection
+        .clone()
         .transaction(|conn| {
-            Box::pin(async {
+            Box::pin(async move {
                 let _ = TrackSectionModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     TrackSectionModel::from_infra_schemas(infra_id, track_sections),
                 )
                 .await?;
 
                 let _ = BufferStopModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     BufferStopModel::from_infra_schemas(infra_id, buffer_stops),
                 )
                 .await?;
 
                 let _ = ElectrificationModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     ElectrificationModel::from_infra_schemas(infra_id, electrifications),
                 )
                 .await?;
 
                 let _ = DetectorModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     DetectorModel::from_infra_schemas(infra_id, detectors),
                 )
                 .await?;
 
                 let _ = OperationalPointModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     OperationalPointModel::from_infra_schemas(infra_id, operational_points),
                 )
                 .await?;
 
                 let _ = RouteModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     RouteModel::from_infra_schemas(infra_id, routes),
                 )
                 .await?;
 
                 let _ = SignalModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     SignalModel::from_infra_schemas(infra_id, signals),
                 )
                 .await?;
 
                 let _ = SwitchModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     SwitchModel::from_infra_schemas(infra_id, switches),
                 )
                 .await?;
 
                 let _ = SpeedSectionModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     SpeedSectionModel::from_infra_schemas(infra_id, speed_sections),
                 )
                 .await?;
 
                 let _ = SwitchTypeModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     SwitchTypeModel::from_infra_schemas(infra_id, extended_switch_types),
                 )
                 .await?;
 
                 let _ = NeutralSectionModel::create_batch::<_, Vec<_>>(
-                    conn,
+                    &mut conn.clone(),
                     NeutralSectionModel::from_infra_schemas(infra_id, neutral_sections),
                 )
                 .await?;

--- a/editoast/src/modelsv2/rolling_stock_livery.rs
+++ b/editoast/src/modelsv2/rolling_stock_livery.rs
@@ -58,7 +58,6 @@ impl RollingStockLiveryModel {
 #[cfg(test)]
 pub mod tests {
     use rstest::*;
-    use std::ops::DerefMut;
 
     use super::RollingStockLiveryModel;
     use crate::modelsv2::fixtures::create_rolling_stock_livery_fixture;
@@ -71,32 +70,31 @@ pub mod tests {
         let db_pool = DbConnectionPoolV2::for_tests();
 
         let (rs_livery, _, image) =
-            create_rolling_stock_livery_fixture(db_pool.get_ok().deref_mut(), "rs_livery_name")
-                .await;
+            create_rolling_stock_livery_fixture(&mut db_pool.get_ok(), "rs_livery_name").await;
 
         assert!(
-            RollingStockLiveryModel::retrieve(db_pool.get_ok().deref_mut(), rs_livery.id)
+            RollingStockLiveryModel::retrieve(&mut db_pool.get_ok(), rs_livery.id)
                 .await
                 .is_ok()
         );
 
-        assert!(Document::retrieve(db_pool.get_ok().deref_mut(), image.id)
+        assert!(Document::retrieve(&mut db_pool.get_ok(), image.id)
             .await
             .is_ok());
 
         assert!(rs_livery
-            .delete_with_compound_image(db_pool.get_ok().deref_mut())
+            .delete_with_compound_image(&mut db_pool.get_ok())
             .await
             .is_ok());
 
         assert!(
-            RollingStockLiveryModel::retrieve(db_pool.get_ok().deref_mut(), rs_livery.id)
+            RollingStockLiveryModel::retrieve(&mut db_pool.get_ok(), rs_livery.id)
                 .await
                 .expect("Failed to retrieve rolling stock livery")
                 .is_none()
         );
 
-        assert!(Document::retrieve(db_pool.get_ok().deref_mut(), image.id)
+        assert!(Document::retrieve(&mut db_pool.get_ok(), image.id)
             .await
             .expect("Failed to retrieve document")
             .is_none());

--- a/editoast/src/modelsv2/rolling_stock_model.rs
+++ b/editoast/src/modelsv2/rolling_stock_model.rs
@@ -201,7 +201,6 @@ impl From<RollingStock> for RollingStockModelChangeset {
 pub mod tests {
     use rstest::*;
     use serde_json::to_value;
-    use std::ops::DerefMut;
 
     use super::RollingStockModel;
     use crate::error::InternalError;
@@ -219,7 +218,7 @@ pub mod tests {
         let rs_name = "fast_rolling_stock_name";
 
         let created_fast_rolling_stock =
-            create_fast_rolling_stock(db_pool.get_ok().deref_mut(), rs_name).await;
+            create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
         // GIVEN
         let rs_name_with_energy_sources_name = "other_rolling_stock_update_rolling_stock";
@@ -230,7 +229,7 @@ pub mod tests {
 
         // WHEN
         let updated_rolling_stock = rolling_stock_with_energy_sources
-            .update(db_pool.get_ok().deref_mut(), rolling_stock_id)
+            .update(&mut db_pool.get_ok(), rolling_stock_id)
             .await
             .expect("Failed to update rolling stock")
             .unwrap();
@@ -247,13 +246,13 @@ pub mod tests {
         // Creating the first rolling stock
         let rs_name = "fast_rolling_stock_name";
         let created_fast_rolling_stock =
-            create_fast_rolling_stock(db_pool.get_ok().deref_mut(), rs_name).await;
+            create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
 
         // Creating the second rolling stock
         let rs_name_with_energy_sources_name = "fast_rolling_stock_with_energy_sources_name";
         let created_fast_rolling_stock_with_energy_sources =
             create_rolling_stock_with_energy_sources(
-                db_pool.get_ok().deref_mut(),
+                &mut db_pool.get_ok(),
                 rs_name_with_energy_sources_name,
             )
             .await;
@@ -261,7 +260,7 @@ pub mod tests {
         // WHEN
         let result = created_fast_rolling_stock_with_energy_sources
             .into_changeset()
-            .update(db_pool.get_ok().deref_mut(), created_fast_rolling_stock.id)
+            .update(&mut db_pool.get_ok(), created_fast_rolling_stock.id)
             .await
             .map_err(|e| map_diesel_error(e, rs_name));
 

--- a/editoast/src/modelsv2/rolling_stock_model/power_restrictions.rs
+++ b/editoast/src/modelsv2/rolling_stock_model/power_restrictions.rs
@@ -1,13 +1,15 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::RollingStockModel;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 editoast_common::schemas! {
     PowerRestriction,
@@ -22,7 +24,7 @@ pub struct PowerRestriction {
 impl RollingStockModel {
     pub async fn get_power_restrictions(conn: &mut DbConnection) -> Result<Vec<PowerRestriction>> {
         let power_restrictions = sql_query(include_str!("sql/get_power_restrictions.sql"))
-            .load::<PowerRestriction>(conn)
+            .load::<PowerRestriction>(conn.write().await.deref_mut())
             .await?;
         Ok(power_restrictions)
     }

--- a/editoast/src/modelsv2/rolling_stock_model/rolling_stock_usage.rs
+++ b/editoast/src/modelsv2/rolling_stock_model/rolling_stock_usage.rs
@@ -1,14 +1,16 @@
+use std::ops::DerefMut;
+
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel::sql_types::Text;
 use diesel_async::RunQueryDsl;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::RollingStockModel;
 use crate::error::Result;
-use editoast_models::DbConnection;
 
 editoast_common::schemas! {
     TrainScheduleScenarioStudyProject,
@@ -41,7 +43,7 @@ impl RollingStockModel {
     ) -> Result<Vec<TrainScheduleScenarioStudyProject>> {
         let result = sql_query(include_str!("sql/get_train_schedules_with_scenario.sql"))
             .bind::<BigInt, _>(self.id)
-            .load::<TrainScheduleScenarioStudyProject>(conn)
+            .load::<TrainScheduleScenarioStudyProject>(conn.write().await.deref_mut())
             .await?;
         Ok(result)
     }

--- a/editoast/src/modelsv2/scenario.rs
+++ b/editoast/src/modelsv2/scenario.rs
@@ -1,15 +1,17 @@
+use std::ops::DerefMut;
+
 use chrono::NaiveDateTime;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
 use editoast_derive::ModelV2;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::modelsv2::Tags;
-use editoast_models::DbConnection;
 
 #[derive(Debug, Clone, ModelV2, Deserialize, Serialize, ToSchema)]
 #[model(table = editoast_models::tables::scenario)]
@@ -37,7 +39,7 @@ impl Scenario {
         let infra_name = infra_dsl::infra
             .filter(infra_dsl::id.eq(self.infra_id))
             .select(infra_dsl::name)
-            .first::<String>(conn)
+            .first::<String>(conn.write().await.deref_mut())
             .await?;
         Ok(infra_name)
     }
@@ -47,7 +49,7 @@ impl Scenario {
         let trains_count = train_schedule
             .filter(timetable_id.eq(self.timetable_id))
             .count()
-            .get_result(conn)
+            .get_result(conn.write().await.deref_mut())
             .await?;
         Ok(trains_count)
     }

--- a/editoast/src/modelsv2/stdcm_search_environment.rs
+++ b/editoast/src/modelsv2/stdcm_search_environment.rs
@@ -2,13 +2,14 @@ use chrono::NaiveDateTime;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
+use editoast_derive::ModelV2;
+use editoast_models::DbConnection;
 use serde::Serialize;
+use std::ops::DerefMut;
 use utoipa::ToSchema;
 
 use crate::error::Result;
 use crate::modelsv2::prelude::{Create, Row};
-use editoast_derive::ModelV2;
-use editoast_models::DbConnection;
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -37,7 +38,7 @@ impl StdcmSearchEnvironment {
         use editoast_models::tables::stdcm_search_environment::dsl::*;
         stdcm_search_environment
             .order_by((search_window_end.desc(), search_window_begin.asc()))
-            .first::<Row<StdcmSearchEnvironment>>(conn)
+            .first::<Row<StdcmSearchEnvironment>>(conn.write().await.deref_mut())
             .await
             .map(Into::into)
             .ok()
@@ -46,7 +47,7 @@ impl StdcmSearchEnvironment {
     pub async fn delete_all(conn: &mut DbConnection) -> Result<()> {
         use editoast_models::tables::stdcm_search_environment::dsl::*;
         diesel::delete(stdcm_search_environment)
-            .execute(conn)
+            .execute(conn.write().await.deref_mut())
             .await?;
         Ok(())
     }
@@ -64,7 +65,6 @@ pub mod test {
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::modelsv2::electrical_profiles::ElectricalProfileSet;
@@ -98,11 +98,11 @@ pub mod test {
     async fn test_overwrite() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let initial_env_count =
-            StdcmSearchEnvironment::count(db_pool.get_ok().deref_mut(), Default::default())
+            StdcmSearchEnvironment::count(&mut db_pool.get_ok(), Default::default())
                 .await
                 .expect("failed to count STDCM envs");
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
-            stdcm_search_env_fixtures(db_pool.get_ok().deref_mut()).await;
+            stdcm_search_env_fixtures(&mut db_pool.get_ok()).await;
 
         let changeset_1 = StdcmSearchEnvironment::changeset()
             .infra_id(infra.id)
@@ -121,30 +121,30 @@ pub mod test {
             .search_window_end(end);
 
         changeset_1
-            .create(db_pool.get_ok().deref_mut())
+            .create(&mut db_pool.get_ok())
             .await
             .expect("Failed to create first search environment");
 
         assert_eq!(
-            StdcmSearchEnvironment::count(db_pool.get_ok().deref_mut(), SelectionSettings::new())
+            StdcmSearchEnvironment::count(&mut db_pool.get_ok(), SelectionSettings::new())
                 .await
                 .expect("Failed to count"),
             initial_env_count + 1
         );
 
         let _ = changeset_2
-            .overwrite(db_pool.get_ok().deref_mut())
+            .overwrite(&mut db_pool.get_ok())
             .await
             .expect("Failed to overwrite search environment");
 
         assert_eq!(
-            StdcmSearchEnvironment::count(db_pool.get_ok().deref_mut(), SelectionSettings::new())
+            StdcmSearchEnvironment::count(&mut db_pool.get_ok(), SelectionSettings::new())
                 .await
                 .expect("Failed to count"),
             1
         );
 
-        let result = StdcmSearchEnvironment::retrieve_latest(db_pool.get_ok().deref_mut())
+        let result = StdcmSearchEnvironment::retrieve_latest(&mut db_pool.get_ok())
             .await
             .expect("Failed to retrieve latest search environment");
 
@@ -155,11 +155,11 @@ pub mod test {
     #[rstest]
     async fn test_retrieve_latest() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        StdcmSearchEnvironment::delete_all(db_pool.get_ok().deref_mut())
+        StdcmSearchEnvironment::delete_all(&mut db_pool.get_ok())
             .await
             .expect("failed to delete envs");
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
-            stdcm_search_env_fixtures(db_pool.get_ok().deref_mut()).await;
+            stdcm_search_env_fixtures(&mut db_pool.get_ok()).await;
 
         let too_old = StdcmSearchEnvironment::changeset()
             .infra_id(infra.id)
@@ -184,12 +184,12 @@ pub mod test {
 
         for changeset in [too_old, too_young.clone(), the_best, too_young] {
             changeset
-                .create(db_pool.get_ok().deref_mut())
+                .create(&mut db_pool.get_ok())
                 .await
                 .expect("Failed to create search environment");
         }
 
-        let result = StdcmSearchEnvironment::retrieve_latest(db_pool.get_ok().deref_mut())
+        let result = StdcmSearchEnvironment::retrieve_latest(&mut db_pool.get_ok())
             .await
             .expect("Failed to retrieve latest search environment");
 
@@ -200,10 +200,10 @@ pub mod test {
     #[rstest]
     async fn test_retrieve_latest_empty() {
         let db_pool = DbConnectionPoolV2::for_tests();
-        StdcmSearchEnvironment::delete_all(db_pool.get_ok().deref_mut())
+        StdcmSearchEnvironment::delete_all(&mut db_pool.get_ok())
             .await
             .expect("failed to delete envs");
-        let result = StdcmSearchEnvironment::retrieve_latest(db_pool.get_ok().deref_mut()).await;
+        let result = StdcmSearchEnvironment::retrieve_latest(&mut db_pool.get_ok()).await;
         assert_eq!(result, None);
     }
 }

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -167,7 +167,6 @@ mod tests {
     use axum::http::StatusCode;
     use rstest::rstest;
     use serde::Deserialize;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::views::test_app::TestAppBuilder;
@@ -196,7 +195,7 @@ mod tests {
         let new_doc = response.json::<PostDocumentResponse>().document_key;
 
         // Get create document
-        let document = Document::retrieve(pool.get_ok().deref_mut(), new_doc)
+        let document = Document::retrieve(&mut pool.get_ok(), new_doc)
             .await
             .expect("Failed to retrieve document")
             .expect("Document not found");
@@ -213,7 +212,7 @@ mod tests {
         let document = Document::changeset()
             .data(b"Document post test data".to_vec())
             .content_type(String::from("text/plain"))
-            .create(pool.get_ok().deref_mut())
+            .create(&mut pool.get_ok())
             .await
             .expect("Failed to create document");
 
@@ -234,7 +233,7 @@ mod tests {
         let document = Document::changeset()
             .data(b"Document post test data".to_vec())
             .content_type(String::from("text/plain"))
-            .create(pool.get_ok().deref_mut())
+            .create(&mut pool.get_ok())
             .await
             .expect("Failed to create document");
 
@@ -245,7 +244,7 @@ mod tests {
         response.assert_status(StatusCode::NO_CONTENT);
 
         // Get create document
-        let document = Document::exists(pool.get_ok().deref_mut(), document.id)
+        let document = Document::exists(&mut pool.get_ok(), document.id)
             .await
             .expect("Failed to retrieve document");
 

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -225,7 +225,6 @@ mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::modelsv2::fixtures::create_electrical_profile_set;
@@ -239,8 +238,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let _set_1 = create_electrical_profile_set(pool.get_ok().deref_mut()).await;
-        let _set_2 = create_electrical_profile_set(pool.get_ok().deref_mut()).await;
+        let _set_1 = create_electrical_profile_set(&mut pool.get_ok()).await;
+        let _set_2 = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let response = app.get("/electrical_profile_set").await;
         response.assert_status(StatusCode::OK);
@@ -262,7 +261,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let electrical_profile_set = create_electrical_profile_set(pool.get_ok().deref_mut()).await;
+        let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let response = app
             .get(&format!(
@@ -286,7 +285,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let electrical_profile_set = create_electrical_profile_set(pool.get_ok().deref_mut()).await;
+        let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let response = app
             .get(&format!(
@@ -316,7 +315,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let electrical_profile_set = create_electrical_profile_set(pool.get_ok().deref_mut()).await;
+        let electrical_profile_set = create_electrical_profile_set(&mut pool.get_ok()).await;
 
         let response = app
             .delete(&format!(
@@ -326,10 +325,9 @@ mod tests {
             .await;
         response.assert_status(StatusCode::NO_CONTENT);
 
-        let exists =
-            ElectricalProfileSet::exists(pool.get_ok().deref_mut(), electrical_profile_set.id)
-                .await
-                .expect("Failed to check if electrical profile set exists");
+        let exists = ElectricalProfileSet::exists(&mut pool.get_ok(), electrical_profile_set.id)
+            .await
+            .expect("Failed to check if electrical profile set exists");
 
         assert!(!exists);
     }
@@ -355,7 +353,7 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let created_ep: ElectricalProfileSet = response.json();
 
-        let created_ep = ElectricalProfileSet::retrieve(pool.get_ok().deref_mut(), created_ep.id)
+        let created_ep = ElectricalProfileSet::retrieve(&mut pool.get_ok(), created_ep.id)
             .await
             .expect("Failed to retrieve created electrical profile set")
             .expect("Electrical profile set not found");

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -115,7 +115,6 @@ mod tests {
     use std::collections::HashMap;
 
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use crate::infra_cache::operation::create::apply_create_operation;
     use crate::modelsv2::prelude::*;
@@ -135,13 +134,13 @@ mod tests {
         let empty_infra = Infra::changeset()
             .name("test_infra".to_owned())
             .last_railjson_version()
-            .create(pool.get_ok().deref_mut())
+            .create(&mut pool.get_ok())
             .await
             .expect("Failed to create infra");
 
         // Create a track and a detector on it
         let track = TrackSection::default().into();
-        apply_create_operation(&track, empty_infra.id, pool.get_ok().deref_mut())
+        apply_create_operation(&track, empty_infra.id, &mut pool.get_ok())
             .await
             .expect("Failed to create track object");
 
@@ -150,7 +149,7 @@ mod tests {
             ..Default::default()
         }
         .into();
-        apply_create_operation(&detector, empty_infra.id, pool.get_ok().deref_mut())
+        apply_create_operation(&detector, empty_infra.id, &mut pool.get_ok())
             .await
             .expect("Failed to create detector object");
 

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -2,7 +2,6 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
 use axum::Extension;
-use diesel_async::AsyncConnection;
 use editoast_authz::BuiltinRole;
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::ApplicableDirectionsTrackRange;
@@ -20,7 +19,6 @@ use itertools::Itertools;
 use json_patch::{AddOperation, Patch, PatchOperation, RemoveOperation, ReplaceOperation};
 use serde_json::json;
 use std::collections::HashMap;
-use std::ops::DerefMut;
 use thiserror::Error;
 use tracing::error;
 use tracing::info;
@@ -91,15 +89,14 @@ async fn edit<'a>(
     }
 
     // TODO: lock for update
-    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
     let mut infra_cache =
-        InfraCache::get_or_load_mut(db_pool.get().await?.deref_mut(), &infra_caches, &infra)
-            .await?;
+        InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
     let operation_results = apply_edit(
-        db_pool.get().await?.deref_mut(),
+        &mut db_pool.get().await?,
         &mut infra,
         &operations,
         &mut infra_cache,
@@ -153,13 +150,12 @@ pub async fn split_track_section<'a>(
     );
 
     // Check the infra
-    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
     let mut infra_cache =
-        InfraCache::get_or_load_mut(db_pool.get().await?.deref_mut(), &infra_caches, &infra)
-            .await?;
+        InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
 
     // Get tracks cache if it exists
     let tracksection_cached = infra_cache.get_track_section(&payload.track)?.clone();
@@ -179,7 +175,7 @@ pub async fn split_track_section<'a>(
     // Calling the DB to get the full object and also the split geo
     let result = infra
         .get_split_track_section_with_data(
-            db_pool.get().await?.deref_mut(),
+            &mut db_pool.get().await?,
             payload.track.clone(),
             distance_fraction,
         )
@@ -332,7 +328,7 @@ pub async fn split_track_section<'a>(
 
     // Apply operations
     apply_edit(
-        db_pool.get().await?.deref_mut(),
+        &mut db_pool.get().await?,
         &mut infra,
         &operations,
         &mut infra_cache,
@@ -854,12 +850,13 @@ async fn apply_edit(
 
     // Apply modifications in one transaction
     connection
+        .clone()
         .transaction(|conn| {
-            Box::pin(async {
+            Box::pin(async move {
                 let mut railjsons = vec![];
                 let mut cache_operations = vec![];
                 for operation in operations {
-                    let railjson = operation.apply(infra_id, conn).await?;
+                    let railjson = operation.apply(infra_id, &mut conn.clone()).await?;
                     match (operation, railjson) {
                         (Operation::Create(_), Some(railjson)) => {
                             railjsons.push(railjson.clone());
@@ -880,17 +877,22 @@ async fn apply_edit(
                 }
 
                 // Bump version
-                infra.bump_version(conn).await?;
+                infra.bump_version(&mut conn.clone()).await?;
                 // Apply operations to infra cache
                 infra_cache.apply_operations(&cache_operations)?;
 
                 // Refresh layers if needed
-                generated_data::update_all(conn, infra_id, &cache_operations, infra_cache)
-                    .await
-                    .expect("Update generated data failed");
+                generated_data::update_all(
+                    &mut conn.clone(),
+                    infra_id,
+                    &cache_operations,
+                    infra_cache,
+                )
+                .await
+                .expect("Update generated data failed");
 
                 // Bump infra generated version to the infra version
-                infra.bump_generated_version(conn).await?;
+                infra.bump_generated_version(&mut conn.clone()).await?;
 
                 Ok(railjsons)
             })
@@ -949,7 +951,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         // Make a call with a bad ID
         let request = app
@@ -968,7 +970,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         // Make a call with a bad distance
         let request = app
@@ -989,7 +991,7 @@ pub mod tests {
         // Init
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
 
         // Refresh the infra to get the good number of infra errors
         let req_refresh =
@@ -997,7 +999,7 @@ pub mod tests {
         app.fetch(req_refresh).assert_status(StatusCode::OK);
 
         // Get infra errors
-        let (init_errors, _) = query_errors(db_pool.get_ok().deref_mut(), &small_infra).await;
+        let (init_errors, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
 
         // Make a call to split the track section
         let request = app
@@ -1012,7 +1014,7 @@ pub mod tests {
         assert_eq!(res.len(), 2);
 
         // Check that infra errors has not increased with the split (omit route error for now)
-        let (errors, _) = query_errors(db_pool.get_ok().deref_mut(), &small_infra).await;
+        let (errors, _) = query_errors(&mut db_pool.get_ok(), &small_infra).await;
         let errors_without_routes: Vec<InfraError> = errors
             .into_iter()
             .filter(|e| {
@@ -1031,8 +1033,11 @@ pub mod tests {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
         let conn = &mut db_pool.get().await.unwrap();
-        let mut small_infra = create_small_infra(conn).await;
-        let mut infra_cache = InfraCache::load(conn, &small_infra).await.unwrap();
+
+        let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let mut infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
+            .await
+            .unwrap();
 
         // Calling "apply_edit" with a OK operation
         let operations: Vec<Operation> = [

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -138,7 +138,6 @@ pub(in crate::views) async fn query_errors(
 mod tests {
     use axum::http::StatusCode;
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use crate::modelsv2::fixtures::create_empty_infra;
     use crate::views::test_app::TestAppBuilder;
@@ -147,7 +146,7 @@ mod tests {
     async fn list_errors_get() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let error_type = "overlapping_electrifications";
         let level = "warnings";

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -90,7 +90,6 @@ mod test {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
-    use std::ops::DerefMut;
     use std::str::FromStr;
 
     use crate::infra_cache::operation::create::apply_create_operation;
@@ -104,7 +103,7 @@ mod test {
     async fn returns_correct_bbox_for_existing_line_code() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let line_code = 1234;
         let geometry_json = json!({
@@ -125,7 +124,7 @@ mod test {
             ..Default::default()
         }
         .into();
-        apply_create_operation(&track_section, empty_infra.id, db_pool.get_ok().deref_mut())
+        apply_create_operation(&track_section, empty_infra.id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create track section object");
 
@@ -140,7 +139,7 @@ mod test {
     async fn returns_bad_request_when_line_code_not_found() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let not_existing_line_code = 123456789;
         let request = app.get(

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -20,7 +20,6 @@ use editoast_derive::EditoastError;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::ops::DerefMut;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
@@ -146,10 +145,10 @@ async fn refresh(
 
     let infras_list = if infras.is_empty() {
         // Retrieve all available infra
-        Infra::all(db_pool.get().await?.deref_mut()).await
+        Infra::all(&mut db_pool.get().await?).await
     } else {
         // Retrieve given infras
-        Infra::retrieve_batch_or_fail(db_pool.get().await?.deref_mut(), infras, |missing| {
+        Infra::retrieve_batch_or_fail(&mut db_pool.get().await?, infras, |missing| {
             InfraApiError::NotFound {
                 infra_id: missing.into_iter().next().unwrap(),
             }
@@ -163,8 +162,7 @@ async fn refresh(
 
     for mut infra in infras_list {
         let infra_cache =
-            InfraCache::get_or_load(db_pool.get().await?.deref_mut(), &infra_caches, &infra)
-                .await?;
+            InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
         if infra.refresh(db_pool.clone(), force, &infra_cache).await? {
             infra_refreshed.push(infra.id);
         }
@@ -298,7 +296,7 @@ async fn get(
     let core_client = app_state.core_client.clone();
 
     let infra_id = infra.infra_id;
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -346,7 +344,7 @@ async fn create(
     }
 
     let infra: Changeset<Infra> = infra_form.into();
-    let infra = infra.create(db_pool.get().await?.deref_mut()).await?;
+    let infra = infra.create(&mut db_pool.get().await?).await?;
     Ok((StatusCode::CREATED, Json(infra)))
 }
 
@@ -381,13 +379,13 @@ async fn clone(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), params.infra_id, || {
-        InfraApiError::NotFound {
-            infra_id: params.infra_id,
-        }
+    let conn = &mut db_pool.get().await?;
+
+    let infra = Infra::retrieve_or_fail(conn, params.infra_id, || InfraApiError::NotFound {
+        infra_id: params.infra_id,
     })
     .await?;
-    let cloned_infra = infra.clone(db_pool.get().await?.deref_mut(), name).await?;
+    let cloned_infra = infra.clone(conn, name).await?;
     Ok(Json(cloned_infra.id))
 }
 
@@ -425,7 +423,7 @@ async fn delete(
     let db_pool = app_state.db_pool_v2.clone();
     let infra_caches = app_state.infra_caches.clone();
     let infra_id = infra.infra_id;
-    if Infra::fast_delete_static(db_pool.get().await?.deref_mut(), infra_id).await? {
+    if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
         infra_caches.remove(&infra_id);
         Ok(StatusCode::NO_CONTENT)
     } else {
@@ -472,7 +470,7 @@ async fn put(
 
     let infra_cs: Changeset<Infra> = patch.into();
     let infra = infra_cs
-        .update_or_fail(db_pool.get().await?.deref_mut(), infra, || {
+        .update_or_fail(&mut db_pool.get().await?, infra, || {
             InfraApiError::NotFound { infra_id: infra }
         })
         .await?;
@@ -503,17 +501,15 @@ async fn get_switch_types(
     }
 
     let db_pool = app_state.db_pool_v2.clone();
+    let conn = &mut db_pool.get().await?;
     let infra_caches = app_state.infra_caches.clone();
 
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra.infra_id, || {
-        InfraApiError::NotFound {
-            infra_id: infra.infra_id,
-        }
+    let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
+        infra_id: infra.infra_id,
     })
     .await?;
 
-    let infra =
-        InfraCache::get_or_load(db_pool.get().await?.deref_mut(), &infra_caches, &infra).await?;
+    let infra = InfraCache::get_or_load(conn, &infra_caches, &infra).await?;
     Ok(Json(
         infra
             .switch_types()
@@ -547,15 +543,13 @@ async fn get_speed_limit_tags(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra.infra_id, || {
-        InfraApiError::NotFound {
-            infra_id: infra.infra_id,
-        }
+    let conn = &mut db_pool.get().await?;
+
+    let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
+        infra_id: infra.infra_id,
     })
     .await?;
-    let speed_limits_tags = infra
-        .get_speed_limit_tags(db_pool.get().await?.deref_mut())
-        .await?;
+    let speed_limits_tags = infra.get_speed_limit_tags(conn).await?;
     Ok(Json(
         speed_limits_tags.into_iter().map(|el| (el.tag)).collect(),
     ))
@@ -594,17 +588,14 @@ async fn get_voltages(
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra.infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra.infra_id, || {
         InfraApiError::NotFound {
             infra_id: infra.infra_id,
         }
     })
     .await?;
     let voltages = infra
-        .get_voltages(
-            db_pool.get().await?.deref_mut(),
-            include_rolling_stock_modes,
-        )
+        .get_voltages(&mut db_pool.get().await?, include_rolling_stock_modes)
         .await?;
     Ok(Json(voltages.into_iter().map(|el| (el.voltage)).collect()))
 }
@@ -630,17 +621,17 @@ async fn get_all_voltages(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let voltages = Infra::get_all_voltages(db_pool.get().await?.deref_mut()).await?;
+    let voltages = Infra::get_all_voltages(&mut db_pool.get().await?).await?;
     Ok(Json(voltages.into_iter().map(|el| (el.voltage)).collect()))
 }
 
 async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) -> Result<()> {
-    let mut infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
     infra.locked = locked;
-    infra.save(db_pool.get().await?.deref_mut()).await
+    infra.save(&mut db_pool.get().await?).await
 }
 
 /// Lock an infra
@@ -724,7 +715,7 @@ async fn load(
     let core_client = app_state.core_client.clone();
 
     let infra_id = path.infra_id;
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
@@ -803,13 +794,13 @@ pub mod tests {
     async fn infra_clone_empty() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let request =
             app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
 
         let cloned_infra_id: i64 = app.fetch(request).assert_status(StatusCode::OK).json_into();
-        let cloned_infra = Infra::retrieve(db_pool.get_ok().deref_mut(), cloned_infra_id)
+        let cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -827,9 +818,9 @@ pub mod tests {
     async fn infra_clone() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let small_infra_id = small_infra.id;
-        let infra_cache = InfraCache::load(db_pool.get_ok().deref_mut(), &small_infra)
+        let infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
             .await
             .unwrap();
 
@@ -842,7 +833,7 @@ pub mod tests {
             ..Default::default()
         }
         .into();
-        apply_create_operation(&switch_type, small_infra_id, db_pool.get_ok().deref_mut())
+        apply_create_operation(&switch_type, small_infra_id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create switch_type object");
 
@@ -854,7 +845,7 @@ pub mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
-        let _cloned_infra = Infra::retrieve(db_pool.get_ok().deref_mut(), cloned_infra_id)
+        let _cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -876,7 +867,7 @@ pub mod tests {
                     table
                 ))
                 .bind::<BigInt, _>(inf_id)
-                .get_result::<Count>(db_pool.get_ok().deref_mut())
+                .get_result::<Count>(&mut db_pool.get_ok().write().await.deref_mut())
                 .await
                 .unwrap();
 
@@ -905,7 +896,7 @@ pub mod tests {
             .core_client(CoreClient::default())
             .build();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         app.fetch(app.delete_infra_request(empty_infra.id))
             .assert_status(StatusCode::NO_CONTENT);
@@ -954,16 +945,13 @@ pub mod tests {
             .db_pool(db_pool.clone())
             .core_client(core.into())
             .build();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
 
         app.fetch(req).assert_status(StatusCode::OK);
 
-        empty_infra
-            .delete(db_pool.get_ok().deref_mut())
-            .await
-            .unwrap();
+        empty_infra.delete(&mut db_pool.get_ok()).await.unwrap();
 
         let req = app.get(format!("/infra/{}", empty_infra.id).as_str());
 
@@ -974,7 +962,7 @@ pub mod tests {
     async fn infra_rename() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req = app
             .put(format!("/infra/{}", empty_infra.id).as_str())
@@ -994,7 +982,7 @@ pub mod tests {
     async fn infra_refresh() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req = app.post(format!("/infra/refresh/?infras={}", empty_infra.id).as_str());
 
@@ -1010,7 +998,7 @@ pub mod tests {
     async fn infra_refresh_force() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req =
             app.post(format!("/infra/refresh/?infras={}&force=true", empty_infra.id).as_str());
@@ -1023,14 +1011,14 @@ pub mod tests {
     async fn infra_get_speed_limit_tags() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let speed_section = SpeedSection {
             speed_limit_by_tag: HashMap::from([("test_tag".into(), Speed(10.))]),
             ..Default::default()
         }
         .into();
-        apply_create_operation(&speed_section, empty_infra.id, db_pool.get_ok().deref_mut())
+        apply_create_operation(&speed_section, empty_infra.id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create speed section object");
 
@@ -1046,8 +1034,8 @@ pub mod tests {
     async fn infra_get_all_voltages() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let infra_1 = create_empty_infra(db_pool.get_ok().deref_mut()).await;
-        let infra_2 = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let infra_1 = create_empty_infra(&mut db_pool.get_ok()).await;
+        let infra_2 = create_empty_infra(&mut db_pool.get_ok()).await;
 
         // Create electrifications
         let electrification_1 = Electrification {
@@ -1056,7 +1044,7 @@ pub mod tests {
             track_ranges: vec![],
         }
         .into();
-        apply_create_operation(&electrification_1, infra_1.id, db_pool.get_ok().deref_mut())
+        apply_create_operation(&electrification_1, infra_1.id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create electrification_1 object");
 
@@ -1066,13 +1054,13 @@ pub mod tests {
             track_ranges: vec![],
         }
         .into();
-        apply_create_operation(&electrification_2, infra_2.id, db_pool.get_ok().deref_mut())
+        apply_create_operation(&electrification_2, infra_2.id, &mut db_pool.get_ok())
             .await
             .expect("Failed to create electrification_2 object");
 
         // Create rolling_stock
         let _rolling_stock = create_rolling_stock_with_energy_sources(
-            db_pool.get_ok().deref_mut(),
+            &mut db_pool.get_ok(),
             "other_rolling_stock_infra_get_all_voltages",
         )
         .await;
@@ -1093,7 +1081,7 @@ pub mod tests {
     async fn infra_get_voltages(#[case] include_rolling_stock_modes: bool) {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         // Create electrification
         let electrification = Electrification {
@@ -1102,17 +1090,13 @@ pub mod tests {
             track_ranges: vec![],
         }
         .into();
-        apply_create_operation(
-            &electrification,
-            empty_infra.id,
-            db_pool.get_ok().deref_mut(),
-        )
-        .await
-        .expect("Failed to create electrification object");
+        apply_create_operation(&electrification, empty_infra.id, &mut db_pool.get_ok())
+            .await
+            .expect("Failed to create electrification object");
 
         // Create rolling_stock
         let _rolling_stock = create_rolling_stock_with_energy_sources(
-            db_pool.get_ok().deref_mut(),
+            &mut db_pool.get_ok(),
             "other_rolling_stock_infra_get_voltages",
         )
         .await;
@@ -1140,7 +1124,7 @@ pub mod tests {
     async fn infra_get_switch_types() {
         let app = TestAppBuilder::default_app();
         let db_pool = app.db_pool();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req = app.get(format!("/infra/{}/switch_types/", empty_infra.id).as_str());
 
@@ -1164,7 +1148,7 @@ pub mod tests {
             .db_pool(db_pool.clone())
             .core_client(core.into())
             .build();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         // Lock infra
         let req = app.post(format!("/infra/{}/lock/", empty_infra.id).as_str());
@@ -1172,7 +1156,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        let infra = Infra::retrieve(db_pool.get_ok().deref_mut(), empty_infra.id)
+        let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1184,7 +1168,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
-        let infra = Infra::retrieve(db_pool.get_ok().deref_mut(), empty_infra.id)
+        let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
             .expect("infra was not cloned");
@@ -1205,7 +1189,7 @@ pub mod tests {
             .db_pool(db_pool.clone())
             .core_client(core.into())
             .build();
-        let empty_infra = create_empty_infra(db_pool.get_ok().deref_mut()).await;
+        let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
 
         let req = app.post(format!("/infra/{}/load", empty_infra.id).as_str());
 

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -11,7 +11,6 @@ use editoast_derive::EditoastError;
 use pathfinding::prelude::yen;
 use serde::Deserialize;
 use serde::Serialize;
-use std::ops::DerefMut;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
@@ -126,12 +125,12 @@ async fn pathfinding_view(
     }
 
     // TODO: lock for share
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
     let infra_cache =
-        InfraCache::get_or_load(db_pool.get().await?.deref_mut(), &infra_caches, &infra).await?;
+        InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
 
     // Check that the starting and ending track locations are valid
     if !infra_cache

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -22,7 +22,6 @@ pub mod work_schedules;
 #[cfg(test)]
 mod test_app;
 
-use std::ops::DerefMut as _;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -214,7 +213,7 @@ async fn check_health(
 ) -> Result<()> {
     let mut db_connection = db_pool.clone().get().await?;
     tokio::try_join!(
-        ping_database(db_connection.deref_mut()).map_err(AppHealthError::Database),
+        ping_database(&mut db_connection).map_err(AppHealthError::Database),
         redis_client.ping_redis().map_err(|e| e.into())
     )?;
     Ok(())

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -1,4 +1,5 @@
 use editoast_derive::EditoastError;
+use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -10,7 +11,6 @@ use crate::error::Result;
 use crate::ListAndCount;
 use crate::Model;
 use crate::SelectionSettings;
-use editoast_models::DbConnection;
 
 editoast_common::schemas! {
     PaginationStats,

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -1,5 +1,3 @@
-use std::ops::DerefMut as _;
-
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
@@ -9,7 +7,6 @@ use axum::Extension;
 use chrono::Utc;
 use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
-use diesel_async::AsyncConnection;
 use editoast_authz::BuiltinRole;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
@@ -213,32 +210,39 @@ async fn create(
         .get()
         .await?
         .transaction::<_, InternalError, _>(|conn| {
-            async {
+            async move {
                 // Check if the project and the study exist
-                let (mut project, study) = check_project_study(conn, project_id, study_id).await?;
+                let (mut project, study) =
+                    check_project_study(&mut conn.clone(), project_id, study_id).await?;
 
                 // Check if the timetable exists
-                let _ = Timetable::retrieve_or_fail(conn, timetable_id, || {
+                let _ = Timetable::retrieve_or_fail(&mut conn.clone(), timetable_id, || {
                     ScenarioError::TimetableNotFound { timetable_id }
                 })
                 .await?;
 
                 // Check if the infra exists
-                if !Infra::exists(conn, infra_id).await? {
+                if !Infra::exists(&mut conn.clone(), infra_id).await? {
                     return Err(ScenarioError::InfraNotFound { infra_id }.into());
                 }
 
                 // Create Scenario
-                let scenario = scenario.study_id(study_id).create(conn).await?;
+                let scenario = scenario
+                    .study_id(study_id)
+                    .create(&mut conn.clone())
+                    .await?;
 
                 // Update study last_modification field
-                study.clone().update_last_modified(conn).await?;
+                study
+                    .clone()
+                    .update_last_modified(&mut conn.clone())
+                    .await?;
 
                 // Update project last_modification field
-                project.update_last_modified(conn).await?;
+                project.update_last_modified(&mut conn.clone()).await?;
 
                 let scenarios_with_details =
-                    ScenarioWithDetails::from_scenario(scenario, conn).await?;
+                    ScenarioWithDetails::from_scenario(scenario, &mut conn.clone()).await?;
 
                 let scenarios_response =
                     ScenarioResponse::new(scenarios_with_details, project, study);
@@ -283,23 +287,27 @@ async fn delete(
         .get()
         .await?
         .transaction::<_, InternalError, _>(|conn| {
-            async {
+            async move {
                 // Check if the project and the study exist
-                let (mut project, study) = check_project_study(conn, project_id, study_id)
-                    .await
-                    .unwrap();
+                let (mut project, study) =
+                    check_project_study(&mut conn.clone(), project_id, study_id)
+                        .await
+                        .unwrap();
 
                 // Delete scenario
-                Scenario::delete_static_or_fail(conn, scenario_id, || ScenarioError::NotFound {
-                    scenario_id,
+                Scenario::delete_static_or_fail(&mut conn.clone(), scenario_id, || {
+                    ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
 
                 // Update project last_modification field
-                project.update_last_modified(conn).await?;
+                project.update_last_modified(&mut conn.clone()).await?;
 
                 // Update study last_modification field
-                study.clone().update_last_modified(conn).await?;
+                study
+                    .clone()
+                    .update_last_modified(&mut conn.clone())
+                    .await?;
 
                 Ok(())
             }
@@ -366,13 +374,14 @@ async fn patch(
         .get()
         .await?
         .transaction::<_, InternalError, _>(|conn| {
-            async {
+            async move {
                 // Check if project and study exist
-                let (mut project, study) = check_project_study(conn, project_id, study_id).await?;
+                let (mut project, study) =
+                    check_project_study(&mut conn.clone(), project_id, study_id).await?;
 
                 // Check if the infra exists
                 if let Some(infra_id) = form.infra_id {
-                    if !Infra::exists(conn, infra_id).await? {
+                    if !Infra::exists(&mut conn.clone(), infra_id).await? {
                         return Err(ScenarioError::InfraNotFound { infra_id }.into());
                     }
                 }
@@ -380,19 +389,22 @@ async fn patch(
                 // Update the scenario
                 let scenario: Changeset<Scenario> = form.into();
                 let scenario = scenario
-                    .update_or_fail(conn, scenario_id, || ScenarioError::NotFound {
+                    .update_or_fail(&mut conn.clone(), scenario_id, || ScenarioError::NotFound {
                         scenario_id,
                     })
                     .await?;
 
                 // Update study last_modification field
-                study.clone().update_last_modified(conn).await?;
+                study
+                    .clone()
+                    .update_last_modified(&mut conn.clone())
+                    .await?;
 
                 // Update project last_modification field
-                project.update_last_modified(conn).await?;
+                project.update_last_modified(&mut conn.clone()).await?;
 
                 let scenario_with_details =
-                    ScenarioWithDetails::from_scenario(scenario, conn).await?;
+                    ScenarioWithDetails::from_scenario(scenario, &mut conn.clone()).await?;
 
                 let scenarios_response =
                     ScenarioResponse::new(scenario_with_details, project, study);
@@ -485,7 +497,9 @@ async fn list(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let _ = check_project_study(db_pool.get().await?.deref_mut(), project_id, study_id).await?;
+    let conn = &mut db_pool.get().await?;
+
+    let _ = check_project_study(conn, project_id, study_id).await?;
 
     let settings = pagination_params
         .validate(1000)?
@@ -493,14 +507,13 @@ async fn list(
         .into_selection_settings()
         .order_by(move || ordering.as_scenario_ordering())
         .filter(move || Scenario::STUDY_ID.eq(study_id));
-    let (scenarios, stats) =
-        Scenario::list_paginated(db_pool.get().await?.deref_mut(), settings).await?;
+    let (scenarios, stats) = Scenario::list_paginated(conn, settings).await?;
 
     let futs = scenarios
         .into_iter()
         .zip(std::iter::repeat(&db_pool).map(|p| p.get()))
         .map(|(scenario, conn)| async {
-            ScenarioWithDetails::from_scenario(scenario, conn.await?.deref_mut()).await
+            ScenarioWithDetails::from_scenario(scenario, &mut conn.await?).await
         });
     let results = futures::future::try_join_all(futs).await?;
 
@@ -536,8 +549,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(
             fixtures.project.id,
@@ -557,8 +569,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(fixtures.project.id, fixtures.study.id, None);
         let request = app.get(&url);
@@ -582,8 +593,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(fixtures.project.id, 99999999, Some(fixtures.scenario.id));
 
@@ -597,10 +607,10 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let project = create_project(pool.get_ok().deref_mut(), "project_test_name").await;
-        let study = create_study(pool.get_ok().deref_mut(), "study_test_name", project.id).await;
-        let infra = create_empty_infra(pool.get_ok().deref_mut()).await;
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
+        let project = create_project(&mut pool.get_ok(), "project_test_name").await;
+        let study = create_study(&mut pool.get_ok(), "study_test_name", project.id).await;
+        let infra = create_empty_infra(&mut pool.get_ok()).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
 
         let url = scenario_url(project.id, study.id, None);
 
@@ -628,7 +638,7 @@ mod tests {
         assert_eq!(response.scenario.timetable_id, study_timetable_id);
         assert_eq!(response.scenario.tags, study_tags);
 
-        let created_scenario = Scenario::retrieve(pool.get_ok().deref_mut(), response.scenario.id)
+        let created_scenario = Scenario::retrieve(&mut pool.get_ok(), response.scenario.id)
             .await
             .expect("Failed to retrieve scenario")
             .expect("Scenario not found");
@@ -645,8 +655,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(
             fixtures.project.id,
@@ -678,8 +687,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(
             fixtures.project.id,
@@ -700,9 +708,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
-        let other_infra = create_empty_infra(pool.get_ok().deref_mut()).await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
+        let other_infra = create_empty_infra(&mut pool.get_ok()).await;
 
         assert_eq!(fixtures.scenario.infra_id, fixtures.infra.id);
         assert_ne!(fixtures.scenario.infra_id, other_infra.id);
@@ -732,8 +739,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let fixtures =
-            create_scenario_fixtures_set(pool.get_ok().deref_mut(), "test_scenario_name").await;
+        let fixtures = create_scenario_fixtures_set(&mut pool.get_ok(), "test_scenario_name").await;
 
         let url = scenario_url(
             fixtures.project.id,
@@ -744,7 +750,7 @@ mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        let exists = Scenario::exists(pool.get_ok().deref_mut(), fixtures.scenario.id)
+        let exists = Scenario::exists(&mut pool.get_ok(), fixtures.scenario.id)
             .await
             .expect("Failed to check if scenario exists");
 

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -197,6 +197,8 @@
 
 // TODO: the documentation of this file needs to be updated (no more search.yml)
 
+use std::ops::DerefMut;
+
 use axum::extract::Json;
 use axum::extract::Query;
 use axum::extract::State;
@@ -220,7 +222,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::value::Value as JsonValue;
 use std::collections::HashSet;
-use std::ops::DerefMut;
 use utoipa::ToSchema;
 
 use crate::error::Result;
@@ -382,7 +383,7 @@ async fn search(
     }
 
     let objects = query
-        .load::<SearchDBResult>(db_pool.get().await?.deref_mut())
+        .load::<SearchDBResult>(&mut db_pool.get().await?.write().await.deref_mut())
         .await?;
     let results: Vec<_> = objects.into_iter().map(|r| r.result).collect();
     Ok(Json(serde_json::to_value(results).unwrap()))

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -160,7 +160,6 @@ pub mod test {
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::modelsv2::stdcm_search_environment::test::stdcm_search_env_fixtures;
@@ -174,7 +173,7 @@ pub mod test {
         let pool = app.db_pool();
 
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
-            stdcm_search_env_fixtures(pool.get_ok().deref_mut()).await;
+            stdcm_search_env_fixtures(&mut pool.get_ok()).await;
 
         let form = StdcmSearchEnvironmentCreateForm {
             infra_id: infra.id,
@@ -195,7 +194,7 @@ pub mod test {
 
         // THEN
         let stdcm_search_env_in_db =
-            StdcmSearchEnvironment::retrieve(pool.get_ok().deref_mut(), stdcm_search_env.id)
+            StdcmSearchEnvironment::retrieve(&mut pool.get_ok(), stdcm_search_env.id)
                 .await
                 .expect("Failed to retrieve stdcm search environment")
                 .expect("Stdcm search environment not found");
@@ -208,12 +207,12 @@ pub mod test {
         let app = TestAppBuilder::default_app();
 
         let pool = app.db_pool();
-        StdcmSearchEnvironment::delete_all(pool.get_ok().deref_mut())
+        StdcmSearchEnvironment::delete_all(&mut pool.get_ok())
             .await
             .expect("failed to delete envs");
 
         let (infra, timetable, work_schedule_group, electrical_profile_set) =
-            stdcm_search_env_fixtures(pool.get_ok().deref_mut()).await;
+            stdcm_search_env_fixtures(&mut pool.get_ok()).await;
 
         let begin = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap().into();
         let end = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap().into();
@@ -225,7 +224,7 @@ pub mod test {
             .timetable_id(timetable.id)
             .search_window_begin(begin)
             .search_window_end(end)
-            .create(pool.get_ok().deref_mut())
+            .create(&mut pool.get_ok())
             .await
             .expect("Failed to create stdcm search environment");
 
@@ -257,7 +256,7 @@ pub mod test {
         // GIVEN
         let app = TestAppBuilder::default_app();
 
-        let _ = StdcmSearchEnvironment::delete_all(app.db_pool().get_ok().deref_mut()).await;
+        let _ = StdcmSearchEnvironment::delete_all(&mut app.db_pool().get_ok()).await;
 
         let request = app.get("/stdcm/search_environment");
 

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,7 +1,6 @@
 pub mod stdcm;
 
 use std::collections::HashMap;
-use std::ops::DerefMut as _;
 
 use axum::extract::Json;
 use axum::extract::Path;
@@ -296,24 +295,23 @@ async fn conflicts(
     let electrical_profile_set_id = electrical_profile_set_id_query.electrical_profile_set_id;
 
     // 1. Retrieve Timetable / Infra / Trains / Simultion
-    let timetable_trains = TimetableWithTrains::retrieve_or_fail(
-        db_pool.get().await?.deref_mut(),
-        timetable_id,
-        || TimetableError::NotFound { timetable_id },
-    )
-    .await?;
+    let timetable_trains =
+        TimetableWithTrains::retrieve_or_fail(&mut db_pool.get().await?, timetable_id, || {
+            TimetableError::NotFound { timetable_id }
+        })
+        .await?;
 
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         TimetableError::InfraNotFound { infra_id }
     })
     .await?;
 
     let (trains, _): (Vec<_>, _) =
-        TrainSchedule::retrieve_batch(db_pool.get().await?.deref_mut(), timetable_trains.train_ids)
+        TrainSchedule::retrieve_batch(&mut db_pool.get().await?, timetable_trains.train_ids)
             .await?;
 
     let simulations = train_simulation_batch(
-        db_pool.get().await?.deref_mut(),
+        &mut db_pool.get().await?,
         redis_client.clone(),
         core_client.clone(),
         &trains,
@@ -365,7 +363,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
 
         let request = app.get(&format!("/timetable/{}", timetable.id));
 
@@ -400,7 +398,7 @@ mod tests {
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
         let retrieved_timetable =
-            Timetable::retrieve(pool.get_ok().deref_mut(), created_timetable.timetable_id)
+            Timetable::retrieve(&mut pool.get_ok(), created_timetable.timetable_id)
                 .await
                 .expect("Failed to retrieve timetable")
                 .expect("Timetable not found");
@@ -413,13 +411,13 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
 
         let request = app.delete(format!("/timetable/{}", timetable.id).as_str());
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        let exists = Timetable::exists(pool.get_ok().deref_mut(), timetable.id)
+        let exists = Timetable::exists(&mut pool.get_ok(), timetable.id)
             .await
             .expect("Failed to check if timetable exists");
 

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::ops::DerefMut;
 use std::sync::Arc;
 
 use axum::extract::Json;
@@ -356,22 +355,21 @@ async fn simulation(
     let train_schedule_id = train_schedule_id.id;
 
     // Retrieve infra or fail
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
 
     // Retrieve train_schedule or fail
-    let train_schedule = TrainSchedule::retrieve_or_fail(
-        db_pool.get().await?.deref_mut(),
-        train_schedule_id,
-        || TrainScheduleError::NotFound { train_schedule_id },
-    )
-    .await?;
+    let train_schedule =
+        TrainSchedule::retrieve_or_fail(&mut db_pool.get().await?, train_schedule_id, || {
+            TrainScheduleError::NotFound { train_schedule_id }
+        })
+        .await?;
 
     Ok(Json(
         train_simulation(
-            db_pool.get().await?.deref_mut(),
+            &mut db_pool.get().await?,
             redis_client,
             core_client,
             train_schedule,
@@ -685,24 +683,24 @@ async fn simulation_summary(
     }
 
     let db_pool = app_state.db_pool_v2.clone();
+    let conn = &mut db_pool.get().await?;
     let redis_client = app_state.redis.clone();
     let core = app_state.core_client.clone();
 
-    let infra = Infra::retrieve_or_fail(db_pool.get().await?.deref_mut(), infra_id, || {
-        TrainScheduleError::InfraNotFound { infra_id }
+    let infra = Infra::retrieve_or_fail(conn, infra_id, || TrainScheduleError::InfraNotFound {
+        infra_id,
     })
     .await?;
-    let train_schedules: Vec<TrainSchedule> = TrainSchedule::retrieve_batch_or_fail(
-        db_pool.get().await?.deref_mut(),
-        train_schedule_ids,
-        |missing| TrainScheduleError::BatchTrainScheduleNotFound {
-            number: missing.len(),
-        },
-    )
-    .await?;
+    let train_schedules: Vec<TrainSchedule> =
+        TrainSchedule::retrieve_batch_or_fail(conn, train_schedule_ids, |missing| {
+            TrainScheduleError::BatchTrainScheduleNotFound {
+                number: missing.len(),
+            }
+        })
+        .await?;
 
     let simulations = train_simulation_batch(
-        db_pool.get().await?.deref_mut(),
+        conn,
         redis_client,
         core,
         &train_schedules,
@@ -805,8 +803,6 @@ async fn get_path(
 
 #[cfg(test)]
 mod tests {
-    use std::ops::DerefMut;
-
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -827,9 +823,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
-        let train_schedule =
-            create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let train_schedule = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
 
         let url = format!("/train_schedule/{}", train_schedule.id);
         let request = app.get(&url);
@@ -852,10 +847,10 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
-        let ts1 = create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
-        let ts2 = create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
-        let ts3 = create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let ts1 = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
+        let ts2 = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
+        let ts3 = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
 
         // Should succeed
         let request = app.post("/train_schedule").json(&json!({
@@ -871,7 +866,7 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
         let train_schedule_base = simple_train_schedule_base();
 
         // Insert train_schedule
@@ -889,9 +884,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
-        let train_schedule =
-            create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let train_schedule = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
 
         let request = app
             .delete("/train_schedule/")
@@ -899,7 +893,7 @@ mod tests {
 
         let _ = app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
-        let exists = TrainSchedule::exists(pool.get_ok().deref_mut(), train_schedule.id)
+        let exists = TrainSchedule::exists(&mut pool.get_ok(), train_schedule.id)
             .await
             .expect("Failed to retrieve train_schedule");
 
@@ -911,9 +905,8 @@ mod tests {
         let app = TestAppBuilder::default_app();
         let pool = app.db_pool();
 
-        let timetable = create_timetable(pool.get_ok().deref_mut()).await;
-        let train_schedule =
-            create_simple_train_schedule(pool.get_ok().deref_mut(), timetable.id).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let train_schedule = create_simple_train_schedule(&mut pool.get_ok(), timetable.id).await;
 
         let mut update_train_schedule_base = simple_train_schedule_base();
         update_train_schedule_base.rolling_stock_name = String::from("NEW ROLLING_STOCK");
@@ -998,11 +991,10 @@ mod tests {
             .db_pool(db_pool.clone())
             .core_client(core.into())
             .build();
-        let small_infra = create_small_infra(db_pool.get_ok().deref_mut()).await;
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
         let rolling_stock =
-            create_fast_rolling_stock(db_pool.get_ok().deref_mut(), "simulation_rolling_stock")
-                .await;
-        let timetable = create_timetable(db_pool.get_ok().deref_mut()).await;
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
+        let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let train_schedule_base: TrainScheduleBase = TrainScheduleBase {
             rolling_stock_name: rolling_stock.name.clone(),
             ..serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
@@ -1014,7 +1006,7 @@ mod tests {
         }
         .into();
         let train_schedule = train_schedule
-            .create(db_pool.get_ok().deref_mut())
+            .create(&mut db_pool.get_ok())
             .await
             .expect("Failed to create train schedule");
         (app, small_infra.id, train_schedule.id)

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -181,7 +181,6 @@ pub mod test {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
-    use std::ops::DerefMut;
 
     use super::*;
     use crate::views::test_app::TestAppBuilder;
@@ -211,7 +210,7 @@ pub mod test {
 
         // THEN
         let created_group = WorkScheduleGroup::retrieve(
-            pool.get_ok().deref_mut(),
+            &mut pool.get_ok(),
             work_schedule_response.work_schedule_group_id,
         )
         .await
@@ -247,7 +246,7 @@ pub mod test {
         WorkScheduleGroup::changeset()
             .name("duplicated work schedule group name".to_string())
             .creation_date(Utc::now().naive_utc())
-            .create(pool.get_ok().deref_mut())
+            .create(&mut pool.get_ok())
             .await
             .expect("Failed to create work schedule group");
 


### PR DESCRIPTION
Create an abstraction of the diesel database connection and transactions

part of the #6980

How to test this PR:

- [ ] Make sure everything work as before
- [ ] No deadlocks in tests