### PR TITLE
Fix update pathfinding when changing rolling stock

### DIFF
--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -93,6 +93,8 @@ const ManageTrainSchedule = ({ trainIdToEdit }: ManageTrainScheduleProps) => {
       <RollingStockSelector
         rollingStockSelected={rollingStock}
         rollingStockComfort={rollingStockComfort}
+        pathProperties={pathProperties}
+        setPathProperties={setPathProperties}
       />
     ),
   };

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -98,7 +98,8 @@ const Itinerary = ({
   return (
     <div className="osrd-config-item">
       <div className="mb-2 d-flex">
-        <Pathfinding pathProperties={pathProperties} setPathProperties={setPathProperties} />
+        (
+        <Pathfinding pathProperties={pathProperties} setPathProperties={setPathProperties} />)
         <button
           type="button"
           className="btn btn-sm btn-only-icon btn-white px-3 ml-2"

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -307,7 +307,9 @@ export const usePathfinding = (
                   matchPathStepAndOp(step, suggestedOp)
                 );
 
-                const theoreticalMargin = i === 0 ? '0%' : step.theoreticalMargin;
+                const theoreticalMargin =
+                  i === 0 ? step.theoreticalMargin || '0%' : step.theoreticalMargin;
+
                 const stopFor = i === pathSteps.length - 1 && !step.stopFor ? '0' : step.stopFor;
                 const stopType =
                   i === pathSteps.length - 1 && !step.stopFor ? undefined : step.stopType;

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
@@ -2,9 +2,11 @@ import { useRef } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
+import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
 import icon from 'assets/pictures/components/train.svg';
 import type { Comfort, RollingStockWithLiveries } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
+import { usePathfinding } from 'modules/pathfinding/hooks/usePathfinding';
 import RollingStock2Img from 'modules/rollingStock/components/RollingStock2Img';
 import {
   comfort2pictogram,
@@ -17,6 +19,8 @@ type RollingStockProps = {
   rollingStockSelected?: RollingStockWithLiveries;
   rollingStockComfort: Comfort;
   image?: JSX.Element;
+  pathProperties?: ManageTrainSchedulePathProperties;
+  setPathProperties: (pathProperties?: ManageTrainSchedulePathProperties) => void;
 };
 
 const RollingStockSelector = ({
@@ -24,12 +28,16 @@ const RollingStockSelector = ({
   rollingStockSelected,
   rollingStockComfort,
   image,
+  pathProperties,
+  setPathProperties,
 }: RollingStockProps) => {
   const { openModal } = useModal();
 
   const ref2scroll = useRef<HTMLDivElement>(null);
 
   const { t } = useTranslation('rollingstock');
+
+  usePathfinding(setPathProperties, pathProperties);
 
   return (
     <div className="osrd-config-item mb-2">


### PR DESCRIPTION
close #8570 

For tested: 
  
  - Create a PF that is invalid due to constraints ( ex: PLY -> MSC with RS 2500V) incompatibilities will be displayed at the bottom of the map.
  - Change RS for thermic, back to the Itinerary tab the incompatibilities should no longer appear.