### PR TITLE
core: add .kotlin folder to ignore files

### DIFF
--- a/core/.dockerignore
+++ b/core/.dockerignore
@@ -2,3 +2,4 @@ build
 Dockerfile
 .gradle
 .idea
+.kotlin

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .idea
+.kotlin
 build
 *.iml
 *.jar


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-58223/Kotlin-Gradle-plugin-shouldnt-store-data-in-project-cache-directory#focus=Comments-27-8370225.0-0