### PR TITLE
front: clean scenario page

### DIFF
--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -169,7 +169,7 @@ const SimulationResults = ({
 
       {/* TRAIN : SPACE SPEED CHART */}
       {selectedTrainRollingStock && trainSimulation && pathProperties && selectedTrainSchedule && (
-        <div className="osrd-simulation-container d-flex mb-2 speedspacechart-container">
+        <div className="osrd-simulation-container speedspacechart-container">
           <div
             className="chart-container"
             style={{
@@ -211,7 +211,7 @@ const SimulationResults = ({
         pathProperties &&
         operationalPoints &&
         infraId && (
-          <div className="osrd-simulation-container mb-2">
+          <div className="time-stop-outputs">
             <TimesStopsOutput
               simulatedTrain={trainSimulation}
               pathProperties={pathProperties}
@@ -230,7 +230,7 @@ const SimulationResults = ({
         selectedTrainRollingStock &&
         operationalPoints &&
         infraId && (
-          <div className="osrd-simulation-container mb-2 bg-white">
+          <div className="driver-train-schedule">
             <DriverTrainSchedule
               train={selectedTrainSchedule}
               simulatedTrain={trainSimulation}

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 import { ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -22,7 +22,6 @@ import { useFormattedOperationalPoints } from 'modules/trainschedule/useFormatte
 import { updateViewport, type Viewport } from 'reducers/map';
 import { useAppDispatch } from 'store';
 
-const MAP_MIN_HEIGHT = 450;
 const SPEED_SPACE_CHART_HEIGHT = 521.5;
 const HANDLE_TAB_RESIZE_HEIGHT = 20;
 
@@ -53,13 +52,11 @@ const SimulationResults = ({
   const { t } = useTranslation('simulation');
   const dispatch = useAppDispatch();
 
-  const timeTableRef = useRef<HTMLDivElement | null>(null);
-  const [extViewport, setExtViewport] = useState<Viewport | undefined>(undefined);
+  const [extViewport, setExtViewport] = useState<Viewport>();
   const [showWarpedMap, setShowWarpedMap] = useState(false);
 
   const [speedSpaceChartContainerHeight, setSpeedSpaceChartContainerHeight] =
     useState(SPEED_SPACE_CHART_HEIGHT);
-  const [heightOfSimulationMap] = useState(MAP_MIN_HEIGHT);
 
   const {
     operationalPoints,
@@ -191,6 +188,23 @@ const SimulationResults = ({
         </div>
       )}
 
+      {/* SIMULATION : MAP */}
+      <div className="simulation-map">
+        <SimulationResultsMap
+          setExtViewport={setExtViewport}
+          geometry={pathProperties?.geometry}
+          trainSimulation={
+            selectedTrainSchedule && trainSimulation
+              ? {
+                  ...trainSimulation,
+                  trainId: selectedTrainSchedule.id,
+                  startTime: selectedTrainSchedule.start_time,
+                }
+              : undefined
+          }
+        />
+      </div>
+
       {/* TIME STOPS TABLE */}
       {selectedTrainSchedule &&
         trainSimulation.status === 'success' &&
@@ -208,27 +222,6 @@ const SimulationResults = ({
             />
           </div>
         )}
-
-      {/* SIMULATION : MAP */}
-      <div ref={timeTableRef}>
-        <div className="osrd-simulation-container mb-2">
-          <div className="osrd-simulation-map" style={{ height: `${heightOfSimulationMap}px` }}>
-            <SimulationResultsMap
-              setExtViewport={setExtViewport}
-              geometry={pathProperties?.geometry}
-              trainSimulation={
-                selectedTrainSchedule && trainSimulation
-                  ? {
-                      ...trainSimulation,
-                      trainId: selectedTrainSchedule.id,
-                      startTime: selectedTrainSchedule.start_time,
-                    }
-                  : undefined
-              }
-            />
-          </div>
-        </div>
-      </div>
 
       {/* TRAIN : DRIVER TRAIN SCHEDULE */}
       {selectedTrainSchedule &&

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -128,7 +128,7 @@ const SimulationResults = ({
       )}
 
       {/* SIMULATION : SPACE TIME CHART */}
-      <div className="simulation-warped-map d-flex flex-row align-items-stretch mb-2 bg-white">
+      <div className="simulation-warped-map d-flex flex-row align-items-stretch mb-2">
         {projectionData && projectionData.projectedTrains.length > 0 && pathProperties && (
           <>
             <button
@@ -237,7 +237,7 @@ const SimulationResults = ({
         selectedTrainRollingStock &&
         operationalPoints &&
         infraId && (
-          <div className="osrd-simulation-container mb-2">
+          <div className="osrd-simulation-container mb-2 bg-white">
             <DriverTrainSchedule
               train={selectedTrainSchedule}
               simulatedTrain={trainSimulation}

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/SimulationResultsMap.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/SimulationResultsMap.tsx
@@ -197,7 +197,7 @@ const SimulationResultMap = ({ geometry, trainSimulation }: SimulationResultMapP
         {...viewport}
         cursor="pointer"
         ref={mapRef}
-        style={{ width: '100%', height: '100%' }}
+        style={{ width: '100%', height: '100%', borderRadius: '10px' }}
         mapStyle={mapBlankStyle}
         onMove={(e) => updateViewportChange(e.viewState)}
         attributionControl={false} // Defined below

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -43,8 +43,19 @@
     border-radius: 4px;
 
     &.speedspacechart-container {
-      background-color: rgb(247, 246, 238);
+      margin-bottom: 41px;
     }
+  }
+
+  .simulation-map {
+    position: relative;
+    height: 720px;
+    margin: 0 30px 56px 38px;
+    border-radius: 10px;
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 1) inset,
+      0 4px 7px -3px rgba(255, 171, 88, 0.17),
+      0 2px 4px rgba(0, 0, 0, 0.22);
   }
 
   /* MAP */

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -39,7 +39,6 @@
 
   .osrd-simulation-container {
     position: relative;
-    background-color: white;
     padding: 1rem;
     border-radius: 4px;
 

--- a/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_simulationresults.scss
@@ -7,7 +7,7 @@
     border-radius: 4px;
     width: 100%;
     background: var(--secondary);
-    z-index: 2;
+    z-index: 10;
     top: 0;
     left: 0;
     padding: 0.5rem;
@@ -56,6 +56,17 @@
       0 1px 0 rgba(255, 255, 255, 1) inset,
       0 4px 7px -3px rgba(255, 171, 88, 0.17),
       0 2px 4px rgba(0, 0, 0, 0.22);
+  }
+
+  .time-stop-outputs {
+    margin: 0 30px 27px 38px;
+  }
+
+  .driver-train-schedule {
+    background-color: white;
+    padding: 1rem;
+    border-radius: 4px;
+    margin-inline: 38px 30px;
   }
 
   /* MAP */

--- a/front/tests/011-op-times-and-stops-tab.spec.ts
+++ b/front/tests/011-op-times-and-stops-tab.spec.ts
@@ -161,7 +161,7 @@ test.describe('Times and Stops Tab Verification', () => {
     await opTimetablePage.clickOnScenarioCollapseButton();
     await opTimetablePage.verifyTimeStopsDataSheetVisibility();
     // Scroll and extract data from output table
-    await scrollContainer(page, '.osrd-simulation-container .time-stops-datasheet .dsg-container');
+    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(outputExpectedCellData, selectedLanguage);
   });
 

--- a/front/tests/012-op-simulation-settings-tab.spec.ts
+++ b/front/tests/012-op-simulation-settings-tab.spec.ts
@@ -169,7 +169,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await opTimetablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('11:52');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await scrollContainer(page, '.osrd-simulation-container .time-stops-datasheet .dsg-container');
+    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(
       expectedCellDataElectricalProfileON,
       selectedLanguage
@@ -230,7 +230,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await opTimetablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('12:02');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await scrollContainer(page, '.osrd-simulation-container .time-stops-datasheet .dsg-container');
+    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataCodeCompoON, selectedLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
     // Remove the composition code option and verify the changes
@@ -294,7 +294,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await opTimetablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('11:54');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await scrollContainer(page, '.osrd-simulation-container .time-stops-datasheet .dsg-container');
+    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataLinearMargin, selectedLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
     // Modify the margin to 'Mareco' and verify the changes
@@ -359,7 +359,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await opTimetablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('12:05');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await scrollContainer(page, '.osrd-simulation-container .time-stops-datasheet .dsg-container');
+    await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataForAllSettings, selectedLanguage);
   });
 });

--- a/front/tests/pages/op-output-table-page-model.ts
+++ b/front/tests/pages/op-output-table-page-model.ts
@@ -16,7 +16,7 @@ class OperationalStudiesOutputTablePage {
     this.columnHeaders = page.locator(
       '[class="dsg-cell dsg-cell-header"] .dsg-cell-header-container'
     );
-    this.tableRows = page.locator('.osrd-simulation-container .time-stops-datasheet .dsg-row');
+    this.tableRows = page.locator('.time-stop-outputs .time-stops-datasheet .dsg-row');
   }
 
   // Retrieve the cell value based on the locator type

--- a/front/tests/pages/op-timetable-page-model.ts
+++ b/front/tests/pages/op-timetable-page-model.ts
@@ -53,7 +53,7 @@ class OperationalStudiesTimetablePage {
     this.speedSpaceChart = page.locator('#container-SpeedSpaceChart');
     this.spaceTimeChart = page.locator('.space-time-chart-container');
     this.timeStopsDataSheet = page.locator('.time-stops-datasheet');
-    this.simulationMap = page.locator('.osrd-simulation-map');
+    this.simulationMap = page.locator('.simulation-map');
     this.simulationDriverTrainSchedule = page.locator('.simulation-driver-train-schedule');
     this.timetableFilterButton = page.getByTestId('timetable-filter-button');
     this.timetableFilterButtonClose = page.getByTestId('timetable-filter-button-close');


### PR DESCRIPTION
closes #9407 

Changes
- background color of the main components of SimulationResults
- style of the map: add border radius and box-shadow, remove useless divs
- small improvements on the margins

Before:
![image](https://github.com/user-attachments/assets/408ed59b-bb9c-4143-8fb6-94d20d9a18b7)
![image](https://github.com/user-attachments/assets/cb54c174-3bb9-4002-8fb9-26a5c1da3a22)
![image](https://github.com/user-attachments/assets/512de829-8852-427e-93cb-2efa12ad6a0c)


After:
![image](https://github.com/user-attachments/assets/47c4cfbf-b726-4a9e-807d-792f5659c757)
![image](https://github.com/user-attachments/assets/ab968f7d-6af6-4da2-835f-ab7417ae5f86)
![image](https://github.com/user-attachments/assets/2c98ca18-7b66-4244-ae31-b6bd9255258e)
