### PR TITLE
front: remove all occurences of console.log

### DIFF
--- a/front/scripts/i18n-api-errors.ts
+++ b/front/scripts/i18n-api-errors.ts
@@ -82,7 +82,7 @@ async function run() {
     ).flat();
 
     if (errors.length > 0) {
-      console.log(errors);
+      console.error(errors);
       process.exit(1);
     } else {
       process.exit(0);

--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -130,18 +130,18 @@ async function run() {
 
     /* eslint-disable no-console */
     if (unusedKeys.length > 0) {
-      console.log(`Unused keys (${unusedKeys.length})`);
-      console.log('----------------------------------');
-      console.log(unusedKeys.map((e) => `${e.locale}:${e.key}`).join('\n'));
-      console.log();
+      console.warn(`Unused keys (${unusedKeys.length})`);
+      console.warn('----------------------------------');
+      console.warn(unusedKeys.map((e) => `${e.locale}:${e.key}`).join('\n'));
+      console.warn();
     }
 
     if (missingKeys.length > 0) {
-      console.log(`Missing keys (${missingKeys.length})`);
-      console.log('------------------------------------');
-      console.log(missingKeys.map((e) => `${e.locale}:${e.key}`).join('\n'));
-      console.log();
-      console.log('/!\\ Failed: missing keys are not allowed in fr & en');
+      console.warn(`Missing keys (${missingKeys.length})`);
+      console.warn('------------------------------------');
+      console.warn(missingKeys.map((e) => `${e.locale}:${e.key}`).join('\n'));
+      console.warn();
+      console.warn('/!\\ Failed: missing keys are not allowed in fr & en');
       process.exit(1);
     }
   } catch (err) {

--- a/front/src/common/Map/WarpedMap/DataLoader.tsx
+++ b/front/src/common/Map/WarpedMap/DataLoader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { featureCollection } from '@turf/helpers';
 import type { BBox2d } from '@turf/helpers/dist/js/lib/geojson';
 import type { FeatureCollection } from 'geojson';
-import { map, sum, uniqBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import { createPortal } from 'react-dom';
 import type { LayerProps, MapRef } from 'react-map-gl/maplibre';
 import ReactMapGL, { Source } from 'react-map-gl/maplibre';
@@ -78,7 +78,6 @@ const DataLoader = ({ bbox, getGeoJSONs, layers }: DataLoaderProps) => {
 
       const querySources = () => {
         // Retrieve OSRD data:
-        let osrdFeaturesCount = 0;
         const osrdData: Partial<Record<Layer, FeatureCollection>> = {};
         layers.forEach((layer) => {
           osrdData[layer] = featureCollection(
@@ -89,7 +88,6 @@ const DataLoader = ({ bbox, getGeoJSONs, layers }: DataLoaderProps) => {
               (f) => f.id
             )
           );
-          osrdFeaturesCount += osrdData[layer]?.features.length || 0;
         });
 
         // Retrieve OSM data:
@@ -113,11 +111,6 @@ const DataLoader = ({ bbox, getGeoJSONs, layers }: DataLoaderProps) => {
               : iter,
           {}
         );
-        const osmFeaturesCount = sum(map(osmData, (collection) => collection.features.length));
-
-        console.timeEnd(TIME_LABEL);
-        console.log('  - OSRD features: ', osrdFeaturesCount);
-        console.log('  - OSM features: ', osmFeaturesCount);
 
         // Finalize:
         getGeoJSONs(osrdData, osmData);

--- a/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
+++ b/front/src/common/Map/WarpedMap/SimulationWarpedMap.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useEffect, useMemo, useState } from 'react';
 
 import bbox from '@turf/bbox';
@@ -25,7 +24,6 @@ import { getOsrdSimulation } from 'reducers/osrdsimulation/selectors';
 import { useAppDispatch } from 'store';
 import { clip } from 'utils/mapHelper';
 
-const TIME_LABEL = 'Warping OSRD and OSM data';
 const WIDTH = 300;
 
 interface PathStatePayload {
@@ -268,7 +266,6 @@ const SimulationWarpedMap = ({
           bbox={state.pathBBox}
           layers={layers}
           getGeoJSONs={(osrdData, osmData) => {
-            console.time(TIME_LABEL);
             const transformed = {
               osm: transformDataStatePayload(osmData, state.transform) as DataStatePayload['osm'],
               osrd: transformDataStatePayload(
@@ -276,7 +273,6 @@ const SimulationWarpedMap = ({
                 state.transform
               ) as DataStatePayload['osrd'],
             };
-            console.timeEnd(TIME_LABEL);
             setState({ ...state, ...transformed, type: 'dataLoaded' });
           }}
         />


### PR DESCRIPTION
I think we should reserve console.log for debugging in development branches, it should not exist in production.
also, when doing a search for console.log to see if none were left when cleaning a branch, they always show up.

- replaced console.log by warn/error/info in different scripts
- removed old debugging/timing logs that were always popping during development.