### PR TITLE
editoast: add 'locked' to the schema definition of rolling stock

### DIFF
--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -50,6 +50,7 @@ pub const ROLLING_STOCK_RAILJSON_VERSION: &str = "3.2";
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct RollingStock {
     pub name: String,
+    pub locked: bool,
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
     pub length: f64,

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -148,6 +148,7 @@ impl From<RollingStockModel> for RollingStock {
     fn from(rolling_stock_model: RollingStockModel) -> Self {
         RollingStock {
             railjson_version: rolling_stock_model.railjson_version,
+            locked: rolling_stock_model.locked,
             metadata: rolling_stock_model.metadata,
             name: rolling_stock_model.name,
             effort_curves: rolling_stock_model.effort_curves,
@@ -175,6 +176,7 @@ impl From<RollingStock> for RollingStockModelChangeset {
     fn from(rolling_stock: RollingStock) -> Self {
         RollingStockModel::changeset()
             .railjson_version(rolling_stock.railjson_version)
+            .locked(rolling_stock.locked)
             .metadata(rolling_stock.metadata)
             .name(rolling_stock.name)
             .effort_curves(rolling_stock.effort_curves)


### PR DESCRIPTION
In the schema definition in Python, the [field `locked` exists](https://github.com/OpenRailAssociation/osrd/blob/a5e9ca26575d885868a4e4a947479fea37c7299e/python/osrd_schemas/osrd_schemas/rolling_stock.py#L197). However, it doesn't exist in the corresponding `editoast` implementation.