### PR TITLE
editoast: remove duplicate query results using `DISTINCT ON (object_id)`

### DIFF
--- a/editoast/src/models/infra/object_queryable.rs
+++ b/editoast/src/models/infra/object_queryable.rs
@@ -51,7 +51,7 @@ impl Infra {
             )
         } else {
             format!("
-            SELECT
+            SELECT DISTINCT ON (object_table.obj_id)
                 object_table.obj_id as obj_id,
                 object_table.data as railjson,
                 ST_AsGeoJSON(ST_Transform(geographic, 4326))::jsonb as geographic


### PR DESCRIPTION
The query in the `Infra::get_objects()` function was returning duplicate rows due to multiple matches in the `LEFT JOIN` when joining `infra_layer_{object_type}` and `infra_object_{object_type}`. This caused the same object to be returned multiple times.