### PR TITLE
editoast: fix the openapi on lock/unlock rolling stock

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2137,12 +2137,8 @@ paths:
               $ref: '#/components/schemas/RollingStockLockedUpdateForm'
         required: true
       responses:
-        '200':
-          description: The created rolling stock
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RollingStock'
+        '204':
+          description: No content when successful
   /rolling_stock/{rolling_stock_id}/usage:
     get:
       tags:

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -471,7 +471,7 @@ struct RollingStockLockedUpdateForm {
     params(RollingStockIdParam),
     request_body = RollingStockLockedUpdateForm,
     responses(
-        (status = 200, description = "The created rolling stock", body = RollingStock)
+        (status = 204, description = "No content when successful")
     )
 )]
 async fn update_locked(

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1384,8 +1384,7 @@ export type PostRollingStockByRollingStockIdLiveryApiArg = {
   rollingStockId: number;
   rollingStockLiveryCreateForm: RollingStockLiveryCreateForm;
 };
-export type PatchRollingStockByRollingStockIdLockedApiResponse =
-  /** status 200 The created rolling stock */ RollingStock;
+export type PatchRollingStockByRollingStockIdLockedApiResponse = unknown;
 export type PatchRollingStockByRollingStockIdLockedApiArg = {
   rollingStockId: number;
   rollingStockLockedUpdateForm: RollingStockLockedUpdateForm;


### PR DESCRIPTION
The endpoint `/rolling_stock/{id}/locked` doesn't return anything, only `NO_CONTENT` which is a 204.