### PR TITLE
editoast: add default log directive to display all HTTP calls

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -76,7 +76,10 @@ uuid = { version = "1.10.0", features = ["serde", "v4"] }
 # For batch dependency updates, see editoast/README.md
 
 async-trait = "0.1.82"
-axum = { version = "0.7.5", default-features = false, features = ["multipart"] }
+axum = { version = "0.7.5", default-features = false, features = [
+  "multipart",
+  "tracing",
+] }
 axum-extra = { version = "0.9.3", default-features = false, features = [
   "typed-header",
 ] }
@@ -181,6 +184,7 @@ async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 axum = { version = "0.7.5", default-features = false, features = [
   "macros",
   "multipart",
+  "tracing",
 ] }
 editoast_authz = { workspace = true, features = ["fixtures"] }
 editoast_models = { workspace = true, features = ["testing"] }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -94,7 +94,12 @@ fn init_tracing(mode: EditoastMode, telemetry_config: &client::TelemetryConfig) 
     let env_filter_layer = tracing_subscriber::EnvFilter::builder()
         // Set the default log level to 'info'
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env_lossy();
+        .from_env_lossy()
+        .add_directive(
+            "tower_http=debug"
+                .parse()
+                .expect("valid 'RUST_LOG' directive"),
+        );
     let fmt_layer = tracing_subscriber::fmt::layer()
         .pretty()
         .with_file(true)


### PR DESCRIPTION
As a webservice, it's convenient that the default logs show all the request that goes in. For each request coming in, we should now see something like this.

```
  2024-09-11T04:58:17.332243Z DEBUG tower_http::trace::on_request: started processing request
    at /home/me/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tower-http-0.5.2/src/trace/on_request.rs
    in tower_http::trace::make_span::request with method: GET, uri: /, version: HTTP/1.1

  2024-09-11T04:58:17.332532Z DEBUG tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 404
    at /home/me/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tower-http-0.5.2/src/trace/on_response.rs
    in tower_http::trace::make_span::request with method: GET, uri: /, version: HTTP/1.1
```