### PR TITLE
core: allow LongString in the x-rpc-path header

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -2,10 +2,7 @@ package fr.sncf.osrd.cli
 
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
-import com.rabbitmq.client.AMQP
-import com.rabbitmq.client.Channel
-import com.rabbitmq.client.ConnectionFactory
-import com.rabbitmq.client.DeliverCallback
+import com.rabbitmq.client.*
 import fr.sncf.osrd.api.*
 import fr.sncf.osrd.api.api_v2.conflicts.ConflictDetectionEndpointV2
 import fr.sncf.osrd.api.api_v2.path_properties.PathPropEndpoint
@@ -154,7 +151,11 @@ class WorkerCommand : CliCommand {
                 val correlationId = message.properties.correlationId
                 val body = message.body
                 val path =
-                    (message.properties.headers["x-rpc-path"] as ByteArray?)?.decodeToString()
+                    if (message.properties.headers["x-rpc-path"] is LongString) {
+                        message.properties.headers["x-rpc-path"].toString()
+                    } else {
+                        (message.properties.headers["x-rpc-path"] as? ByteArray?)?.decodeToString()
+                    }
                 if (path == null) {
                     logger.error("missing x-rpc-path header")
                     channel.basicReject(message.envelope.deliveryTag, false)


### PR DESCRIPTION
The RabbitMQ management client doesn't allow us to set the headers as bytes, so we should be more lenient as to the received data type.