### PR TITLE
front: add a 'packageManager' version

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -238,5 +238,6 @@
       "text",
       "cobertura"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
When following the [official procedure](https://yarnpkg.com/getting-started/install) to install `yarn`,
 `corepack` yells about not finding a `packageManager` defined in `package.json`,
and then choose one to add it.

```
! Corepack is about to download https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz
? Do you want to continue? [Y/n] Y

! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```

:warning: It is to be noted that `yarn` documents installation through `corepack` which itself is still [experimental](https://nodejs.org/api/corepack.html#corepack).