### PR TITLE
editoast: remove always-on directive

### DIFF
--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -69,4 +69,6 @@ ENV DYNAMIC_ASSETS_PATH=/assets
 
 # We use jemalloc to reduce allocation fragmentation
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
+# tower_http in debug mode allows to capture span from `tower_http::trace::TraceLayer` middleware
+ENV RUST_LOG="info,tower_http=debug"
 CMD ["editoast", "runserver"]

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -81,12 +81,7 @@ fn init_tracing(mode: EditoastMode, telemetry_config: &client::TelemetryConfig) 
     let env_filter_layer = tracing_subscriber::EnvFilter::builder()
         // Set the default log level to 'info'
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env_lossy()
-        .add_directive(
-            "tower_http=debug"
-                .parse()
-                .expect("valid 'RUST_LOG' directive"),
-        );
+        .from_env_lossy();
     let fmt_layer = tracing_subscriber::fmt::layer()
         .pretty()
         .with_file(true)


### PR DESCRIPTION
This modification was done in order to bring logs for any request that comes in thanks to the `tower_http::trace::TraceLayer` middleware. But the code has a sneaky behavior where it's actually impossible to turn it of anymore.

For example, `RUST_LOG=info,tower_http=none` will still show `tower_http` logs.

Let's remove it.