### PR TITLE
core, editoast: add work schedules to v2 conflict detection endpoint

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/ConflictDetectionEndpoint.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ConflictDetectionEndpoint.java
@@ -13,6 +13,7 @@ import fr.sncf.osrd.reporting.warnings.Warning;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -74,6 +75,8 @@ public class ConflictDetectionEndpoint implements Take {
             @Json(name = "train_ids")
             public final Collection<Long> trainIds;
 
+            public final transient Collection<Long> workScheduleIds;
+
             @Json(name = "start_time")
             public final double startTime;
 
@@ -87,6 +90,7 @@ public class ConflictDetectionEndpoint implements Take {
                 ROUTING,
             }
 
+            @NotNull
             @Json(name = "conflict_type")
             public final ConflictType conflictType;
 
@@ -96,9 +100,25 @@ public class ConflictDetectionEndpoint implements Take {
                     Collection<Long> trainIds,
                     double startTime,
                     double endTime,
-                    ConflictType conflictType,
+                    @NotNull ConflictType conflictType,
                     Collection<ConflictRequirement> requirements) {
                 this.trainIds = trainIds;
+                this.workScheduleIds = List.of();
+                this.startTime = startTime;
+                this.endTime = endTime;
+                this.conflictType = conflictType;
+                this.requirements = requirements;
+            }
+
+            public Conflict(
+                    Collection<Long> trainIds,
+                    Collection<Long> workScheduleIds,
+                    double startTime,
+                    double endTime,
+                    @NotNull ConflictType conflictType,
+                    Collection<ConflictRequirement> requirements) {
+                this.trainIds = trainIds;
+                this.workScheduleIds = workScheduleIds;
                 this.startTime = startTime;
                 this.endTime = endTime;
                 this.conflictType = conflictType;

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -90,7 +90,7 @@ public final class ApiServerCommand implements CliCommand {
                     new FkRegex("/project_signals", new SignalProjectionEndpoint(infraManager)),
                     new FkRegex("/v2/signal_projection", new SignalProjectionEndpointV2(infraManager)),
                     new FkRegex("/detect_conflicts", new ConflictDetectionEndpoint()),
-                    new FkRegex("/v2/conflict_detection", new ConflictDetectionEndpointV2()),
+                    new FkRegex("/v2/conflict_detection", new ConflictDetectionEndpointV2(infraManager)),
                     new FkRegex("/cache_status", new InfraCacheStatusEndpoint(infraManager)),
                     new FkRegex("/version", new VersionEndpoint()),
                     new FkRegex("/stdcm", new STDCMEndpoint(infraManager)),

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -98,7 +98,7 @@ class WorkerCommand : CliCommand {
                 "/project_signals" to SignalProjectionEndpoint(infraManager),
                 "/v2/signal_projection" to SignalProjectionEndpointV2(infraManager),
                 "/detect_conflicts" to ConflictDetectionEndpoint(),
-                "/v2/conflict_detection" to ConflictDetectionEndpointV2(),
+                "/v2/conflict_detection" to ConflictDetectionEndpointV2(infraManager),
                 "/cache_status" to InfraCacheStatusEndpoint(infraManager),
                 "/version" to VersionEndpoint(),
                 "/stdcm" to STDCMEndpoint(infraManager),

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
@@ -63,3 +63,10 @@ class SpacingRequirement(
     @Json(name = "begin_time") val beginTime: TimeDelta,
     @Json(name = "end_time") val endTime: TimeDelta,
 )
+
+data class WorkSchedule(
+    /** List of affected track ranges */
+    @Json(name = "track_ranges") val trackRanges: Collection<UndirectedTrackRange> = listOf(),
+    @Json(name = "start_time") val startTime: TimeDelta,
+    @Json(name = "end_time") val endTime: TimeDelta,
+)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/RequirementsParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/RequirementsParser.kt
@@ -1,25 +1,38 @@
 package fr.sncf.osrd.api.api_v2
 
 import fr.sncf.osrd.api.api_v2.conflicts.TrainRequirementsRequest
-import fr.sncf.osrd.conflicts.TrainRequirements
+import fr.sncf.osrd.api.api_v2.conflicts.WorkSchedulesRequest
+import fr.sncf.osrd.conflicts.*
+import fr.sncf.osrd.sim_infra.api.RawSignalingInfra
 import fr.sncf.osrd.standalone_sim.result.ResultTrain
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.TimeDelta
+import fr.sncf.osrd.utils.units.seconds
 import java.time.Duration.between
 import java.time.ZonedDateTime
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
-fun parseRawTrainsRequirements(
+val requirementsParserLogger: Logger = LoggerFactory.getLogger("RequirementsParser")
+
+fun parseTrainsRequirements(
     trainsRequirements: Map<Long, TrainRequirementsRequest>,
     startTime: ZonedDateTime
-): List<TrainRequirements> {
-    val res = mutableListOf<TrainRequirements>()
+): List<Requirements> {
+    val res = mutableListOf<Requirements>()
     for ((id, trainRequirements) in trainsRequirements) {
         val delta = TimeDelta(between(startTime, trainRequirements.startTime).toMillis())
         val spacingRequirements =
             parseSpacingRequirements(trainRequirements.spacingRequirements, delta)
         val routingRequirements =
             parseRoutingRequirements(trainRequirements.routingRequirements, delta)
-        res.add(TrainRequirements(id, spacingRequirements, routingRequirements))
+        res.add(
+            Requirements(
+                RequirementId(id, RequirementType.TRAIN),
+                spacingRequirements,
+                routingRequirements
+            )
+        )
     }
     return res
 }
@@ -63,6 +76,92 @@ fun parseRoutingRequirements(
                 }
             )
         )
+    }
+    return res
+}
+
+fun parseWorkSchedulesRequest(
+    infra: RawSignalingInfra,
+    workSchedulesRequest: WorkSchedulesRequest,
+    startTime: ZonedDateTime
+): Collection<Requirements> {
+    val delta = TimeDelta(between(startTime, workSchedulesRequest.startTime).toMillis())
+    return convertWorkScheduleMap(infra, workSchedulesRequest.workScheduleRequirements, delta)
+}
+
+/**
+ * Convert work schedules into timetable spacing requirements, taking work schedule ids into
+ * account.
+ */
+fun convertWorkScheduleMap(
+    rawInfra: RawSignalingInfra,
+    workSchedules: Map<Long, WorkSchedule>,
+    timeToAdd: TimeDelta = 0.seconds
+): Collection<Requirements> {
+    val res = mutableListOf<Requirements>()
+    for (entry in workSchedules) {
+        val workScheduleRequirements = mutableListOf<ResultTrain.SpacingRequirement>()
+        workScheduleRequirements.addAll(convertWorkSchedule(rawInfra, entry.value, timeToAdd))
+        res.add(
+            Requirements(
+                RequirementId(entry.key, RequirementType.WORK_SCHEDULE),
+                workScheduleRequirements,
+                listOf()
+            )
+        )
+    }
+    return res
+}
+
+/**
+ * Convert work schedules into timetable spacing requirements, without taking work schedule id into
+ * account.
+ */
+fun convertWorkScheduleCollection(
+    rawInfra: RawSignalingInfra,
+    workSchedules: Collection<WorkSchedule>,
+    timeToAdd: TimeDelta = 0.seconds,
+): Requirements {
+    val workSchedulesRequirements = mutableListOf<ResultTrain.SpacingRequirement>()
+    for (workSchedule in workSchedules) {
+        workSchedulesRequirements.addAll(convertWorkSchedule(rawInfra, workSchedule, timeToAdd))
+    }
+    return Requirements(
+        RequirementId(DEFAULT_WORK_SCHEDULE_ID, RequirementType.WORK_SCHEDULE),
+        workSchedulesRequirements,
+        listOf()
+    )
+}
+
+private fun convertWorkSchedule(
+    rawInfra: RawSignalingInfra,
+    workSchedule: WorkSchedule,
+    timeToAdd: TimeDelta = 0.seconds,
+): Collection<ResultTrain.SpacingRequirement> {
+    val res = mutableListOf<ResultTrain.SpacingRequirement>()
+    for (range in workSchedule.trackRanges) {
+        val track = rawInfra.getTrackSectionFromName(range.trackSection) ?: continue
+        for (chunk in rawInfra.getTrackSectionChunks(track)) {
+            val chunkStartOffset = rawInfra.getTrackChunkOffset(chunk)
+            val chunkEndOffset = chunkStartOffset + rawInfra.getTrackChunkLength(chunk).distance
+            if (chunkStartOffset > range.end || chunkEndOffset < range.begin) continue
+            val zone = rawInfra.getTrackChunkZone(chunk)
+            if (zone == null) {
+                requirementsParserLogger.info(
+                    "Skipping part of work schedule [${workSchedule.startTime}; ${workSchedule.endTime}] " +
+                        "because it is on a track not fully covered by routes: $track",
+                )
+                continue
+            }
+            res.add(
+                ResultTrain.SpacingRequirement(
+                    rawInfra.getZoneName(zone),
+                    (workSchedule.startTime + timeToAdd).seconds,
+                    (workSchedule.endTime + timeToAdd).seconds,
+                    true
+                )
+            )
+        }
     }
     return res
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionRequest.kt
@@ -6,17 +6,26 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.RoutingRequirement
 import fr.sncf.osrd.api.api_v2.SpacingRequirement
+import fr.sncf.osrd.api.api_v2.WorkSchedule
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import java.time.ZonedDateTime
 
 class ConflictDetectionRequest(
+    var infra: String,
+    @Json(name = "expected_version") var expectedVersion: String,
     @Json(name = "trains_requirements") val trainsRequirements: Map<Long, TrainRequirementsRequest>,
+    @Json(name = "work_schedules") val workSchedules: WorkSchedulesRequest? = null,
 )
 
 class TrainRequirementsRequest(
     @Json(name = "start_time") val startTime: ZonedDateTime,
     @Json(name = "spacing_requirements") val spacingRequirements: Collection<SpacingRequirement>,
     @Json(name = "routing_requirements") val routingRequirements: Collection<RoutingRequirement>,
+)
+
+class WorkSchedulesRequest(
+    @Json(name = "start_time") val startTime: ZonedDateTime,
+    @Json(name = "work_schedule_requirements") val workScheduleRequirements: Map<Long, WorkSchedule>
 )
 
 val conflictRequestAdapter: JsonAdapter<ConflictDetectionRequest> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/conflicts/ConflictDetectionResponse.kt
@@ -14,6 +14,7 @@ class ConflictDetectionResponse(
 
 class Conflict(
     @Json(name = "train_ids") val trainIds: Collection<Long>,
+    @Json(name = "work_schedule_ids") val workScheduleIds: Collection<Long>,
     @Json(name = "start_time") val startTime: ZonedDateTime,
     @Json(name = "end_time") val endTime: ZonedDateTime,
     @Json(name = "conflict_type")

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.TrackLocation
-import fr.sncf.osrd.api.api_v2.UndirectedTrackRange
+import fr.sncf.osrd.api.api_v2.WorkSchedule
 import fr.sncf.osrd.api.api_v2.conflicts.TrainRequirementsRequest
 import fr.sncf.osrd.api.api_v2.standalone_sim.MarginValue
 import fr.sncf.osrd.api.api_v2.standalone_sim.MarginValueAdapter
@@ -65,13 +65,6 @@ data class StepTimingData(
     @Json(name = "arrival_time") val arrivalTime: ZonedDateTime,
     @Json(name = "arrival_time_tolerance_before") val arrivalTimeToleranceBefore: Duration,
     @Json(name = "arrival_time_tolerance_after") val arrivalTimeToleranceAfter: Duration,
-)
-
-data class WorkSchedule(
-    /** List of affected track ranges */
-    @Json(name = "track_ranges") val trackRanges: Collection<UndirectedTrackRange> = listOf(),
-    @Json(name = "start_time") val startTime: TimeDelta,
-    @Json(name = "end_time") val endTime: TimeDelta,
 )
 
 val stdcmRequestAdapter: JsonAdapter<STDCMRequestV2> =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -70,7 +70,6 @@ class STDCMEndpoint(private val infraManager: InfraManager) : Take {
                     startTime,
                     steps,
                     makeBlockAvailability(
-                        infra,
                         request.spacingRequirements,
                         gridMarginBeforeTrain = request.gridMarginBeforeSTDCM,
                         gridMarginAfterTrain = request.gridMarginAfterSTDCM
@@ -157,7 +156,7 @@ private fun checkForConflicts(
     departureTime: Double
 ) {
     val requirements = TrainRequirements(0, spacingRequirements, listOf())
-    val conflictDetector = IncrementalConflictDetectorImpl(listOf(requirements))
+    val conflictDetector = incrementalConflictDetector(listOf(requirements))
     val conflicts =
         conflictDetector.checkConflicts(
             simResult.spacingRequirements.map {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/BlockAvailabilityTests.kt
@@ -146,7 +146,7 @@ class BlockAvailabilityTests {
     @Test
     fun testNotEnoughPath() {
         val explorer = makeExplorer(4, 4)
-        val availability = makeBlockAvailability(infra, listOf())
+        val availability = makeBlockAvailability(listOf())
         assertThrows<BlockAvailabilityInterface.NotEnoughLookaheadError> {
             availability.getAvailability(
                 explorer,
@@ -161,7 +161,7 @@ class BlockAvailabilityTests {
     @Test
     fun testFullPath() {
         val explorer = makeExplorer(5, 5)
-        val availability = makeBlockAvailability(infra, listOf())
+        val availability = makeBlockAvailability(listOf())
         assertDoesNotThrow {
             availability.getAvailability(
                 explorer,
@@ -178,10 +178,7 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 1)
         val duration = 120.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true))
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true)))
         val res =
             availability.getAvailability(
                 explorer,
@@ -198,10 +195,7 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 1)
         val duration = 120.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(SpacingRequirement(zoneNames[0], 10.0, duration, true))
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 10.0, duration, true)))
         val res =
             availability.getAvailability(
                 explorer,
@@ -219,7 +213,6 @@ class BlockAvailabilityTests {
         val duration = 1200.0
         val availability =
             makeBlockAvailability(
-                infra,
                 listOf(
                     SpacingRequirement(zoneNames[0], 0.0, duration - 1, true),
                     SpacingRequirement(zoneNames[0], duration + 1, 2 * duration, true)
@@ -242,10 +235,7 @@ class BlockAvailabilityTests {
         val startTime = 1200.0
         val availability =
             makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[0], startTime, POSITIVE_INFINITY, true),
-                )
+                listOf(SpacingRequirement(zoneNames[0], startTime, POSITIVE_INFINITY, true))
             )
         val res =
             availability.getAvailability(
@@ -268,7 +258,6 @@ class BlockAvailabilityTests {
         val minStartTime = 1200.0
         val availability =
             makeBlockAvailability(
-                infra,
                 listOf(
                     SpacingRequirement(zoneNames[0], minStartTime + 2, POSITIVE_INFINITY, true),
                     SpacingRequirement(zoneNames[1], minStartTime, POSITIVE_INFINITY, true),
@@ -291,12 +280,7 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 5, rollingStock = VERY_LONG_FAST_TRAIN)
         val occupancyEnd = 1200.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true),
-                )
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true)))
 
         // The train is so long that it never leaves the first zone
         // We expect a conflict (with the first zone) even on the last meter of the simulation
@@ -319,12 +303,7 @@ class BlockAvailabilityTests {
         var explorer = makeExplorer(5, 4)
         val occupancyEnd = 6000.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true),
-                )
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true)))
         val firstSimEndOffset = explorer.getSimulatedLength()
         availability.getAvailability(explorer, Offset(0.meters), firstSimEndOffset, 0.0)
         explorer.moveForward()
@@ -354,12 +333,7 @@ class BlockAvailabilityTests {
         var explorer = makeExplorer(5, 1)
         val occupancyEnd = 1200.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true),
-                )
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, occupancyEnd, true)))
         val firstSimEndOffset = explorer.getSimulatedLength()
         availability.getAvailability(explorer, Offset(0.meters), firstSimEndOffset, 0.0)
         explorer =
