### PR TITLE
editoast: add 'label' to towed rolling stock

### DIFF
--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -696,6 +696,8 @@ diesel::table! {
         rolling_resistance -> Jsonb,
         gamma -> Jsonb,
         version -> Int8,
+        #[max_length = 255]
+        label -> Varchar,
     }
 }
 

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -4,6 +4,7 @@ use super::RollingResistance;
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TowedRollingStock {
     pub name: String,
+    pub label: String,
     pub railjson_version: String,
 
     pub mass: f64,

--- a/editoast/migrations/2024-10-24-143158_add-towed-rolling-stock-field-description/down.sql
+++ b/editoast/migrations/2024-10-24-143158_add-towed-rolling-stock-field-description/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE towed_rolling_stock
+DROP label;

--- a/editoast/migrations/2024-10-24-143158_add-towed-rolling-stock-field-description/up.sql
+++ b/editoast/migrations/2024-10-24-143158_add-towed-rolling-stock-field-description/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE towed_rolling_stock
+ADD label VARCHAR(255) NOT NULL DEFAULT '';

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10274,6 +10274,7 @@ components:
       required:
       - id
       - name
+      - label
       - railjson_version
       - locked
       - mass
@@ -10295,6 +10296,8 @@ components:
         inertia_coefficient:
           type: number
           format: double
+        label:
+          type: string
         length:
           type: number
           format: double
@@ -10327,6 +10330,7 @@ components:
       type: object
       required:
       - name
+      - label
       - locked
       - mass
       - length
@@ -10344,6 +10348,8 @@ components:
         inertia_coefficient:
           type: number
           format: double
+        label:
+          type: string
         length:
           type: number
           format: double

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -32,12 +32,14 @@ pub struct TowedRollingStockModel {
     pub gamma: Gamma,
 
     pub version: i64,
+    pub label: String,
 }
 
 impl From<TowedRollingStockModel> for TowedRollingStock {
     fn from(model: TowedRollingStockModel) -> Self {
         Self {
             name: model.name,
+            label: model.label,
             railjson_version: model.railjson_version,
             mass: model.mass,
             length: model.length,
@@ -54,6 +56,7 @@ impl From<TowedRollingStock> for Changeset<TowedRollingStockModel> {
     fn from(towed_rolling_stock: TowedRollingStock) -> Self {
         TowedRollingStockModel::changeset()
             .name(towed_rolling_stock.name)
+            .label(towed_rolling_stock.label)
             .railjson_version(towed_rolling_stock.railjson_version)
             .mass(towed_rolling_stock.mass)
             .length(towed_rolling_stock.length)

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -50,6 +50,7 @@ editoast_common::schemas! {
 struct TowedRollingStock {
     id: i64,
     name: String,
+    label: String,
     railjson_version: String,
     locked: bool,
 
@@ -66,6 +67,7 @@ impl From<TowedRollingStockModel> for TowedRollingStock {
     fn from(towed_rolling_stock: TowedRollingStockModel) -> Self {
         Self {
             id: towed_rolling_stock.id,
+            label: towed_rolling_stock.label,
             name: towed_rolling_stock.name,
             railjson_version: towed_rolling_stock.railjson_version,
             locked: towed_rolling_stock.locked,
@@ -94,6 +96,7 @@ pub enum TowedRollingStockError {
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct TowedRollingStockForm {
     pub name: String,
+    pub label: String,
     pub locked: bool,
 
     pub mass: f64,
@@ -110,6 +113,7 @@ impl From<TowedRollingStockForm> for Changeset<TowedRollingStockModel> {
         TowedRollingStockModel::changeset()
             .railjson_version(ROLLING_STOCK_RAILJSON_VERSION.to_string())
             .name(towed_rolling_stock_form.name)
+            .label(towed_rolling_stock_form.label)
             .locked(towed_rolling_stock_form.locked)
             .mass(towed_rolling_stock_form.mass)
             .length(towed_rolling_stock_form.length)
@@ -363,6 +367,7 @@ mod tests {
     fn create_towed_rolling_stock(app: &TestApp, name: &str, locked: bool) -> TowedRollingStock {
         let towed_rolling_stock_json = json!({
             "name": name,
+            "label": name,
             "locked": locked,
             "mass": 42000,
             "length": 16500,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3241,6 +3241,7 @@ export type TowedRollingStock = {
   gamma: Gamma;
   id: number;
   inertia_coefficient: number;
+  label: string;
   length: number;
   locked: boolean;
   mass: number;
@@ -3253,6 +3254,7 @@ export type TowedRollingStockForm = {
   comfort_acceleration: number;
   gamma: Gamma;
   inertia_coefficient: number;
+  label: string;
   length: number;
   locked: boolean;
   mass: number;

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -233,6 +233,7 @@ class TowedRollingStock(BaseModel, extra="forbid"):
     """
 
     name: str = Field(max_length=255)
+    label: str = Field(max_length=255)
     railjson_version: RAILJSON_ROLLING_STOCK_VERSION_TYPE = Field(default=RAILJSON_ROLLING_STOCK_VERSION)
     locked: bool = Field(default=False, description="Whether the rolling stock can be edited/deleted or not")
     mass: NonNegativeFloat = Field(description="The mass of the train, in kg")


### PR DESCRIPTION
Follow up of #9202. We're missing a long name. I used `label`.