### PR TITLE
front: convert frequency between osrd and nge

### DIFF
--- a/front/src/applications/operationalStudies/components/NGE/types.ts
+++ b/front/src/applications/operationalStudies/components/NGE/types.ts
@@ -55,6 +55,7 @@ export type Trainrun = {
   frequencyId: number;
   trainrunTimeCategoryId: number;
   labelIds: (number | string)[];
+  trainrunFrequency: TrainrunFrequency;
 };
 
 export type TimeLock = {


### PR DESCRIPTION
close #8399 
close https://github.com/osrd-project/osrd-confidential/issues/663

## OSRD -> NGE
 - Tag a train in OSRD with `frequency::30` or `frequency::120`.
 - In the NGE tab, check that the trainrun frequency is 30 or 120.
 - Without a tag, the default frequency is 60.

## NGE -> OSRD
 - Change frequency on a run train.
 - 120 we will have the tag `frequency::120` and 30 the tag `frequency::30`.

/!\ At the moment we only manage 3 frequencies 30, 60, and 120