### PR TITLE
front: imported trains are loaded automatically without refresh

### DIFF
--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -187,7 +187,10 @@ const ScenarioContent = ({
             )}
             {displayTrainScheduleManagement === MANAGE_TRAIN_SCHEDULE_TYPES.import && (
               <div className="scenario-managetrainschedule">
-                <ImportTrainSchedule timetableId={scenario.timetable_id} />
+                <ImportTrainSchedule
+                  timetableId={scenario.timetable_id}
+                  upsertTrainSchedules={upsertTrainSchedules}
+                />
               </div>
             )}
             <div className="scenario-results">

--- a/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
@@ -4,14 +4,20 @@ import { useTranslation } from 'react-i18next';
 
 import type { ImportedTrainSchedule } from 'applications/operationalStudies/types';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleBase } from 'common/api/osrdEditoastApi';
+import type { TrainScheduleBase, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders';
 import { ImportTrainScheduleConfig } from 'modules/trainschedule/components/ImportTrainSchedule';
 import ImportTrainScheduleTrainsList from 'modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 
-const ImportTrainSchedule = ({ timetableId }: { timetableId: number }) => {
+const ImportTrainSchedule = ({
+  timetableId,
+  upsertTrainSchedules,
+}: {
+  timetableId: number;
+  upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void;
+}) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['rollingstock']);
   const [trainsList, setTrainsList] = useState<ImportedTrainSchedule[]>([]);
@@ -47,6 +53,7 @@ const ImportTrainSchedule = ({ timetableId }: { timetableId: number }) => {
         timetableId={timetableId}
         trainsList={trainsList}
         trainsJsonData={trainsJsonData}
+        upsertTrainSchedules={upsertTrainSchedules}
       />
     </main>
   ) : (

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
@@ -10,6 +10,7 @@ import {
   osrdEditoastApi,
   type LightRollingStockWithLiveries,
   type TrainScheduleBase,
+  type TrainScheduleResult,
 } from 'common/api/osrdEditoastApi';
 import { Loader } from 'common/Loaders';
 import { ImportTrainScheduleTrainDetail } from 'modules/trainschedule/components/ImportTrainSchedule';
@@ -34,6 +35,7 @@ type ImportTrainScheduleTrainsListProps = {
   isLoading: boolean;
   timetableId: number;
   trainsJsonData: TrainScheduleBase[];
+  upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void;
 };
 
 const ImportTrainScheduleTrainsList = ({
@@ -42,6 +44,7 @@ const ImportTrainScheduleTrainsList = ({
   isLoading,
   timetableId,
   trainsJsonData,
+  upsertTrainSchedules,
 }: ImportTrainScheduleTrainsListProps) => {
   const { t } = useTranslation(['operationalStudies/importTrainSchedule']);
 
@@ -73,7 +76,8 @@ const ImportTrainScheduleTrainsList = ({
           ? trainsJsonData
           : generateTrainSchedulesPayloads(formattedTrainsList);
 
-      await postTrainSchedule({ id: timetableId, body: payloads }).unwrap();
+      const trainSchedules = await postTrainSchedule({ id: timetableId, body: payloads }).unwrap();
+      upsertTrainSchedules(trainSchedules);
       dispatch(
         setSuccess({
           title: t('success'),


### PR DESCRIPTION
closes #8679

Once the trains are imported, the new trainSchedules need to be refetched manually with the `upsertTrainSchedules` function