### PR TITLE
front: fix open data import

### DIFF
--- a/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ImportTrainSchedule.tsx
@@ -23,6 +23,7 @@ const ImportTrainSchedule = ({
   const [trainsList, setTrainsList] = useState<ImportedTrainSchedule[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [trainsJsonData, setTrainsJsonData] = useState<TrainScheduleBase[]>([]);
+  const [trainsXmlData, setTrainsXmlData] = useState<ImportedTrainSchedule[]>([]);
 
   const { data: { results: rollingStocks } = { results: [] }, isError } =
     osrdEditoastApi.endpoints.getLightRollingStock.useQuery({
@@ -46,6 +47,7 @@ const ImportTrainSchedule = ({
         setIsLoading={setIsLoading}
         setTrainsList={setTrainsList}
         setTrainsJsonData={setTrainsJsonData}
+        setTrainsXmlData={setTrainsXmlData}
       />
       <ImportTrainScheduleTrainsList
         isLoading={isLoading}
@@ -53,6 +55,7 @@ const ImportTrainSchedule = ({
         timetableId={timetableId}
         trainsList={trainsList}
         trainsJsonData={trainsJsonData}
+        trainsXmlData={trainsXmlData}
         upsertTrainSchedules={upsertTrainSchedules}
       />
     </main>

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -33,12 +33,14 @@ interface ImportTrainScheduleConfigProps {
   setTrainsList: (trainsList: ImportedTrainSchedule[]) => void;
   setIsLoading: (isLoading: boolean) => void;
   setTrainsJsonData: (trainsJsonData: TrainScheduleBase[]) => void;
+  setTrainsXmlData: (trainsXmlData: ImportedTrainSchedule[]) => void;
 }
 
 const ImportTrainScheduleConfig = ({
   setTrainsList,
   setIsLoading,
   setTrainsJsonData,
+  setTrainsXmlData,
 }: ImportTrainScheduleConfigProps) => {
   const { t } = useTranslation(['operationalStudies/importTrainSchedule']);
   const [from, setFrom] = useState<ImportStation | undefined>();
@@ -110,6 +112,7 @@ const ImportTrainScheduleConfig = ({
     setTrainsList([]);
     setIsLoading(true);
     setTrainsJsonData([]);
+    setTrainsXmlData([]);
 
     const result = await getGraouTrainSchedules(config);
     const importedTrainSchedules = validateImportedTrainSchedules(result);
@@ -168,7 +171,6 @@ const ImportTrainScheduleConfig = ({
   ): Step[] =>
     ocpTTs
       .map((ocpTT, index): Step | null => {
-        // Add explicit typing for return value
         const ocpRef = ocpTT.getAttribute('ocpRef');
         const times = ocpTT.getElementsByTagName('times')[0];
         let departureTime = times?.getAttribute('departure') || '';
@@ -300,7 +302,7 @@ const ImportTrainScheduleConfig = ({
     });
     const trains = Array.from(xmlDoc.getElementsByTagName('train'));
     const updatedTrainSchedules = mapTrainNames(trainSchedules, trains);
-
+    setTrainsXmlData(updatedTrainSchedules);
     return updatedTrainSchedules;
   };
 

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainsList.tsx
@@ -36,6 +36,7 @@ type ImportTrainScheduleTrainsListProps = {
   isLoading: boolean;
   timetableId: number;
   trainsJsonData: TrainScheduleBase[];
+  trainsXmlData: ImportedTrainSchedule[];
   upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void;
 };
 
@@ -45,6 +46,7 @@ const ImportTrainScheduleTrainsList = ({
   isLoading,
   timetableId,
   trainsJsonData,
+  trainsXmlData,
   upsertTrainSchedules,
 }: ImportTrainScheduleTrainsListProps) => {
   const { t } = useTranslation(['operationalStudies/importTrainSchedule']);
@@ -77,10 +79,15 @@ const ImportTrainScheduleTrainsList = ({
 
   async function generateTrainSchedules() {
     try {
-      const payloads =
-        trainsJsonData.length > 0
-          ? trainsJsonData
-          : generateTrainSchedulesPayloads(formattedTrainsList);
+      let payloads;
+
+      if (trainsXmlData.length > 0) {
+        payloads = generateTrainSchedulesPayloads(trainsXmlData, true);
+      } else if (trainsJsonData.length > 0) {
+        payloads = trainsJsonData;
+      } else {
+        payloads = generateTrainSchedulesPayloads(formattedTrainsList, false);
+      }
 
       const trainSchedules = await postTrainSchedule({ id: timetableId, body: payloads }).unwrap();
       upsertTrainSchedules(trainSchedules);


### PR DESCRIPTION
closes #9315 

How to test : 
- Enter origin / destination in the import tab for openData import
- Export the timetable into a json file, and try importing it.
- Try importing Viriato files with the files in the link : https://sncf.sharepoint.com/sites/OSRD644GrpO365/Documents%20partages/Forms/AllItems.aspx?id=%2Fsites%2FOSRD644GrpO365%2FDocuments%20partages%2FDonn%C3%A9es%2F3%2DFichiers%20Viriato&viewid=21cdca8b%2D1763%2D4a6e%2Da9e3%2Dc9c036f6a510