### PR TITLE
front: enable @typescript-eslint/no-unsafe-return

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -44,6 +44,7 @@
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
 
     "@typescript-eslint/ban-types": [
       "error",

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 
 import Form, { getDefaultRegistry } from '@rjsf/core';
-import type { FieldProps } from '@rjsf/utils';
+import type { FieldProps, RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
+import type { GeoJsonProperties, Geometry } from 'geojson';
 import type { JSONSchema7 } from 'json-schema';
 import { omit, head, max as fnMax, min as fnMin, isNil } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +35,13 @@ import HelpModal from './HelpModal';
 import { LinearMetadataTooltip } from './tooltip';
 import 'common/IntervalsDataViz/style.scss';
 
-const IntervalEditorComponent = (props: FieldProps) => {
+export type FormContext = {
+  geometry: Geometry;
+  length: number;
+  isCreation: boolean;
+};
+
+const IntervalEditorComponent = (props: FieldProps<GeoJsonProperties, RJSFSchema, FormContext>) => {
   const { name, formContext, formData, schema, onChange, registry } = props;
   const { openModal, closeModal } = useModal();
   const { t } = useTranslation();
@@ -59,10 +66,10 @@ const IntervalEditorComponent = (props: FieldProps) => {
 
   // Get the distance of the geometry
   const distance = useMemo(() => {
-    if (!isNil(formContext.length)) {
+    if (!isNil(formContext?.length)) {
       return formContext.length;
     }
-    if (formContext.geometry?.type === 'LineString') {
+    if (formContext?.geometry?.type === 'LineString') {
       return getLineStringDistance(formContext.geometry);
     }
     return 0;
@@ -414,16 +421,16 @@ const IntervalEditorComponent = (props: FieldProps) => {
   );
 };
 
-export const FormComponent = (props: FieldProps) => {
+export const FormComponent = (props: FieldProps<GeoJsonProperties, RJSFSchema, FormContext>) => {
   const { name, formContext, schema, registry } = props;
   const Fields = getDefaultRegistry().fields;
 
   // Get the distance of the geometry
   const distance = useMemo(() => {
-    if (!isNil(formContext.length)) {
-      return formContext.length!;
+    if (!isNil(formContext?.length)) {
+      return formContext.length;
     }
-    if (formContext.geometry?.type === 'LineString') {
+    if (formContext?.geometry?.type === 'LineString') {
       return getLineStringDistance(formContext.geometry);
     }
     return 0;

--- a/front/src/applications/editor/data/utils.ts
+++ b/front/src/applications/editor/data/utils.ts
@@ -134,6 +134,7 @@ export function nestEntity(entity: EditorEntity, type: EditoastType): EditorEnti
 
       if (isLast) props[k] = oldProperties[key];
       else props[k] = props[k] || {};
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return props[k];
     }, newProperties);
   });

--- a/front/src/common/Map/Layers/GeoJSONs.tsx
+++ b/front/src/common/Map/Layers/GeoJSONs.tsx
@@ -418,7 +418,7 @@ interface EditorSourceProps {
 export const EditorSource = ({ id, data, layers, layerOrder }: EditorSourceProps) => {
   const dataFingerPrint =
     data.type === 'FeatureCollection'
-      ? data.features.map((f) => f.properties?.id).concat()
+      ? data.features.map((f) => f.properties?.id as unknown).concat()
       : data.properties?.id;
   return (
     <Source type="geojson" id={id} data={data}>

--- a/front/src/common/api/documentApi.ts
+++ b/front/src/common/api/documentApi.ts
@@ -1,3 +1,4 @@
+import type { NewDocumentResponse } from 'common/api/osrdEditoastApi';
 import mainConfig from 'config/config';
 
 export const getDocument = async (documentKey: number): Promise<Blob> => {
@@ -13,6 +14,6 @@ export const postDocument = async (image: Blob) => {
     },
     body: image,
   });
-  const data = await res.json();
+  const data: NewDocumentResponse = await res.json();
   return data.document_key;
 };

--- a/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
+++ b/front/src/modules/simulationResult/components/ChartHelpers/enableInteractivity.tsx
@@ -302,7 +302,8 @@ export const enableInteractivity = <
       setChart(newChart);
     })
     .filter(
-      (event) => (event.button === 0 || event.button === 1) && (event.ctrlKey || event.shiftKey)
+      (event: MouseEvent) =>
+        (event.button === 0 || event.button === 1) && (event.ctrlKey || event.shiftKey)
     );
 
   // Updates in real time the position of the pointer and the vertical/horizontal guidelines


### PR DESCRIPTION
Part of #8772

Disallow returning `any` values, to avoid having these spread to other parts of the codebase due to type inference.

See https://typescript-eslint.io/rules/no-unsafe-return/