### PR TITLE
front: restore vias shown in bold in output table

### DIFF
--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -31,7 +31,7 @@ import {
 } from '../types';
 
 export const formatSuggestedViasToRowVias = (
-  operationalPoints: SuggestedOP[],
+  operationalPoints: (SuggestedOP & { isWaypoint?: boolean })[],
   pathSteps: PathStep[],
   t: TFunction<'timesStops', undefined>,
   startTime?: IsoDateTimeString,
@@ -95,7 +95,7 @@ export const formatSuggestedViasToRowVias = (
       name: name || t('waypoint', { id: filteredOp.opId }),
       stopFor,
       theoreticalMargin,
-      isWaypoint: pathStep !== undefined,
+      isWaypoint: op.isWaypoint || pathStep !== undefined,
     };
   });
 };


### PR DESCRIPTION
Restoring waypoint displayed in bold in the output table, effectively bringing peace and order back to the Galaxy.

boolean `isWaypoint` is built in two different ways in the input table and the output table.

when formatSuggestedViasToRowVias is called in the output table, operationalPoints already have `isWaypoint`, but in the input table, `isWaypoint` is computed in formatSuggestedViasToRowVias itself.

so we need to make sure not to override it when we are in the output table case.


closes #8761

no longer reverts befdbe1e94c789a6b280379d4c084abee7848e0f.