### PR TITLE
editoast: rename all test modules to follow rust idiom

### DIFF
--- a/editoast/editoast_derive/src/search.rs
+++ b/editoast/editoast_derive/src/search.rs
@@ -362,7 +362,7 @@ pub fn expand_store(input: &DeriveInput) -> Result<TokenStream> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use darling::FromDeriveInput;
     use pretty_assertions::assert_eq;
 

--- a/editoast/editoast_osrdyne_client/src/lib.rs
+++ b/editoast/editoast_osrdyne_client/src/lib.rs
@@ -171,7 +171,7 @@ impl HTTPClient {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[tokio::test]

--- a/editoast/editoast_schemas/src/infra/operational_point.rs
+++ b/editoast/editoast_schemas/src/infra/operational_point.rs
@@ -108,7 +108,7 @@ impl OperationalPoint {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use serde_json::from_str;
 
     use super::OperationalPointExtensions;

--- a/editoast/editoast_schemas/src/infra/signal.rs
+++ b/editoast/editoast_schemas/src/infra/signal.rs
@@ -88,7 +88,7 @@ impl OSRDIdentified for Signal {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use serde_json::from_str;
 
     use super::SignalExtensions;

--- a/editoast/editoast_schemas/src/infra/speed_section.rs
+++ b/editoast/editoast_schemas/src/infra/speed_section.rs
@@ -99,7 +99,7 @@ impl OSRDIdentified for SpeedSection {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use serde_json::from_str;
     use serde_json::from_value;
     use serde_json::json;

--- a/editoast/editoast_schemas/src/infra/track_section.rs
+++ b/editoast/editoast_schemas/src/infra/track_section.rs
@@ -65,7 +65,7 @@ impl TrackSection {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use geojson;
     use serde_json::from_str;
 

--- a/editoast/editoast_search/src/sqlquery.rs
+++ b/editoast/editoast_search/src/sqlquery.rs
@@ -169,7 +169,7 @@ fn value_to_sql(value: &TypedAst, string_bindings: &mut Vec<String>) -> String {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use super::SqlQuery;
     use crate::context::TypedAst;

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -362,7 +362,7 @@ impl From<reqwest::Error> for CoreError {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use reqwest::Method;

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -429,7 +429,7 @@ impl GeneratedData for ErrorLayer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use rstest::rstest;
 
     use super::buffer_stops;

--- a/editoast/src/generated_data/utils.rs
+++ b/editoast/src/generated_data/utils.rs
@@ -59,7 +59,7 @@ impl<'a> InvolvedObjects<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::HashSet;
 
     use super::InvolvedObjects;

--- a/editoast/src/infra_cache/object_cache/route_cache.rs
+++ b/editoast/src/infra_cache/object_cache/route_cache.rs
@@ -15,7 +15,7 @@ impl Cache for Route {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
 
     use crate::infra_cache::tests::create_small_infra_cache;
     use crate::infra_cache::Graph;

--- a/editoast/src/models/projects.rs
+++ b/editoast/src/models/projects.rs
@@ -117,7 +117,7 @@ impl Project {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -61,7 +61,7 @@ impl StdcmSearchEnvironmentChangeset {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;
     use rstest::rstest;

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -73,7 +73,7 @@ fn dates_in_order(a: Option<Option<NaiveDate>>, b: Option<Option<NaiveDate>>) ->
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -82,7 +82,7 @@ async fn get_line_bbox(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use axum::http::StatusCode;
     use editoast_schemas::infra::TrackSectionSncfExtension;
     use editoast_schemas::primitives::Identifier;

--- a/editoast/src/views/projects.rs
+++ b/editoast/src/views/projects.rs
@@ -357,7 +357,7 @@ async fn patch(
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -761,7 +761,7 @@ pub(super) struct SearchResultItemTrainSchedule {
 pub struct SearchConfigFinder;
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
 
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -155,14 +155,14 @@ async fn retrieve_latest(
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use axum::http::StatusCode;
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
     use super::*;
-    use crate::models::stdcm_search_environment::test::stdcm_search_env_fixtures;
+    use crate::models::stdcm_search_environment::tests::stdcm_search_env_fixtures;
     use crate::views::test_app::TestAppBuilder;
     use crate::{Create, Retrieve};
 

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -441,7 +441,7 @@ async fn list(
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use axum::http::StatusCode;
     use pretty_assertions::assert_eq;
     use rstest::rstest;

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -276,7 +276,7 @@ async fn project_path(
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod tests {
     use axum::http::StatusCode;
     use chrono::NaiveDate;
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
While the majority of editoast test modules are called "tests", some are mistakenly called "test". Rename all test modules to "tests" so that they follow rust idiom.