### PR TITLE
front: fix train update timetable

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -88,10 +88,10 @@ const useLazyLoadTrains = ({
         // do not happen during the same react cycle.
         // if we update a train, one is going to re-fetch first and the 2 are out of sync during a few cycles.
         // these cycles do not make sense to render.
-        const outOfSync = [...trainSchedulesById.values()].some((trainShedule) => {
-          const summary = rawSummaries[trainShedule.id];
+        const outOfSync = [...trainSchedulesById.values()].some((trainSchedule) => {
+          const summary = rawSummaries[trainSchedule.id];
           if (summary?.status === 'success') {
-            return trainShedule.path.length !== summary.path_item_times_final.length;
+            return trainSchedule.path.length !== summary.path_item_times_final.length;
           }
           return false;
         });

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -51,6 +51,11 @@ const useUpdateTrainSchedule = (
           trainScheduleForm: trainSchedule,
         }).unwrap();
 
+        osrdEditoastApi.util.invalidateTags(['train_schedule']);
+        // We explicitely invalidate the cache to avoid a race condition between the automatic cache invalidation
+        // by putTrainScheduleById and the call to postTrainScheduleSimulationSummary in useLazyLoadTrain.ts
+        // Awaiting a set amount of time here would also work : await new Promise((resolve) => setTimeout(resolve, 1000));
+
         upsertTrainSchedules([trainScheduleResult]);
         dispatch(
           setSuccess({


### PR DESCRIPTION
Fix at least part of https://github.com/OpenRailAssociation/osrd/issues/8854

So what happened was that, in order :

- the timetable got updated via putTrainScheduleById in useUpdateTrainSchedule.ts
- the cache was supposed to be invalidated automatically, according to its invalidatesTags in generatedEditoastApi.ts
- the simulation summary was requested via postTrainScheduleSimulationSummary in useLazyLoadTrains.ts (editoast actually receives and correctly responds to the request every time)
- the result of the fetched simulation summary was not actually used, but instead a cached version was used and displayed in the train card, hence the outdated data

There seemed to be some sort of race condition between the cache invalidation and the call to postTrainScheduleSimulationSummary.

Indeed, adding a one second timer between the call to putTrainScheduleById and postTrainScheduleSimulationSummary solves the issue.

Explicitly invalidating the cache also seems to solve the issue.

Both of these solutions seem hackish, I would rather find a way to specifically await the automatic cache invalidation, but I don't know how. Any suggestions or corrections would be very welcome.