### PR TITLE
core: stdcm: add rolling stock length to speed limits in output sim

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -119,7 +119,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         stopAtEnd: Boolean,
     ): Envelope {
         val context = build(rollingStock, physicsPath, timeStep, comfort)
-        val mrsp = computeMRSP(trainPath, rollingStock, false, trainTag)
+        val mrsp = computeMRSP(trainPath, rollingStock, true, trainTag)
         val stopPositions = stops.map { it.position }.toMutableList()
         if (stopAtEnd) stopPositions.add(physicsPath.length)
         val maxSpeedEnvelope = MaxSpeedEnvelope.from(context, stopPositions.toDoubleArray(), mrsp)


### PR DESCRIPTION
fix https://github.com/OpenRailAssociation/osrd/issues/9458

todo: write tests, fix current tests

Note: this is very likely to introduce bugs and will require https://github.com/OpenRailAssociation/osrd/issues/9487 to be "correctly" implemented. I don't know if it's worth merging the "potentially bugged" version before then.