### PR TITLE
editoast: add train_schedule object to search endpoint

### DIFF
--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
@@ -9,7 +9,6 @@ editoast_common::schemas! {
 
 #[derive(Debug, Derivative, Clone, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
-#[schema(as = TrainScheduleOptionsV2)] // Avoiding conflict with v1. TODO: remove after migration to v2
 #[derivative(Default)]
 pub struct TrainScheduleOptions {
     #[derivative(Default(value = "true"))]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8770,6 +8770,7 @@ components:
       - $ref: '#/components/schemas/SearchResultItemProject'
       - $ref: '#/components/schemas/SearchResultItemStudy'
       - $ref: '#/components/schemas/SearchResultItemScenario'
+      - $ref: '#/components/schemas/SearchResultItemTrainSchedule'
       description: A search result item that depends on the query's `object`
     SearchResultItemOperationalPoint:
       type: object
@@ -9002,6 +9003,72 @@ components:
           type: integer
           format: int64
         line_name:
+          type: string
+    SearchResultItemTrainSchedule:
+      type: object
+      description: A search result item for a query with `object = "trainschedule"`
+      required:
+      - id
+      - train_name
+      - labels
+      - rolling_stock_name
+      - timetable_id
+      - start_time
+      - schedule
+      - margins
+      - initial_speed
+      - comfort
+      - path
+      - constraint_distribution
+      - power_restrictions
+      - options
+      properties:
+        comfort:
+          type: integer
+          format: int64
+        constraint_distribution:
+          type: integer
+          format: int64
+        id:
+          type: integer
+          format: int64
+          minimum: 0
+        initial_speed:
+          type: number
+          format: double
+        labels:
+          type: array
+          items:
+            type: string
+            nullable: true
+        margins:
+          $ref: '#/components/schemas/Margins'
+        options:
+          $ref: '#/components/schemas/TrainScheduleOptions'
+        path:
+          type: array
+          items:
+            $ref: '#/components/schemas/PathItem'
+        power_restrictions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PowerRestrictionItem'
+        rolling_stock_name:
+          type: string
+        schedule:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleItem'
+        speed_limit_tag:
+          type: string
+          nullable: true
+        start_time:
+          type: string
+          format: date-time
+        timetable_id:
+          type: integer
+          format: int64
+        train_name:
           type: string
     Side:
       type: string
@@ -10206,7 +10273,7 @@ components:
             format: int64
             description: Timetable attached to the train schedule
             nullable: true
-    TrainScheduleOptionsV2:
+    TrainScheduleOptions:
       type: object
       properties:
         use_electrical_profiles:

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2848,13 +2848,67 @@ export type SearchResultItemScenario = {
   tags: string[];
   trains_count: number;
 };
+export type Margins = {
+  boundaries: string[];
+  /** The values of the margins. Must contains one more element than the boundaries
+    Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km` */
+  values: string[];
+};
+export type TrainScheduleOptions = {
+  use_electrical_profiles?: boolean;
+};
+export type PathItem = PathItemLocation & {
+  /** Metadata given to mark a point as wishing to be deleted by the user.
+    It's useful for soft deleting the point (waiting to fix / remove all references)
+    If true, the train schedule is consider as invalid and must be edited */
+  deleted?: boolean;
+  id: string;
+};
+export type PowerRestrictionItem = {
+  from: string;
+  to: string;
+  value: string;
+};
+export type ReceptionSignal = 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';
+export type ScheduleItem = {
+  /** The expected arrival time at the stop.
+    This will be used to compute the final simulation time. */
+  arrival?: string | null;
+  at: string;
+  /** Whether the schedule item is locked (only for display purposes) */
+  locked?: boolean;
+  reception_signal?: ReceptionSignal;
+  /** Duration of the stop.
+    Can be `None` if the train does not stop.
+    If `None`, `reception_signal` must be `Open`.
+    `Some("PT0S")` means the train stops for 0 seconds. */
+  stop_for?: string | null;
+};
+export type SearchResultItemTrainSchedule = {
+  comfort: number;
+  constraint_distribution: number;
+  id: number;
+  initial_speed: number;
+  labels: (string | null)[];
+  margins: Margins;
+  options: TrainScheduleOptions;
+  path: PathItem[];
+  power_restrictions: PowerRestrictionItem[];
+  rolling_stock_name: string;
+  schedule: ScheduleItem[];
+  speed_limit_tag?: string | null;
+  start_time: string;
+  timetable_id: number;
+  train_name: string;
+};
 export type SearchResultItem =
   | SearchResultItemTrack
   | SearchResultItemOperationalPoint
   | SearchResultItemSignal
   | SearchResultItemProject
   | SearchResultItemStudy
-  | SearchResultItemScenario;
+  | SearchResultItemScenario
+  | SearchResultItemTrainSchedule;
 export type SearchQuery = boolean | number | number | string | (SearchQuery | null)[];
 export type SearchPayload = {
   /** Whether to return the SQL query instead of executing it
@@ -3032,7 +3086,6 @@ export type PathfindingItem = {
   timing_data?: StepTimingData | null;
 };
 export type Distribution = 'STANDARD' | 'MARECO';
-export type ReceptionSignal = 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';
 export type TrainScheduleBase = {
   comfort?: Comfort;
   constraint_distribution: Distribution;


### PR DESCRIPTION
#9124 

Bellow is a test using the below request :
Based on the openapi request : Returns all infra objects of some type according to a hierarchical query.

POST : 
{{baseUrl}}/search?page=1&page_size=25
Body :
```json 
{
    "object": "trainschedule",
    "query": [
        "and",
        [
            "search",
            [
                "train_name"
            ],
            "10222"
        ],
        [
            "=",
            [
                "timetable_id"
            ],
            1
        ]
    ]
}
```

Answer : 
```json
[
    {
        "comfort": 0,
        "constraint_distribution": 0,
        "id": 1,
        "initial_speed": 0,
        "labels": [
            "all-stops",
            "H3C4"
        ],
        "margins": {
            "boundaries": [],
            "values": [
                "0%"
            ]
        },
        "options": {
            "use_electrical_profiles": true
        },
        "path": [
            {
                "deleted": false,
                "id": "0",
                "operational_point": "d9e37c1e-6667-11e3-89ff-01f464e0362d"
            },
            {
                "deleted": false,
                "id": "1",
                "operational_point": "d9a37fbe-6667-11e3-89ff-01f464e0362d"
            },
            {
                "deleted": false,
                "id": "2",
                "operational_point": "d97702c4-6667-11e3-89ff-01f464e0362d"
            }
        ],
        "power_restrictions": [],
        "rolling_stock_name": "69400US",
        "schedule": [
            {
                "arrival": "PT6720S",
                "at": "1",
                "locked": true,
                "reception_signal": "OPEN",
                "stop_for": "PT1680S"
            },
            {
                "arrival": "PT10200S",
                "at": "2",
                "locked": true,
                "reception_signal": "OPEN",
                "stop_for": "P0D"
            }
        ],
        "speed_limit_tag": "ME100",
        "start_time": "2024-09-17T10:03:00+00:00",
        "timetable_id": 1,
        "train_name": "102224"
    }
]
```