### PR TITLE
front: fix space time chart when first or last waypoint are hidden

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/__tests__/utils.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+
+import cutSpaceTimeRect from '../utils';
+
+describe('interpolateRange', () => {
+  it('should return null if the interpolated range ends before the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 5,
+      timeStart: 100,
+      timeEnd: 200,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 1, 3);
+    expect(interpolatedRange).toBeNull();
+  });
+
+  it('should return null if the interpolated range starts after the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 5,
+      timeStart: 100,
+      timeEnd: 200,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 5, 7);
+    expect(interpolatedRange).toBeNull();
+  });
+
+  it('should return the same range if its ranges are inside the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 5,
+      timeStart: 100,
+      timeEnd: 200,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 2, 7);
+    expect(interpolatedRange).toEqual(range);
+  });
+
+  it('should return the interpolated range when the start position is outside the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 5,
+      timeStart: 100,
+      timeEnd: 200,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 4, 5);
+    expect(interpolatedRange).toEqual({
+      spaceStart: 4,
+      spaceEnd: 5,
+      timeStart: 150,
+      timeEnd: 200,
+    });
+  });
+
+  it('should return the interpolated range when the end position is is outside the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 6,
+      timeStart: 100,
+      timeEnd: 160,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 3, 5);
+    expect(interpolatedRange).toEqual({
+      spaceStart: 3,
+      spaceEnd: 5,
+      timeStart: 100,
+      timeEnd: 140,
+    });
+  });
+
+  it('should return the interpolated range when both positions are outside the cut space', () => {
+    const range = {
+      spaceStart: 3,
+      spaceEnd: 6,
+      timeStart: 100,
+      timeEnd: 160,
+    };
+    const interpolatedRange = cutSpaceTimeRect(range, 4, 5);
+    expect(interpolatedRange).toEqual({
+      spaceStart: 4,
+      spaceEnd: 5,
+      timeStart: 120,
+      timeEnd: 140,
+    });
+  });
+});

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/utils.ts
@@ -1,0 +1,34 @@
+import type { LayerRangeData } from '../../../types';
+
+const cutSpaceTimeRect = (
+  range: LayerRangeData,
+  minSpace: number,
+  maxSpace: number
+): LayerRangeData | null => {
+  let { timeStart, timeEnd, spaceStart, spaceEnd } = range;
+
+  if (spaceEnd <= minSpace || spaceStart >= maxSpace) {
+    return null;
+  }
+
+  if (spaceStart < minSpace) {
+    const interpolationFactor = (minSpace - spaceStart) / (spaceEnd - spaceStart);
+    spaceStart = minSpace;
+    timeStart += (timeEnd - timeStart) * interpolationFactor;
+  }
+
+  if (spaceEnd > maxSpace) {
+    const interpolationFactor = (spaceEnd - maxSpace) / (spaceEnd - spaceStart);
+    spaceEnd = maxSpace;
+    timeEnd -= (timeEnd - timeStart) * interpolationFactor;
+  }
+
+  return {
+    spaceStart,
+    spaceEnd,
+    timeStart,
+    timeEnd,
+  };
+};
+
+export default cutSpaceTimeRect;

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -42,6 +42,13 @@ export type WaypointsPanelData = {
   projectionPath: TrainScheduleBase['path'];
 };
 
+export type LayerRangeData = {
+  spaceStart: number;
+  spaceEnd: number;
+  timeStart: number;
+  timeEnd: number;
+};
+
 export type AspectLabel =
   | 'VL'
   | '300VL'


### PR DESCRIPTION
Filter data from projected path (path and occupancy blocks) and conflicts when the first or last waypoint is hidden. Allow the space time chart to look as if it started/ended with the first/last displayed waypoint.

part of #8628 (see last comment of the issue)

before : 
![Capture d’écran 2024-10-29 à 16 46 57](https://github.com/user-attachments/assets/fb3c10dd-d820-4d43-b56e-a95701793416)

after : 
![Capture d’écran 2024-10-29 à 16 46 24](https://github.com/user-attachments/assets/4fd599a9-93c4-4e95-85c1-6c296e036ade)

To test : 
- Add at least 2 trains with only 1min difference for departure time
- With the waypoints panel, hide the first x waypoints and/or the last x waypoints