### PR TITLE
core: fix chunk offset filter when building the chunk path

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
@@ -312,22 +312,22 @@ fun buildChunkPath(
     pathEndOffset: Offset<Path>
 ): ChunkPath {
     val filteredChunks = mutableDirStaticIdxArrayListOf<TrackChunk>()
-    var totalBlocksLength = Offset<Path>(0.meters)
+    var totalChunksLength = Offset<Path>(0.meters)
     var mutBeginOffset = pathBeginOffset
     var mutEndOffset = pathEndOffset
     for (dirChunkId in chunks) {
-        if (totalBlocksLength > pathEndOffset) break
+        if (totalChunksLength >= pathEndOffset) break
         val length = infra.getTrackChunkLength(dirChunkId.value)
-        val blockEndOffset = totalBlocksLength + length.distance
+        val chunkEndOffset = totalChunksLength + length.distance
 
-        // if the block ends before the path starts, it can be safely skipped
-        if (pathBeginOffset > blockEndOffset) {
+        // If the chunk ends before the path starts, it can be safely skipped
+        if (pathBeginOffset >= chunkEndOffset) {
             mutBeginOffset -= length.distance
             mutEndOffset -= length.distance
         } else {
             filteredChunks.add(dirChunkId)
         }
-        totalBlocksLength += length.distance
+        totalChunksLength += length.distance
     }
     return ChunkPath(filteredChunks, mutBeginOffset, mutEndOffset)
 }


### PR DESCRIPTION
Fixes #9336.

The idea is the following: the start offset was exactly the length of the first track section's chunk. When building the chunk path, since the offset was at the end of the chunk, the chunk would be returned in the chunk path. And since the route path did not have that chunk, it throws an exception.

This correction does not work as it creates more bugs all around, we sometimes need the information about the chunks on either sides.