### PR TITLE
editoast: make authorizer's logs less noisy

### DIFF
--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, future::Future, sync::Arc};
 
 use tracing::debug;
+use tracing::Level;
 
 use crate::roles::{BuiltinRoleSet, RoleConfig};
 
@@ -93,7 +94,7 @@ impl<S: StorageDriver> Authorizer<S> {
     }
 
     /// Check that the user has all the required builting roles
-    #[tracing::instrument(skip_all, fields(user = %self.user, user_roles = ?self.user_roles, ?required_roles), ret, err)]
+    #[tracing::instrument(skip_all, fields(user = %self.user, user_roles = ?self.user_roles, ?required_roles), ret(level = Level::DEBUG), err)]
     pub async fn check_roles(
         &self,
         required_roles: HashSet<S::BuiltinRole>,


### PR DESCRIPTION
So far, each request on an endpoint show the returned value of the authorizer.

```
  2024-09-11T05:01:31.226339Z  INFO editoast_authz::authorizer: return: true
    at editoast_authz/src/authorizer.rs
    in editoast_authz::authorizer::check_roles with user: superuser (Super User), user_roles: {}, required_roles: {RollingStockCollectionRead}
    in tower_http::trace::make_span::request with method: GET, uri: /light_rolling_stock, version: HTTP/1.1
```

It makes the logs on `editoast` pretty noisy. The `ret` on the `tracing::instrument` produces a log event (without `ret` we would still have the span). Ideally, we would like the information of the span to live for the entire duration of the request/response cycle.

However, since the authorizer is not a middleware (feature is on the way I believe), we cannot make the span lives for the entire request/response cycle, it only lives for the very beginning of the endpoint. This means that useful contextual information like `user`, `user_roles` or `required_roles` won't be visible through the logs produced in the endpoint.

In the meantime, leaving `ret`, but making the default level to `DEBUG` seems an OK improvement.