### PR TITLE
core: pin takes version

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' } # Apache 2.0
 moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' } # Apache 2.0
 moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' } # Apache 2.0
 moshi-kotlin = { module = 'com.squareup.moshi:moshi-kotlin', version.ref = 'moshi' } # Apache 2.0
-takes = { module = 'org.takes:takes', version = '1.24.+' } # MIT
+takes = { module = 'org.takes:takes', version = '1.24.4' } # MIT
 javax-json-api = { module = 'javax.json:javax.json-api', version = '1.1.4' } # GPLv2 with classpath exemption
 okhttp = { module = 'com.squareup.okhttp3:okhttp', version = '4.12.0' } # Apache 2.0
 classgraph = { module = 'io.github.classgraph:classgraph', version = '4.8.+' } # MIT


### PR DESCRIPTION
Pin takes to `1.24.4`, as using `1.24.5` leads to:
```txt
ConflictDetectionEndpoint.java:50:
            return new RsJson(new RsWithBody(ConflictDetectionResult.adapter.toJson(result)));
                   ^
  class file for jakarta.json.JsonStructure not found
```