### PR TITLE
core: stdcm: fix small bug, missing lookahead at node creation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -178,6 +178,14 @@ internal constructor(
         }
         val endStopDuration = getEndStopDuration()
         val endAtStop = endStopDuration != null
+        if (endAtStop) {
+            // We don't use the result, just making sure that there's enough lookahead to compute it
+            // (otherwise there would be an error when computing the end node for this new edge)
+            graph.delayManager.getMaxAdditionalStopDuration(
+                getExplorerWithNewEnvelope()!!,
+                prevNode.timeData.earliestReachableTime
+            )
+        }
         val standardAllowanceSpeedRatio = graph.getStandardAllowanceSpeedRatio(envelope!!)
         var res: STDCMEdge? =
             STDCMEdge(


### PR DESCRIPTION
Because we now check for conflicts on node creation (for max stop duration), we have to make sure there's enough lookahead in a context where we can still add lookahead