### PR TITLE
front: handles various TODOs

### DIFF
--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -65,7 +65,7 @@ const Editor = () => {
     setRenderingFingerprint(Date.now());
   }, [setRenderingFingerprint]);
 
-  const [isFormSubmited, setIsFormSubmited] = useState(false);
+  const [isFormSubmitted, setIsFormSubmitted] = useState(false);
   const { data: infra } = useInfra(infraID);
   const { updateInfra } = useInfraActions();
 
@@ -152,8 +152,8 @@ const Editor = () => {
       infraID,
       isInfraLocked: isLocked,
       isLoading,
-      isFormSubmited,
-      setIsFormSubmited,
+      isFormSubmitted,
+      setIsFormSubmitted,
       switchTypes,
       mapState: {
         viewport,
@@ -170,8 +170,8 @@ const Editor = () => {
       viewport,
       isLoading,
       isLocked,
-      isFormSubmited,
-      setIsFormSubmited,
+      isFormSubmitted,
+      setIsFormSubmitted,
     ]
   );
 

--- a/front/src/applications/editor/Editor.tsx
+++ b/front/src/applications/editor/Editor.tsx
@@ -30,7 +30,7 @@ import useInfra from 'modules/infra/useInfra';
 import type { EditorSliceActions } from 'reducers/editor';
 import { getEditorState, getInfraLockStatus } from 'reducers/editor/selectors';
 import { loadDataModel, updateTotalsIssue } from 'reducers/editor/thunkActions';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { getIsLoading } from 'reducers/main/mainSelector';
 import { updateViewport, type Viewport } from 'reducers/map';
 import { useAppDispatch } from 'store';
@@ -208,7 +208,7 @@ const Editor = () => {
       const params = searchParams.get('selection');
       if (!params && searchParams.size !== 0) {
         dispatch(
-          setFailure({
+          notifyFailure({
             name: t('Editor.tools.select-items.errors.unable-to-select'),
             message: t('Editor.tools.select-items.errors.invalid-url'),
           })
@@ -245,7 +245,7 @@ const Editor = () => {
             if (mapRef.current) centerMapOnObject(+urlInfra, entities, dispatch, mapRef.current);
           } catch (e) {
             dispatch(
-              setFailure(
+              notifyFailure(
                 castErrorToFailure(e, {
                   name: t('Editor.tools.select-items.errors.unable-to-select'),
                   message: t('Editor.tools.select-items.errors.invalid-url'),

--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -51,7 +51,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
 }: PropsWithChildren<EditorFormProps<T>>) {
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState<GeoJsonProperties>(data.properties);
-  const [submited, setsubmited] = useState<boolean>(false);
+  const [submitted, setSubmitted] = useState<boolean>(false);
   const { t } = useTranslation('infraEditor');
 
   const editorState = useSelector(getEditorState);
@@ -89,15 +89,15 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
 
   return (
     <div>
-      {submited && error !== null && (
+      {submitted && error !== null && (
         <div className="form-error mt-3 mb-3">
           <p className="mb-0">{error}</p>
         </div>
       )}
       <Form
         fields={{ ...fields, ...(overrideFields || {}) }}
-        liveValidate={submited}
-        showErrorList={submited ? 'top' : false}
+        liveValidate={submitted}
+        showErrorList={submitted ? 'top' : false}
         action={undefined}
         noHtml5Validate
         validator={validator}
@@ -110,7 +110,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
           length: data.properties?.length,
           isCreation: isNil(formData?.id) || formData?.id === NEW_ENTITY_ID,
         }}
-        onError={() => setsubmited(true)}
+        onError={() => setSubmitted(true)}
         onSubmit={async () => {
           try {
             setError(null);
@@ -118,7 +118,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
           } catch (e) {
             setError(getErrorMessage(e));
           } finally {
-            setsubmited(true);
+            setSubmitted(true);
           }
         }}
         onChange={(event) => {

--- a/front/src/applications/editor/components/EditorForm.tsx
+++ b/front/src/applications/editor/components/EditorForm.tsx
@@ -51,7 +51,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
 }: PropsWithChildren<EditorFormProps<T>>) {
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState<GeoJsonProperties>(data.properties);
-  const [submited, setSubmited] = useState<boolean>(false);
+  const [submited, setsubmited] = useState<boolean>(false);
   const { t } = useTranslation('infraEditor');
 
   const editorState = useSelector(getEditorState);
@@ -110,7 +110,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
           length: data.properties?.length,
           isCreation: isNil(formData?.id) || formData?.id === NEW_ENTITY_ID,
         }}
-        onError={() => setSubmited(true)}
+        onError={() => setsubmited(true)}
         onSubmit={async () => {
           try {
             setError(null);
@@ -118,7 +118,7 @@ function EditorForm<T extends Omit<EditorEntity, 'objType'> & { objType: string 
           } catch (e) {
             setError(getErrorMessage(e));
           } finally {
-            setSubmited(true);
+            setsubmited(true);
           }
         }}
         onChange={(event) => {

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -15,7 +15,7 @@ import { TbZoomIn, TbZoomOut, TbZoomCancel } from 'react-icons/tb';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import {
   getZoomedViewBox,
-  transalteViewBox,
+  translateViewBox,
   splitAt,
   mergeIn,
   resizeSegment,
@@ -191,7 +191,7 @@ const IntervalEditorComponent = (
             }}
             onDragX={(gap, finalize) => {
               setMode(!finalize ? 'dragging' : null);
-              setViewBox((vb) => transalteViewBox(data, vb, gap));
+              setViewBox((vb) => translateViewBox(data, vb, gap));
             }}
             onResize={(index, gap, finalized) => {
               setMode(!finalized ? 'resizing' : null);

--- a/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
+++ b/front/src/applications/editor/components/LinearMetadata/FormComponent.tsx
@@ -209,7 +209,7 @@ const IntervalEditorComponent = (
                   }
                 }
               } catch (e) {
-                // TODO: should we display it ?
+                // Nothing to do here, no proper place to display the error
               }
             }}
           />
@@ -398,7 +398,7 @@ const IntervalEditorComponent = (
                     }
                     customOnChange(newData);
                   } catch (error) {
-                    // TODO: Should we display the resize error ?
+                    // Nothing to do here, no proper place to display the error
                   } finally {
                     setSelectedData(newItem);
                   }

--- a/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/pointEdition/components/PointEditionLeftPanel.tsx
@@ -45,7 +45,7 @@ const PointEditionLeftPanel = <Entity extends EditorEntity>({
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const infraID = useInfraID();
-  const { state, setState, isFormSubmited, setIsFormSubmited } = useContext(
+  const { state, setState, isFormSubmitted, setIsFormSubmitted } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<PointEditionState<Entity>>;
   const submitBtnRef = useRef<HTMLButtonElement>(null);
@@ -64,11 +64,11 @@ const PointEditionLeftPanel = <Entity extends EditorEntity>({
   // the toolbar button instead of the form one.
   // See https://github.com/rjsf-team/react-jsonschema-form/issues/500
   useEffect(() => {
-    if (isFormSubmited && setIsFormSubmited && submitBtnRef.current) {
+    if (isFormSubmitted && setIsFormSubmitted && submitBtnRef.current) {
       submitBtnRef.current.click();
-      setIsFormSubmited(false);
+      setIsFormSubmitted(false);
     }
-  }, [isFormSubmited]);
+  }, [isFormSubmitted]);
 
   useEffect(() => {
     const firstLoading = trackState.type === 'idle';

--- a/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
+++ b/front/src/applications/editor/tools/pointEdition/tool-factory.tsx
@@ -79,9 +79,9 @@ function getPointEditionTool<T extends EditorPoint>({
               false
             );
           },
-          async onClick({ setIsFormSubmited }) {
-            if (setIsFormSubmited) {
-              setIsFormSubmited(true);
+          async onClick({ setIsFormSubmitted }) {
+            if (setIsFormSubmitted) {
+              setIsFormSubmitted(true);
             }
           },
         },

--- a/front/src/applications/editor/tools/routeEdition/components/RouteEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/routeEdition/components/RouteEditionLeftPanel.tsx
@@ -35,7 +35,7 @@ const RouteEditionPanel = () => {
   const infraID = useInfraID();
   const dispatch = useAppDispatch();
   const [postPathfinding] = osrdEditoastApi.endpoints.postInfraByInfraIdPathfinding.useMutation();
-  const { state, setState, isFormSubmited, setIsFormSubmited } = useContext(
+  const { state, setState, isFormSubmitted, setIsFormSubmitted } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<RouteEditionState>;
 
@@ -290,14 +290,14 @@ const RouteEditionPanel = () => {
    * When clicking on the save button in the toolbar
    */
   useEffect(() => {
-    if (isFormSubmited && setIsFormSubmited && state.entity) {
-      setIsFormSubmited(false);
+    if (isFormSubmitted && setIsFormSubmitted && state.entity) {
+      setIsFormSubmitted(false);
       saveEntity(
         state.entity,
         state.entity.properties.id !== NEW_ENTITY_ID ? state.initialEntity : undefined
       );
     }
-  }, [isFormSubmited, saveEntity, state.entity, state.initialEntity, setIsFormSubmited]);
+  }, [isFormSubmitted, saveEntity, state.entity, state.initialEntity, setIsFormSubmitted]);
 
   return (
     <div className="position-relative">

--- a/front/src/applications/editor/tools/routeEdition/tool.tsx
+++ b/front/src/applications/editor/tools/routeEdition/tool.tsx
@@ -29,9 +29,9 @@ const RouteEditionTool: Tool<RouteEditionState> = {
         isDisabled({ state: { isComplete } }) {
           return !isComplete;
         },
-        async onClick({ setIsFormSubmited }) {
-          if (setIsFormSubmited) {
-            setIsFormSubmited(true);
+        async onClick({ setIsFormSubmitted }) {
+          if (setIsFormSubmitted) {
+            setIsFormSubmitted(true);
           }
         },
       },

--- a/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/SwitchEditionLeftPanel.tsx
@@ -28,7 +28,7 @@ const SwitchEditionLeftPanel = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const infraID = useInfraID();
-  const { state, setState, isFormSubmited, setIsFormSubmited } = useContext(
+  const { state, setState, isFormSubmitted, setIsFormSubmitted } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<SwitchEditionState>;
   const submitBtnRef = useRef<HTMLButtonElement>(null);
@@ -49,11 +49,11 @@ const SwitchEditionLeftPanel = () => {
   // the toolbar button instead of the form one.
   // See https://github.com/rjsf-team/react-jsonschema-form/issues/500
   useEffect(() => {
-    if (isFormSubmited && setIsFormSubmited && submitBtnRef.current) {
+    if (isFormSubmitted && setIsFormSubmitted && submitBtnRef.current) {
       submitBtnRef.current.click();
-      setIsFormSubmited(false);
+      setIsFormSubmitted(false);
     }
-  }, [isFormSubmited]);
+  }, [isFormSubmitted]);
 
   if (!switchType || !flatSwitchEntity) return null;
   return (

--- a/front/src/applications/editor/tools/switchEdition/components/TrackNodeTypeDiagram.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/TrackNodeTypeDiagram.tsx
@@ -6,40 +6,16 @@ import link from 'assets/pictures/trackNodeTypes/link.svg';
 import pointSwitch from 'assets/pictures/trackNodeTypes/point_switch.svg';
 import singleSlipSwitch from 'assets/pictures/trackNodeTypes/single_slip_switch.svg';
 
-import type { TrackNodeTypeId } from '../types';
+const SOURCES: Record<string, string> = {
+  crossing,
+  single_slip_switch: singleSlipSwitch,
+  double_slip_switch: doubleSlipSwitch,
+  link,
+  point_switch: pointSwitch,
+};
 
-enum TRACK_NODE_TYPES_ID {
-  CROSSING = 'crossing',
-  SINGLE_SLIP_SWITCH = 'single_slip_switch',
-  DOUBLE_SLIP_SWITCH = 'double_slip_switch',
-  LINK = 'link',
-  POINT_SWITCH = 'point_switch',
-}
-
-const TrackNodeTypeDiagram = ({ trackNodeType }: { trackNodeType: TrackNodeTypeId }) => {
-  const trackNodeTypeImage = useMemo(() => {
-    let source: string | undefined;
-    switch (trackNodeType) {
-      case TRACK_NODE_TYPES_ID.CROSSING:
-        source = crossing;
-        break;
-      case TRACK_NODE_TYPES_ID.SINGLE_SLIP_SWITCH:
-        source = singleSlipSwitch;
-        break;
-      case TRACK_NODE_TYPES_ID.DOUBLE_SLIP_SWITCH:
-        source = doubleSlipSwitch;
-        break;
-      case TRACK_NODE_TYPES_ID.LINK:
-        source = link;
-        break;
-      case TRACK_NODE_TYPES_ID.POINT_SWITCH:
-        source = pointSwitch;
-        break;
-      default:
-        source = undefined;
-    }
-    return source;
-  }, [trackNodeType]);
+const TrackNodeTypeDiagram = ({ trackNodeType }: { trackNodeType: string }) => {
+  const trackNodeTypeImage = useMemo(() => SOURCES[trackNodeType], [trackNodeType]);
   return trackNodeTypeImage && <img src={trackNodeTypeImage} alt={trackNodeType} />;
 };
 

--- a/front/src/applications/editor/tools/switchEdition/components/TrackNodeTypeDiagram.tsx
+++ b/front/src/applications/editor/tools/switchEdition/components/TrackNodeTypeDiagram.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import crossing from 'assets/pictures/trackNodeTypes/crossing.svg';
 import doubleSlipSwitch from 'assets/pictures/trackNodeTypes/double_slip_switch.svg';
 import link from 'assets/pictures/trackNodeTypes/link.svg';
@@ -15,7 +13,7 @@ const SOURCES: Record<string, string> = {
 };
 
 const TrackNodeTypeDiagram = ({ trackNodeType }: { trackNodeType: string }) => {
-  const trackNodeTypeImage = useMemo(() => SOURCES[trackNodeType], [trackNodeType]);
+  const trackNodeTypeImage = SOURCES[trackNodeType];
   return trackNodeTypeImage && <img src={trackNodeTypeImage} alt={trackNodeType} />;
 };
 

--- a/front/src/applications/editor/tools/switchEdition/tool.tsx
+++ b/front/src/applications/editor/tools/switchEdition/tool.tsx
@@ -6,11 +6,12 @@ import { TbSwitch2 } from 'react-icons/tb';
 import { NEW_ENTITY_ID } from 'applications/editor/data/utils';
 import { DEFAULT_COMMON_TOOL_STATE } from 'applications/editor/tools/consts';
 import type { Tool } from 'applications/editor/types';
+import type { SwitchType } from 'common/api/osrdEditoastApi';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { save } from 'reducers/editor/thunkActions';
 
 import { SwitchEditionLayers, SwitchEditionLeftPanel, SwitchMessages } from './components';
-import type { SwitchEditionState, SwitchEntity, SwitchType } from './types';
+import type { SwitchEditionState, SwitchEntity } from './types';
 import { getNewSwitch } from './utils';
 
 function getInitialState({
@@ -63,9 +64,9 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
             false
           );
         },
-        async onClick({ setIsFormSubmited }) {
-          if (setIsFormSubmited) {
-            setIsFormSubmited(true);
+        async onClick({ setIsFormSubmitted }) {
+          if (setIsFormSubmitted) {
+            setIsFormSubmitted(true);
           }
         },
       },
@@ -115,7 +116,7 @@ const SwitchEditionTool: Tool<SwitchEditionState> = {
               onConfirm={async () => {
                 await dispatch(
                   // We have to put state.initialEntity in array because delete initially works with selection which can get multiple elements
-                  // The cast is required because of the Partial<SwitchEntity> returned by getNewSwitch which doesnt fit with EditorEntity
+                  // The cast is required because of the Partial<SwitchEntity> returned by getNewSwitch which doesn't fit with EditorEntity
                   save(infraID, { delete: [state.initialEntity as SwitchEntity] })
                 );
                 setState(getInitialState({ switchTypes }));

--- a/front/src/applications/editor/tools/switchEdition/types.ts
+++ b/front/src/applications/editor/tools/switchEdition/types.ts
@@ -6,25 +6,6 @@ import type { EditorEntity } from 'applications/editor/typesEditorEntity';
 export const ENDPOINTS = ['BEGIN', 'END'] as const;
 export type EndPoint = (typeof ENDPOINTS)[number];
 
-type SwitchPortConnection = {
-  src: string;
-  dst: string;
-};
-
-// TODO : Would be better and safer if editoast was sending this type in the getSwitchTypes endpoint so we can remove all related types
-export type SwitchType = {
-  id: TrackNodeTypeId;
-  ports: string[];
-  groups: Record<string, SwitchPortConnection[]>;
-};
-
-export type TrackNodeTypeId =
-  | 'crossing'
-  | 'single_slip_switch'
-  | 'double_slip_switch'
-  | 'link'
-  | 'point_switch';
-
 export type TrackEndpoint = {
   endpoint: EndPoint;
   track: string;

--- a/front/src/applications/editor/tools/switchEdition/useSwitchTypes.ts
+++ b/front/src/applications/editor/tools/switchEdition/useSwitchTypes.ts
@@ -2,9 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { isNil } from 'lodash';
 
-import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-
-import type { SwitchType } from './types';
+import { osrdEditoastApi, type SwitchType } from 'common/api/osrdEditoastApi';
 
 // Client preferred order
 const trackNodeTypeOrder = [

--- a/front/src/applications/editor/tools/trackEdition/components/TrackEditionLeftPanel.tsx
+++ b/front/src/applications/editor/tools/trackEdition/components/TrackEditionLeftPanel.tsx
@@ -29,7 +29,7 @@ const TrackEditionLeftPanel = () => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
   const infraID = useInfraID();
-  const { state, setState, isFormSubmited, setIsFormSubmited, editorState } = useContext(
+  const { state, setState, isFormSubmitted, setIsFormSubmitted, editorState } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<TrackEditionState>;
   const submitBtnRef = useRef<HTMLButtonElement>(null);
@@ -41,11 +41,11 @@ const TrackEditionLeftPanel = () => {
   // the toolbar button instead of the form one.
   // See https://github.com/rjsf-team/react-jsonschema-form/issues/500
   useEffect(() => {
-    if (isFormSubmited && setIsFormSubmited && submitBtnRef.current) {
+    if (isFormSubmitted && setIsFormSubmitted && submitBtnRef.current) {
       submitBtnRef.current.click();
-      setIsFormSubmited(false);
+      setIsFormSubmitted(false);
     }
-  }, [isFormSubmited]);
+  }, [isFormSubmitted]);
 
   const schema = useMemo(() => {
     let jsonschema = getJsonSchemaForLayer(

--- a/front/src/applications/editor/tools/trackEdition/tool.tsx
+++ b/front/src/applications/editor/tools/trackEdition/tool.tsx
@@ -43,9 +43,9 @@ const TrackEditionTool: Tool<TrackEditionState> = {
         isDisabled({ isLoading, isInfraLocked, state }) {
           return isLoading || state.track.geometry.coordinates.length < 2 || isInfraLocked || false;
         },
-        async onClick({ setIsFormSubmited }) {
-          if (setIsFormSubmited) {
-            setIsFormSubmited(true);
+        async onClick({ setIsFormSubmitted }) {
+          if (setIsFormSubmitted) {
+            setIsFormSubmitted(true);
           }
         },
       },

--- a/front/src/applications/editor/tools/trackSplit/components/TrackSplitLeftPanel.tsx
+++ b/front/src/applications/editor/tools/trackSplit/components/TrackSplitLeftPanel.tsx
@@ -16,7 +16,7 @@ import { saveSplitTrackSection } from 'reducers/editor/thunkActions';
 const TrackSplitLeftPanel = () => {
   const { t } = useTranslation(['translation', 'infraEditor']);
   const infraID = useInfraID();
-  const { state, setState, isFormSubmited, setIsFormSubmited, switchTool, dispatch } = useContext(
+  const { state, setState, isFormSubmitted, setIsFormSubmitted, switchTool, dispatch } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<TrackSplitState>;
 
@@ -43,11 +43,11 @@ const TrackSplitLeftPanel = () => {
    * When clicking on the save button in the toolbar
    */
   useEffect(() => {
-    if (isFormSubmited && setIsFormSubmited) {
-      setIsFormSubmited(false);
+    if (isFormSubmitted && setIsFormSubmitted) {
+      setIsFormSubmitted(false);
       submit(state);
     }
-  }, [isFormSubmited, setIsFormSubmited]);
+  }, [isFormSubmitted, setIsFormSubmitted]);
 
   const isValid = isOffsetValid(state.offset, state.track);
   const trackLength = state.track.properties.length;

--- a/front/src/applications/editor/tools/trackSplit/tool.tsx
+++ b/front/src/applications/editor/tools/trackSplit/tool.tsx
@@ -44,9 +44,9 @@ const TrackSplitTool: Tool<TrackSplitState> = {
         isDisabled({ state, isLoading, isInfraLocked }) {
           return isLoading || isInfraLocked || false || !isOffsetValid(state.offset, state.track);
         },
-        async onClick({ setIsFormSubmited }) {
-          if (setIsFormSubmited) {
-            setIsFormSubmited(true);
+        async onClick({ setIsFormSubmitted }) {
+          if (setIsFormSubmitted) {
+            setIsFormSubmitted(true);
           }
         },
       },

--- a/front/src/applications/editor/types.ts
+++ b/front/src/applications/editor/types.ts
@@ -5,8 +5,7 @@ import type { Map, MapLayerMouseEvent } from 'maplibre-gl';
 import type { IconType } from 'react-icons/lib/iconBase';
 import type { ViewState } from 'react-map-gl/maplibre';
 
-import type { SwitchType } from 'applications/editor/tools/switchEdition/types';
-import type { Operation } from 'common/api/osrdEditoastApi';
+import type { Operation, SwitchType } from 'common/api/osrdEditoastApi';
 import type { ModalContextType } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import type { EditorState } from 'reducers/editor';
 import type { AppDispatch } from 'store';
@@ -58,9 +57,9 @@ export type ExtendedEditorContextType<S> = EditorContextType<S> & {
   infraID: number | undefined;
   switchTypes: SwitchType[] | undefined;
   isLoading?: boolean;
-  isFormSubmited?: boolean;
+  isFormSubmitted?: boolean;
   isInfraLocked?: boolean;
-  setIsFormSubmited?: (isSubmit: boolean) => void;
+  setIsFormSubmitted?: (isSubmit: boolean) => void;
 };
 
 export type ReadOnlyEditorContextType<S> = Omit<
@@ -93,7 +92,7 @@ export type Tool<S> = {
     infraID: number | undefined;
     switchTypes: SwitchType[] | undefined;
   }) => S;
-  // When user click on tool button on the side bar.
+  // When user click on tool button on the sidebar:
   onClick?: (context: ReadOnlyEditorContextType<CommonToolState>) => void;
   requiredLayers?: Set<Layer>;
   incompatibleLayers?: Layer[];

--- a/front/src/applications/operationalStudies/components/Project/PictureUploader.tsx
+++ b/front/src/applications/operationalStudies/components/Project/PictureUploader.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { getDocument } from 'common/api/documentApi';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { getUserSafeWord } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 
@@ -201,7 +201,7 @@ export default function PictureUploader({
 
       if (isSizeTooLarge || isWrongType) {
         dispatch(
-          setFailure({
+          notifyFailure({
             name: isSizeTooLarge
               ? t('error.uploadImageSizeTitle')
               : t('error.uploadImageTypeTitle'),

--- a/front/src/applications/operationalStudies/components/Study/StateStep.tsx
+++ b/front/src/applications/operationalStudies/components/Study/StateStep.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { StudyState } from 'applications/operationalStudies/consts';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { setSuccess } from 'reducers/main';
+import { notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 
 type Props = {
@@ -38,7 +38,7 @@ export default function StateStep({
         studyPatchForm: { name: studyName, state, tags },
       });
       dispatch(
-        setSuccess({
+        notifySuccess({
           title: t('studyUpdated'),
           text: t('studyUpdatedDetails', { name: studyName }),
         })

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -10,7 +10,7 @@ import {
   type TimetableDetailedResult,
   type TrainScheduleResult,
 } from 'common/api/osrdEditoastApi';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { updateSelectedTrainId, updateTrainIdUsedForProjection } from 'reducers/simulationResults';
 import {
   getSelectedTrainId,
@@ -110,7 +110,7 @@ const useScenarioData = (
 
   useEffect(() => {
     if (fetchTrainSchedulesError) {
-      dispatch(setFailure(castErrorToFailure(fetchTrainSchedulesError)));
+      dispatch(notifyFailure(castErrorToFailure(fetchTrainSchedulesError)));
     }
   }, [fetchTrainSchedulesError]);
 

--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -18,7 +18,7 @@ import { formatSuggestedOperationalPoints, upsertPathStepsInOPs } from 'modules/
 import { getSupportedElectrification, isThermal } from 'modules/rollingStock/helpers/electric';
 import { adjustConfWithTrainToModify } from 'modules/trainschedule/components/ManageTrainSchedule/helpers/adjustConfWithTrainToModify';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import type { OperationalStudiesConfSliceActions } from 'reducers/osrdconf/operationalStudiesConf';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
@@ -251,7 +251,7 @@ const useSetupItineraryForTrainUpdate = (
             setPathProperties(itinerary.pathProperties);
           }
         } catch (e) {
-          dispatch(setFailure(castErrorToFailure(e)));
+          dispatch(notifyFailure(castErrorToFailure(e)));
         }
       }
 

--- a/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
@@ -8,7 +8,7 @@ import type { TrainScheduleBase, TrainScheduleResult } from 'common/api/osrdEdit
 import { Loader } from 'common/Loaders';
 import { ImportTrainScheduleConfig } from 'modules/trainschedule/components/ImportTrainSchedule';
 import ImportTrainScheduleTrainsList from 'modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 
 const ImportTrainSchedule = ({
@@ -32,7 +32,7 @@ const ImportTrainSchedule = ({
   useEffect(() => {
     if (isError) {
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('rollingstock:errorMessages.unableToRetrieveRollingStock'),
           message: t('rollingstock:errorMessages.unableToRetrieveRollingStockMessage'),
         })

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -11,7 +11,7 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getStdcmV2Activated } from 'reducers/user/userSelectors';
@@ -67,7 +67,7 @@ const useStdcm = (
 
   const triggerShowFailureNotification = (error: Error) => {
     if (showFailureNotification) {
-      dispatch(setFailure(error));
+      dispatch(notifyFailure(error));
     }
   };
 

--- a/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
@@ -9,7 +9,7 @@ import type {
   TrainScheduleBase,
 } from 'common/api/osrdEditoastApi';
 import type { InfraState } from 'reducers/infra';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
 import { dateTimeFormatting, dateTimeToIso } from 'utils/date';
 import { mToMm } from 'utils/physics';
@@ -66,7 +66,7 @@ export const checkStdcmConf = (
   if (pathSteps[0] === null) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noOrigin'),
       })
@@ -76,7 +76,7 @@ export const checkStdcmConf = (
   if (!(osrdconf.originTime && osrdconf.originUpperBoundTime) && !stdcmV2Activated) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noOriginTime'),
       })
@@ -85,7 +85,7 @@ export const checkStdcmConf = (
   if (pathSteps[pathSteps.length - 1] === null) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noDestination'),
       })
@@ -94,7 +94,7 @@ export const checkStdcmConf = (
   if (!rollingStockID) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noRollingStock'),
       })
@@ -103,7 +103,7 @@ export const checkStdcmConf = (
   if (!infraID) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noName'),
       })
@@ -112,7 +112,7 @@ export const checkStdcmConf = (
   if (!timetableID) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noTimetable'),
       })
@@ -133,7 +133,7 @@ export const checkStdcmConf = (
   } else if (!startTime) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.noOriginTime'),
       })
@@ -151,7 +151,7 @@ export const checkStdcmConf = (
   ) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('operationalStudies/manageTrainSchedule:errorMessages.trainScheduleTitle'),
         message: t('operationalStudies/manageTrainSchedule:errorMessages.originTimeOutsideWindow', {
           low: dateTimeFormatting(searchDatetimeWindow.begin, false, false),

--- a/front/src/common/IntervalsDataViz/IntervalItem.tsx
+++ b/front/src/common/IntervalsDataViz/IntervalItem.tsx
@@ -10,13 +10,13 @@ import {
 } from './utils';
 
 interface IntervalItemProps<T> extends IntervalItemBaseProps<T> {
-  dragingStartAt: number | null;
+  draggingStartAt: number | null;
   fullLength: number;
   min: number;
   max: number;
   resizing: { index: number | null; startAt: number } | null;
   segment: LinearMetadataItem & { index: number };
-  setDraginStartAt: (dragingStartAt: number) => void;
+  setDraggingStartAt: (draggingStartAt: number) => void;
   setResizing: (
     resizing: { index: number | null; startAt: number; startPosition: number } | null
   ) => void;
@@ -25,7 +25,7 @@ interface IntervalItemProps<T> extends IntervalItemBaseProps<T> {
 const IntervalItem = <T extends { [key: string]: string | number }>({
   creating,
   data,
-  dragingStartAt,
+  draggingStartAt,
   emptyValue,
   field,
   fullLength,
@@ -42,7 +42,7 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
   options,
   resizing,
   segment,
-  setDraginStartAt,
+  setDraggingStartAt,
   setResizing,
   disableDrag = true,
 }: IntervalItemProps<T>) => {
@@ -84,21 +84,21 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
         width: `${((segment.end - segment.begin) / fullLength) * 100}%`,
       }}
       onClick={(e) => {
-        if (!dragingStartAt && onClick && data[segment.index]) {
+        if (!draggingStartAt && onClick && data[segment.index]) {
           const item = data[segment.index];
           const point = getPositionFromMouseEventAndSegment(e, item);
           onClick(e, item, segment.index, point);
         }
       }}
       onDoubleClick={(e) => {
-        if (!dragingStartAt && onDoubleClick && data[segment.index]) {
+        if (!draggingStartAt && onDoubleClick && data[segment.index]) {
           const item = data[segment.index];
           const point = getPositionFromMouseEventAndSegment(e, item);
           onDoubleClick(e, item, segment.index, point);
         }
       }}
       onMouseOver={(e) => {
-        if (!dragingStartAt) {
+        if (!draggingStartAt) {
           // handle mouse over
           if (onMouseOver && data[segment.index]) {
             const item = data[segment.index];
@@ -111,7 +111,7 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
       role="button"
       tabIndex={0}
       onMouseEnter={(e) => {
-        if (!dragingStartAt && onMouseEnter && data[segment.index]) {
+        if (!draggingStartAt && onMouseEnter && data[segment.index]) {
           const item = data[segment.index];
           const point = getPositionFromMouseEventAndSegment(e, item);
           onMouseEnter(e, item, segment.index, point);
@@ -124,14 +124,13 @@ const IntervalItem = <T extends { [key: string]: string | number }>({
           onCreate(point);
           setResizing({ index: segment.index + 1, startAt: e.clientX, startPosition: point + 1 });
         } else {
-          // TODO use the frag tool context here
-          setDraginStartAt(e.clientX);
+          setDraggingStartAt(e.clientX);
         }
         e.stopPropagation();
         e.preventDefault();
       }}
       onWheel={(e) => {
-        if (!dragingStartAt && onWheel && data[segment.index]) {
+        if (!draggingStartAt && onWheel && data[segment.index]) {
           const item = data[segment.index];
           const point = getPositionFromMouseEventAndSegment(e, item);
           onWheel(e, item, segment.index, point);

--- a/front/src/common/IntervalsDataViz/dataviz.tsx
+++ b/front/src/common/IntervalsDataViz/dataviz.tsx
@@ -91,7 +91,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
   // Need to compute the full length of the segment, to compute size in %
   const [fullLength, setFullLength] = useState<number>(0);
   // If the user is doing a drag'n'drop
-  const [draginStartAt, setDraginStartAt] = useState<number | null>(null);
+  const [draggingStartAt, setDraggingStartAt] = useState<number | null>(null);
   // Store the data for the resizing:
   const [resizing, setResizing] = useState<{
     index: number | null;
@@ -233,20 +233,20 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
     let fnUp: ((e: MouseEvent) => void) | undefined;
     let fnMove: ((e: MouseEvent) => void) | undefined;
 
-    if (onDragX && draginStartAt && wrapper.current) {
+    if (onDragX && draggingStartAt && wrapper.current) {
       const wrapperWidth = wrapper.current.offsetWidth;
 
       // function for key up
       fnUp = (e) => {
-        const delta = ((draginStartAt - e.clientX) / wrapperWidth) * fullLength;
+        const delta = ((draggingStartAt - e.clientX) / wrapperWidth) * fullLength;
         onDragX(delta, true);
-        setDraginStartAt(null);
+        setDraggingStartAt(null);
       };
       // function for move
       fnMove = (e) => {
-        const delta = ((draginStartAt - e.clientX) / wrapperWidth) * fullLength;
+        const delta = ((draggingStartAt - e.clientX) / wrapperWidth) * fullLength;
         onDragX(delta, false);
-        setDraginStartAt(e.clientX);
+        setDraggingStartAt(e.clientX);
       };
 
       document.addEventListener('mouseup', fnUp, true);
@@ -259,7 +259,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
         document.removeEventListener('mousemove', fnMove, true);
       }
     };
-  }, [draginStartAt, onDragX, wrapper, fullLength]);
+  }, [draggingStartAt, onDragX, wrapper, fullLength]);
 
   /**
    * When resize starts
@@ -314,7 +314,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
       <div
         className={cx(
           'data',
-          viewBox !== null && draginStartAt && 'dragging',
+          viewBox !== null && draggingStartAt && 'dragging',
           resizing && 'resizing',
           (viewBox === null || viewBox[0] === 0) && 'start-visible',
           (viewBox === null || viewBox[1] === last(data)?.end) && 'end-visible'
@@ -350,7 +350,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           // display vertical bar when hover element
           setHoverAtx(e.clientX - (wrapperObject ? wrapperObject.getBoundingClientRect().x : 0));
 
-          if (!draginStartAt && onMouseMove && wrapperObject) {
+          if (!draggingStartAt && onMouseMove && wrapperObject) {
             const point =
               (viewBox ? viewBox[0] : 0) + getPositionFromMouseEvent(e, fullLength, wrapperObject);
             const result = getHoveredItem(data, e.clientX);
@@ -363,7 +363,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
         className={cx(
           'data',
           highlighted.length > 0 && 'has-highlight',
-          viewBox !== null && draginStartAt && 'dragging',
+          viewBox !== null && draggingStartAt && 'dragging',
           resizing && 'resizing',
           (viewBox === null || viewBox[0] === 0) && 'start-visible',
           (viewBox === null || viewBox[1] === last(data)?.end) && 'end-visible'
@@ -374,7 +374,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           <SimpleScale className="scale-y" begin={min} end={max} />
         )}
 
-        {!isNil(hoverAtx) && hoverAtx > 0 && !draginStartAt && (
+        {!isNil(hoverAtx) && hoverAtx > 0 && !draggingStartAt && (
           <div
             className="hover-x"
             style={{
@@ -393,7 +393,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
           <IntervalItem
             creating={creating}
             data={data}
-            dragingStartAt={draginStartAt}
+            draggingStartAt={draggingStartAt}
             emptyValue={emptyValue}
             field={field}
             fullLength={fullLength}
@@ -411,7 +411,7 @@ export const LinearMetadataDataviz = <T extends { [key: string]: any }>({
             options={options}
             resizing={resizing}
             segment={segment}
-            setDraginStartAt={setDraginStartAt}
+            setDraggingStartAt={setDraggingStartAt}
             setResizing={setResizing}
             disableDrag={disableDrag}
           />

--- a/front/src/common/IntervalsEditor/IntervalsEditor.tsx
+++ b/front/src/common/IntervalsEditor/IntervalsEditor.tsx
@@ -8,7 +8,7 @@ import {
   mergeIn,
   resizeSegment,
   splitAt,
-  transalteViewBox,
+  translateViewBox,
 } from 'common/IntervalsDataViz/data';
 import { LinearMetadataDataviz } from 'common/IntervalsDataViz/dataviz';
 import type { LinearMetadataItem, OperationalPoint } from 'common/IntervalsDataViz/types';
@@ -18,7 +18,7 @@ import IntervalsEditorCommonForm from './IntervalsEditorCommonForm';
 import IntervalsEditorMarginForm from './IntervalsEditorMarginForm';
 import IntervalsEditorSelectForm from './IntervalsEditorSelectForm';
 import ToolButtons from './IntervalsEditorToolButtons';
-import IntervalsEditorTootlip from './IntervalsEditorTooltip';
+import IntervalsEditorTooltip from './IntervalsEditorTooltip';
 import {
   type AdditionalDataItem,
   INTERVALS_EDITOR_TOOLS,
@@ -31,7 +31,7 @@ import { createEmptySegmentAt, removeSegment } from './utils';
 import ZoomButtons from './ZoomButtons';
 
 export type IntervalsEditorProps = {
-  /** Additionnal read-only data that will be displayed along the path, below the intervals editor */
+  /** Additional read-only data that will be displayed along the path, below the intervals editor */
   additionalData?: AdditionalDataItem[];
   /** Default value used when a new range is created */
   defaultValue: number | string;
@@ -285,7 +285,7 @@ const IntervalsEditor = (props: IntervalsEditorProps) => {
             onDragX={(gap, finalize) => {
               setMode(!finalize ? 'dragging' : null);
 
-              setViewBox((vb) => transalteViewBox(data, vb, gap));
+              setViewBox((vb) => translateViewBox(data, vb, gap));
             }}
             onResize={(index, gap, finalized) => {
               setMode(!finalized ? 'resizing' : null);
@@ -307,7 +307,6 @@ const IntervalsEditor = (props: IntervalsEditorProps) => {
                   }
                 }
               } catch (e) {
-                // TODO: should we display it ?
                 console.warn(e);
               }
             }}
@@ -327,7 +326,7 @@ const IntervalsEditor = (props: IntervalsEditorProps) => {
         {/* Data visualisation tooltip when item is hovered */}
         {mode !== 'dragging' && hovered !== null && data[hovered.index] && (
           <div className="tooltip" ref={tooltipRef}>
-            <IntervalsEditorTootlip item={data[hovered.index]} point={hovered.point} />
+            <IntervalsEditorTooltip item={data[hovered.index]} point={hovered.point} />
           </div>
         )}
 

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -15,7 +15,7 @@ import SelectImproved from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import SignalCard from 'common/Map/Search/SignalCard';
 import { createMapSearchQuery, onResultSearchClick } from 'common/Map/utils';
 import { useInfraID } from 'common/osrdContext';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import type { Viewport } from 'reducers/map';
 import { getMap } from 'reducers/map/selectors';
 import { useAppDispatch } from 'store';
@@ -140,7 +140,7 @@ const MapSearchSignal = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchSi
       .catch((e) => {
         setSearchResults([]);
         dispatch(
-          setFailure(
+          notifyFailure(
             castErrorToFailure(e, { name: t('map-search:errorMessages.unableToSearchSignal') })
           )
         );

--- a/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
+++ b/front/src/common/Map/Settings/MapSettingsSpeedLimits.tsx
@@ -16,7 +16,7 @@ import {
   Icon2SVG,
 } from 'common/Map/Settings/MapSettingsLayers';
 import { useInfraID } from 'common/osrdContext';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { updateLayersSettings } from 'reducers/map';
 import type { MapState } from 'reducers/map';
 import { getMap } from 'reducers/map/selectors';
@@ -79,7 +79,7 @@ const FormatSwitch = ({ name, icon: IconComponent, color = '', disabled }: Forma
   useEffect(() => {
     if (isGetSpeedLimitTagsError && getSpeedLimitTagsError) {
       dispatch(
-        setFailure(
+        notifyFailure(
           castErrorToFailure(getSpeedLimitTagsError, {
             name: t('errorMessages.unableToRetrieveTags'),
           })

--- a/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
+++ b/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useOsrdConfSelectors, useOsrdConfActions, useInfraID } from 'common/osrdContext';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -38,7 +38,7 @@ export const useStoreDataForSpeedLimitByTagSelector = () => {
     // Update the document title using the browser API
     if (error) {
       dispatch(
-        setFailure(castErrorToFailure(error, { name: t('errorMessages.unableToRetrieveTags') }))
+        notifyFailure(castErrorToFailure(error, { name: t('errorMessages.unableToRetrieveTags') }))
       );
     }
   }, [error]);

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBar.tsx
@@ -7,7 +7,7 @@ import { MdCancel, MdCheck } from 'react-icons/md';
 
 import { type Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import InfraLockState from 'modules/infra/consts';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -41,7 +41,7 @@ export default function ActionsBar({ infra, isFocused, setIsFocused, inputValue 
         }
       } catch (e) {
         if (e instanceof Error) {
-          dispatch(setFailure(castErrorToFailure(e)));
+          dispatch(notifyFailure(castErrorToFailure(e)));
         }
       } finally {
         setIsWaiting(false);
@@ -58,7 +58,7 @@ export default function ActionsBar({ infra, isFocused, setIsFocused, inputValue 
       } catch (e) {
         if (e instanceof Error) {
           dispatch(
-            setFailure({
+            notifyFailure({
               name: e.name,
               message: e.message,
             })
@@ -78,7 +78,7 @@ export default function ActionsBar({ infra, isFocused, setIsFocused, inputValue 
       } catch (e) {
         if (e instanceof Error) {
           dispatch(
-            setFailure({
+            notifyFailure({
               name: e.name,
               message: e.message,
             })
@@ -99,7 +99,7 @@ export default function ActionsBar({ infra, isFocused, setIsFocused, inputValue 
       } catch (e) {
         if (e instanceof Error) {
           dispatch(
-            setFailure({
+            notifyFailure({
               name: e.name,
               message: e.message,
             })

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBarDelete.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorEditionActionsBarDelete.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { type Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { Spinner } from 'common/Loaders';
 import { useInfraActions, useInfraID } from 'common/osrdContext';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -30,7 +30,7 @@ export default function InfraSelectorEditionActionsBarDelete({
       await deleteInfra({ infraId: infra.id });
       setRunningDelete(false);
       dispatch(
-        setSuccess({
+        notifySuccess({
           title: t('infraDeleted', { name: infra.name }),
           text: '',
         })
@@ -40,7 +40,7 @@ export default function InfraSelectorEditionActionsBarDelete({
       }
     } catch (e) {
       if (e instanceof Error) {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       }
     }
   }

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModal.tsx
@@ -9,7 +9,7 @@ import { type Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
 import { Loader } from 'common/Loaders';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { useDebounce } from 'utils/helpers';
@@ -59,7 +59,7 @@ const InfraSelectorModal = ({ onlySelectionMode = false, isInEditor }: InfraSele
   useEffect(() => {
     if (isError && error) {
       dispatch(
-        setFailure(
+        notifyFailure(
           castErrorToFailure(error, {
             name: t('infraManagement:errorMessages.unableToRetrieveInfraList'),
           })

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -14,7 +14,7 @@ import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
 import Tipped from 'common/Tipped';
 import Pathfinding from 'modules/pathfinding/components/Pathfinding/Pathfinding';
 import TypeAndPath from 'modules/pathfinding/components/Pathfinding/TypeAndPath';
-import { setWarning } from 'reducers/main';
+import { notifyWarning } from 'reducers/main';
 import { updateViewport } from 'reducers/map';
 import { getMap } from 'reducers/map/selectors';
 import { useAppDispatch } from 'store';
@@ -71,7 +71,7 @@ const Itinerary = ({
   const notifyRestrictionResetWarning = () => {
     if (!isEmptyArray(powerRestrictions)) {
       dispatch(
-        setWarning({
+        notifyWarning({
           title: t('warningMessages.pathfindingChange'),
           text: t('warningMessages.powerRestrictionsReset'),
         })

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -21,7 +21,7 @@ import {
 } from 'modules/pathfinding/utils';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
-import { setFailure, setWarning } from 'reducers/main';
+import { notifyFailure, notifyWarning } from 'reducers/main';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { isEmptyArray } from 'utils/array';
@@ -215,7 +215,7 @@ export const usePathfinding = (
         const pathfindingInput = generatePathfindingParams();
         if (!pathfindingInput || !infraId) {
           dispatch(
-            setFailure({
+            notifyFailure({
               name: t('pathfinding'),
               message: t('pathfindingMissingParamsSimple'),
             })
@@ -283,7 +283,7 @@ export const usePathfinding = (
 
               if (!isEmptyArray(powerRestrictions)) {
                 dispatch(
-                  setWarning({
+                  notifyWarning({
                     title: t('warningMessages.pathfindingChange'),
                     text: t('warningMessages.powerRestrictionsReset'),
                   })
@@ -330,7 +330,7 @@ export const usePathfinding = (
         } catch (e) {
           if (isObject(e)) {
             if ('error' in e) {
-              dispatch(setFailure(castErrorToFailure(e, { name: t('pathfinding') })));
+              dispatch(notifyFailure(castErrorToFailure(e, { name: t('pathfinding') })));
               pathfindingDispatch({ type: 'PATHFINDING_ERROR', message: 'failedRequest' });
             } else if ('data' in e && isObject(e.data) && 'message' in e.data) {
               pathfindingDispatch({ type: 'PATHFINDING_ERROR', message: e.data.message as string });

--- a/front/src/modules/project/components/AddOrEditProjectModal.tsx
+++ b/front/src/modules/project/components/AddOrEditProjectModal.tsx
@@ -24,7 +24,7 @@ import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import TextareaSNCF from 'common/BootstrapSNCF/TextareaSNCF';
 import { useOsrdConfActions } from 'common/osrdContext';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { getUserSafeWord } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
@@ -113,7 +113,7 @@ export default function AddOrEditProjectModal({
       return await postDocument(image);
     } catch (error) {
       dispatch(
-        setFailure(castErrorToFailure(error, { name: t('error.unableToPostDocumentTitle') }))
+        notifyFailure(castErrorToFailure(error, { name: t('error.unableToPostDocumentTitle') }))
       );
       return null;
     }
@@ -143,7 +143,7 @@ export default function AddOrEditProjectModal({
           })
           .catch((error) => {
             dispatch(
-              setFailure(
+              notifyFailure(
                 castErrorToFailure(error, {
                   name: t('error.unableToCreateProjectTitle'),
                 })
@@ -189,7 +189,7 @@ export default function AddOrEditProjectModal({
           })
           .catch((error) => {
             dispatch(
-              setFailure(
+              notifyFailure(
                 castErrorToFailure(error, {
                   name: t('error.unableToUpdateProjectTitle'),
                 })
@@ -212,7 +212,7 @@ export default function AddOrEditProjectModal({
           navigate(`/operational-studies/projects/`);
           closeModal();
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('projectDeleted'),
               text: t('projectDeletedDetails', { name: project.name }),
             })
@@ -220,7 +220,7 @@ export default function AddOrEditProjectModal({
         })
         .catch((e) => {
           dispatch(
-            setFailure(
+            notifyFailure(
               castErrorToFailure(e, {
                 name: t('error.unableToDeleteProject'),
               })

--- a/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardDetail.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCard/RollingStockCardDetail.tsx
@@ -12,7 +12,7 @@ import RollingStockCurves from 'modules/rollingStock/components/RollingStockCurv
 import { STANDARD_COMFORT_LEVEL } from 'modules/rollingStock/consts';
 import { convertUnits } from 'modules/rollingStock/helpers/utils';
 import type { EffortCurveForms } from 'modules/rollingStock/types';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -67,7 +67,7 @@ export default function RollingStockCardDetail({
   useEffect(() => {
     if (error) {
       dispatch(
-        setFailure(
+        notifyFailure(
           castErrorToFailure(error, {
             name: t('errorMessages.unableToRetrieveRollingStockMessage'),
             message: t('errorMessages.unableToRetrieveRollingStock'),

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorButtons.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorButtons.tsx
@@ -6,7 +6,7 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { RollingStock } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import RollingStockEditorFormModal from 'modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormModal';
-import { setSuccess, setFailure } from 'reducers/main';
+import { notifySuccess, notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure, getErrorStatus } from 'utils/error';
 
@@ -41,7 +41,7 @@ const RollingStockEditorButtons = ({
         .unwrap()
         .then(() => {
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('messages.success'),
               text: t('messages.rollingStockDeleted'),
             })
@@ -57,7 +57,7 @@ const RollingStockEditorButtons = ({
             );
           }
           dispatch(
-            setFailure(
+            notifyFailure(
               castErrorToFailure(error, {
                 name: t('messages.failure'),
                 message: t('messages.rollingStockNotDeleted'),
@@ -80,14 +80,14 @@ const RollingStockEditorButtons = ({
         setIsEditing(true);
         resetFilters();
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('messages.success'),
             text: t('messages.rollingStockAdded'),
           })
         );
       })
       .catch((error) => {
-        dispatch(setFailure(castErrorToFailure(error, { name: t('messages.failure') })));
+        dispatch(notifyFailure(castErrorToFailure(error, { name: t('messages.failure') })));
       });
   };
 

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
@@ -27,7 +27,7 @@ import {
   rollingStockEditorQueryArg,
 } from 'modules/rollingStock/helpers/utils';
 import type { EffortCurveForms, RollingStockParametersValues } from 'modules/rollingStock/types';
-import { addFailureNotification, setFailure, setSuccess } from 'reducers/main';
+import { addFailureNotification, notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import { usePrevious } from 'utils/hooks/state';
@@ -103,7 +103,7 @@ const RollingStockEditorForm = ({
       .then((res) => {
         if (setOpenedRollingStockCardId) setOpenedRollingStockCardId(res.id);
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('messages.success'),
             text: t('messages.rollingStockAdded'),
           })
@@ -112,7 +112,7 @@ const RollingStockEditorForm = ({
       })
       .catch((error) => {
         dispatch(
-          setFailure(
+          notifyFailure(
             castErrorToFailure(error, {
               name: t('messages.failure'),
             })
@@ -130,7 +130,7 @@ const RollingStockEditorForm = ({
         .unwrap()
         .then(() => {
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('messages.success'),
               text: t('messages.rollingStockUpdated'),
             })
@@ -139,7 +139,7 @@ const RollingStockEditorForm = ({
         })
         .catch((error) => {
           dispatch(
-            setFailure(
+            notifyFailure(
               castErrorToFailure(error, {
                 name: t('messages.failure'),
               })

--- a/front/src/modules/rollingStock/hooks/useFilterRollingStock.tsx
+++ b/front/src/modules/rollingStock/hooks/useFilterRollingStock.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { LightRollingStock, LightRollingStockWithLiveries } from 'common/api/osrdEditoastApi';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -169,7 +169,7 @@ export default function useFilterRollingStock() {
 
   useEffect(() => {
     if (isError && error) {
-      dispatch(setFailure(castErrorToFailure(error)));
+      dispatch(notifyFailure(castErrorToFailure(error)));
     }
   }, [isError]);
 

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -21,7 +21,7 @@ import SelectImprovedSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import TextareaSNCF from 'common/BootstrapSNCF/TextareaSNCF';
 import { useInfraID, useOsrdConfActions } from 'common/osrdContext';
 import { InfraSelectorModal } from 'modules/infra/components/InfraSelector';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 import useInputChange from 'utils/hooks/useInputChange';
@@ -180,7 +180,7 @@ export default function AddOrEditScenarioModal({
           closeModal();
         })
         .catch((error) => {
-          dispatch(setFailure(castErrorToFailure(error)));
+          dispatch(notifyFailure(castErrorToFailure(error)));
         });
     }
   };
@@ -203,7 +203,7 @@ export default function AddOrEditScenarioModal({
         .unwrap()
         .then(() => {
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('scenarioUpdated'),
               text: t('scenarioUpdatedDetails', { name: currentScenario.name }),
             })
@@ -211,7 +211,7 @@ export default function AddOrEditScenarioModal({
           closeModal();
         })
         .catch((error) => {
-          dispatch(setFailure(castErrorToFailure(error)));
+          dispatch(notifyFailure(castErrorToFailure(error)));
         });
     }
   };
@@ -225,7 +225,7 @@ export default function AddOrEditScenarioModal({
           navigate(`projects/${projectId}/studies/${studyId}`);
           closeModal();
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('scenarioDeleted'),
               text: t('scenarioDeletedDetails', { name: scenario.name }),
             })
@@ -234,7 +234,7 @@ export default function AddOrEditScenarioModal({
         .catch((error) => {
           console.error(error);
           dispatch(
-            setFailure({
+            notifyFailure({
               name: t('errorMessages.error'),
               message: t('errorMessages.unableToDeleteScenarioMessage'),
             })

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
@@ -14,7 +14,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
@@ -60,7 +60,7 @@ const ScenarioExplorerModal = ({
 
   useEffect(() => {
     if (isProjectsError) {
-      dispatch(setFailure(castErrorToFailure(projectsError)));
+      dispatch(notifyFailure(castErrorToFailure(projectsError)));
     }
   }, [isProjectsError]);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -11,7 +11,7 @@ import {
   type TrainScheduleResult,
 } from 'common/api/osrdEditoastApi';
 import { useOsrdConfSelectors } from 'common/osrdContext';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { getBatchPackage } from 'utils/batch';
 import { castErrorToFailure } from 'utils/error';
@@ -105,7 +105,7 @@ const useLazyProjectTrains = ({
           await projectNextPackage(_path, packageToProject);
         } catch (e) {
           console.error('error', e);
-          dispatch(setFailure(castErrorToFailure(e)));
+          dispatch(notifyFailure(castErrorToFailure(e)));
         }
       }
     };

--- a/front/src/modules/study/components/AddOrEditStudyModal.tsx
+++ b/front/src/modules/study/components/AddOrEditStudyModal.tsx
@@ -22,7 +22,7 @@ import SelectImprovedSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import TextareaSNCF from 'common/BootstrapSNCF/TextareaSNCF';
 import { useOsrdConfActions } from 'common/osrdContext';
 import { checkStudyFields, createSelectOptions } from 'modules/study/utils';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { formatDateForInput, getEarliestDate } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
@@ -133,7 +133,7 @@ export default function AddOrEditStudyModal({ editionMode, study }: Props) {
         .unwrap()
         .then(() => {
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('studyUpdated'),
               text: t('studyUpdatedDetails', { name: study.name }),
             })
@@ -152,7 +152,7 @@ export default function AddOrEditStudyModal({ editionMode, study }: Props) {
         .unwrap()
         .then(() => {
           dispatch(
-            setSuccess({
+            notifySuccess({
               title: t('studyDeleted'),
               text: t('studyDeletedDetails', { name: study.name }),
             })
@@ -186,13 +186,13 @@ export default function AddOrEditStudyModal({ editionMode, study }: Props) {
 
   /* Notify API errors */
   useEffect(() => {
-    if (createStudyError) dispatch(setFailure(castErrorToFailure(createStudyError)));
+    if (createStudyError) dispatch(notifyFailure(castErrorToFailure(createStudyError)));
   }, [createStudyError]);
   useEffect(() => {
-    if (patchStudyError) dispatch(setFailure(castErrorToFailure(patchStudyError)));
+    if (patchStudyError) dispatch(notifyFailure(castErrorToFailure(patchStudyError)));
   }, [patchStudyError]);
   useEffect(() => {
-    if (deleteStudyError) dispatch(setFailure(castErrorToFailure(deleteStudyError)));
+    if (deleteStudyError) dispatch(notifyFailure(castErrorToFailure(deleteStudyError)));
   }, [deleteStudyError]);
 
   useModalFocusTrap(modalRef, closeModal);

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -15,7 +15,7 @@ import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import StationCard, { type ImportStation } from 'common/StationCard';
 import UploadFileModal from 'common/uploadFileModal';
 import StationSelector from 'modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleStationSelector';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { formatIsoDate } from 'utils/date';
 
@@ -62,7 +62,7 @@ const ImportTrainScheduleConfig = ({
     });
     if (isInvalidTrainSchedules) {
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('errorMessages.error'),
           message: t('errorMessages.errorImport'),
         })
@@ -114,22 +114,25 @@ const ImportTrainScheduleConfig = ({
     let error = false;
     if (!from) {
       dispatch(
-        setFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoFrom') })
+        notifyFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoFrom') })
       );
     }
     if (!to) {
       dispatch(
-        setFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoTo') })
+        notifyFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoTo') })
       );
     }
     if (!date) {
       dispatch(
-        setFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoDate') })
+        notifyFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorNoDate') })
       );
     }
     if (JSON.stringify(from) === JSON.stringify(to)) {
       dispatch(
-        setFailure({ name: t('errorMessages.error'), message: t('errorMessages.errorSameFromTo') })
+        notifyFailure({
+          name: t('errorMessages.error'),
+          message: t('errorMessages.errorSameFromTo'),
+        })
       );
       error = true;
     }

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
@@ -15,7 +15,7 @@ import {
 import { Loader } from 'common/Loaders';
 import { ImportTrainScheduleTrainDetail } from 'modules/trainschedule/components/ImportTrainSchedule';
 import rollingstockOpenData2OSRD from 'modules/trainschedule/components/ImportTrainSchedule/rollingstock_opendata2osrd.json';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 
 import { generateTrainSchedulesPayloads } from './generateTrainSchedulesPayloads';
@@ -79,7 +79,7 @@ const ImportTrainScheduleTrainsList = ({
       const trainSchedules = await postTrainSchedule({ id: timetableId, body: payloads }).unwrap();
       upsertTrainSchedules(trainSchedules);
       dispatch(
-        setSuccess({
+        notifySuccess({
           title: t('success'),
           text: t('status.calculatingTrainScheduleCompleteAllSuccess', {
             trainsList,
@@ -89,7 +89,7 @@ const ImportTrainScheduleTrainsList = ({
       );
     } catch (error) {
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('failure'),
           message: t('status.calculatingTrainScheduleCompleteAllFailure', {
             trainsList,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
@@ -11,7 +11,7 @@ import type {
 import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import trainNameWithNum from 'modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { formatToIsoDate, isoDateToMs } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
@@ -77,7 +77,7 @@ const AddTrainScheduleButton = ({
         }).unwrap();
 
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('trainAdded'),
             text: `${baseTrainName}: ${sec2time(formattedStartTimeMs / 1000)}`,
           })
@@ -86,7 +86,7 @@ const AddTrainScheduleButton = ({
         upsertTrainSchedules(newTrainSchedules);
       } catch (e) {
         setIsWorking(false);
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       }
     }
   };

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash';
 import type { Dispatch } from 'redux';
 
 import type { ValidConfig } from 'modules/trainschedule/components/ManageTrainSchedule/types';
-import { setFailure } from 'reducers/main';
+import { notifyFailure } from 'reducers/main';
 import type { OsrdConfState } from 'reducers/osrdconf/types';
 import { isInvalidFloatNumber } from 'utils/numbers';
 import { kmhToMs, mToMm } from 'utils/physics';
@@ -39,7 +39,7 @@ const checkCurrentConfig = (
   if (pathSteps[0] === null) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noOrigin'),
       })
@@ -48,7 +48,7 @@ const checkCurrentConfig = (
   if (!startTime) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noDepartureTime'),
       })
@@ -57,7 +57,7 @@ const checkCurrentConfig = (
   if (pathSteps[pathSteps.length - 1] === null) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noDestination'),
       })
@@ -66,7 +66,7 @@ const checkCurrentConfig = (
   if (!rollingStockName) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noRollingStock'),
       })
@@ -75,7 +75,7 @@ const checkCurrentConfig = (
   if (!trainName) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noName'),
       })
@@ -84,7 +84,7 @@ const checkCurrentConfig = (
   if (!timetableID) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.noTimetable'),
       })
@@ -94,7 +94,7 @@ const checkCurrentConfig = (
   if (isInvalidFloatNumber(initialSpeed!, 1)) {
     error = true;
     dispatch(
-      setFailure({
+      notifyFailure({
         name: t('errorMessages.trainScheduleTitle'),
         message: t('errorMessages.invalidInitialSpeed'),
       })
@@ -106,7 +106,7 @@ const checkCurrentConfig = (
     if (trainCount < 1) {
       error = true;
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('errorMessages.trainScheduleTitle'),
           message: t('errorMessages.noTrainCount'),
         })
@@ -115,7 +115,7 @@ const checkCurrentConfig = (
     if (trainDelta < 1) {
       error = true;
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('errorMessages.trainScheduleTitle'),
           message: t('errorMessages.noDelta'),
         })
@@ -124,7 +124,7 @@ const checkCurrentConfig = (
     if (trainStep < 1) {
       error = true;
       dispatch(
-        setFailure({
+        notifyFailure({
           name: t('errorMessages.trainScheduleTitle'),
           message: t('errorMessages.noTrainStep'),
         })

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig.ts
@@ -1,15 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { compact } from 'lodash';
+import { compact, omit } from 'lodash';
 import type { Dispatch } from 'redux';
 
 import type { ValidConfig } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { notifyFailure } from 'reducers/main';
-import type { OsrdConfState } from 'reducers/osrdconf/types';
+import type { OsrdConfState, PathStep } from 'reducers/osrdconf/types';
 import { isInvalidFloatNumber } from 'utils/numbers';
 import { kmhToMs, mToMm } from 'utils/physics';
 
 import formatMargin from './formatMargin';
 import formatSchedule from './formatSchedule';
+import type { TrainScheduleBase } from '../../../../../common/api/generatedEditoastApi';
 
 const checkCurrentConfig = (
   osrdconf: OsrdConfState,
@@ -145,22 +146,28 @@ const checkCurrentConfig = (
     rollingStockComfort,
     initialSpeed: initialSpeed ? kmhToMs(initialSpeed) : 0,
     usingElectricalProfiles,
-    path: compact(pathSteps).map((step) => {
-      // TODO use lodash pick
-      const {
-        arrival,
-        locked,
-        stopFor,
-        positionOnPath,
-        coordinates,
-        name,
-        ch,
-        metadata,
-        kp,
-        receptionSignal,
-        theoreticalMargin,
-        ...stepLocation
-      } = step;
+    path: compact(pathSteps).map((step: PathStep) => {
+      const { ch } = step;
+      const stepLocation = omit(
+        step,
+        // These are all the keys of PathStep that are in the path function
+        // expected results:
+        'arrival',
+        'arrivalType',
+        'arrivalToleranceBefore',
+        'arrivalToleranceAfter',
+        'locked',
+        'stopFor',
+        'stopType',
+        'theoreticalMargin',
+        'receptionSignal',
+        'kp',
+        'positionOnPath',
+        'coordinates',
+        'name',
+        'ch',
+        'metadata'
+      ) as TrainScheduleBase['path'][number];
 
       if ('track' in stepLocation) {
         return {

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -6,7 +6,7 @@ import { osrdEditoastApi, type TrainScheduleResult } from 'common/api/osrdEditoa
 import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import checkCurrentConfig from 'modules/trainschedule/components/ManageTrainSchedule/helpers/checkCurrentConfig';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { formatToIsoDate } from 'utils/date';
@@ -53,7 +53,7 @@ const useUpdateTrainSchedule = (
 
         upsertTrainSchedules([trainScheduleResult]);
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('trainUpdated'),
             text: `${confName}: ${formatToIsoDate(startTime, true)}`,
           })
@@ -62,7 +62,7 @@ const useUpdateTrainSchedule = (
         setDisplayTrainScheduleManagement(MANAGE_TRAIN_SCHEDULE_TYPES.none);
         setTrainIdToEdit(undefined);
       } catch (e) {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       } finally {
         setIsWorking(false);
       }

--- a/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import { osrdEditoastApi, type TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import DeleteModal from 'common/BootstrapSNCF/ModalSNCF/DeleteModal';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
@@ -107,7 +107,7 @@ const TimetableToolbar = ({
       .then(() => {
         removeTrains(selectedTrainIds);
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('timetable.trainsSelectionDeletedCount', { count: trainsCount }),
             text: '',
           })
@@ -117,7 +117,7 @@ const TimetableToolbar = ({
         if (selectedTrainId && selectedTrainIds.includes(selectedTrainId)) {
           dispatch(updateSelectedTrainId(selectedTrainId));
         } else {
-          dispatch(setFailure(castErrorToFailure(e)));
+          dispatch(notifyFailure(castErrorToFailure(e)));
         }
       });
   };

--- a/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
@@ -13,7 +13,7 @@ import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import type { TrainScheduleBase, TrainScheduleResult } from 'common/api/osrdEditoastApi';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import trainNameWithNum from 'modules/trainschedule/components/ManageTrainSchedule/helpers/trainNameHelper';
-import { setFailure, setSuccess } from 'reducers/main';
+import { notifyFailure, notifySuccess } from 'reducers/main';
 import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { formatToIsoDate, isoDateToMs } from 'utils/date';
@@ -72,14 +72,14 @@ const TimetableTrainCard = ({
       .then(() => {
         removeTrains([train.id]);
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('timetable.trainDeleted', { name: train.trainName }),
             text: '',
           })
         );
       })
       .catch((e) => {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
         if (isSelected) {
           dispatch(updateSelectedTrainId(train.id));
         }
@@ -96,7 +96,7 @@ const TimetableTrainCard = ({
     const trainsResults = await getTrainSchedule({ body: { ids: [train.id] } })
       .unwrap()
       .catch((e) => {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       });
 
     if (trainsResults) {
@@ -116,13 +116,13 @@ const TimetableTrainCard = ({
         }).unwrap();
         upsertTrainSchedules([trainScheduleResult]);
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: t('timetable.trainAdded'),
             text: `${trainName}`,
           })
         );
       } catch (e) {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       }
     }
   };

--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -14,7 +14,7 @@ import {
 import type { EditorEntity, EditorSchema } from 'applications/editor/typesEditorEntity';
 import type { Operation } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { setLoading, setSuccess, setFailure, setSuccessWithoutMessage } from 'reducers/main';
+import { notifyLoadingStart, notifySuccess, notifyFailure, notifyLoadingEnd } from 'reducers/main';
 import { updateIssuesSettings } from 'reducers/map';
 import infra_schema from 'reducers/osrdconf/infra_schema.json';
 import type { AppDispatch, GetState } from 'store';
@@ -29,7 +29,7 @@ export function loadDataModel() {
   return async (dispatch: AppDispatch, getState: GetState) => {
     // check if we need to load the model
     if (!Object.keys(getState().editor.editorSchema).length) {
-      dispatch(setLoading());
+      dispatch(notifyLoadingStart());
       try {
         const schemaResponse = infra_schema as JSONSchema7;
         // parse the schema
@@ -61,10 +61,10 @@ export function loadDataModel() {
               },
             } as EditorSchema[0];
           });
-        dispatch(setSuccessWithoutMessage());
+        dispatch(notifyLoadingEnd());
         dispatch(loadDataModelAction(schema));
       } catch (e) {
-        dispatch(setFailure(castErrorToFailure(e)));
+        dispatch(notifyFailure(castErrorToFailure(e)));
       }
     }
   };
@@ -73,7 +73,7 @@ export function loadDataModel() {
 export function updateTotalsIssue(infraID: number | undefined) {
   return async (dispatch: AppDispatch, getState: GetState) => {
     const { editor } = getState();
-    dispatch(setLoading());
+    dispatch(notifyLoadingStart());
     try {
       let total = 0;
       let filterTotal = 0;
@@ -113,9 +113,9 @@ export function updateTotalsIssue(infraID: number | undefined) {
       }
       dispatch(updateTotalsIssueAction({ total, filterTotal }));
     } catch (e) {
-      dispatch(setFailure(castErrorToFailure(e)));
+      dispatch(notifyFailure(castErrorToFailure(e)));
     } finally {
-      dispatch(setSuccessWithoutMessage());
+      dispatch(notifyLoadingEnd());
     }
   };
 }
@@ -169,7 +169,7 @@ export function saveOperations(
 ) {
   return async (dispatch: AppDispatch) => {
     if (shouldLoad) {
-      dispatch(setLoading());
+      dispatch(notifyLoadingStart());
     }
     try {
       if (isNil(infraId)) throw new Error('No infrastructure');
@@ -182,7 +182,7 @@ export function saveOperations(
       if ('data' in response) {
         // success message
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: i18next.t('common.success.save.title'),
             text: i18next.t('common.success.save.text'),
           })
@@ -192,7 +192,7 @@ export function saveOperations(
       throw response.error;
     } catch (e) {
       dispatch(
-        setFailure(
+        notifyFailure(
           castErrorToFailure(e, {
             name: i18next.t('common.failure.save.title'),
             message: i18next.t('common.failure.save.text'),
@@ -227,7 +227,7 @@ export function saveSplitTrackSection(
   offset: number
 ) {
   return async (dispatch: AppDispatch): Promise<string[]> => {
-    dispatch(setLoading());
+    dispatch(notifyLoadingStart());
     try {
       if (isNil(infraId)) throw new Error('No infrastructure');
       const response = await dispatch(
@@ -239,7 +239,7 @@ export function saveSplitTrackSection(
       if ('data' in response) {
         // success message
         dispatch(
-          setSuccess({
+          notifySuccess({
             title: i18next.t('common.success.save.title'),
             text: i18next.t('common.success.save.text'),
           })
@@ -249,7 +249,7 @@ export function saveSplitTrackSection(
       throw response.error;
     } catch (e) {
       dispatch(
-        setFailure(
+        notifyFailure(
           castErrorToFailure(e, {
             name: i18next.t('common.failure.save.title'),
             message: i18next.t('common.failure.save.text'),

--- a/front/src/reducers/main/index.ts
+++ b/front/src/reducers/main/index.ts
@@ -20,11 +20,13 @@ export const mainSlice = createSlice({
   name: 'main',
   initialState: mainInitialState,
   reducers: {
-    // TODO rename setLoading, setSucess with more meaningful names like pushLoadingNotification, pushSucessNotification, ...
-    setLoading(state) {
+    notifyLoadingStart(state) {
       state.loading += 1;
     },
-    setSuccess(state, action: PayloadAction<{ title: string; text: string }>) {
+    notifyLoadingEnd(state) {
+      state.loading = state.loading > 0 ? state.loading - 1 : 0;
+    },
+    notifySuccess(state, action: PayloadAction<{ title: string; text: string }>) {
       state.loading = state.loading > 0 ? state.loading - 1 : 0;
       state.notifications.push({
         type: 'success',
@@ -33,10 +35,7 @@ export const mainSlice = createSlice({
         date: new Date(),
       });
     },
-    setSuccessWithoutMessage(state) {
-      state.loading = state.loading > 0 ? state.loading - 1 : 0;
-    },
-    setWarning(state, action: PayloadAction<{ title: string; text: string }>) {
+    notifyWarning(state, action: PayloadAction<{ title: string; text: string }>) {
       state.loading = state.loading > 0 ? state.loading - 1 : 0;
       state.notifications.push({
         type: 'warning',
@@ -45,7 +44,7 @@ export const mainSlice = createSlice({
         date: new Date(),
       });
     },
-    setFailure(state, action: PayloadAction<Error>) {
+    notifyFailure(state, action: PayloadAction<Error>) {
       state.loading = state.loading > 0 ? state.loading - 1 : 0;
       state.notifications.push({
         type: 'error',
@@ -88,11 +87,11 @@ export const mainSlice = createSlice({
 });
 
 export const {
-  setLoading,
-  setSuccess,
-  setSuccessWithoutMessage,
-  setWarning,
-  setFailure,
+  notifyLoadingStart,
+  notifySuccess,
+  notifyLoadingEnd,
+  notifyWarning,
+  notifyFailure,
   addSuccessNotification,
   addFailureNotification,
   deleteNotification,

--- a/front/src/reducers/main/mainReducer.spec.ts
+++ b/front/src/reducers/main/mainReducer.spec.ts
@@ -2,14 +2,14 @@ import { expect, it } from 'vitest';
 
 import {
   mainInitialState,
-  setLoading,
-  setSuccess,
-  setWarning,
-  setFailure,
+  notifyLoadingStart,
+  notifySuccess,
+  notifyWarning,
+  notifyFailure,
   deleteNotification,
   updateLastInterfaceVersion,
   type MainState,
-  setSuccessWithoutMessage,
+  notifyLoadingEnd,
   addFailureNotification,
   addSuccessNotification,
 } from 'reducers/main';
@@ -30,7 +30,7 @@ describe('mainReducer', () => {
 
   it('should handle setLoading', () => {
     const store = createStore(mainInitialState);
-    const action = setLoading();
+    const action = notifyLoadingStart();
     store.dispatch(action);
     const mainState = store.getState().main;
     expect(mainState).toEqual({
@@ -42,7 +42,7 @@ describe('mainReducer', () => {
 
   it('should handle setSuccess', () => {
     const store = createStore(mainStateWithSinglePendingRequest);
-    const action = setSuccess({
+    const action = notifySuccess({
       title: 'Test title',
       text: 'Test text',
     });
@@ -64,7 +64,7 @@ describe('mainReducer', () => {
 
   it('should handle setSuccessWithoutMessage', () => {
     const store = createStore(mainStateWithSinglePendingRequest);
-    const action = setSuccessWithoutMessage();
+    const action = notifyLoadingEnd();
     store.dispatch(action);
     const mainState = store.getState().main;
     expect(mainState).toEqual({
@@ -76,7 +76,7 @@ describe('mainReducer', () => {
 
   it('should handle setWarning', () => {
     const store = createStore(mainStateWithSinglePendingRequest);
-    const action = setWarning({
+    const action = notifyWarning({
       title: 'Test title',
       text: 'Test text',
     });
@@ -98,7 +98,7 @@ describe('mainReducer', () => {
 
   it('should handle setFailure', () => {
     const store = createStore(mainStateWithSinglePendingRequest);
-    const action = setFailure(new Error('Test error'));
+    const action = notifyFailure(new Error('Test error'));
     store.dispatch(action);
     const mainState = store.getState().main;
     expect(mainState).toEqual({


### PR DESCRIPTION
This commit solves some TODO comments from the front codebase.

It relates to ticket #7861.

Details:
- Renames notification reducers
- Rewrites `checkCurrentConfig().path`
- Fixes speed limits selection count in the editor
- Cleans some TODOs, typos and dead code in the editor codebase
- Cleans up linear metadata code