### PR TITLE
editoast: use DateTime with timezone in work schedule API

### DIFF
--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -354,7 +354,7 @@ pub async fn create_small_infra(conn: &mut DbConnection) -> Infra {
 pub async fn create_work_schedule_group(conn: &mut DbConnection) -> WorkScheduleGroup {
     WorkScheduleGroup::changeset()
         .name("Empty work schedule group".to_string())
-        .creation_date(Utc::now().naive_utc())
+        .creation_date(Utc::now())
         .create(conn)
         .await
         .expect("Failed to create empty work schedule group")

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -1,4 +1,5 @@
-use chrono::NaiveDateTime;
+use chrono::DateTime;
+use chrono::Utc;
 use editoast_derive::Model;
 use editoast_schemas::infra::TrackRange;
 use strum::FromRepr;
@@ -12,7 +13,7 @@ use utoipa::ToSchema;
 #[model(gen(ops = crd, batch_ops = c, list))]
 pub struct WorkScheduleGroup {
     pub id: i64,
-    pub creation_date: NaiveDateTime,
+    pub creation_date: DateTime<Utc>,
     pub name: String,
 }
 
@@ -29,8 +30,8 @@ pub enum WorkScheduleType {
 #[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {
     pub id: i64,
-    pub start_date_time: NaiveDateTime,
-    pub end_date_time: NaiveDateTime,
+    pub start_date_time: DateTime<Utc>,
+    pub end_date_time: DateTime<Utc>,
     #[model(json)]
     pub track_ranges: Vec<TrackRange>,
     pub obj_id: String,

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -107,7 +107,7 @@ def test_between_trains(small_scenario: Scenario, fast_rolling_stock: int):
 
 def test_work_schedules(small_scenario: Scenario, fast_rolling_stock: int):
     requests.post(EDITOAST_URL + f"infra/{small_scenario.infra}/load")
-    start_time = datetime.datetime(2024, 1, 1, 14, 0, 0)
+    start_time = datetime.datetime(2024, 1, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
     end_time = start_time + datetime.timedelta(days=4)
     # TODO: we cannot delete work schedules for now, so let's give a unique name
     # to avoid collisions
@@ -217,10 +217,10 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
                    [                             ] < departure time window
     """
     requests.post(EDITOAST_URL + f"infra/{small_scenario.infra}/load")
-    origin_start_time = datetime.datetime(2024, 1, 1, 8, 0, 0)
-    origin_end_time = datetime.datetime(2025, 1, 1, 8, 0, 0)
-    destination_start_time = datetime.datetime(2023, 1, 1, 8, 0, 0)
-    destination_end_time = datetime.datetime(2024, 1, 1, 16, 0, 0)
+    origin_start_time = datetime.datetime(2024, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
+    origin_end_time = datetime.datetime(2025, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
+    destination_start_time = datetime.datetime(2023, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
+    destination_end_time = datetime.datetime(2024, 1, 1, 16, 0, 0, tzinfo=datetime.timezone.utc)
     # TODO: we cannot delete work schedules for now, so let's give a unique name
     # to avoid collisions
     now = datetime.datetime.now()


### PR DESCRIPTION
The timezone was stored in the database, but was stripped at the HTTP API boundary.

This is a breaking change: the timezone is required when submitting a work schedule, and is always returned when projecting a work schedule.

Closes: https://github.com/OpenRailAssociation/osrd/issues/9652