### PR TITLE
core: allowances: log more details on binary search failure

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/AbstractAllowanceWithRanges.java
@@ -367,6 +367,8 @@ public abstract class AbstractAllowanceWithRanges implements Allowance {
                 logger.warn("Closest time = {}, target time = {} +- {}", lastTime, targetTime, tolerance);
                 // TODO: raise a warning to be included in the response
             } else {
+                logger.error("Couldn't reach target time for allowance section.");
+                logger.error("Closest time = {}, target time = {} +- {}", lastTime, targetTime, tolerance);
                 if (lastError != null) {
                     // If we couldn't converge and an error happened, it has more info
                     // than a generic error


### PR DESCRIPTION
See https://github.com/OpenRailAssociation/osrd/issues/8614

I couldn't reproduce the issue above so this isn't a fix, it just logs more info, it will help if it happens again