### PR TITLE
Fix editoast signal projection cache

### DIFF
--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -342,6 +342,9 @@ async fn compute_batch_signal_updates<'a>(
     path_blocks: &'a Vec<Identifier>,
     trains_details: &'a HashMap<i64, TrainSimulationDetails>,
 ) -> Result<HashMap<i64, Vec<SignalUpdate>>> {
+    if trains_details.is_empty() {
+        return Ok(HashMap::new());
+    }
     let request = SignalUpdatesRequest {
         infra: infra.id,
         expected_version: infra.version.clone(),


### PR DESCRIPTION
close #8615

Avoids sending requests to core if all signal projection is cached.