### PR TITLE
front: replace any with unknown in generated OpenAPI code

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -147,6 +147,12 @@
       "rules": {
         "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
       }
+    },
+    {
+      "files": ["src/common/api/generatedEditoastApi.ts", "src/common/api/osrdGatewayApi.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": ["error", { "fixToUnknown": true }]
+      }
     }
   ]
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1624,7 +1624,7 @@ export type NewDocumentResponse = {
 };
 export type InternalError = {
   context: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
   message: string;
   status?: number;
@@ -2019,7 +2019,7 @@ export type AddOperation = {
     within the target document where the operation is performed. */
   path: string;
   /** Value to add to the target location. */
-  value: any;
+  value: unknown;
 };
 export type RemoveOperation = {
   /** JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
@@ -2031,7 +2031,7 @@ export type ReplaceOperation = {
     within the target document where the operation is performed. */
   path: string;
   /** Value to replace with. */
-  value: any;
+  value: unknown;
 };
 export type MoveOperation = {
   /** JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
@@ -2054,7 +2054,7 @@ export type TestOperation = {
     within the target document where the operation is performed. */
   path: string;
   /** Value to test against. */
-  value: any;
+  value: unknown;
 };
 export type PatchOperation =
   | (AddOperation & {


### PR DESCRIPTION
`any` is problematic because it spreads to the rest of the codebase and is annoying to unwrap. Also it causes warnings at codegen time:

    /home/simon/src/osrd/front/src/common/api/generatedEditoastApi.ts
      1627:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
      2022:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
      2034:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
      2057:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

Fix this by turning on the `fixToUnknown` rule for `no-explicit-any` to automatically convert any `any` type to `unknown`.

Ideally the codegen should be fixed to use `unknown` instead of `any`, see:
https://github.com/oazapfts/oazapfts/issues/676