### PR TITLE
editoast: provide search object list to the store explicitely

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -131,7 +131,7 @@ pub fn search(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// assert_eq!(Store::find("bar"), Some(Bar::search_config()));
 /// assert_eq!(Store::find("nope"), None);
 /// ```
-#[proc_macro_derive(SearchConfigStore, attributes(search))]
+#[proc_macro_derive(SearchConfigStore, attributes(search_config_store))]
 pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     search::expand_store(&input)

--- a/editoast/editoast_search/src/search_object.rs
+++ b/editoast/editoast_search/src/search_object.rs
@@ -17,7 +17,6 @@ pub struct Property {
 }
 
 pub struct SearchConfig {
-    pub name: String,
     pub table: String,
     pub criterias: Vec<Criteria>,
     pub properties: Vec<Property>,
@@ -61,7 +60,7 @@ pub trait SearchConfigStore {
     fn find<S: AsRef<str>>(object_name: S) -> Option<SearchConfig>;
 
     /// Returns the search object configurations of all objects in the store
-    fn all() -> Vec<SearchConfig>;
+    fn all() -> Vec<(&'static str, SearchConfig)>;
 }
 
 impl SearchConfig {

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -401,7 +401,6 @@ async fn search(
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "track",
     table = "search_track",
     column(name = "infra_id", data_type = "INT"),
     column(name = "line_code", data_type = "INT"),
@@ -422,7 +421,6 @@ pub(super) struct SearchResultItemTrack {
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "operationalpoint",
     table = "search_operational_point",
     migration(src_table = "infra_object_operational_point"),
     joins = "
@@ -500,7 +498,6 @@ pub(super) struct SearchResultItemOperationalPointTrackSections {
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "signal",
     table = "search_signal",
     migration(
         src_table = "infra_object_signal",
@@ -578,7 +575,6 @@ pub(super) struct SearchResultItemSignal {
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "project",
     table = "search_project",
     joins = "INNER JOIN project ON project.id = search_project.id",
     column(name = "id", data_type = "integer"),
@@ -610,7 +606,6 @@ pub(super) struct SearchResultItemProject {
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "study",
     table = "search_study",
     migration(src_table = "study"),
     joins = "INNER JOIN study ON study.id = search_study.id",
@@ -650,7 +645,6 @@ pub(super) struct SearchResultItemStudy {
 
 #[derive(Search, Serialize, ToSchema)]
 #[search(
-    name = "scenario",
     table = "search_scenario",
     joins = "
         INNER JOIN scenario ON scenario.id = search_scenario.id
@@ -691,4 +685,12 @@ pub(super) struct SearchResultItemScenario {
 
 /// See [editoast_search::SearchConfigStore::find]
 #[derive(SearchConfigStore)]
+#[search_config_store(
+    object(name = "track", config = SearchResultItemTrack),
+    object(name = "operationalpoint", config = SearchResultItemOperationalPoint),
+    object(name = "signal", config = SearchResultItemSignal),
+    object(name = "project", config = SearchResultItemProject),
+    object(name = "study", config = SearchResultItemStudy),
+    object(name = "scenario", config = SearchResultItemScenario),
+)]
 pub struct SearchConfigFinder;


### PR DESCRIPTION
Search object configurations used to be collected in a static list for each `Search` macro invocation.
This list is then used in `derive(SearchConfigStore)` to generate the store logic.

On top of being a Rust antipattern, it now triggers some warnings on
nightly 1.83.0 about mixing immutable and mutable references on static
data (which is indeed a bad idea). This static list also confuses
rust-analyzer. Also getting rid of it removes our only use of unsafe.
