### PR TITLE
front: turn on eslint recommended type checked hints

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -12,7 +12,7 @@
     "plugin:import/recommended",
     "plugin:import/typescript",
     "prettier",
-    "plugin:@typescript-eslint/base"
+    "plugin:@typescript-eslint/recommended-type-checked"
   ],
   "plugins": ["import", "only-warn", "prettier", "react", "react-hooks", "vitest"],
   "parserOptions": {
@@ -43,9 +43,6 @@
     "@typescript-eslint/consistent-type-imports": ["error", { "fixStyle": "inline-type-imports" }],
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": "error",
-    "@typescript-eslint/no-unnecessary-type-assertion": "error",
-    "@typescript-eslint/no-unsafe-return": "error",
-    "@typescript-eslint/no-unsafe-call": "error",
     "@typescript-eslint/non-nullable-type-assertion-style": "error",
 
     "@typescript-eslint/no-restricted-types": [


### PR DESCRIPTION
See https://typescript-eslint.io/getting-started/typed-linting/

- [x] `no-unsafe-return` (#8884)
- [ ] `no-unsafe-member-access` (43 errors)
- [ ] `no-unsafe-argument` (#10234)
- [ ] `no-unsafe-assignment` (71 errors)
- [x] `no-unsafe-call` (3 errors, #8923)
- [ ] `no-misused-promises`
- [ ] `no-floating-promises`
- [ ] `restrict-template-expressions`
- [ ] `only-throw-error`
- [ ] `require-await`
- [ ] More?