### PR TITLE
ci: checkout code before getting labeler's configuration file

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Label PR
         uses: actions/labeler@v5
         with:


### PR DESCRIPTION
The current configuration cannot be found (see [this build](https://github.com/OpenRailAssociation/osrd/actions/runs/11157830802/job/31012849645?pr=9165)). Found the answer in https://github.com/actions/labeler/issues/628 and indeed, it was written in [the documentation](https://github.com/actions/labeler?tab=readme-ov-file#using-configuration-path-input-together-with-the-actionscheckout-action).