### PR TITLE
core: pathfinding: log a little extra info about failures

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -118,9 +118,7 @@ private fun findRoute(
             return routeId
         }
     }
-    val error = OSRDError(ErrorType.ScheduleMetadataExtractionFailed)
-    error.context["reason"] = "Couldn't find a route matching the given chunk list"
-    throw error
+    throw OSRDError(ErrorType.MissingRouteFromChunkPath)
 }
 
 /** Returns false if the route differs from the path */

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -162,7 +162,12 @@ public enum ErrorType {
     InvalidSTDCMStepWithTimingData(
             "invalid_stdcm_step_with_timing_data",
             "An STDCM step with planned timing data must be a stop",
-            ErrorCause.USER);
+            ErrorCause.USER),
+    MissingRouteFromChunkPath(
+            "missing_route_from_chunk_path",
+            "couldn't find a route matching the given chunk list",
+            ErrorCause.INTERNAL),
+    ;
 
     public final String type;
     public final String message;


### PR DESCRIPTION
We barely logged anything on pathfindings. We now log:

1. success
2. no path found at all, including the last reached waypoint index
3. no path found because of [constraint type / error type]

Not much, but it can still help

This PR also fixes the "couldn't find route" error, it had an irrelevant type. 