### PR TITLE
editoast: units comments and better variable name

### DIFF
--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -58,12 +58,16 @@ pub struct RollingStock {
     pub base_power_class: Option<String>,
     /// In m
     pub length: f64,
+    /// In m/s
     pub max_speed: f64,
     pub startup_time: f64,
+    /// In m/s²
     pub startup_acceleration: f64,
+    /// In m/s²
     pub comfort_acceleration: f64,
     pub gamma: Gamma,
     pub inertia_coefficient: f64,
+    /// In kg
     pub mass: f64,
     pub rolling_resistance: RollingResistance,
     pub loading_gauge: LoadingGaugeType,

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -147,10 +147,10 @@ impl PhysicsConsistParameters {
         if let (Some(towed_rolling_stock), Some(total_mass)) =
             (self.towed_rolling_stock.as_ref(), self.total_mass)
         {
-            let mass_carriage = total_mass - self.traction_engine.mass;
+            let towed_mass = total_mass - self.traction_engine.mass;
             let traction_engine_inertia =
                 self.traction_engine.mass * self.traction_engine.inertia_coefficient;
-            let towed_inertia = mass_carriage * towed_rolling_stock.inertia_coefficient;
+            let towed_inertia = towed_mass * towed_rolling_stock.inertia_coefficient;
             (traction_engine_inertia + towed_inertia) / total_mass
         } else {
             self.traction_engine.inertia_coefficient
@@ -178,15 +178,15 @@ impl PhysicsConsistParameters {
             let towed_rs_rr = &towed_rolling_stock.rolling_resistance;
             let traction_engine_mass = self.traction_engine.mass; // kg
 
-            let carriage_mass = total_mass - traction_engine_mass; // kg
+            let towed_mass = total_mass - traction_engine_mass; // kg
 
             let traction_engine_solid_friction_a = traction_engine_rr.A * 1000.0; // convert from kN to N
             let traction_engine_viscosity_friction_b = traction_engine_rr.B * 1000.0 * 3.6; // convert from kN/(km/h) to N/(m/s)
             let traction_engine_aerodynamic_drag_c = traction_engine_rr.C * 1000.0 * 3.6 * 3.6; // convert from kN/(km/h)² to N/(m/s)²
 
-            let towed_solid_friction_a = towed_rs_rr.A * 1e-2 * carriage_mass; // convert from daN/t to N
-            let towed_viscosity_friction_b = towed_rs_rr.B * 1e-2 * carriage_mass * 3.6; // convert from (daN/t)/(km/h) to N/(m/s)
-            let towed_aerodynamic_drag_c = towed_rs_rr.C * 1e-2 * carriage_mass * 3.6 * 3.6; // convert from (daN/t)/(km/h)² to N/(m/s)²
+            let towed_solid_friction_a = towed_rs_rr.A * 1e-2 * towed_mass; // convert from daN/t to N
+            let towed_viscosity_friction_b = towed_rs_rr.B * 1e-2 * towed_mass * 3.6; // convert from (daN/t)/(km/h) to N/(m/s)
+            let towed_aerodynamic_drag_c = towed_rs_rr.C * 1e-2 * towed_mass * 3.6 * 3.6; // convert from (daN/t)/(km/h)² to N/(m/s)²
 
             let solid_friction_a = traction_engine_solid_friction_a + towed_solid_friction_a;
             let viscosity_friction_b =

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -225,16 +225,16 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
     TowedRollingStock {
         name: "TOWED_ROLLING_STOCK".to_string(),
         label: "towed".to_string(),
-        mass: 50000.0,
-        length: 30.0, // m
-        comfort_acceleration: 0.2,
+        mass: 50000.0,             // kg
+        length: 30.0,              // m
+        comfort_acceleration: 0.2, // In m/s²
         startup_acceleration: 0.06,
         inertia_coefficient: 1.05,
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,
-            B: 0.01,
-            C: 0.0002,
+            A: 1.0,    // In kN
+            B: 0.01,   // In kN/(km/h)
+            C: 0.0002, // In kN/(km/h)²
         },
         gamma: Gamma {
             gamma_type: "CONST".to_string(),
@@ -250,9 +250,9 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         loading_gauge: LoadingGaugeType::G1,
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
-        comfort_acceleration: 0.1,
+        comfort_acceleration: 0.1, // In m/s²
         inertia_coefficient: 1.10,
-        startup_acceleration: 0.04,
+        startup_acceleration: 0.04, // In m/s²
         startup_time: 1.0,
         effort_curves: EffortCurves::default(),
         electrical_power_startup_time: None,
@@ -268,9 +268,9 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,
-            B: 0.01,
-            C: 0.0005,
+            A: 1.0,    // In kN
+            B: 0.01,   // In kN/(km/h)
+            C: 0.0005, // In kN/(km/h)²
         },
         length: 140.0,   // m
         mass: 15000.0,   // kg


### PR DESCRIPTION
fix #9528 

Some improvements for stdcm consist

- [x] Add units comments
- [x] Rename `carriage_mass` to `towed_mass` in stdcm consist
