### PR TITLE
front: fix waypoint removal in itinerary pathfinding module

### DIFF
--- a/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
@@ -37,7 +37,8 @@ const ModalSuggestedVias = ({ suggestedVias }: ModalSuggestedViasProps) => {
   const removeViaFromPath = (op: SuggestedOP) => {
     const updatedPathSteps = compact(pathSteps).filter(
       (step) =>
-        ('uic' in step && step.uic !== op.uic) || ('track' in step && step.track !== op.track)
+        ('uic' in step && (step.uic !== op.uic || step.ch !== op.ch)) ||
+        ('track' in step && (step.track !== op.track || step.offset !== op.offsetOnTrack))
     );
     dispatch(
       updatePathSteps({


### PR DESCRIPTION
Close #9259

The waypoint removal did not check the ch code, only the uic

I am not sure if the ch code should also be checked in the case of a track : ('track' in step && step.track !== op.track)