### PR TITLE
core: stdcm: ignore mareco discontinity and fallback on linear

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -134,6 +134,13 @@ fun buildFinalEnvelope(
                     "Can't slow down enough to match the given standard allowance"
                 )
                 break
+            } else if (e.osrdErrorType == ErrorType.AllowanceConvergenceDiscontinuity) {
+                // May be caused by this bug:
+                // https://github.com/OpenRailAssociation/osrd/issues/9037
+                // It's quite difficult to fix this issue for now, but we can
+                // still fallback on linear allowance to have a result
+                postProcessingLogger.warn("Discontinuity in mareco search space")
+                break
             } else throw e
         }
     }


### PR DESCRIPTION
See https://github.com/OpenRailAssociation/osrd/issues/9037 and [this `if`](https://github.com/OpenRailAssociation/osrd/blob/dev/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java#L75-L81) for context

It's *quite* difficult to fix this properly. I'd prefer if we wait for the future simulation v3. In the meantime, we can fallback on linear allowances if it happens. 