@@ -390,10 +364,7 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 5)
         val duration = 120.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true))
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true)))
         val res1 =
             availability.getAvailability(
                 explorer,
@@ -418,7 +389,6 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 5)
         val availability =
             makeBlockAvailability(
-                infra,
                 listOf(SpacingRequirement(zoneNames[0], 0.0, POSITIVE_INFINITY, true))
             )
         val res =
@@ -437,7 +407,6 @@ class BlockAvailabilityTests {
         val explorer = makeExplorer(5, 5)
         val availability =
             makeBlockAvailability(
-                infra,
                 listOf(SpacingRequirement(zoneNames.last(), 0.0, POSITIVE_INFINITY, true))
             )
         val res =
@@ -453,10 +422,7 @@ class BlockAvailabilityTests {
         val startTime = 1200.0
         val availability =
             makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[0], 0.0, startTime - 1, true),
-                )
+                listOf(SpacingRequirement(zoneNames[0], 0.0, startTime - 1, true))
             )
         val res =
             availability.getAvailability(
@@ -477,10 +443,7 @@ class BlockAvailabilityTests {
         val duration = 120.0
         val availability =
             makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames.last(), startTime, startTime + duration, true),
-                )
+                listOf(SpacingRequirement(zoneNames.last(), startTime, startTime + duration, true))
             )
         val res =
             availability.getAvailability(
@@ -502,12 +465,10 @@ class BlockAvailabilityTests {
         val startSecondConflict = 6000.0
         val availability =
             makeBlockAvailability(
-                infra,
                 listOf(
                     SpacingRequirement(zoneNames[0], 0.0, endFirstConflict, true),
                     SpacingRequirement(zoneNames[0], startSecondConflict, POSITIVE_INFINITY, true),
                 ),
-                listOf(),
                 listOf(),
                 marginBefore,
                 marginAfter
@@ -549,10 +510,7 @@ class BlockAvailabilityTests {
         var explorer = makeExplorer(4, 4)
         val duration = 120.0
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true))
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[0], 0.0, duration, true)))
         assertThrows<BlockAvailabilityInterface.NotEnoughLookaheadError> {
             availability.getAvailability(
                 explorer,
@@ -622,12 +580,7 @@ class BlockAvailabilityTests {
                 )
             )
         val availability =
-            makeBlockAvailability(
-                infra,
-                listOf(
-                    SpacingRequirement(zoneNames[2], 0.0, 120.0, true),
-                )
-            )
+            makeBlockAvailability(listOf(SpacingRequirement(zoneNames[2], 0.0, 120.0, true)))
         val res =
             availability.getAvailability(
                 explorer,
@@ -653,8 +606,7 @@ class BlockAvailabilityTests {
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds)
                 )
             )
