### PR TITLE
front: fix dropped ch in NGE when missing from infra

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -329,7 +329,15 @@ const importTimetable = async (
           return op.obj_id;
         }
 
-        const node = createNode({ trigram: 'trigram' in pathItem ? pathItem.trigram : undefined });
+        let trigram: string | undefined;
+        if ('trigram' in pathItem) {
+          trigram = pathItem.trigram;
+          if (pathItem.secondary_code) {
+            trigram += `/${pathItem.secondary_code}`;
+          }
+        }
+
+        const node = createNode({ trigram });
         return node.id;
       });
 


### PR DESCRIPTION
To test:

- Create a node "SAVA/XD" in NGE
- Create a train run from this new node to any other node
- Go to micro mode
- Go back to NGE

Without this patch, the node would show up as "SAVA" in NGE. With this patch, it should show up as "SAVA/XD".

This bug is only triggered for trigrams which can't be found in the infrastructure.