### PR TITLE
Remove invalid imports in models fixtures

### DIFF
--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -227,13 +227,9 @@ async fn show_stdcm_search_env(
 #[cfg(test)]
 mod tests {
     use crate::{
-        models::{
-            fixtures::{
-                create_electrical_profile_set, create_empty_infra, create_scenario_fixtures_set,
-                create_timetable, create_work_schedule_group, simple_train_schedule_form,
-            },
-            train_schedule::TrainSchedule,
-            Changeset,
+        models::fixtures::{
+            create_electrical_profile_set, create_empty_infra, create_scenario_fixtures_set,
+            create_timetable, create_work_schedule_group, simple_train_schedule_changeset,
         },
         Create,
     };
@@ -253,9 +249,7 @@ mod tests {
         conn: &mut DbConnection,
     ) {
         for start_time in start_times {
-            let train_schedule_changeset: Changeset<TrainSchedule> =
-                simple_train_schedule_form(timetable_id).into();
-            train_schedule_changeset
+            simple_train_schedule_changeset(timetable_id)
                 .start_time(start_time.and_utc())
                 .create(conn)
                 .await

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -29,7 +29,6 @@ use crate::models::RollingStockModel;
 use crate::models::Scenario;
 use crate::models::Study;
 use crate::models::Tags;
-use crate::views::train_schedule::TrainScheduleForm;
 
 pub fn project_changeset(name: &str) -> Changeset<Project> {
     Project::changeset()
@@ -74,23 +73,18 @@ pub async fn create_timetable(conn: &mut DbConnection) -> Timetable {
 
 pub fn simple_train_schedule_base() -> TrainScheduleBase {
     serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
-        .expect("Unable to parse")
+        .expect("Unable to parse test train schedule")
 }
 
-pub fn simple_train_schedule_form(timetable_id: i64) -> TrainScheduleForm {
-    let train_schedule: TrainScheduleBase = simple_train_schedule_base();
-    TrainScheduleForm {
-        timetable_id: Some(timetable_id),
-        train_schedule,
-    }
+pub fn simple_train_schedule_changeset(timetable_id: i64) -> Changeset<TrainSchedule> {
+    Changeset::<TrainSchedule>::from(simple_train_schedule_base()).timetable_id(timetable_id)
 }
 
 pub async fn create_simple_train_schedule(
     conn: &mut DbConnection,
     timetable_id: i64,
 ) -> TrainSchedule {
-    let train_schedule: Changeset<TrainSchedule> = simple_train_schedule_form(timetable_id).into();
-    train_schedule
+    simple_train_schedule_changeset(timetable_id)
         .create(conn)
         .await
         .expect("Failed to create train schedule")

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -35,7 +35,7 @@ editoast_common::schemas! {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Model, ToSchema)]
 #[model(table = editoast_models::tables::rolling_stock)]
 #[model(gen(ops = crud, batch_ops = r, list))]
-#[model(changeset(derive(Validate), public))]
+#[model(changeset(derive(Validate, Deserialize), public))]
 #[schema(as = RollingStock)]
 pub struct RollingStockModel {
     pub id: i64,

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -7,7 +7,10 @@ use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PowerRestrictionItem;
 use editoast_schemas::train_schedule::ScheduleItem;
+use editoast_schemas::train_schedule::TrainScheduleBase;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
+
+use super::Model as _;
 
 #[derive(Debug, Default, Clone, Model)]
 #[model(table = editoast_models::tables::train_schedule)]
@@ -35,4 +38,39 @@ pub struct TrainSchedule {
     pub power_restrictions: Vec<PowerRestrictionItem>,
     #[model(json)]
     pub options: TrainScheduleOptions,
+}
+
+impl From<TrainScheduleBase> for TrainScheduleChangeset {
+    fn from(
+        TrainScheduleBase {
+            train_name,
+            labels,
+            rolling_stock_name,
+            start_time,
+            path,
+            schedule,
+            margins,
+            initial_speed,
+            comfort,
+            constraint_distribution,
+            speed_limit_tag,
+            power_restrictions,
+            options,
+        }: TrainScheduleBase,
+    ) -> Self {
+        TrainSchedule::changeset()
+            .comfort(comfort)
+            .constraint_distribution(constraint_distribution)
+            .initial_speed(initial_speed)
+            .labels(labels.into_iter().map(Some).collect())
+            .margins(margins)
+            .path(path)
+            .power_restrictions(power_restrictions)
+            .rolling_stock_name(rolling_stock_name)
+            .schedule(schedule)
+            .speed_limit_tag(speed_limit_tag.map(|s| s.0))
+            .start_time(start_time)
+            .train_name(train_name)
+            .options(options)
+    }
 }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -795,9 +795,8 @@ pub mod tests {
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::fast_rolling_stock_changeset;
     use crate::models::fixtures::get_rolling_stock_with_invalid_effort_curves;
-    use crate::models::fixtures::simple_train_schedule_form;
+    use crate::models::fixtures::simple_train_schedule_changeset;
     use crate::models::rolling_stock_model::RollingStockModel;
-    use crate::models::train_schedule::TrainSchedule;
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
 
@@ -955,20 +954,13 @@ pub mod tests {
         )
         .await;
 
-        let mut schedule_form_1 = simple_train_schedule_form(timetable_1.id);
-        let mut schedule_form_2 = simple_train_schedule_form(timetable_1.id);
-        schedule_form_1
-            .train_schedule
-            .rolling_stock_name
-            .clone_from(&rolling_stock.name);
-        schedule_form_2.train_schedule.rolling_stock_name = rolling_stock.name;
-        let train_schedule_1: Changeset<TrainSchedule> = schedule_form_1.into();
-        let _ = train_schedule_1
+        simple_train_schedule_changeset(timetable_1.id)
+            .rolling_stock_name(rolling_stock.name.clone())
             .create(&mut db_pool.get_ok())
             .await
             .unwrap();
-        let train_schedule_2: Changeset<TrainSchedule> = schedule_form_2.into();
-        let _ = train_schedule_2
+        simple_train_schedule_changeset(timetable_1.id)
+            .rolling_stock_name(rolling_stock.name)
             .create(&mut db_pool.get_ok())
             .await
             .unwrap();

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -794,9 +794,7 @@ pub mod tests {
     use crate::models::fixtures::create_study;
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::fast_rolling_stock_changeset;
-    use crate::models::fixtures::fast_rolling_stock_form;
     use crate::models::fixtures::get_rolling_stock_with_invalid_effort_curves;
-    use crate::models::fixtures::rolling_stock_with_energy_sources_form;
     use crate::models::fixtures::simple_train_schedule_form;
     use crate::models::rolling_stock_model::RollingStockModel;
     use crate::models::train_schedule::TrainSchedule;
@@ -814,6 +812,15 @@ pub mod tests {
         fn rolling_stock_get_by_id_request(&self, rolling_stock_id: i64) -> axum_test::TestRequest {
             self.get(format!("/rolling_stock/{rolling_stock_id}").as_str())
         }
+    }
+
+    fn fast_rolling_stock_form(name: &str) -> RollingStockForm {
+        let mut form = serde_json::from_str::<RollingStockForm>(include_str!(
+            "../tests/example_rolling_stock_1.json"
+        ))
+        .expect("Unable to parse exemple rolling stock");
+        form.name = name.to_owned();
+        form
     }
 
     #[rstest]
@@ -1182,8 +1189,11 @@ pub mod tests {
             .await
             .expect("Failed to create rolling stock");
 
-        let second_rs_name = "second_fast_rolling_stock_name";
-        let second_fast_rolling_stock_form = rolling_stock_with_energy_sources_form(second_rs_name);
+        let mut second_fast_rolling_stock_form: RollingStockForm = serde_json::from_str(
+            include_str!("../tests/example_rolling_stock_2_energy_sources.json"),
+        )
+        .expect("Unable to parse rolling stock with energy sources");
+        second_fast_rolling_stock_form.name = "second_fast_rolling_stock_name".to_owned();
 
         let request = app
             .patch(format!("/rolling_stock/{}", locked_fast_rolling_stock.id).as_str())

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -142,27 +142,13 @@ pub struct TrainScheduleForm {
 }
 
 impl From<TrainScheduleForm> for TrainScheduleChangeset {
-    fn from(value: TrainScheduleForm) -> Self {
-        let TrainScheduleForm {
+    fn from(
+        TrainScheduleForm {
             timetable_id,
-            train_schedule: ts,
-        } = value;
-
-        TrainSchedule::changeset()
-            .flat_timetable_id(timetable_id)
-            .comfort(ts.comfort)
-            .constraint_distribution(ts.constraint_distribution)
-            .initial_speed(ts.initial_speed)
-            .labels(ts.labels.into_iter().map(Some).collect())
-            .margins(ts.margins)
-            .path(ts.path)
-            .power_restrictions(ts.power_restrictions)
-            .rolling_stock_name(ts.rolling_stock_name)
-            .schedule(ts.schedule)
-            .speed_limit_tag(ts.speed_limit_tag.map(|s| s.0))
-            .start_time(ts.start_time)
-            .train_name(ts.train_name)
-            .options(ts.options)
+            train_schedule,
+        }: TrainScheduleForm,
+    ) -> Self {
+        Self::from(train_schedule).flat_timetable_id(timetable_id)
     }
 }
 


### PR DESCRIPTION
Some `views` definitions are used for `models` fixtures. This is incorrect, and these are replaced by the schema instead.

There's also an import from `infra_cache`, which will be removed in another PR.
