### PR TITLE
front: update useMemo() dependencies in useOutputTableData()

### DIFF
--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -127,7 +127,7 @@ function useOutputTableData(
       }
       return sugOpPoint;
     });
-  }, [simulatedTrain, pathProperties, operationalPoints, selectedTrainSchedule, path]);
+  }, [simulatedTrain, operationalPoints, selectedTrainSchedule, pathStepsWithOpPointIndices]);
   return outputTableData;
 }
 export default useOutputTableData;


### PR DESCRIPTION
pathProperties and path aren't consumed by this function, so drop them. pathStepsWithOpPointIndices was consumed but was missing from the dependencies.