### PR TITLE
Fix Core being unauthorized to load an infra when authentication is enabled

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/APIClient.java
+++ b/core/src/main/java/fr/sncf/osrd/api/APIClient.java
@@ -9,11 +9,11 @@ public abstract class APIClient {
 
     final OkHttpClient httpClient;
     final HttpUrl baseUrl;
-    final String authorizationToken;
+    final String authenticationHeader;
 
-    APIClient(String baseUrl, String authorizationToken, OkHttpClient httpClient) {
+    APIClient(String baseUrl, String authenticationHeader, OkHttpClient httpClient) {
         this.baseUrl = HttpUrl.parse(baseUrl);
-        this.authorizationToken = authorizationToken;
+        this.authenticationHeader = authenticationHeader;
         this.httpClient = httpClient;
     }
 
@@ -23,7 +23,7 @@ public abstract class APIClient {
                 .encodedQuery(queryParameters)
                 .build();
         var builder = new Request.Builder().url(url);
-        if (authorizationToken != null) builder = builder.header("Authorization", authorizationToken);
+        if (authenticationHeader != null) builder = builder.header(authenticationHeader, "");
         return builder.build();
     }
 

--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -42,7 +42,7 @@ public final class ApiServerCommand implements CliCommand {
     @Parameter(
             names = {"--editoast-authorization"},
             description = "The HTTP Authorization header sent to editoast")
-    private String editoastAuthorization;
+    private String editoastAuthorization = "x-osrd-core";
 
     @Parameter(
             names = {"-j", "--threads"},

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -36,7 +36,7 @@ class WorkerCommand : CliCommand {
         names = ["--editoast-authorization"],
         description = "The HTTP Authorization header sent to editoast"
     )
-    private var editoastAuthorization: String? = null
+    private var editoastAuthorization: String = "x-osrd-core"
 
     val WORKER_ID: String?
     val WORKER_KEY: String?

--- a/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
+++ b/core/src/test/java/fr/sncf/osrd/api/ApiTest.java
@@ -59,8 +59,8 @@ public class ApiTest {
     /** Setup infra handler mock */
     @BeforeEach
     public void setUp() throws IOException {
-        infraManager = new InfraManager("http://test.com/", "", mockHttpClient(".*/infra/(.*)/railjson.*"));
+        infraManager = new InfraManager("http://test.com/", null, mockHttpClient(".*/infra/(.*)/railjson.*"));
         electricalProfileSetManager = new ElectricalProfileSetManager(
-                "http://test.com/", "", mockHttpClient(".*/electrical_profile_set/(.*)/"));
+                "http://test.com/", null, mockHttpClient(".*/electrical_profile_set/(.*)/"));
     }
 }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -73,7 +73,7 @@ use thiserror::Error;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, Layer as _};
 use validator::ValidationErrorsKind;
-use views::authorizer_middleware;
+use views::authentication_middleware;
 use views::infra::InfraApiError;
 use views::search::SearchConfigFinder;
 
@@ -444,7 +444,7 @@ async fn runserver(
         .merge(views::router())
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
-            authorizer_middleware,
+            authentication_middleware,
         ))
         .layer(OtelAxumLayer::default())
         .layer(DefaultBodyLimit::disable())

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -24,7 +24,7 @@ use crate::{
 use axum_test::TestRequest;
 use axum_test::TestServer;
 
-use super::authorizer_middleware;
+use super::authentication_middleware;
 
 /// A builder interface for [TestApp]
 ///
@@ -150,7 +150,7 @@ impl TestAppBuilder {
             .merge(crate::views::router())
             .route_layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
-                authorizer_middleware,
+                authentication_middleware,
             ))
             .layer(OtelAxumLayer::default())
             .layer(TraceLayer::new_for_http())

--- a/gateway/actix_proxy/src/lib.rs
+++ b/gateway/actix_proxy/src/lib.rs
@@ -301,7 +301,7 @@ impl InnerProxyService {
     fn iter_forwarded_req_headers<'a>(
         &'a self,
         headers: &'a HeaderMap,
-    ) -> impl Iterator<Item = (&HeaderName, &HeaderValue)> + 'a {
+    ) -> impl Iterator<Item = (&'a HeaderName, &'a HeaderValue)> + 'a {
         if let Some(forwarded_headers) = &self.proxy.forwarded_headers {
             Either::Left(forwarded_headers.iter().filter_map(|header_name| {
                 headers.get(header_name).map(|value| (header_name, value))

--- a/gateway/gateway.toml
+++ b/gateway/gateway.toml
@@ -14,6 +14,7 @@ endpoint = "http://localhost:4317"
 prefix = "/api"
 upstream = "http://localhost:8090"
 require_auth = true
+blocked_headers = ["x-osrd-core"]
 
 [[targets]]
 upstream = "http://localhost:3000"

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -136,6 +136,8 @@ pub struct ProxyTarget {
     /// A list of headers that need to be forwarded. If omitted, all headers are forwarded.
     /// Omitting this field is not recommended, as it can introduce normalization induced priviledge escalation.
     pub forwarded_headers: Option<Vec<String>>,
+    /// A list of headers that will be removed from the request before being forwarded.
+    pub blocked_headers: Option<Vec<String>>,
     /// A connection, send and read timeout
     #[serde(default, with = "humantime_serde")]
     pub timeout: Option<Duration>,


### PR DESCRIPTION
When querying `GET /infra/42/railjson`, Core is unable to set the `x-remote-user` header usually set by the gateway to authenticate the user. When it's missing, editoast rejects the request automatically... and no infra can be loaded anymore.

The problems also appears with `/health` btw.

What's done here:

* Editoast endpoints that do not require the user to have any role can be accessed even if the `x-remote-user` header is missing. Editoast still have to be reached though, so we're either dealing with an authenticated user that went through the gateway, or we're already behind it.
* When Editoast detects that the `x-osrd-core` header, all verification checks are short-circuited.
* Core sends the `x-osrd-core` by default. This can be customized using a CLI parameter that was already there. I'm not sure why it's there since editoast doesn't support authentication tokens. If it's useful, I'll add another option instead. (I'll also rename the existing one if changing its behavior is ok.)
* Gateway: each proxy target can be provided a list of headers to remove. This is a bit redundant with the `forwarded_headers` option. The default configuration rejects `x-osrd-core` so that no one besides Core will be able to make editoast interpret the header ([not even him](https://youtu.be/fQGbXmkSArs?feature=shared&t=20)).

> [!NOTE]
> The `AuthorizerExt` extractor is now incorrectly named. I'll change that in a follow up PR (or just before merging this one if you prefer) in order not to conflict with everyone.