### PR TITLE
front: ensure NGE's Node.id is always a number

### DIFF
--- a/front/src/applications/operationalStudies/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/components/NGE/types.ts
@@ -7,7 +7,7 @@ export type Haltezeit = {
 };
 
 export type Node = {
-  id: number | string; // TODO: in NGE this is a number
+  id: number;
   /** Trigram */
   betriebspunktName: string;
   fullName: string;
@@ -67,9 +67,9 @@ export type TimeLock = {
 
 export type TrainrunSection = {
   id: number;
-  sourceNodeId: number | string;
+  sourceNodeId: number;
   sourcePortId: number;
-  targetNodeId: number | string;
+  targetNodeId: number;
   targetPortId: number;
 
   travelTime: TimeLock;


### PR DESCRIPTION
We were abusing this field to store the OSRD OP ID. However, NGE's type expects this value to always be an integer. Using anything else is quite fragile and might result in fireworks (e.g. when NGE tries to perform math on string values to auto-increment the ID).

Stop storing the OP ID, instead just use a boring auto-incremented integer like we do for other object IDs.