### PR TITLE
front: wait for timetable load before conflicts call

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -128,6 +128,7 @@ const useLazyLoadTrains = ({
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
     allTrainsProjected,
+    allTrainsLoaded,
   };
 };
 

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -44,11 +44,6 @@ const useScenarioData = (
       },
     });
 
-  const { data: conflicts } = osrdEditoastApi.endpoints.getTimetableByIdConflicts.useQuery({
-    id: scenario.timetable_id,
-    infraId: scenario.infra_id,
-  });
-
   const projectionPath = usePathProjection(infra);
 
   const simulationResults = useSimulationResults();
@@ -59,6 +54,7 @@ const useScenarioData = (
     setTrainScheduleSummariesById,
     setProjectedTrainsById,
     allTrainsProjected,
+    allTrainsLoaded,
   } = useLazyLoadTrains({
     infraId: scenario.infra_id,
     trainIdsToFetch,
@@ -66,6 +62,16 @@ const useScenarioData = (
     path: projectionPath?.path,
     trainSchedules,
   });
+
+  const { data: conflicts } = osrdEditoastApi.endpoints.getTimetableByIdConflicts.useQuery(
+    {
+      id: scenario.timetable_id,
+      infraId: scenario.infra_id,
+    },
+    {
+      skip: !allTrainsLoaded,
+    }
+  );
 
   const trainScheduleSummaries = useMemo(
     () => sortBy(Array.from(trainScheduleSummariesById.values()), 'startTime'),


### PR DESCRIPTION
PR to ensure that we wait for the timetable to load before launching the conflicts query.