### PR TITLE
editoast, schemas: add 'freight_compatible' to the rolling stock model

### DIFF
--- a/editoast/README.md
+++ b/editoast/README.md
@@ -94,7 +94,7 @@ To make sure it is always valid a CI check has been set up. To update the
 OpenApi when a change has been made to an endpoint, run the following command:
 
 ```sh
-cargo run openapi > openapi.yaml
+cargo run -- openapi > openapi.yaml
 ```
 
 ## Batch dependency updates

--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -462,6 +462,7 @@ diesel::table! {
         raise_pantograph_time -> Nullable<Float8>,
         version -> Int8,
         supported_signaling_systems -> Array<Nullable<Text>>,
+        freight_compatible -> Nullable<Bool>,
     }
 }
 

--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -462,7 +462,7 @@ diesel::table! {
         raise_pantograph_time -> Nullable<Float8>,
         version -> Int8,
         supported_signaling_systems -> Array<Nullable<Text>>,
-        freight_compatible -> Nullable<Bool>,
+        freight_compatible -> Bool,
     }
 }
 

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -76,4 +76,5 @@ pub struct RollingStock {
     pub railjson_version: String,
     #[serde(default)]
     pub metadata: Option<RollingStockMetadata>,
+    pub freight_compatible: Option<bool>,
 }

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -76,5 +76,5 @@ pub struct RollingStock {
     pub railjson_version: String,
     #[serde(default)]
     pub metadata: Option<RollingStockMetadata>,
-    pub freight_compatible: Option<bool>,
+    pub freight_compatible: bool,
 }

--- a/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/down.sql
+++ b/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE rolling_stock
+DROP COLUMN freight_compatible;

--- a/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/up.sql
+++ b/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE rolling_stock
+ADD freight_compatible BOOLEAN;

--- a/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/up.sql
+++ b/editoast/migrations/2024-09-06-114952_add-rolling-stock-freight-compatible/up.sql
@@ -1,3 +1,3 @@
 -- Your SQL goes here
 ALTER TABLE rolling_stock
-ADD freight_compatible BOOLEAN;
+ADD freight_compatible BOOLEAN NOT NULL DEFAULT FALSE;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6108,6 +6108,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
+        freight_compatible:
+          type: boolean
+          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         id:
@@ -7689,6 +7692,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
+        freight_compatible:
+          type: boolean
+          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         id:
@@ -7841,6 +7847,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
+        freight_compatible:
+          type: boolean
+          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         inertia_coefficient:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6095,6 +6095,7 @@ components:
       - power_restrictions
       - energy_sources
       - supported_signaling_systems
+      - freight_compatible
       properties:
         base_power_class:
           type: string
@@ -6110,7 +6111,6 @@ components:
             $ref: '#/components/schemas/EnergySource'
         freight_compatible:
           type: boolean
-          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         id:
@@ -7675,6 +7675,7 @@ components:
       - raise_pantograph_time
       - version
       - supported_signaling_systems
+      - freight_compatible
       properties:
         base_power_class:
           type: string
@@ -7694,7 +7695,6 @@ components:
             $ref: '#/components/schemas/EnergySource'
         freight_compatible:
           type: boolean
-          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         id:
@@ -7827,6 +7827,7 @@ components:
       - loading_gauge
       - power_restrictions
       - supported_signaling_systems
+      - freight_compatible
       properties:
         base_power_class:
           type: string
@@ -7849,7 +7850,6 @@ components:
             $ref: '#/components/schemas/EnergySource'
         freight_compatible:
           type: boolean
-          nullable: true
         gamma:
           $ref: '#/components/schemas/Gamma'
         inertia_coefficient:

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -75,6 +75,7 @@ pub struct RollingStockModel {
     #[schema(value_type = Vec<String>)]
     #[model(remote = "Vec<Option<String>>")]
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
+    pub freight_compatible: Option<bool>,
 }
 
 impl RollingStockModel {
@@ -167,6 +168,7 @@ impl From<RollingStockModel> for RollingStock {
             electrical_power_startup_time: rolling_stock_model.electrical_power_startup_time,
             raise_pantograph_time: rolling_stock_model.raise_pantograph_time,
             supported_signaling_systems: rolling_stock_model.supported_signaling_systems,
+            freight_compatible: rolling_stock_model.freight_compatible,
         }
     }
 }
