### PR TITLE
core: remove rolling stock length from safety speeds

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -57,6 +57,8 @@ fun computeMRSP(
  * @param addRollingStockLength whether the rolling stock length should be taken into account in the
  *   computation.
  * @param trainTag corresponding train.
+ * @param safetySpeedRanges Extra speed ranges, used for safety speeds. Note: rolling stock length
+ *   is *not* added at the end of these ranges.
  * @return the corresponding MRSP as an Envelope.
  */
 fun computeMRSP(
@@ -120,7 +122,7 @@ fun computeMRSP(
             addSpeedSection(
                 builder,
                 range.lower,
-                Distance.min(range.upper + offset.meters, pathLength.meters),
+                Distance.min(range.upper, pathLength.meters),
                 speed,
                 newAttrs,
                 speedLimitProperties

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -348,7 +348,7 @@ class StandaloneSimulationTest {
                     DistanceRangeMap.RangeMapEntry(100.meters, 5_000.meters, 30.kilometersPerHour)
                 )
             )
-        val offsetEndSafetySpeed = 5_000 + rollingStock.length
+        val offsetEndSafetySpeed = 5_000.0
         val mrspWithSafetySpeed = computeMRSP(pathProps, rollingStock, true, null, safetySpeeds)
         assertEquals(mrsp.endPos, mrspWithSafetySpeed.endPos)
         var position = 0.0

--- a/front/tests/008-train-schedule.spec.ts
+++ b/front/tests/008-train-schedule.spec.ts
@@ -66,9 +66,9 @@ test.describe('Verifying that all elements in the train schedule are loaded corr
     await opTimetablePage.verifyTrainCount(20);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Invalid', 4);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'All', 20);
-    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Honored', 12);
-    await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Valid', 12);
-    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Not honored', 4);
+    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Honored', 11);
+    await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Valid', 11);
+    await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'Not honored', 5);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'Invalid', 0);
     await opTimetablePage.filterHonoredAndVerifyTrainCount(selectedLanguage, 'All', 4);
     await opTimetablePage.filterValidityAndVerifyTrainCount(selectedLanguage, 'All', 20);

--- a/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
+++ b/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
@@ -26,8 +26,8 @@
     "margin": {
       "theoretical": "1 min/100km",
       "theoreticalS": "9 s",
-      "actual": "174 s",
-      "difference": "165 s"
+      "actual": "291 s",
+      "difference": "283 s"
     },
     "calculatedArrival": "11:47:40",
     "calculatedDeparture": "11:52:40"
@@ -45,8 +45,8 @@
       "actual": "12 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "12:05:21",
-    "calculatedDeparture": "12:07:25"
+    "calculatedArrival": "12:05:20",
+    "calculatedDeparture": "12:07:24"
   },
   {
     "stationName": "North_East_station",
@@ -61,7 +61,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "12:16:23",
+    "calculatedArrival": "12:16:22",
     "calculatedDeparture": ""
   }
 ]


### PR DESCRIPTION
Safety speeds end when the train *head* reaches the end, and not its *tail* like all other speed limits.