### PR TITLE
core: stdcm: implement variable stop durations

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/train/TrainStop.java
+++ b/core/src/main/java/fr/sncf/osrd/train/TrainStop.java
@@ -24,6 +24,14 @@ public class TrainStop {
     }
 
     @Override
+    public String toString() {
+        return "TrainStop{" + "position="
+                + position + ", duration="
+                + duration + ", onStopSignal="
+                + onStopSignal + '}';
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(position, duration);
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -211,6 +211,12 @@ private fun parseSteps(
     if (pathItems.any { it.stopDuration == null && it.stepTimingData != null }) {
         throw OSRDError(ErrorType.InvalidSTDCMStepWithTimingData)
     }
+
+    // Semantically a stop at the start location doesn't change anything,
+    // it's not *wrong* so there's no error, but it's easier to consider
+    // that it's not a stop.
+    pathItems.first().stopDuration = null
+
     return pathItems
         .map {
             STDCMStep(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
@@ -57,7 +57,7 @@ class STDCMRequestV2(
 
 class STDCMPathItem(
     val locations: List<TrackLocation>,
-    @Json(name = "stop_duration") val stopDuration: Duration?,
+    @Json(name = "stop_duration") var stopDuration: Duration?,
     @Json(name = "step_timing_data") val stepTimingData: StepTimingData?,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -118,6 +118,8 @@ class STDCMEndpoint(private val infraManager: InfraManager) : Take {
 
 private fun parseSteps(infra: FullInfra, steps: List<STDCMRequest.STDCMStep>): List<STDCMStep> {
     assert(steps.last().stop)
+    steps.first().stop = false
+    steps.first().stopDuration = null
     return steps
         .stream()
         .map { step: STDCMRequest.STDCMStep ->

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMStep.kt
@@ -8,8 +8,8 @@ import kotlin.math.abs
 
 data class STDCMStep(
     val locations: Collection<PathfindingEdgeLocationId<Block>>,
-    val duration: Double?,
-    val stop: Boolean,
+    val duration: Double? = null,
+    val stop: Boolean = false,
     val plannedTimingData: PlannedTimingData? = null,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -80,7 +80,7 @@ internal constructor(
      * Returns true if the total run time at the start of the edge is above the specified threshold
      */
     fun isRunTimeTooLong(edge: STDCMEdge): Boolean {
-        val totalRunTime = edge.timeData.totalRunningTime
+        val totalRunTime = edge.timeData.timeSinceDeparture
 
         // TODO: we should use the A* heuristic here, but that requires a small refactoring
         return totalRunTime > maxRunTime

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/DelayManager.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface.Availability
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
 import java.util.*
 
 /**
@@ -129,5 +130,21 @@ internal constructor(
             endOffsetOnPath.cast(),
             startTime
         )
+    }
+
+    /** Return how much time we can add to the stop at the end of the explorer */
+    fun getMaxAdditionalStopDuration(
+        explorerWithNewEnvelope: InfraExplorerWithEnvelope,
+        endTime: Double,
+    ): Double {
+        val availability =
+            blockAvailability.getAvailability(
+                explorerWithNewEnvelope,
+                explorerWithNewEnvelope.getSimulatedLength() - 10.meters,
+                explorerWithNewEnvelope.getSimulatedLength(),
+                endTime,
+            )
+        if (availability is BlockAvailabilityInterface.Available) return availability.maximumDelay
+        return 0.0
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -55,7 +55,7 @@ data class STDCMEdge(
         return if (!endAtStop) {
             // We move on to the next block
             STDCMNode(
-                timeData.withAddedTime(totalTime, null),
+                timeData.withAddedTime(totalTime, null, null),
                 endSpeed,
                 infraExplorerWithNewEnvelope,
                 this,
@@ -71,8 +71,16 @@ data class STDCMEdge(
             val firstStopAfterIndex = graph.getFirstStopAfterIndex(waypointIndex)!!
             val stopDuration = firstStopAfterIndex.duration!!
             val locationOnEdge = envelopeStartOffset + length.distance
+
             STDCMNode(
-                timeData.withAddedTime(totalTime, stopDuration),
+                timeData.withAddedTime(
+                    totalTime,
+                    stopDuration,
+                    graph.delayManager.getMaxAdditionalStopDuration(
+                        infraExplorerWithNewEnvelope,
+                        timeData.earliestReachableTime + totalTime
+                    )
+                ),
                 endSpeed,
                 infraExplorerWithNewEnvelope,
                 this,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -1,13 +1,10 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.isTimeStrictlyPositive
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
-import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.units.Distance.Companion.fromMeters
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -121,21 +118,8 @@ internal constructor(
                 if (envelope.endPos == 0.0) envelope
                 else LinearAllowance.scaleEnvelope(envelope, speedRatio)
             val stopDuration = getEndStopDuration()
-            val envelopeWithStop =
-                if (stopDuration == null) scaledEnvelope
-                else
-                    EnvelopeStopWrapper(
-                        scaledEnvelope,
-                        listOf(
-                            TrainStop(
-                                envelope.endPos,
-                                stopDuration,
-                                // TODO: forward and use onStopSignal param from request
-                                isTimeStrictlyPositive(stopDuration)
-                            )
-                        )
-                    )
-            explorerWithNewEnvelope = infraExplorer.clone().addEnvelope(envelopeWithStop)
+            explorerWithNewEnvelope = infraExplorer.clone().addEnvelope(scaledEnvelope)
+            if (stopDuration != null) explorerWithNewEnvelope!!.addStop(stopDuration)
         }
         return explorerWithNewEnvelope
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -101,14 +101,12 @@ class STDCMGraph(
     override fun getAdjacentEdges(node: STDCMNode): Collection<STDCMEdge> {
         val res = ArrayList<STDCMEdge>()
         val maxMarginDuration = estimateMaxMarginDuration(node)
-        val baseNodeCost = node.timeData.timeSinceDeparture + node.remainingTimeEstimation
         val visitedNodesParameters =
             VisitedNodes.Parameters(
                 null,
-                node.timeData.earliestReachableTime,
-                node.timeData.maxDepartureDelayingWithoutConflict,
+                node.timeData,
                 maxMarginDuration,
-                baseNodeCost
+                node.remainingTimeEstimation,
             )
         if (node.locationOnEdge != null) {
             val explorer = node.infraExplorer.clone()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -137,8 +137,9 @@ class STDCMPathfinding(
                     graph.tag
                 ) ?: return null
         logger.info(
-            "departure time = ${res.departureTime.toInt()}s, " +
-                "total travel time = ${res.envelope.totalTime.toInt()}s"
+            "departure time = +${res.departureTime.toInt()}s, " +
+                "total travel time = ${res.envelope.totalTime.toInt()}s, " +
+                "total stop time = ${res.stopResults.sumOf { it.duration }.toInt()}s"
         )
         return res
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -128,7 +128,6 @@ class STDCMPathfinding(
                 .makeResult(
                     fullInfra.rawInfra,
                     path,
-                    startTime,
                     graph.standardAllowance,
                     rollingStock,
                     timeStep,
@@ -219,6 +218,7 @@ class STDCMPathfinding(
     ): Set<STDCMNode> {
         val res = HashSet<STDCMNode>()
         val firstStep = steps[0]
+        assert(!firstStep.stop)
         for (location in firstStep.locations) {
             val infraExplorers =
                 initInfraExplorerWithEnvelope(fullInfra, location, rollingStock, stops, constraints)
@@ -229,17 +229,17 @@ class STDCMPathfinding(
                         TimeData(
                             earliestReachableTime = startTime,
                             maxDepartureDelayingWithoutConflict = maxDepartureDelay,
-                            totalDepartureDelay = 0.0,
+                            departureTime = startTime,
                             timeOfNextConflictAtLocation = 0.0,
                             totalRunningTime = 0.0,
-                            totalStopTime = 0.0,
+                            stopTimeData = listOf(),
                         ),
                         0.0,
                         explorer,
                         null,
                         0,
                         location.offset,
-                        firstStep.duration,
+                        null,
                         firstStep.plannedTimingData,
                         null,
                         0.0,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -62,6 +62,8 @@ data class TimeData(
      */
     val timeSinceDeparture = totalRunningTime + stopTimeData.sumOf { it.currentDuration }
 
+    val totalStopDuration = stopTimeData.sumOf { it.currentDuration }
+
     /** Returns a copy of the current instance, with added travel / stop time. */
     fun withAddedTime(
         extraTravelTime: Double,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -68,9 +68,12 @@ data class TimeData(
     fun withAddedTime(
         extraTravelTime: Double,
         extraStopTime: Double?,
+        maxAdditionalStopTime: Double?
     ): TimeData {
         var newStopData = stopTimeData
         var maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict
+        val nextEarliestReachableTime =
+            earliestReachableTime + extraTravelTime + (extraStopTime ?: 0.0)
         if (extraStopTime != null) {
             val stopDataCopy = newStopData.toMutableList()
             stopDataCopy.add(
@@ -81,11 +84,10 @@ data class TimeData(
                 )
             )
             newStopData = stopDataCopy
-            maxDepartureDelayingWithoutConflict = Double.POSITIVE_INFINITY
+            maxDepartureDelayingWithoutConflict = maxAdditionalStopTime!!
         }
         return copy(
-            earliestReachableTime =
-                earliestReachableTime + extraTravelTime + (extraStopTime ?: 0.0),
+            earliestReachableTime = nextEarliestReachableTime,
             totalRunningTime = totalRunningTime + extraTravelTime,
             stopTimeData = newStopData,
             maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -70,6 +70,9 @@ data class TimeData(
         extraStopTime: Double?,
         maxAdditionalStopTime: Double?
     ): TimeData {
+        assert((extraStopTime == null) == (maxAdditionalStopTime == null)) {
+            "Can't set just one of 'stop duration' or 'max additional stop duration' without the other"
+        }
         var newStopData = stopTimeData
         var maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict
         val nextEarliestReachableTime =

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
@@ -1,16 +1,13 @@
 package fr.sncf.osrd.stdcm.graph
 
-import com.google.common.collect.Comparators.min
-import com.google.common.collect.ImmutableRangeMap
-import com.google.common.collect.ImmutableRangeSet
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
-import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeMap
 import com.google.common.collect.TreeRangeSet
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.utils.units.Distance
-import kotlin.Double.Companion.POSITIVE_INFINITY
+import kotlin.math.min
 
 /**
  * This class keeps track of which nodes have already been visited.
@@ -28,17 +25,15 @@ import kotlin.Double.Companion.POSITIVE_INFINITY
  * already been covered?
  *
  * The time check is where most complexity lies: we often pass by the same places at different
- * times, but in ways that have been fully covered by previously seen nodes. For each location, we
- * keep track of two things:
- * 1. When have we *visited* this place? This considers the ranges that have been covered by
- *    previously seen nodes, possibly by shifting the departure time
- * 2. When could we reach this place, including engineering margins? This isn't just a "visited"
- *    flag as it would increase the path cost, but it can avoid a lot of redundant computations
+ * times, but in ways that have been fully covered by previously seen nodes. We have a range map of
+ * "conditionally visited ranges". We may consider that a range is already visited if, for example,
+ * we need to add more than 42 seconds of stop duration to reach it.
  *
- * When testing for a time range, we only test the range that can be reached by delaying the
- * departure time. We consider it "already visited" when the whole range is either flagged as
- * visited, or the new cost value isn't lower than what could be obtained by adding engineering
- * margins.
+ * Currently, there are 3 range types: unconditionally visited, visited if adding less than x
+ * seconds of stop duration, and visited if adding less than x seconds of margin. *When we add a
+ * criteria to chose one path over another, we likely need to add an extra visited range type*.
+ * Otherwise, we may consider that a range is visited despite being better according to the new
+ * criteria.
  */
 data class VisitedNodes(val minDelay: Double) {
 
@@ -46,96 +41,204 @@ data class VisitedNodes(val minDelay: Double) {
     data class Fingerprint(
         val identifier: EdgeIdentifier,
         val waypointIndex: Int,
-        val startOffset: Distance
-    )
-
-    /** Parameters for either function, having a class avoids repetitions */
-    data class Parameters(
-        var fingerprint: Fingerprint?,
-        val startTime: Double,
-        val duration: Double,
-        val maxMarginDuration: Double,
-        val baseNodeCost: Double,
+        val startOffset: Distance,
     )
 
     /**
-     * Linear function with slope of 1. Used to represent the cost to reach a given time with margin
+     * Parameters for either function (is visited / mark as visited), having a class avoids
+     * repetitions
      */
-    data class LinearFunction(private val y0: Double) : Comparable<LinearFunction> {
-        fun apply(x: Double): Double = y0 + x
+    data class Parameters(
+        var fingerprint: Fingerprint?,
+        val timeData: TimeData,
+        val maxMarginDuration: Double,
+        val remainingTimeEstimation: Double = 0.0,
+    ) {
+        val nodeCost = timeData.totalRunningTime + remainingTimeEstimation
+    }
 
-        override fun compareTo(other: LinearFunction): Int {
-            return y0.compareTo(other.y0)
+    /** Any class that implements this interface may be added to the visited ranges. */
+    private sealed interface ConditionallyVisitedRange {
+        /** Is the given (sub)range covered by `this`? */
+        fun isVisited(
+            range: Range<Double>,
+            parameters: Parameters,
+        ): Boolean
+
+        /**
+         * Returns the range that is most likely to define elements as "already visited". Used to
+         * merge overlapping ranges in the range map.
+         */
+        fun mergeWith(other: ConditionallyVisitedRange?): ConditionallyVisitedRange
+    }
+
+    /**
+     * The given range is already visited by changing departure time. Such ranges are *always*
+     * already visited.
+     */
+    private data object VisitedWithDepartureTimeChange : ConditionallyVisitedRange {
+        override fun isVisited(
+            range: Range<Double>,
+            parameters: Parameters,
+        ): Boolean {
+            // If the other option were better, it would have been visited first
+            return true
+        }
+
+        override fun mergeWith(other: ConditionallyVisitedRange?): ConditionallyVisitedRange {
+            return this
         }
     }
 
     /**
-     * For each location, the time ranges that have been visited. We know they can always be
-     * ignored.
+     * The given range is already visited by adding stop durations. A candidate is already visited
+     * if their cost is higher or equal, or for equal cost if they add at least as much stop time as
+     * this.
      */
-    private val visitedRangesPerLocation = mutableMapOf<Fingerprint, RangeSet<Double>>()
+    private data class VisitedWithAddedStopTime(
+        // the time t is visited at f(t) seconds of total stop duration
+        private val visitedWithStopTime: LinearFunction,
+        // If the cost is higher, we don't even consider stop time
+        private val baseCost: Double,
+    ) : ConditionallyVisitedRange {
+        override fun isVisited(
+            range: Range<Double>,
+            parameters: Parameters,
+        ): Boolean {
+            if (parameters.nodeCost > baseCost) return true
+            val stopDurationForVisited = visitedWithStopTime.apply(range.lowerEndpoint())
+            return stopDurationForVisited <= parameters.timeData.totalStopDuration
+        }
+
+        override fun mergeWith(other: ConditionallyVisitedRange?): ConditionallyVisitedRange {
+            if (other is VisitedWithDepartureTimeChange) return other
+            if (other is VisitedWithAddedStopTime) {
+                if (!areTimesEqual(baseCost, other.baseCost))
+                    return if (baseCost < other.baseCost) this else other
+                return if (visitedWithStopTime < other.visitedWithStopTime) this else other
+            }
+            return this
+        }
+    }
 
     /**
-     * Time ranges that can be reached by adding margins. This isn't just "visited" as it would add
-     * the margin duration to the cost function. The values represent the estimated cost of a path
-     * that reach any given time of the range.
+     * The given range is already visited by adding margins. A candidate is already visited if their
+     * cost is higher or equal (accounting for any extra travel time).
      */
-    private val reachableRangesPerLocation =
-        mutableMapOf<Fingerprint, RangeMap<Double, LinearFunction>>()
+    private data class VisitedWithAddedTravelTime(
+        // the time t is visited at f(t) seconds of total running time duration
+        private val visitedWithTravelTime: LinearFunction,
+    ) : ConditionallyVisitedRange {
+        override fun isVisited(
+            range: Range<Double>,
+            parameters: Parameters,
+        ): Boolean {
+            val runningTimeForVisited = visitedWithTravelTime.apply(range.lowerEndpoint())
+            return runningTimeForVisited <= parameters.nodeCost
+        }
+
+        override fun mergeWith(other: ConditionallyVisitedRange?): ConditionallyVisitedRange {
+            if (other is VisitedWithAddedTravelTime) {
+                return if (visitedWithTravelTime < other.visitedWithTravelTime) this else other
+            }
+            return other ?: this
+        }
+    }
+
+    private val visitedRangesPerLocation =
+        mutableMapOf<Fingerprint, RangeMap<Double, ConditionallyVisitedRange>>()
 
     /** Returns true if the input has already been visited */
     fun isVisited(
         parameters: Parameters,
     ): Boolean {
-        val alreadyVisitedTimes =
-            visitedRangesPerLocation[parameters.fingerprint!!] ?: ImmutableRangeSet.of()
-        val alreadyReachableRanges =
-            reachableRangesPerLocation[parameters.fingerprint!!]
-                ?: ImmutableRangeMap.of(Range.all<Double>(), LinearFunction(POSITIVE_INFINITY))
+        val visitedRanges = visitedRangesPerLocation[parameters.fingerprint!!] ?: return false
+        val timeData = parameters.timeData
 
         val visitingRange =
-            Range.closed(parameters.startTime, parameters.startTime + parameters.duration)
-
-        // List the ranges that are being explored, outside the previously visited ranges
-        val rangesToCheck = TreeRangeSet.create<Double>()
-        rangesToCheck.add(visitingRange)
-        rangesToCheck.removeAll(alreadyVisitedTimes)
-
-        // then check what's left against the reachable ranges
-        for (range in rangesToCheck.asRanges()) {
-            val alreadyReachableMap = alreadyReachableRanges.subRangeMap(range)
-            for (entry in alreadyReachableMap.asMapOfRanges()) {
-                if (entry.value.apply(entry.key.upperEndpoint()) > parameters.baseNodeCost)
-                    return false
-            }
+            Range.closedOpen(
+                timeData.earliestReachableTime,
+                timeData.earliestReachableTime + timeData.maxDepartureDelayingWithoutConflict
+            )
+        if (visitingRange.isEmpty) {
+            // Special case for empty range, `subRangeMap` returns an empty list
+            val value = visitedRanges.get(timeData.earliestReachableTime) ?: return false
+            return value.isVisited(visitingRange, parameters)
         }
-        return true
+        val subMap = visitedRanges.subRangeMap(visitingRange)
+
+        // Keep track of any range that isn't covered by the map
+        val uncovered = TreeRangeSet.create<Double>()
+        uncovered.add(visitingRange)
+        for (entry in subMap.asMapOfRanges()) {
+            uncovered.remove(entry.key)
+            // Value isn't visited: we can early return "false"
+            if (!entry.value.isVisited(entry.key, parameters)) return false
+        }
+        // If any area is left uncovered, we still return "false"
+        return uncovered.isEmpty
     }
 
     /** Marks the input as visited */
     fun markAsVisited(
         parameters: Parameters,
     ) {
-        val visitedTimes =
-            visitedRangesPerLocation.getOrPut(parameters.fingerprint!!) { TreeRangeSet.create() }
+        val visitedRanges =
+            visitedRangesPerLocation.getOrPut(parameters.fingerprint!!) { TreeRangeMap.create() }
 
-        // We still add some padding to the end of the range, to avoid evaluating trains that are
-        // close to one another separately
-        val endVisitedTime = parameters.startTime + parameters.duration + minDelay
-        val newRange = Range.closed(parameters.startTime, endVisitedTime)
-        visitedTimes.add(newRange)
+        val timeData = parameters.timeData
+        val startTime = timeData.earliestReachableTime
+        val maxDepartureTimeChange =
+            min(
+                timeData.maxDepartureDelayingWithoutConflict,
+                timeData.stopTimeData.minOfOrNull { it.maxDepartureDelayBeforeStop }
+                    ?: Double.POSITIVE_INFINITY
+            )
 
-        if (parameters.maxMarginDuration > 0.0) {
-            val reachableRanges =
-                reachableRangesPerLocation.getOrPut(parameters.fingerprint!!) {
-                    val map = TreeRangeMap.create<Double, LinearFunction>()
-                    map.put(Range.all(), LinearFunction(POSITIVE_INFINITY))
-                    map
-                }
-            val reachableRange =
-                Range.closed(endVisitedTime, endVisitedTime + parameters.maxMarginDuration)
-            val value = LinearFunction(parameters.baseNodeCost - endVisitedTime)
-            reachableRanges.merge(reachableRange, value) { f, g -> min(f, g) }
+        // We still add some padding to the end of each range and value, to avoid evaluating trains
+        // that are close to one another separately (`minDelay`)
+        val endRangeDepartureTimeChange = startTime + maxDepartureTimeChange + minDelay
+        val endRangeExtraStopTime =
+            startTime + timeData.maxDepartureDelayingWithoutConflict + minDelay
+        val endRangeExtraTravelTime = endRangeExtraStopTime + parameters.maxMarginDuration
+
+        fun putRange(start: Double, end: Double, value: ConditionallyVisitedRange) {
+            if (start < end) {
+                val range = Range.closedOpen(start, end)
+                visitedRanges.merge(range, value) { a, b -> a.mergeWith(b) }
+            }
         }
+
+        // Visited with just departure time change, this is always considered as "visited".
+        // (The end of all ranges depends on conflicting occupancy along the path)
+        putRange(
+            startTime,
+            endRangeDepartureTimeChange,
+            VisitedWithDepartureTimeChange,
+        )
+        // Visited with extra stop duration, starting from the end of the previous range
+        putRange(
+            endRangeDepartureTimeChange,
+            endRangeExtraStopTime,
+            VisitedWithAddedStopTime(
+                LinearFunction(timeData.totalStopDuration - endRangeDepartureTimeChange),
+                parameters.nodeCost,
+            )
+        )
+        // Visited with extra margins, starting from the end of the previous range
+        putRange(
+            endRangeExtraStopTime,
+            endRangeExtraTravelTime,
+            VisitedWithAddedTravelTime(LinearFunction(parameters.nodeCost - endRangeExtraStopTime))
+        )
+    }
+}
+
+/** Linear function with slope of 1. Used to represent the cost to reach a given time with margin */
+private data class LinearFunction(private val y0: Double) : Comparable<LinearFunction> {
+    fun apply(x: Double): Double = y0 + x
+
+    override fun compareTo(other: LinearFunction): Int {
+        return y0.compareTo(other.y0)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -47,7 +47,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     /**
      * Returns a copy with the given envelope, the previous one is ignored. This keeps stop data.
      */
-    fun withNewEnvelope(envelope: Envelope): InfraExplorerWithEnvelope
+    fun withReplacedEnvelope(envelope: Envelope): InfraExplorerWithEnvelope
 
     /** Add a stop to the end of the last simulated envelope */
     fun addStop(stopDuration: Double)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -70,7 +70,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun withNewEnvelope(envelope: Envelope): InfraExplorerWithEnvelope {
+    override fun withReplacedEnvelope(envelope: Envelope): InfraExplorerWithEnvelope {
         return copy(
             envelopes =
                 appendOnlyLinkedListOf(
@@ -108,7 +108,7 @@ data class InfraExplorerWithEnvelopeImpl(
             envelopeCache = null
             spacingRequirementsCache = null
         } else {
-            assert(stops.isEmpty() || stops.last().duration == stopDuration)
+            assert(stops.last().duration == stopDuration)
         }
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMPathfindingBuilder.kt
@@ -24,24 +24,25 @@ import fr.sncf.osrd.train.TestTrains
  * values were set with tests in mind, but it could be moved to the non-test module if it becomes
  * relevant
  */
-class STDCMPathfindingBuilder {
+data class STDCMPathfindingBuilder(
     // region NON-OPTIONAL
-    private var infra: FullInfra? = null
-    private var steps: MutableList<STDCMStep> = ArrayList()
+    var infra: FullInfra? = null,
+    var steps: MutableList<STDCMStep> = ArrayList(),
 
     // endregion NON-OPTIONAL
     // region OPTIONAL
-    private var rollingStock = TestTrains.REALISTIC_FAST_TRAIN
-    private var startTime = 0.0
-    private var comfort = Comfort.STANDARD
-    private var pathfindingTimeout = Pathfinding.TIMEOUT
-    private var unavailableTimes: Multimap<BlockId, OccupancySegment> = ImmutableMultimap.of()
-    private var timeStep = 2.0
-    private var maxDepartureDelay = (3600 * 2).toDouble()
-    private var maxRunTime = Double.POSITIVE_INFINITY
-    private var tag = ""
-    private var standardAllowance: AllowanceValue? = null
-    private var blockAvailability: BlockAvailabilityInterface? = null
+    var rollingStock: RollingStock = TestTrains.REALISTIC_FAST_TRAIN,
+    var startTime: Double = 0.0,
+    var comfort: Comfort = Comfort.STANDARD,
+    var pathfindingTimeout: Double = Pathfinding.TIMEOUT,
+    var unavailableTimes: Multimap<BlockId, OccupancySegment> = ImmutableMultimap.of(),
+    var timeStep: Double = 2.0,
+    var maxDepartureDelay: Double = (3600 * 2).toDouble(),
+    var maxRunTime: Double = Double.POSITIVE_INFINITY,
+    var tag: String = "",
+    var standardAllowance: AllowanceValue? = null,
+    var blockAvailability: BlockAvailabilityInterface? = null,
+) {
     // endregion OPTIONAL
     // region SETTERS
     /** Sets the infra to be used */
@@ -51,7 +52,7 @@ class STDCMPathfindingBuilder {
     }
 
     /** Set the rolling stock to be used for the simulation. Defaults to REALISTIC_FAST_TRAIN */
-    fun setRollingStock(rollingStock: RollingStock?): STDCMPathfindingBuilder {
+    fun setRollingStock(rollingStock: RollingStock): STDCMPathfindingBuilder {
         this.rollingStock = rollingStock
         return this
     }
@@ -64,7 +65,7 @@ class STDCMPathfindingBuilder {
         startLocations: Set<PathfindingEdgeLocationId<Block>>,
         plannedTimingData: PlannedTimingData? = null
     ): STDCMPathfindingBuilder {
-        steps.add(0, STDCMStep(startLocations, 0.0, true, plannedTimingData))
+        steps.add(0, STDCMStep(startLocations, null, false, plannedTimingData))
         return this
     }
 
@@ -89,12 +90,6 @@ class STDCMPathfindingBuilder {
     /** Set the earliest time at which the train can leave. Defaults to 0 */
     fun setStartTime(startTime: Double): STDCMPathfindingBuilder {
         this.startTime = startTime
-        return this
-    }
-
-    /** Sets the rolling stock comfort parameter used for the simulation. Defaults to "standard" */
-    fun setComfort(comfort: Comfort): STDCMPathfindingBuilder {
-        this.comfort = comfort
         return this
     }
 
@@ -127,12 +122,6 @@ class STDCMPathfindingBuilder {
         return this
     }
 
-    /** Sets the train tag used to determine the speed limits by category. Defaults to empty */
-    fun setTag(tag: String): STDCMPathfindingBuilder {
-        this.tag = tag
-        return this
-    }
-
     /** Sets the standard allowance used for the new train. Defaults to null (no allowance) */
     fun setStandardAllowance(allowance: AllowanceValue?): STDCMPathfindingBuilder {
         standardAllowance = allowance
@@ -157,7 +146,6 @@ class STDCMPathfindingBuilder {
     /** Runs the pathfinding request with the given parameters */
     fun run(): STDCMResult? {
         assert(infra != null) { "infra is a required parameter and was not set" }
-        assert(rollingStock != null) { "rolling stock is a required parameter and was not set" }
         assert(steps.size >= 2) { "Not enough steps have been set" }
         assert(blockAvailability == null || unavailableTimes.isEmpty) {
             "Can't set both block availability and unavailable times"
@@ -166,7 +154,7 @@ class STDCMPathfindingBuilder {
             blockAvailability ?: DummyBlockAvailability(infra!!.blockInfra, unavailableTimes)
         return findPath(
             infra!!,
-            rollingStock!!,
+            rollingStock,
             comfort,
             startTime,
             steps,

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/StopTests.kt
@@ -624,8 +624,7 @@ class StopTests {
         val arrivalTime =
             res.departureTime + res.envelope.totalTime + res.stopResults.first().duration
         assertEquals(3_000.0, res.departureTime, timeStep)
-        assertEquals(15_000.0, res.departureTime + arrivalTime, timeStep)
-        assertEquals(5_000.0, res.stopResults.first().duration, timeStep)
+        assertEquals(15_000.0, arrivalTime, timeStep)
     }
 
     companion object {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -5,12 +5,12 @@ import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.graph.VisitedNodes
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.utils.units.meters
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class VisitedNodesTests {
 

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -221,10 +221,10 @@ class STDCMHeuristicTests {
             TimeData(
                 earliestReachableTime = 0.0,
                 maxDepartureDelayingWithoutConflict = 0.0,
-                totalDepartureDelay = 0.0,
+                departureTime = 0.0,
                 timeOfNextConflictAtLocation = 0.0,
                 totalRunningTime = 0.0,
-                totalStopTime = 0.0,
+                stopTimeData = listOf(),
             )
         val defaultNode =
             STDCMNode(


### PR DESCRIPTION
Fix #7691 

Change summary: 

1. Implement variable stop duration
2. Improve the concept of "visited" nodes to handle different criteria
    1. We had a binary concept of "visited range" and "visited with some extra allowance time"
    2. This concept was generalized and includes "visited with some extra stop duration"
3. Manage stops in the infra explorer with envelopes
    1. For the conflict detection, we had the stops directly in the incremental envelope
    2. We now explicitly keep the list and wrap the envelop on any access
4. Improve logging when postprocessing fail
    1. It's always very painful to figure out where the mismatch happens between exploration and postprocessing
    2. It's still painful but easier