### PR TITLE
Fix no cache docker

### DIFF
--- a/editoast/src/redis_utils.rs
+++ b/editoast/src/redis_utils.rs
@@ -45,6 +45,7 @@ fn no_cache_cmd_handler(cmd: &redis::Cmd) -> std::result::Result<redis::Value, R
         {
             Ok(redis::Value::Nil)
         },
+        redis::Arg::Simple(cmd_name_bytes) if cmd_name_bytes == "PING".as_bytes() => Ok(redis::Value::Status("PONG".to_string())),
         redis::Arg::Simple(cmd_name_bytes) => unimplemented!(
             "redis command '{}' is not supported by editoast::redis_utils::RedisConnection with '--no-cache'", String::from_utf8(cmd_name_bytes.to_vec())?
         ),


### PR DESCRIPTION
Faking the ping command to pass the health check.

### How to test it?

Edit the `docker-compose.yml` file.
Add to the `editoast`, `environment` variable list the following item:

```yaml
NO_CACHE: "true"
```