### PR TITLE
github: add 21ˢᵗ century support to commit message check

### DIFF
--- a/.github/scripts/check-commit-titles.sh
+++ b/.github/scripts/check-commit-titles.sh
@@ -12,7 +12,7 @@ if [ -z "$NOCOLOR" ]; then
 fi
 
 
-checks='check_fixup check_printable_ascii check_forbidden_chars check_structure'
+checks='check_fixup check_forbidden_chars check_structure'
 
 
 check_fixup() {
@@ -21,15 +21,9 @@ check_fixup() {
     fi
 }
 
-check_printable_ascii() {
-    if grep -q -P -v '^[\x20-\x7F]*$'; then
-        echo 'Commit titles must be printable ascii only'
-    fi
-}
-
 check_forbidden_chars() {
-    if grep -q -P -v '^[^#]*$'; then
-        echo 'Forbidden character found: #'
+    if grep -q -P -v '^[^#[:cntrl:]]*$'; then
+        echo 'Forbidden character found ("#" or control character)'
     fi
 }
 


### PR DESCRIPTION
While commit messages are written in English, and many English words us exclusively ASCII characters, that's not the case of all words, for instance "touché". Even if that were the case, commit titles may need to contain non-ASCII characters for proper nouns, quotes of other languages, symbols, superscript characters (does that one ring a bell?) and so on.

Relax the strict ASCII rules to allow any printable Unicode character.