### PR TITLE
core: docker: add profiles to single-worker compose

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -97,22 +97,28 @@ Using a specific script (just through `docker compose` CLI and a set of docker-c
 allows to run a single core worker for all infra on localhost network:
 
 ```sh
-./scripts/single-worker-compose.sh up -d
+# run all services:
+./scripts/single-worker-compose.sh --profile "*" up -d
 
 # or exclude 'core' service straight away:
-./scripts/single-worker-compose.sh up -d --scale core=0
+./scripts/single-worker-compose.sh --profile with-editoast up -d
+
+# one can also only exclude 'editoast' service
+./scripts/single-worker-compose.sh --profile with-core up -d
+
+# Please have a look at script or docker-compose file for advanced use.
 ```
 
 Then, it is easy to replace the desired component for debug purpose. \
 For core:
 
 ```sh
-./scripts/single-worker-compose.sh down core # if 'core' is running
+./scripts/single-worker-compose.sh  --profile "*" down core # if 'core' is running
 ./gradlew shadowJar && ALL_INFRA=true java -jar -ea -Xmx12g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof build/libs/osrd-all.jar worker --editoast-url http://localhost:8090/
 ```
 
 Clean or restart the whole stack can be necessary sometimes and is also available
 through docker compose CLI (the following wipes the database too):
 ```sh
-./scripts/single-worker-compose.sh down -v
+./scripts/single-worker-compose.sh  --profile "*" down -v
 ```

--- a/docker/docker-compose.single-worker.yml
+++ b/docker/docker-compose.single-worker.yml
@@ -2,6 +2,12 @@ services:
   editoast:
     environment:
       - EDITOAST_CORE_SINGLE_WORKER=true
+    profiles:
+      - with-editoast
+
+  wait-healthy:
+    profiles:
+      - with-editoast
 
   osrdyne:
     volumes: !reset []
@@ -16,3 +22,5 @@ services:
       - /bin/sh
       - -c
       - "exec java $JAVA_OPTS -ea -jar /app/osrd_core.jar worker"
+    profiles:
+      - with-core

--- a/scripts/single-worker-compose.sh
+++ b/scripts/single-worker-compose.sh
@@ -6,6 +6,12 @@
 set -e
 
 # We override the default docker-compose file with "host" and "single-worker" versions in the docker folder
+
+# From docker/docker-compose.single-worker.yml, profiles are provided:
+# - no profile means all other services (except editoast and core)
+# - `--profile "*"` means all services
+# - `--profile with-editoast` means all other services and editoast
+# - `--profile with-core` means all other services and core
 docker compose \
     -p "osrd" \
     -f "docker-compose.yml" \


### PR DESCRIPTION
This will avoid dealing with unwanted services (especially at build)