### PR TITLE
Move most CLI commands into the client module

### DIFF
--- a/editoast/src/client/electrical_profiles_commands.rs
+++ b/editoast/src/client/electrical_profiles_commands.rs
@@ -1,0 +1,142 @@
+use std::{error::Error, fs::File, io::BufReader, path::PathBuf, sync::Arc};
+
+use clap::{Args, Subcommand};
+use editoast_models::DbConnectionPoolV2;
+use editoast_schemas::infra::ElectricalProfileSetData;
+
+use crate::models::electrical_profiles::ElectricalProfileSet;
+use crate::models::prelude::*;
+
+#[derive(Subcommand, Debug)]
+pub enum ElectricalProfilesCommands {
+    Import(ImportProfileSetArgs),
+    Delete(DeleteProfileSetArgs),
+    List(ListProfileSetArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Add a set of electrical profiles")]
+pub struct ImportProfileSetArgs {
+    /// Electrical profile set name
+    name: String,
+    /// Electrical profile set file path
+    electrical_profile_set_path: PathBuf,
+}
+
+#[derive(Args, Debug)]
+#[command(
+    about,
+    long_about = "Delete electrical profile sets corresponding to the given ids"
+)]
+pub struct DeleteProfileSetArgs {
+    /// List of infra ids
+    profile_set_ids: Vec<i64>,
+}
+
+#[derive(Args, Debug)]
+#[command(
+    about,
+    long_about = "List electrical profile sets in the database, <id> - <name>"
+)]
+pub struct ListProfileSetArgs {
+    // Wether to display the list in a ready to parse format
+    #[arg(long, default_value_t = false)]
+    quiet: bool,
+}
+
+pub async fn electrical_profile_set_import(
+    args: ImportProfileSetArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let electrical_profile_set_file = File::open(args.electrical_profile_set_path)?;
+
+    let electrical_profile_set_data: ElectricalProfileSetData =
+        serde_json::from_reader(BufReader::new(electrical_profile_set_file))?;
+    let ep_set = ElectricalProfileSet::changeset()
+        .name(args.name)
+        .data(electrical_profile_set_data);
+
+    let created_ep_set = ep_set.create(&mut db_pool.get().await?).await?;
+    println!("✅ Electrical profile set {} created", created_ep_set.id);
+    Ok(())
+}
+
+pub async fn electrical_profile_set_list(
+    args: ListProfileSetArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let electrical_profile_sets = ElectricalProfileSet::list_light(&mut db_pool.get().await?)
+        .await
+        .unwrap();
+    if !args.quiet {
+        println!("Electrical profile sets:\nID - Name");
+    }
+    for electrical_profile_set in electrical_profile_sets {
+        println!(
+            "{:<2} - {}",
+            electrical_profile_set.id, electrical_profile_set.name
+        );
+    }
+    Ok(())
+}
+
+pub async fn electrical_profile_set_delete(
+    args: DeleteProfileSetArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    for profile_set_id in args.profile_set_ids {
+        let deleted =
+            ElectricalProfileSet::delete_static(&mut db_pool.get().await?, profile_set_id)
+                .await
+                .unwrap();
+        if !deleted {
+            println!("❎ Electrical profile set {} not found", profile_set_id);
+        } else {
+            println!("✅ Electrical profile set {} deleted", profile_set_id);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::fixtures::create_electrical_profile_set;
+
+    use super::*;
+
+    #[rstest::rstest]
+    async fn test_electrical_profile_set_delete() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let electrical_profile_set = create_electrical_profile_set(&mut db_pool.get_ok()).await;
+
+        let args = DeleteProfileSetArgs {
+            profile_set_ids: vec![electrical_profile_set.id],
+        };
+
+        // WHEN
+        electrical_profile_set_delete(args, db_pool.clone().into())
+            .await
+            .unwrap();
+
+        // THEN
+        let empty = !ElectricalProfileSet::list_light(&mut db_pool.get_ok())
+            .await
+            .unwrap()
+            .iter()
+            .any(|eps| eps.id == electrical_profile_set.id);
+        assert!(empty);
+    }
+
+    #[rstest::rstest]
+    async fn test_electrical_profile_set_list_doesnt_fail() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let _ = create_electrical_profile_set(&mut db_pool.get_ok()).await;
+        for quiet in [true, false] {
+            let args = ListProfileSetArgs { quiet };
+            electrical_profile_set_list(args, db_pool.clone().into())
+                .await
+                .unwrap();
+        }
+    }
+}

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -1,0 +1,231 @@
+use std::path::PathBuf;
+use std::{error::Error, fs::File, io::BufReader, sync::Arc};
+
+use clap::Args;
+use colored::Colorize as _;
+use editoast_models::DbConnectionPoolV2;
+use editoast_schemas::rolling_stock::RollingStock;
+use validator::ValidationErrorsKind;
+
+use crate::models::prelude::*;
+use crate::{models::RollingStockModel, CliError};
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Import a rolling stock given a json file")]
+pub struct ImportRollingStockArgs {
+    /// Rolling stock file path
+    rolling_stock_path: Vec<PathBuf>,
+}
+
+pub async fn import_rolling_stock(
+    args: ImportRollingStockArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    for rolling_stock_path in args.rolling_stock_path {
+        let rolling_stock_file = File::open(rolling_stock_path)?;
+        let rolling_stock_form: RollingStock =
+            serde_json::from_reader(BufReader::new(rolling_stock_file))?;
+        let rolling_stock: Changeset<RollingStockModel> = rolling_stock_form.into();
+        match rolling_stock.validate_imported_rolling_stock() {
+            Ok(()) => {
+                println!(
+                    "🍞 Importing rolling stock {}",
+                    rolling_stock
+                        .name
+                        .as_ref()
+                        .map(|n| n.bold())
+                        .unwrap_or("rolling stock witout name".bold())
+                );
+                let rolling_stock = rolling_stock
+                    .locked(false)
+                    .version(0)
+                    .create(&mut db_pool.get().await?)
+                    .await?;
+                println!(
+                    "✅ Rolling stock {}[{}] saved!",
+                    &rolling_stock.name.bold(),
+                    &rolling_stock.id
+                );
+            }
+            Err(e) => {
+                let mut error_message = "❌ Rolling stock was not created!".to_string();
+                if let Some(ValidationErrorsKind::Field(field_errors)) = e.errors().get("__all__") {
+                    for error in field_errors {
+                        if &error.code == "electrical_power_startup_time" {
+                            error_message.push_str(
+                                "\nRolling stock is electrical, but electrical_power_startup_time is missing"
+                            );
+                        }
+                        if &error.code == "raise_pantograph_time" {
+                            error_message.push_str(
+                                "\nRolling stock is electrical, but raise_pantograph_time is missing"
+                            );
+                        }
+                    }
+                }
+                return Err(Box::new(CliError::new(2, error_message)));
+            }
+        };
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::client::generate_temp_file;
+    use crate::models::RollingStockModel;
+
+    use editoast_models::DbConnectionPoolV2;
+    use rstest::rstest;
+
+    fn get_fast_rolling_stock_schema(name: &str) -> RollingStock {
+        let mut rolling_stock_form: RollingStock =
+            serde_json::from_str(include_str!("../tests/example_rolling_stock_1.json"))
+                .expect("Unable to parse");
+        rolling_stock_form.name = name.to_string();
+        rolling_stock_form
+    }
+
+    #[rstest]
+    async fn import_rolling_stock_ko_file_not_found() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let args = ImportRollingStockArgs {
+            rolling_stock_path: vec!["non/existing/railjson/file/location".into()],
+        };
+
+        // WHEN
+        let result = import_rolling_stock(args, db_pool.into()).await;
+
+        // THEN
+        assert!(result.is_err())
+    }
+
+    #[rstest]
+    async fn import_non_electric_rs_without_startup_and_panto_values() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_name =
+            "fast_rolling_stock_import_non_electric_rs_without_startup_and_panto_values";
+        let mut non_electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
+        non_electric_rs.effort_curves.modes.remove("25000V");
+
+        let file = generate_temp_file(&non_electric_rs);
+        let args = ImportRollingStockArgs {
+            rolling_stock_path: vec![file.path().into()],
+        };
+
+        // WHEN
+        let result = import_rolling_stock(args, db_pool.clone().into()).await;
+
+        // THEN
+        assert!(
+            result.is_ok(),
+            "import should succeed, as raise_panto and startup are not required for non electric",
+        );
+        use crate::models::Retrieve;
+        let created_rs =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
+                .await
+                .unwrap();
+        assert!(created_rs.is_some());
+    }
+
+    #[rstest]
+    async fn import_non_electric_rs_with_startup_and_panto_values() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_name =
+            "fast_rolling_stock_import_non_electric_rs_with_startup_and_panto_values";
+        let mut non_electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
+        non_electric_rs.effort_curves.modes.remove("25000V");
+
+        let file = generate_temp_file(&non_electric_rs);
+        let args = ImportRollingStockArgs {
+            rolling_stock_path: vec![file.path().into()],
+        };
+
+        // WHEN
+        let result = import_rolling_stock(args, db_pool.clone().into()).await;
+
+        // THEN
+        assert!(result.is_ok(), "import should succeed");
+        use crate::models::Retrieve;
+        let created_rs =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
+                .await
+                .expect("failed to retrieve rolling stock")
+                .unwrap();
+        let RollingStockModel {
+            electrical_power_startup_time,
+            raise_pantograph_time,
+            ..
+        } = created_rs;
+        assert!(electrical_power_startup_time.is_some());
+        assert!(raise_pantograph_time.is_some());
+    }
+
+    #[rstest]
+    async fn import_electric_rs_without_startup_and_panto_values() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_name =
+            "fast_rolling_stock_import_electric_rs_without_startup_and_panto_values";
+        let mut electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
+        electric_rs.raise_pantograph_time = None;
+        electric_rs.electrical_power_startup_time = None;
+        let file = generate_temp_file(&electric_rs);
+        let args = ImportRollingStockArgs {
+            rolling_stock_path: vec![file.path().into()],
+        };
+
+        // WHEN
+        let result = import_rolling_stock(args, db_pool.clone().into()).await;
+
+        // THEN
+        assert!(
+            result.is_err(),
+            "import should fail, as raise_panto and startup are required for electric"
+        );
+        use crate::models::Retrieve;
+        let created_rs =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
+                .await
+                .unwrap();
+        assert!(created_rs.is_none());
+    }
+
+    #[rstest]
+    async fn import_electric_rs_with_startup_and_panto_values() {
+        // GIVEN
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let rolling_stock_name =
+            "fast_rolling_stock_import_electric_rs_with_startup_and_panto_values";
+        let electric_rolling_stock = get_fast_rolling_stock_schema(rolling_stock_name);
+        let file = generate_temp_file(&electric_rolling_stock);
+        let args = ImportRollingStockArgs {
+            rolling_stock_path: vec![file.path().into()],
+        };
+
+        // WHEN
+        let result = import_rolling_stock(args, db_pool.clone().into()).await;
+
+        // THEN
+        assert!(result.is_ok(), "import should succeed");
+        use crate::models::Retrieve;
+        let created_rs =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .unwrap();
+        let RollingStockModel {
+            electrical_power_startup_time,
+            raise_pantograph_time,
+            ..
+        } = created_rs;
+        assert!(electrical_power_startup_time.is_some());
+        assert!(raise_pantograph_time.is_some());
+    }
+}

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -1,0 +1,308 @@
+use std::{error::Error, fs::File, io::BufReader, path::PathBuf, sync::Arc};
+
+use clap::{Args, Subcommand};
+use colored::Colorize as _;
+use editoast_models::{DbConnection, DbConnectionPoolV2};
+use editoast_schemas::infra::RailJson;
+
+use crate::map::MapLayers;
+use crate::models::prelude::*;
+use crate::{infra_cache::InfraCache, models::Infra, views::infra::InfraApiError, CliError};
+use crate::{map, ValkeyClient};
+
+use super::ValkeyConfig;
+
+#[derive(Subcommand, Debug)]
+pub enum InfraCommands {
+    Clone(InfraCloneArgs),
+    Clear(ClearArgs),
+    Generate(GenerateArgs),
+    ImportRailjson(ImportRailjsonArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(about, long_about = "Clone an infrastructure")]
+pub struct InfraCloneArgs {
+    /// Infrastructure ID
+    id: u64,
+    /// Infrastructure new name
+    new_name: Option<String>,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Clear infra generated data")]
+pub struct ClearArgs {
+    /// List of infra ids
+    infra_ids: Vec<u64>,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Refresh infra generated data")]
+pub struct GenerateArgs {
+    /// List of infra ids
+    infra_ids: Vec<u64>,
+    #[arg(short, long)]
+    /// Force the refresh of an infra (even if the generated version is up to date)
+    force: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(about, long_about = "Import an infra given a railjson file")]
+pub struct ImportRailjsonArgs {
+    /// Infra name
+    infra_name: String,
+    /// Railjson file path
+    railjson_path: PathBuf,
+    /// Whether the import should refresh generated data
+    #[arg(short = 'g', long)]
+    generate: bool,
+}
+
+pub async fn clone_infra(
+    infra_args: InfraCloneArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let infra = Infra::retrieve(&mut db_pool.get().await?, infra_args.id as i64)
+        .await?
+        .ok_or_else(|| {
+            // When EditoastError will be removed from the models crate,
+            // this can become a retrieve_or_fail
+            CliError::new(
+                1,
+                format!("❌ Infrastructure not found, ID: {}", infra_args.id),
+            )
+        })?;
+    let new_name = infra_args
+        .new_name
+        .unwrap_or_else(|| format!("{} (clone)", infra.name));
+    let cloned_infra = infra.clone(&mut db_pool.get().await?, new_name).await?;
+    println!(
+        "✅ Infra {} (ID: {}) was successfully cloned",
+        cloned_infra.name.bold(),
+        cloned_infra.id
+    );
+    Ok(())
+}
+
+pub async fn import_railjson(
+    args: ImportRailjsonArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let railjson_file = match File::open(args.railjson_path.clone()) {
+        Ok(file) => file,
+        Err(_) => {
+            let error = CliError::new(
+                1,
+                format!(
+                    "❌ Railjson file not found, Path: {}",
+                    args.railjson_path.to_string_lossy()
+                ),
+            );
+            return Err(Box::new(error));
+        }
+    };
+
+    let infra_name = args.infra_name.clone().bold();
+
+    let infra = Infra::changeset()
+        .name(args.infra_name)
+        .last_railjson_version();
+    let railjson: RailJson = serde_json::from_reader(BufReader::new(railjson_file))?;
+
+    println!("🍞 Importing infra {infra_name}");
+    let mut infra = infra.persist(railjson, &mut db_pool.get().await?).await?;
+
+    infra
+        .bump_version(&mut db_pool.get().await?)
+        .await
+        .map_err(|_| InfraApiError::NotFound { infra_id: infra.id })?;
+
+    println!("✅ Infra {infra_name}[{}] saved!", infra.id);
+    // Generate only if the was set
+    if args.generate {
+        let infra_cache = InfraCache::load(&mut db_pool.get().await?, &infra).await?;
+        infra.refresh(db_pool, true, &infra_cache).await?;
+        println!(
+            "✅ Infra {infra_name}[{}] generated data refreshed!",
+            infra.id
+        );
+    };
+    Ok(())
+}
+
+/// Run the clear subcommand
+/// This command clear all generated data for the given infra
+pub async fn clear_infra(
+    args: ClearArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+    valkey_config: ValkeyConfig,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let mut infras = vec![];
+    if args.infra_ids.is_empty() {
+        // Retrieve all available infra
+        for infra in Infra::all(&mut db_pool.get().await?).await {
+            infras.push(infra);
+        }
+    } else {
+        // Retrieve given infras
+        infras = batch_retrieve_infras(&mut db_pool.get().await?, &args.infra_ids).await?;
+    };
+
+    for mut infra in infras {
+        println!(
+            "🍞 Infra {}[{}] is clearing:",
+            infra.name.clone().bold(),
+            infra.id
+        );
+        build_valkey_pool_and_invalidate_all_cache(valkey_config.clone(), infra.id).await?;
+        infra.clear(&mut db_pool.get().await?).await?;
+        println!("✅ Infra {}[{}] cleared!", infra.name.bold(), infra.id);
+    }
+    Ok(())
+}
+
+/// Run the generate sub command
+/// This command refresh all infra given as input (if no infra given then refresh all of them)
+pub async fn generate_infra(
+    args: GenerateArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+    valkey_config: ValkeyConfig,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let mut infras = vec![];
+    if args.infra_ids.is_empty() {
+        // Retrieve all available infra
+        for infra in Infra::all(&mut db_pool.get().await?).await {
+            infras.push(infra);
+        }
+    } else {
+        // Retrieve given infras
+        infras = batch_retrieve_infras(&mut db_pool.get().await?, &args.infra_ids).await?;
+    }
+    for mut infra in infras {
+        println!(
+            "🍞 Infra {}[{}] is generating:",
+            infra.name.clone().bold(),
+            infra.id
+        );
+        let infra_cache = InfraCache::load(&mut db_pool.get().await?, &infra).await?;
+        if infra
+            .refresh(db_pool.clone(), args.force, &infra_cache)
+            .await?
+        {
+            build_valkey_pool_and_invalidate_all_cache(valkey_config.clone(), infra.id).await?;
+            println!("✅ Infra {}[{}] generated!", infra.name.bold(), infra.id);
+        } else {
+            println!(
+                "✅ Infra {}[{}] already generated!",
+                infra.name.bold(),
+                infra.id
+            );
+        }
+    }
+    println!(
+        "🚨 You may want to refresh the search caches. If so, use {}.",
+        "editoast search refresh".bold()
+    );
+    Ok(())
+}
+
+async fn build_valkey_pool_and_invalidate_all_cache(
+    valkey_config: ValkeyConfig,
+    infra_id: i64,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let valkey = ValkeyClient::new(valkey_config).unwrap();
+    let mut conn = valkey.get_connection().await.unwrap();
+    Ok(map::invalidate_all(
+        &mut conn,
+        &MapLayers::parse().layers.keys().cloned().collect(),
+        infra_id,
+    )
+    .await
+    .map_err(|e| {
+        Box::new(CliError::new(
+            1,
+            format!("Couldn't refresh valkey cache layers: {e}"),
+        ))
+    })?)
+}
+
+async fn batch_retrieve_infras(
+    conn: &mut DbConnection,
+    ids: &[u64],
+) -> Result<Vec<Infra>, Box<dyn Error + Send + Sync>> {
+    let (infras, missing) = Infra::retrieve_batch(conn, ids.iter().map(|id| *id as i64)).await?;
+    if !missing.is_empty() {
+        let error = CliError::new(
+            1,
+            format!(
+                "❌ Infrastructures not found: {missing}",
+                missing = missing
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        );
+        return Err(Box::new(error));
+    }
+    Ok(infras)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{distributions::Alphanumeric, thread_rng, Rng as _};
+
+    use crate::client::generate_temp_file;
+
+    use super::*;
+
+    #[rstest::rstest]
+    async fn import_railjson_ko_file_not_found() {
+        // GIVEN
+        let railjson_path = "non/existing/railjson/file/location";
+        let args: ImportRailjsonArgs = ImportRailjsonArgs {
+            infra_name: "test".into(),
+            railjson_path: railjson_path.into(),
+            generate: false,
+        };
+
+        // WHEN
+        let result = import_railjson(args.clone(), DbConnectionPoolV2::for_tests().into()).await;
+
+        // THEN
+        assert!(result.is_err());
+        assert_eq!(
+            result
+                .unwrap_err()
+                .downcast_ref::<CliError>()
+                .unwrap()
+                .exit_code,
+            1
+        );
+    }
+
+    #[rstest::rstest]
+    async fn import_railjson_ok() {
+        // GIVEN
+        let railjson = Default::default();
+        let file = generate_temp_file::<RailJson>(&railjson);
+        let infra_name = format!(
+            "{}_{}",
+            "infra",
+            (0..10)
+                .map(|_| thread_rng().sample(Alphanumeric) as char)
+                .collect::<String>(),
+        );
+        let args: ImportRailjsonArgs = ImportRailjsonArgs {
+            infra_name: infra_name.clone(),
+            railjson_path: file.path().into(),
+            generate: false,
+        };
+
+        // WHEN
+        let result = import_railjson(args, DbConnectionPoolV2::for_tests().into()).await;
+
+        // THEN
+        assert!(result.is_ok());
+    }
+}

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod electrical_profiles_commands;
+pub mod infra_commands;
 mod postgres_config;
 pub mod roles;
 pub mod search_commands;
@@ -15,6 +16,7 @@ use clap::Subcommand;
 use clap::ValueEnum;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
+use infra_commands::InfraCommands;
 pub use postgres_config::PostgresConfig;
 use roles::RolesCommand;
 use search_commands::SearchCommands;
@@ -107,14 +109,6 @@ pub struct ExportTimetableArgs {
     pub path: PathBuf,
 }
 
-#[derive(Subcommand, Debug)]
-pub enum InfraCommands {
-    Clone(InfraCloneArgs),
-    Clear(ClearArgs),
-    Generate(GenerateArgs),
-    ImportRailjson(ImportRailjsonArgs),
-}
-
 #[derive(Args, Debug, Derivative, Clone)]
 #[derivative(Default)]
 pub struct MapLayersConfig {
@@ -161,44 +155,6 @@ pub struct RunserverArgs {
 }
 
 #[derive(Args, Debug)]
-#[command(about, long_about = "Refresh infra generated data")]
-pub struct GenerateArgs {
-    /// List of infra ids
-    pub infra_ids: Vec<u64>,
-    #[arg(short, long)]
-    /// Force the refresh of an infra (even if the generated version is up to date)
-    pub force: bool,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Clear infra generated data")]
-pub struct ClearArgs {
-    /// List of infra ids
-    pub infra_ids: Vec<u64>,
-}
-
-#[derive(Args, Debug, Clone)]
-#[command(about, long_about = "Import an infra given a railjson file")]
-pub struct ImportRailjsonArgs {
-    /// Infra name
-    pub infra_name: String,
-    /// Railjson file path
-    pub railjson_path: PathBuf,
-    /// Whether the import should refresh generated data
-    #[arg(short = 'g', long)]
-    pub generate: bool,
-}
-
-#[derive(Args, Debug, Clone)]
-#[command(about, long_about = "Clone an infrastructure")]
-pub struct InfraCloneArgs {
-    /// Infrastructure ID
-    pub id: u64,
-    /// Infrastructure new name
-    pub new_name: Option<String>,
-}
-
-#[derive(Args, Debug)]
 #[command(about, long_about = "Import a rolling stock given a json file")]
 pub struct ImportRollingStockArgs {
     /// Rolling stock file path
@@ -239,4 +195,12 @@ pub enum EditoastUrlError {
     #[error("Invalid url '{url}'")]
     #[editoast_error(status = 500)]
     InvalidUrl { url: String },
+}
+
+#[cfg(test)]
+pub fn generate_temp_file<T: serde::Serialize>(object: &T) -> tempfile::NamedTempFile {
+    use std::io::Write as _;
+    let mut tmp_file = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp_file, "{}", serde_json::to_string(object).unwrap()).unwrap();
+    tmp_file
 }

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -5,6 +5,7 @@ pub mod roles;
 pub mod search_commands;
 pub mod stdcm_search_env_commands;
 mod telemetry_config;
+pub mod timetables_commands;
 mod valkey_config;
 
 use std::env;
@@ -24,6 +25,7 @@ use stdcm_search_env_commands::StdcmSearchEnvCommands;
 pub use telemetry_config::TelemetryConfig;
 pub use telemetry_config::TelemetryKind;
 use thiserror::Error;
+use timetables_commands::TimetablesCommands;
 use url::Url;
 pub use valkey_config::ValkeyConfig;
 
@@ -82,31 +84,6 @@ pub enum Commands {
     Roles(RolesCommand),
     #[command(about, long_about = "Healthcheck")]
     Healthcheck,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum TimetablesCommands {
-    Import(ImportTimetableArgs),
-    Export(ExportTimetableArgs),
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Import a train schedule given a JSON file")]
-pub struct ImportTimetableArgs {
-    /// The timetable id on which attach the trains to
-    #[arg(long)]
-    pub id: Option<i64>,
-    /// The input file path
-    pub path: PathBuf,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Export the train schedules of a given timetable")]
-pub struct ExportTimetableArgs {
-    /// The timetable id on which get the train schedules from
-    pub id: i64,
-    /// The output file path
-    pub path: PathBuf,
 }
 
 #[derive(Args, Debug, Derivative, Clone)]

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod electrical_profiles_commands;
+pub mod import_rolling_stock;
 pub mod infra_commands;
 mod postgres_config;
 pub mod roles;
@@ -17,6 +18,7 @@ use clap::Subcommand;
 use clap::ValueEnum;
 use derivative::Derivative;
 use editoast_derive::EditoastError;
+use import_rolling_stock::ImportRollingStockArgs;
 use infra_commands::InfraCommands;
 pub use postgres_config::PostgresConfig;
 use roles::RolesCommand;
@@ -129,13 +131,6 @@ pub struct RunserverArgs {
     /// The timeout to use when performing the healthcheck, in milliseconds
     #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 500)]
     pub health_check_timeout_ms: u64,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Import a rolling stock given a json file")]
-pub struct ImportRollingStockArgs {
-    /// Rolling stock file path
-    pub rolling_stock_path: Vec<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,5 +1,6 @@
 mod postgres_config;
 pub mod roles;
+pub mod search_commands;
 pub mod stdcm_search_env_commands;
 mod telemetry_config;
 mod valkey_config;
@@ -15,6 +16,7 @@ use derivative::Derivative;
 use editoast_derive::EditoastError;
 pub use postgres_config::PostgresConfig;
 use roles::RolesCommand;
+use search_commands::SearchCommands;
 use stdcm_search_env_commands::StdcmSearchEnvCommands;
 pub use telemetry_config::TelemetryConfig;
 pub use telemetry_config::TelemetryKind;
@@ -109,13 +111,6 @@ pub enum ElectricalProfilesCommands {
     Import(ImportProfileSetArgs),
     Delete(DeleteProfileSetArgs),
     List(ListProfileSetArgs),
-}
-
-#[derive(Subcommand, Debug)]
-pub enum SearchCommands {
-    List,
-    MakeMigration(MakeMigrationArgs),
-    Refresh(RefreshArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -253,31 +248,6 @@ pub struct OsmToRailjsonArgs {
     pub osm_pbf_in: PathBuf,
     /// Output file in Railjson format
     pub railjson_out: PathBuf,
-}
-
-#[derive(Args, Debug)]
-#[command(
-    about,
-    long_about = "Generate a migration's up.sql and down.sql content for a search object"
-)]
-pub struct MakeMigrationArgs {
-    /// The search object to generate a migration for
-    pub object: String,
-    /// The directory of the migration
-    pub migration: PathBuf,
-    #[arg(short, long)]
-    /// Overwrites the existing up.sql and down.sql files' content
-    pub force: bool,
-    #[arg(long)]
-    /// Skips the default generation of down.sql to have smarter rollbacks
-    pub skip_down: bool,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Updates the content of the search cache tables")]
-pub struct RefreshArgs {
-    /// The search objects to refresh. If none, all search objects are refreshed
-    pub objects: Vec<String>,
 }
 
 /// Retrieve the ROOT_URL env var. If not found returns default local url.

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,3 +1,4 @@
+pub mod electrical_profiles_commands;
 mod postgres_config;
 pub mod roles;
 pub mod search_commands;
@@ -58,7 +59,7 @@ pub enum Commands {
         about,
         long_about = "Commands related to electrical profile sets"
     )]
-    ElectricalProfiles(ElectricalProfilesCommands),
+    ElectricalProfiles(electrical_profiles_commands::ElectricalProfilesCommands),
     ImportRollingStock(ImportRollingStockArgs),
     OsmToRailjson(OsmToRailjsonArgs),
     #[command(about, long_about = "Prints the OpenApi of the service")]
@@ -104,13 +105,6 @@ pub struct ExportTimetableArgs {
     pub id: i64,
     /// The output file path
     pub path: PathBuf,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum ElectricalProfilesCommands {
-    Import(ImportProfileSetArgs),
-    Delete(DeleteProfileSetArgs),
-    List(ListProfileSetArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -195,15 +189,6 @@ pub struct ImportRailjsonArgs {
     pub generate: bool,
 }
 
-#[derive(Args, Debug)]
-#[command(about, long_about = "Add a set of electrical profiles")]
-pub struct ImportProfileSetArgs {
-    /// Electrical profile set name
-    pub name: String,
-    /// Electrical profile set file path
-    pub electrical_profile_set_path: PathBuf,
-}
-
 #[derive(Args, Debug, Clone)]
 #[command(about, long_about = "Clone an infrastructure")]
 pub struct InfraCloneArgs {
@@ -211,27 +196,6 @@ pub struct InfraCloneArgs {
     pub id: u64,
     /// Infrastructure new name
     pub new_name: Option<String>,
-}
-
-#[derive(Args, Debug)]
-#[command(
-    about,
-    long_about = "Delete electrical profile sets corresponding to the given ids"
-)]
-pub struct DeleteProfileSetArgs {
-    /// List of infra ids
-    pub profile_set_ids: Vec<i64>,
-}
-
-#[derive(Args, Debug)]
-#[command(
-    about,
-    long_about = "List electrical profile sets in the database, <id> - <name>"
-)]
-pub struct ListProfileSetArgs {
-    // Wether to display the list in a ready to parse format
-    #[arg(long, default_value_t = false)]
-    pub quiet: bool,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/client/search_commands.rs
+++ b/editoast/src/client/search_commands.rs
@@ -1,0 +1,148 @@
+use std::{error::Error, fs, path::PathBuf, sync::Arc};
+
+use clap::{Args, Subcommand};
+use colored::Colorize as _;
+use diesel::sql_query;
+use diesel_async::RunQueryDsl as _;
+use editoast_models::DbConnectionPoolV2;
+use editoast_search::SearchConfigStore as _;
+
+use crate::{views::search::SearchConfigFinder, CliError};
+
+#[derive(Subcommand, Debug)]
+pub enum SearchCommands {
+    List,
+    MakeMigration(MakeMigrationArgs),
+    Refresh(RefreshArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(
+    about,
+    long_about = "Generate a migration's up.sql and down.sql content for a search object"
+)]
+pub struct MakeMigrationArgs {
+    /// The search object to generate a migration for
+    object: String,
+    /// The directory of the migration
+    migration: PathBuf,
+    #[arg(short, long)]
+    /// Overwrites the existing up.sql and down.sql files' content
+    force: bool,
+    #[arg(long)]
+    /// Skips the default generation of down.sql to have smarter rollbacks
+    skip_down: bool,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Updates the content of the search cache tables")]
+pub struct RefreshArgs {
+    /// The search objects to refresh. If none, all search objects are refreshed
+    objects: Vec<String>,
+}
+
+pub fn list_search_objects() {
+    SearchConfigFinder::all().into_iter().for_each(|(name, _)| {
+        println!("{name}");
+    });
+}
+
+pub fn make_search_migration(args: MakeMigrationArgs) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let MakeMigrationArgs {
+        object,
+        migration,
+        force,
+        skip_down,
+    } = args;
+    let Some(search_config) = SearchConfigFinder::find(&object) else {
+        let error = format!("❌ No search object found for {object}");
+        return Err(Box::new(CliError::new(2, error)));
+    };
+    if !search_config.has_migration() {
+        let error = format!("❌ No migration defined for {object}");
+        return Err(Box::new(CliError::new(2, error)));
+    }
+    if !migration.is_dir() {
+        let error = format!(
+            "❌ {} is not a directory",
+            migration.to_str().unwrap_or("<unprintable path>")
+        );
+        return Err(Box::new(CliError::new(2, error)));
+    }
+    let up_path = migration.join("up.sql");
+    let down_path = migration.join("down.sql");
+    let up_path_str = up_path.to_str().unwrap_or("<unprintable path>").to_owned();
+    let down_path_str = down_path
+        .to_str()
+        .unwrap_or("<unprintable path>")
+        .to_owned();
+    if !force
+        && (up_path.exists() && fs::read(up_path.clone()).is_ok_and(|v| !v.is_empty())
+            || down_path.exists() && fs::read(down_path.clone()).is_ok_and(|v| !v.is_empty()))
+    {
+        let error = format!("❌ Migration {} already has content\nCowardly refusing to overwrite it\nUse {} at your own risk",
+        migration.to_str().unwrap_or("<unprintable path>"),
+        "--force".bold());
+        return Err(Box::new(CliError::new(2, error)));
+    }
+    println!(
+        "🤖 Generating migration {}",
+        migration.to_str().unwrap_or("<unprintable path>")
+    );
+    let (up, down) = search_config.make_up_down();
+    if let Err(err) = fs::write(up_path, up) {
+        let error = format!("❌ Failed to write to {up_path_str}: {err}");
+        return Err(Box::new(CliError::new(2, error)));
+    }
+    println!("➡️  Wrote to {up_path_str}");
+    if !skip_down {
+        if let Err(err) = fs::write(down_path, down) {
+            let error = format!("❌ Failed to write to {down_path_str}: {err}");
+            return Err(Box::new(CliError::new(2, error)));
+        }
+        println!("➡️  Wrote to {down_path_str}");
+    }
+    println!(
+        "✅ Migration {} generated!\n🚨 Don't forget to run {} or {} to apply it",
+        migration.to_str().unwrap_or("<unprintable path>"),
+        "diesel migration run".bold(),
+        "diesel migration redo".bold(),
+    );
+    Ok(())
+}
+
+pub async fn refresh_search_tables(
+    args: RefreshArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let objects = if args.objects.is_empty() {
+        SearchConfigFinder::all()
+            .into_iter()
+            .filter_map(|(name, config)| config.has_migration().then(|| name.to_owned()))
+            .collect()
+    } else {
+        args.objects
+    };
+
+    for object in objects {
+        let Some(search_config) = SearchConfigFinder::find(&object) else {
+            eprintln!("❌ No search object found for {object}");
+            continue;
+        };
+        if !search_config.has_migration() {
+            eprintln!("❌ No migration defined for {object}");
+            continue;
+        }
+        println!("🤖 Refreshing search table for {}", object);
+        println!("🚮 Dropping {} content", search_config.table);
+        sql_query(search_config.clear_sql())
+            .execute(&mut db_pool.get().await?.write().await)
+            .await?;
+        println!("♻️  Regenerating {}", search_config.table);
+        sql_query(search_config.refresh_table_sql())
+            .execute(&mut db_pool.get().await?.write().await)
+            .await?;
+        println!("✅ Search table for {} refreshed!", object);
+    }
+    Ok(())
+}

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -1,0 +1,176 @@
+use std::io::BufReader;
+use std::{error::Error, fs::File, path::PathBuf, sync::Arc};
+
+use clap::{Args, Subcommand};
+use editoast_models::DbConnectionPoolV2;
+use editoast_schemas::train_schedule::TrainScheduleBase;
+
+use crate::models::prelude::*;
+use crate::models::train_schedule::TrainSchedule;
+use crate::views::train_schedule::TrainScheduleForm;
+use crate::{
+    models::timetable::{Timetable, TimetableWithTrains},
+    views::train_schedule::TrainScheduleResult,
+    CliError,
+};
+
+#[derive(Subcommand, Debug)]
+pub enum TimetablesCommands {
+    Import(ImportTimetableArgs),
+    Export(ExportTimetableArgs),
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Import a train schedule given a JSON file")]
+pub struct ImportTimetableArgs {
+    /// The timetable id on which attach the trains to
+    #[arg(long)]
+    id: Option<i64>,
+    /// The input file path
+    path: PathBuf,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Export the train schedules of a given timetable")]
+pub struct ExportTimetableArgs {
+    /// The timetable id on which get the train schedules from
+    id: i64,
+    /// The output file path
+    path: PathBuf,
+}
+
+pub async fn trains_export(
+    args: ExportTimetableArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let train_ids = match TimetableWithTrains::retrieve(&mut db_pool.get().await?, args.id).await? {
+        Some(timetable) => timetable.train_ids,
+        None => {
+            let error = CliError::new(1, format!("❌ Timetable not found, id: {0}", args.id));
+            return Err(Box::new(error));
+        }
+    };
+
+    let (train_schedules, missing): (Vec<_>, _) =
+        TrainSchedule::retrieve_batch(&mut db_pool.get().await?, train_ids).await?;
+
+    assert!(missing.is_empty());
+
+    let train_schedules: Vec<TrainScheduleBase> = train_schedules
+        .into_iter()
+        .map(|ts| Into::<TrainScheduleResult>::into(ts).train_schedule)
+        .collect();
+
+    let file = File::create(args.path.clone())?;
+    serde_json::to_writer_pretty(file, &train_schedules)?;
+
+    println!(
+        "✅ Train schedules exported to {0}",
+        args.path.to_string_lossy()
+    );
+
+    Ok(())
+}
+
+pub async fn trains_import(
+    args: ImportTimetableArgs,
+    db_pool: Arc<DbConnectionPoolV2>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let train_file = match File::open(args.path.clone()) {
+        Ok(file) => file,
+        Err(e) => {
+            let error = CliError::new(
+                1,
+                format!("❌ Could not open file {:?} ({:?})", args.path, e),
+            );
+            return Err(Box::new(error));
+        }
+    };
+
+    let timetable = match args.id {
+        Some(timetable) => match Timetable::retrieve(&mut db_pool.get().await?, timetable).await? {
+            Some(timetable) => timetable,
+            None => {
+                let error = CliError::new(1, format!("❌ Timetable not found, id: {0}", timetable));
+                return Err(Box::new(error));
+            }
+        },
+        None => Timetable::create(&mut db_pool.get().await?).await?,
+    };
+
+    let train_schedules: Vec<TrainScheduleBase> =
+        serde_json::from_reader(BufReader::new(train_file))?;
+    let changesets: Vec<Changeset<TrainSchedule>> = train_schedules
+        .into_iter()
+        .map(|train_schedule| {
+            TrainScheduleForm {
+                timetable_id: Some(timetable.id),
+                train_schedule,
+            }
+            .into()
+        })
+        .collect();
+    let inserted: Vec<_> =
+        TrainSchedule::create_batch(&mut db_pool.get().await?, changesets).await?;
+
+    println!(
+        "✅ {} train schedules created for timetable with id {}",
+        inserted.len(),
+        timetable.id
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn get_trainschedule_json_array() -> &'static str {
+        include_str!("../tests/train_schedules/simple_array.json")
+    }
+
+    #[rstest::rstest]
+    async fn import_export_timetable_schedule() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+
+        let timetable = Timetable::create(&mut db_pool.get_ok()).await.unwrap();
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(get_trainschedule_json_array().as_bytes())
+            .unwrap();
+
+        // Test import
+        let args = ImportTimetableArgs {
+            path: file.path().into(),
+            id: Some(timetable.id),
+        };
+        let result = trains_import(args, db_pool.clone().into()).await;
+        assert!(result.is_ok(), "{:?}", result);
+
+        // Test to export the import
+        let export_file = NamedTempFile::new().unwrap();
+        let args = ExportTimetableArgs {
+            path: export_file.path().into(),
+            id: timetable.id,
+        };
+        let export_result = trains_export(args, db_pool.clone().into()).await;
+        assert!(export_result.is_ok(), "{:?}", export_result);
+
+        // Test to reimport the exported import
+        let reimport_args = ImportTimetableArgs {
+            path: export_file.path().into(),
+            id: Some(timetable.id),
+        };
+        let reimport_result = trains_import(reimport_args, db_pool.clone().into()).await;
+        assert!(reimport_result.is_ok(), "{:?}", reimport_result);
+
+        Timetable::delete_static(&mut db_pool.get_ok(), timetable.id)
+            .await
+            .unwrap();
+    }
+}

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -19,22 +19,22 @@ use axum::{Router, ServiceExt};
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use clap::Parser;
 use client::electrical_profiles_commands::*;
+use client::import_rolling_stock::*;
 use client::infra_commands::*;
 use client::roles;
 use client::roles::RolesCommand;
 use client::search_commands::*;
 use client::stdcm_search_env_commands::handle_stdcm_search_env_command;
 use client::timetables_commands::*;
-use client::{Client, Color, Commands, ImportRollingStockArgs, RunserverArgs, ValkeyConfig};
+use client::{Client, Color, Commands, RunserverArgs, ValkeyConfig};
 use client::{MapLayersConfig, PostgresConfig};
 use dashmap::DashMap;
 use editoast_models::DbConnectionPool;
 use editoast_models::DbConnectionPoolV2;
 use editoast_osrdyne_client::OsrdyneClient;
-use editoast_schemas::rolling_stock::RollingStock;
 use generated_data::speed_limit_tags_config::SpeedLimitTagIds;
 use infra_cache::InfraCache;
-use models::{Changeset, RollingStockModel};
+use models::RollingStockModel;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tower::Layer as _;
 use tower_http::cors::{Any, CorsLayer};
@@ -43,7 +43,6 @@ use tower_http::normalize_path::NormalizePathLayer;
 use tower_http::trace::TraceLayer;
 use views::check_health;
 
-use colored::*;
 use core::mq_client;
 use map::MapLayers;
 use models::prelude::*;
@@ -52,15 +51,13 @@ use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::Resource;
 use std::env;
 use std::error::Error;
-use std::fs::File;
-use std::io::{BufReader, IsTerminal};
+use std::io::IsTerminal;
 use std::process::exit;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, Layer as _};
-use validator::ValidationErrorsKind;
 pub use valkey_utils::{ValkeyClient, ValkeyConnection};
 use views::authentication_middleware;
 
@@ -403,59 +400,6 @@ async fn runserver(
     Ok(())
 }
 
-async fn import_rolling_stock(
-    args: ImportRollingStockArgs,
-    db_pool: Arc<DbConnectionPoolV2>,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    for rolling_stock_path in args.rolling_stock_path {
-        let rolling_stock_file = File::open(rolling_stock_path)?;
-        let rolling_stock_form: RollingStock =
-            serde_json::from_reader(BufReader::new(rolling_stock_file))?;
-        let rolling_stock: Changeset<RollingStockModel> = rolling_stock_form.into();
-        match rolling_stock.validate_imported_rolling_stock() {
-            Ok(()) => {
-                println!(
-                    "🍞 Importing rolling stock {}",
-                    rolling_stock
-                        .name
-                        .as_ref()
-                        .map(|n| n.bold())
-                        .unwrap_or("rolling stock witout name".bold())
-                );
-                let rolling_stock = rolling_stock
-                    .locked(false)
-                    .version(0)
-                    .create(&mut db_pool.get().await?)
-                    .await?;
-                println!(
-                    "✅ Rolling stock {}[{}] saved!",
-                    &rolling_stock.name.bold(),
-                    &rolling_stock.id
-                );
-            }
-            Err(e) => {
-                let mut error_message = "❌ Rolling stock was not created!".to_string();
-                if let Some(ValidationErrorsKind::Field(field_errors)) = e.errors().get("__all__") {
-                    for error in field_errors {
-                        if &error.code == "electrical_power_startup_time" {
-                            error_message.push_str(
-                                "\nRolling stock is electrical, but electrical_power_startup_time is missing"
-                            );
-                        }
-                        if &error.code == "raise_pantograph_time" {
-                            error_message.push_str(
-                                "\nRolling stock is electrical, but raise_pantograph_time is missing"
-                            );
-                        }
-                    }
-                }
-                return Err(Box::new(CliError::new(2, error_message)));
-            }
-        };
-    }
-    Ok(())
-}
-
 /// Prints the OpenApi to stdout
 fn generate_openapi() {
     let openapi = OpenApiRoot::build_openapi();
@@ -489,165 +433,5 @@ impl From<anyhow::Error> for CliError {
             exit_code: 1,
             message: format!("❌ {err}"),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::client::generate_temp_file;
-    use crate::models::RollingStockModel;
-
-    use editoast_models::DbConnectionPoolV2;
-    use rstest::rstest;
-
-    fn get_fast_rolling_stock_schema(name: &str) -> RollingStock {
-        let mut rolling_stock_form: RollingStock =
-            serde_json::from_str(include_str!("./tests/example_rolling_stock_1.json"))
-                .expect("Unable to parse");
-        rolling_stock_form.name = name.to_string();
-        rolling_stock_form
-    }
-
-    #[rstest]
-    async fn import_rolling_stock_ko_file_not_found() {
-        // GIVEN
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let args = ImportRollingStockArgs {
-            rolling_stock_path: vec!["non/existing/railjson/file/location".into()],
-        };
-
-        // WHEN
-        let result = import_rolling_stock(args, db_pool.into()).await;
-
-        // THEN
-        assert!(result.is_err())
-    }
-
-    #[rstest]
-    async fn import_non_electric_rs_without_startup_and_panto_values() {
-        // GIVEN
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let rolling_stock_name =
-            "fast_rolling_stock_import_non_electric_rs_without_startup_and_panto_values";
-        let mut non_electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
-        non_electric_rs.effort_curves.modes.remove("25000V");
-
-        let file = generate_temp_file(&non_electric_rs);
-        let args = ImportRollingStockArgs {
-            rolling_stock_path: vec![file.path().into()],
-        };
-
-        // WHEN
-        let result = import_rolling_stock(args, db_pool.clone().into()).await;
-
-        // THEN
-        assert!(
-            result.is_ok(),
-            "import should succeed, as raise_panto and startup are not required for non electric",
-        );
-        use crate::models::Retrieve;
-        let created_rs =
-            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
-                .await
-                .unwrap();
-        assert!(created_rs.is_some());
-    }
-
-    #[rstest]
-    async fn import_non_electric_rs_with_startup_and_panto_values() {
-        // GIVEN
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let rolling_stock_name =
-            "fast_rolling_stock_import_non_electric_rs_with_startup_and_panto_values";
-        let mut non_electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
-        non_electric_rs.effort_curves.modes.remove("25000V");
-
-        let file = generate_temp_file(&non_electric_rs);
-        let args = ImportRollingStockArgs {
-            rolling_stock_path: vec![file.path().into()],
-        };
-
-        // WHEN
-        let result = import_rolling_stock(args, db_pool.clone().into()).await;
-
-        // THEN
-        assert!(result.is_ok(), "import should succeed");
-        use crate::models::Retrieve;
-        let created_rs =
-            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
-                .await
-                .expect("failed to retrieve rolling stock")
-                .unwrap();
-        let RollingStockModel {
-            electrical_power_startup_time,
-            raise_pantograph_time,
-            ..
-        } = created_rs;
-        assert!(electrical_power_startup_time.is_some());
-        assert!(raise_pantograph_time.is_some());
-    }
-
-    #[rstest]
-    async fn import_electric_rs_without_startup_and_panto_values() {
-        // GIVEN
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let rolling_stock_name =
-            "fast_rolling_stock_import_electric_rs_without_startup_and_panto_values";
-        let mut electric_rs = get_fast_rolling_stock_schema(rolling_stock_name);
-        electric_rs.raise_pantograph_time = None;
-        electric_rs.electrical_power_startup_time = None;
-        let file = generate_temp_file(&electric_rs);
-        let args = ImportRollingStockArgs {
-            rolling_stock_path: vec![file.path().into()],
-        };
-
-        // WHEN
-        let result = import_rolling_stock(args, db_pool.clone().into()).await;
-
-        // THEN
-        assert!(
-            result.is_err(),
-            "import should fail, as raise_panto and startup are required for electric"
-        );
-        use crate::models::Retrieve;
-        let created_rs =
-            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
-                .await
-                .unwrap();
-        assert!(created_rs.is_none());
-    }
-
-    #[rstest]
-    async fn import_electric_rs_with_startup_and_panto_values() {
-        // GIVEN
-        let db_pool = DbConnectionPoolV2::for_tests();
-        let rolling_stock_name =
-            "fast_rolling_stock_import_electric_rs_with_startup_and_panto_values";
-        let electric_rolling_stock = get_fast_rolling_stock_schema(rolling_stock_name);
-        let file = generate_temp_file(&electric_rolling_stock);
-        let args = ImportRollingStockArgs {
-            rolling_stock_path: vec![file.path().into()],
-        };
-
-        // WHEN
-        let result = import_rolling_stock(args, db_pool.clone().into()).await;
-
-        // THEN
-        assert!(result.is_ok(), "import should succeed");
-        use crate::models::Retrieve;
-        let created_rs =
-            RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
-                .await
-                .expect("Failed to retrieve rolling stock")
-                .unwrap();
-        let RollingStockModel {
-            electrical_power_startup_time,
-            raise_pantograph_time,
-            ..
-        } = created_rs;
-        assert!(electrical_power_startup_time.is_some());
-        assert!(raise_pantograph_time.is_some());
     }
 }


### PR DESCRIPTION
This is a first step towards having a proper `client` module. Next steps include:

- The remaining few commands (openapi, healthcheck, runserver, ...)
- Move the big `match` in the `run` function in the `client` module
- Move the `AppState` in the `views` module (and remove its `db_pool_v1` component while we're at it)
- Replace most `return Box::new(CliError::new(...` by `anyhow::bail!` since `anyhow`'s paradigm fits perfectly our error management on the `client` side

> [!NOTE]
> The diff is large but this PR just moves things around without modification (except for imports and visibility).
