### PR TITLE
core: use infra explorer in pathfinding endpoint

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
@@ -218,7 +218,7 @@ private fun buildBlockName(
     val detectors = mutableListOf<DirDetectorId>()
     detectors.add(rawInfra.getZonePathEntry(descriptor.path[0]))
     detectors.add(rawInfra.getZonePathExit(descriptor.path.last()))
-    val detectorStr = detectors.map { "${rawInfra.getDetectorName(it.value)}" }
+    val detectorStr = detectors.map { rawInfra.getDetectorName(it.value) }
     val rawStringId = "$signals;$detectorStr;$trackNodeConfigNames"
 
     // We need to hash the result, these strings are way too long for identifiers

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyLinkedList.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyLinkedList.kt
@@ -93,6 +93,18 @@ class AppendOnlyLinkedList<T>(private var lastNode: Node<T>? = null, var size: I
         return AppendOnlyLinkedList(node, untilIndex)
     }
 
+    /**
+     * Iterate over the list backwards, returning the first seen element that fits the predicate.
+     */
+    fun findLast(predicate: (T) -> Boolean): T? {
+        var node = lastNode
+        while (node != null) {
+            if (predicate.invoke(node.element)) return node.element
+            node = node.prev
+        }
+        return null
+    }
+
     /** Utility function for debugger views. */
     override fun toString(): String {
         return toList().toString()

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyMap.kt
@@ -1,0 +1,52 @@
+package fr.sncf.osrd.utils
+
+/**
+ * Append-only map implementation. The internal structure is a linked list. Used to store data on
+ * diverging paths while minimizing copies. See also `AppendOnlyLinkedList`. On duplicates, the
+ * previous value is effectively replaced, but it still takes some space in the list.
+ */
+class AppendOnlyMap<K, V>(private val list: AppendOnlyLinkedList<Pair<K, V>>) {
+    /**
+     * Returns the value associated with the key. O(n) in worst case, O(1) if the value is near the
+     * end.
+     */
+    operator fun get(k: K): V? {
+        return list.findLast { it.first == k }?.second
+    }
+
+    /** Add the given pair of values to the map. O(1). */
+    operator fun set(k: K, v: V) {
+        list.add(Pair(k, v))
+    }
+
+    /** Returns a copy of the map. The underlying structure is *not* copied. O(1). */
+    fun shallowCopy(): AppendOnlyMap<K, V> {
+        return AppendOnlyMap(list.shallowCopy())
+    }
+
+    /**
+     * Returns true if the key is in the key set. O(n) in worst case, O(1) if the value is near the
+     * end. It would be nice to optimize this with a pre-filter similar to bloom filters (though
+     * likely overkill here)
+     */
+    fun containsKey(key: K): Boolean {
+        return list.findLast { it.first == key } != null
+    }
+
+    /**
+     * Generates a "normal" map from the current instance values. Θ(n) once, but operations on the
+     * resulting map should be O(1) (unlike operations on the `AppendOnlyMap` itself).
+     */
+    fun toMap(): Map<K, V> {
+        return list.toList().toMap()
+    }
+
+    override fun toString(): String {
+        return toMap().toString()
+    }
+}
+
+/** Returns a new empty list */
+fun <K, V> appendOnlyMapOf(): AppendOnlyMap<K, V> {
+    return AppendOnlyMap(appendOnlyLinkedListOf())
+}

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/BloomFilter.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/BloomFilter.kt
@@ -1,0 +1,37 @@
+package fr.sncf.osrd.utils
+
+import java.util.BitSet
+
+/** Simple bloom filter implementation. */
+class BloomFilter<T>(private val bitField: BitSet, private val nHash: Int) {
+
+    /** Add a value to the set. */
+    fun add(value: T) {
+        var hash = value.hashCode()
+        for (i in 0..nHash) {
+            bitField.set(hash % bitField.size())
+            hash = hash.hashCode()
+        }
+    }
+
+    /**
+     * Check whether a value can be present in the set. False positive are possible, false negative
+     * are not.
+     */
+    fun mayContain(value: T): Boolean {
+        var hash = value.hashCode()
+        for (i in 0..nHash) {
+            if (!bitField.get(hash % bitField.size())) return false
+            hash = hash.hashCode()
+        }
+        return true
+    }
+
+    fun copy(): BloomFilter<T> {
+        return BloomFilter(bitField.clone() as BitSet, nHash)
+    }
+}
+
+fun <T> emptyBloomFilter(bitsetSize: Int = 2048, nHash: Int = 2): BloomFilter<T> {
+    return BloomFilter(BitSet(bitsetSize), nHash)
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/IncompatibleConstraintsPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/IncompatibleConstraintsPostProcessing.kt
@@ -1,0 +1,148 @@
+package fr.sncf.osrd.api.api_v2.pathfinding
+
+import fr.sncf.osrd.api.FullInfra
+import fr.sncf.osrd.api.pathfinding.constraints.ElectrificationConstraints
+import fr.sncf.osrd.api.pathfinding.constraints.LoadingGaugeConstraints
+import fr.sncf.osrd.api.pathfinding.constraints.SignalingSystemConstraints
+import fr.sncf.osrd.api.pathfinding.makePathProps
+import fr.sncf.osrd.graph.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.filterIntersection
+import fr.sncf.osrd.utils.units.Distance
+import fr.sncf.osrd.utils.units.Offset
+
+fun buildIncompatibleConstraintsResponse(
+    infra: FullInfra,
+    possiblePathWithoutErrorNoConstraints: PathfindingResultId<Block>?,
+    constraints: Collection<PathfindingConstraint<Block>>,
+    initialRequest: PathfindingBlockRequest,
+): IncompatibleConstraintsPathResponse? {
+    if (
+        possiblePathWithoutErrorNoConstraints == null ||
+            possiblePathWithoutErrorNoConstraints.ranges.isEmpty()
+    )
+        return null
+
+    val pathRanges = possiblePathWithoutErrorNoConstraints.ranges
+    val pathProps =
+        makePathProps(infra.rawInfra, infra.blockInfra, pathRanges.map { it.edge }, Offset.zero())
+
+    val elecConstraints = constraints.filterIsInstance<ElectrificationConstraints>()
+    assert(elecConstraints.size < 2)
+    val elecBlockedRangeValues =
+        getConstraintsDistanceRange(
+                infra,
+                pathRanges,
+                pathProps.getElectrification(),
+                elecConstraints.firstOrNull()
+            )
+            .map { RangeValue(Pathfinding.Range(Offset(it.lower), Offset(it.upper)), it.value) }
+
+    val gaugeConstraints = constraints.filterIsInstance<LoadingGaugeConstraints>()
+    assert(gaugeConstraints.size < 2)
+    val gaugeBlockedRanges =
+        getConstraintsDistanceRange(
+                infra,
+                pathRanges,
+                pathProps.getLoadingGauge(),
+                gaugeConstraints.firstOrNull()
+            )
+            .map { RangeValue<String>(Pathfinding.Range(Offset(it.lower), Offset(it.upper)), null) }
+
+    val signalingSystemConstraints = constraints.filterIsInstance<SignalingSystemConstraints>()
+    assert(signalingSystemConstraints.size < 2)
+    val blockList = pathRanges.map { it.edge }
+    val pathSignalingSystem = getPathSignalingSystems(infra, blockList)
+    val signalingSystemBlockedRangeValues =
+        getConstraintsDistanceRange(
+                infra,
+                pathRanges,
+                pathSignalingSystem,
+                signalingSystemConstraints.firstOrNull()
+            )
+            .map { RangeValue(Pathfinding.Range(Offset(it.lower), Offset(it.upper)), it.value) }
+
+    if (
+        listOf(elecBlockedRangeValues, gaugeBlockedRanges, signalingSystemBlockedRangeValues).all {
+            it.isEmpty()
+        }
+    ) {
+        return null
+    }
+
+    return IncompatibleConstraintsPathResponse(
+        runPathfindingPostProcessing(infra, initialRequest, possiblePathWithoutErrorNoConstraints),
+        IncompatibleConstraints(
+            elecBlockedRangeValues,
+            gaugeBlockedRanges,
+            signalingSystemBlockedRangeValues
+        )
+    )
+}
+
+private fun <T> getConstraintsDistanceRange(
+    infra: FullInfra,
+    pathRanges: List<Pathfinding.EdgeRange<BlockId, Block>>,
+    pathConstrainedValues: DistanceRangeMap<T>,
+    constraint: PathfindingConstraint<Block>?
+): DistanceRangeMap<T> {
+    if (constraint == null) {
+        return distanceRangeMapOf()
+    }
+
+    val blockedRanges = getBlockedRanges(infra, pathRanges, constraint)
+    val filteredRangeValues = filterIntersection(pathConstrainedValues, blockedRanges)
+    val travelledPathOffset = pathRanges.first().start.distance
+    filteredRangeValues.shiftPositions(-travelledPathOffset)
+    return filteredRangeValues
+}
+
+private fun getBlockedRanges(
+    infra: FullInfra,
+    pathRanges: List<Pathfinding.EdgeRange<BlockId, Block>>,
+    currentConstraint: PathfindingConstraint<Block>
+): DistanceRangeMap<Boolean> {
+    val blockList = pathRanges.map { it.edge }
+    val blockedRanges = distanceRangeMapOf<Boolean>()
+    var startBlockPathOffset = Distance.ZERO
+    for (block in blockList) {
+        currentConstraint.apply(block).map {
+            blockedRanges.put(
+                startBlockPathOffset + it.start.distance,
+                startBlockPathOffset + it.end.distance,
+                true
+            )
+        }
+        startBlockPathOffset += infra.blockInfra.getBlockLength(block).distance
+    }
+    blockedRanges.truncate(
+        pathRanges.first().start.distance,
+        startBlockPathOffset - infra.blockInfra.getBlockLength(blockList.last()).distance +
+            pathRanges.last().end.distance
+    )
+    return blockedRanges
+}
+
+private fun getPathSignalingSystems(
+    infra: FullInfra,
+    blockList: List<BlockId>
+): DistanceRangeMap<String> {
+    val pathSignalingSystem = distanceRangeMapOf<String>()
+    var startBlockPathOffset = Distance.ZERO
+    for (block in blockList) {
+        val blockLength = infra.blockInfra.getBlockLength(block).distance
+        val blockSignalingSystemIdx = infra.blockInfra.getBlockSignalingSystem(block)
+        val blockSignalingSystemName =
+            infra.signalingSimulator.sigModuleManager.getName(blockSignalingSystemIdx)
+        pathSignalingSystem.put(
+            startBlockPathOffset,
+            startBlockPathOffset + blockLength,
+            blockSignalingSystemName
+        )
+        startBlockPathOffset += blockLength
+    }
+    return pathSignalingSystem
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/graph/PathfindingGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/graph/PathfindingGraph.kt
@@ -1,0 +1,45 @@
+package fr.sncf.osrd.graph
+
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.stdcm.graph.extendLookaheadUntil
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
+import java.util.Objects
+
+data class PathfindingEdge(val infraExplorer: InfraExplorer) {
+    val block = infraExplorer.getCurrentBlock()
+    val length = infraExplorer.getCurrentBlockLength()
+
+    override fun equals(other: Any?): Boolean {
+        return if (other !is PathfindingEdge) false
+        else
+            this.infraExplorer.getLastEdgeIdentifier() ==
+                other.infraExplorer.getLastEdgeIdentifier()
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(infraExplorer.getLastEdgeIdentifier())
+    }
+}
+
+class PathfindingGraph : Graph<PathfindingEdge, PathfindingEdge, Block> {
+    override fun getEdgeEnd(edge: PathfindingEdge): PathfindingEdge {
+        return edge
+    }
+
+    override fun getAdjacentEdges(node: PathfindingEdge): Collection<PathfindingEdge> {
+        val res = ArrayList<PathfindingEdge>()
+        val extended = mutableListOf<InfraExplorer>()
+        if (node.infraExplorer.getLookahead().size > 0) {
+            extended.add(node.infraExplorer.clone())
+        } else {
+            extended.addAll(extendLookaheadUntil(node.infraExplorer, 1))
+        }
+        for (newPath in extended) {
+            if (newPath.getLookahead().size == 0) continue
+            newPath.moveForward()
+            val newEdge = PathfindingEdge(newPath)
+            res.add(newEdge)
+        }
+        return res
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.stdcm.ProgressLogger
 import fr.sncf.osrd.stdcm.STDCMResult
 import fr.sncf.osrd.stdcm.STDCMStep
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
@@ -83,8 +84,8 @@ class STDCMPathfinding(
     private val timeStep: Double,
     private val maxDepartureDelay: Double,
     private val maxRunTime: Double,
-    private val tag: String?,
-    private val standardAllowance: AllowanceValue?,
+    tag: String?,
+    standardAllowance: AllowanceValue?,
     private val pathfindingTimeout: Double = Pathfinding.TIMEOUT
 ) {
 
@@ -236,7 +237,7 @@ class STDCMPathfinding(
                             stopTimeData = listOf(),
                         ),
                         0.0,
-                        explorer,
+                        explorer as InfraExplorerWithEnvelope,
                         null,
                         0,
                         location.offset,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.stdcm.graph
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.sim_infra.impl.buildChunkPath
-import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
@@ -54,26 +54,15 @@ fun makeChunkPathFromEdges(graph: STDCMGraph, edges: List<STDCMEdge>): ChunkPath
     return buildChunkPath(graph.rawInfra, chunks, firstOffset, lastOffset)
 }
 
-/** Converts an offset on a block into an offset on its STDCM edge */
-fun convertOffsetToEdge(
-    blockOffset: Offset<Block>,
-    envelopeStartOffset: Offset<Block>
-): Offset<STDCMEdge> {
-    return Offset(blockOffset.distance - envelopeStartOffset.distance)
-}
-
 /**
  * Extends all the given infra explorers until they have the min amount of blocks in lookahead, or
  * they reach the destination. The min number of blocks is arbitrary, it should aim for the required
  * lookahead for proper spacing resource generation. If the value is too low, there would be
- * exceptions thrown and we would try again with an extended path. If it's too large, we would
+ * exceptions thrown, and we would try again with an extended path. If it's too large, we would
  * "fork" too early. Either way the result wouldn't change, it's just a matter of performances.
  */
-fun extendLookaheadUntil(
-    input: InfraExplorerWithEnvelope,
-    minBlocks: Int
-): Collection<InfraExplorerWithEnvelope> {
-    val res = mutableListOf<InfraExplorerWithEnvelope>()
+fun extendLookaheadUntil(input: InfraExplorer, minBlocks: Int): Collection<InfraExplorer> {
+    val res = mutableListOf<InfraExplorer>()
     val candidates = mutableListOf(input)
     while (candidates.isNotEmpty()) {
         val candidate = candidates.removeFirst()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -13,7 +13,9 @@ import fr.sncf.osrd.sim_infra.utils.PathPropertiesView
 import fr.sncf.osrd.sim_infra.utils.getRouteBlocks
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.utils.AppendOnlyLinkedList
+import fr.sncf.osrd.utils.AppendOnlyMap
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
+import fr.sncf.osrd.utils.appendOnlyMapOf
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
@@ -128,7 +130,7 @@ fun initInfraExplorer(
                 blockInfra,
                 appendOnlyLinkedListOf(),
                 appendOnlyLinkedListOf(),
-                mutableMapOf(),
+                appendOnlyMapOf(),
                 incrementalPath,
                 blockToPathProperties,
                 stops = stops,
@@ -145,7 +147,7 @@ private class InfraExplorerImpl(
     private val blockInfra: BlockInfra,
     private var blocks: AppendOnlyLinkedList<BlockId>,
     private var routes: AppendOnlyLinkedList<RouteId>,
-    private var blockRoutes: MutableMap<BlockId, RouteId>,
+    private var blockRoutes: AppendOnlyMap<BlockId, RouteId>,
     private var incrementalPath: IncrementalPath,
     private var pathPropertiesCache: MutableMap<BlockId, PathProperties>,
     private var currentIndex: Int = 0,
@@ -251,7 +253,7 @@ private class InfraExplorerImpl(
             this.blockInfra,
             this.blocks.shallowCopy(),
             this.routes.shallowCopy(),
-            this.blockRoutes.toMutableMap(),
+            this.blockRoutes.shallowCopy(),
             this.incrementalPath.clone(),
             this.pathPropertiesCache,
             this.currentIndex,
@@ -335,7 +337,6 @@ private class InfraExplorerImpl(
         blocks.addAll(addedBlocks)
         routes.add(route)
         for (block in addedBlocks) {
-            assert(!blockRoutes.containsKey(block))
             blockRoutes[block] = route
         }
         for (i in 0 ..< nBlocksToSkip) moveForward()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -289,7 +289,13 @@ private class InfraExplorerImpl(
             } else {
                 // If a block cannot be explored, give up
                 val isRouteBlocked =
-                    constraints.any { constraint -> constraint.apply(block).isNotEmpty() }
+                    constraints.any { constraint ->
+                        constraint.apply(block).any {
+                            if (firstLocation != null && firstLocation.edge == block)
+                                firstLocation.offset.distance < it.end.distance
+                            else true
+                        }
+                    }
                 if (isRouteBlocked) return false
                 val endLocationsOnBlock = stops.last().filter { it.edge == block }
                 val endPath = endLocationsOnBlock.isNotEmpty()

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -288,11 +288,14 @@ private class InfraExplorerImpl(
                 nBlocksToSkip++
             } else {
                 // If a block cannot be explored, give up
+                val endLocation = stops.last().firstOrNull { it.edge == block }
                 val isRouteBlocked =
                     constraints.any { constraint ->
                         constraint.apply(block).any {
                             if (firstLocation != null && firstLocation.edge == block)
                                 firstLocation.offset.distance < it.end.distance
+                            else if (endLocation != null)
+                                endLocation.offset.distance > it.start.distance
                             else true
                         }
                     }


### PR DESCRIPTION
Fixes #6784.

Use infra explorer in pathfinding endpoint. This makes us explore the graph using both blocks and routes, ensuring that if we do find a block path, the corresponding routes exist.

As intended, corrects https://github.com/osrd-project/osrd-confidential/issues/333, a path is found between Metz and Nancy:
![image](https://github.com/user-attachments/assets/c5cbc075-6f66-4074-af18-5457a5bec5c3)

Benchmark run on same infra: results are slightly better (up by 0.3% for a payload insaaannee), and basically we're getting less repeated_tracks errors (instead the path is just not found):
![image](https://github.com/user-attachments/assets/42cb072f-494a-4f47-aca5-76abedafbc9f)
