### PR TITLE
Add codeowners to script repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 /docker                                                  @openrailassociation/OSRD-DevOps
 /docker-compose.yml                                      @openrailassociation/OSRD-DevOps
 
+# -- Scripts --
+/scripts                                                 @openrailassociation/OSRD-DevOps
+
 # --- NIX ---
 /nix                                                     @openrailassociation/OSRD-DevOps
 /flake.lock                                              @openrailassociation/OSRD-DevOps


### PR DESCRIPTION
Making a change in a script, I realized I was able to merge my changes without any review. 

I would say that scripts are under the responsibility of the devops team, hence this PR.