### PR TITLE
core: rename TrackRange to DirectionalTrackRange to fit railjson

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
@@ -7,14 +7,14 @@ import fr.sncf.osrd.sim_infra.api.TrackSection
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.TimeDelta
 
-data class TrackRange(
+data class DirectionalTrackRange(
     @Json(name = "track_section") val trackSection: String,
     var begin: Offset<TrackSection>,
     var end: Offset<TrackSection>,
     val direction: EdgeDirection,
 )
 
-data class UndirectedTrackRange(
+data class TrackRange(
     @Json(name = "track_section") val trackSection: String,
     var begin: Offset<TrackSection>,
     var end: Offset<TrackSection>,
@@ -66,7 +66,7 @@ class SpacingRequirement(
 
 data class WorkSchedule(
     /** List of affected track ranges */
-    @Json(name = "track_ranges") val trackRanges: Collection<UndirectedTrackRange> = listOf(),
+    @Json(name = "track_ranges") val trackRanges: Collection<TrackRange> = listOf(),
     @Json(name = "start_time") val startTime: TimeDelta,
     @Json(name = "end_time") val endTime: TimeDelta,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropRequest.kt
@@ -4,11 +4,11 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.api.api_v2.TrackRange
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 
 class PathPropRequest(
-    @Json(name = "track_section_ranges") val trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
     val infra: String,
     /** The expected infrastructure version */
     @Json(name = "expected_version") val expectedVersion: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.api.api_v2.TrackRange
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.conflicts.TravelledPath
 import fr.sncf.osrd.graph.Pathfinding.Range
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -24,7 +24,7 @@ class PathfindingBlockSuccess(
 
     // Route ids
     val routes: List<String>,
-    @Json(name = "track_section_ranges") val trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
     val length: Length<Path>,
 
     /** Offsets of the waypoints given as input */
@@ -49,12 +49,12 @@ class PathfindingBlockSuccess(
 }
 
 class NotFoundInBlocks(
-    @Json(name = "track_section_ranges") val trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
     val length: Length<Path>,
 ) : PathfindingBlockResponse
 
 class NotFoundInRoutes(
-    @Json(name = "track_section_ranges") val trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
     val length: Length<Path>,
 ) : PathfindingBlockResponse
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingPostProcessing.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.api_v2.pathfinding
 
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.api_v2.TrackRange
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.api.pathfinding.makeRoutePath
 import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
@@ -103,13 +103,13 @@ fun makePathItemPositions(path: Pathfinding.Result<StaticIdx<Block>, Block>): Li
     return res
 }
 
-fun makeTrackRanges(oldRoutePath: List<RJSRoutePath>): List<TrackRange> {
-    val res = mutableListOf<TrackRange>()
+fun makeTrackRanges(oldRoutePath: List<RJSRoutePath>): List<DirectionalTrackRange> {
+    val res = mutableListOf<DirectionalTrackRange>()
     for (routeRange in oldRoutePath) {
         for (trackRange in routeRange.trackSections) {
             if (res.isEmpty() || res[res.size - 1].trackSection != trackRange.trackSectionID) {
                 res.add(
-                    TrackRange(
+                    DirectionalTrackRange(
                         trackRange.trackSectionID,
                         Offset(trackRange.begin.meters),
                         Offset(trackRange.end.meters),

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionRequest.kt
@@ -4,15 +4,15 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.api.api_v2.SignalSighting
-import fr.sncf.osrd.api.api_v2.TrackRange
 import fr.sncf.osrd.api.api_v2.ZoneUpdate
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.TimeDelta
 
 class SignalProjectionRequest(
     val blocks: List<String>,
-    @Json(name = "track_section_ranges") var trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") var trackSectionRanges: List<DirectionalTrackRange>,
     var routes: List<String>,
     @Json(name = "train_simulations") var trainSimulations: Map<Long, TrainSimulation>,
     var infra: String,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
@@ -2,8 +2,8 @@ package fr.sncf.osrd.api.api_v2.standalone_sim
 
 import com.squareup.moshi.*
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.api.api_v2.RangeValues
-import fr.sncf.osrd.api.api_v2.TrackRange
 import fr.sncf.osrd.conflicts.TravelledPath
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock.GammaType
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
@@ -88,7 +88,7 @@ class EffortCurve(
 class SimulationPath(
     val blocks: List<String>,
     val routes: List<String>,
-    @Json(name = "track_section_ranges") val trackSectionRanges: List<TrackRange>,
+    @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
     @Json(name = "path_item_positions") val pathItemPositions: List<Offset<Path>>
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathPropUtils.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.pathfinding
 
 import com.google.common.collect.Iterables
-import fr.sncf.osrd.api.api_v2.TrackRange
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.graph.PathfindingEdgeRangeId
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.infra.trackranges.RJSDirectionalTrackRange
@@ -82,7 +82,10 @@ fun makePathProps(rawInfra: RawSignalingInfra, rjsPath: RJSTrainPath): PathPrope
 }
 
 /** Builds a PathProperties from a List<TrackRange> */
-fun makePathProps(rawInfra: RawSignalingInfra, trackRanges: List<TrackRange>): PathProperties {
+fun makePathProps(
+    rawInfra: RawSignalingInfra,
+    trackRanges: List<DirectionalTrackRange>
+): PathProperties {
     val chunkPath = makeChunkPath(rawInfra, trackRanges)
     return makePathProperties(rawInfra, chunkPath)
 }
@@ -159,7 +162,10 @@ fun makeChunkPath(rawInfra: RawSignalingInfra, rjsPath: RJSTrainPath): ChunkPath
     return buildChunkPath(rawInfra, chunks, Length(startOffset), Length(endOffset))
 }
 
-fun makeChunkPath(rawInfra: RawSignalingInfra, trackRanges: List<TrackRange>): ChunkPath {
+fun makeChunkPath(
+    rawInfra: RawSignalingInfra,
+    trackRanges: List<DirectionalTrackRange>
+): ChunkPath {
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
     val firstRange = trackRanges[0]
     var startOffset = firstRange.begin.distance

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -1,8 +1,8 @@
 package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.api.ApiTest
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.api.api_v2.RangeValues
-import fr.sncf.osrd.api.api_v2.TrackRange
 import fr.sncf.osrd.api.api_v2.path_properties.*
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.utils.takes.TakesUtils
@@ -19,13 +19,13 @@ class PathPropEndpointTest : ApiTest() {
     fun simpleSmallInfraTest() {
         val trackSectionRanges =
             listOf(
-                TrackRange(
+                DirectionalTrackRange(
                     "TA0",
                     Offset(50.meters),
                     Offset(2000.meters),
                     EdgeDirection.START_TO_STOP
                 ),
-                TrackRange(
+                DirectionalTrackRange(
                     "TA1",
                     Offset(0.meters),
                     Offset(1950.meters),

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingV2Test.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingV2Test.kt
@@ -1,8 +1,8 @@
 package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.api.ApiTest
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.api.api_v2.TrackLocation
-import fr.sncf.osrd.api.api_v2.TrackRange
 import fr.sncf.osrd.api.api_v2.pathfinding.*
 import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
@@ -51,19 +51,19 @@ class PathfindingV2Test : ApiTest() {
         assertEquals(2, parsed.routes.size)
         assertEquals(
             listOf(
-                TrackRange(
+                DirectionalTrackRange(
                     "ne.micro.foo_b",
                     Offset(50.meters),
                     Offset(200.meters),
                     EdgeDirection.START_TO_STOP
                 ),
-                TrackRange(
+                DirectionalTrackRange(
                     "ne.micro.foo_to_bar",
                     Offset(0.meters),
                     Offset(10_000.meters),
                     EdgeDirection.START_TO_STOP
                 ),
-                TrackRange(
+                DirectionalTrackRange(
                     "ne.micro.bar_a",
                     Offset(0.meters),
                     Offset(100.meters),

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm
 
 import com.google.common.collect.HashMultimap
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.api_v2.UndirectedTrackRange
+import fr.sncf.osrd.api.api_v2.TrackRange
 import fr.sncf.osrd.api.api_v2.WorkSchedule
 import fr.sncf.osrd.api.api_v2.convertWorkScheduleCollection
 import fr.sncf.osrd.api.stdcm.makeTrainSchedule
@@ -192,13 +192,7 @@ class FullSTDCMTests {
                         smallInfra.rawInfra,
                         listOf(
                             WorkSchedule(
-                                listOf(
-                                    UndirectedTrackRange(
-                                        "TB0",
-                                        Offset(0.meters),
-                                        Offset(2000.meters)
-                                    )
-                                ),
+                                listOf(TrackRange("TB0", Offset(0.meters), Offset(2000.meters))),
                                 0.seconds,
                                 3600.seconds
                             )


### PR DESCRIPTION
In the v2 api, TrackRange is directed, while RJSTrackRange isn't. They should both be the same to avoid confusions.