### PR TITLE
editoast: locked rolling stocked returns a 409

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4979,7 +4979,7 @@ components:
         status:
           type: integer
           enum:
-          - 400
+          - 409
         type:
           type: string
           enum:

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -131,7 +131,7 @@ pub enum RollingStockError {
     NameAlreadyUsed { name: String },
 
     #[error("RollingStock '{rolling_stock_id}' is locked")]
-    #[editoast_error(status = 400)]
+    #[editoast_error(status = 409)]
     RollingStockIsLocked { rolling_stock_id: i64 },
 
     #[error("RollingStock '{rolling_stock_id}' is used")]
@@ -1178,7 +1178,7 @@ pub mod tests {
         // WHEN
         let response: InternalError = app
             .fetch(request)
-            .assert_status(StatusCode::BAD_REQUEST)
+            .assert_status(StatusCode::CONFLICT)
             .json_into();
 
         // THEN
@@ -1288,7 +1288,7 @@ pub mod tests {
         // WHEN
         let response: InternalError = app
             .fetch(request)
-            .assert_status(StatusCode::BAD_REQUEST)
+            .assert_status(StatusCode::CONFLICT)
             .json_into();
 
         // THEN


### PR DESCRIPTION
When a rolling stock is locked and we try to update it, we return a [400 BAD_REQUEST](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1). I don't think the request is malformed in case of a locked rolling stock.

Based on the description of what is a 409, the behavior of our system in case a rolling stock is already locked is more a [409 CONFLICT](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8).

⚠️ This PR is a proposition. If other developers disagree, we can just close it.