### PR TITLE
core: add context to logged exceptions

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/OSRDError.java
@@ -470,7 +470,8 @@ public final class OSRDError extends RuntimeException {
      */
     @Override
     public String getMessage() {
-        return message;
+        if (context.isEmpty()) return message;
+        else return String.format("%s, context=%s", message, context);
     }
 
     /** The JSON adapter for serializing and deserializing OSRDError instances. */


### PR DESCRIPTION
I just found myself seeing an exception in core logs, and I *really* wanted to read the included context