### PR TITLE
Fix x-remote-user usage

### DIFF
--- a/gateway/src/request_modifier.rs
+++ b/gateway/src/request_modifier.rs
@@ -2,18 +2,25 @@ use actix_auth::{AuthStatus, RequestAuth, RequestAuthExt};
 use actix_proxy::{ClientRequest, HeaderName, HeaderValue, WebsocketsRequest};
 use actix_web::error::ErrorForbidden;
 
-fn check_auth(request_auth: &RequestAuth) -> Result<String, actix_web::Error> {
+struct UserInformation {
+    identity: String,
+    name: String,
+}
+
+fn check_auth(request_auth: &RequestAuth) -> Result<UserInformation, actix_web::Error> {
     match request_auth.status() {
         AuthStatus::Unknown => Err(ErrorForbidden("authentication required")),
         AuthStatus::Error(_) => Err(ErrorForbidden("authentication error")),
         AuthStatus::Known {
             provider_handler,
             user_id,
-            ..
+            username,
         } => {
             let provider_id = request_auth.context().get_provider_id(*provider_handler);
-            let remote_user = format!("{provider_id}/{user_id}");
-            Ok(remote_user)
+            Ok(UserInformation {
+                identity: format!("{provider_id}/{user_id}"),
+                name: username.clone().unwrap_or_default(),
+            })
         }
     }
 }
@@ -21,7 +28,8 @@ fn check_auth(request_auth: &RequestAuth) -> Result<String, actix_web::Error> {
 #[derive(Clone)]
 pub struct ProxyAuthAdapter;
 
-static AUTH_USER_ID: HeaderName = HeaderName::from_static("x-remote-user");
+static AUTH_USER_ID: HeaderName = HeaderName::from_static("x-remote-user-identity");
+static AUTH_USER_NAME: HeaderName = HeaderName::from_static("x-remote-user-name");
 
 impl actix_proxy::RequestModifier for ProxyAuthAdapter {
     fn modify_http_request(
@@ -34,7 +42,15 @@ impl actix_proxy::RequestModifier for ProxyAuthAdapter {
         };
         let remote_user = check_auth(&request_auth)?;
         let headers = back_request.headers_mut();
-        headers.insert(AUTH_USER_ID.clone(), HeaderValue::from_str(&remote_user)?);
+        headers.insert(
+            AUTH_USER_ID.clone(),
+            HeaderValue::from_str(&remote_user.identity)?,
+        );
+        headers.insert(
+            AUTH_USER_NAME.clone(),
+            HeaderValue::from_str(&remote_user.name)?,
+        );
+
         Ok(())
     }
 
@@ -47,6 +63,8 @@ impl actix_proxy::RequestModifier for ProxyAuthAdapter {
             return Err(ErrorForbidden("missing authentication data"));
         };
         let remote_user = check_auth(&request_auth)?;
-        Ok(back_request.set_header(AUTH_USER_ID.clone(), remote_user))
+        Ok(back_request
+            .set_header(AUTH_USER_ID.clone(), remote_user.identity)
+            .set_header(AUTH_USER_NAME.clone(), remote_user.name))
     }
 }


### PR DESCRIPTION
- Editoast: stop splitting the provider and the identity id
- Gateway: provide the x-remote-name (match the design doc)