### PR TITLE
front: upgrade @reduxjs/toolkit

### DIFF
--- a/front/src/reducers/editor/thunkActions.ts
+++ b/front/src/reducers/editor/thunkActions.ts
@@ -179,7 +179,7 @@ export function saveOperations(
           body: operations,
         })
       );
-      if ('data' in response) {
+      if (response.data) {
         // success message
         dispatch(
           setSuccess({
@@ -236,7 +236,7 @@ export function saveSplitTrackSection(
           trackOffset: { track: trackId, offset },
         })
       );
-      if ('data' in response) {
+      if (response.data) {
         // success message
         dispatch(
           setSuccess({

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2719,14 +2719,14 @@
     immutable "^4.3.4"
 
 "@reduxjs/toolkit@^2.1.0":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.3.tgz#5ce71cbf162f98c5dafb49bd3f1e11c5486ab9c4"
-  integrity sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.7.tgz#199e3d10ccb39267cb5aee92c0262fd9da7fdfb2"
+  integrity sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==
   dependencies:
     immer "^10.0.3"
     redux "^5.0.1"
     redux-thunk "^3.1.0"
-    reselect "^5.0.1"
+    reselect "^5.1.0"
 
 "@remix-run/router@1.19.2":
   version "1.19.2"
@@ -13261,11 +13261,6 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
-reselect@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.0.tgz#c479139ab9dd91be4d9c764a7f3868210ef8cd21"
-  integrity sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==
 
 reselect@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
rtk-query now always returns the "data" field in the object, but it may be undefined:

```ts
{ data: PostInfraByInfraIdApiResponse; error?: undefined; } | { data?: undefined; error: ApiError | SerializedError; }
```

Thus `'data' in response` will always be true.