### PR TITLE
editoast: bump async-trait from 0.1.82 to 0.1.83 in /editoast

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -410,9 +410,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -83,7 +83,7 @@ uuid = { version = "1.10.0", features = ["serde", "v4"] }
 [dependencies]
 # For batch dependency updates, see editoast/README.md
 
-async-trait = "0.1.82"
+async-trait = "0.1.83"
 axum = { version = "0.7.7", default-features = false, features = [
   "multipart",
   "tracing",


### PR DESCRIPTION
⚠️ Dependabot created [a PR](https://github.com/OpenRailAssociation/osrd/pull/8980) but ended-up in a weird state, so I just manually recreated it.

Bumps [async-trait](https://github.com/dtolnay/async-trait) from 0.1.82 to 0.1.83.
- [Release notes](https://github.com/dtolnay/async-trait/releases)
- [Commits](https://github.com/dtolnay/async-trait/compare/0.1.82...0.1.83)

---
updated-dependencies:
- dependency-name: async-trait dependency-type: direct:production update-type: version-update:semver-patch ...