### PR TITLE
core: fix "negative" routing requirements + add requirement margin for stop on closed signal (conflict detection)

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.Offset
@@ -416,8 +417,7 @@ class SpacingRequirementAutomaton(
 
         // TODO: use a lookup table
         fun findLastStopBeforeZone(): ProcessedStop? {
-            for (i in processedStops.size - 1 downTo 0) {
-                val stop = processedStops[i]
+            for (stop in processedStops.reversed()) {
                 if (stop.nextZoneIdx <= pendingRequirement.zoneIndex) {
                     return stop
                 }
@@ -432,7 +432,7 @@ class SpacingRequirementAutomaton(
             if (stopEndTime.isInfinite()) {
                 return null
             }
-            beginTime = maxOf(beginTime, stopEndTime)
+            beginTime = maxOf(beginTime, stopEndTime - CLOSED_SIGNAL_RESERVATION_MARGIN)
         }
 
         val departureTime = callbacks.departureTimeFromRange(zoneEntryOffset, zoneExitOffset)

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -366,21 +366,22 @@ fun routingRequirements(
             ) ?: return null
         val limitingBlock = blockPath[limitingSignalSpec.blockIndex]
         val signal = blockInfra.getBlockSignals(limitingBlock)[limitingSignalSpec.signalIndex]
-        val limitingSignalOffset =
+        val limitingSignalOffsetInBlock =
             blockInfra.getSignalsPositions(limitingBlock)[limitingSignalSpec.signalIndex].distance
 
-        val blockOffset = blockOffsets[limitingSignalSpec.blockIndex]
-        val sightDistance = rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
+        val limitingBlockOffset = blockOffsets[limitingSignalSpec.blockIndex]
+        val signalSightDistance =
+            rawInfra.getSignalSightDistance(rawInfra.getPhysicalSignal(signal))
 
         // find the location at which establishing the route becomes necessary
-        var criticalPos = blockOffset + limitingSignalOffset - sightDistance
+        val criticalPos = limitingBlockOffset + limitingSignalOffsetInBlock - signalSightDistance
         var criticalTime = envelope.interpolateArrivalAtClamp(criticalPos.distance.meters)
 
         // check if an arrival on stop signal is scheduled between the critical position and the
         // entry signal of the route (both position and time, as there is a time margin)
         // in this case, just move the critical position to just after the stop
         val entrySignalOffset =
-            blockOffset + blockInfra.getSignalsPositions(firstRouteBlock).first().distance
+            limitingBlockOffset + blockInfra.getSignalsPositions(firstRouteBlock).first().distance
         for (stop in stops.reversed()) {
             val stopTravelledOffset = pathOffsetBuilder.toTravelledPath(stop.pathOffset)
             if (

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -381,12 +381,13 @@ fun routingRequirements(
         // entry signal of the route (both position and time, as there is a time margin)
         // in this case, just move the critical position to just after the stop
         val entrySignalOffset =
-            limitingBlockOffset + blockInfra.getSignalsPositions(firstRouteBlock).first().distance
+            blockOffsets[routeStartBlockIndex] +
+                blockInfra.getSignalsPositions(firstRouteBlock).first().distance
         for (stop in stops.reversed()) {
             val stopTravelledOffset = pathOffsetBuilder.toTravelledPath(stop.pathOffset)
             if (
                 stop.receptionSignal.isStopOnClosedSignal &&
-                    entrySignalOffset <= stopTravelledOffset
+                    stopTravelledOffset <= entrySignalOffset
             ) {
                 // stop duration is included in interpolateDepartureFromClamp()
                 val stopDepartureTime =

--- a/core/src/test/java/fr/sncf/osrd/standalone_sim/ConflictDetectionTest.java
+++ b/core/src/test/java/fr/sncf/osrd/standalone_sim/ConflictDetectionTest.java
@@ -499,6 +499,10 @@ public class ConflictDetectionTest {
         var directStartTime = 300; // 5 min after stopping train
         var reqOvertaking = convertRequirements(1L, directStartTime, simResultNorthOvertaking.train);
 
+        // check that requirements are all ending after they begin
+        assertRequirementsPeriodsConsistency(reqOvertaking);
+        assertRequirementsPeriodsConsistency(reqWithStop);
+
         // check spacing and routing requirements for the zone of the switch after (East) Mid_West_station
         var switchZoneName = "zone.[DC4:INCREASING, DC5:INCREASING, DD0:DECREASING]";
 
@@ -540,6 +544,18 @@ public class ConflictDetectionTest {
                 .get();
         assertEquals(overtakingSwitchLimitingSignalSight, overtakingSwitchRouteReqWithStop.beginTime);
         assertEquals(overtakingSwitchZoneExitTime, overtakingSwitchRouteCrossingZoneReqWithStop.endTime);
+    }
+
+    private static void assertRequirementsPeriodsConsistency(TrainRequirements requirements) {
+        for (var spacingReq : requirements.getSpacingRequirements()) {
+            assert (spacingReq.beginTime <= spacingReq.endTime);
+        }
+        for (var routingReq : requirements.getRoutingRequirements()) {
+            var routingReqBegin = routingReq.beginTime;
+            for (var zoneReq : routingReq.zones) {
+                assert (routingReqBegin <= zoneReq.endTime);
+            }
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Fix routing requirements cases where 'begin' was later than 'end' (stop on closed signal only).
* Also a 20 s anticipation for the start of resource requirement when stopping on closed signal.

Fix: https://github.com/OpenRailAssociation/osrd/issues/8813