### PR TITLE
osrdyne: exit if the provided configuration file doesn't exist

### DIFF
--- a/osrdyne/src/config.rs
+++ b/osrdyne/src/config.rs
@@ -54,12 +54,15 @@ impl Default for OsrdyneConfig {
 }
 
 pub fn parse_config(file: Option<PathBuf>) -> Result<OsrdyneConfig, figment::Error> {
-    let mut fig = Figment::from(Serialized::defaults(OsrdyneConfig::default()))
-        .merge(Yaml::file("osrdyne.yml"));
-    if let Some(file) = file {
+    let provider = if let Some(file) = file {
         log::info!("Using configuration file: {}", file.display());
-        fig = fig.merge(Yaml::file(file));
-    }
-    // We use `__` as a separator for nested keys
-    fig.merge(Env::prefixed("OSRDYNE__").split("__")).extract()
+        Yaml::file_exact(file)
+    } else {
+        Yaml::file("osrdyne.yml")
+    };
+    Figment::from(Serialized::defaults(OsrdyneConfig::default()))
+        .merge(provider)
+        // We use `__` as a separator for nested keys
+        .merge(Env::prefixed("OSRDYNE__").split("__"))
+        .extract()
 }


### PR DESCRIPTION
`Yaml::file_exact` fails if the path doesn't point to a file.
`Yaml::file` does not (by design).

Yet another "what is wrong with my setup again?" and its just `osrdyne.yml` instead of `osrdyne.yaml`...