-        val availability =
-            makeBlockAvailability(infra, listOf(), listOf(), steps) as BlockAvailability
+        val availability = makeBlockAvailability(listOf(), steps) as BlockAvailability
         val res =
             availability.getAvailability(
                 explorer,
@@ -688,7 +640,7 @@ class BlockAvailabilityTests {
                 )
             )
 
-        val availability = makeBlockAvailability(infra, listOf(), listOf(), steps)
+        val availability = makeBlockAvailability(listOf(), steps)
         val res =
             availability.getAvailability(explorer, Offset(0.meters), Offset(50.meters), 0.0)
                 as BlockAvailabilityInterface.Available
@@ -734,8 +686,7 @@ class BlockAvailabilityTests {
                 )
             )
 
-        val availability =
-            makeBlockAvailability(infra, requirements, listOf(), steps) as BlockAvailability
+        val availability = makeBlockAvailability(requirements, steps) as BlockAvailability
         val stepMaximumDelay = lastAvailableTime - timeAtStep + availability.internalMarginForSteps
         val res =
             availability.getAvailability(
@@ -773,7 +724,7 @@ class BlockAvailabilityTests {
                 // Requirement starting way after
                 SpacingRequirement(zoneNames[0], timeAtZoneEnd * 2, timeAtZoneEnd * 3, true),
             )
-        val availability = makeBlockAvailability(infra, requirements, listOf(), steps)
+        val availability = makeBlockAvailability(requirements, steps)
         val res =
             availability.getAvailability(
                 explorer,
@@ -809,7 +760,7 @@ class BlockAvailabilityTests {
                 // Requirement starting at the same moment as well
                 SpacingRequirement(zoneNames[0], 0.0, timeAtZoneEnd, true),
             )
-        val availability = makeBlockAvailability(infra, requirements, listOf(), steps)
+        val availability = makeBlockAvailability(requirements, steps)
         val res =
             availability.getAvailability(
                 explorer,
@@ -841,8 +792,7 @@ class BlockAvailabilityTests {
                     PlannedTimingData(minDelay.seconds, 0.seconds, 10.seconds)
                 )
             )
-        val availability =
-            makeBlockAvailability(infra, listOf(), listOf(), steps) as BlockAvailability
+        val availability = makeBlockAvailability(listOf(), steps) as BlockAvailability
         val res =
             availability.getAvailability(
                 explorer,
@@ -886,8 +836,7 @@ class BlockAvailabilityTests {
                     PlannedTimingData(0.seconds, 0.seconds, timeAtZoneEnd.seconds)
                 )
             )
-        val availability =
-            makeBlockAvailability(infra, listOf(), listOf(), steps) as BlockAvailability
+        val availability = makeBlockAvailability(listOf(), steps) as BlockAvailability
         assertEquals(internalMarginForSteps, availability.internalMarginForSteps)
         val res =
             availability.getAvailability(
@@ -941,7 +890,7 @@ class BlockAvailabilityTests {
                 )
             )
 
-        val availability = makeBlockAvailability(infra, requirements, listOf(), steps)
+        val availability = makeBlockAvailability(requirements, steps)
         val res =
             availability.getAvailability(
                 explorer,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2950,6 +2950,7 @@ components:
       type: object
       required:
       - train_ids
+      - work_schedule_ids
       - start_time
       - end_time
       - conflict_type
@@ -2979,6 +2980,12 @@ components:
             type: integer
             format: int64
           description: List of train ids involved in the conflict
+        work_schedule_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+          description: List of work schedule ids involved in the conflict
     ConflictDetectionResponse:
       type: object
       required:
@@ -2990,6 +2997,7 @@ components:
             type: object
             required:
             - train_ids
+            - work_schedule_ids
             - start_time
             - end_time
             - conflict_type
@@ -3019,6 +3027,12 @@ components:
                   type: integer
                   format: int64
                 description: List of train ids involved in the conflict
+              work_schedule_ids:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                description: List of work schedule ids involved in the conflict
           description: List of conflicts detected
     ConflictRequirement:
       type: object

--- a/editoast/src/core/stdcm.rs
+++ b/editoast/src/core/stdcm.rs
@@ -55,7 +55,7 @@ pub struct STDCMRequest {
     /// Margin to apply to the whole train
     pub margin: Option<MarginValue>,
     /// List of planned work schedules
-    pub work_schedules: Vec<STDCMWorkSchedule>,
+    pub work_schedules: Vec<LightWorkSchedule>,
 }
 
 #[derive(Debug, Serialize)]
@@ -81,7 +81,7 @@ pub struct STDCMStepTimingData {
 
 /// Lighter description of a work schedule, only contains what's relevant
 #[derive(Debug, Serialize)]
-pub struct STDCMWorkSchedule {
+pub struct LightWorkSchedule {
     /// Start time as a time delta from the stdcm start time in ms
     pub start_time: u64,
     /// End time as a time delta from the stdcm start time in ms

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -338,14 +338,16 @@ async fn conflicts(
         );
     }
     let conflict_detection_request = ConflictDetectionRequest {
+        infra: infra_id,
+        expected_version: infra.version,
         trains_requirements,
-        infra_id,
+        work_schedules: None,
     };
 
     // 3. Call core
-    let conflicts = conflict_detection_request.fetch(&core_client).await?;
+    let conflict_detection_response = conflict_detection_request.fetch(&core_client).await?;
 
-    Ok(Json(conflicts.conflicts))
+    Ok(Json(conflict_detection_response.conflicts))
 }
 
 #[cfg(test)]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2759,6 +2759,8 @@ export type Conflict = {
   start_time: string;
   /** List of train ids involved in the conflict */
   train_ids: number[];
+  /** List of work schedule ids involved in the conflict */
+  work_schedule_ids: number[];
 };
 export type ReportTrain = {
   /** Total energy consumption */


### PR DESCRIPTION
Fixes #8589.

Add work shedule list to conflict detection endpoint. Put their ids into the payload to be able to send them back to editoast in the corresponding conflict groups.
If a conflict group is found on a zone between 2 times, but all the conflicts are work schedules, ignore it.