@@ -194,6 +196,7 @@ impl From<RollingStock> for RollingStockModelChangeset {
             .electrical_power_startup_time(rolling_stock.electrical_power_startup_time)
             .raise_pantograph_time(rolling_stock.raise_pantograph_time)
             .supported_signaling_systems(rolling_stock.supported_signaling_systems)
+            .freight_compatible(rolling_stock.freight_compatible)
     }
 }
 

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -75,7 +75,7 @@ pub struct RollingStockModel {
     #[schema(value_type = Vec<String>)]
     #[model(remote = "Vec<Option<String>>")]
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
-    pub freight_compatible: Option<bool>,
+    pub freight_compatible: bool,
 }
 
 impl RollingStockModel {

--- a/editoast/src/tests/example_rolling_stock_1.json
+++ b/editoast/src/tests/example_rolling_stock_1.json
@@ -982,5 +982,6 @@
     "power_restrictions": {"C2":"2", "C5":"5"},
     "electrical_power_startup_time": 5.0,
     "raise_pantograph_time": 15.0,
-    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"]
+    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
+    "freight_compatible": null
 }

--- a/editoast/src/tests/example_rolling_stock_2_energy_sources.json
+++ b/editoast/src/tests/example_rolling_stock_2_energy_sources.json
@@ -209,5 +209,6 @@
     "power_restrictions": {},
     "electrical_power_startup_time": 6.0,
     "raise_pantograph_time": 16.0,
-    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"]
+    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
+    "freight_compatible": true
 }

--- a/editoast/src/tests/example_rolling_stock_3.json
+++ b/editoast/src/tests/example_rolling_stock_3.json
@@ -68,5 +68,6 @@
     "power_restrictions": {},
     "electrical_power_startup_time": 4.0,
     "raise_pantograph_time": 14.0,
