### PR TITLE
Use standard oidc crate

### DIFF
--- a/gateway/Cargo.lock
+++ b/gateway/Cargo.lock
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "5.0.0-alpha.4"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098af5a5110b4deacf3200682963713b143ae9d28762b739bdb7b98429dfaf68"
+checksum = "23d385da3c602d29036d2f70beed71c36604df7570be17fed4c5b839616785bf"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1911,8 +1911,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openidconnect"
-version = "4.0.0-alpha.2"
-source = "git+https://github.com/multun/openidconnect-rs.git?branch=updated-at-string#964d84bf68006b002d4dc7bd19438584ddf6d1c8"
+version = "4.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93a50789d0b649986bfb104cdef97736ca072d579ec88496d5c6f9abed0ea85"
 dependencies = [
  "base64 0.21.7",
  "chrono",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -52,10 +52,7 @@ phf = "0.11"
 # actix_auth
 actix-web-httpauth = "0.8"
 
-# switch to https://github.com/ramosbugs/openidconnect-rs/pull/165 if it ever lands
-openidconnect = { git = "https://github.com/multun/openidconnect-rs.git", branch = "updated-at-string", features = [
-  "accept-string-epoch",
-] }
+openidconnect = "4.0.0-rc.1"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }


### PR DESCRIPTION
We don't longer need to handle epoch as string.