### PR TITLE
front: fix missing output table

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -47,10 +47,10 @@ const TimesStops = ({
   const [rows, setRows] = useState<PathWaypointRow[]>([]);
 
   useEffect(() => {
-    if (allWaypoints && pathSteps) {
+    if (allWaypoints) {
       const suggestedOPs = formatSuggestedViasToRowVias(
         allWaypoints,
-        pathSteps,
+        pathSteps || [],
         t,
         startTime,
         tableType


### PR DESCRIPTION
in `TimesStops.tsx`

`pathSteps` is only for the input table, so the condition `if (allWaypoints && pathSteps) {` was preventing `formatSuggestedViasToRowVias` from being called.

closes #8755 