### PR TITLE
editoast: lmr towed max speed

### DIFF
--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -700,6 +700,7 @@ diesel::table! {
         version -> Int8,
         #[max_length = 255]
         label -> Varchar,
+        max_speed -> Nullable<Float8>,
     }
 }
 

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -18,4 +18,5 @@ pub struct TowedRollingStock {
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system in m/s^2
     pub const_gamma: f64,
+    pub max_speed: Option<f64>,
 }

--- a/editoast/migrations/2024-12-03-144258_towed-rolling-stock-add-field-max-speed/down.sql
+++ b/editoast/migrations/2024-12-03-144258_towed-rolling-stock-add-field-max-speed/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE towed_rolling_stock
+DROP max_speed;

--- a/editoast/migrations/2024-12-03-144258_towed-rolling-stock-add-field-max-speed/up.sql
+++ b/editoast/migrations/2024-12-03-144258_towed-rolling-stock-add-field-max-speed/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE towed_rolling_stock
+ADD max_speed FLOAT8;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10654,6 +10654,10 @@ components:
         mass:
           type: number
           format: double
+        max_speed:
+          type: number
+          format: double
+          nullable: true
         name:
           type: string
         railjson_version:
@@ -10707,6 +10711,10 @@ components:
         mass:
           type: number
           format: double
+        max_speed:
+          type: number
+          format: double
+          nullable: true
         name:
           type: string
         rolling_resistance:

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -239,6 +239,7 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
             C: 0.0002, // In N/(m/s)²
         },
         const_gamma: 1.0,
+        max_speed: Some(35.0),
         railjson_version: "3.4".to_string(),
     }
 }

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -25,6 +25,8 @@ pub struct TowedRollingStockModel {
     pub mass: f64,
     /// In m
     pub length: f64,
+    /// In km/h
+    pub max_speed: Option<f64>,
     pub comfort_acceleration: f64,
     pub startup_acceleration: f64,
     pub inertia_coefficient: f64,
@@ -48,6 +50,7 @@ impl From<TowedRollingStockModel> for TowedRollingStock {
             inertia_coefficient: model.inertia_coefficient,
             rolling_resistance: model.rolling_resistance,
             const_gamma: model.const_gamma,
+            max_speed: model.max_speed,
         }
     }
 }

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -60,6 +60,7 @@ struct TowedRollingStock {
     inertia_coefficient: f64,
     rolling_resistance: RollingResistancePerWeight,
     const_gamma: f64,
+    max_speed: Option<f64>,
 }
 
 impl From<TowedRollingStockModel> for TowedRollingStock {
@@ -77,6 +78,7 @@ impl From<TowedRollingStockModel> for TowedRollingStock {
             inertia_coefficient: towed_rolling_stock.inertia_coefficient,
             rolling_resistance: towed_rolling_stock.rolling_resistance,
             const_gamma: towed_rolling_stock.const_gamma,
+            max_speed: towed_rolling_stock.max_speed,
         }
     }
 }
@@ -105,6 +107,7 @@ pub struct TowedRollingStockForm {
     pub inertia_coefficient: f64,
     pub rolling_resistance: RollingResistancePerWeight,
     pub const_gamma: f64,
+    pub max_speed: Option<f64>,
 }
 
 impl From<TowedRollingStockForm> for Changeset<TowedRollingStockModel> {
@@ -121,6 +124,7 @@ impl From<TowedRollingStockForm> for Changeset<TowedRollingStockModel> {
             .inertia_coefficient(towed_rolling_stock_form.inertia_coefficient)
             .rolling_resistance(towed_rolling_stock_form.rolling_resistance)
             .const_gamma(towed_rolling_stock_form.const_gamma)
+            .max_speed(towed_rolling_stock_form.max_speed)
     }
 }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
+use validator::Validate;
 
 use crate::core::conflict_detection::Conflict;
 use crate::core::conflict_detection::TrainRequirements;
@@ -138,6 +139,8 @@ async fn stdcm(
     if !authorized {
         return Err(AuthorizationError::Unauthorized.into());
     }
+
+    stdcm_request.validate()?;
 
     let conn = &mut db_pool.get().await?;
 

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
+use validator::Validate;
 
 use crate::core::pathfinding::PathfindingInputError;
 use crate::error::Result;
@@ -65,7 +66,7 @@ struct StepTimingData {
 }
 
 /// An STDCM request
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Validate, ToSchema)]
 pub(super) struct Request {
     /// Deprecated, first step arrival time should be used instead
     pub(super) start_time: Option<DateTime<Utc>>,
@@ -102,10 +103,13 @@ pub(super) struct Request {
     #[schema(value_type = Option<String>, example = json!(["5%", "2min/100km"]))]
     pub(super) margin: Option<MarginValue>,
     /// Total mass of the consist in kg
+    #[validate(range(exclusive_min = 0.0))]
     pub(super) total_mass: Option<f64>,
     /// Total length of the consist in meters
+    #[validate(range(exclusive_min = 0.0))]
     pub(super) total_length: Option<f64>,
     /// Maximum speed of the consist in km/h
+    #[validate(range(exclusive_min = 0.0))]
     pub(super) max_speed: Option<f64>,
     pub(super) loading_gauge_type: Option<LoadingGaugeType>,
 }

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { min } from 'lodash';
 import { useSelector } from 'react-redux';
 
 import type { LightRollingStockWithLiveries, TowedRollingStock } from 'common/api/osrdEditoastApi';
@@ -57,9 +58,8 @@ const useStdcmConsist = () => {
     }
 
     if (!maxSpeedChanged) {
-      dispatch(
-        updateMaxSpeed(rollingStock?.max_speed ? Math.floor(rollingStock.max_speed) : undefined)
-      );
+      const consistMaxSpeed = min([rollingStock?.max_speed, towed?.max_speed]);
+      dispatch(updateMaxSpeed(consistMaxSpeed ? Math.floor(consistMaxSpeed) : undefined));
     }
   };
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3372,6 +3372,7 @@ export type TowedRollingStock = {
   length: number;
   locked: boolean;
   mass: number;
+  max_speed?: number | null;
   name: string;
   railjson_version: string;
   rolling_resistance: RollingResistancePerWeight;
@@ -3385,6 +3386,7 @@ export type TowedRollingStockForm = {
   length: number;
   locked: boolean;
   mass: number;
+  max_speed?: number | null;
   name: string;
   rolling_resistance: RollingResistancePerWeight;
   startup_acceleration: number;


### PR DESCRIPTION
fix [#9637](https://github.com/OpenRailAssociation/osrd/issues/9637)

- [x] Add stdcm request validation
- [x] Handle max speed zero value in simulation computation (if it used in another place without request validation)
- [x] Add max_speed to towed rolling stock

The frontend validation done in another PR