-    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"]
+    "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
+    "freight_compatible": true
 }

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -51,7 +51,7 @@ pub struct RollingStockForm {
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub locked: Option<bool>,
     pub metadata: Option<RollingStockMetadata>,
-    pub freight_compatible: Option<bool>,
+    pub freight_compatible: bool,
 }
 
 impl From<RollingStockForm> for Changeset<RollingStockModel> {

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -51,6 +51,7 @@ pub struct RollingStockForm {
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub locked: Option<bool>,
     pub metadata: Option<RollingStockMetadata>,
+    pub freight_compatible: Option<bool>,
 }
 
 impl From<RollingStockForm> for Changeset<RollingStockModel> {
@@ -77,6 +78,7 @@ impl From<RollingStockForm> for Changeset<RollingStockModel> {
             .electrical_power_startup_time(rolling_stock.electrical_power_startup_time)
             .raise_pantograph_time(rolling_stock.raise_pantograph_time)
             .supported_signaling_systems(rolling_stock.supported_signaling_systems)
+            .freight_compatible(rolling_stock.freight_compatible)
     }
 }
 
@@ -115,6 +117,7 @@ impl From<RollingStockModel> for RollingStockForm {
             supported_signaling_systems: value.supported_signaling_systems,
             locked: Some(value.locked),
             metadata: value.metadata,
+            freight_compatible: value.freight_compatible,
         }
     }
 }

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -229,7 +229,7 @@ struct LightRollingStock {
     power_restrictions: HashMap<String, String>,
     energy_sources: Vec<EnergySource>,
     supported_signaling_systems: RollingStockSupportedSignalingSystems,
-    freight_compatible: Option<bool>,
+    freight_compatible: bool,
 }
 
 impl From<RollingStockModel> for LightRollingStock {

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -229,6 +229,7 @@ struct LightRollingStock {
     power_restrictions: HashMap<String, String>,
     energy_sources: Vec<EnergySource>,
     supported_signaling_systems: RollingStockSupportedSignalingSystems,
+    freight_compatible: Option<bool>,
 }
 
 impl From<RollingStockModel> for LightRollingStock {
@@ -254,6 +255,7 @@ impl From<RollingStockModel> for LightRollingStock {
             energy_sources,
             locked,
             supported_signaling_systems,
+            freight_compatible,
             ..
         }: RollingStockModel,
     ) -> Self {
@@ -278,6 +280,7 @@ impl From<RollingStockModel> for LightRollingStock {
             power_restrictions,
             energy_sources,
             supported_signaling_systems,
+            freight_compatible,
         }
     }
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2371,6 +2371,7 @@ export type LightRollingStock = {
   comfort_acceleration: number;
   effort_curves: LightEffortCurves;
   energy_sources: EnergySource[];
+  freight_compatible?: boolean | null;
   gamma: Gamma;
   id: number;
   inertia_coefficient: number;
@@ -2560,6 +2561,7 @@ export type RollingStock = {
   effort_curves: EffortCurves;
   electrical_power_startup_time: number | null;
   energy_sources: EnergySource[];
+  freight_compatible?: boolean | null;
   gamma: Gamma;
   id: number;
   inertia_coefficient: number;
@@ -2588,6 +2590,7 @@ export type RollingStockForm = {
   /** The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric. */
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
+  freight_compatible?: boolean | null;
   gamma: Gamma;
   inertia_coefficient: number;
   length: number;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2371,7 +2371,7 @@ export type LightRollingStock = {
   comfort_acceleration: number;
   effort_curves: LightEffortCurves;
   energy_sources: EnergySource[];
-  freight_compatible?: boolean | null;
+  freight_compatible: boolean;
   gamma: Gamma;
   id: number;
   inertia_coefficient: number;
@@ -2561,7 +2561,7 @@ export type RollingStock = {
   effort_curves: EffortCurves;
   electrical_power_startup_time: number | null;
   energy_sources: EnergySource[];
-  freight_compatible?: boolean | null;
+  freight_compatible: boolean;
   gamma: Gamma;
   id: number;
   inertia_coefficient: number;
@@ -2590,7 +2590,7 @@ export type RollingStockForm = {
   /** The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric. */
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
-  freight_compatible?: boolean | null;
+  freight_compatible: boolean;
   gamma: Gamma;
   inertia_coefficient: number;
   length: number;

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCard.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import { AiOutlineColumnWidth } from 'react-icons/ai';
 import { BsLightningFill } from 'react-icons/bs';
 import { FaWeightHanging } from 'react-icons/fa';
+import { GoContainer } from 'react-icons/go';
 import { IoIosSpeedometer } from 'react-icons/io';
 import { MdLocalGasStation } from 'react-icons/md';
 
@@ -112,6 +113,11 @@ const RollingStockCard = ({
           <div className="row">
             <div className="col-5">
               <div className="rollingstock-tractionmode text-nowrap">
+                {rollingStock.freight_compatible && (
+                  <span className="text-black">
+                    <GoContainer />
+                  </span>
+                )}
                 {tractionModes.thermal && (
                   <span className="text-pink">
                     <MdLocalGasStation />

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -226,6 +226,9 @@ class RollingStock(BaseModel, extra="forbid"):
         ge=0,
     )
     supported_signaling_systems: List[str] = Field(default_factory=list)
+    freight_compatible: Optional[bool] = Field(
+        description="The type of the train, wether it's a locomotive or something else", default=None
+    )
 
 
 if __name__ == "__main__":

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -12,7 +12,7 @@ from pydantic import (
 
 from .infra import LoadingGaugeType
 
-RAILJSON_ROLLING_STOCK_VERSION_TYPE = Literal["3.2"]
+RAILJSON_ROLLING_STOCK_VERSION_TYPE = Literal["3.3"]
 RAILJSON_ROLLING_STOCK_VERSION = get_args(RAILJSON_ROLLING_STOCK_VERSION_TYPE)[0]
 
 

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osrd_schemas"
-version = "0.8.13"
+version = "0.8.14"
 description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 

--- a/tests/data/rolling_stocks/electric_rolling_stock.json
+++ b/tests/data/rolling_stocks/electric_rolling_stock.json
@@ -977,5 +977,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": false
 }

--- a/tests/data/rolling_stocks/fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock.json
@@ -76,5 +76,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": true
 }

--- a/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
@@ -75,5 +75,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": true
 }

--- a/tests/data/rolling_stocks/short_fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_fast_rolling_stock.json
@@ -75,5 +75,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": true
 }

--- a/tests/data/rolling_stocks/short_slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_slow_rolling_stock.json
@@ -75,5 +75,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": true
 }

--- a/tests/data/rolling_stocks/slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/slow_rolling_stock.json
@@ -75,5 +75,6 @@
     "BAPR",
     "TVM300",
     "TVM430"
-  ]
+  ],
+  "freight_compatible": true
 }


### PR DESCRIPTION
Classify rolling stock between those that can be used as fret, and those who don't (or those we don't know). A new field `freight_compatible` is added to the rolling stock schema (both python `osrd_schemas` and `editoast`), then also to the rolling stock model (DB), and finally in all API exposed struct like `LightRollingStock` and `RollingStockForm`.

Since there is still a lot of rolling stock for which we don't know any information, the new field is nullable.

⚠️ First thing to review: what do you think of the naming `freight_compatible`. If you don't like it, have other ideas, don't spend time reviewing the rest of the PR, let's discuss that first.

I also added a little icon for freight compatible train in the rolling stock editor.

![image](https://github.com/user-attachments/assets/9454bf05-3c63-471e-99ff-4ca122f4b4e7)
