### PR TITLE
core, editoast: add zones to path properties

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
@@ -45,6 +45,8 @@ interface PathProperties {
     @JvmName("getSpeedLimitProperties")
     fun getSpeedLimitProperties(trainTag: String?): DistanceRangeMap<SpeedLimitProperty>
 
+    fun getZones(): DistanceRangeMap<ZoneId>
+
     @JvmName("getLength") fun getLength(): Distance
 
     @JvmName("getTrackLocationAtOffset")

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
@@ -90,6 +90,20 @@ data class PathPropertiesImpl(
         }
     }
 
+    override fun getZones(): DistanceRangeMap<ZoneId> {
+        return getRangeMapFromUndirected { chunkId ->
+            val zoneId = infra.getTrackChunkZone(chunkId)
+            if (zoneId != null) {
+                val chunkLength = infra.getTrackChunkLength(chunkId).distance
+                distanceRangeMapOf(
+                    listOf(DistanceRangeMap.RangeMapEntry(Distance.ZERO, chunkLength, zoneId))
+                )
+            } else {
+                distanceRangeMapOf()
+            }
+        }
+    }
+
     override fun getLength(): Distance {
         return chunkPath.endOffset - chunkPath.beginOffset
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
@@ -60,6 +60,10 @@ data class PathPropertiesView(
         return sliceRangeMap(base.getSpeedLimitProperties(trainTag))
     }
 
+    override fun getZones(): DistanceRangeMap<ZoneId> {
+        return sliceRangeMap(base.getZones())
+    }
+
     override fun getLength(): Distance {
         return endOffset - startOffset
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponse.kt
@@ -16,7 +16,8 @@ class PathPropResponse(
     val curves: RangeValues<Double>,
     val electrifications: RangeValues<Electrification>,
     val geometry: RJSLineString,
-    @Json(name = "operational_points") val operationalPoints: List<OperationalPointResponse>
+    @Json(name = "operational_points") val operationalPoints: List<OperationalPointResponse>,
+    val zones: RangeValues<String>,
 )
 
 interface Electrification

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponseConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponseConverter.kt
@@ -21,7 +21,8 @@ fun makePathPropResponse(
         makeCurves(pathProperties),
         makeElectrifications(pathProperties),
         makeGeographic(pathProperties),
-        makeOperationalPoints(pathProperties, rawInfra)
+        makeOperationalPoints(pathProperties, rawInfra),
+        makeZones(pathProperties, rawInfra)
     )
 }
 
@@ -105,6 +106,11 @@ private fun makeOperationalPoints(
         res.add(opResult)
     }
     return res
+}
+
+private fun makeZones(path: PathProperties, rawInfra: RawSignalingInfra): RangeValues<String> {
+    val zoneIds = makeRangeValues(path.getZones())
+    return RangeValues(zoneIds.internalBoundaries, zoneIds.values.map { rawInfra.getZoneName(it) })
 }
 
 private fun <T> makeRangeValues(distanceRangeMap: DistanceRangeMap<T>): RangeValues<T> {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7182,6 +7182,29 @@ components:
                   format: double
                 description: List of `n+1` values associated to the ranges
           nullable: true
+        zones:
+          allOf:
+          - type: object
+            description: Zones along a path. Each value is associated to a range of the path.
+            required:
+            - boundaries
+            - values
+            properties:
+              boundaries:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                description: |-
+                  List of `n` boundaries of the ranges.
+                  A boundary is a distance from the beginning of the path in mm.
+              values:
+                type: array
+                items:
+                  type: string
+                description: List of `n+1` values associated to the ranges
+          nullable: true
     PathPropertiesInput:
       type: object
       required:
@@ -7748,6 +7771,7 @@ components:
       - electrifications
       - geometry
       - operational_points
+      - zones
     RailJson:
       type: object
       description: An infrastructure description in the RailJson format

--- a/editoast/src/core/path_properties.rs
+++ b/editoast/src/core/path_properties.rs
@@ -29,6 +29,8 @@ pub struct PathPropertiesResponse {
     pub geometry: GeoJsonLineString,
     /// Operational points along the path
     pub operational_points: Vec<OperationalPointOnPath>,
+    /// Zones along the path
+    pub zones: PropertyZoneValues,
 }
 
 /// Property f64 values along a path. Each value is associated to a range of the path.
@@ -76,6 +78,16 @@ pub struct OperationalPointOnPath {
     extensions: OperationalPointExtensions,
     /// Distance from the beginning of the path in mm
     position: u64,
+}
+
+/// Zones along a path. Each value is associated to a range of the path.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PropertyZoneValues {
+    /// List of `n` boundaries of the ranges.
+    /// A boundary is a distance from the beginning of the path in mm.
+    boundaries: Vec<u64>,
+    /// List of `n+1` values associated to the ranges
+    values: Vec<String>,
 }
 
 impl<'a> AsCoreRequest<Json<PathPropertiesResponse>> for PathPropertiesRequest<'a> {

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -25,6 +25,7 @@ use crate::core::path_properties::OperationalPointOnPath;
 use crate::core::path_properties::PathPropertiesRequest;
 use crate::core::path_properties::PropertyElectrificationValues;
 use crate::core::path_properties::PropertyValuesF64;
+use crate::core::path_properties::PropertyZoneValues;
 use crate::core::pathfinding::TrackRange;
 use crate::core::AsCoreRequest;
 use crate::error::Result;
@@ -70,6 +71,9 @@ struct PathProperties {
     /// Operational points along the path
     #[schema(inline)]
     operational_points: Option<Vec<OperationalPointOnPath>>,
+    /// Zones along the path
+    #[schema(inline)]
+    zones: Option<PropertyZoneValues>,
 }
 
 impl PathProperties {
@@ -92,6 +96,10 @@ impl PathProperties {
         if self.operational_points.is_some() {
             properties.insert(Property::OperationalPoints);
         }
+        if self.zones.is_some() {
+            properties.insert(Property::Zones);
+        }
+
         properties
     }
 
@@ -105,6 +113,7 @@ impl PathProperties {
                 Property::Electrifications => self.electrifications = None,
                 Property::Geometry => self.geometry = None,
                 Property::OperationalPoints => self.operational_points = None,
+                Property::Zones => self.zones = None,
             }
         }
         self
@@ -135,6 +144,7 @@ enum Property {
     Electrifications,
     Geometry,
     OperationalPoints,
+    Zones,
 }
 
 type Properties = EnumSet<Property>;
@@ -196,6 +206,7 @@ async fn post(
             electrifications: Some(computed_path_properties.electrifications),
             geometry: Some(computed_path_properties.geometry),
             operational_points: Some(computed_path_properties.operational_points),
+            zones: Some(computed_path_properties.zones),
         };
 
         // Cache new properties

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2281,8 +2281,21 @@ export type PathProperties = {
     /** List of `n+1` values associated to the ranges */
     values: number[];
   } | null;
+  zones?: {
+    /** List of `n` boundaries of the ranges.
+        A boundary is a distance from the beginning of the path in mm. */
+    boundaries: number[];
+    /** List of `n+1` values associated to the ranges */
+    values: string[];
+  } | null;
 };
