### PR TITLE
github: allow digits in module names

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -34,7 +34,7 @@ check_forbidden_chars() {
 }
 
 check_structure() {
-    if grep -q -E -v '^([-_.a-z]+[,:] )*[-_.a-z]+: [a-z](:[^ ]|[^:])*$'; then
+    if grep -q -E -v '^([-_.a-z0-9]+[,:] )*[-_.a-z0-9]+: [a-z](:[^ ]|[^:])*$'; then
         echo 'Invalid commit title structure'
     fi
 }


### PR DESCRIPTION
Module names might have digits in them, e.g. "i18n" or "modelsv2". Stop forbidding these.