### PR TITLE
editoast: do not panic on incorrect pagination

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4240,7 +4240,10 @@ components:
       - $ref: '#/components/schemas/EditoastOperationErrorInvalidPatch'
       - $ref: '#/components/schemas/EditoastOperationErrorModifyId'
       - $ref: '#/components/schemas/EditoastOperationErrorObjectNotFound'
+      - $ref: '#/components/schemas/EditoastPaginationErrorInvalidPageNumber'
       - $ref: '#/components/schemas/EditoastPaginationErrorInvalidPageSize'
+      - $ref: '#/components/schemas/EditoastPaginationErrorPageOutOfBound'
+      - $ref: '#/components/schemas/EditoastPaginationErrorPageSizeTooBig'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsInvalidNumberOfPaths'
@@ -4766,7 +4769,85 @@ components:
           type: string
           enum:
           - editoast:operation:ObjectNotFound
+    EditoastPaginationErrorInvalidPageNumber:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - page
+          properties:
+            page:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:pagination:InvalidPageNumber
     EditoastPaginationErrorInvalidPageSize:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - page_size
+          properties:
+            page_size:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:pagination:InvalidPageSize
+    EditoastPaginationErrorPageOutOfBound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - page
+          - page_size
+          - total_count
+          properties:
+            page:
+              type: integer
+            page_size:
+              type: integer
+            total_count:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:pagination:PageOutOfBound
+    EditoastPaginationErrorPageSizeTooBig:
       type: object
       required:
       - type
@@ -4792,7 +4873,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:pagination:InvalidPageSize
+          - editoast:pagination:PageSizeTooBig
     EditoastPathfindingErrorInfraNotFound:
       type: object
       required:

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -112,7 +112,7 @@ async fn list_errors(
         .into_iter()
         .map(|information| InfraErrorResponse { information })
         .collect::<Vec<_>>();
-    let stats = PaginationStats::new(results.len() as u64, total_count, page, page_size);
+    let stats = PaginationStats::new(results.len() as u64, total_count, page, page_size)?;
     Ok(Json(ErrorListResponse { stats, results }))
 }
 

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -75,21 +75,36 @@ impl PaginationStats {
     /// - If the page or the page_size are null
     /// - If `(page - 1) * page_size + current_page_count <= total_count`. In other words if
     ///   the `current_page_count` is inconsistent with the pagination settings and the `total_count`.
-    pub fn new(current_page_count: u64, total_count: u64, page: u64, page_size: u64) -> Self {
-        assert!(page > 0);
-        assert!(page_size > 0);
-        assert!((page - 1) * page_size + current_page_count <= total_count);
+    pub fn new(
+        current_page_count: u64,
+        total_count: u64,
+        page: u64,
+        page_size: u64,
+    ) -> Result<Self, PaginationError> {
+        if page == 0 {
+            return Err(PaginationError::InvalidPageNumber { page });
+        }
+        if page_size == 0 {
+            return Err(PaginationError::InvalidPageSize { page_size });
+        }
+        if (page - 1) * page_size + current_page_count > total_count {
+            return Err(PaginationError::PageOutOfBound {
+                page,
+                page_size,
+                total_count,
+            });
+        }
         let page_count = total_count.div_ceil(page_size);
         let previous = (page > 1 && total_count > 0).then_some(page - 1);
         let next = ((page - 1) * page_size + current_page_count < total_count).then_some(page + 1);
-        Self {
+        Ok(Self {
             count: total_count,
             page_size,
             page_count,
             current: page,
             previous,
             next,
-        }
+        })
     }
 }
 
@@ -115,7 +130,7 @@ pub trait PaginatedList: ListAndCount + 'static {
             .get_pagination_settings()
             .expect("the limit and the offset must be set in order to call list_paginated");
         let (results, count) = Self::list_and_count(conn, settings).await?;
-        let stats = PaginationStats::new(results.len() as u64, count, page, page_size);
+        let stats = PaginationStats::new(results.len() as u64, count, page, page_size)?;
         Ok((results, stats))
     }
 }
