### PR TITLE
front: fix the warning display above the GET

### DIFF
--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -64,6 +64,7 @@ const ScenarioContent = ({
     trainScheduleUsedForProjection,
     trainIdUsedForProjection,
     projectedTrains,
+    allTrainsProjected,
     simulationResults,
     conflicts,
     upsertTrainSchedules,
@@ -236,6 +237,7 @@ const ScenarioContent = ({
                     trainScheduleUsedForProjection={trainScheduleUsedForProjection}
                     trainIdUsedForProjection={trainIdUsedForProjection}
                     infraId={infra.id}
+                    allTrainsProjected={allTrainsProjected}
                     timetableTrainNb={timetable.train_ids.length}
                   />
                 )

--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -46,7 +46,7 @@ const useLazyLoadTrains = ({
   const [trainScheduleSummariesById, setTrainScheduleSummariesById] = useState<
     Map<number, TrainScheduleWithDetails>
   >(new Map());
-  const [trainIdsToProject, setTrainIdsToProject] = useState<number[]>([]);
+  const [trainIdsToProject, setTrainIdsToProject] = useState<Set<number>>(new Set());
   const [allTrainsLoaded, setAllTrainsLoaded] = useState(false);
 
   const [postTrainScheduleSimulationSummary] =
@@ -56,6 +56,8 @@ const useLazyLoadTrains = ({
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({ pageSize: 1000 });
 
   const trainSchedulesById = useMemo(() => mapBy(trainSchedules, 'id'), [trainSchedules]);
+
+  const allTrainsProjected = useMemo(() => trainIdsToProject.size === 0, [trainIdsToProject]);
 
   const { projectedTrainsById, setProjectedTrainsById } = useLazyProjectTrains({
     infraId,
@@ -96,7 +98,7 @@ const useLazyLoadTrains = ({
 
         if (!outOfSync) {
           // launch the projection of the trains
-          setTrainIdsToProject((prev) => [...prev, ...packageToFetch]);
+          setTrainIdsToProject((prev) => new Set([...prev, ...packageToFetch]));
 
           // format the summaries to display them in the timetable
           const newFormattedSummaries = formatTrainScheduleSummaries(
@@ -125,6 +127,7 @@ const useLazyLoadTrains = ({
     projectedTrainsById,
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
+    allTrainsProjected,
   };
 };
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -65,6 +65,7 @@ const useScenarioData = (
     projectedTrainsById,
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
+    allTrainsProjected,
   } = useLazyLoadTrains({
     infraId: scenario.infra_id,
     trainIdsToFetch,
@@ -187,6 +188,7 @@ const useScenarioData = (
     trainScheduleUsedForProjection,
     trainIdUsedForProjection,
     projectedTrains,
+    allTrainsProjected,
     simulationResults,
     conflicts,
     removeTrains,

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -41,6 +41,7 @@ type SimulationResultsProps = {
   trainIdUsedForProjection?: number;
   simulationResults: SimulationResultsData;
   timetableTrainNb: number;
+  allTrainsProjected: boolean;
 };
 
 const SimulationResults = ({
@@ -58,6 +59,7 @@ const SimulationResults = ({
     path,
   },
   timetableTrainNb,
+  allTrainsProjected,
 }: SimulationResultsProps) => {
   const { t } = useTranslation('simulation');
   const dispatch = useAppDispatch();
@@ -170,7 +172,7 @@ const SimulationResults = ({
 
             <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
               <div className="chart-container">
-                {spaceTimeData.length !== timetableTrainNb && (
+                {!allTrainsProjected && (
                   <ProjectionLoadingMessage
                     projectedTrainsNb={spaceTimeData.length}
                     totalTrains={timetableTrainNb}

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -16,7 +16,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmV2SuccessResponse) => {
   const timetableId = useSelector(getTimetableID);
 
   const [spaceTimeData, setSpaceTimeData] = useState<TrainSpaceTimeData[]>([]);
-  const [trainIdsToProject, setTrainIdsToProject] = useState<number[]>([]);
+  const [trainIdsToProject, setTrainIdsToProject] = useState<Set<number>>(new Set());
 
   const { data: timetable } = osrdEditoastApi.endpoints.getTimetableById.useQuery(
     { id: timetableId! },

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -21,11 +21,11 @@ const BATCH_SIZE = 10;
 
 type useLazyLoadTrainsProp = {
   infraId?: number;
-  trainIdsToProject: number[];
+  trainIdsToProject: Set<number>;
   path?: PathfindingResultSuccess;
   trainSchedules?: TrainScheduleResult[];
   moreTrainsToCome?: boolean;
-  setTrainIdsToProject: Dispatch<SetStateAction<number[]>>;
+  setTrainIdsToProject: Dispatch<SetStateAction<Set<number>>>;
 };
 
 /**
@@ -90,9 +90,9 @@ const useLazyProjectTrains = ({
     const projectTrains = async (
       seqNum: number,
       _path: PathfindingResultSuccess,
-      _trainToProjectIds: number[]
+      _trainToProjectIds: Set<number>
     ) => {
-      const shouldProjectIds = _trainToProjectIds.filter(
+      const shouldProjectIds = Array.from(_trainToProjectIds).filter(
         (trainId) => !requestedProjectedTrainIds.current.has(trainId)
       );
 
@@ -120,10 +120,10 @@ const useLazyProjectTrains = ({
     // reset the state when all the trains have been projected
     if (
       !moreTrainsToCome &&
-      trainIdsToProject.length > 0 &&
-      requestedProjectedTrainIds.current.size === trainIdsToProject.length
+      trainIdsToProject.size > 0 &&
+      requestedProjectedTrainIds.current.size === trainIdsToProject.size
     ) {
-      setTrainIdsToProject([]);
+      setTrainIdsToProject(new Set());
       requestedProjectedTrainIds.current = new Set();
     }
   }, [moreTrainsToCome, projectedTrainsById]);
@@ -136,7 +136,7 @@ const useLazyProjectTrains = ({
       setProjectedTrainsById(new Map());
 
       const trainIds = trainSchedules.map((trainSchedule) => trainSchedule.id);
-      setTrainIdsToProject(trainIds);
+      setTrainIdsToProject(new Set(trainIds));
     }
   }, [path]);
 


### PR DESCRIPTION
closes #8878 

Add a new boolean allTrainsProjected and display the warning "Projecting..." only if this boolean is not truthy.