### PR TITLE
front: fix last waypoints hidden with warning

### DIFF
--- a/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
@@ -136,7 +136,11 @@ const WaypointsPanel = ({
         <div className="name">{t('simulation:waypointsPanel.name')}</div>
         <div className="secondary-code">{t('simulation:waypointsPanel.secondaryCode')}</div>
       </div>
-      <div className="waypoints-panel-body">
+      <div
+        className={cx('waypoints-panel-body', {
+          'with-warning': selectedWaypoints.size < 2,
+        })}
+      >
         <div className="waypoint-item selector-all">
           <Checkbox
             small

--- a/front/src/styles/scss/applications/operationalStudies/_waypointsPanel.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_waypointsPanel.scss
@@ -44,6 +44,10 @@
     padding-left: calc(1.125rem - 0.125rem); // 0.125rem > checkbox border
     overflow-y: scroll;
 
+    &.with-warning {
+      padding-bottom: 144px; // height + margin of the warning message
+    }
+
     .waypoint-item {
       height: 2.5rem;
       display: flex;


### PR DESCRIPTION
Add a padding-bottom to the waypoints panel body when the warning message is displayed, allowing the last waypoints from the manchette not to be hidden by it

fix last bug mentionned here https://github.com/OpenRailAssociation/osrd/issues/8628#issuecomment-2435259268

To display the warning message, there need to be less than 2 waypoints checked in the panel