### PR TITLE
core: signaling: pick the right signaling system for next signal

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
@@ -131,7 +131,9 @@ private fun computeSignalAspectChangeEvents(
             )
             .toMutableMap()
 
-    val lastSignal = pathSignals.last().signal
+    val blockSignals = blockInfra.getBlockSignals(blockPath.last())
+    // We can't just `pathSignals.last().signal` as the simulation includes the whole block
+    val lastSignal = blockSignals[blockSignals.size - 1]
     val lastSignalDriver = loadedSignalInfra.getDrivers(lastSignal).lastOrNull()
     val lastSignalInputSystem =
         if (lastSignalDriver != null) {


### PR DESCRIPTION
We'd use the last of the path signals to get the least restricting aspect for the next signal. But the `.evaluate` call simulates whole blocks. If there a sig system change after the end of the path but before the end of the last block, we'd get an error.