### PR TITLE
front: stdcm: fix time interpolation in output table

### DIFF
--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -1,4 +1,5 @@
 import type { SimulationResponse } from 'common/api/osrdEditoastApi';
+import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 
 import type { StdcmResultsOperationalPointsList } from '../types';
@@ -76,8 +77,15 @@ function getTimeAtPosition(
   trainDepartureHour: number,
   trainDepartureMinute: number
 ): string {
-  const index = trainPositions.findIndex((pos) => pos >= trainPosition);
-  const timeInMillis = trainTimes[index];
+  const timeInMillis = interpolateValue(
+    {
+      positions: trainPositions,
+      speeds: [],
+      times: trainTimes,
+    },
+    trainPosition,
+    'times'
+  );
   const timeInMinutes = Math.round(timeInMillis / 60000);
   return addMinutesToTime(trainDepartureHour, trainDepartureMinute, timeInMinutes);
 }


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/9626

The back-end returns sparse data for time per position and expects the front-end to interpolate, but we didn't. The results were significantly off.

This fixes both the table displayed in the result page and the one in the pdf file.