### PR TITLE
front: fix missing rolling stock images in train schedule list

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -52,7 +52,7 @@ const useLazyLoadTrains = ({
   const [postTrainScheduleSimulationSummary] =
     osrdEditoastApi.endpoints.postTrainScheduleSimulationSummary.useLazyQuery();
 
-  const { data: { results: rollingStocks } = { results: [] } } =
+  const { data: { results: rollingStocks } = { results: null } } =
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({ pageSize: 1000 });
 
   const trainSchedulesById = useMemo(() => mapBy(trainSchedules, 'id'), [trainSchedules]);
@@ -103,7 +103,7 @@ const useLazyLoadTrains = ({
             packageToFetch,
             rawSummaries,
             trainSchedulesById,
-            rollingStocks
+            rollingStocks!
           );
 
           // as formattedSummaries is a dictionary, we replace the previous values with the new ones
@@ -115,10 +115,10 @@ const useLazyLoadTrains = ({
       setAllTrainsLoaded(true);
     };
 
-    if (infraId && trainIdsToFetch && trainIdsToFetch.length > 0) {
+    if (infraId && trainIdsToFetch && rollingStocks && trainIdsToFetch.length > 0) {
       getTrainScheduleSummaries(infraId, trainIdsToFetch);
     }
-  }, [infraId, trainIdsToFetch]);
+  }, [infraId, trainIdsToFetch, rollingStocks]);
 
   return {
     trainScheduleSummariesById,


### PR DESCRIPTION
We were calling formatTrainScheduleSummaries() before the rolling stock list got fetched. As a result all rolling stocks in the formatted train schedule summaries were null on first load.

Wait for the rolling stock list to be available before kicking off the train schedule summaries lazy loading.

To reproduce:

- Go to a scenario with less than 10 trains, wait for it to load completely (to ensure core is properly spin up)
- Reload the page
- Before this patch, rolling stock images would be missing

Closes: https://github.com/OpenRailAssociation/osrd/issues/8723