### PR TITLE
front: don't group major version upgrades with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
-        patterns:
-          - "*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "front:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Major version upgrades of dependencies often times break the API in some way and are more risky than minor/patch version upgrades. Let's keep these in separate pull requests.