### PR TITLE
editoast: stdcm simulation convoy parameters

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2512,6 +2512,11 @@ paths:
                   - 5%
                   - 2min/100km
                   nullable: true
+                max_speed:
+                  type: number
+                  format: double
+                  description: Maximum speed of the consist in km/h
+                  nullable: true
                 maximum_departure_delay:
                   type: integer
                   format: int64
@@ -2566,6 +2571,16 @@ paths:
                     Enforces that the path used by the train should be free and
                     available at least that many milliseconds before its passage.
                   minimum: 0
+                total_length:
+                  type: number
+                  format: double
+                  description: Total length of the consist in meters
+                  nullable: true
+                total_mass:
+                  type: number
+                  format: double
+                  description: Total mass of the consist in kg
+                  nullable: true
                 work_schedule_group_id:
                   type: integer
                   format: int64
@@ -8523,6 +8538,11 @@ components:
           - 5%
           - 2min/100km
           nullable: true
+        max_speed:
+          type: number
+          format: double
+          description: Maximum speed of the consist in km/h
+          nullable: true
         maximum_departure_delay:
           type: integer
           format: int64
@@ -8577,6 +8597,16 @@ components:
             Enforces that the path used by the train should be free and
             available at least that many milliseconds before its passage.
           minimum: 0
+        total_length:
+          type: number
+          format: double
+          description: Total length of the consist in meters
+          nullable: true
+        total_mass:
+          type: number
+          format: double
+          description: Total mass of the consist in kg
+          nullable: true
         work_schedule_group_id:
           type: integer
           format: int64

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -804,7 +804,7 @@ pub mod tests {
         }
     }
 
-    fn fast_rolling_stock_form(name: &str) -> RollingStockForm {
+    pub fn fast_rolling_stock_form(name: &str) -> RollingStockForm {
         let mut form = serde_json::from_str::<RollingStockForm>(include_str!(
             "../tests/example_rolling_stock_1.json"
         ))

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -26,9 +26,11 @@ use crate::client::get_app_version;
 use crate::core::pathfinding::PathfindingResult;
 use crate::core::pathfinding::PathfindingResultSuccess;
 use crate::core::simulation::CompleteReportTrain;
+use crate::core::simulation::PhysicsRollingStock;
 use crate::core::simulation::ReportTrain;
 use crate::core::simulation::SignalSighting;
 use crate::core::simulation::SimulationMargins;
+use crate::core::simulation::SimulationParameters;
 use crate::core::simulation::SimulationPath;
 use crate::core::simulation::SimulationPowerRestrictionItem;
 use crate::core::simulation::SimulationRequest;
@@ -585,7 +587,10 @@ fn build_simulation_request(
         speed_limit_tag: train_schedule.speed_limit_tag.clone(),
         power_restrictions,
         options: train_schedule.options.clone(),
-        rolling_stock: rolling_stock.into(),
+        rolling_stock: PhysicsRollingStock::new(
+            rolling_stock.into(),
+            SimulationParameters::default(),
+        ),
         electrical_profile_set_id,
     }
 }

--- a/front/public/locales/en/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/en/operationalStudies/manageTrainSchedule.json
@@ -85,7 +85,7 @@
   "noOriginChosen": "Departure undefined",
   "noDestinationChosen": "Arrival undefined",
   "noPowerRestriction": "No power restriction",
-  "noSpeedLimitByTag": "No composition code",
+  "noSpeedLimitByTag": "None",
   "noTimetable": "Select a timetable",
   "noTrainCompo": "No rolling stock defined…",
   "origin": "Origin",

--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -6,6 +6,7 @@
     "consist": "Consist",
     "length": "Length",
     "tonnage": "Tonnage",
+    "maxSpeed": "Max speed",
     "tractionEngine": "Traction engine"
   },
   "datetimeOutsideWindow": "Date must be between {{low}} and {{high}}",

--- a/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
+++ b/front/public/locales/fr/operationalStudies/manageTrainSchedule.json
@@ -85,7 +85,7 @@
   "noOriginChosen": "Départ non défini",
   "noDestinationChosen": "Arrivée non définie",
   "noPowerRestriction": "Aucune restriction de puissance",
