### PR TITLE
tests: add "locked" property to mocked rolling-stock

### DIFF
--- a/tests/data/rolling_stocks/electric_rolling_stock.json
+++ b/tests/data/rolling_stocks/electric_rolling_stock.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
+++ b/tests/data/rolling_stocks/fast_rolling_stock_high_gamma.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 400,
   "max_speed": 80,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/short_fast_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_fast_rolling_stock.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 15,
   "max_speed": 20,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/short_slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/short_slow_rolling_stock.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 15,
   "max_speed": 10,
   "startup_time": 10,

--- a/tests/data/rolling_stocks/slow_rolling_stock.json
+++ b/tests/data/rolling_stocks/slow_rolling_stock.json
@@ -1,5 +1,6 @@
 {
   "railjson_version": "3.2",
+  "locked": true,
   "length": 400,
   "max_speed": 10,
   "startup_time": 10,


### PR DESCRIPTION
Since https://github.com/OpenRailAssociation/osrd/pull/9024, this is required to be able to use:
```sh
./scripts/load-railjson-rolling-stock.sh tests/data/rolling_stocks/fast_rolling_stock.json
```