### PR TITLE
front: simplify OP matching in useOutputTableData()

### DIFF
--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -68,10 +68,6 @@ function useOutputTableData(
     pathStepsWithOpPointIndices,
     (pathStep) => `${pathStep.uic}-${pathStep.secondary_code}`
   );
-  const operationPointsByNameCh = keyBy(
-    operationalPoints,
-    (opPoint) => `${opPoint.name}-${opPoint.ch}`
-  );
 
   const outputTableData = useMemo(() => {
     const pathStepRows = pathStepsWithPositionOnPath.map((pathStep) => {
@@ -81,7 +77,7 @@ function useOutputTableData(
     });
 
     const suggestedOpRows = suggestedOperationalPoints.map((sugOpPoint, sugOpIndex) => {
-      const opPoint = operationPointsByNameCh[`${sugOpPoint.name}-${sugOpPoint.ch}`];
+      const opPoint = operationalPoints.find((op) => op.id === sugOpPoint.opId);
       if (!opPoint) {
         return sugOpPoint;
       }


### PR DESCRIPTION
We were using a map keyed by the name and ch of OPs. This is more complicated than it needs to be and isn't robust (there is no guarantee that names+ch are unique).

Instead, just use the OP ID.

Original discussion: https://github.com/OpenRailAssociation/osrd/pull/8555/files#r1735948569