### PR TITLE
front: replace some type assertions with non-null assertions

### DIFF
--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -174,13 +174,13 @@ const MapUnplugged = ({
                 feature.properties.id !== toolState.hovered?.id
               ) {
                 partialToolState.hovered = {
-                  id: feature.properties?.id as string,
+                  id: feature.properties.id,
                   type: LAYER_TO_EDITOAST_DICT[feature.sourceLayer as Layer],
                   renderedEntity: feature,
                 };
               } else if (feature.sourceLayer === 'errors') {
                 partialToolState.hovered = {
-                  id: feature.properties?.obj_id as string,
+                  id: feature.properties.obj_id,
                   type: feature.properties?.obj_type,
                   renderedEntity: feature,
                   error: feature.properties as InfraError,
@@ -255,23 +255,20 @@ const MapUnplugged = ({
               : e;
             if (toolState.hovered && activeTool.onClickEntity) {
               if (toolState.hovered.type) {
-                getEntity(
-                  infraID as number,
-                  toolState.hovered.id,
-                  toolState.hovered.type,
-                  dispatch
-                ).then((entity) => {
-                  if (activeTool.onClickEntity) {
-                    // Those features lack a proper "geometry", and have a "_geometry"
-                    // instead. This fixes it:
-                    entity = {
-                      ...entity,
-                      // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/no-explicit-any
-                      geometry: entity.geometry || (entity as any)._geometry,
-                    };
-                    activeTool.onClickEntity(entity, eventWithFeature, extendedContext);
+                getEntity(infraID!, toolState.hovered.id, toolState.hovered.type, dispatch).then(
+                  (entity) => {
+                    if (activeTool.onClickEntity) {
+                      // Those features lack a proper "geometry", and have a "_geometry"
+                      // instead. This fixes it:
+                      entity = {
+                        ...entity,
+                        // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/no-explicit-any
+                        geometry: entity.geometry || (entity as any)._geometry,
+                      };
+                      activeTool.onClickEntity(entity, eventWithFeature, extendedContext);
+                    }
                   }
-                });
+                );
               }
             }
             if (activeTool.onClickMap) {

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -328,10 +328,10 @@ const EntitySumUp = ({ entity, id, objType, classes, status, error }: EntitySumU
       setState({ type: 'loading' });
 
       if (!entity) {
-        entity = await getEntity(infraID as number, id, objType as EditoastType, dispatch);
+        entity = await getEntity(infraID!, id, objType as EditoastType, dispatch);
       }
 
-      const additionalEntities = await getAdditionalEntities(infraID as number, entity, dispatch);
+      const additionalEntities = await getAdditionalEntities(infraID!, entity, dispatch);
       setState({
         type: 'ready',
         entity,

--- a/front/src/applications/editor/components/InfraErrors/InfraErrorCorrectorModal.tsx
+++ b/front/src/applications/editor/components/InfraErrors/InfraErrorCorrectorModal.tsx
@@ -19,7 +19,7 @@ const InfraErrorCorrectorModal = () => {
 
   const { data: infraAutoFixes, isLoading } =
     osrdEditoastApi.endpoints.getInfraByInfraIdAutoFixes.useQuery(
-      { infraId: infraId as number },
+      { infraId: infraId! },
       { skip: !infraId }
     );
 

--- a/front/src/applications/editor/components/LayersModal.tsx
+++ b/front/src/applications/editor/components/LayersModal.tsx
@@ -1,17 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import {
-  groupBy,
-  mapKeys,
-  mapValues,
-  sum,
-  isString,
-  isArray,
-  uniq,
-  isNil,
-  concat,
-  compact,
-} from 'lodash';
+import { groupBy, mapKeys, mapValues, sum, isString, isArray, uniq, concat, compact } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { GiElectric, GiUnplugged } from 'react-icons/gi';
 import { MdSpeed } from 'react-icons/md';
@@ -80,8 +69,8 @@ const LayersModal = ({ initialLayers, selection, frozenLayers, onChange }: Layer
 
   const { data: speedLimitTagsByInfraId } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
-      { infraId: infraID as number },
-      { skip: isNil(infraID) }
+      { infraId: infraID! },
+      { skip: !infraID }
     );
   const { data: speedLimitTags } = osrdEditoastApi.endpoints.getSpeedLimitTags.useQuery();
 

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -421,7 +421,7 @@ export const FormComponent = (props: FieldProps) => {
   // Get the distance of the geometry
   const distance = useMemo(() => {
     if (!isNil(formContext.length)) {
-      return formContext.length as number;
+      return formContext.length!;
     }
     if (formContext.geometry?.type === 'LineString') {
       return getLineStringDistance(formContext.geometry);

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
@@ -72,24 +72,22 @@ const PointEditionLeftPanel = <Entity extends EditorEntity>({
 
   useEffect(() => {
     const firstLoading = trackState.type === 'idle';
-    const trackId = state.entity.properties.track as string | undefined;
+    const trackId: string | undefined = state.entity.properties.track;
 
     if (trackId && trackState.id !== trackId) {
       setTrackState({ type: 'isLoading', id: trackId });
-      getEntity<TrackSectionEntity>(infraID as number, trackId, 'TrackSection', dispatch).then(
-        (track) => {
-          setTrackState({ type: 'ready', id: trackId, track });
+      getEntity<TrackSectionEntity>(infraID!, trackId, 'TrackSection', dispatch).then((track) => {
+        setTrackState({ type: 'ready', id: trackId, track });
 
-          if (!firstLoading) {
-            const { position } = state.entity.properties;
-            const turfPosition =
-              (position * length(track, { units: 'meters' })) / track.properties.length;
-            const point = along(track, turfPosition, { units: 'meters' });
+        if (!firstLoading) {
+          const { position } = state.entity.properties;
+          const turfPosition =
+            (position * length(track, { units: 'meters' })) / track.properties.length;
+          const point = along(track, turfPosition, { units: 'meters' });
 
-            setState({ ...state, entity: { ...state.entity, geometry: point.geometry } });
-          }
+          setState({ ...state, entity: { ...state.entity, geometry: point.geometry } });
         }
-      );
+      });
     }
   }, [infraID, setState, state, state.entity.properties.track, trackState.id, trackState.type]);
 

--- a/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
@@ -168,21 +168,19 @@ function getPointEditionTool<T extends EditorPoint>({
         newEntity.properties = newEntity.properties || {};
         newEntity.properties.track = nearestPoint.trackSectionID;
 
-        getEntity(infraID as number, newEntity.properties.track, 'TrackSection', dispatch).then(
-          (track) => {
-            const distanceAlongTrack = calculateDistanceAlongTrack(
-              track as TrackSectionEntity,
-              newEntity.geometry as Point
-            );
-            newEntity.properties.position = distanceAlongTrack;
+        getEntity(infraID!, newEntity.properties.track, 'TrackSection', dispatch).then((track) => {
+          const distanceAlongTrack = calculateDistanceAlongTrack(
+            track as TrackSectionEntity,
+            newEntity.geometry as Point
+          );
+          newEntity.properties.position = distanceAlongTrack;
 
-            setState({
-              ...state,
-              entity: newEntity,
-              nearestPoint: null,
-            });
-          }
-        );
+          setState({
+            ...state,
+            entity: newEntity,
+            nearestPoint: null,
+          });
+        });
       }
     },
     onMove(e, { setState, state }) {
@@ -247,7 +245,7 @@ function getPointEditionTool<T extends EditorPoint>({
 
       if (typeof trackId !== 'string') return;
 
-      getEntity(infraID as number, trackId, 'TrackSection', dispatch).then((track) => {
+      getEntity(infraID!, trackId, 'TrackSection', dispatch).then((track) => {
         const dbPosition = entity.properties.position;
         const computedPosition = nearestPointOnLine(
           (track as Feature<LineString>).geometry,

--- a/front/src/applications/editor/tools/rangeEdition/components/RangeEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/components/RangeEditionLeftPanel.tsx
@@ -102,7 +102,7 @@ const RangeEditionLeftPanel = () => {
 
   const { data: voltages } = osrdEditoastApi.endpoints.getInfraByInfraIdVoltages.useQuery(
     {
-      infraId: infraID as number,
+      infraId: infraID!,
     },
     { skip: !infraID }
   );
@@ -110,7 +110,7 @@ const RangeEditionLeftPanel = () => {
   const { data: speedLimitTagsByInfraId } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
       {
-        infraId: infraID as number,
+        infraId: infraID!,
       },
       { skip: !infraID }
     );
@@ -190,7 +190,7 @@ const RangeEditionLeftPanel = () => {
       optionsState: { type: 'loading' },
     });
     const routesAndNodesPositions = await getRoutesFromSwitch({
-      infraId: infraID as number,
+      infraId: infraID!,
       body,
     }).unwrap();
     const { routes, available_node_positions } = routesAndNodesPositions;
@@ -206,7 +206,7 @@ const RangeEditionLeftPanel = () => {
     setSwitchesRouteCandidates(routes);
     setAvailableSwitchesPositions(available_node_positions);
     const trackRangesResults = await getTrackRangesByRoutes({
-      infraId: infraID as number,
+      infraId: infraID!,
       routes: routes.join(','),
     }).unwrap();
     const newRouteElements = makeRouteElements(trackRangesResults, routes);

--- a/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/electrification/ElectrificationEditionLayers.tsx
@@ -93,20 +93,17 @@ export const ElectrificationEditionLayers = () => {
         ),
       }));
 
-      getEntities<TrackSectionEntity>(
-        infraID as number,
-        missingTrackIDs,
-        'TrackSection',
-        dispatch
-      ).then((res) => {
-        setState((s) => ({
-          ...s,
-          trackSectionsCache: {
-            ...s.trackSectionsCache,
-            ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
-          },
-        }));
-      });
+      getEntities<TrackSectionEntity>(infraID!, missingTrackIDs, 'TrackSection', dispatch).then(
+        (res) => {
+          setState((s) => ({
+            ...s,
+            trackSectionsCache: {
+              ...s.trackSectionsCache,
+              ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
+            },
+          }));
+        }
+      );
     }
   }, [entity.properties?.track_ranges]);
 
@@ -121,20 +118,17 @@ export const ElectrificationEditionLayers = () => {
         },
       }));
 
-      getEntity<TrackSectionEntity>(
-        infraID as number,
-        hoveredItem.id,
-        'TrackSection',
-        dispatch
-      ).then((track) => {
-        setState((s) => ({
-          ...s,
-          trackSectionsCache: {
-            ...s.trackSectionsCache,
-            [hoveredItem.id]: { type: 'success', track },
-          },
-        }));
-      });
+      getEntity<TrackSectionEntity>(infraID!, hoveredItem.id, 'TrackSection', dispatch).then(
+        (track) => {
+          setState((s) => ({
+            ...s,
+            trackSectionsCache: {
+              ...s.trackSectionsCache,
+              [hoveredItem.id]: { type: 'success', track },
+            },
+          }));
+        }
+      );
     }
   }, [hoveredItem]);
 

--- a/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/SpeedSectionEditionLayers.tsx
@@ -163,20 +163,17 @@ export const SpeedSectionEditionLayers = () => {
         ),
       }));
 
-      getEntities<TrackSectionEntity>(
-        infraID as number,
-        missingTrackIDs,
-        'TrackSection',
-        dispatch
-      ).then((res) => {
-        setState((s) => ({
-          ...s,
-          trackSectionsCache: {
-            ...s.trackSectionsCache,
-            ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
-          },
-        }));
-      });
+      getEntities<TrackSectionEntity>(infraID!, missingTrackIDs, 'TrackSection', dispatch).then(
+        (res) => {
+          setState((s) => ({
+            ...s,
+            trackSectionsCache: {
+              ...s.trackSectionsCache,
+              ...mapValues(res, (track) => ({ type: 'success', track }) as TrackState),
+            },
+          }));
+        }
+      );
     }
   }, [entity.properties?.track_ranges]);
 
@@ -191,20 +188,17 @@ export const SpeedSectionEditionLayers = () => {
         },
       }));
 
-      getEntity<TrackSectionEntity>(
-        infraID as number,
-        hoveredItem.id,
-        'TrackSection',
-        dispatch
-      ).then((track) => {
-        setState((s) => ({
-          ...s,
-          trackSectionsCache: {
-            ...s.trackSectionsCache,
-            [hoveredItem.id]: { type: 'success', track },
-          },
-        }));
-      });
+      getEntity<TrackSectionEntity>(infraID!, hoveredItem.id, 'TrackSection', dispatch).then(
+        (track) => {
+          setState((s) => ({
+            ...s,
+            trackSectionsCache: {
+              ...s.trackSectionsCache,
+              [hoveredItem.id]: { type: 'success', track },
+            },
+          }));
+        }
+      );
     }
   }, [hoveredItem]);
 

--- a/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/tool-factory.tsx
@@ -317,7 +317,7 @@ function getRangeEditionTool<T extends EditorRange>({
       if (interactionState.type === 'selectSwitch') {
         if (feature.sourceLayer && LAYERS_SET.has(feature.sourceLayer)) {
           const newHoveredItem = {
-            id: feature.properties?.id as string,
+            id: feature.properties.id,
             type: LAYER_TO_EDITOAST_DICT[feature.sourceLayer as Layer],
             renderedEntity: feature,
           };
@@ -325,7 +325,7 @@ function getRangeEditionTool<T extends EditorRange>({
             if (feature.sourceLayer === 'switches') {
               setState({
                 hovered: {
-                  id: feature.properties?.id as string,
+                  id: feature.properties.id,
                   type: LAYER_TO_EDITOAST_DICT[feature.sourceLayer as Layer],
                   renderedEntity: feature,
                 },
@@ -376,8 +376,8 @@ function getRangeEditionTool<T extends EditorRange>({
           itemType: 'PSLSign',
           position: hoveredExtremity.geometry.coordinates,
           track: trackState.track,
-          signIndex: feature.properties?.speedSectionSignIndex as number,
-          signType: feature.properties?.speedSectionSignType as string,
+          signIndex: feature.properties?.speedSectionSignIndex,
+          signType: feature.properties?.speedSectionSignType,
         };
         if (!isEqual(newHoveredItem, hoveredItem))
           setState({
@@ -387,7 +387,7 @@ function getRangeEditionTool<T extends EditorRange>({
       // Handle hovering EditorEntity elements:
       else if (feature.sourceLayer && LAYERS_SET.has(feature.sourceLayer)) {
         const newHoveredItem = {
-          id: feature.properties?.id as string,
+          id: feature.properties.id,
           type: LAYER_TO_EDITOAST_DICT[feature.sourceLayer as Layer],
           renderedEntity: feature,
         };

--- a/front/src/applications/editor/tools/routeEdition/components/WayPointInput.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/WayPointInput.tsx
@@ -96,7 +96,7 @@ const WayPointInput = ({ endPoint, wayPoint, onChange }: WayPointInputProps) => 
     ) {
       if (wayPoint && wayPoint.id !== NEW_ENTITY_ID) {
         setEntityState({ type: 'loading' });
-        getEntity<WayPointEntity>(infraID as number, wayPoint.id, wayPoint.type, dispatch)
+        getEntity<WayPointEntity>(infraID!, wayPoint.id, wayPoint.type, dispatch)
           .then((entity) => {
             setEntityState({ type: 'data', entity });
             // we call the onchange here to populate the state `extremitiesEntities`

--- a/front/src/applications/editor/tools/routeEdition/utils.ts
+++ b/front/src/applications/editor/tools/routeEdition/utils.ts
@@ -262,12 +262,12 @@ export async function getCompatibleRoutesPayload(
 
   return {
     starting: {
-      track: entryPointEntity.properties.track as string,
-      position: entryPointEntity.properties.position as number,
+      track: entryPointEntity.properties.track!,
+      position: entryPointEntity.properties.position!,
     },
     ending: {
-      track: exitPointEntity.properties.track as string,
-      position: exitPointEntity.properties.position as number,
+      track: exitPointEntity.properties.track!,
+      position: exitPointEntity.properties.position!,
     },
   };
 }

--- a/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
+++ b/front/src/applications/editor/tools/selection/components/SelectionLayers.tsx
@@ -75,9 +75,7 @@ const SelectionLayers = () => {
             objType={state.hovered.type}
             error={state.hovered.error}
             status={
-              state.selection.find(
-                (item) => item.properties.id === (state.hovered?.id as string)
-              ) && 'selected'
+              state.selection.find((item) => item.properties.id === state.hovered?.id) && 'selected'
             }
           />
         </Popup>

--- a/front/src/applications/editor/tools/selection/tool.tsx
+++ b/front/src/applications/editor/tools/selection/tool.tsx
@@ -224,12 +224,12 @@ const SelectionTool: Tool<SelectionState> = {
 
           setState({ isLoading: true });
           getMixedEntities(
-            infraID as number,
+            infraID!,
             selection.flatMap((entity) =>
               entity.properties?.id
                 ? [
                     {
-                      id: entity.properties.id as string,
+                      id: entity.properties.id,
                       type: LAYER_TO_EDITOAST_DICT[entity.sourceLayer as Layer],
                     },
                   ]
@@ -269,8 +269,8 @@ const SelectionTool: Tool<SelectionState> = {
           const selection = selectInZone(
             map
               .queryRenderedFeatures([
-                map.project([min(lngs) as number, min(lats) as number]),
-                map.project([max(lngs) as number, max(lats) as number]),
+                map.project([min(lngs)!, min(lats)!]),
+                map.project([max(lngs)!, max(lats)!]),
               ] as [PointLike, PointLike])
               .filter((f) => !f.layer.id.startsWith('osm')),
             {
@@ -281,12 +281,12 @@ const SelectionTool: Tool<SelectionState> = {
 
           setState({ isLoading: true });
           getMixedEntities(
-            infraID as number,
+            infraID!,
             selection.flatMap((entity) =>
               entity.properties?.id
                 ? [
                     {
-                      id: entity.properties.id as string,
+                      id: entity.properties.id,
                       type: LAYER_TO_EDITOAST_DICT[entity.sourceLayer as Layer],
                     },
                   ]

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLayers.tsx
@@ -72,7 +72,7 @@ const SwitchEditionLayers = () => {
       (trackStatus.type === 'loaded' && trackStatus.trackSection.properties.id !== hoveredTrackId)
     ) {
       setTrackStatus({ type: 'loading', trackSectionID: hoveredTrackId });
-      getEntity<TrackSectionEntity>(infraID as number, hoveredTrackId, 'TrackSection', dispatch)
+      getEntity<TrackSectionEntity>(infraID!, hoveredTrackId, 'TrackSection', dispatch)
         .then((trackSection) => {
           setTrackStatus({ type: 'loaded', trackSection });
         })
@@ -134,7 +134,7 @@ const SwitchEditionLayers = () => {
       setGeometryState({ type: 'ready' });
     } else {
       setGeometryState({ type: 'loading' });
-      getEntity<TrackSectionEntity>(infraID as number, port.track, 'TrackSection', dispatch).then(
+      getEntity<TrackSectionEntity>(infraID!, port.track, 'TrackSection', dispatch).then(
         (track) => {
           if (!track || !track.geometry.coordinates.length) setGeometryState({ type: 'ready' });
 

--- a/front/src/applications/editor/tools/switchEdition/components/TrackSectionEndpointSelector.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/TrackSectionEndpointSelector.tsx
@@ -90,14 +90,11 @@ const TrackSectionEndpointSelector = ({ schema, formData, onChange, name }: Fiel
 
   useEffect(() => {
     if (typeof formData?.track === 'string') {
-      getEntity<TrackSectionEntity>(
-        infraID as number,
-        formData.track,
-        'TrackSection',
-        dispatch
-      ).then((track) => {
-        setTrackSection(track);
-      });
+      getEntity<TrackSectionEntity>(infraID!, formData.track, 'TrackSection', dispatch).then(
+        (track) => {
+          setTrackSection(track);
+        }
+      );
     } else {
       setTrackSection(null);
     }

--- a/front/src/applications/editor/tools/switchEdition/utils.ts
+++ b/front/src/applications/editor/tools/switchEdition/utils.ts
@@ -16,7 +16,7 @@ export function getNewSwitch(type: SwitchType): Partial<SwitchEntity> {
     objType: 'Switch',
     properties: {
       ports: {},
-      switch_type: type.id as string,
+      switch_type: type.id,
       id: NEW_ENTITY_ID,
     },
   };
@@ -76,7 +76,7 @@ export function flatSwitchToSwitch(
     properties: {
       ...omitBy(flatSwitch.properties, (_, key) => key.indexOf(FLAT_SWITCH_PORTS_PREFIX) === 0),
       id: flatSwitch.properties.id,
-      switch_type: switchType.id as string,
+      switch_type: switchType.id,
       ports: {
         ...switchType.ports.reduce(
           (iter, port) => ({

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -350,7 +350,7 @@ const TrackEditionTool: Tool<TrackEditionState> = {
       } else if (point && typeof editionState.hoveredPointIndex !== 'number') {
         newState.editionState = {
           ...editionState,
-          hoveredPointIndex: point.feature.properties?.index as number,
+          hoveredPointIndex: point.feature.properties.index,
         };
       }
     }

--- a/front/src/applications/editor/tools/trackSplit/components/TrackSplitLeftPanel.tsx
+++ b/front/src/applications/editor/tools/trackSplit/components/TrackSplitLeftPanel.tsx
@@ -26,7 +26,7 @@ const TrackSplitLeftPanel = () => {
         // Call the API to split the track
         const res = await dispatch(saveSplitTrackSection(infraID, s.track.properties.id, s.offset));
         // From the result, get the two newly tracksections
-        const tracksections = await getEntities(infraID as number, res, 'TrackSection', dispatch);
+        const tracksections = await getEntities(infraID!, res, 'TrackSection', dispatch);
         // Redirect to the selection tool with the tracksections selected
         switchTool({
           toolType: TOOL_NAMES.SELECTION,

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -18,15 +18,15 @@ const useSimulationResults = (): SimulationResultsData => {
 
   const { data: selectedTrainSchedule } = osrdEditoastApi.endpoints.getTrainScheduleById.useQuery(
     {
-      id: selectedTrainId as number,
+      id: selectedTrainId!,
     },
     { skip: !selectedTrainId }
   );
 
   const { data: rawPath } = osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useQuery(
     {
-      id: selectedTrainId as number,
-      infraId: infraId as number,
+      id: selectedTrainId!,
+      infraId: infraId!,
     },
     { skip: !selectedTrainId || !infraId }
   );
@@ -34,7 +34,7 @@ const useSimulationResults = (): SimulationResultsData => {
 
   const { data: trainSimulation } =
     osrdEditoastApi.endpoints.getTrainScheduleByIdSimulation.useQuery(
-      { id: selectedTrainId as number, infraId: infraId as number, electricalProfileSetId },
+      { id: selectedTrainId!, infraId: infraId!, electricalProfileSetId },
       { skip: !selectedTrainId || !infraId }
     );
 

--- a/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
+++ b/front/src/applications/rollingStockEditor/views/RollingStockEditor.tsx
@@ -25,7 +25,7 @@ const RollingStockEditor = () => {
   const { data: selectedRollingStock } =
     osrdEditoastApi.endpoints.getRollingStockByRollingStockId.useQuery(
       {
-        rollingStockId: openedRollingStockCardId as number,
+        rollingStockId: openedRollingStockCardId!,
       },
       {
         skip: !openedRollingStockCardId,

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -25,14 +25,15 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmV2SuccessResponse) => {
     }
   );
 
+  const trainIds = timetable?.train_ids;
   const { currentData: trainSchedules } = osrdEditoastApi.endpoints.postTrainSchedule.useQuery(
     {
       body: {
-        ids: timetable?.train_ids as number[],
+        ids: trainIds!,
       },
     },
     {
-      skip: !timetable || !timetable.train_ids.length,
+      skip: !trainIds || !trainIds.length,
     }
   );
 

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -52,7 +52,7 @@ const useStdcm = (showFailureNotification: boolean = true) => {
   const { data: stdcmRollingStock } =
     osrdEditoastApi.endpoints.getLightRollingStockByRollingStockId.useQuery(
       {
-        rollingStockId: osrdconf.rollingStockID as number,
+        rollingStockId: osrdconf.rollingStockID!,
       },
       { skip: !osrdconf.rollingStockID }
     );

--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -35,7 +35,7 @@ const useStdcmResults = (
   const { data: otherSelectedTrainSchedule } =
     osrdEditoastApi.endpoints.getTrainScheduleById.useQuery(
       {
-        id: selectedTrainId as number,
+        id: selectedTrainId!,
       },
       { skip: !selectedTrainId || selectedTrainId === STDCM_TRAIN_ID }
     );

--- a/front/src/applications/stdcm/views/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/views/StdcmConfig.tsx
@@ -69,7 +69,7 @@ const StdcmConfig = ({
   const { t } = useTranslation(['translation', 'stdcm', 'simulation']);
 
   const { data: infra } = osrdEditoastApi.endpoints.getInfraByInfraId.useQuery(
-    { infraId: infraID as number },
+    { infraId: infraID! },
     {
       skip: !infraID,
       pollingInterval: !isInfraLoaded ? 1000 : undefined,

--- a/front/src/common/Map/Search/MapSearchLine.tsx
+++ b/front/src/common/Map/Search/MapSearchLine.tsx
@@ -67,7 +67,7 @@ const MapSearchLine = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchLine
     if (map.mapSearchMarker) {
       dispatch(updateMapSearchMarker(undefined));
     }
-    await getTrackPath({ infraId: infraID as number, lineCode: searchResultItem.line_code })
+    await getTrackPath({ infraId: infraID!, lineCode: searchResultItem.line_code })
       .unwrap()
       .then((trackPath) => {
         const boundaries = bbox({

--- a/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
+++ b/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
@@ -40,7 +40,7 @@ const FormatSwitch = ({ name, icon: IconComponent, color = '', disabled }: Forma
     isError: isGetSpeedLimitTagsError,
     error: getSpeedLimitTagsError,
   } = osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
-    { infraId: infraID as number },
+    { infraId: infraID! },
     {
       skip: !infraID,
     }

--- a/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
+++ b/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
@@ -243,7 +243,7 @@ const SimulationWarpedMap = ({
   useEffect(() => {
     if (state.type !== 'dataLoaded') return;
 
-    getImprovedOSRDData(infraID as number, state.osrd, dispatch).then((betterFeatures) => {
+    getImprovedOSRDData(infraID!, state.osrd, dispatch).then((betterFeatures) => {
       if (!isEmpty(betterFeatures)) {
         const betterTransformedFeatures = mapValues(betterFeatures, state.transform);
         const newTransformedOSRDData = mapValues(state.osrd, (collection: FeatureCollection) => ({

--- a/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
+++ b/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
@@ -30,7 +30,7 @@ export const useStoreDataForSpeedLimitByTagSelector = () => {
   const { data: speedLimitsTagsByInfraId = [], error } =
     osrdEditoastApi.endpoints.getInfraByInfraIdSpeedLimitTags.useQuery(
       {
-        infraId: infraID as number,
+        infraId: infraID!,
       },
       { skip: !infraID }
     );

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -253,7 +253,7 @@ const TypeAndPath = ({ setDisplayTypeAndPath }: TypeAndPathProps) => {
               className="form-control form-control-sm text-zone"
               type="text"
               value={inputText}
-              onChange={(e) => handleInput(e.target.value, e.target.selectionStart as number)}
+              onChange={(e) => handleInput(e.target.value, e.target.selectionStart!)}
               placeholder={tManageTrainSchedule('inputOPTrigramsExample')}
               autoFocus
               data-testid="type-and-path-input"

--- a/front/src/modules/pathfinding/hooks/useInfraStatus.ts
+++ b/front/src/modules/pathfinding/hooks/useInfraStatus.ts
@@ -17,7 +17,7 @@ export default function useInfraStatus() {
   const [isInfraError, setIsInfraError] = useState(false);
 
   const { data: infra } = osrdEditoastApi.endpoints.getInfraByInfraId.useQuery(
-    { infraId: infraId as number },
+    { infraId: infraId! },
     {
       refetchOnMountOrArgChange: true,
       pollingInterval: !isInfraLoaded ? 1000 : undefined,
@@ -28,7 +28,7 @@ export default function useInfraStatus() {
   useEffect(() => {
     if (reloadCount <= 5 && infra && infra.state === 'TRANSIENT_ERROR') {
       setTimeout(() => {
-        reloadInfra({ infraId: infraId as number }).unwrap();
+        reloadInfra({ infraId: infraId! }).unwrap();
         setReloadCount((count) => count + 1);
       }, 1000);
     }
@@ -47,7 +47,7 @@ export default function useInfraStatus() {
           setIsInfraLoaded(false);
           break;
         case 'NOT_LOADED': {
-          reloadInfra({ infraId: infraId as number }).unwrap();
+          reloadInfra({ infraId: infraId! }).unwrap();
           setIsInfraLoaded(false);
           break;
         }
@@ -69,7 +69,7 @@ export default function useInfraStatus() {
 
   useEffect(() => {
     if (isInfraError) {
-      reloadInfra({ infraId: infraId as number }).unwrap();
+      reloadInfra({ infraId: infraId! }).unwrap();
       setIsInfraLoaded(false);
     }
   }, [isInfraError]);

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardButtons.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardButtons.tsx
@@ -28,7 +28,7 @@ const RollingStockCardButtons = ({
 
   const { getRollingStockComfort } = useOsrdConfSelectors();
   const currentComfortInStore = useSelector(getRollingStockComfort);
-  const [comfort, setComfort] = useState(currentComfortInStore as string);
+  const [comfort, setComfort] = useState<string>(currentComfortInStore);
 
   const { updateRollingStockComfort, updateRollingStockID } = useOsrdConfActions();
 

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
@@ -228,8 +228,8 @@ const RollingStockEditorParameterFormColumn = ({
             isInvalid={
               property.type === 'number' &&
               (Number.isNaN(rollingStockValues[property.title]) ||
-                (rollingStockValues[property.title] as number) < (property.min as number) ||
-                (rollingStockValues[property.title] as number) > (property.max as number))
+                (rollingStockValues[property.title] as number) < property.min! ||
+                (rollingStockValues[property.title] as number) > property.max!)
             }
             errorMsg={
               property.max

--- a/front/src/modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector.ts
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector.ts
@@ -10,7 +10,7 @@ export const useStoreDataForRollingStockSelector = () => {
 
   const { data: rollingStock } = osrdEditoastApi.endpoints.getRollingStockByRollingStockId.useQuery(
     {
-      rollingStockId: rollingStockId as number,
+      rollingStockId: rollingStockId!,
     },
     {
       skip: !rollingStockId,

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -42,7 +42,7 @@ export const filterNullValueInCurve = (curve: EffortCurveForm) =>
       }
       return result;
     },
-    { speeds: [] as number[], max_efforts: [] as number[] }
+    { speeds: [], max_efforts: [] }
   );
 
 export const getDefaultRollingStockMode = (selectedMode: string | null): EffortCurveForms | null =>
@@ -151,7 +151,7 @@ export const rollingStockEditorQueryArg = (
       { unit: 'm/s', value: data.maxSpeed.value },
       data.maxSpeed,
       data.mass
-    ) as number, // Back-end needs value in m/s.
+    )!, // Back-end needs value in m/s.
     startup_time: data.startupTime,
     startup_acceleration: data.startupAcceleration,
     comfort_acceleration: data.comfortAcceleration,
@@ -166,17 +166,17 @@ export const rollingStockEditorQueryArg = (
         { unit: 'N', value: data.rollingResistanceA.value },
         data.rollingResistanceA,
         data.mass
-      ) as number, // Back-end needs value in N.
+      )!, // Back-end needs value in N.
       B: handleUnitValue(
         { unit: 'N/(m/s)', value: data.rollingResistanceB.value },
         data.rollingResistanceB,
         data.mass
-      ) as number, // Back-end needs value in N/(m/s).
+      )!, // Back-end needs value in N/(m/s).
       C: handleUnitValue(
         { unit: 'N/(m/s)²', value: data.rollingResistanceC.value },
         data.rollingResistanceC,
         data.mass
-      ) as number, // Back-end needs value in N/(m/s)².
+      )!, // Back-end needs value in N/(m/s)².
       type: 'davis',
     },
     loading_gauge: data.loadingGauge,

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -175,7 +175,7 @@ export default function AddOrEditScenarioModal({
         .unwrap()
         .then(({ id }) => {
           dispatch(updateScenarioID(id));
-          loadInfra({ infraId: infraID as number }).unwrap();
+          loadInfra({ infraId: infraID! }).unwrap();
           navigate(`projects/${projectId}/studies/${studyId}/scenarios/${id}`);
           closeModal();
         })

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -34,22 +34,22 @@ const ScenarioExplorer = ({
 
   const { updateInfraID, updateTimetableID, updateScenarioID } = useOsrdConfActions();
   const { data: projectDetails } = osrdEditoastApi.endpoints.getProjectsByProjectId.useQuery(
-    { projectId: globalProjectId as number },
+    { projectId: globalProjectId! },
     { skip: !globalProjectId }
   );
 
   const { data: studyDetails } =
     osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyId.useQuery(
-      { projectId: globalProjectId as number, studyId: globalStudyId as number },
+      { projectId: globalProjectId!, studyId: globalStudyId! },
       { skip: !globalProjectId && !globalStudyId }
     );
 
   const { currentData: scenario, isSuccess: isScenarioSuccess } =
     osrdEditoastApi.endpoints.getProjectsByProjectIdStudiesAndStudyIdScenariosScenarioId.useQuery(
       {
-        projectId: globalProjectId as number,
-        studyId: globalStudyId as number,
-        scenarioId: globalScenarioId as number,
+        projectId: globalProjectId!,
+        studyId: globalStudyId!,
+        scenarioId: globalScenarioId!,
       },
       {
         skip: !globalProjectId || !globalStudyId || !globalScenarioId,
@@ -58,7 +58,7 @@ const ScenarioExplorer = ({
     );
 
   const { data: timetable } = osrdEditoastApi.endpoints.getTimetableById.useQuery(
-    { id: timetableID as number },
+    { id: timetableID! },
     { skip: !timetableID }
   );
 

--- a/front/src/modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues.ts
+++ b/front/src/modules/simulationResult/components/ChartHelpers/getScaleDomainFromValues.ts
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 import { mmToM } from 'utils/physics';
 
 export const getScaleDomainFromValues = (values: number[]) => {
-  const [minScaleValue, maxScaleValue] = d3.extent(values) as number[];
+  const [minScaleValue, maxScaleValue] = d3.extent(values);
   // These values needs to be in meters
-  return [mmToM(minScaleValue), mmToM(maxScaleValue) + 100];
+  return [mmToM(minScaleValue!), mmToM(maxScaleValue!) + 100];
 };

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
@@ -32,12 +32,13 @@ const useSpeedSpaceChart = (
   const [formattedPowerRestrictions, setFormattedPowerRestrictions] =
     useState<LayerData<PowerRestrictionValues>[]>();
 
+  const rollingStockName = trainScheduleResult?.rolling_stock_name;
   const { data: rollingStock } =
     osrdEditoastApi.endpoints.getRollingStockNameByRollingStockName.useQuery(
       {
-        rollingStockName: trainScheduleResult?.rolling_stock_name as string,
+        rollingStockName: rollingStockName!,
       },
-      { skip: !trainScheduleResult }
+      { skip: !rollingStockName }
     );
 
   const pathProperties = usePathProperties(infraId, pathfindingResult, [

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayloads.ts
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayloads.ts
@@ -20,10 +20,10 @@ export function generateTrainSchedulesPayloads(
             train.departureTime,
             step.arrivalTime
           );
-          const schedulePoint = {
+          const schedulePoint: NonNullable<TrainScheduleBase['schedule']>[number] = {
             at: stepId,
             arrival: formatDurationAsISO8601(timeDifferenceInSeconds),
-            stop_for: null as string | null,
+            stop_for: null,
           };
           if (step.duration || index === train.steps.length - 1) {
             schedulePoint.stop_for = `PT${step.duration || 0}S`;

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/TrainSettings.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/TrainSettings.tsx
@@ -123,7 +123,7 @@ export default function TrainSettings() {
           noMargin
           unit="km/h"
           textRight
-          isInvalid={isInvalidFloatNumber(initialSpeed as number, 1)}
+          isInvalid={isInvalidFloatNumber(initialSpeed!, 1)}
           errorMsg={t('errorMessages.invalidInitialSpeed')}
         />
       </div>

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
@@ -91,7 +91,7 @@ const checkCurrentConfig = (
     );
   }
 
-  if (isInvalidFloatNumber(initialSpeed as number, 1)) {
+  if (isInvalidFloatNumber(initialSpeed!, 1)) {
     error = true;
     dispatch(
       setFailure({
@@ -135,9 +135,9 @@ const checkCurrentConfig = (
   if (error) return null;
   return {
     constraintDistribution,
-    rollingStockName: rollingStockName as string,
+    rollingStockName: rollingStockName!,
     baseTrainName: trainName,
-    timetableId: timetableID as number,
+    timetableId: timetableID!,
     trainCount,
     trainStep,
     trainDelta,


### PR DESCRIPTION
In general I prefer to avoid `as` type assertions as much as possible, because it makes the compiler ignore any type mismatch. The non-null assertion operator `!` is a bit better: if the types don't match, the compiler will error out.

Use it in a bunch of places.

See https://github.com/OpenRailAssociation/osrd/pull/8698#discussion_r1745144151