-export type Property = 'slopes' | 'curves' | 'electrifications' | 'geometry' | 'operational_points';
+export type Property =
+  | 'slopes'
+  | 'curves'
+  | 'electrifications'
+  | 'geometry'
+  | 'operational_points'
+  | 'zones';
 export type PathPropertiesInput = {
   /** List of track sections */
   track_section_ranges: TrackRange[];


### PR DESCRIPTION
This will be useful to display conflicts on the space time chart. Conflicts are represented as a list of zones and time ranges, the frontend needs to translate the zone names into space ranges.

<details>

<summary>Hack patch to test</summary>

- Apply patch
- Open the form to create a new train
- Run a pathfinding request
- Use the browser devtools to inspect the `/path_properties` response

```diff
diff --git a/front/src/modules/pathfinding/hooks/usePathfinding.ts b/front/src/modules/pathfinding/hooks/usePathfinding.ts
index 6444535a55d4..f2e14239bf4d 100644
--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -237,7 +237,7 @@ export const usePathfinding = (
 
             const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {
               infraId,
-              props: ['electrifications', 'geometry', 'operational_points'],
+              props: ['electrifications', 'geometry', 'operational_points', 'zones'],
               pathPropertiesInput: {
                 track_section_ranges: pathResult.track_section_ranges,
               },
```

</details>

Closes: https://github.com/OpenRailAssociation/osrd/issues/8682