### PR TITLE
Isolate runserver CLI in client module and move AppState into views

### DIFF
--- a/editoast/editoast_osrdyne_client/src/lib.rs
+++ b/editoast/editoast_osrdyne_client/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use serde::Deserialize;
+use url::Url;
 
 #[cfg(any(test, feature = "mock_client"))]
 mod mock_client;
@@ -22,15 +23,13 @@ struct HTTPClient {
 }
 
 impl OsrdyneClient {
-    pub fn new(osrdyne_url: &str) -> Result<Self, url::ParseError> {
-        let client = HTTPClient {
-            client: reqwest::Client::new(),
-            base_url: url::Url::parse(osrdyne_url)?,
-        };
-        let client = OsrdyneClient {
-            inner: OsrdyneClientInternal::HTTPClient(client),
-        };
-        Ok(client)
+    pub fn new(osrdyne_url: Url) -> Self {
+        OsrdyneClient {
+            inner: OsrdyneClientInternal::HTTPClient(HTTPClient {
+                client: reqwest::Client::new(),
+                base_url: osrdyne_url,
+            }),
+        }
     }
 
     #[cfg(any(test, feature = "mock_client"))]

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4287,7 +4287,6 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorBatchTrainScheduleNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
-      - $ref: '#/components/schemas/EditoastValkeyConfigErrorUrl'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorNameAlreadyUsed'
       description: Generated error type for Editoast
       discriminator:
@@ -5683,30 +5682,6 @@ components:
           type: string
           enum:
           - editoast:train_schedule:NotFound
-    EditoastValkeyConfigErrorUrl:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - url
-          properties:
-            url:
-              type: string
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:valkey:Url
     EditoastWorkScheduleErrorNameAlreadyUsed:
       type: object
       required:

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -16,9 +16,9 @@ pub async fn healthcheck_cmd(
     valkey_config: ValkeyConfig,
     core_config: CoreArgs,
 ) -> anyhow::Result<()> {
-    let valkey = ValkeyClient::new(valkey_config).unwrap();
+    let valkey = ValkeyClient::new(valkey_config.into()).unwrap();
     let core_client = CoreClient::new_mq(mq_client::Options {
-        uri: core_config.mq_url,
+        uri: core_config.mq_url.to_string(),
         worker_pool_identifier: String::from("core"),
         timeout: core_config.core_timeout,
         single_worker: core_config.core_single_worker,

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use editoast_models::DbConnectionPoolV2;
+
+use crate::{
+    core::{mq_client, CoreClient},
+    views::check_health,
+    ValkeyClient,
+};
+
+use super::{CoreArgs, ValkeyConfig};
+
+pub async fn healthcheck_cmd(
+    db_pool: Arc<DbConnectionPoolV2>,
+    valkey_config: ValkeyConfig,
+    core_config: CoreArgs,
+) -> anyhow::Result<()> {
+    let valkey = ValkeyClient::new(valkey_config).unwrap();
+    let core_client = CoreClient::new_mq(mq_client::Options {
+        uri: core_config.mq_url,
+        worker_pool_identifier: String::from("core"),
+        timeout: core_config.core_timeout,
+        single_worker: core_config.core_single_worker,
+        num_channels: core_config.core_client_channels_size,
+    })
+    .await?;
+    check_health(db_pool, valkey.into(), core_client.into())
+        .await
+        .map_err(|e| anyhow!("❌ healthcheck failed: {e}"))?;
+    println!("✅ Healthcheck passed");
+    Ok(())
+}

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -18,7 +18,7 @@ pub async fn healthcheck_cmd(
 ) -> anyhow::Result<()> {
     let valkey = ValkeyClient::new(valkey_config.into()).unwrap();
     let core_client = CoreClient::new_mq(mq_client::Options {
-        uri: core_config.mq_url.to_string(),
+        uri: core_config.mq_url,
         worker_pool_identifier: String::from("core"),
         timeout: core_config.core_timeout,
         single_worker: core_config.core_single_worker,

--- a/editoast/src/client/healthcheck.rs
+++ b/editoast/src/client/healthcheck.rs
@@ -9,7 +9,7 @@ use crate::{
     ValkeyClient,
 };
 
-use super::{CoreArgs, ValkeyConfig};
+use super::{runserver::CoreArgs, ValkeyConfig};
 
 pub async fn healthcheck_cmd(
     db_pool: Arc<DbConnectionPoolV2>,

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -210,7 +210,7 @@ async fn build_valkey_pool_and_invalidate_all_cache(
     valkey_config: ValkeyConfig,
     infra_id: i64,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let valkey = ValkeyClient::new(valkey_config).unwrap();
+    let valkey = ValkeyClient::new(valkey_config.into()).unwrap();
     let mut conn = valkey.get_connection().await.unwrap();
     Ok(map::invalidate_all(
         &mut conn,

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -214,7 +214,7 @@ async fn build_valkey_pool_and_invalidate_all_cache(
     let mut conn = valkey.get_connection().await.unwrap();
     Ok(map::invalidate_all(
         &mut conn,
-        &MapLayers::parse().layers.keys().cloned().collect(),
+        &MapLayers::default().layers.keys().cloned().collect(),
         infra_id,
     )
     .await

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -97,10 +97,6 @@ pub struct MapLayersConfig {
     #[derivative(Default(value = "18"))]
     #[arg(long, env, default_value_t = 18)]
     pub max_zoom: u64,
-    /// Number maximum of tiles before we consider invalidating full Valkey cache is required
-    #[derivative(Default(value = "250_000"))]
-    #[arg(long, env, default_value_t = 250_000)]
-    pub max_tiles: u64,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -32,6 +32,7 @@ use url::Url;
 pub use valkey_config::ValkeyConfig;
 
 use crate::error::Result;
+use crate::views::OpenApiRoot;
 
 #[derive(Parser, Debug)]
 #[command(author, version)]
@@ -150,6 +151,12 @@ pub struct OsmToRailjsonArgs {
     pub osm_pbf_in: PathBuf,
     /// Output file in Railjson format
     pub railjson_out: PathBuf,
+}
+
+/// Prints the OpenApi to stdout
+pub fn print_openapi() {
+    let openapi = OpenApiRoot::build_openapi();
+    print!("{}", serde_yaml::to_string(&openapi).unwrap());
 }
 
 /// Retrieve the ROOT_URL env var. If not found returns default local url.

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -106,8 +106,8 @@ pub struct MapLayersConfig {
 #[derive(Args, Debug)]
 #[command(about, long_about = "Launch the server")]
 pub struct CoreArgs {
-    #[clap(long, env = "OSRD_MQ_URL", default_value_t = String::from("amqp://osrd:password@127.0.0.1:5672/%2f"))]
-    pub mq_url: String,
+    #[clap(long, env = "OSRD_MQ_URL", default_value_t = Url::parse("amqp://osrd:password@127.0.0.1:5672/%2f").unwrap())]
+    pub mq_url: Url,
     #[clap(long, env = "EDITOAST_CORE_TIMEOUT", default_value_t = 180)]
     pub core_timeout: u64,
     #[clap(long, env = "EDITOAST_CORE_SINGLE_WORKER", default_value_t = false)]
@@ -138,8 +138,8 @@ pub struct RunserverArgs {
     // only recieve 401 responses.
     #[clap(long, env = "EDITOAST_DISABLE_AUTHORIZATION", default_value_t = true)]
     pub disable_authorization: bool,
-    #[clap(long, env = "OSRDYNE_API_URL", default_value_t = String::from("http://127.0.0.1:4242/"))]
-    pub osrdyne_api_url: String,
+    #[clap(long, env = "OSRDYNE_API_URL", default_value_t = Url::parse("http://127.0.0.1:4242/").unwrap())]
+    pub osrdyne_api_url: Url,
     /// The timeout to use when performing the healthcheck, in milliseconds
     #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 500)]
     pub health_check_timeout_ms: u64,

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -127,10 +127,6 @@ pub struct RunserverArgs {
     pub address: String,
     #[command(flatten)]
     pub core: CoreArgs,
-    #[clap(long, env = "ROOT_PATH", default_value_t = String::new())]
-    pub root_path: String,
-    #[clap(long)]
-    pub workers: Option<usize>,
     /// If this option is set, any role and permission check will be bypassed. Even if no user is
     /// provided by the request headers of if the provided user doesn't have the required privileges.
     // TODO: once the whole role system will be deployed, the default value of this option should

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -4,6 +4,7 @@ pub mod import_rolling_stock;
 pub mod infra_commands;
 mod postgres_config;
 pub mod roles;
+pub mod runserver;
 pub mod search_commands;
 pub mod stdcm_search_env_commands;
 mod telemetry_config;
@@ -23,6 +24,8 @@ use import_rolling_stock::ImportRollingStockArgs;
 use infra_commands::InfraCommands;
 pub use postgres_config::PostgresConfig;
 use roles::RolesCommand;
+use runserver::CoreArgs;
+use runserver::RunserverArgs;
 use search_commands::SearchCommands;
 use stdcm_search_env_commands::StdcmSearchEnvCommands;
 pub use telemetry_config::TelemetryConfig;
@@ -89,52 +92,6 @@ pub enum Commands {
     Roles(RolesCommand),
     #[command(about, long_about = "Healthcheck")]
     Healthcheck(CoreArgs),
-}
-
-#[derive(Args, Debug, Derivative, Clone)]
-#[derivative(Default)]
-pub struct MapLayersConfig {
-    #[derivative(Default(value = "18"))]
-    #[arg(long, env, default_value_t = 18)]
-    pub max_zoom: u64,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Launch the server")]
-pub struct CoreArgs {
-    #[clap(long, env = "OSRD_MQ_URL", default_value_t = Url::parse("amqp://osrd:password@127.0.0.1:5672/%2f").unwrap())]
-    pub mq_url: Url,
-    #[clap(long, env = "EDITOAST_CORE_TIMEOUT", default_value_t = 180)]
-    pub core_timeout: u64,
-    #[clap(long, env = "EDITOAST_CORE_SINGLE_WORKER", default_value_t = false)]
-    pub core_single_worker: bool,
-    #[clap(long, env = "CORE_CLIENT_CHANNELS_SIZE", default_value_t = 8)]
-    pub core_client_channels_size: usize,
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Launch the server")]
-pub struct RunserverArgs {
-    #[command(flatten)]
-    pub map_layers_config: MapLayersConfig,
-    #[arg(long, env = "EDITOAST_PORT", default_value_t = 8090)]
-    pub port: u16,
-    #[arg(long, env = "EDITOAST_ADDRESS", default_value_t = String::from("0.0.0.0"))]
-    pub address: String,
-    #[command(flatten)]
-    pub core: CoreArgs,
-    /// If this option is set, any role and permission check will be bypassed. Even if no user is
-    /// provided by the request headers of if the provided user doesn't have the required privileges.
-    // TODO: once the whole role system will be deployed, the default value of this option should
-    // be set to false. It's currently set to true in order to pass integration tests, which otherwise
-    // only recieve 401 responses.
-    #[clap(long, env = "EDITOAST_DISABLE_AUTHORIZATION", default_value_t = true)]
-    pub disable_authorization: bool,
-    #[clap(long, env = "OSRDYNE_API_URL", default_value_t = Url::parse("http://127.0.0.1:4242/").unwrap())]
-    pub osrdyne_api_url: Url,
-    /// The timeout to use when performing the healthcheck, in milliseconds
-    #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 500)]
-    pub health_check_timeout_ms: u64,
 }
 
 #[derive(Args, Debug)]

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod electrical_profiles_commands;
+pub mod healthcheck;
 pub mod import_rolling_stock;
 pub mod infra_commands;
 mod postgres_config;

--- a/editoast/src/client/postgres_config.rs
+++ b/editoast/src/client/postgres_config.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use derivative::Derivative;
 use url::Url;
 
-use crate::error::Result;
+use crate::views;
 
 #[derive(Args, Debug, Derivative, Clone)]
 #[derivative(Default)]
@@ -21,8 +21,16 @@ pub struct PostgresConfig {
     pub pool_size: usize,
 }
 
-impl PostgresConfig {
-    pub fn url(&self) -> Result<Url> {
-        Ok(self.database_url.clone())
+impl From<PostgresConfig> for views::PostgresConfig {
+    fn from(
+        PostgresConfig {
+            database_url,
+            pool_size,
+        }: PostgresConfig,
+    ) -> Self {
+        views::PostgresConfig {
+            database_url,
+            pool_size,
+        }
     }
 }

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -1,0 +1,94 @@
+use chrono::Duration;
+use clap::Args;
+use url::Url;
+
+use crate::views;
+
+use super::{PostgresConfig, ValkeyConfig};
+
+#[derive(Args, Debug, Clone)]
+struct MapLayersConfig {
+    #[arg(long, env, default_value_t = 18)]
+    max_zoom: u64,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Launch the server")]
+pub struct CoreArgs {
+    #[clap(long, env = "OSRD_MQ_URL", default_value_t = Url::parse("amqp://osrd:password@127.0.0.1:5672/%2f").unwrap())]
+    pub(super) mq_url: Url,
+    #[clap(long, env = "EDITOAST_CORE_TIMEOUT", default_value_t = 180)]
+    pub(super) core_timeout: u64,
+    #[clap(long, env = "EDITOAST_CORE_SINGLE_WORKER", default_value_t = false)]
+    pub(super) core_single_worker: bool,
+    #[clap(long, env = "CORE_CLIENT_CHANNELS_SIZE", default_value_t = 8)]
+    pub(super) core_client_channels_size: usize,
+}
+
+#[derive(Args, Debug)]
+#[command(about, long_about = "Launch the server")]
+pub struct RunserverArgs {
+    #[command(flatten)]
+    map_layers_config: MapLayersConfig,
+    #[arg(long, env = "EDITOAST_PORT", default_value_t = 8090)]
+    port: u16,
+    #[arg(long, env = "EDITOAST_ADDRESS", default_value_t = String::from("0.0.0.0"))]
+    address: String,
+    #[command(flatten)]
+    core: CoreArgs,
+    /// If this option is set, any role and permission check will be bypassed. Even if no user is
+    /// provided by the request headers of if the provided user doesn't have the required privileges.
+    // TODO: once the whole role system will be deployed, the default value of this option should
+    // be set to false. It's currently set to true in order to pass integration tests, which otherwise
+    // only recieve 401 responses.
+    #[clap(long, env = "EDITOAST_DISABLE_AUTHORIZATION", default_value_t = true)]
+    disable_authorization: bool,
+    #[clap(long, env = "OSRDYNE_API_URL", default_value_t = Url::parse("http://127.0.0.1:4242/").unwrap())]
+    osrdyne_api_url: Url,
+    /// The timeout to use when performing the healthcheck, in milliseconds
+    #[clap(long, env = "EDITOAST_HEALTH_CHECK_TIMEOUT_MS", default_value_t = 500)]
+    health_check_timeout_ms: u64,
+}
+
+/// Create and run the server
+pub async fn runserver(
+    RunserverArgs {
+        map_layers_config,
+        port,
+        address,
+        core:
+            CoreArgs {
+                mq_url,
+                core_timeout,
+                core_single_worker,
+                core_client_channels_size,
+            },
+        disable_authorization,
+        osrdyne_api_url,
+        health_check_timeout_ms,
+    }: RunserverArgs,
+    postgres: PostgresConfig,
+    valkey: ValkeyConfig,
+) -> anyhow::Result<()> {
+    let config = views::ServerConfig {
+        port,
+        address,
+        health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
+        map_layers_max_zoom: map_layers_config.max_zoom as u8,
+        disable_authorization,
+        postgres_config: postgres.into(),
+        osrdyne_config: views::OsrdyneConfig {
+            mq_url,
+            osrdyne_api_url,
+            core: views::CoreConfig {
+                timeout: Duration::seconds(core_timeout as i64),
+                single_worker: core_single_worker,
+                num_channels: core_client_channels_size,
+            },
+        },
+        valkey_config: valkey.into(),
+    };
+
+    let server = views::Server::new(config).await?;
+    server.start().await.map_err(Into::into)
+}

--- a/editoast/src/core/mq_client.rs
+++ b/editoast/src/core/mq_client.rs
@@ -17,6 +17,7 @@ use tokio::{
     task,
     time::{timeout, Duration},
 };
+use url::Url;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -151,7 +152,7 @@ impl ChannelWorker {
 pub struct Options {
     /// format `amqp://username:password@host:port/vhost`
     /// for instance: `amqp://osrd:password@localhost:5672/%2f` for the default vhost
-    pub uri: String,
+    pub uri: Url,
     /// Exchange name
     pub worker_pool_identifier: String,
     /// Default timeout for the response
@@ -265,7 +266,7 @@ impl RabbitMQClient {
     }
 
     async fn connection_loop(
-        uri: String,
+        uri: Url,
         hostname: String,
         connection: Arc<RwLock<Option<Connection>>>,
     ) {
@@ -279,7 +280,7 @@ impl RabbitMQClient {
 
             // Connection should be re-established
             let new_connection = Connection::connect(
-                &uri,
+                uri.as_str(),
                 ConnectionProperties::default().with_connection_name(hostname.clone().into()),
             )
             .await;

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -237,8 +237,6 @@ async fn runserver(
                 core_single_worker,
                 core_client_channels_size,
             },
-        root_path,
-        workers,
         disable_authorization,
         osrdyne_api_url,
         health_check_timeout_ms,
@@ -251,8 +249,6 @@ async fn runserver(
         address,
         health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
         map_layers_config,
-        root_path,
-        workers,
         disable_authorization,
         postgres_config: postgres.into(),
         osrdyne_config: views::OsrdyneConfig {

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -248,7 +248,7 @@ async fn runserver(
         port,
         address,
         health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
-        map_layers_config,
+        map_layers_max_zoom: map_layers_config.max_zoom as u8,
         disable_authorization,
         postgres_config: postgres.into(),
         osrdyne_config: views::OsrdyneConfig {

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -12,7 +12,6 @@ mod valkey_utils;
 mod views;
 
 use crate::core::CoreClient;
-use crate::views::OpenApiRoot;
 use axum::extract::DefaultBodyLimit;
 use axum::extract::FromRef;
 use axum::{Router, ServiceExt};
@@ -21,6 +20,7 @@ use clap::Parser;
 use client::electrical_profiles_commands::*;
 use client::import_rolling_stock::*;
 use client::infra_commands::*;
+use client::print_openapi;
 use client::roles;
 use client::roles::RolesCommand;
 use client::search_commands::*;
@@ -176,7 +176,7 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
             osm_to_railjson::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
         }
         Commands::Openapi => {
-            generate_openapi();
+            print_openapi();
             Ok(())
         }
         Commands::ElectricalProfiles(subcommand) => match subcommand {
@@ -394,12 +394,6 @@ async fn runserver(
     let listener = tokio::net::TcpListener::bind((args.address.clone(), args.port)).await?;
     axum::serve(listener, service).await.expect("unreachable");
     Ok(())
-}
-
-/// Prints the OpenApi to stdout
-fn generate_openapi() {
-    let openapi = OpenApiRoot::build_openapi();
-    print!("{}", serde_yaml::to_string(&openapi).unwrap());
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/editoast/src/map/layers.rs
+++ b/editoast/src/map/layers.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use serde::Deserialize;
-use serde::Serialize;
 
 // select C.stuff from A inner join B C on C.id = C.id;
 //                       \___________________________/
@@ -10,7 +9,7 @@ use serde::Serialize;
 type JoinExpr = String;
 
 /// Layer view description
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Debug, Deserialize)]
 pub struct View {
     pub on_field: String,
     pub data_expr: String,
@@ -23,7 +22,7 @@ pub struct View {
 }
 
 /// Layer description
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Debug, Deserialize)]
 pub struct Layer {
     pub table_name: String,
     pub views: HashMap<String, View>,
@@ -33,14 +32,20 @@ pub struct Layer {
     pub attribution: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Debug, Deserialize)]
 pub struct MapLayers {
     pub layers: HashMap<String, Layer>,
 }
 
 impl MapLayers {
-    /// Parses file containing layers' description into MapLayers struct
-    pub fn parse() -> MapLayers {
-        serde_yaml::from_str(include_str!("../../map_layers.yml")).unwrap()
+    pub fn new(layers: HashMap<String, Layer>) -> Self {
+        Self { layers }
+    }
+}
+
+impl Default for MapLayers {
+    fn default() -> Self {
+        serde_yaml::from_str(include_str!("../../map_layers.yml"))
+            .expect("static data should be valid")
     }
 }

--- a/editoast/src/models/layers/geo_json_and_data.rs
+++ b/editoast/src/models/layers/geo_json_and_data.rs
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_query_creation() {
-        let map_layers = MapLayers::parse();
+        let map_layers = MapLayers::default();
         let expected_queries = [
         "
         WITH bbox AS (

--- a/editoast/src/valkey_utils.rs
+++ b/editoast/src/valkey_utils.rs
@@ -155,7 +155,7 @@ impl ValkeyConnection {
             Err(_) => {
                 return Err(RedisError::from((
                     ErrorKind::IoError,
-                    "An error occured serializing to json",
+                    "An error occurred serializing to json",
                 ))
                 .into())
             }
@@ -182,7 +182,7 @@ impl ValkeyConnection {
                     .map_err(|_| {
                         RedisError::from((
                             ErrorKind::IoError,
-                            "An error occured serializing to json",
+                            "An error occurred serializing to json",
                         ))
                         .into()
                     })

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -113,9 +113,7 @@ struct ViewMetadata {
 )]
 async fn layer_view(
     State(AppState {
-        map_layers,
-        map_layers_config,
-        ..
+        map_layers, config, ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path((layer_slug, view_slug)): Path<(String, String)>,
@@ -155,7 +153,7 @@ async fn layer_view(
         tiles: vec![tiles_url_pattern],
         attribution: layer.attribution.clone().unwrap_or_default(),
         minzoom: 5,
-        maxzoom: map_layers_config.max_zoom,
+        maxzoom: config.map_layers_max_zoom as u64,
     }))
 }
 
@@ -282,7 +280,7 @@ mod tests {
 
     #[rstest]
     async fn layer_view_ko() {
-        let map_layers = MapLayers::parse();
+        let map_layers = MapLayers::default();
         let error: InternalError =
             LayersError::new_view_not_found("does_not_exist", &map_layers.layers["track_sections"])
                 .into();

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -68,7 +68,6 @@ use url::Url;
 use utoipa::ToSchema;
 
 use crate::client::get_app_version;
-use crate::client::MapLayersConfig;
 use crate::core::mq_client;
 use crate::core::version::CoreVersionRequest;
 use crate::core::AsCoreRequest;
@@ -365,7 +364,7 @@ pub struct ServerConfig {
     pub port: u16,
     pub address: String,
     pub health_check_timeout: Duration,
-    pub map_layers_config: MapLayersConfig,
+    pub map_layers_max_zoom: u8,
     pub disable_authorization: bool,
 
     pub postgres_config: PostgresConfig,
@@ -390,7 +389,6 @@ pub struct AppState {
     pub valkey: Arc<ValkeyClient>,
     pub infra_caches: Arc<DashMap<i64, InfraCache>>,
     pub map_layers: Arc<MapLayers>,
-    pub map_layers_config: Arc<MapLayersConfig>,
     pub speed_limit_tag_ids: Arc<SpeedLimitTagIds>,
     pub disable_authorization: bool,
     pub core_client: Arc<CoreClient>,
@@ -456,8 +454,7 @@ impl AppState {
             infra_caches,
             core_client,
             osrdyne_client,
-            map_layers: Arc::new(MapLayers::parse()),
-            map_layers_config: Arc::new(config.map_layers_config.clone()),
+            map_layers: Arc::new(MapLayers::default()),
             speed_limit_tag_ids,
             disable_authorization: config.disable_authorization,
             health_check_timeout: config.health_check_timeout,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -366,8 +366,6 @@ pub struct ServerConfig {
     pub address: String,
     pub health_check_timeout: Duration,
     pub map_layers_config: MapLayersConfig,
-    pub root_path: String,
-    pub workers: Option<usize>,
     pub disable_authorization: bool,
 
     pub postgres_config: PostgresConfig,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -434,7 +434,7 @@ impl AppState {
                 num_channels,
             } = config.osrdyne_config.core.clone();
             let options = mq_client::Options {
-                uri: config.osrdyne_config.mq_url.to_string(),
+                uri: config.osrdyne_config.mq_url.clone(),
                 worker_pool_identifier: "core".to_owned(),
                 timeout: timeout.num_seconds() as u64,
                 single_worker,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -15,7 +15,6 @@ use tower_http::trace::TraceLayer;
 use url::Url;
 
 use crate::{
-    client::MapLayersConfig,
     core::{mocking::MockingClient, CoreClient},
     generated_data::speed_limit_tags_config::SpeedLimitTagIds,
     infra_cache::InfraCache,
@@ -88,8 +87,8 @@ impl TestAppBuilder {
             port: 0,
             address: String::default(),
             health_check_timeout: chrono::Duration::milliseconds(500),
-            map_layers_config: MapLayersConfig::default().into(),
             disable_authorization: true,
+            map_layers_max_zoom: 18,
             postgres_config: PostgresConfig {
                 database_url: Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap(),
                 pool_size: 32,
@@ -170,8 +169,7 @@ impl TestAppBuilder {
             osrdyne_client,
             valkey,
             infra_caches,
-            map_layers: MapLayers::parse().into(),
-            map_layers_config: Arc::new(config.map_layers_config.clone()),
+            map_layers: Arc::new(MapLayers::default()),
             speed_limit_tag_ids,
             disable_authorization: true,
             health_check_timeout: config.health_check_timeout,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -89,8 +89,6 @@ impl TestAppBuilder {
             address: String::default(),
             health_check_timeout: chrono::Duration::milliseconds(500),
             map_layers_config: MapLayersConfig::default().into(),
-            root_path: String::default(),
-            workers: None,
             disable_authorization: true,
             postgres_config: PostgresConfig {
                 database_url: Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap(),


### PR DESCRIPTION
Follow up of #9349

Moves in the `client` module the following commands:

- health check
- openapi generation
- runserver

Reaching a proper split (import wise) of the run server command required a bit of refactoring. We want `client` to depend of `views`, and not the other way around. So we cannot use `client` definitions anywhere in `views`.

What's done to achieve that:

- Introduce a `ServerConfig` structure that aggregates all server parameters.
- Move `AppState` into `views` (still re-exported at crate-level, for now at least)
- Add the config to the state.
- Get rid of most occurrences of `client` definitions usage outside of the module. `MapLayerConfig` has been removed from the state, `ValkeyConfig` moved in `mod valkey_utils`, `PostgresConfig` and `CoreConfig` duplicated in `mod views`.

What's been done simultaneously:

- Use the type `url::Url` instead of `String` where it makes sense 
- Remove unused CLI parameters
- Remove useless `Default` implementations in `client`
- Restrict `client` structs visibility where possible.

# Next steps

1. Move the big `match` in the `run` function in the `client` module
2. Expose `ROOT-URL` and `DYNAMIC_ASSET_PATH` in `clap` and remove their accessor functions from `client`
3. Move `get_app_version` in `editoast_common`
4. Move `valkey_utils` in `editoast_common` (wdyt?)
5. Remove `db_pool_v1` from the `AppState`
7. Replace most `return Box::new(CliError::new(...` by `anyhow::bail!` since `anyhow`'s paradigm fits perfectly our error management on the `client` side
8. Use the `AppState.config.disable_authorization` and remove `AppState.disable_authorization`
9. The `editoast_client` crate is ready to be split!

(Some of these points could be included in the current PR, but I figured it's big enough already...)