### PR TITLE
front: fix stdcm conflicts not being properly displayed

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -42,17 +42,14 @@ const useStdcmResults = (
     [selectedTrainId, stdcmTrainResult, otherSelectedTrainSchedule]
   );
 
-  const {
-    path: pathFinding,
-    simulation,
-    departure_time: departureTime,
-  } = stdcmResponse?.status === 'success'
-    ? stdcmResponse
-    : { path: undefined, simulation: undefined, departure_time: undefined };
+  const { simulation, departure_time: departureTime } =
+    stdcmResponse?.status === 'success'
+      ? stdcmResponse
+      : { simulation: undefined, departure_time: undefined };
 
   const speedSpaceChartData = useSpeedSpaceChart(
     stdcmTrainResult,
-    pathFinding,
+    stdcmResponse?.path,
     simulation,
     departureTime
   );
@@ -90,8 +87,8 @@ const useStdcmResults = (
       }
     };
 
-    if (infraId && stdcmResponse && pathFinding) {
-      getPathProperties(infraId, pathFinding);
+    if (infraId && stdcmResponse && stdcmResponse?.path) {
+      getPathProperties(infraId, stdcmResponse.path);
     }
   }, [stdcmResponse]);
 


### PR DESCRIPTION
The display of stdcm results is depending on the presence of path propertie coming from the stdcm response path. PathProperties was saved only if the stdcm response was success, not with conflicts status.

fix #9628  