### PR TITLE
front: stdcm: various fixes

### DIFF
--- a/front/src/applications/stdcmV2/components/StdcmVias.tsx
+++ b/front/src/applications/stdcmV2/components/StdcmVias.tsx
@@ -111,9 +111,8 @@ const StdcmVias = ({ disabled = false, setCurrentSimulationInputs }: StdcmConfig
   return (
     <div className="stdcm-v2-vias-list">
       {intermediatePoints.length > 0 &&
-        intermediatePoints.map((pathStep, index) => {
+        compact(intermediatePoints).map((pathStep, index) => {
           const pathStepIndex = index + 1;
-          if (!pathStep) return null;
           return (
             <div className="stdcm-v2-vias-bundle" key={pathStep.id}>
               <StdcmDefaultCard

--- a/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
+++ b/front/src/applications/stdcmV2/views/StdcmViewV2.tsx
@@ -98,6 +98,8 @@ const StdcmViewV2 = () => {
   useEffect(() => {
     if (!isDebugMode) {
       loadStdcmEnvironment();
+    } else {
+      setShowBtnToLaunchSimulation(true);
     }
   }, [isDebugMode]);
 

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
@@ -87,7 +87,10 @@ const Map = ({
   const terrain3DExaggeration = useSelector(getTerrain3DExaggeration);
   const { viewport, mapSearchMarker, mapStyle, showOSM, layersSettings } = useSelector(getMap);
 
-  const pathGeometry = useMemo(() => geometry || pathProperties?.geometry, [pathProperties]);
+  const pathGeometry = useMemo(
+    () => geometry || pathProperties?.geometry,
+    [pathProperties, geometry]
+  );
 
   const mapViewport = useMemo(
     () =>


### PR DESCRIPTION
This PR addresses several issues:
- The viewport of the map is now updated every time the `pathProperties` change.
- The launch button is always enabled in debug mode. ([#9156](https://github.com/OpenRailAssociation/osrd/issues/9156))
- Indices no longer disappear from the via list when there is a null `pathStep`.