-  "noSpeedLimitByTag": "Aucune composition",
+  "noSpeedLimitByTag": "Aucun",
   "noTimetable": "Choisissez une grille horaire",
   "noTrainCompo": "Aucun matériel défini…",
   "origin": "Origine",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -6,6 +6,7 @@
     "consist": "Convoi",
     "length": "Longueur",
     "tonnage": "Tonnage",
+    "maxSpeed": "Vitesse max.",
     "tractionEngine": "Engin de traction"
   },
   "datetimeOutsideWindow": "La date et l'heure doivent être comprises entre le {{low}} et le {{high}}",

--- a/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConfV2.ts
@@ -12,7 +12,7 @@ import type { InfraState } from 'reducers/infra';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
 import { dateTimeFormatting, dateTimeToIso } from 'utils/date';
-import { mToMm } from 'utils/physics';
+import { kmhToMs, mToMm, tToKg } from 'utils/physics';
 import { ISO8601Duration2sec, sec2ms, time2sec } from 'utils/timeManipulation';
 
 import createMargin from './createMargin';
@@ -26,6 +26,9 @@ type ValidStdcmConfig = {
   rollingStockComfort: TrainScheduleBase['comfort'];
   path: PathfindingItem[];
   speedLimitByTag?: string;
+  totalMass?: number;
+  totalLength?: number;
+  maxSpeed?: number;
   maximumRunTime?: number;
   startTime?: string; // must be a datetime
   latestStartTime?: string;
@@ -61,6 +64,9 @@ export const checkStdcmConf = (
     searchDatetimeWindow,
     workScheduleGroupId,
     electricalProfileSetId,
+    totalLength,
+    totalMass,
+    maxSpeed,
   } = osrdconf;
   let error = false;
   if (pathSteps[0] === null) {
@@ -224,6 +230,9 @@ export const checkStdcmConf = (
       maximumRunTime,
     }),
     speedLimitByTag,
+    totalMass,
+    totalLength,
+    maxSpeed,
     margin: standardStdcmAllowance,
     gridMarginBefore,
     gridMarginAfter,
@@ -246,6 +255,9 @@ export const formatStdcmPayload = (
     margin: createMargin(validConfig.margin),
     rolling_stock_id: validConfig.rollingStockId,
     speed_limit_tags: validConfig.speedLimitByTag,
+    total_mass: validConfig.totalMass ? tToKg(validConfig.totalMass) : undefined,
+    max_speed: validConfig.maxSpeed ? kmhToMs(validConfig.maxSpeed) : undefined,
+    total_length: validConfig.totalLength,
     ...(!stdcmV2Activated && {
       maximum_run_time: toMsOrUndefined(validConfig.maximumRunTime),
       maximum_departure_delay: sec2ms(

--- a/front/src/applications/stdcmV2/components/StdcmConsist.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmConsist.tsx
@@ -10,11 +10,12 @@ import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSe
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
-import type { StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
+import { type StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
 import { useAppDispatch } from 'store';
 
-import StdcmCard from './StdcmCard';
 import type { StdcmConfigCardProps } from '../types';
+import StdcmCard from './StdcmCard';
+import useStdcmConsist from '../hooks/useStdcmConsist';
 
 const ConsistCardTitle = ({
   rollingStock,
@@ -39,6 +40,15 @@ const StdcmConsist = ({ setCurrentSimulationInputs, disabled = false }: StdcmCon
   const dispatch = useAppDispatch();
 
   const { rollingStock } = useStoreDataForRollingStockSelector();
+
+  const {
+    totalMass,
+    onTotalMassChange,
+    totalLength,
+    onTotalLengthChange,
+    maxSpeed,
+    onMaxSpeedChange,
+  } = useStdcmConsist();
 
   const { filters, searchRollingStock, searchRollingStockById, filteredRollingStockList } =
     useFilterRollingStock({ isStdcm: true });
@@ -129,22 +139,38 @@ const StdcmConsist = ({ setCurrentSimulationInputs, disabled = false }: StdcmCon
           id="tonnage"
           label={t('consist.tonnage')}
           trailingContent="t"
-          inputFieldWrapperClassname="weight"
+          type="number"
+          min={0}
+          value={totalMass ?? ''}
+          onChange={onTotalMassChange}
         />
         <Input
           id="length"
           label={t('consist.length')}
           trailingContent="m"
-          inputFieldWrapperClassname="length"
+          type="number"
+          min={0}
+          value={totalLength ?? ''}
+          onChange={onTotalLengthChange}
         />
       </div>
-      <SpeedLimitByTagSelector
-        disabled={disabled}
-        selectedSpeedLimitByTag={speedLimitByTag}
-        speedLimitsByTags={speedLimitsByTags}
-        dispatchUpdateSpeedLimitByTag={dispatchUpdateSpeedLimitByTag}
-        className="speed-limit-by-tag-selector"
-      />
+      <div className="stdcm-v2-consist__properties">
+        <SpeedLimitByTagSelector
+          disabled={disabled}
+          selectedSpeedLimitByTag={speedLimitByTag}
+          speedLimitsByTags={speedLimitsByTags}
+          dispatchUpdateSpeedLimitByTag={dispatchUpdateSpeedLimitByTag}
+        />
+        <Input
+          id="maxSpeed"
+          label={t('consist.maxSpeed')}
+          trailingContent="km/h"
+          type="number"
+          min={0}
+          value={maxSpeed ?? ''}
+          onChange={onMaxSpeedChange}
+        />
+      </div>
     </StdcmCard>
   );
 };

--- a/front/src/applications/stdcmV2/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcmV2/hooks/useStdcmConsist.ts
@@ -1,0 +1,43 @@
+import { useSelector } from 'react-redux';
+
+import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
+import { type StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
+import type { StdcmConfSelectors } from 'reducers/osrdconf/stdcmConf/selectors';
+import { useAppDispatch } from 'store';
+
+const useStdcmConsist = () => {
+  const dispatch = useAppDispatch();
+  const { getTotalMass, getTotalLength, getMaxSpeed } =
+    useOsrdConfSelectors() as StdcmConfSelectors;
+  const { updateTotalMass, updateTotalLength, updateMaxSpeed } =
+    useOsrdConfActions() as StdcmConfSliceActions;
+
+  const totalMass = useSelector(getTotalMass);
+  const onTotalMassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const totalMassValue = Number(e.target.value);
+    dispatch(updateTotalMass(totalMassValue === 0 ? undefined : totalMassValue));
+  };
+
+  const totalLength = useSelector(getTotalLength);
+  const onTotalLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const totalLengthValue = Number(e.target.value);
+    dispatch(updateTotalLength(totalLengthValue === 0 ? undefined : totalLengthValue));
+  };
+
+  const maxSpeed = useSelector(getMaxSpeed);
+  const onMaxSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const totalMaxSpeed = Number(e.target.value);
+    dispatch(updateMaxSpeed(totalMaxSpeed === 0 ? undefined : totalMaxSpeed));
+  };
+
+  return {
+    totalMass,
+    onTotalMassChange,
+    totalLength,
+    onTotalLengthChange,
+    maxSpeed,
+    onMaxSpeedChange,
+  };
+};
+
+export default useStdcmConsist;

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1481,6 +1481,8 @@ export type PostTimetableByIdStdcmApiArg = {
     electrical_profile_set_id?: number | null;
     /** Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km` */
     margin?: string | null;
+    /** Maximum speed of the consist in km/h */
+    max_speed?: number | null;
     /** By how long we can shift the departure time in milliseconds
         Deprecated, first step data should be used instead */
     maximum_departure_delay?: number | null;
@@ -1504,6 +1506,10 @@ export type PostTimetableByIdStdcmApiArg = {
         Enforces that the path used by the train should be free and
         available at least that many milliseconds before its passage. */
     time_gap_before?: number;
+    /** Total length of the consist in meters */
+    total_length?: number | null;
+    /** Total mass of the consist in kg */
+    total_mass?: number | null;
     work_schedule_group_id?: number | null;
   };
 };

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -10,6 +10,9 @@ import { updateOriginPathStep, updateDestinationPathStep } from '../helpers';
 export const stdcmConfInitialState: OsrdStdcmConfState = {
   maximumRunTime: 43200,
   standardStdcmAllowance: undefined,
+  totalMass: undefined,
+  totalLength: undefined,
+  maxSpeed: undefined,
   ...defaultCommonConf,
 };
 
@@ -24,6 +27,24 @@ export const stdcmConfSlice = createSlice({
       state.originDate = stdcmConfInitialState.originDate;
       state.originTime = stdcmConfInitialState.originTime;
       state.speedLimitByTag = stdcmConfInitialState.speedLimitByTag;
+    },
+    updateTotalMass(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['totalMass']>
+    ) {
+      state.totalMass = action.payload;
+    },
+    updateTotalLength(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['totalLength']>
+    ) {
+      state.totalLength = action.payload;
+    },
+    updateMaxSpeed(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['maxSpeed']>
+    ) {
+      state.maxSpeed = action.payload;
     },
     updateStdcmConfigWithData(
       state: Draft<OsrdStdcmConfState>,

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -10,6 +10,9 @@ const buildStdcmConfSelectors = () => {
     ...commonConfSelectors,
     getStandardStdcmAllowance: makeOsrdConfSelector('standardStdcmAllowance'),
     getMaximumRunTime: makeOsrdConfSelector('maximumRunTime'),
+    getTotalMass: makeOsrdConfSelector('totalMass'),
+    getTotalLength: makeOsrdConfSelector('totalLength'),
+    getMaxSpeed: makeOsrdConfSelector('maxSpeed'),
   };
 };
 

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -160,6 +160,26 @@ describe('stdcmConfReducers', () => {
     });
   });
 
+  describe('Consist updates', () => {
+    const store = createStore();
+    it('should handle totalMass', () => {
+      store.dispatch(stdcmConfSliceActions.updateTotalMass(345));
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.totalMass).toEqual(345);
+    });
+
+    it('should handle totalLength', () => {
+      store.dispatch(stdcmConfSliceActions.updateTotalLength(345));
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.totalLength).toEqual(345);
+    });
+    it('should handle maxSpeed', () => {
+      store.dispatch(stdcmConfSliceActions.updateMaxSpeed(110));
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.maxSpeed).toEqual(110);
+    });
+  });
+
   describe('Destination updates', () => {
     const store = createStore(initialStateSTDCMConfig);
     const newDestination = {

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -53,6 +53,9 @@ export interface StandardAllowance {
 export interface OsrdStdcmConfState extends OsrdConfState {
   maximumRunTime: number;
   standardStdcmAllowance?: StandardAllowance;
+  totalMass?: number;
+  totalLength?: number;
+  maxSpeed?: number;
 }
 
 export type PathStep = PathItemLocation & {

--- a/front/src/styles/scss/applications/stdcmV2/_card.scss
+++ b/front/src/styles/scss/applications/stdcmV2/_card.scss
@@ -114,16 +114,13 @@
       padding-bottom: 0.5rem;
 
       .stdcm-v2-consist__properties {
-        display: flex;
+        display: grid;
+        grid-template-columns: 7.4375rem 7.938rem;
         justify-content: space-between;
         padding-block: 0.6875rem;
 
-        .weight {
-          width: 7.4375rem;
-        }
-
-        .length {
-          width: 7.9375rem;
+        .osrd-config-item {
+          padding-right: 0.188rem;
         }
 
         * > .base-label-wrapper > label {

--- a/front/src/utils/physics.ts
+++ b/front/src/utils/physics.ts
@@ -93,3 +93,11 @@ export function percentageToDecimal(value: number) {
 export function decimalToPercentage(value: number) {
   return value * 100;
 }
+
+/**
+ * ex: converts 12t to 12000
+ * @param value in ton
+ */
+export function tToKg(value: number) {
+  return value * 1000;
+}


### PR DESCRIPTION
part of #8670 and https://github.com/osrd-project/osrd-confidential/issues/368

- [x] Send simulation length and mass to Editoast.
- [x] If parameters are provided, send them to the core; otherwise, send the rolling stock mass and length.

How to test:
- Create a new STDCM simulation with parameters and check the results.