### PR TITLE
front: group related packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      nivo:
+        patterns:
+          - "@nivo/*"
+      rjsf:
+        patterns:
+          - "@rjsf/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      turf:
+        patterns:
+          - "@turf/*"
     commit-message:
       prefix: "front:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Some packages are released together in tandem. Group these together in dependabot PRs, because they usually all need to be upgraded together. Also results in less noise.