### PR TITLE
ci, editoast, gateway: update 'opentelemetry' dependencies all at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     directory: "/gateway/"
     schedule:
       interval: "daily"
+    groups:
+      opentelemetry:
+        patterns:
+          - "*opentelemetry*"
     commit-message:
       prefix: "gateway:"
     open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/editoast/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      opentelemetry:
+        patterns:
+          - "*opentelemetry*"
     commit-message:
       prefix: "editoast:"
     open-pull-requests-limit: 100

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -59,6 +59,8 @@ postgres-openssl = "0.5.0"
 pretty_assertions = "1.4.1"
 rand = "0.8.5"
 rangemap = "1.5.1"
+# 0.12.0 to 0.12.4 have weird timeout issues https://github.com/seanmonstar/reqwest/issues/2283
+# This bug was introduced between 0.12.0 and 0.12.3.
 reqwest = { version = "0.11.27", features = ["json"] }
 rstest = { version = "0.19.0", default-features = false }
 serde = { version = "1.0.210", features = ["derive"] }
@@ -111,6 +113,7 @@ futures.workspace = true
 futures-util.workspace = true
 geos.workspace = true
 headers = "0.4.0"
+hostname.workspace = true
 image = { version = "0.25.2", default-features = false, features = [
   "bmp",
   "gif",
@@ -124,6 +127,7 @@ itertools.workspace = true
 json-patch = { version = "2.0.0", default-features = false, features = [
   "utoipa",
 ] }
+lapin = "2.5.0"
 mime = "0.3.17"
 mvt.workspace = true
 opentelemetry = { version = "0.23.0", default-features = false, features = [
@@ -139,6 +143,7 @@ opentelemetry-otlp = { version = "0.16.0", default-features = false, features = 
 ] }
 opentelemetry-semantic-conventions = "0.15.0"
 opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio", "trace"] }
+ordered-float = { version = "4.2.2", features = ["serde"] }
 osm_to_railjson = { path = "./osm_to_railjson" }
 paste.workspace = true
 pathfinding = "4.11.0"
@@ -152,11 +157,6 @@ redis = { version = "0.25.4", default-features = false, features = [
   "tokio-native-tls-comp",
 ] }
 regex = "1.10.6"
-# 0.12.0 to 0.12.4 have weird timeout issues https://github.com/seanmonstar/reqwest/issues/2283
-# This bug was introduced between 0.12.0 and 0.12.3.
-hostname.workspace = true
-lapin = "2.5.0"
-ordered-float = { version = "4.2.2", features = ["serde"] }
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true


### PR DESCRIPTION
Based on a nice idea from https://github.com/OpenRailAssociation/osrd/pull/8990, and since Opentelemetry updates is clearly not frictionless at the moment, maybe this can help. And also moving to `weekly` update to limit a bit the noise.