### PR TITLE
editoast: activate 'datadog' feature on production images

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -29,7 +29,7 @@ group "release" {
 
 target "base" {
   args = {
-    OSRD_GIT_DESCRIBE  = "${OSRD_GIT_DESCRIBE}"
+    OSRD_GIT_DESCRIBE = "${OSRD_GIT_DESCRIBE}"
   }
 }
 
@@ -79,7 +79,11 @@ target "editoast-test" {
   }
 }
 
-target "base-editoast" {}
+target "base-editoast" {
+  args = {
+    CARGO_FEATURES = "datadog"
+  }
+}
 target "editoast" {
   inherits = ["base", "base-editoast"]
   context = "editoast"

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -46,13 +46,14 @@ COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 ARG CARGO_PROFILE=release
+ARG CARGO_FEATURES
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/editoast/target \
-    cargo chef cook --profile ${CARGO_PROFILE} --recipe-path recipe.json
+    cargo chef cook --features="${CARGO_FEATURES}" --profile="${CARGO_PROFILE}" --recipe-path recipe.json
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/editoast/target \
-    cargo install --profile ${CARGO_PROFILE} --locked --path .
+    cargo install --features="${CARGO_FEATURES}" --profile="${CARGO_PROFILE}" --locked --path .
 
 ###############
 # Running env #


### PR DESCRIPTION
Our default deployment need Datadog so let's make it an option for building production images.