### PR TITLE
editoast, osrdyne: fix the multi infra status response

### DIFF
--- a/osrdyne/src/pool.rs
+++ b/osrdyne/src/pool.rs
@@ -376,7 +376,7 @@ async fn orphan_processor(
 pub struct ActivityMessage {
     pub kind: ActivityMessageKind,
     pub worker_key: Key,
-    pub worker_id: Vec<u8>,
+    pub worker_id: String,
 }
 
 pub enum ActivityMessageKind {
@@ -431,6 +431,10 @@ async fn activity_processor(
             .and_then(|v| v.as_long_string().map(|s| s.as_bytes()));
 
         if let Some(worker_id) = worker_id {
+            let Ok(worker_id) = String::from_utf8(worker_id.to_vec()) else {
+                continue;
+            };
+
             let kind = headers
                 .as_ref()
                 .and_then(|h| h.inner().get("x-event"))
@@ -442,7 +446,7 @@ async fn activity_processor(
             let activity = ActivityMessage {
                 kind,
                 worker_key: key.clone(),
-                worker_id: worker_id.to_owned(),
+                worker_id,
             };
             status_tracker.send(activity).await?;
         }

--- a/osrdyne/src/status_tracker.rs
+++ b/osrdyne/src/status_tracker.rs
@@ -16,9 +16,9 @@ pub enum WorkerStatus {
 pub async fn status_tracker(
     mut known_workers_watch: tokio::sync::watch::Receiver<Arc<Vec<WorkerMetadata>>>,
     mut activity_receiver: tokio::sync::mpsc::Receiver<ActivityMessage>,
-    worker_status_watch: tokio::sync::watch::Sender<Arc<HashMap<Vec<u8>, WorkerStatus>>>,
+    worker_status_watch: tokio::sync::watch::Sender<Arc<HashMap<String, WorkerStatus>>>,
 ) {
-    let mut worker_states = HashMap::<Vec<u8>, WorkerStatus>::new();
+    let mut worker_states = HashMap::<String, WorkerStatus>::new();
     let mut first_run = true;
     loop {
         select! {
@@ -29,20 +29,18 @@ pub async fn status_tracker(
                 }
                 let known_workers = known_workers_watch.borrow_and_update().clone();
 
-                let known_workers_ids = HashSet::<Vec<u8>>::from_iter(
+                let known_workers_ids = HashSet::<String>::from_iter(
                     known_workers
                         .iter()
-                        .map(|w: &WorkerMetadata| w.worker_id.to_string().into_bytes()),
+                        .map(|w: &WorkerMetadata| w.worker_id.to_string()),
                 );
                 worker_states.retain(|id, _| known_workers_ids.contains(id));
 
                 for worker in known_workers.iter() {
-                    let worker_id = worker.worker_id.to_string().into_bytes();
-                    if !worker_states.contains_key(&worker_id) {
-                        // If this is the first time we have a worker list, mark all workers as ready
-                        // They may have been loaded from a previous OSRDyne run
-                        worker_states.insert(worker_id.to_vec(), if !first_run {WorkerStatus::Loading} else {WorkerStatus::Ready});
-                    }
+                    let worker_id = worker.worker_id.to_string();
+                    // If this is the first time we have a worker list, mark all workers as ready
+                    // They may have been loaded from a previous OSRDyne run
+                    worker_states.entry(worker_id).or_insert_with(|| if !first_run {WorkerStatus::Loading} else {WorkerStatus::Ready});
                 }
                 first_run = false;
             },
@@ -51,7 +49,7 @@ pub async fn status_tracker(
                     match activity.kind {
                         ActivityMessageKind::Ready => {
                             if !worker_states.contains_key(&activity.worker_id) {
-                                log::warn!("Received Ready message for unknown worker {}", String::from_utf8_lossy(&activity.worker_id));
+                                log::warn!("Received Ready message for unknown worker {}", activity.worker_id);
                             }
                             worker_states.insert(activity.worker_id, WorkerStatus::Ready);
                         }


### PR DESCRIPTION
- Build up list querys correctly on editoast side
- Aggregate the worker status results correctly on editoast side
- Use a by worker_id map (instead of a by worker_key) in osrdyne response