### PR TITLE
core: operational-studies: add safety speed to mrsp

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/MRSPEnvelopeBuilder.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/MRSPEnvelopeBuilder.java
@@ -39,7 +39,7 @@ public final class MRSPEnvelopeBuilder {
     public enum LimitKind implements SelfTypeHolder {
         SPEED_LIMIT,
         TRAIN_LIMIT,
-        ;
+        SAFETY_APPROACH_SPEED;
 
         @Override
         public @NotNull Class<? extends SelfTypeHolder> getSelfType() {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -44,6 +44,12 @@ sealed class SpeedLimitSource : SelfTypeHolder {
             return 1
         }
     }
+
+    /**
+     * The speed limit comes from a safety approach area: the train must slow down before reaching
+     * the next signal
+     */
+    data object SafetyApproachSpeed : SpeedLimitSource()
 }
 
 /**

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/TrackProperties.kt
@@ -44,12 +44,6 @@ sealed class SpeedLimitSource : SelfTypeHolder {
             return 1
         }
     }
-
-    /**
-     * The speed limit comes from a safety approach area: the train must slow down before reaching
-     * the next signal
-     */
-    data object SafetyApproachSpeed : SpeedLimitSource()
 }
 
 /**

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
@@ -20,7 +20,9 @@ data class ChunkPath(
     val chunks: DirStaticIdxList<TrackChunk>,
     val beginOffset: Offset<Path>,
     val endOffset: Offset<Path>
-)
+) {
+    val length: Distance = endOffset.distance - beginOffset.distance
+}
 
 data class PathPropertiesImpl(
     val infra: RawSignalingInfra,

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -1,0 +1,100 @@
+package fr.sncf.osrd.standalone_sim
+
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.api_v2.standalone_sim.SimulationScheduleItem
+import fr.sncf.osrd.conflicts.TravelledPath
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.impl.ChunkPath
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.Speed
+import fr.sncf.osrd.utils.units.kilometersPerHour
+import fr.sncf.osrd.utils.units.meters
+
+/**
+ * Compute safety speed ranges, areas where the train has a lower speed limit because of a scheduled
+ * stop. For details, see https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields
+ * (or google "VISA (VItesse Sécuritaire d'Approche)" for resources in French)
+ */
+fun makeSafetySpeedRanges(
+    infra: FullInfra,
+    chunkPath: ChunkPath,
+    routes: StaticIdxList<Route>,
+    schedule: List<SimulationScheduleItem>
+): DistanceRangeMap<Speed> {
+    val rawInfra = infra.rawInfra
+    val zonePaths = routes.flatMap { rawInfra.getRoutePath(it) }
+    val zonePathStartOffset = getRoutePathStartOffset(rawInfra, chunkPath, zonePaths)
+    val signalOffsets = getSignalOffsets(infra, zonePaths, zonePathStartOffset)
+
+    val stopsWithSafetySpeed = schedule.filter { it.receptionSignal.isStopOnClosedSignal }
+
+    val res = distanceRangeMapOf<Speed>()
+    for (stop in stopsWithSafetySpeed) {
+        // Currently, safety speed is applied to the next signal no matter the sight distance
+        val nextSignalOffset =
+            signalOffsets.firstOrNull { it >= stop.pathOffset }?.distance ?: chunkPath.length
+        res.put(
+            lower = nextSignalOffset - 200.meters,
+            upper = nextSignalOffset,
+            value = 30.kilometersPerHour,
+        )
+        if (stop.receptionSignal == RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP) {
+            res.put(
+                lower = nextSignalOffset - 100.meters,
+                upper = nextSignalOffset,
+                value = 10.kilometersPerHour,
+            )
+        }
+    }
+    // Safety speed areas may extend outside the path
+    return res.subMap(0.meters, chunkPath.length)
+}
+
+/** Return the offsets of block-delimiting signals on the path. */
+fun getSignalOffsets(
+    infra: FullInfra,
+    zonePaths: List<StaticIdx<ZonePath>>,
+    pathStartOffset: Offset<Path>,
+): List<Offset<TravelledPath>> {
+    val res = mutableListOf<Offset<TravelledPath>>()
+    val rawInfra = infra.rawInfra
+    val signalingInfra = infra.loadedSignalInfra
+    var prevZonePathsLength = 0.meters
+    for (zonePath in zonePaths) {
+        val signalPositions = rawInfra.getSignalPositions(zonePath)
+        val signals = rawInfra.getSignals(zonePath)
+        for ((signal, signalPosition) in signals zip signalPositions) {
+            val isDelimiter =
+                signalingInfra.getLogicalSignals(signal).any { signalingInfra.isBlockDelimiter(it) }
+            if (isDelimiter) {
+                res.add(
+                    Offset(prevZonePathsLength + signalPosition.distance - pathStartOffset.distance)
+                )
+            }
+        }
+        prevZonePathsLength += rawInfra.getZonePathLength(zonePath).distance
+    }
+    return res.filter { it.distance >= 0.meters }
+}
+
+/** Returns the offset where the train actually starts, compared to the start of the first route. */
+fun getRoutePathStartOffset(
+    infra: RawInfra,
+    chunkPath: ChunkPath,
+    zonePaths: List<ZonePathId>
+): Offset<Path> {
+    var prevChunksLength = Offset<Path>(0.meters)
+    val routeChunks = zonePaths.flatMap { infra.getZonePathChunks(it) }
+    for (chunk in routeChunks) {
+        if (chunk == chunkPath.chunks.first()) {
+            return prevChunksLength + chunkPath.beginOffset.distance
+        }
+        prevChunksLength += infra.getTrackChunkLength(chunk.value).distance
+    }
+    throw RuntimeException("Unreachable (couldn't find first chunk in route list)")
+}

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -3,6 +3,7 @@ package fr.sncf.osrd.standalone_sim;
 import static fr.sncf.osrd.api.pathfinding.PathPropUtilsKt.makeChunkPath;
 import static fr.sncf.osrd.envelope_sim_infra.MRSPKt.computeMRSP;
 import static fr.sncf.osrd.sim_infra.api.PathPropertiesKt.makePathPropertiesWithRouteNames;
