### PR TITLE
workschedules

### DIFF
--- a/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
+++ b/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
@@ -203,6 +203,7 @@ const StdcmViewV2 = () => {
                   selectedSimulationIndex={selectedSimulationIndex}
                   showStatusBanner={showStatusBanner}
                   simulationsList={simulationsList}
+                  pathTrackRanges={stdcmV2Results?.stdcmResponse.path.track_section_ranges}
                 />
               )}
             </div>

--- a/front/src/assets/pictures/workSchedules/ScheduledMaintenanceUp.svg
+++ b/front/src/assets/pictures/workSchedules/ScheduledMaintenanceUp.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="56px" height="56px" viewBox="0 0 56 56" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Assets/Maintenance/ScheduledMaintenanceUp</title>
+    <g id="Assets/Maintenance/ScheduledMaintenanceUp" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M56,0 L56,28 L28,56 L0,56 L56,0 Z M28,0 L0,28 L0,0 L28,0 Z" id="Shape" fill="#F5F5F5"></path>
+    </g>
+</svg>

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -97,8 +97,7 @@ const ScenarioExplorer = ({
         updateStdcmEnvironment({
           infraID: scenario.infra_id,
           timetableID: scenario.timetable_id,
-          electricalProfileSetId: undefined,
-          workScheduleGroupId: undefined,
+          electricalProfileSetId: scenario.electrical_profile_set_id,
           searchDatetimeWindow: scenarioDateTimeWindow,
         })
       );

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -3,10 +3,17 @@ import { useRef, useState } from 'react';
 import { KebabHorizontal } from '@osrd-project/ui-icons';
 import { Manchette } from '@osrd-project/ui-manchette';
 import { useManchettesWithSpaceTimeChart } from '@osrd-project/ui-manchette-with-spacetimechart';
-import { ConflictLayer, PathLayer, SpaceTimeChart } from '@osrd-project/ui-spacetimechart';
+import {
+  ConflictLayer,
+  PathLayer,
+  SpaceTimeChart,
+  WorkScheduleLayer,
+} from '@osrd-project/ui-spacetimechart';
 import type { Conflict } from '@osrd-project/ui-spacetimechart';
 
 import type { OperationalPoint, TrainSpaceTimeData } from 'applications/operationalStudies/types';
+import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
+import type { PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import type { WaypointsPanelData } from 'modules/simulationResult/types';
 
 import SettingsPanel from './SettingsPanel';
@@ -19,6 +26,7 @@ type ManchetteWithSpaceTimeChartProps = {
   selectedTrainScheduleId?: number;
   waypointsPanelData?: WaypointsPanelData;
   conflicts?: Conflict[];
+  workSchedules?: PostWorkSchedulesProjectPathApiResponse;
 };
 const DEFAULT_HEIGHT = 561;
 
@@ -28,6 +36,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   selectedTrainScheduleId,
   waypointsPanelData,
   conflicts = [],
+  workSchedules,
 }: ManchetteWithSpaceTimeChartProps) => {
   const [heightOfManchetteWithSpaceTimeChart] = useState(DEFAULT_HEIGHT);
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
@@ -97,6 +106,17 @@ const ManchetteWithSpaceTimeChartWrapper = ({
             {spaceTimeChartProps.paths.map((path) => (
               <PathLayer key={path.id} path={path} color={path.color} />
             ))}
+            {workSchedules && (
+              <WorkScheduleLayer
+                workSchedules={workSchedules.map((ws) => ({
+                  type: ws.type,
+                  timeStart: new Date(ws.start_date_time),
+                  timeEnd: new Date(ws.end_date_time),
+                  spaceRanges: ws.path_position_ranges.map(({ start, end }) => [start, end]),
+                }))}
+                imageUrl={upward}
+              />
+            )}
             {settings.showConflicts && <ConflictLayer conflicts={conflicts} />}
           </SpaceTimeChart>
         </div>

--- a/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
@@ -39,6 +39,7 @@ const buildCommonConfSelectors = <ConfState extends OsrdConfState>(
     getScenarioID: makeOsrdConfSelector('scenarioID'),
     getTimetableID: makeOsrdConfSelector('timetableID'),
     getElectricalProfileSetId: makeOsrdConfSelector('electricalProfileSetId'),
+    getWorkScheduleGroupId: makeOsrdConfSelector('workScheduleGroupId'),
     getSearchDatetimeWindow: makeOsrdConfSelector('searchDatetimeWindow'),
     getRollingStockID: makeOsrdConfSelector('rollingStockID'),
     getSpeedLimitByTag: makeOsrdConfSelector('speedLimitByTag'),

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -89,8 +89,10 @@ export const stdcmConfSlice = createSlice({
       state.infraID = action.payload.infraID;
       state.timetableID = action.payload.timetableID;
       state.electricalProfileSetId = action.payload.electricalProfileSetId;
-      state.workScheduleGroupId = action.payload.workScheduleGroupId;
       state.searchDatetimeWindow = action.payload.searchDatetimeWindow;
+      if (action.payload.workScheduleGroupId) {
+        state.workScheduleGroupId = action.payload.workScheduleGroupId;
+      }
     },
     updateOriginArrival(
       state: Draft<OsrdStdcmConfState>,


### PR DESCRIPTION
- Display the workschedules in the stdcm debug interface.
- Add the new workschedule layer in the spacetime chart. 

### testing this branch
You need to create some workschedules manually.

For example here, taking these 2 track_sections in grenoble-lyon

- `62967baa-6667-11e3-81ff-01f464e0362d`
- `62961b24-6667-11e3-81ff-01f464e0362d`

`POST /work_schedules` :
```
{
    "work_schedule_group_name": "grenoble-lyon",
    "work_schedules": [
        {
            "start_date_time": "2024-10-10T19:00:00",
            "end_date_time": "2024-10-10T19:30:00",
            "track_ranges": [
                {
                    "track": "62967baa-6667-11e3-81ff-01f464e0362d",
                    "begin": 0,
                    "end": 5000.0
                }
            ],
            "obj_id": "work_schedule_obj_id",
            "work_schedule_type": "TRACK"
        },
                {
            "start_date_time": "2024-10-10T19:00:00",
            "end_date_time": "2024-10-10T19:30:00",
            "track_ranges": [
                {
                    "track": "",
                    "begin": 10000.0,
                    "end": 20000.0
                }
            ],
            "obj_id": "work_schedule_obj_id",
            "work_schedule_type": "TRACK"
        }
    ]
}
```
then update the stdcm search with `POST /stdcm/search_environment`

```
{
    "infra_id": 2,
    "electrical_profile_set_id": null,
    "work_schedule_group_id": ___, ====> the id of the group schedule you just created
    "search_window_begin": "2024-10-01T00:00:00",
    "search_window_end": "2024-10-31T00:00:00",
    "timetable_id": 3
}
```

![Screenshot_20241021_171934](https://github.com/user-attachments/assets/64438389-e4dd-4e5a-a7ed-f57dcf4e8779)


closes [#8643](https://github.com/OpenRailAssociation/osrd/issues/8643)
