### PR TITLE
core: stdcm: refactor time data into a new data class

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -34,8 +34,8 @@ data class ProgressLogger(
             val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]
             val str =
                 "node sample for progress $nSamplesReached/$nStepsProgress: " +
-                    "time=${node.time.toInt()}s, " +
-                    "since departure=${node.timeSinceDeparture.toInt()}s, " +
+                    "time=${node.timeData.earliestReachableTime.toInt()}s, " +
+                    "since departure=${node.timeData.timeSinceDeparture.toInt()}s, " +
                     "best remaining time=${node.remainingTimeEstimation.toInt()}s, " +
                     "loc=$geo, " +
                     "#visited nodes=$seenSteps"

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/BacktrackingManager.kt
@@ -40,7 +40,7 @@ class BacktrackingManager(private val graph: STDCMGraph) {
         val newNode = newPreviousEdge.getEdgeEnd(graph)
         return STDCMEdgeBuilder.fromNode(graph, newNode, edge.infraExplorer)
             .setEnvelope(envelope)
-            .findEdgeSameNextOccupancy(edge.timeNextOccupancy)
+            .findEdgeSameNextOccupancy(edge.timeData.timeOfNextConflictAtLocation)
     }
 
     /**
@@ -79,6 +79,6 @@ class BacktrackingManager(private val graph: STDCMGraph) {
         val prevNode = old.previousNode
         return STDCMEdgeBuilder.fromNode(graph, prevNode, old.infraExplorer)
             .setEnvelope(newEnvelope)
-            .findEdgeSameNextOccupancy(old.timeNextOccupancy)
+            .findEdgeSameNextOccupancy(old.timeData.timeOfNextConflictAtLocation)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -80,7 +80,10 @@ internal constructor(
      * Returns true if the total run time at the start of the edge is above the specified threshold
      */
     fun isRunTimeTooLong(edge: STDCMEdge): Boolean {
-        val totalRunTime = edge.timeStart - edge.totalDepartureTimeShift - minScheduleTimeStart
+        val totalRunTime =
+            edge.timeData.earliestReachableTime -
+                edge.timeData.totalDepartureDelay -
+                minScheduleTimeStart
         // We could use the A* heuristic here, but it would break STDCM on any infra where the
         // coordinates don't match the actual distance (which is the case when generated).
         // Ideally we should add a switch in the railjson format

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -80,13 +80,9 @@ internal constructor(
      * Returns true if the total run time at the start of the edge is above the specified threshold
      */
     fun isRunTimeTooLong(edge: STDCMEdge): Boolean {
-        val totalRunTime =
-            edge.timeData.earliestReachableTime -
-                edge.timeData.totalDepartureDelay -
-                minScheduleTimeStart
-        // We could use the A* heuristic here, but it would break STDCM on any infra where the
-        // coordinates don't match the actual distance (which is the case when generated).
-        // Ideally we should add a switch in the railjson format
+        val totalRunTime = edge.timeData.totalRunningTime
+
+        // TODO: we should use the A* heuristic here, but that requires a small refactoring
         return totalRunTime > maxRunTime
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -231,13 +231,13 @@ private fun getTimeOnEdges(
         val atStop = edge.endAtStop && remainingDistance == edge.length.distance
         if (remainingDistance < edge.length.distance || atStop) {
             val absoluteTime = edge.getApproximateTimeAtLocation(Offset(remainingDistance))
-            return absoluteTime - edge.totalDepartureTimeShift
+            return absoluteTime - edge.timeData.totalDepartureDelay
         }
         remainingDistance -= edge.length.distance
     }
     // End of the last edge, this case is easier to handle separately
     val absoluteTime = edges.last().getApproximateTimeAtLocation(edges.last().length)
-    return absoluteTime - edges.last().totalDepartureTimeShift
+    return absoluteTime - edges.last().timeData.totalDepartureDelay
 }
 
 /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -55,15 +55,7 @@ data class STDCMEdge(
         return if (!endAtStop) {
             // We move on to the next block
             STDCMNode(
-                TimeData(
-                    earliestReachableTime = totalTime + timeData.earliestReachableTime,
-                    maxDepartureDelayingWithoutConflict =
-                        timeData.maxDepartureDelayingWithoutConflict,
-                    totalDepartureDelay = timeData.totalDepartureDelay,
-                    timeOfNextConflictAtLocation = timeData.timeOfNextConflictAtLocation,
-                    totalRunningTime = timeData.totalRunningTime + totalTime,
-                    totalStopTime = timeData.totalStopTime,
-                ),
+                timeData.withAddedTime(totalTime, 0.0),
                 endSpeed,
                 infraExplorerWithNewEnvelope,
                 this,
@@ -80,16 +72,7 @@ data class STDCMEdge(
             val stopDuration = firstStopAfterIndex.duration!!
             val locationOnEdge = envelopeStartOffset + length.distance
             STDCMNode(
-                TimeData(
-                    earliestReachableTime =
-                        totalTime + timeData.earliestReachableTime + stopDuration,
-                    maxDepartureDelayingWithoutConflict =
-                        timeData.maxDepartureDelayingWithoutConflict,
-                    totalDepartureDelay = timeData.totalDepartureDelay,
-                    timeOfNextConflictAtLocation = timeData.timeOfNextConflictAtLocation,
-                    totalRunningTime = timeData.totalRunningTime + totalTime,
-                    totalStopTime = timeData.totalStopTime + stopDuration,
-                ),
+                timeData.withAddedTime(totalTime, stopDuration),
                 endSpeed,
                 infraExplorerWithNewEnvelope,
                 this,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -197,11 +197,9 @@ internal constructor(
         val standardAllowanceSpeedRatio = graph.getStandardAllowanceSpeedRatio(envelope!!)
         var res: STDCMEdge? =
             STDCMEdge(
-                TimeData(
-                    earliestReachableTime = actualStartTime,
-                    maxDepartureDelayingWithoutConflict = maximumDelay,
-                    totalDepartureDelay =
-                        prevNode.timeData.totalDepartureDelay + departureTimeShift,
+                prevNode.timeData.shifted(
+                    timeShift = delayNeeded,
+                    delayAddedToLastDeparture = departureTimeShift,
                     timeOfNextConflictAtLocation =
                         graph.delayManager.findNextOccupancy(
                             getExplorerWithNewEnvelope()!!,
@@ -209,9 +207,7 @@ internal constructor(
                             startOffset,
                             envelope!!,
                         ),
-                    totalRunningTime = prevNode.timeData.totalRunningTime,
-                    totalStopTime = prevNode.timeData.totalStopTime,
-                    delayAddedToLastDeparture = departureTimeShift,
+                    maxDepartureDelayingWithoutConflict = maximumDelay,
                 ),
                 infraExplorer,
                 getExplorerWithNewEnvelope()!!,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -101,12 +101,12 @@ class STDCMGraph(
     override fun getAdjacentEdges(node: STDCMNode): Collection<STDCMEdge> {
         val res = ArrayList<STDCMEdge>()
         val maxMarginDuration = estimateMaxMarginDuration(node)
-        val baseNodeCost = node.timeSinceDeparture + node.remainingTimeEstimation
+        val baseNodeCost = node.timeData.timeSinceDeparture + node.remainingTimeEstimation
         val visitedNodesParameters =
             VisitedNodes.Parameters(
                 null,
-                node.time,
-                node.maximumAddedDelay,
+                node.timeData.earliestReachableTime,
+                node.timeData.maxDepartureDelayingWithoutConflict,
                 maxMarginDuration,
                 baseNodeCost
             )
@@ -155,10 +155,13 @@ class STDCMGraph(
             val edge = node.previousEdge ?: return maxTime
 
             val latestTimeWithMaxShift =
-                edge.timeStart + edge.totalTime + edge.maximumAddedDelayAfter
+                edge.timeData.earliestReachableTime +
+                    edge.totalTime +
+                    edge.timeData.maxDepartureDelayingWithoutConflict
 
             // Only consider this specific edge, not the rest of the path
-            val maxDelayAddedOnEdge = max(0.0, edge.timeNextOccupancy - latestTimeWithMaxShift)
+            val maxDelayAddedOnEdge =
+                max(0.0, edge.timeData.timeOfNextConflictAtLocation - latestTimeWithMaxShift)
             maxTime = min(maxTime, maxDelayAddedOnEdge)
 
             remainingDistance -= edge.length.distance

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -59,6 +59,7 @@ data class STDCMNode(
             )
         // Firstly, minimize the total run time: highest priority node takes the least time to
         // complete the path
+        // TODO: with variable stop times, stop duration and running time should be separated
         return if (!areTimesEqual(runTimeEstimation, otherRunTimeEstimation))
             runTimeEstimation.compareTo(otherRunTimeEstimation)
         // Minimise the difference with the planned arrival times
@@ -136,6 +137,8 @@ data class STDCMNode(
     /**
      * Takes into account the real current departure time shift to return the real current time at
      * which the train arrives at this node.
+     *
+     * TODO: this version will be invalid with variable stop times and will need to be updated.
      */
     fun getRealTime(currentTotalAddedDelay: Double): Double {
         assert(currentTotalAddedDelay >= timeData.totalDepartureDelay)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -24,7 +24,6 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
 import java.time.Instant
 import java.util.*
-import kotlin.collections.HashSet
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -159,7 +158,7 @@ class STDCMPathfinding(
                 throw OSRDError(ErrorType.PathfindingTimeoutError)
             val endNode = queue.poll() ?: return null
             progressLogger.processNode(endNode)
-            if (endNode.timeSinceDeparture + endNode.remainingTimeEstimation > maxRunTime)
+            if (endNode.timeData.timeSinceDeparture + endNode.remainingTimeEstimation > maxRunTime)
                 return null
             if (endNode.waypointIndex >= graph.steps.size - 1) {
                 return buildResult(endNode)
@@ -227,11 +226,16 @@ class STDCMPathfinding(
             for (explorer in extended) {
                 val node =
                     STDCMNode(
-                        startTime,
+                        TimeData(
+                            earliestReachableTime = startTime,
+                            maxDepartureDelayingWithoutConflict = maxDepartureDelay,
+                            totalDepartureDelay = 0.0,
+                            timeOfNextConflictAtLocation = 0.0,
+                            totalRunningTime = 0.0,
+                            totalStopTime = 0.0,
+                        ),
                         0.0,
                         explorer,
-                        0.0,
-                        maxDepartureDelay,
                         null,
                         0,
                         location.offset,
@@ -239,7 +243,6 @@ class STDCMPathfinding(
                         firstStep.plannedTimingData,
                         null,
                         0.0,
-                        graph.bestPossibleTime
                     )
                 res.add(node)
             }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -136,7 +136,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     /** Computes the departure time, made of the sum of all delays added over the path */
     private fun computeDepartureTime(edges: List<STDCMEdge>, startTime: Double): Double {
         var addedDelay = 0.0
-        for (edge in edges) addedDelay += edge.addedDelay
+        for (edge in edges) addedDelay += edge.timeData.delayAddedToLastDeparture
         val totalAddedDelay = addDelayForPlannedNodes(edges, addedDelay)
         return startTime + totalAddedDelay
     }
@@ -172,7 +172,9 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
     }
 
     private fun getMaxNodeDelay(nodes: List<STDCMNode>): Double {
-        return nodes.minOfOrNull { it.maximumAddedDelay + it.totalPrevAddedDelay }!!
+        return nodes.minOfOrNull {
+            it.timeData.maxDepartureDelayingWithoutConflict + it.timeData.totalDepartureDelay
+        }!!
     }
 
     /** Builds the list of stops from the edges */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -67,4 +67,43 @@ data class TimeData(
      * lengthening stop durations.
      */
     val timeSinceDeparture = totalRunningTime + totalStopTime
+
+    /** Returns a copy of the current instance, with added travel / stop time. */
+    fun withAddedTime(
+        extraTravelTime: Double,
+        extraStopTime: Double,
+    ): TimeData {
+        return copy(
+            earliestReachableTime = earliestReachableTime + extraTravelTime + extraStopTime,
+            totalRunningTime = totalRunningTime + extraTravelTime,
+            totalStopTime = totalStopTime + extraStopTime
+        )
+    }
+
+    /**
+     * Return a copy of the current instance, with "shifted" time values. Used to create new edges.
+     *
+     * @param timeShift by how much we delay the new element compared to the earliest possible time.
+     *   A value >0 means that we want to arrive later (to avoid a conflict)
+     * @param delayAddedToLastDeparture how much extra delay we add to the last departure (train
+     *   start time or last stop). This is one method to reach `timeShift`
+     * @param timeOfNextConflictAtLocation when is the first conflict at the given location
+     * @param maxDepartureDelayingWithoutConflict how much delay we can add at the given location
+     *   without causing conflict
+     */
+    fun shifted(
+        timeShift: Double,
+        delayAddedToLastDeparture: Double,
+        timeOfNextConflictAtLocation: Double,
+        maxDepartureDelayingWithoutConflict: Double,
+    ): TimeData {
+        assert(timeShift >= delayAddedToLastDeparture)
+        return copy(
+            earliestReachableTime = earliestReachableTime + timeShift,
+            maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict,
+            totalDepartureDelay = totalDepartureDelay + delayAddedToLastDeparture,
+            timeOfNextConflictAtLocation = timeOfNextConflictAtLocation,
+            delayAddedToLastDeparture = delayAddedToLastDeparture
+        )
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -1,0 +1,70 @@
+package fr.sncf.osrd.stdcm.graph
+
+/**
+ * This class combines all the time-related elements of a node/edge.
+ *
+ * It contains data about the possible times that can be covered, as well as extra context about
+ * stop times, time since departure, when the closest conflicts are, and so on.
+ *
+ * Some node-specific or edge-specific values and getters are left in their specific classes.
+ *
+ * Note: stop duration are described as mutable, but this feature isn't implemented yet.
+ */
+data class TimeData(
+    /**
+     * Earliest time when we can enter the current location. For edges, this is the entry time. This
+     * is *not* the time at which the train *will* reach this location: we can delay departure times
+     * or add allowances further on the path.
+     */
+    val earliestReachableTime: Double,
+
+    /**
+     * We can delay departure time from either the train start or stops. This value represents how
+     * much more delay we can add to the last departure without causing any conflict.
+     */
+    val maxDepartureDelayingWithoutConflict: Double,
+
+    /**
+     * By how much we have added delay to any departure, both train departure time and lengthening
+     * stop duration.
+     */
+    val totalDepartureDelay: Double,
+
+    /**
+     * Time of the next conflict on the given location. Used both to identify edges that go through
+     * the same "opening", and to figure out how much delay we can add locally (with margins).
+     */
+    val timeOfNextConflictAtLocation: Double,
+
+    /**
+     * Time the train has spent moving since its departure. Does not include stop times. This value
+     * is constant for this given partial path, unlike departure and stop times it can't be changed
+     * retroactively further down the path.
+     */
+    val totalRunningTime: Double,
+
+    /**
+     * Time the train has spent stopped since its departure. Includes both used-requested minimum
+     * stop duration, and extra stop times added to avoid conflicts.
+     */
+    val totalStopTime: Double,
+
+    /**
+     * Global delay that have been added to avoid conflicts on the given element, by delaying the
+     * last departure.
+     */
+    val delayAddedToLastDeparture: Double = 0.0,
+) {
+    // Getters for different handy values. They may not all be used,
+    // but they're here if we need them. It also shows how the values
+    // are related to each other.
+
+    /** This is the time at which we may start the train path, if there's no extra delay */
+    val earliestDepartureTime = earliestReachableTime - totalRunningTime - totalStopTime
+
+    /**
+     * Time elapsed since the departure time. This may be changed further down the path by
+     * lengthening stop durations.
+     */
+    val timeSinceDeparture = totalRunningTime + totalStopTime
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -8,6 +8,7 @@ import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
+import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
@@ -215,13 +216,21 @@ class STDCMHeuristicTests {
                     newExplorer.getLookahead().all { lookahead.contains(it) }
                 }
         }
+
+        val defaultTimeData =
+            TimeData(
+                earliestReachableTime = 0.0,
+                maxDepartureDelayingWithoutConflict = 0.0,
+                totalDepartureDelay = 0.0,
+                timeOfNextConflictAtLocation = 0.0,
+                totalRunningTime = 0.0,
+                totalStopTime = 0.0,
+            )
         val defaultNode =
             STDCMNode(
-                0.0,
+                defaultTimeData,
                 0.0,
                 explorer,
-                0.0,
-                0.0,
                 null,
                 0,
                 Offset(0.meters),
@@ -229,17 +238,12 @@ class STDCMHeuristicTests {
                 null,
                 null,
                 0.0,
-                0.0
             )
         val defaultEdge =
             STDCMEdge(
+                defaultTimeData,
                 explorer,
                 explorer,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
                 defaultNode,
                 Offset(0.meters),
                 0,


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/8587

**Now is the time for reviews about these time fields, their name, their structure, their docstrings, and so on**

Change summary:

1. Move time-related data from edges and nodes into a new struct
2. Improve how these values are forwarded between nodes and edges
3. Add comments for what still needs to be changed for variable stop times