+import static fr.sncf.osrd.utils.DistanceRangeMapKt.distanceRangeMapOf;
 
 import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.api.FullInfra;
@@ -61,8 +62,10 @@ public class StandaloneSim {
                 var rollingStock = trainSchedule.rollingStock;
 
                 // MRSP & SpeedLimits
-                var mrsp = computeMRSP(trainPath, rollingStock, true, trainSchedule.tag);
-                var speedLimits = computeMRSP(trainPath, rollingStock, false, trainSchedule.tag);
+                var mrsp = computeMRSP(
+                        trainPath, rollingStock, true, trainSchedule.tag, distanceRangeMapOf(new ArrayList<>()));
+                var speedLimits = computeMRSP(
+                        trainPath, rollingStock, false, trainSchedule.tag, distanceRangeMapOf(new ArrayList<>()));
                 mrsp = driverBehaviour.applyToMRSP(mrsp);
                 cacheSpeedLimits.put(trainSchedule, ResultEnvelopePoint.from(speedLimits));
 

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/StandaloneSim.java
@@ -3,7 +3,6 @@ package fr.sncf.osrd.standalone_sim;
 import static fr.sncf.osrd.api.pathfinding.PathPropUtilsKt.makeChunkPath;
 import static fr.sncf.osrd.envelope_sim_infra.MRSPKt.computeMRSP;
 import static fr.sncf.osrd.sim_infra.api.PathPropertiesKt.makePathPropertiesWithRouteNames;
-import static fr.sncf.osrd.utils.DistanceRangeMapKt.distanceRangeMapOf;
 
 import fr.sncf.osrd.DriverBehaviour;
 import fr.sncf.osrd.api.FullInfra;
@@ -62,10 +61,8 @@ public class StandaloneSim {
                 var rollingStock = trainSchedule.rollingStock;
 
                 // MRSP & SpeedLimits
-                var mrsp = computeMRSP(
-                        trainPath, rollingStock, true, trainSchedule.tag, distanceRangeMapOf(new ArrayList<>()));
-                var speedLimits = computeMRSP(
-                        trainPath, rollingStock, false, trainSchedule.tag, distanceRangeMapOf(new ArrayList<>()));
+                var mrsp = computeMRSP(trainPath, rollingStock, true, trainSchedule.tag, null);
+                var speedLimits = computeMRSP(trainPath, rollingStock, false, trainSchedule.tag, null);
                 mrsp = driverBehaviour.applyToMRSP(mrsp);
                 cacheSpeedLimits.put(trainSchedule, ResultEnvelopePoint.from(speedLimits));
 

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -17,9 +17,7 @@ import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
 import fr.sncf.osrd.envelope_sim.allowances.LinearAllowance
 import fr.sncf.osrd.envelope_sim.allowances.MarecoAllowance
 import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceRange
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.FixedTime
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.Percentage
-import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.TimePerDistance
+import fr.sncf.osrd.envelope_sim.allowances.utils.AllowanceValue.*
 import fr.sncf.osrd.envelope_sim.pipelines.MaxEffortEnvelope
 import fr.sncf.osrd.envelope_sim.pipelines.MaxSpeedEnvelope
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
@@ -65,7 +63,10 @@ fun runStandaloneSimulation(
     pathItemPositions: List<Offset<Path>>
 ): SimulationSuccess {
     // MRSP & SpeedLimits
-    val mrsp = computeMRSP(pathProps, rollingStock, true, speedLimitTag)
+    val safetySpeedRanges = makeSafetySpeedRanges(infra, chunkPath, routes, schedule)
+    val mrsp = computeMRSP(pathProps, rollingStock, true, speedLimitTag, safetySpeedRanges)
+    // We don't use speed safety ranges in the MRSP displayed in the front
+    // (just like we don't add the train length)
     val speedLimits = computeMRSP(pathProps, rollingStock, false, speedLimitTag)
 
     // Build paths and contexts

--- a/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSPTest.kt
@@ -4,7 +4,7 @@ import fr.sncf.osrd.api.pathfinding.makePathProps
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopeTestUtils
 import fr.sncf.osrd.envelope.MRSPEnvelopeBuilder.LimitKind
-import fr.sncf.osrd.envelope_sim.EnvelopeProfile
+import fr.sncf.osrd.envelope_sim.EnvelopeProfile.CONSTANT_SPEED
 import fr.sncf.osrd.railjson.schema.common.RJSWaypointRef
 import fr.sncf.osrd.railjson.schema.common.graph.ApplicableDirection
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
@@ -238,32 +238,33 @@ class MRSPTest {
                 Envelope.make(
                     // No speed section at first => train speed limit
                     EnvelopeTestUtils.makeFlatPart(
-                        LimitKind.TRAIN_LIMIT,
+                        listOf(LimitKind.TRAIN_LIMIT, CONSTANT_SPEED, HasMissingSpeedTag),
                         0.0,
                         POSITION1,
                         TestTrains.MAX_SPEED
                     ),
                     // Speed section with incorrect train tag => speed 1
                     EnvelopeTestUtils.makeFlatPart(
-                        listOf(LimitKind.SPEED_LIMIT, EnvelopeProfile.CONSTANT_SPEED, UnknownTag()),
+                        listOf(
+                            LimitKind.SPEED_LIMIT,
+                            CONSTANT_SPEED,
+                            UnknownTag(),
+                            HasMissingSpeedTag
+                        ),
                         POSITION1,
                         POSITION2,
                         SPEED1
                     ),
                     // Speed section with correct train tag => speed 3
                     EnvelopeTestUtils.makeFlatPart(
-                        listOf(
-                            LimitKind.SPEED_LIMIT,
-                            EnvelopeProfile.CONSTANT_SPEED,
-                            GivenTrainTag(TRAIN_TAG2)
-                        ),
+                        listOf(LimitKind.SPEED_LIMIT, CONSTANT_SPEED, GivenTrainTag(TRAIN_TAG2)),
                         POSITION2,
                         POSITION3,
                         SPEED3
                     ),
                     // No speed section at end => train speed limit
                     EnvelopeTestUtils.makeFlatPart(
-                        LimitKind.TRAIN_LIMIT,
+                        listOf(LimitKind.TRAIN_LIMIT, CONSTANT_SPEED, HasMissingSpeedTag),
                         POSITION3,
                         pathLength,
                         TestTrains.MAX_SPEED
@@ -313,8 +314,20 @@ class MRSPTest {
                 TRAIN_TAG1,
                 Envelope.make(
                     EnvelopeTestUtils.makeFlatPart(
-                        LimitKind.TRAIN_LIMIT,
+                        listOf(LimitKind.TRAIN_LIMIT, CONSTANT_SPEED, HasMissingSpeedTag),
                         0.0,
+                        POSITION1,
+                        TestTrains.MAX_SPEED
+                    ),
+                    EnvelopeTestUtils.makeFlatPart(
+                        LimitKind.TRAIN_LIMIT,
+                        POSITION1,
+                        POSITION2,
+                        TestTrains.MAX_SPEED
+                    ),
+                    EnvelopeTestUtils.makeFlatPart(
+                        listOf(LimitKind.TRAIN_LIMIT, CONSTANT_SPEED, HasMissingSpeedTag),
+                        POSITION2,
                         pathLength,
                         TestTrains.MAX_SPEED
                     )

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -16,14 +16,13 @@ import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
-import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.OPEN
-import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
-import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.STOP
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.*
 import fr.sncf.osrd.sim_infra.api.makePathProperties
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.*
 import fr.sncf.osrd.utils.units.*
 import java.util.stream.Stream
+import kotlin.math.min
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -124,9 +123,9 @@ class StandaloneSimulationTest {
                         .interpolateDepartureFrom(halfDistance.distance.meters)
                         .seconds + 120.seconds,
                     15.seconds,
-                    STOP
+                    OPEN
                 ),
-                SimulationScheduleItem(twoThirdDistance, null, 30.seconds, SHORT_SLIP_STOP),
+                SimulationScheduleItem(twoThirdDistance, null, 30.seconds, OPEN),
                 SimulationScheduleItem(
                     Offset<TravelledPath>(pathLength),
                     maxEffortEnvelope.totalTime.seconds + 300.seconds,
@@ -283,6 +282,77 @@ class StandaloneSimulationTest {
             // (there are margin-specific tests for that), just that allowances
             // are used.
             assertEquals(expectedDiff, marginTime - baseTime, 6.0)
+        }
+    }
+
+    /** Test that the safety speeds are properly computed for a given path */
+    @Test
+    fun testSafetySpeed() {
+        // Path length = 10400m
+        // SIGNAL OFFSETS on this path: 150m and 10150m
+        // Then, buffer stop at the end of the last route: 10400m
+        val schedule =
+            listOf(
+                // Start of path, check that it doesn't extend beyond the start
+                SimulationScheduleItem(
+                    Offset(42.meters),
+                    42.seconds,
+                    42.seconds,
+                    SHORT_SLIP_STOP,
+                ),
+                // OPEN, check that this is ignored
+                SimulationScheduleItem(
+                    Offset(10_000.meters),
+                    42.seconds,
+                    42.seconds,
+                    OPEN,
+                ),
+                // STOP before the last buffer stop
+                SimulationScheduleItem(
+                    Offset(10_300.meters),
+                    42.seconds,
+                    42.seconds,
+                    STOP,
+                ),
+            )
+        val safetySpeedRanges =
+            makeSafetySpeedRanges(infra, chunkPath, routes.toIdxList(), schedule)
+        val expected =
+            distanceRangeMapOf(
+                listOf(
+                    DistanceRangeMap.RangeMapEntry(0.meters, 50.meters, 30.kilometersPerHour),
+                    DistanceRangeMap.RangeMapEntry(50.meters, 150.meters, 10.kilometersPerHour),
+                    DistanceRangeMap.RangeMapEntry(
+                        10_200.meters,
+                        10_400.meters,
+                        30.kilometersPerHour
+                    ),
+                ),
+            )
+        assertEquals(expected, safetySpeedRanges)
+    }
+
+    /** Test that for a given safety speed range, they are correctly applied to the mrsp */
+    @Test
+    fun testSafetySpeedMRSP() {
+        // Distance range spans across two mrsp sections, one below and one above 30km/h
+        val safetySpeeds =
+            distanceRangeMapOf(
+                listOf(
+                    DistanceRangeMap.RangeMapEntry(100.meters, 5_000.meters, 30.kilometersPerHour)
+                )
+            )
+        val offsetEndSafetySpeed = 5_000 + rollingStock.length
+        val mrspWithSafetySpeed = computeMRSP(pathProps, rollingStock, true, null, safetySpeeds)
+        assertEquals(mrsp.endPos, mrspWithSafetySpeed.endPos)
+        var position = 0.0
+        while (position < mrsp.endPos) {
+            var expected = mrsp.interpolateSpeedLeftDir(position, 1.0)
+            if (position in 101.0..offsetEndSafetySpeed)
+                expected = min(expected, 30.kilometersPerHour.metersPerSecond)
+            val actual = mrspWithSafetySpeed.interpolateSpeedLeftDir(position, 1.0)
+            assertEquals(expected, actual)
+            position += 1.0
         }
     }
 

--- a/front/tests/008-train-schedule.spec.ts
+++ b/front/tests/008-train-schedule.spec.ts
@@ -66,9 +66,9 @@ test.describe('Verifying that all elements in the train schedule are loaded corr
     await opTimetablePage.verifyTrainCount(20);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Invalid', 4);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'All', 20);
-    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Honored', 12);
-    await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Valid', 12);
-    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Not honored', 4);
+    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Honored', 13);
+    await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Valid', 13);
+    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Not honored', 3);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Invalid', 0);
     await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'All', 4);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'All', 20);

--- a/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
+++ b/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
@@ -25,8 +25,8 @@
     "margin": {
       "theoretical": "1 min/100km",
       "theoreticalS": "9 s",
-      "actual": "167 s",
-      "difference": "159 s"
+      "actual": "114 s",
+      "difference": "106 s"
     },
     "calculatedArrival": "11:30:39",
     "calculatedDeparture": "11:35:39"

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -181,7 +181,7 @@ def test_mrsp_sources(
         "values": [
             {"speed": 27.778, "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"}},
             {"speed": 22.222, "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"}},
-            {"speed": 80, "source": None},
+            {"speed": 80.0, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
 
@@ -192,7 +192,7 @@ def test_mrsp_sources(
         "values": [
             {"speed": 39.444, "source": {"speed_limit_source_type": "unknown_tag"}},
             {"speed": 31.111, "source": {"speed_limit_source_type": "unknown_tag"}},
-            {"speed": 80, "source": None},
+            {"speed": 80.0, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
 

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -177,7 +177,7 @@ def test_mrsp_sources(
         "values": [
             {"speed": 27.778, "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"}},
             {"speed": 22.222, "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"}},
-            {"speed": 80, "source": None},
+            {"speed": 80, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
 
@@ -188,7 +188,7 @@ def test_mrsp_sources(
         "values": [
             {"speed": 39.444, "source": {"speed_limit_source_type": "unknown_tag"}},
             {"speed": 31.111, "source": {"speed_limit_source_type": "unknown_tag"}},
-            {"speed": 80, "source": None},
+            {"speed": 80, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
 


### PR DESCRIPTION
Fix #8810 & #8868

1. refactor how MRSP attributes are handled. The main difference is the introduction of the `HasMissingTag` attribute, which is kept even if the speed limit comes from a different source (#8868).
1. Compute safety speeds on the new path and use them as parameters for the MRSP (#8810)
2. Adapt and add unit tests
