### PR TITLE
front: re-enable dependabot for direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,12 +23,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/front/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"
     commit-message:
       prefix: "front:"
-    # Security updates only:
-    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 100
     labels:
       - "dependencies"
       - "area:front"


### PR DESCRIPTION
In #2969, dependabot got disabled because it was too spammy. However, disabling dependency updates makes us fall behind pretty hard and makes version upgrades quite painful. Instead of gradually integrating new dependency upgrades and finding bugs as they arise, we're forced to make a huge commit upgrading many packages at once. Regressions are harder to narrow down and humans have to remember and volunteer to perform this unrewarding upgrade task.

As a middle ground, re-enable dependabot updates for direct dependencies only, and group all updates in a single weekly PR. This should make it less spammy than enabling it for all dependencies (transitive dependencies included), while at the same time allowing us to keep up with new versions of libraries we're using.