### PR TITLE
core: add a new updateMap() function to DistanceRangeMap

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/DistanceRangeMap.kt
@@ -52,12 +52,25 @@ interface DistanceRangeMap<T> : Iterable<DistanceRangeMap.RangeMapEntry<T>> {
 
     /**
      * Updates the map with another one, using a merge function to fuse the values of intersecting
-     * ranges
+     * ranges. Doesn't keep any range from update where there is no intersection.
      */
-    fun <U> updateMap(update: DistanceRangeMap<U>, updateFunction: BiFunction<T, U, T>)
+    fun <U> updateMapIntersection(update: DistanceRangeMap<U>, updateFunction: BiFunction<T, U, T>)
+
+    /**
+     * Updates the map with another one, using a merge function to fuse the values of intersecting
+     * ranges. Calls default on the values of the ranges from update where there is no intersection.
+     */
+    fun updateMap(
+        update: DistanceRangeMap<T>,
+        updateFunction: (T, T) -> T,
+        default: (T) -> T = { it }
+    )
 
     /** Returns true if there is no entry at all */
     fun isEmpty(): Boolean
+
+    /** Clear the map */
+    fun clear()
 }
 
 fun <T> distanceRangeMapOf(

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/EnvelopeTrainPath.kt
@@ -58,7 +58,7 @@ object EnvelopeTrainPath {
         val res = mutableMapOf<String, DistanceRangeMap<Electrification>>()
         for (entry in profileMap.entries) {
             val electrificationMapWithProfiles = electrificationMap.clone()
-            electrificationMapWithProfiles.updateMap(entry.value) {
+            electrificationMapWithProfiles.updateMapIntersection(entry.value) {
                 obj: Electrification,
                 profile: String ->
                 obj.withElectricalProfile(profile)

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/EnvelopeTrainPathUtils.kt
@@ -12,10 +12,12 @@ import fr.sncf.osrd.utils.units.Distance
 fun buildElectrificationMap(path: PathProperties): DistanceRangeMap<Electrification> {
     val res: DistanceRangeMap<Electrification> = DistanceRangeMapImpl()
     res.put(Distance.ZERO, path.getLength(), NonElectrified())
-    res.updateMap(path.getElectrification()) { _: Electrification?, electrificationMode: String ->
+    res.updateMapIntersection(path.getElectrification()) {
+        _: Electrification?,
+        electrificationMode: String ->
         if (electrificationMode == "") NonElectrified() else Electrified(electrificationMode)
     }
-    res.updateMap(path.getNeutralSections()) {
+    res.updateMapIntersection(path.getNeutralSections()) {
         electrification: Electrification?,
         neutralSection: NeutralSection ->
         Neutral(neutralSection.lowerPantograph, electrification, neutralSection.isAnnouncement)


### PR DESCRIPTION
The old one is now called updateMapIntersection(). The new one inserts the non overlapping ranges without modification.