### PR TITLE
front: Import trainSchedules from Viriato file

### DIFF
--- a/front/public/locales/en/operationalStudies/importTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/importTrainSchedule.json
@@ -1,15 +1,21 @@
 {
+  "cancel": "Cancel",
   "closeOSRDConfig": "Close",
+  "download": "Download",
   "date": "DATE",
   "datetime": "Date & time",
   "endTime": "END",
   "errorMessages": {
     "error": "An error has occurred",
+    "errorEmptyFile": "Empty file",
     "errorImport": "Unable to convert data to TrainSchedule",
+    "errorInvalidJSONFormat": "Invalid JSON format",
+    "errorInvalidXMLFormat": "Invalid XML format",
     "errorNoDate": "You must enter a date.",
     "errorNoFrom": "You must fill in an origin.",
     "errorNoTo": "You must fill in a destination.",
-    "errorSameFromTo": "Origin and destination must be different"
+    "errorSameFromTo": "Origin and destination must be different",
+    "errorUnsupportedFileType": "Unsupported file type"
   },
   "failure": "Operation failed",
   "from": "Origin",

--- a/front/public/locales/fr/operationalStudies/importTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/importTrainSchedule.json
@@ -1,15 +1,21 @@
 {
+  "cancel": "Annuler",
   "closeOSRDConfig": "Fermer",
   "date": "DATE",
   "datetime": "Date & horaires",
+  "download": "Télécharger",
   "endTime": "FIN",
   "errorMessages": {
     "error": "Une erreur est survenue",
+    "errorEmptyFile": "Fichier vide",
     "errorImport": "Impossible de convertir les données en TrainSchedule",
+    "errorInvalidJSONFormat": "Format JSON invalide",
+    "errorInvalidXMLFormat": "Format XML invalide",
     "errorNoDate": "Vous devez renseigner une date.",
     "errorNoFrom": "Vous devez renseigner une origine.",
     "errorNoTo": "Vous devez renseigner une destination.",
-    "errorSameFromTo": "L'origine et la destination doivent être différentes."
+    "errorSameFromTo": "L'origine et la destination doivent être différentes.",
+    "errorUnsupportedFileType": "Type de fichier non supporté"
   },
   "failure": "Opération échouée",
   "from": "Origine",

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -17,13 +17,14 @@ import type { RangedValue } from 'common/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { ArrayElement } from 'utils/types';
 
-interface Step {
+export interface Step {
   uic: number;
+  chCode?: string;
   yard?: string;
   name: string;
-  trigram: string;
-  latitude: number;
-  longitude: number;
+  trigram?: string;
+  latitude?: number;
+  longitude?: number;
   arrivalTime: string;
   departureTime: string;
   duration?: number;
@@ -45,6 +46,11 @@ export type TrainScheduleImportConfig = {
   date: string;
   startTime: string;
   endTime: string;
+};
+
+export type CichDictValue = {
+  ciCode: number | string;
+  chCode?: string;
 };
 
 // Extraction of some required and non nullable properties from osrdEditoastApi's PathProperties type

--- a/front/src/common/Map/Search/useSearchOperationalPoint.tsx
+++ b/front/src/common/Map/Search/useSearchOperationalPoint.tsx
@@ -108,6 +108,8 @@ export default function useSearchOperationalPoint({
     sortedSearchResults,
     filteredAndSortedSearchResults,
     mainOperationalPointsOnly,
+    searchResults,
+    searchOperationalPoints,
     setSearchTerm,
     setChCodeFilter,
     setSearchResults,

--- a/front/src/common/uploadFileModal.tsx
+++ b/front/src/common/uploadFileModal.tsx
@@ -11,25 +11,51 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 interface UploadFileModalProps {
   handleSubmit: (file: File) => void;
 }
+
 const UploadFileModal = ({ handleSubmit }: UploadFileModalProps) => {
-  const { t } = useTranslation(['translation']);
+  const { t } = useTranslation(['operationalStudies/importTrainSchedule']);
   const { closeModal } = useContext(ModalContext);
   const [selectedFile, setSelectedFile] = useState<File | undefined>(undefined);
   const [isValid, setIsValid] = useState<string | undefined>(undefined);
 
+  const parseXML = (xmlString: string) => {
+    try {
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(xmlString, 'application/xml');
+      const parserError = xmlDoc.getElementsByTagName('parsererror');
+      if (parserError.length > 0) {
+        throw new Error('Invalid XML');
+      }
+      return undefined;
+    } catch (error) {
+      return t('errorMessages.errorInvalidXMLFormat').toString();
+    }
+  };
+  // TODO : create the translation keys
   const validateFile = useCallback(
     async (fileToValidate: File): Promise<string | undefined> => {
-      if (fileToValidate.type !== 'application/json') {
-        return t('jsonUpload.notJSONFormat').toString();
-      }
       if (fileToValidate.size === 0) {
-        return t('jsonUpload.emptyFile').toString();
+        return t('errorMessages.errorEmptyFile').toString();
       }
-      try {
-        JSON.parse(await fileToValidate.text());
-      } catch (e) {
-        return t('jsonUpload.badJSON').toString();
+      if (fileToValidate.type === 'application/json') {
+        try {
+          JSON.parse(await fileToValidate.text());
+        } catch (e) {
+          return t('errorMessages.errorInvalidJSONFormat').toString();
+        }
+      } else if (
+        fileToValidate.type === 'application/railml' ||
+        fileToValidate.name.endsWith('.railml')
+      ) {
+        const fileContent = await fileToValidate.text();
+        const xmlError = parseXML(fileContent);
+        if (xmlError) {
+          return xmlError;
+        }
+      } else {
+        return t('errorMessages.errorUnsupportedFileType').toString();
       }
+
       return undefined;
     },
     [t]
@@ -47,7 +73,7 @@ const UploadFileModal = ({ handleSubmit }: UploadFileModalProps) => {
           <input
             type="file"
             name="file"
-            accept=".json"
+            accept=".json,.xml,.railml"
             onChange={async (e) => {
               if (e.target.files && e.target.files.length > 0) {
                 const error = await validateFile(e.target.files[0]);
@@ -73,7 +99,7 @@ const UploadFileModal = ({ handleSubmit }: UploadFileModalProps) => {
                 className="btn btn-block btn-sm btn-secondary"
                 onClick={closeModal}
               >
-                {t('common.cancel')}
+                {t('cancel')}
               </button>
             </div>
             <div className="col-6">
@@ -85,7 +111,7 @@ const UploadFileModal = ({ handleSubmit }: UploadFileModalProps) => {
                   if (selectedFile) handleSubmit(selectedFile);
                 }}
               >
-                {t('common.download')}
+                {t('download')}
               </button>
             </div>
           </div>

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -17,7 +17,7 @@ import { getBatchPackage } from 'utils/batch';
 import { castErrorToFailure } from 'utils/error';
 import { mapBy } from 'utils/types';
 
-const BATCH_SIZE = 10;
+const BATCH_SIZE = 5;
 
 type useLazyLoadTrainsProp = {
   infraId?: number;

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
@@ -20,6 +20,7 @@ import { useAppDispatch } from 'store';
 
 import { generateTrainSchedulesPayloads } from './generateTrainSchedulesPayloads';
 import type { RollingstockOpenData2OSRDKeys } from './types';
+import { findValidTrainNameKey } from '../ManageTrainSchedule/helpers/trainNameHelper';
 
 function LoadingIfSearching({ isLoading, t }: { isLoading: boolean; t: TFunction }) {
   return (
@@ -47,18 +48,23 @@ const ImportTrainScheduleTrainsList = ({
   upsertTrainSchedules,
 }: ImportTrainScheduleTrainsListProps) => {
   const { t } = useTranslation(['operationalStudies/importTrainSchedule']);
-
   const rollingStockDict = useMemo(
     () => keyBy(rollingStocks, (rollingStock) => rollingStock.name),
     [rollingStocks]
   );
 
-  // Format the trains list to match the train names provided by the backend
   const formattedTrainsList = useMemo(
     () =>
       trainsList.map(({ rollingStock, ...train }) => {
-        const validTrainName =
-          rollingstockOpenData2OSRD[rollingStock as RollingstockOpenData2OSRDKeys];
+        if (!rollingStock) {
+          return { ...train, rollingStock: '' };
+        }
+
+        const validTrainNameKey = findValidTrainNameKey(rollingStock);
+        const validTrainName = validTrainNameKey
+          ? rollingstockOpenData2OSRD[validTrainNameKey as keyof typeof rollingstockOpenData2OSRD]
+          : rollingStock;
+
         return { ...train, rollingStock: validTrainName };
       }),
     [trainsList]

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/handleParseFiles.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/handleParseFiles.ts
@@ -1,0 +1,79 @@
+import { t } from 'i18next';
+import type { Dispatch } from 'redux';
+
+import type { ImportedTrainSchedule } from 'applications/operationalStudies/types';
+import { type TrainScheduleBase } from 'common/api/osrdEditoastApi';
+import { setFailure } from 'reducers/main';
+
+export const handleFileReadingError = (error: Error) => {
+  console.error('File reading error:', error);
+};
+
+export const handleJsonParsingError = (error: Error, dispatch: Dispatch) => {
+  console.error('Error parsing JSON:', error);
+  dispatch(
+    setFailure({
+      name: t('errorMessages.error'),
+      message: t('errorMessages.errorInvalidJSONFormat'),
+    })
+  );
+};
+
+export const handleXmlParsingError = (error: Error, dispatch: Dispatch) => {
+  console.error('Error parsing XML/RailML:', error);
+  dispatch(
+    setFailure({
+      name: t('errorMessages.error'),
+      message: t('errorMessages.errorInvalidXMLFormat'),
+    })
+  );
+};
+
+export const processJsonFile = (
+  fileContent: string,
+  setTrainsJsonData: (data: TrainScheduleBase[]) => void,
+  dispatch: Dispatch
+) => {
+  try {
+    const importedTrainSchedules: TrainScheduleBase[] = JSON.parse(fileContent);
+    if (importedTrainSchedules && importedTrainSchedules.length > 0) {
+      setTrainsJsonData(importedTrainSchedules);
+    }
+  } catch (error) {
+    handleJsonParsingError(error as Error, dispatch);
+  }
+};
+
+export const processXmlFile = async (
+  fileContent: string,
+  parseRailML: (xmlDoc: Document) => Promise<ImportedTrainSchedule[]>,
+  updateTrainSchedules: (schedules: ImportedTrainSchedule[]) => void,
+  dispatch: Dispatch
+) => {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(fileContent, 'application/xml');
+    const parserError = xmlDoc.getElementsByTagName('parsererror');
+
+    if (parserError.length > 0) {
+      throw new Error('Invalid XML');
+    }
+
+    const importedTrainSchedules = await parseRailML(xmlDoc);
+    if (importedTrainSchedules && importedTrainSchedules.length > 0) {
+      updateTrainSchedules(importedTrainSchedules);
+    }
+  } catch (error) {
+    handleXmlParsingError(error as Error, dispatch);
+  }
+};
+
+export const handleUnsupportedFileType = (dispatch: Dispatch) => {
+  console.error('Unsupported file type');
+  dispatch(
+    setFailure({
+      name: t('errorMessages.error'),
+      message: t('errorMessages.errorUnsupportedFileType'),
+    })
+  );
+};

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper.ts
@@ -1,3 +1,7 @@
+import rollingstockOpenData2OSRD from 'modules/trainschedule/components/ImportTrainSchedule/rollingstock_opendata2osrd.json';
+
+import type { RollingstockOpenData2OSRDKeys } from '../../ImportTrainSchedule/types';
+
 const trainNameWithNum = (name: string, actualTrainCount: number, total: number): string => {
   if (total === 1) {
     return name;
@@ -7,6 +11,27 @@ const trainNameWithNum = (name: string, actualTrainCount: number, total: number)
     return (parseInt(name, 10) + (actualTrainCount - 1)).toString();
   }
   return `${name} ${actualTrainCount}`;
+};
+
+const normalizeString = (rollingStock: string): string =>
+  rollingStock.toUpperCase().replace(/[_\W]/g, '');
+
+export const findValidTrainNameKey = (
+  rollingStock: string
+): RollingstockOpenData2OSRDKeys | undefined => {
+  const normalizedRollingStock = normalizeString(rollingStock);
+
+  return Object.keys(rollingstockOpenData2OSRD).find((key) => {
+    const rollingStockKey = normalizeString(key);
+    const rollingStockValue = normalizeString(
+      rollingstockOpenData2OSRD[key as keyof typeof rollingstockOpenData2OSRD]
+    );
+
+    return (
+      normalizedRollingStock.includes(rollingStockKey) ||
+      normalizedRollingStock.includes(rollingStockValue)
+    );
+  }) as RollingstockOpenData2OSRDKeys | undefined;
 };
 
 export default trainNameWithNum;


### PR DESCRIPTION
closes #8718 

To test the feature, download the folder containing the different import files.
We're testing the imports "Etoile de Veynes", "Etude Medoc", "MSC-AIX_LNPCA", "RP Trame" and "Test_Vir4".
_Link to the files :_
[https://sncf.sharepoint.com/sites/OSRD644GrpO365/Documents%20partages/Forms/AllItems.aspx?id=%2Fsites%2FOSRD644GrpO365%2FDocuments%20partages%2FDonn%C3%A9es%2F3%2DFichiers%20Viriato&viewid=21cdca8b%2D1763%2D4a6e%2Da9e3%2Dc9c036f6a510](url)

**Many trains are invalid :** 
In most cases, it's due to the fact that the rolling stock is not found : 

- Edit the train
- Check the error popup message with the rollingstock name
- Try changing the rollingstock with the correct one

When we have a rollingstock, sometimes we have errors : 
- Pathfinding works but the simulation fails
- Pathfinding doesn't work (most of the time -> Canton manquant)


What would be nice, for a future feature, is to be able to multi edit the invalid trains, and affect them correct rollingstocks simultaneously. 