### PR TITLE
github: add e2e tests maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,9 @@
 /chartos                                                 @openrailassociation/OSRD-Editoast
 /python                                                  @openrailassociation/OSRD-Editoast
 
+# --- E2E TESTS  ---
+/front/tests                                             @openrailassociation/OSRD-E2E-Tests
+
 # --- INTEGRATION TESTS  ---
 /tests                                                   @openrailassociation/OSRD-Tests
 


### PR DESCRIPTION
Need to wait for https://github.com/OpenRailAssociation/openrail-org-config/pull/34