### PR TITLE
front: drop unnecessary cast in useOutputTableData()

### DIFF
--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -113,7 +113,7 @@ function useOutputTableData(
         return {
           ...sugOpPoint,
           ...formattedScheduleData,
-          receptionSignal: schedule?.reception_signal || '',
+          receptionSignal: schedule?.reception_signal,
           calculatedArrival,
           calculatedDeparture:
             opPoint.duration > 0
@@ -142,7 +142,7 @@ function useOutputTableData(
 
     const startTime = convertIsoUtcToLocalTime(selectedTrainSchedule.start_time);
     const formattedWaypoints = formatSuggestedViasToRowVias(
-      allWaypoints as SuggestedOP[],
+      allWaypoints,
       [],
       t,
       startTime,


### PR DESCRIPTION
The cast was performed to avoid running into this error:

    ERROR(TypeScript)  Argument of type '({ isWaypoint: boolean; arrival?: string | null | undefined; stopFor?: string | null | undefined; departure?: string | null | undefined; positionOnPath: number; offset: number; track: string; ... 21 more ...; metadata?: { ...; } | undefined; } | ... 8 more ... | { ...; })[]' is not assignable to parameter of type 'SuggestedOP[]'.
     Type '{ isWaypoint: boolean; arrival?: string | null | undefined; stopFor?: string | null | undefined; departure?: string | null | undefined; positionOnPath: number; offset: number; track: string; ... 21 more ...; metadata?: { ...; } | undefined; } | ... 8 more ... | { ...; }' is not assignable to type 'SuggestedOP'.
       Type '{ isWaypoint: boolean; arrival?: string | null | undefined; stopFor?: string | null | undefined; departure?: string | null | undefined; positionOnPath: number; offset: number; track: string; ... 21 more ...; metadata?: { ...; } | undefined; }' is not assignable to type 'SuggestedOP'.
         Types of property 'receptionSignal' are incompatible.
           Type 'string' is not assignable to type 'ReceptionSignal | undefined'.
    FILE  /app/src/modules/timesStops/hooks/useOutputTableData.ts:145:7

       143 |     const startTime = convertIsoUtcToLocalTime(selectedTrainSchedule.start_time);
       144 |     const formattedWaypoints = formatSuggestedViasToRowVias(
     > 145 |       allWaypoints,
           |       ^^^^^^^^^^^^
       146 |       [],
       147 |       t,
       148 |       startTime,

This is fixed by avoiding to mix up the empty string in receptionSignal, instead leaving the field undefined.