### PR TITLE
editoast: remove redundant prefix in the error's name

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4101,11 +4101,11 @@ components:
       - $ref: '#/components/schemas/EditoastRollingStockErrorBasePowerClassEmpty'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotCreateCompoundImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotReadImage'
+      - $ref: '#/components/schemas/EditoastRollingStockErrorIsLocked'
+      - $ref: '#/components/schemas/EditoastRollingStockErrorIsUsed'
       - $ref: '#/components/schemas/EditoastRollingStockErrorKeyNotFound'
       - $ref: '#/components/schemas/EditoastRollingStockErrorLiveryMultipartError'
       - $ref: '#/components/schemas/EditoastRollingStockErrorNameAlreadyUsed'
-      - $ref: '#/components/schemas/EditoastRollingStockErrorRollingStockIsLocked'
-      - $ref: '#/components/schemas/EditoastRollingStockErrorRollingStockIsUsed'
       - $ref: '#/components/schemas/EditoastSTDCMErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastSTDCMErrorInvalidPathItems'
       - $ref: '#/components/schemas/EditoastSTDCMErrorRollingStockNotFound'
@@ -4889,6 +4889,57 @@ components:
           type: string
           enum:
           - editoast:rollingstocks:CannotReadImage
+    EditoastRollingStockErrorIsLocked:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - rolling_stock_id
+          properties:
+            rolling_stock_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 409
+        type:
+          type: string
+          enum:
+          - editoast:rollingstocks:IsLocked
+    EditoastRollingStockErrorIsUsed:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - rolling_stock_id
+          - usage
+          properties:
+            rolling_stock_id:
+              type: integer
+            usage:
+              type: array
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 409
+        type:
+          type: string
+          enum:
+          - editoast:rollingstocks:IsUsed
     EditoastRollingStockErrorKeyNotFound:
       type: object
       required:
@@ -4956,57 +5007,6 @@ components:
           type: string
           enum:
           - editoast:rollingstocks:NameAlreadyUsed
-    EditoastRollingStockErrorRollingStockIsLocked:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - rolling_stock_id
-          properties:
-            rolling_stock_id:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 409
-        type:
-          type: string
-          enum:
-          - editoast:rollingstocks:RollingStockIsLocked
-    EditoastRollingStockErrorRollingStockIsUsed:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - rolling_stock_id
-          - usage
-          properties:
-            rolling_stock_id:
-              type: integer
-            usage:
-              type: array
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 409
-        type:
-          type: string
-          enum:
-          - editoast:rollingstocks:RollingStockIsUsed
     EditoastSTDCMErrorInfraNotFound:
       type: object
       required:
@@ -8103,9 +8103,9 @@ components:
                 type: string
       - type: object
         required:
-        - RollingStockIsLocked
+        - IsLocked
         properties:
-          RollingStockIsLocked:
+          IsLocked:
             type: object
             required:
             - rolling_stock_id
@@ -8115,9 +8115,9 @@ components:
                 format: int64
       - type: object
         required:
-        - RollingStockIsUsed
+        - IsUsed
         properties:
-          RollingStockIsUsed:
+          IsUsed:
             type: object
             required:
             - rolling_stock_id

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -130,13 +130,13 @@ pub enum RollingStockError {
     #[editoast_error(status = 400)]
     NameAlreadyUsed { name: String },
 
-    #[error("RollingStock '{rolling_stock_id}' is locked")]
+    #[error("Rolling stock '{rolling_stock_id}' is locked")]
     #[editoast_error(status = 409)]
-    RollingStockIsLocked { rolling_stock_id: i64 },
+    IsLocked { rolling_stock_id: i64 },
 
-    #[error("RollingStock '{rolling_stock_id}' is used")]
+    #[error("Rolling stock '{rolling_stock_id}' is used")]
     #[editoast_error(status = 409)]
-    RollingStockIsUsed {
+    IsUsed {
         rolling_stock_id: i64,
         usage: Vec<TrainScheduleScenarioStudyProject>,
     },
@@ -440,7 +440,7 @@ async fn delete(
         delete_rolling_stock(conn, rolling_stock_id).await?;
         return Ok(StatusCode::NO_CONTENT);
     }
-    Err(RollingStockError::RollingStockIsUsed {
+    Err(RollingStockError::IsUsed {
         rolling_stock_id,
         usage: trains,
     }
@@ -678,7 +678,7 @@ pub async fn retrieve_existing_rolling_stock(
 
 fn assert_rolling_stock_unlocked(rolling_stock: &RollingStockModel) -> Result<()> {
     if rolling_stock.locked {
-        return Err(RollingStockError::RollingStockIsLocked {
+        return Err(RollingStockError::IsLocked {
             rolling_stock_id: rolling_stock.id,
         }
         .into());
@@ -1183,10 +1183,7 @@ pub mod tests {
             .json_into();
 
         // THEN
-        assert_eq!(
-            response.error_type,
-            "editoast:rollingstocks:RollingStockIsLocked"
-        );
+        assert_eq!(response.error_type, "editoast:rollingstocks:IsLocked");
     }
 
     #[rstest]
@@ -1293,10 +1290,7 @@ pub mod tests {
             .json_into();
 
         // THEN
-        assert_eq!(
-            response.error_type,
-            "editoast:rollingstocks:RollingStockIsLocked"
-        );
+        assert_eq!(response.error_type, "editoast:rollingstocks:IsLocked");
 
         let rolling_stock_exists =
             RollingStockModel::exists(&mut db_pool.get_ok(), locked_fast_rolling_stock.id)

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -137,8 +137,8 @@
       "NameAlreadyUsed": "Name '{{name}}' already used",
       "KeyNotFound": "Rolling stock '{{rolling_stock_key.key}}' could not be found",
       "LiveryMultipartError": "Invalid multipart request while uploading livery",
-      "RollingStockIsLocked": "RollingStock '{{rolling_stock_id}}' is locked",
-      "RollingStockIsUsed": "RollingStock '{{rolling_stock_id}}' is used"
+      "IsLocked": "Rolling stock '{{rolling_stock_id}}' is locked",
+      "IsUsed": "Rolling stock '{{rolling_stock_id}}' is used"
     },
     "scenario": {
       "NotFound": "Scenario not found"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -137,8 +137,8 @@
       "NameAlreadyUsed": "Un matériel roulant avec le nom '{{name}}' existe déjà",
       "KeyNotFound": "Matériel roulant '{{rolling_stock_key.key}}' non trouvé",
       "LiveryMultipartError": "Requête multipart invalide pour upload de livrée",
-      "RollingStockIsLocked": "Matériel roulant '{{rolling_stock_id}}' est verrouillé",
-      "RollingStockIsUsed": "Matériel roulant '{{rolling_stock_id}}' est occupé"
+      "IsLocked": "Matériel roulant '{{rolling_stock_id}}' est verrouillé",
+      "IsUsed": "Matériel roulant '{{rolling_stock_id}}' est occupé"
     },
     "scenario": {
       "NotFound": "Scénario non trouvé",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2757,12 +2757,12 @@ export type RollingStockError =
       };
     }
   | {
-      RollingStockIsLocked: {
+      IsLocked: {
         rolling_stock_id: number;
       };
     }
   | {
-      RollingStockIsUsed: {
+      IsUsed: {
         rolling_stock_id: number;
         usage: TrainScheduleScenarioStudyProject[];
       };


### PR DESCRIPTION
The `struct` is already named `RollingStockError` so having the variant also prefixed with the same name is redundant. It's even a (pedantic) lint in clippy [`enum_variant_names`](https://rust-lang.github.io/rust-clippy/master/index.html#/enum_variant_names).