### PR TITLE
editoast: add CLI to import towed rolling stock

### DIFF
--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -67,6 +67,7 @@ pub enum Commands {
     )]
     ElectricalProfiles(electrical_profiles_commands::ElectricalProfilesCommands),
     ImportRollingStock(ImportRollingStockArgs),
+    ImportTowedRollingStock(ImportRollingStockArgs),
     OsmToRailjson(OsmToRailjsonArgs),
     #[command(about, long_about = "Prints the OpenApi of the service")]
     Openapi,

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -169,6 +169,9 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
     match client.command {
         Commands::Runserver(args) => runserver(args, pg_config, valkey_config).await,
         Commands::ImportRollingStock(args) => import_rolling_stock(args, db_pool.into()).await,
+        Commands::ImportTowedRollingStock(args) => {
+            import_towed_rolling_stock(args, db_pool.into()).await
+        }
         Commands::OsmToRailjson(args) => {
             osm_to_railjson::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
         }

--- a/editoast/src/tests/example_towed_rolling_stock_1.json
+++ b/editoast/src/tests/example_towed_rolling_stock_1.json
@@ -1,0 +1,22 @@
+
+{
+    "name": "towed_rolling_stock",
+    "label": "some towed rolling stock",
+    "railjson_version": "3.2",
+    "locked": false,
+    "mass": 900000.0,
+    "length": 400.0,
+    "comfort_acceleration": 0.25,
+    "startup_acceleration": 0.05,
+    "inertia_coefficient": 1.05,
+    "rolling_resistance": {
+        "type": "davis",
+        "A": 5400,
+        "B": 200,
+        "C": 12
+    },
+    "gamma": {
+        "value": 0.5,
+        "type": "CONST"
+    }
+}


### PR DESCRIPTION
Closes #8668 

This new CLI brings a simple way to import Towed rolling stock in the DB from JSON files, without the need to start the `editoast` web service.