### PR TITLE
front: stdcm: linked train search improvements

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
@@ -33,16 +33,21 @@ const StdcmLinkedPathSearch = ({
 
   const {
     displaySearchButton,
-    hasSearchBeenLaunched,
     launchTrainScheduleSearch,
     linkedPathDate,
     linkedPathResults,
+    resetLinkedPathSearch,
     selectableSlot,
     setDisplaySearchButton,
     setLinkedPathDate,
     setTrainNameInput,
     trainNameInput,
   } = useLinkedPathSearch();
+
+  const removeLinkedPathCard = () => {
+    setShowLinkedPathSearch(false);
+    resetLinkedPathSearch();
+  };
 
   return (
     <div className={`stdcm-linked-path-search-container ${className}`}>
@@ -59,7 +64,7 @@ const StdcmLinkedPathSearch = ({
           disabled={disabled}
           name={cardName}
           title={
-            <button type="button" onClick={() => setShowLinkedPathSearch(false)}>
+            <button type="button" onClick={removeLinkedPathCard}>
               {t('translation:common.delete').toLowerCase()}
             </button>
           }
@@ -98,18 +103,17 @@ const StdcmLinkedPathSearch = ({
               {t('find')}
             </button>
           )}
-          {!displaySearchButton && !linkedPathResults.length && (
+          {!displaySearchButton && !linkedPathResults && (
             <div className="stdcm-linked-path-button white">
               <Gear size="lg" className="stdcm-linked-path-loading" />
             </div>
           )}
-          {linkedPathResults.length > 0 ? (
-            <StdcmLinkedPathResults linkedPathResults={linkedPathResults} linkedOp={linkedOp} />
-          ) : (
-            hasSearchBeenLaunched && (
+          {linkedPathResults &&
+            (linkedPathResults.length > 0 ? (
+              <StdcmLinkedPathResults linkedPathResults={linkedPathResults} linkedOp={linkedOp} />
+            ) : (
               <p className="text-center mb-0">{t('noCorrespondingResults')}</p>
-            )
-          )}
+            ))}
         </StdcmCard>
       )}
     </div>

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { DatePicker, Select, TimePicker, TolerancePicker } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
@@ -38,9 +38,7 @@ type StdcmOpScheduleProps = {
 
 const defaultDate = (date?: Date) => {
   const newDate = date ? new Date(date) : new Date();
-  newDate.setHours(0);
-  newDate.setMinutes(0);
-  newDate.setSeconds(0);
+  newDate.setHours(0, 0, 0);
   return newDate;
 };
 
@@ -63,13 +61,13 @@ const StdcmOpSchedule = ({
     useMemo(() => {
       const isArrivalDateValid =
         opTimingData?.arrivalDate &&
-        isArrivalDateInSearchTimeWindow(opTimingData.arrivalDate, searchDatetimeWindow);
+        isArrivalDateInSearchTimeWindow(new Date(opTimingData.arrivalDate), searchDatetimeWindow);
       return {
         arrivalDate:
           opTimingData && isArrivalDateValid
             ? new Date(opTimingData.arrivalDate)
             : defaultDate(searchDatetimeWindow?.begin),
-        arrivalTime: opTimingData?.arrivalTime || '--:--',
+        arrivalTime: opTimingData?.arrivalTime,
         arrivalTimeHours: opTimingData?.arrivalTimehours,
         arrivalTimeMinutes: opTimingData?.arrivalTimeMinutes,
         arrivalToleranceValues: {
@@ -100,6 +98,20 @@ const StdcmOpSchedule = ({
     }),
     [t, searchDatetimeWindow]
   );
+
+  useEffect(() => {
+    if (
+      (!isArrivalDateInSearchTimeWindow(arrivalDate, searchDatetimeWindow) ||
+        !opTimingData?.arrivalDate) &&
+      opScheduleTimeType === 'preciseTime'
+    ) {
+      onArrivalChange({
+        date: defaultDate(searchDatetimeWindow?.begin),
+        hours: arrivalTimeHours || 0,
+        minutes: arrivalTimeMinutes || 0,
+      });
+    }
+  }, [searchDatetimeWindow, opScheduleTimeType]);
 
   return (
     <>

--- a/front/src/applications/stdcm/utils/computeOpSchedules.ts
+++ b/front/src/applications/stdcm/utils/computeOpSchedules.ts
@@ -4,12 +4,26 @@ import {
   substractDurationToIsoDate,
 } from 'utils/date';
 
-const computeOpSchedules = (startTime: string, secondsFromStartTime: string) => {
+/**
+ * Computes the operation schedules for a given start time and duration.
+ *
+ * @param startTime - The ISO string representing the start time.
+ * @param msFromStartTime - The duration in milliseconds from the start time.
+ * @returns An object containing the origin and destination schedules.
+ *
+ * The function extracts the date and time from the provided ISO start time and calculates the destination arrival time
+ * by adding the specified duration. It then returns an object with the origin and destination schedules, including
+ * the date, time, and ISO arrival times.
+ *
+ * Note: A margin of 1800 seconds (30 minutes) is applied to the departure and arrival times to allow for necessary
+ * activities such as preparation for the next departure.
+ */
+const computeOpSchedules = (startTime: string, msFromStartTime: number) => {
   const { arrivalDate: originDate, arrivalTime: originTime } = extractDateAndTimefromISO(
     startTime,
     'DD/MM/YY'
   );
-  const destinationArrivalTime = addDurationToIsoDate(startTime, secondsFromStartTime);
+  const destinationArrivalTime = addDurationToIsoDate(startTime, msFromStartTime, 'millisecond');
   const { arrivalDate: destinationDate, arrivalTime: destinationTime } = extractDateAndTimefromISO(
     destinationArrivalTime,
     'DD/MM/YY'
@@ -19,12 +33,12 @@ const computeOpSchedules = (startTime: string, secondsFromStartTime: string) => 
     origin: {
       date: originDate,
       time: originTime,
-      isoArrivalTime: substractDurationToIsoDate(startTime, 'PT1800S'),
+      isoArrivalTime: substractDurationToIsoDate(startTime, 1800),
     },
     destination: {
       date: destinationDate,
       time: destinationTime,
-      isoArrivalTime: addDurationToIsoDate(destinationArrivalTime, 'PT1800S'),
+      isoArrivalTime: addDurationToIsoDate(destinationArrivalTime, 1800),
     },
   };
 };

--- a/front/src/utils/__tests__/date.spec.ts
+++ b/front/src/utils/__tests__/date.spec.ts
@@ -95,7 +95,7 @@ describe('extractDateAndTimefromISO', () => {
 
 describe('isArrivalDateInSearchTimeWindow', () => {
   it('should return true if searchDatetimeWindow is undefined', () => {
-    const result = isArrivalDateInSearchTimeWindow('2024-08-01T10:00:00Z', undefined);
+    const result = isArrivalDateInSearchTimeWindow(new Date('2024-08-01T10:00:00Z'), undefined);
     expect(result).toBe(true);
   });
 
@@ -104,7 +104,10 @@ describe('isArrivalDateInSearchTimeWindow', () => {
       begin: new Date('2024-08-01T00:00:00Z'),
       end: new Date('2024-08-02T00:00:00Z'),
     };
-    const result = isArrivalDateInSearchTimeWindow('2024-08-01T10:00:00Z', searchDatetimeWindow);
+    const result = isArrivalDateInSearchTimeWindow(
+      new Date('2024-08-01T10:00:00Z'),
+      searchDatetimeWindow
+    );
     expect(result).toBe(true);
   });
 
@@ -113,7 +116,10 @@ describe('isArrivalDateInSearchTimeWindow', () => {
       begin: new Date('2024-08-01T00:00:00Z'),
       end: new Date('2024-08-02T00:00:00Z'),
     };
-    const result = isArrivalDateInSearchTimeWindow('2024-07-30T23:59:59Z', searchDatetimeWindow);
+    const result = isArrivalDateInSearchTimeWindow(
+      new Date('2024-07-30T23:59:59Z'),
+      searchDatetimeWindow
+    );
     expect(result).toBe(false);
   });
 });

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import dayjs, { type ManipulateType } from 'dayjs';
 import 'dayjs/locale/fr';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import timezone from 'dayjs/plugin/timezone';
@@ -6,10 +6,8 @@ import utc from 'dayjs/plugin/utc';
 import i18next from 'i18next';
 
 import type { ScheduleConstraint } from 'applications/stdcm/types';
-import type { IsoDateTimeString, IsoDurationString } from 'common/types';
+import type { IsoDateTimeString } from 'common/types';
 import i18n from 'i18n';
-
-import { ISO8601Duration2sec } from './timeManipulation';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -151,16 +149,18 @@ export function convertIsoUtcToLocalTime(isoUtcString: IsoDateTimeString): strin
 
 export function addDurationToIsoDate(
   startTime: IsoDateTimeString,
-  duration: IsoDurationString
+  duration: number,
+  durationUnit: ManipulateType = 'second'
 ): IsoDateTimeString {
-  return dayjs(startTime).add(ISO8601Duration2sec(duration), 'second').format();
+  return dayjs(startTime).add(duration, durationUnit).format();
 }
 
 export function substractDurationToIsoDate(
   startTime: IsoDateTimeString,
-  duration: IsoDurationString
+  duration: number,
+  durationUnit: ManipulateType = 'second'
 ): IsoDateTimeString {
-  return dayjs(startTime).subtract(ISO8601Duration2sec(duration), 'second').format();
+  return dayjs(startTime).subtract(duration, durationUnit).format();
 }
 
 /**
@@ -191,18 +191,17 @@ export function extractDateAndTimefromISO(arrivalTime: string, dateFormat: strin
 /**
  * Checks if the given arrival date falls within the specified search time window.
  *
- * @param {string} arrivalTime - The arrival time as a string, which will be parsed into a Date object.
+ * @param {Date} arrivalDate - The arrival time, which is a Date object.
  * @param {{ begin: Date; end: Date } | undefined} searchDatetimeWindow - An object containing the start and end dates of the search window. If undefined, the function will return true.
  * @returns {boolean} - Returns true if the arrival date is within the search time window, or if the search time window is undefined. Returns false otherwise.
  */
 export function isArrivalDateInSearchTimeWindow(
-  arrivalTime: string,
+  arrivalDate: Date,
   searchDatetimeWindow?: { begin: Date; end: Date }
 ) {
   if (!searchDatetimeWindow) {
     return true;
   }
-  const arrivalDate = new Date(arrivalTime);
   return arrivalDate >= searchDatetimeWindow.begin && arrivalDate <= searchDatetimeWindow.end;
 }
 

--- a/front/tests/pages/stdcm-page-model.ts
+++ b/front/tests/pages/stdcm-page-model.ts
@@ -315,7 +315,7 @@ class STDCMPage {
     await expect(this.dynamicOriginCh).toHaveValue('BV');
     await expect(this.originArrival).toHaveValue('preciseTime');
     await expect(this.dateOriginArrival).toHaveValue('17/10/24');
-    await expect(this.timeOriginArrival).toHaveValue('');
+    await expect(this.timeOriginArrival).toHaveValue('00:00');
     await expect(this.toleranceOriginArrival).toHaveValue('-30/+30');
     await this.dynamicOriginCh.selectOption('BC');
     await this.originArrival.selectOption('respectDestinationSchedule');
@@ -340,7 +340,7 @@ class STDCMPage {
     await expect(this.toleranceDestinationArrival).not.toBeVisible();
     await this.destinationArrival.selectOption('preciseTime');
     await expect(this.dateDestinationArrival).toHaveValue('17/10/24');
-    await expect(this.timeDestinationArrival).toHaveValue('');
+    await expect(this.timeDestinationArrival).toHaveValue('00:00');
     await expect(this.toleranceDestinationArrival).toHaveValue('-30/+30');
     await this.dateDestinationArrival.fill('18/10/24');
     await this.timeDestinationArrival.click();


### PR DESCRIPTION
Closes #9618 
Closes #9619 
Partially closes #9545

- App no longer crashes when using the datePicker on debug mode.
- We now get the final arrival time using the summary endpoint.
- The op search payload has been adapted so that it can be searched by `obj_id` or by `uic` code and `ch` code.