### PR TITLE
core: improve worker lifetime

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -175,16 +175,16 @@ public enum ErrorType {
     public final String type;
     public final String message;
     public final ErrorCause cause;
-    public final boolean isCacheable;
+    public final boolean isRecoverable;
 
     ErrorType(String type, String message, ErrorCause cause) {
         this(type, message, cause, true);
     }
 
-    ErrorType(String type, String message, ErrorCause cause, boolean isCacheable) {
+    ErrorType(String type, String message, ErrorCause cause, boolean isRecoverable) {
         this.type = "core:" + type;
         this.message = message;
         this.cause = cause;
-        this.isCacheable = isCacheable;
+        this.isRecoverable = isRecoverable;
     }
 }

--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -26,11 +26,12 @@ public enum ErrorType {
     StrictWarningError("strict_warning", "Warning was reported with strict mode enabled", ErrorCause.USER),
     AssertionError("assert_error", "assert check failed", ErrorCause.INTERNAL),
     UnknownError("unknown_error", "An unknown exception was thrown", ErrorCause.INTERNAL),
-    InfraSoftLoadingError("infra_loading:soft_error", "soft error while loading new infra", ErrorCause.USER),
+    InfraSoftLoadingError("infra_loading:soft_error", "soft error while loading new infra", ErrorCause.USER, false),
     InfraHardLoadingError("infra_loading:hard_error", "hard error while loading new infra", ErrorCause.USER),
     InfraHardError("infra:hard_error", "hard error while parsing infra", ErrorCause.USER),
     InfraLoadingCacheException("infra_loading:cache_exception", "cached exception", ErrorCause.INTERNAL),
-    InfraLoadingInvalidStatusException("infra_loading:invalid_status", "Status doesn’t exist", ErrorCause.INTERNAL),
+    InfraLoadingInvalidStatusException(
+            "infra_loading:invalid_status", "infra not loaded correctly", ErrorCause.INTERNAL),
     InfraInvalidStatusWhileWaitingStable(
             "infra_loading:invalid_status_waiting_stable", "invalid status after waitUntilStable", ErrorCause.INTERNAL),
     InfraInvalidVersionException("infra:invalid_version", "Invalid infra version", ErrorCause.USER),

--- a/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.api;
 
 import fr.sncf.osrd.reporting.exceptions.ErrorCause;
+import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import org.takes.Response;
 import org.takes.rs.RsJson;
@@ -9,11 +10,16 @@ import org.takes.rs.RsWithStatus;
 
 public class ExceptionHandler {
 
-    /** Handles an exception, returns an HTTP response with all relevant information */
-    public static Response handle(Throwable ex) {
+    /** Handles an exception, returns an HTTP response with all relevant information or
+     * re-throw if exception is an OSRDError of type InfraSoftLoadingError */
+    public static Response handle(Throwable ex) throws OSRDError {
         ex.printStackTrace();
-        if (ex instanceof OSRDError) return toResponse((OSRDError) ex);
-        else if (ex instanceof AssertionError) return toResponse(OSRDError.newAssertionWrapper((AssertionError) ex));
+        if (ex instanceof OSRDError osrdError) {
+            if (osrdError.osrdErrorType == ErrorType.InfraSoftLoadingError) {
+                throw osrdError;
+            }
+            return toResponse(osrdError);
+        } else if (ex instanceof AssertionError) return toResponse(OSRDError.newAssertionWrapper((AssertionError) ex));
         else {
             return toResponse(OSRDError.newUnknownError(ex));
         }

--- a/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
+++ b/core/src/main/java/fr/sncf/osrd/api/ExceptionHandler.java
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.api;
 
 import fr.sncf.osrd.reporting.exceptions.ErrorCause;
-import fr.sncf.osrd.reporting.exceptions.ErrorType;
 import fr.sncf.osrd.reporting.exceptions.OSRDError;
 import org.takes.Response;
 import org.takes.rs.RsJson;
@@ -15,7 +14,7 @@ public class ExceptionHandler {
     public static Response handle(Throwable ex) throws OSRDError {
         ex.printStackTrace();
         if (ex instanceof OSRDError osrdError) {
-            if (osrdError.osrdErrorType == ErrorType.InfraSoftLoadingError) {
+            if (!osrdError.osrdErrorType.isRecoverable) {
                 throw osrdError;
             }
             return toResponse(osrdError);

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -12,6 +12,8 @@ import fr.sncf.osrd.api.api_v2.standalone_sim.SimulationEndpoint
 import fr.sncf.osrd.api.api_v2.stdcm.STDCMEndpointV2
 import fr.sncf.osrd.api.pathfinding.PathfindingBlocksEndpoint
 import fr.sncf.osrd.api.stdcm.STDCMEndpoint
+import fr.sncf.osrd.reporting.exceptions.ErrorType
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
@@ -154,7 +156,26 @@ class WorkerCommand : CliCommand {
             connection.createChannel().use { channel -> reportActivity(channel, "started") }
 
             if (!ALL_INFRA) {
-                infraManager.load(infraId, null, diagnosticRecorder)
+                try {
+                    infraManager.load(infraId, null, diagnosticRecorder)
+                } catch (e: OSRDError) {
+                    if (e.osrdErrorType == ErrorType.InfraHardLoadingError) {
+                        logger.warn("Failed to load infra $infraId with a perennial error: $e")
+                        // go on and future requests will be consumed and rejected
+                    } else if (e.osrdErrorType == ErrorType.InfraSoftLoadingError) {
+                        logger.error("Failed to load infra $infraId with a temporary error: $e")
+                        // Stop worker and let another worker spawn eventually
+                        throw e
+                    } else {
+                        logger.error(
+                            "Failed to load infra $infraId with an unexpected OSRD Error: $e"
+                        )
+                        throw e
+                    }
+                } catch (t: Throwable) {
+                    logger.error("Failed to load infra $infraId with an unexpected exception: $t")
+                    throw t
+                }
             }
 
             connection.createChannel().use { channel -> reportActivity(channel, "ready") }
@@ -250,6 +271,10 @@ class WorkerCommand : CliCommand {
                             "ERROR, exception received"
                                 .toByteArray() // TODO: have a valid payload for uncaught exceptions
                         status = "core_error".encodeToByteArray()
+                        // Stop worker and let another worker spawn eventually
+                        if (t is OSRDError && t.osrdErrorType == ErrorType.InfraSoftLoadingError) {
+                            throw t
+                        }
                     } finally {
                         span.end()
                     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
@@ -62,7 +62,7 @@ class PathfindingBlocksEndpointV2(private val infraManager: InfraManager) : Take
             pathfindingLogger.info("No path found")
             RsJson(RsWithBody(pathfindingResponseAdapter.toJson(error.response)))
         } catch (ex: Throwable) {
-            if (ex is OSRDError && ex.osrdErrorType.isCacheable) {
+            if (ex is OSRDError && ex.osrdErrorType.isRecoverable) {
                 pathfindingLogger.info("Pathfinding failed: ${ex.message}")
                 val response = PathfindingFailed(ex)
                 RsJson(RsWithBody(pathfindingResponseAdapter.toJson(response)))

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
@@ -61,15 +61,12 @@ class PathfindingBlocksEndpointV2(private val infraManager: InfraManager) : Take
         } catch (error: NoPathFoundException) {
             pathfindingLogger.info("No path found")
             RsJson(RsWithBody(pathfindingResponseAdapter.toJson(error.response)))
-        } catch (error: OSRDError) {
-            if (!error.osrdErrorType.isCacheable) {
-                ExceptionHandler.handle(error)
-            } else {
-                pathfindingLogger.info("Pathfinding failed: ${error.message}")
-                val response = PathfindingFailed(error)
+        } catch (ex: Throwable) {
+            if (ex is OSRDError && ex.osrdErrorType.isCacheable) {
+                pathfindingLogger.info("Pathfinding failed: ${ex.message}")
+                val response = PathfindingFailed(ex)
                 RsJson(RsWithBody(pathfindingResponseAdapter.toJson(response)))
             }
-        } catch (ex: Throwable) {
             ExceptionHandler.handle(ex)
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
@@ -72,14 +72,11 @@ class SimulationEndpoint(
                     request.path.pathItemPositions,
                 )
             return RsJson(RsWithBody(simulationResponseAdapter.toJson(res)))
-        } catch (error: OSRDError) {
-            if (!error.osrdErrorType.isCacheable) {
-                return ExceptionHandler.handle(error)
-            } else {
-                val response = SimulationFailed(error)
+        } catch (ex: Throwable) {
+            if (ex is OSRDError && ex.osrdErrorType.isCacheable) {
+                val response = SimulationFailed(ex)
                 return RsJson(RsWithBody(simulationResponseAdapter.toJson(response)))
             }
-        } catch (ex: Throwable) {
             return ExceptionHandler.handle(ex)
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
@@ -73,7 +73,7 @@ class SimulationEndpoint(
                 )
             return RsJson(RsWithBody(simulationResponseAdapter.toJson(res)))
         } catch (ex: Throwable) {
-            if (ex is OSRDError && ex.osrdErrorType.isCacheable) {
+            if (ex is OSRDError && ex.osrdErrorType.isRecoverable) {
                 val response = SimulationFailed(ex)
                 return RsJson(RsWithBody(simulationResponseAdapter.toJson(response)))
             }


### PR DESCRIPTION
🔍 review the commits separately, ignore whitespace on first commit.

fixes #9388

Done:
* fix rabbit's connection closing
* stop worker when unable to process requests after infra load

Details:
The worker is able to process requests if infra load:
* ... went fine, happy path (just process request)
* ... failed with a perennial error (expected behavior is reject requests on the same version of the same infra)

If infra load failed with a temporary error (and after possible retries), better just stop and let orchestrator decide to retry or not.

No retry implemented so far (easier to test the behavior... and easier to code 😇).
Hand-tested on the cases I could think of and reproduce, more test is welcome.