### PR TITLE
front: turn on @typescript-eslint/no-unnecessary-type-assertion lint

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -11,11 +11,13 @@
     "airbnb",
     "plugin:import/recommended",
     "plugin:import/typescript",
-    "prettier"
+    "prettier",
+    "plugin:@typescript-eslint/base"
   ],
   "plugins": ["import", "only-warn", "prettier", "react", "react-hooks", "vitest"],
   "parserOptions": {
-    "ecmaVersion": "latest"
+    "ecmaVersion": "latest",
+    "project": true
   },
   "rules": {
     "import/order": [
@@ -41,6 +43,7 @@
     "@typescript-eslint/consistent-type-imports": ["error", { "fixStyle": "inline-type-imports" }],
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
 
     "@typescript-eslint/ban-types": [
       "error",

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -328,12 +328,7 @@ const EntitySumUp = ({ entity, id, objType, classes, status, error }: EntitySumU
       setState({ type: 'loading' });
 
       if (!entity) {
-        entity = await getEntity(
-          infraID as number,
-          id as string,
-          objType as EditoastType,
-          dispatch
-        );
+        entity = await getEntity(infraID as number, id, objType as EditoastType, dispatch);
       }
 
       const additionalEntities = await getAdditionalEntities(infraID as number, entity, dispatch);

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -167,7 +167,7 @@ const IntervalEditorComponent = (props: FieldProps) => {
                     setHovered(null);
                   }
                   setClickPrevent(false);
-                }, 150) as number;
+                }, 150);
                 setClickTimeout(timer);
               }
             }}

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLayers.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLayers.tsx
@@ -46,7 +46,7 @@ export const BasePointEditionLayers = ({
   const renderedEntity = useMemo(() => {
     let res: EditorEntity | null = null;
     if (entity.geometry && !isEqual(entity.geometry, NULL_GEOMETRY)) {
-      res = entity as EditorEntity;
+      res = entity;
     } else if (nearestPoint) {
       if (mergeEntityWithNearestPoint) {
         res = mergeEntityWithNearestPoint(entity, nearestPoint);

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
@@ -112,7 +112,7 @@ const PointEditionLeftPanel = <Entity extends EditorEntity>({
       )}
       <EditorForm
         key={formKey}
-        data={state.entity as Entity}
+        data={state.entity}
         overrideUiSchema={{
           logical_signals: {
             items: {

--- a/front/src/applications/editor/tools/rangeEdition/components/RangeEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/RangeEditionLeftPanel.tsx
@@ -59,8 +59,8 @@ const RangeEditionLeftPanel = () => {
     useState<AvailableSwitchPositions>({});
 
   // The 2 main checkboxes
-  const isPermanentSpeedLimit = speedSectionIsPsl(entity as SpeedSectionEntity);
-  const isSpeedRestriction = speedSectionIsSpeedRestriction(entity as SpeedSectionEntity);
+  const isPermanentSpeedLimit = speedSectionIsPsl(entity);
+  const isSpeedRestriction = speedSectionIsSpeedRestriction(entity);
 
   const isNew = entity.properties.id === NEW_ENTITY_ID;
   const infraID = useInfraID();
@@ -68,7 +68,7 @@ const RangeEditionLeftPanel = () => {
 
   /** Reset both highlighted and selected track_ranges, route ids and switches lists */
   const resetSpeedRestrictionSelections = () => {
-    const newEntity = cloneDeep(entity) as SpeedSectionEntity;
+    const newEntity = cloneDeep(entity);
     newEntity.properties.on_routes = [];
     newEntity.properties.track_ranges = [];
     setState({
@@ -81,7 +81,7 @@ const RangeEditionLeftPanel = () => {
 
   const toggleSpeedRestriction = () => {
     const selectiontype = isSpeedRestriction ? 'idle' : 'selectSwitch';
-    const newEntity = cloneDeep(entity) as SpeedSectionEntity;
+    const newEntity = cloneDeep(entity);
     newEntity.properties.extensions = undefined;
     newEntity.properties.track_ranges = [];
     if (isSpeedRestriction) {
@@ -123,7 +123,7 @@ const RangeEditionLeftPanel = () => {
   const updateSpeedSectionExtensions = (
     extensions: SpeedSectionEntity['properties']['extensions']
   ) => {
-    const newEntity = cloneDeep(entity) as SpeedSectionEntity;
+    const newEntity = cloneDeep(entity);
     newEntity.properties.extensions = extensions;
     setState({
       entity: newEntity,
@@ -144,7 +144,7 @@ const RangeEditionLeftPanel = () => {
     if (isEmpty(routeElements)) {
       return;
     }
-    const newEntity = cloneDeep(entity) as SpeedSectionEntity;
+    const newEntity = cloneDeep(entity);
     const { properties } = newEntity;
     if (select) {
       properties.on_routes = toggleElement(properties.on_routes || [], routeId);
@@ -195,7 +195,7 @@ const RangeEditionLeftPanel = () => {
     }).unwrap();
     const { routes, available_node_positions } = routesAndNodesPositions;
 
-    const newEntity = cloneDeep(entity) as SpeedSectionEntity;
+    const newEntity = cloneDeep(entity);
     if (isSpeedRestriction) {
       newEntity.properties.on_routes = [];
     }

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/PslSignCard.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/PslSignCard.tsx
@@ -157,9 +157,7 @@ const PslSignCard = ({
               type="button"
               className="btn btn-danger btn-sm px-2 ml-2"
               aria-label={t('Editor.tools.speed-edition.sign-remove')}
-              onClick={() =>
-                removeSign(signInfo as Exclude<PslSignInformation, { signType: PSL_SIGN_TYPES.Z }>)
-              }
+              onClick={() => removeSign(signInfo)}
             >
               <Trash />
             </button>

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -56,7 +56,7 @@ export const SpeedSectionEditionLayers = () => {
     setState,
   } = useContext(EditorContext) as ExtendedEditorContextType<RangeEditionState<SpeedSectionEntity>>;
   const isPermanentSpeedLimit = speedSectionIsPsl(entity);
-  const isSpeedRestriction = speedSectionIsSpeedRestriction(entity as SpeedSectionEntity);
+  const isSpeedRestriction = speedSectionIsSpeedRestriction(entity);
 
   const { mapStyle, layersSettings, issuesSettings, showIGNBDORTHO } = useSelector(getMap);
   const infraID = useInfraID();

--- a/front/src/applications/editor/tools/rangeEdition/utils.ts
+++ b/front/src/applications/editor/tools/rangeEdition/utils.ts
@@ -180,7 +180,7 @@ export function getTrackRangeFeatures(
         itemType: 'TrackRange',
         rangeIndex,
       }),
-      point(track.geometry.coordinates[0] as Position, {
+      point(track.geometry.coordinates[0], {
         ...properties,
         id: `speedSectionRangeExtremity::${rangeIndex}::${begin}`,
         track: range.track,

--- a/front/src/applications/editor/tools/routeEdition/components/RouteEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/RouteEditionLeftPanel.tsx
@@ -169,7 +169,7 @@ const RouteEditionPanel = () => {
         .map((str) => chroma(str).hex());
 
       const features = await getRouteGeometries(
-        infraID as number,
+        infraID,
         route.properties.entry_point,
         route.properties.exit_point,
         candidates,

--- a/front/src/applications/editor/tools/routeEdition/utils.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.ts
@@ -169,7 +169,7 @@ async function getRouteGeometryByRoute(
 ): Promise<Feature<LineString, { id: string }>> {
   const trackRangesResp = dispatch(
     osrdEditoastApi.endpoints.getInfraByInfraIdRoutesTrackRanges.initiate({
-      infraId: infra as number,
+      infraId: infra,
       routes: route.properties.id,
     })
   );

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
@@ -91,7 +91,7 @@ const SwitchEditionLeftPanel = () => {
           SchemaField: CustomSchemaField,
         }}
         onSubmit={async (flatSwitch) => {
-          const entityToSave = flatSwitchToSwitch(switchType, flatSwitch as FlatSwitchEntity);
+          const entityToSave = flatSwitchToSwitch(switchType, flatSwitch);
 
           const res = await dispatch(
             save(

--- a/front/src/applications/editor/tools/trackEdition/components/AttachedRangesItemsList.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components/AttachedRangesItemsList.tsx
@@ -128,12 +128,12 @@ const AttachedRangesItemsList = ({ id, itemType }: AttachedRangesItemsListProps)
                       if (entity.objType === 'SpeedSection') {
                         switchTool({
                           toolType: TOOL_NAMES.SPEED_SECTION_EDITION,
-                          toolState: getEditSpeedSectionState(entity as SpeedSectionEntity),
+                          toolState: getEditSpeedSectionState(entity),
                         });
                       } else
                         switchTool({
                           toolType: TOOL_NAMES.ELECTRIFICATION_EDITION,
-                          toolState: getEditElectrificationState(entity as ElectrificationEntity),
+                          toolState: getEditElectrificationState(entity),
                         });
                     }}
                   >

--- a/front/src/applications/editor/tools/translationTools.ts
+++ b/front/src/applications/editor/tools/translationTools.ts
@@ -47,7 +47,7 @@ export function translateDefinitions(
   return Object.keys(defsList).reduce<{
     [key: string]: JSONSchema7;
   }>((acc, defName) => {
-    const currentEntity = defsList![defName] as JSONSchema7;
+    const currentEntity = defsList[defName] as JSONSchema7;
     const properties =
       currentEntity.properties && translateProperties(currentEntity.properties, defName, t);
 

--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -250,10 +250,10 @@ const importTimetable = async (
     }
 
     const node = {
-      id: id!,
+      id,
       betriebspunktName: trigram || '',
       fullName: fullName || '',
-      positionX: positionX!,
+      positionX,
       positionY: positionY || 0,
       ports: [],
       transitions: [],
@@ -356,7 +356,7 @@ const importTimetable = async (
       // convert them.
       let prevPort: Port | null = null;
       return pathNodeIds.slice(0, -1).map((sourceNodeId, i) => {
-        const targetNodeId = pathNodeIds[i + 1]!;
+        const targetNodeId = pathNodeIds[i + 1];
 
         const sourcePort = createPort(trainrunSectionId);
         const targetPort = createPort(trainrunSectionId);

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -178,12 +178,12 @@ export const preparePathPropertiesData = (
   const electrificationsRanges = transformBoundariesDataToRangesData(
     electrifications as NonNullable<PathProperties['electrifications']>,
     pathLength
-  ) as ElectricalRangesData<ElectrificationValue>[];
+  );
 
   const electricalProfilesRanges = transformBoundariesDataToRangesData(
     electricalProfiles,
     pathLength
-  ) as ElectricalRangesData<ElectricalProfileValue>[];
+  );
 
   const electrificationRanges = formatElectrificationRanges(
     electrificationsRanges,

--- a/front/src/applications/operationalStudies/views/Study.tsx
+++ b/front/src/applications/operationalStudies/views/Study.tsx
@@ -156,7 +156,7 @@ export default function Study() {
           } else if (sortOption === 'NameAsc') {
             filteredScenarios = [...filteredScenarios].sort((a, b) => a.name.localeCompare(b.name));
           }
-          setScenariosList(filteredScenarios as ScenarioWithDetails[]);
+          setScenariosList(filteredScenarios);
         } catch (error) {
           console.error(error);
         }

--- a/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
+++ b/front/src/applications/operationalStudies/views/v2/ScenarioV2.tsx
@@ -110,7 +110,7 @@ const Scenario = () => {
     handleOperation({
       event,
       dispatch,
-      timeTableId: scenarioData!.scenario.timetable_id,
+      timeTableId: scenarioData.scenario.timetable_id,
       netzgrafikDto,
       addUpsertedTrainSchedules: (upsertedTrainSchedules: TrainScheduleResult[]) => {
         setNgeUpsertedTrainSchedules((prev) =>

--- a/front/src/applications/referenceMap/Home.tsx
+++ b/front/src/applications/referenceMap/Home.tsx
@@ -29,7 +29,7 @@ const HomeReferenceMap = () => {
   useEffect(() => {
     if (infraID) {
       // if the infra in the store is not found, then we set it to undefined
-      getInfraByInfraId({ infraId: infraID as number }).then((resp) => {
+      getInfraByInfraId({ infraId: infraID }).then((resp) => {
         if (resp.error && 'status' in resp.error && resp.error.status === 404) {
           dispatch(updateInfraID(undefined));
         }

--- a/front/src/common/IntervalsDataViz/data.ts
+++ b/front/src/common/IntervalsDataViz/data.ts
@@ -682,7 +682,7 @@ export function entityDoUpdate<T extends EditorEntity>(entity: T, sourceLine: Li
         newProps[name] = value;
       }
     });
-    newProps.length = getLineStringDistance(entity.geometry as LineString);
+    newProps.length = getLineStringDistance(entity.geometry);
     return { ...entity, properties: newProps };
   }
   return entity;

--- a/front/src/common/IntervalsEditor/IntervalsEditor.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditor.tsx
@@ -241,7 +241,7 @@ const IntervalsEditor = (props: IntervalsEditorProps) => {
                     setHovered(null);
                   }
                   setClickPrevent(false);
-                }, 50) as number;
+                }, 50);
                 setClickTimeout(timer);
               }
               if (selectedTool === INTERVALS_EDITOR_TOOLS.CUT_TOOL) {

--- a/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditorMarginForm.tsx
@@ -34,7 +34,7 @@ const IntervalsEditorMarginForm = ({
           const result = cloneDeep(data);
           if (result && result[selectedIntervalIndex]) {
             result[selectedIntervalIndex].value = parseFloat(e.target.value);
-            setData(result as IntervalItem[]);
+            setData(result);
           }
         }}
         value={(interval.value as number) || 0}

--- a/front/src/common/Map/WarpedMap/DataLoader.tsx
+++ b/front/src/common/Map/WarpedMap/DataLoader.tsx
@@ -74,7 +74,7 @@ const DataLoader = ({ bbox, getGeoJSONs, layers }: DataLoaderProps) => {
 
   useEffect(() => {
     if (state === 'render' && mapRef) {
-      const m = mapRef as MapRef;
+      const m = mapRef;
 
       const querySources = () => {
         // Retrieve OSRD data:

--- a/front/src/common/Map/WarpedMap/core/projection.ts
+++ b/front/src/common/Map/WarpedMap/core/projection.ts
@@ -163,9 +163,8 @@ export function clipAndProjectGeoJSON<T extends Geometry | Feature | FeatureColl
     };
 
   if (geojson.type === 'Feature') {
-    const clippedFeature = shouldClip
-      ? (clip(geojson, zone) as Feature | null)
-      : (geojson as Feature);
+    const feature: Feature = geojson;
+    const clippedFeature = shouldClip ? clip(feature, zone) : feature;
 
     if (clippedFeature) {
       const newGeometry = projectGeometry(clippedFeature.geometry, projection);

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -128,7 +128,7 @@ export default function AddOrEditProjectModal({
     } else {
       try {
         if (tempProjectImage) {
-          const imageId = await uploadImage(tempProjectImage as Blob);
+          const imageId = await uploadImage(tempProjectImage);
           if (imageId) currentProject.image = imageId;
         }
         const request = postProject({
@@ -165,7 +165,7 @@ export default function AddOrEditProjectModal({
         let imageId = currentProject.image;
 
         if (tempProjectImage) {
-          imageId = await uploadImage(tempProjectImage as Blob);
+          imageId = await uploadImage(tempProjectImage);
           // if the upload of the new image fails, keep the old one
           if (!imageId && currentProject.image) {
             imageId = currentProject.image;

--- a/front/src/modules/rollingStock/hooks/useCompleteRollingStockSchemasProperties.ts
+++ b/front/src/modules/rollingStock/hooks/useCompleteRollingStockSchemasProperties.ts
@@ -17,7 +17,7 @@ function useCompleteRollingStockSchemasProperties(): readonly SchemaProperty[] {
   const completeRsSchemaProperties = useMemo(() => {
     const sigSystemsIndex = RS_SCHEMA_PROPERTIES.findIndex(
       (s) => s.title === 'supportedSignalingSystems'
-    )!;
+    );
     const completeSigSystemsSchema = {
       ...RS_SCHEMA_PROPERTIES[sigSystemsIndex],
       enum: supportedSignalingSystems || [],

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerProject2Image.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerProject2Image.tsx
@@ -9,7 +9,7 @@ const Project2Image = ({ project }: { project: ProjectWithStudies }) => {
   useMemo(async () => {
     if (!project || !project.image) return;
     try {
-      const blobImage = await getDocument(project.image as number);
+      const blobImage = await getDocument(project.image);
       if (blobImage) setImageUrl(URL.createObjectURL(blobImage));
     } catch (error: unknown) {
       console.error(error);

--- a/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
+++ b/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
@@ -118,7 +118,7 @@ const updateChart = <
 
   chart.xAxisGrid.call(gridX(newX, chart.height));
   chart.yAxisGrid.call(gridY(newY, chart.width));
-  if (chart.y2AxisGrid) chart.y2AxisGrid.call(gridY2(newY2 as SimulationD3Scale, chart.width));
+  if (chart.y2AxisGrid) chart.y2AxisGrid.call(gridY2(newY2, chart.width));
 
   // * update lines, areas, rects by aiming their specific class.
 

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/helpers.ts
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/helpers.ts
@@ -2,7 +2,7 @@ import along from '@turf/along';
 import { lineString } from '@turf/helpers';
 import type { Feature, LineString } from 'geojson';
 
-import type { PositionSpeedTime, PositionsSpeedTimes } from 'reducers/osrdsimulation/types';
+import type { PositionsSpeedTimes } from 'reducers/osrdsimulation/types';
 
 import type { TrainPosition } from './types';
 
@@ -18,7 +18,7 @@ import type { TrainPosition } from './types';
 
 function getPosition(positionValues: PositionsSpeedTimes<Date>, baseKey?: string) {
   const key = baseKey as keyof PositionsSpeedTimes<Date>;
-  return positionValues[key] as PositionSpeedTime<Date>;
+  return positionValues[key];
 }
 
 // TODO: fix warped map - probably remove this function and use finalOutput as key ?

--- a/front/src/modules/simulationResult/components/SpaceCurvesSlopes/SpaceCurvesSlopesV2.tsx
+++ b/front/src/modules/simulationResult/components/SpaceCurvesSlopes/SpaceCurvesSlopesV2.tsx
@@ -151,7 +151,7 @@ const SpaceCurvesSlopesV2 = ({
     const operationalPointsZone = chartLocal.drawZone
       .append('g')
       .attr('id', 'gev-operationalPointsZone');
-    operationalPoints!.forEach((op) => {
+    operationalPoints.forEach((op) => {
       operationalPointsZone
         .append('line')
         .datum(mmToM(op.position))

--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -91,7 +91,7 @@ const TimesStops = ({
         if (!rowData.stopFor && op.fromRowIndex !== allWaypoints.length - 1) {
           rowData.onStopSignal = false;
         }
-        if (rowData.theoreticalMargin && !marginRegExValidation.test(rowData.theoreticalMargin!)) {
+        if (rowData.theoreticalMargin && !marginRegExValidation.test(rowData.theoreticalMargin)) {
           rowData.isMarginValid = false;
           setRows(row);
         } else {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -7,7 +7,6 @@ import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import checkCurrentConfig from 'modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig';
 import { setFailure, setSuccess } from 'reducers/main';
-import { type OsrdConfState } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/osrdsimulation/actions';
 import { useAppDispatch } from 'store';
 import { formatToIsoDate } from 'utils/date';
@@ -33,7 +32,7 @@ const useUpdateTrainSchedule = (
 
   return async function submitConfUpdateTrainSchedules() {
     const formattedSimulationConf = checkCurrentConfig(
-      simulationConf as OsrdConfState,
+      simulationConf,
       t,
       dispatch,
       rollingStock?.name

--- a/front/src/utils/mapHelper.ts
+++ b/front/src/utils/mapHelper.ts
@@ -148,7 +148,7 @@ export function clip<T extends Feature | FeatureCollection>(tree: T, zone: Zone)
   if (tree.type === 'FeatureCollection') {
     return {
       ...tree,
-      features: (tree as FeatureCollection).features.flatMap((f) => {
+      features: tree.features.flatMap((f) => {
         const res = clip(f, zone);
         if (!res) return [];
         return [res];
@@ -157,7 +157,7 @@ export function clip<T extends Feature | FeatureCollection>(tree: T, zone: Zone)
   }
 
   if (tree.type === 'Feature') {
-    const feature = tree as Feature;
+    const feature: Feature = tree;
 
     if (feature.geometry.type === 'LineString' || feature.geometry.type === 'MultiLineString') {
       if (zone.type === 'polygon') {
@@ -272,8 +272,8 @@ export function getNearestPoint(lines: Feature<LineString>[], coord: Coord): Nea
   const nearestPoints: Feature<Point>[] = lines.map((line) => {
     const point = nearestPointOnLine(line, coord, { units: 'meters' });
     const angle = getAngle(
-      line.geometry.coordinates[point.properties.index as number],
-      line.geometry.coordinates[(point.properties.index as number) + 1]
+      line.geometry.coordinates[point.properties.index],
+      line.geometry.coordinates[point.properties.index + 1]
     );
     return {
       ...point,


### PR DESCRIPTION
First part of https://github.com/OpenRailAssociation/osrd/pull/8772

Enable typed hinting so that ESLint has information about types
and can provide more feedback. Only enable a single typed lint
rule for now (rest will be a lot more work to fix).

The rule @typescript-eslint/no-unnecessary-type-assertion prevents
unnecessary type assertions (e.g. casting a string to a string).
Reducing type assertions is nice because type assertions override
type checking and thus may hide type mismatches.