### PR TITLE
docker: fix FromAsCasing warning in dockerfiles

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -1,4 +1,4 @@
-FROM alpine as exec_as_builder
+FROM alpine AS exec_as_builder
 
 RUN apk add build-base
 COPY docker/exec-as.c .

--- a/front/docker/Dockerfile.nginx
+++ b/front/docker/Dockerfile.nginx
@@ -1,6 +1,6 @@
 ### BUILD STAGE
 
-FROM node:20-bookworm as build
+FROM node:20-bookworm AS build
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN yarn generate-licenses && yarn build
 
 ### TESTS STAGE
 
-FROM build as tests
+FROM build AS tests
 
 # Allow to import tests data files
 COPY --from=test_data . /tests/data

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -9,14 +9,14 @@ WORKDIR /gateway
 #######################
 # Cargo chef : Recipe #
 #######################
-FROM chef as planner
+FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 ######################
 # Cargo chef : build #
 ######################
-FROM chef as run_builder
+FROM chef AS run_builder
 RUN apk add --no-cache musl-dev build-base jemalloc-dev openssl-dev mold
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 COPY --from=planner /gateway/recipe.json recipe.json
@@ -47,7 +47,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.20 as running_env
+FROM alpine:3.20 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools
 COPY --from=run_builder /usr/local/cargo/bin/osrd_gateway /usr/local/bin/osrd_gateway
 

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -9,14 +9,14 @@ WORKDIR /osrdyne
 #######################
 # Cargo chef : Recipe #
 #######################
-FROM chef as planner
+FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 ######################
 # Cargo chef : build #
 ######################
-FROM chef as run_builder
+FROM chef AS run_builder
 RUN apk add --no-cache musl-dev build-base jemalloc-dev mold
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 COPY --from=planner /osrdyne/recipe.json recipe.json
@@ -47,7 +47,7 @@ COPY . .
 #######################
 # Running env : build #
 #######################
-FROM alpine:3.20 as running_env
+FROM alpine:3.20 AS running_env
 RUN apk add --no-cache curl ca-certificates bind-tools
 COPY --from=run_builder /usr/local/cargo/bin/osrdyne /usr/local/bin/osrdyne
 


### PR DESCRIPTION
Fix the warning generated by docker when from and as casing do not match in dockerfiles, see https://docs.docker.com/reference/build-checks/from-as-casing/
