### PR TITLE
front: fix travel time >1h in OSRD → NGE conversion

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -464,8 +464,9 @@ const importTimetable = async (
         }
 
         const travelTime = { ...DEFAULT_TIME_LOCK };
-        if (targetArrival.time && sourceDeparture.time) {
-          travelTime.time = (targetArrival.time - sourceDeparture.time + 60) % 60;
+        if (targetArrival.consecutiveTime !== null && sourceDeparture.consecutiveTime !== null) {
+          travelTime.time = targetArrival.consecutiveTime - sourceDeparture.consecutiveTime;
+          travelTime.consecutiveTime = travelTime.time;
         }
 
         const trainrunSection = {


### PR DESCRIPTION
Multiple issues here:

- Source or target "time" may be zero or null, zero means it's set but top of the hour, null means unset/unknown. We still want to compute the travel time if it's zero.
- Travel "time" field doesn't need to be computed modulo 1h, because it's a duration, not an absolute time.
- Travel "consecutiveTime" field needs to be populated as well.

Closes: https://github.com/OpenRailAssociation/osrd/issues/8862