### PR TITLE
editoast: add 'core' connectivity to the healthcheck

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3525,6 +3525,25 @@ components:
       enum:
       - STANDARD
       - MARECO
+    EditoastAppHealthErrorCore:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:app_health:Core
     EditoastAppHealthErrorDatabase:
       type: object
       required:
@@ -4145,6 +4164,7 @@ components:
           - editoast:electrical_profiles:NotFound
     EditoastError:
       oneOf:
+      - $ref: '#/components/schemas/EditoastAppHealthErrorCore'
       - $ref: '#/components/schemas/EditoastAppHealthErrorDatabase'
       - $ref: '#/components/schemas/EditoastAppHealthErrorTimeout'
       - $ref: '#/components/schemas/EditoastAppHealthErrorValkey'

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -85,7 +85,7 @@ pub enum Commands {
     #[command(subcommand, about, long_about = "Roles related commands")]
     Roles(RolesCommand),
     #[command(about, long_about = "Healthcheck")]
-    Healthcheck,
+    Healthcheck(CoreArgs),
 }
 
 #[derive(Args, Debug, Derivative, Clone)]
@@ -102,6 +102,19 @@ pub struct MapLayersConfig {
 
 #[derive(Args, Debug)]
 #[command(about, long_about = "Launch the server")]
+pub struct CoreArgs {
+    #[clap(long, env = "OSRD_MQ_URL", default_value_t = String::from("amqp://osrd:password@127.0.0.1:5672/%2f"))]
+    pub mq_url: String,
+    #[clap(long, env = "EDITOAST_CORE_TIMEOUT", default_value_t = 180)]
+    pub core_timeout: u64,
+    #[clap(long, env = "EDITOAST_CORE_SINGLE_WORKER", default_value_t = false)]
+    pub core_single_worker: bool,
+    #[clap(long, env = "CORE_CLIENT_CHANNELS_SIZE", default_value_t = 8)]
+    pub core_client_channels_size: usize,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Launch the server")]
 pub struct RunserverArgs {
     #[command(flatten)]
     pub map_layers_config: MapLayersConfig,
@@ -109,12 +122,8 @@ pub struct RunserverArgs {
     pub port: u16,
     #[arg(long, env = "EDITOAST_ADDRESS", default_value_t = String::from("0.0.0.0"))]
     pub address: String,
-    #[clap(long, env = "OSRD_MQ_URL", default_value_t = String::from("amqp://osrd:password@127.0.0.1:5672/%2f"))]
-    pub mq_url: String,
-    #[clap(long, env = "EDITOAST_CORE_TIMEOUT", default_value_t = 180)]
-    pub core_timeout: u64,
-    #[clap(long, env = "EDITOAST_CORE_SINGLE_WORKER", default_value_t = false)]
-    pub core_single_worker: bool,
+    #[command(flatten)]
+    pub core: CoreArgs,
     #[clap(long, env = "ROOT_PATH", default_value_t = String::new())]
     pub root_path: String,
     #[clap(long)]
@@ -131,8 +140,6 @@ pub struct RunserverArgs {
     /// The timeout to use when performing the healthcheck, in milliseconds
     #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 500)]
     pub health_check_timeout_ms: u64,
-    #[clap(long, env = "CORE_CLIENT_CHANNELS_SIZE", default_value_t = 8)]
-    pub core_client_channels_size: usize,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -71,6 +71,16 @@ impl CoreClient {
         error
     }
 
+    pub async fn ping(&self) -> Result<bool, CoreError> {
+        match self {
+            CoreClient::MessageQueue(mq_client) => {
+                mq_client.ping().await.map_err(|_| CoreError::BrokenPipe)
+            }
+            #[cfg(test)]
+            CoreClient::Mocked(_) => Ok(true),
+        }
+    }
+
     #[tracing::instrument(
         target = "editoast::coreclient",
         name = "core:fetch",
@@ -248,7 +258,7 @@ impl CoreResponse for () {
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "coreclient")]
-enum CoreError {
+pub enum CoreError {
     #[error("Cannot parse Core response: {msg}")]
     #[editoast_error(status = 500)]
     CoreResponseFormatError { msg: String },

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -224,7 +224,8 @@
     "app_health": {
       "Timeout": "Service has not responded in time",
       "Database": "Database is in error",
-      "Valkey": "Valkey is in error"
+      "Valkey": "Valkey is in error",
+      "Core": "Core is in error"
     }
   }
 }

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -221,7 +221,8 @@
     "app_health": {
       "Timeout": "Le serveur n'a pas répondu à temps",
       "Database": "Erreur de base de données",
-      "Valkey": "Erreur de Valkey"
+      "Valkey": "Erreur de Valkey",
+      "Core": "Erreur de core"
     }
   }
 }


### PR DESCRIPTION
We should also check connectivity to the `core` for the healthcheck. 