@@ -146,7 +161,7 @@ impl PaginationQueryParam {
     pub fn validate(self, max_page_size: i64) -> Result<PaginationQueryParam> {
         let (page, page_size) = self.unpack();
         if page_size > max_page_size || page_size < 1 || page < 1 {
-            return Err(PaginationError::InvalidPageSize {
+            return Err(PaginationError::PageSizeTooBig {
                 provided_page_size: page_size,
                 max_page_size,
             }
@@ -185,9 +200,22 @@ impl<M: Model + 'static> From<PaginationQueryParam> for SelectionSettings<M> {
 pub enum PaginationError {
     #[error("Invalid page size ({provided_page_size}), expected an integer 0 < page_size <= {max_page_size}")]
     #[editoast_error(status = 400)]
-    InvalidPageSize {
+    PageSizeTooBig {
         provided_page_size: i64,
         max_page_size: i64,
+    },
+    #[error("page number must be strictly positive, was {page}")]
+    #[editoast_error(status = 400)]
+    InvalidPageNumber { page: u64 },
+    #[error("page size must be strictly positive, was {page_size}")]
+    #[editoast_error(status = 400)]
+    InvalidPageSize { page_size: u64 },
+    #[error("no more information after page {page} when page size is {page_size} (total number of elements is {total_count})")]
+    #[editoast_error(status = 404)]
+    PageOutOfBound {
+        page: u64,
+        page_size: u64,
+        total_count: u64,
     },
 }
 
@@ -198,7 +226,7 @@ mod pagination_stats_tests {
     #[test]
     fn no_results() {
         assert_eq!(
-            PaginationStats::new(0, 0, 1, 25),
+            PaginationStats::new(0, 0, 1, 25).unwrap(),
             PaginationStats {
                 count: 0,
                 page_size: 25,
@@ -213,7 +241,7 @@ mod pagination_stats_tests {
     #[test]
     fn single_result() {
         assert_eq!(
-            PaginationStats::new(1, 1, 1, 25),
+            PaginationStats::new(1, 1, 1, 25).unwrap(),
             PaginationStats {
                 count: 1,
                 page_size: 25,
@@ -228,7 +256,7 @@ mod pagination_stats_tests {
     #[test]
     fn first_page() {
         assert_eq!(
-            PaginationStats::new(25, 26, 1, 25),
+            PaginationStats::new(25, 26, 1, 25).unwrap(),
             PaginationStats {
                 count: 26,
                 page_size: 25,
@@ -243,7 +271,7 @@ mod pagination_stats_tests {
     #[test]
     fn second_page() {
         assert_eq!(
-            PaginationStats::new(1, 26, 2, 25),
+            PaginationStats::new(1, 26, 2, 25).unwrap(),
             PaginationStats {
                 count: 26,
                 page_size: 25,

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -460,7 +460,7 @@ mod tests {
             .assert_status(StatusCode::BAD_REQUEST)
             .json_into();
 
-        assert_eq!(response.error_type, "editoast:pagination:InvalidPageSize");
+        assert_eq!(response.error_type, "editoast:pagination:PageSizeTooBig");
         assert_eq!(response.context["provided_page_size"], 1010);
         assert_eq!(response.context["max_page_size"], 1000);
     }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -102,8 +102,10 @@
       "ObjectNotFound": "Object '{{obj_id}}', could not be found in the infrastructure '{{infra_id}}'"
     },
     "pagination": {
-      "InvalidPage": "Invalid page number ({{page}})",
-      "InvalidPageSize": "Invalid page size ({{provided_page_size}}), expected an integer 0 < page_size <= {{max_page_size}}"
+      "InvalidPageNumber": "Invalid page number '{{page}}', should be stricty positive",
+      "InvalidPageSize": "Invalid page size '{{page_size}}', should be strictly positive",
+      "PageSizeTooBig": "Page size '{{provided_page_size}}' is bigger than maximum page size '{{max_page_size}}'",
+      "PageOutOfBound": "No more element on page '{{page}}' with a page size of '{{page_size}}' (total number of elements is '{{total_count}}')"
     },
     "pathfinding": {
       "ElectricalProfilesOverlap": "Electrical Profile overlaps with others",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -102,8 +102,10 @@
       "ObjectNotFound": "Objet '{{obj_id}}' non trouvé dans l'infrastructure '{{infra_id}}'"
     },
     "pagination": {
-      "InvalidPage": "Le numéro de page '{{page}}' est invalide",
-      "InvalidPageSize": "La taille de la page '{{provided_page_size}}' est invalide, il doit être un entier compris entre 0 et {{max_page_size}}"
+      "InvalidPageNumber": "Le numéro de page '{{page}}' doit être strictement positif",
+      "InvalidPageSize": "Le numéro de page '{{page_size}}' doit être strictement positif",
+      "PageSizeTooBig": "La taille de la page '{{provided_page_size}}' est plus grand que la taille maximum de page '{{max_page_size}}'",
+      "PageOutOfBound": "La page '{{page}}' ne contient pas d'éléments avec une taille de page de '{{page_size}}' (le nombre total d'éléments est '{{total_count}}')"
     },
     "pathfinding": {
       "ElectricalProfilesOverlap": "Des profils électriques se chevauchent",


### PR DESCRIPTION
Once, I did put a `page` and `page_size` that went out of bound... and got a 500. I don't expect `editoast` to panic in such case, and we could reply with either an empty `Vec` and a 200, or more likely something like a 404 (I chose this one). Note that on the way, I also remove panic for `page==0` and `page_size==0` too and transformed them into a 400.

Note that I renamed and change the semantic of the existing `InvalidPageSize` into `PageSizeTooBig` (because it was actually not triggered when `page_size==0`) and then I created a **new** `InvalidPageSize` that actually only check for a strictly positive number.

Here is the result.
```
 ❯ xh 'localhost:8090/light_rolling_stock?page_size=100&page=100'
HTTP/1.1 404 Not Found
Access-Control-Allow-Origin: *
Content-Length: 214
Content-Type: application/json
Date: Fri, 25 Oct 2024 15:21:28 GMT
Vary: origin, access-control-request-method, access-control-request-headers

{
    "status": 404,
    "type": "editoast:pagination:OutOfBound",
    "context": {
        "page_size": 100,
        "total_count": 464,
        "page": 100
    },
    "message": "no more information after page 100 when page size is 100 (total number of elements is 464)"
}
```