### PR TITLE
core: disable colors when the output isn't compatible

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
     // the logging API stub
     implementation libs.slf4j
+    implementation libs.jansi
 
     // the logging API implementation
     implementation libs.logback.core

--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ mockito-junit-jupiter = { module = 'org.mockito:mockito-junit-jupiter', version.
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher', version = '1.11.+' } # EPL 2.0
 jcip-annotations = { module = 'net.jcip:jcip-annotations', version = '1.0' } # CC Attribution
 spotbugs-annotations = { module = 'com.github.spotbugs:spotbugs-annotations', version = '4.8.+' } # LGPLv2.1
+jansi = { module = 'org.fusesource.jansi:jansi', version = '2.4.+' } # Apache 2.0
 
 opentelemetry-api = { module = 'io.opentelemetry:opentelemetry-api', version.ref = 'otel' }
 opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations', version = '2.9.0' }

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -1,5 +1,6 @@
 <configuration>
     <appender name="COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
         <encoder>
             <pattern>[%date{"HH:mm:ss,SSS"}] %highlight(%-7([%level])) %23([%logger{0}]) %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
This should leave colors in a tty but remove them from datadog and such