### PR TITLE
front: prevent the via card to be demounted and remounted several times

### DIFF
--- a/front/src/applications/stdcm/views/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/views/StdcmConfig.tsx
@@ -1,3 +1,4 @@
+// /!\ This file will be removed soon, don't update it /!\
 import { useEffect, useMemo, useState } from 'react';
 
 import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';

--- a/front/src/applications/stdcmV2/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmResults/StdcmResults.tsx
@@ -131,7 +131,7 @@ const StcdmResults = ({
             hideAttribution
             showStdcmAssets
             setMapCanvas={setMapCanvas}
-            pathProperties={selectedSimulation.outputs?.pathProperties}
+            pathGeometry={selectedSimulation.outputs?.pathProperties.geometry}
             simulationPathSteps={selectedSimulation.outputs?.results.simulationPathSteps}
           />
         </div>

--- a/front/src/applications/stdcmV2/components/StdcmVias.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmVias.tsx
@@ -97,7 +97,7 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
   };
 
   const addViaOnClick = (pathStepIndex: number) => {
-    const newPathSteps = addElementAtIndex(pathSteps, pathStepIndex, null);
+    const newPathSteps = addElementAtIndex(pathSteps, pathStepIndex, { id: nextId(), uic: -1 });
     dispatch(updatePathSteps({ pathSteps: newPathSteps }));
   };
 
@@ -113,8 +113,9 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
       {intermediatePoints.length > 0 &&
         intermediatePoints.map((pathStep, index) => {
           const pathStepIndex = index + 1;
+          if (!pathStep) return null;
           return (
-            <div className="stdcm-v2-vias-bundle" key={nextId('via-')}>
+            <div className="stdcm-v2-vias-bundle" key={pathStep.id}>
               <StdcmDefaultCard
                 hasTip
                 text={t('trainPath.addVia')}
@@ -130,7 +131,7 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
                       <img src={IntermediatePointIcon} alt="intermediate-point" />
                       <span className="icon-index">{pathStepIndex}</span>
                     </div>
-                    <button type="button" onClick={() => deleteViaOnClick(index, pathStep!.id)}>
+                    <button type="button" onClick={() => deleteViaOnClick(index, pathStep.id)}>
                       {t('translation:common.delete')}
                     </button>
                   </div>
@@ -142,11 +143,11 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
                   <StdcmOperationalPoint
                     updatePoint={(e) => updatePathStepsList(e, pathStepIndex)}
                     point={pathStep}
-                    opPointId={pathStep?.id || nextId('via-')}
+                    opPointId={pathStep.id}
                     disabled={disabled}
                   />
                 </div>
-                {pathStep && (
+                {'uic' in pathStep && pathStep.uic !== -1 && (
                   <>
                     <StdcmStopType
                       stopTypes={stopTypes[pathStep.id]}

--- a/front/src/applications/stdcmV2/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcmV2/hooks/useStaticPathfinding.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { compact } from 'lodash';
+import { useSelector } from 'react-redux';
+
+import { osrdEditoastApi, type PathfindingResult } from 'common/api/osrdEditoastApi';
+import { useOsrdConfSelectors } from 'common/osrdContext';
+import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
+import usePathProperties from 'modules/pathfinding/hooks/usePathProperties';
+import { getPathfindingQuery } from 'modules/pathfinding/utils';
+import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
+
+const useStaticPathfinding = () => {
+  const { getPathSteps } = useOsrdConfSelectors();
+
+  const { infra } = useInfraStatus();
+  const pathSteps = useSelector(getPathSteps);
+  const { rollingStock } = useStoreDataForRollingStockSelector();
+
+  const [pathfinding, setPathfinding] = useState<PathfindingResult>();
+
+  const [postPathfindingBlocks] =
+    osrdEditoastApi.endpoints.postInfraByInfraIdPathfindingBlocks.useMutation();
+
+  const pathStepsLocations = useMemo(
+    () =>
+      compact(
+        pathSteps.map((step) => (step && (!('uic' in step) || step.uic !== -1) ? step : null))
+      ),
+    [pathSteps]
+  );
+
+  const pathProperties = usePathProperties(
+    infra?.id,
+    pathfinding?.status === 'success' ? pathfinding : undefined,
+    ['geometry']
+  );
+
+  useEffect(() => {
+    const launchPathfinding = async () => {
+      setPathfinding(undefined);
+      if (infra?.state !== 'CACHED' || !rollingStock || pathStepsLocations.length < 2) {
+        return;
+      }
+
+      const payload = getPathfindingQuery({
+        infraId: infra.id,
+        rollingStock,
+        origin: pathStepsLocations.at(0) || null,
+        destination: pathStepsLocations.at(-1) || null,
+        pathSteps: pathStepsLocations,
+      });
+
+      if (payload === null) {
+        return;
+      }
+
+      const pathfindingResult = await postPathfindingBlocks(payload).unwrap();
+
+      setPathfinding(pathfindingResult);
+    };
+
+    launchPathfinding();
+  }, [pathStepsLocations, rollingStock, infra]);
+
+  const result = useMemo(
+    () =>
+      pathfinding
+        ? { status: pathfinding.status, geometry: pathProperties?.geometry ?? undefined }
+        : null,
+    [pathfinding, pathProperties]
+  );
+
+  return result;
+};
+
+export default useStaticPathfinding;


### PR DESCRIPTION
closes #8986 
closes #9107

The via card was remounted because its key changed at each re-render (the key was nextId()). To avoid this, I modified the behaviour to create a via and give by default an id and a uic (= -1). This way, we can use the via.id for the key. It solves the main issue.

To handle the "fake" uic and avoid sending invalid payload to the pathfinding endpoint, I created a new hook usePathfindingIsPossible which filter the invalid uic and launch a pathfinding.
This hook is simpler than the existing usePathfinding hook, but I had to do some refacto in the map props (to give the path geometry separately from the path properties). This will be useful for a later refacto.