### PR TITLE
core: update start of free block in signal projection (space-time chart) when stopping on closed signal

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -219,7 +219,7 @@ fun run(
             routePath,
             blockPath,
             detailedBlockPath,
-            pathStops,
+            pathStops.filter { it.receptionSignal.isStopOnClosedSignal },
             loadedSignalInfra,
             blockInfra,
             envelopeWithStops,
@@ -260,7 +260,7 @@ fun routingRequirements(
     routePath: StaticIdxList<Route>,
     blockPath: StaticIdxList<Block>,
     detailedBlockPath: List<BlockPathElement>,
-    stops: List<PathStop>,
+    sortedClosedSignalStops: List<PathStop>,
     loadedSignalInfra: LoadedSignalInfra,
     blockInfra: BlockInfra,
     envelope: EnvelopeInterpolate,
@@ -383,12 +383,9 @@ fun routingRequirements(
         val entrySignalOffset =
             blockOffsets[routeStartBlockIndex] +
                 blockInfra.getSignalsPositions(firstRouteBlock).first().distance
-        for (stop in stops.reversed()) {
+        for (stop in sortedClosedSignalStops.reversed()) {
             val stopTravelledOffset = pathOffsetBuilder.toTravelledPath(stop.pathOffset)
-            if (
-                stop.receptionSignal.isStopOnClosedSignal &&
-                    stopTravelledOffset <= entrySignalOffset
-            ) {
+            if (stopTravelledOffset <= entrySignalOffset) {
                 // stop duration is included in interpolateDepartureFromClamp()
                 val stopDepartureTime =
                     envelope.interpolateDepartureFromClamp(stopTravelledOffset.distance.meters)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/CommonSchemas.kt
@@ -37,7 +37,7 @@ class ZoneUpdate(
     @Json(name = "is_entry") val isEntry: Boolean,
 )
 
-class SignalSighting(
+class SignalCriticalPosition(
     val signal: String,
     val time: TimeDelta,
     val position: Offset<TravelledPath>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionEndpointV2.kt
@@ -41,7 +41,7 @@ class SignalProjectionEndpointV2(private val infraManager: InfraManager) : Take 
                         chunkPath,
                         blockPath,
                         routePath,
-                        trainSimulation.signalSightings,
+                        trainSimulation.signalCriticalPositions,
                         trainSimulation.zoneUpdates,
                         trainSimulation.simulationEndTime
                     )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/project_signals/SignalProjectionRequest.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
-import fr.sncf.osrd.api.api_v2.SignalSighting
+import fr.sncf.osrd.api.api_v2.SignalCriticalPosition
 import fr.sncf.osrd.api.api_v2.ZoneUpdate
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -21,7 +21,8 @@ class SignalProjectionRequest(
 )
 
 class TrainSimulation(
-    @Json(name = "signal_sightings") val signalSightings: Collection<SignalSighting>,
+    @Json(name = "signal_critical_positions")
+    val signalCriticalPositions: Collection<SignalCriticalPosition>,
     @Json(name = "zone_updates") val zoneUpdates: Collection<ZoneUpdate>,
     @Json(name = "simulation_end_time") val simulationEndTime: TimeDelta,
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationResponse.kt
@@ -45,7 +45,8 @@ class CompleteReportTrain(
     speeds: List<Double>,
     @Json(name = "energy_consumption") energyConsumption: Double,
     @Json(name = "path_item_times") pathItemTimes: List<TimeDelta>,
-    @Json(name = "signal_sightings") val signalSightings: List<SignalSighting>,
+    @Json(name = "signal_critical_positions")
+    val signalCriticalPositions: List<SignalCriticalPosition>,
     @Json(name = "zone_updates") val zoneUpdates: List<ZoneUpdate>,
     @Json(name = "spacing_requirements") val spacingRequirements: List<SpacingRequirement>,
     @Json(name = "routing_requirements") val routingRequirements: List<RoutingRequirement>

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -104,7 +104,7 @@ fun runScheduleMetadataExtractor(
         }
     val closedSignalStops = pathStops.filter { it.receptionSignal.isStopOnClosedSignal }
 
-    val signalSightings = mutableListOf<SignalSighting>()
+    val signalCriticalPositions = mutableListOf<SignalCriticalPosition>()
     var indexClosedSignalStop = 0
 
     var closedSignalStopOffset =
@@ -160,8 +160,8 @@ fun runScheduleMetadataExtractor(
             }
         }
 
-        signalSightings.add(
-            SignalSighting(
+        signalCriticalPositions.add(
+            SignalCriticalPosition(
                 rawInfra.getPhysicalSignalName(
                     loadedSignalInfra.getPhysicalSignal(pathSignal.signal)
                 )!!,
@@ -227,7 +227,7 @@ fun runScheduleMetadataExtractor(
         reportTrain.speeds,
         reportTrain.energyConsumption,
         reportTrain.pathItemTimes,
-        signalSightings,
+        signalCriticalPositions,
         zoneUpdates,
         spacingRequirements.requirements.map {
             SpacingRequirement(it.zone, it.beginTime.seconds, it.endTime.seconds)

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7966,12 +7966,12 @@ components:
                 time_end:
                   type: integer
                   format: int64
-                  description: The aspects stop being displayed at this time (number of seconds since `departure_time`)
+                  description: The aspects stop being displayed at this time (number of ms since `departure_time`)
                   minimum: 0
                 time_start:
                   type: integer
                   format: int64
-                  description: The aspects start being displayed at this time (number of mseconds since `departure_time`)
+                  description: The aspects start being displayed at this time (number of ms since `departure_time`)
                   minimum: 0
             description: List of signal updates along the path
           space_time_curves:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3306,7 +3306,7 @@ components:
       - $ref: '#/components/schemas/ReportTrain'
       - type: object
         required:
-        - signal_sightings
+        - signal_critical_positions
         - zone_updates
         - spacing_requirements
         - routing_requirements
@@ -3315,10 +3315,10 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/RoutingRequirement'
-          signal_sightings:
+          signal_critical_positions:
             type: array
             items:
-              $ref: '#/components/schemas/SignalSighting'
+              $ref: '#/components/schemas/SignalCriticalPosition'
           spacing_requirements:
             type: array
             items:
@@ -9504,8 +9504,11 @@ components:
           maxLength: 255
           minLength: 1
       additionalProperties: false
-    SignalSighting:
+    SignalCriticalPosition:
       type: object
+      description: |-
+        First position (space and time) along the path where given signal must
+        be free (sighting time or closed-signal stop ending)
       required:
       - signal
       - time
@@ -9586,7 +9589,7 @@ components:
             - $ref: '#/components/schemas/ReportTrain'
             - type: object
               required:
-              - signal_sightings
+              - signal_critical_positions
               - zone_updates
               - spacing_requirements
               - routing_requirements
@@ -9595,10 +9598,10 @@ components:
                   type: array
                   items:
                     $ref: '#/components/schemas/RoutingRequirement'
-                signal_sightings:
+                signal_critical_positions:
                   type: array
                   items:
-                    $ref: '#/components/schemas/SignalSighting'
+                    $ref: '#/components/schemas/SignalCriticalPosition'
                 spacing_requirements:
                   type: array
                   items:

--- a/editoast/src/core/signal_projection.rs
+++ b/editoast/src/core/signal_projection.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use utoipa::ToSchema;
 
-use crate::core::simulation::SignalSighting;
+use crate::core::simulation::SignalCriticalPosition;
 use crate::core::simulation::ZoneUpdate;
 use crate::core::{AsCoreRequest, Json};
 
@@ -22,7 +22,7 @@ pub struct SignalUpdatesRequest<'a> {
     pub routes: &'a Vec<Identifier>,
     /// Path description as block ids
     pub blocks: &'a Vec<Identifier>,
-    /// List of signal sightings and zone updates for each train
+    /// List of signal critical positions and zone updates for each train
     pub train_simulations: HashMap<i64, TrainSimulation<'a>>,
 }
 
@@ -51,7 +51,7 @@ pub struct SignalUpdate {
 
 #[derive(Debug, Serialize)]
 pub struct TrainSimulation<'a> {
-    pub signal_sightings: &'a Vec<SignalSighting>,
+    pub signal_critical_positions: &'a Vec<SignalCriticalPosition>,
     pub zone_updates: &'a Vec<ZoneUpdate>,
     pub simulation_end_time: u64,
 }

--- a/editoast/src/core/signal_projection.rs
+++ b/editoast/src/core/signal_projection.rs
@@ -32,9 +32,9 @@ pub struct SignalUpdate {
     pub signal_id: String,
     /// The name of the signaling system of the signal
     signaling_system: String,
-    /// The aspects start being displayed at this time (number of mseconds since `departure_time`)
+    /// The aspects start being displayed at this time (number of ms since `departure_time`)
     pub time_start: u64,
-    /// The aspects stop being displayed at this time (number of seconds since `departure_time`)
+    /// The aspects stop being displayed at this time (number of ms since `departure_time`)
     pub time_end: u64,
     /// The route starts at this position in mm on the train path
     pub position_start: u64,

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -26,7 +26,7 @@ use std::hash::Hash;
 editoast_common::schemas! {
     CompleteReportTrain,
     RoutingRequirement,
-    SignalSighting,
+    SignalCriticalPosition,
     SpacingRequirement,
     RoutingZoneRequirement,
     ZoneUpdate,
@@ -306,14 +306,16 @@ pub struct ReportTrain {
 pub struct CompleteReportTrain {
     #[serde(flatten)]
     pub report_train: ReportTrain,
-    pub signal_sightings: Vec<SignalSighting>,
+    pub signal_critical_positions: Vec<SignalCriticalPosition>,
     pub zone_updates: Vec<ZoneUpdate>,
     pub spacing_requirements: Vec<SpacingRequirement>,
     pub routing_requirements: Vec<RoutingRequirement>,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
-pub struct SignalSighting {
+/// First position (space and time) along the path where given signal must
+/// be free (sighting time or closed-signal stop ending)
+pub struct SignalCriticalPosition {
     pub signal: String,
     /// Time in ms
     pub time: u64,

--- a/editoast/src/tests/small_infra/stdcm/test_1/stdcm_core_response.json
+++ b/editoast/src/tests/small_infra/stdcm/test_1/stdcm_core_response.json
@@ -155,7 +155,7 @@
                         "time_tail_free": 42.075
                     }
                 },
-                "signal_sightings": [
+                "signal_critical_positions": [
                     {
                         "offset": 0.0,
                         "signal": "SA1",

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -658,7 +658,7 @@ mod tests {
                     energy_consumption: 0.0,
                     path_item_times: vec![0, 10],
                 },
-                signal_sightings: vec![],
+                signal_critical_positions: vec![],
                 zone_updates: vec![],
                 spacing_requirements: vec![],
                 routing_requirements: vec![],

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -29,7 +29,7 @@ use crate::core::pathfinding::PathfindingResultSuccess;
 use crate::core::simulation::CompleteReportTrain;
 use crate::core::simulation::PhysicsConsistParameters;
 use crate::core::simulation::ReportTrain;
-use crate::core::simulation::SignalSighting;
+use crate::core::simulation::SignalCriticalPosition;
 use crate::core::simulation::SimulationMargins;
 use crate::core::simulation::SimulationPath;
 use crate::core::simulation::SimulationPowerRestrictionItem;
@@ -961,7 +961,7 @@ mod tests {
                     "speeds": [],
                     "energy_consumption": 0.0,
                     "path_item_times": [0, 1000, 2000, 3000],
-                    "signal_sightings": [],
+                    "signal_critical_positions": [],
                     "zone_updates": [],
                     "spacing_requirements": [],
                     "routing_requirements": []

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -39,7 +39,7 @@ use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::train_schedule::train_simulation_batch;
 use crate::views::train_schedule::CompleteReportTrain;
 use crate::views::train_schedule::ReportTrain;
-use crate::views::train_schedule::SignalSighting;
+use crate::views::train_schedule::SignalCriticalPosition;
 use crate::views::train_schedule::ZoneUpdate;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
@@ -208,7 +208,7 @@ async fn project_path(
 
         let CompleteReportTrain {
             report_train,
-            signal_sightings,
+            signal_critical_positions,
             zone_updates,
             ..
         } = match sim {
@@ -222,7 +222,7 @@ async fn project_path(
         let train_details = TrainSimulationDetails {
             positions,
             times,
-            signal_sightings,
+            signal_critical_positions,
             zone_updates,
             train_path: track_ranges,
         };
@@ -334,7 +334,7 @@ struct TrainSimulationDetails {
     positions: Vec<u64>,
     times: Vec<u64>,
     train_path: Vec<TrackRange>,
-    signal_sightings: Vec<SignalSighting>,
+    signal_critical_positions: Vec<SignalCriticalPosition>,
     zone_updates: Vec<ZoneUpdate>,
 }
 
@@ -362,7 +362,7 @@ async fn compute_batch_signal_updates<'a>(
                 (
                     *id,
                     TrainSimulation {
-                        signal_sightings: &details.signal_sightings,
+                        signal_critical_positions: &details.signal_critical_positions,
                         zone_updates: &details.zone_updates,
                         simulation_end_time: details.times[details.times.len() - 1],
                     },
@@ -586,7 +586,7 @@ mod tests {
             positions,
             times,
             train_path,
-            signal_sightings: vec![],
+            signal_critical_positions: vec![],
             zone_updates: vec![],
         };
 
@@ -620,7 +620,7 @@ mod tests {
             positions: positions.clone(),
             times: times.clone(),
             train_path,
-            signal_sightings: vec![],
+            signal_critical_positions: vec![],
             zone_updates: vec![],
         };
 
@@ -657,7 +657,7 @@ mod tests {
             positions,
             times,
             train_path,
-            signal_sightings: vec![],
+            signal_critical_positions: vec![],
             zone_updates: vec![],
         };
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3295,9 +3295,9 @@ export type ProjectPathTrainResult = {
     signal_id: string;
     /** The name of the signaling system of the signal */
     signaling_system: string;
-    /** The aspects stop being displayed at this time (number of seconds since `departure_time`) */
+    /** The aspects stop being displayed at this time (number of ms since `departure_time`) */
     time_end: number;
-    /** The aspects start being displayed at this time (number of mseconds since `departure_time`) */
+    /** The aspects start being displayed at this time (number of ms since `departure_time`) */
     time_start: number;
   }[];
   /** List of space-time curves sections along the path */

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3093,7 +3093,7 @@ export type RoutingRequirement = {
   route: string;
   zones: RoutingZoneRequirement[];
 };
-export type SignalSighting = {
+export type SignalCriticalPosition = {
   /** Position in mm */
   position: number;
   signal: string;
@@ -3133,7 +3133,7 @@ export type SimulationResponse =
       };
       final_output: ReportTrain & {
         routing_requirements: RoutingRequirement[];
-        signal_sightings: SignalSighting[];
+        signal_critical_positions: SignalCriticalPosition[];
         spacing_requirements: SpacingRequirement[];
         zone_updates: ZoneUpdate[];
       };

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/__tests__/sampleData.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/__tests__/sampleData.ts
@@ -38,7 +38,7 @@ export const simulation: SimulationResponseSuccess = {
         ],
       },
     ],
-    signal_sightings: [
+    signal_critical_positions: [
       {
         signal: 'signal',
         state: 'state',

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -29,7 +29,7 @@ def test_conflicts(
     expected_conflict_types: set[str],
 ):
     requests.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
-    train_schedule_payload = [
+    stopping_train_schedule_payload = [
         {
             "comfort": "STANDARD",
             "constraint_distribution": "STANDARD",
@@ -57,7 +57,11 @@ def test_conflicts(
             "train_name": "with_stop",
         }
     ]
-    requests.post(f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedule", json=train_schedule_payload)
+    stopping_train_schedule_response = requests.post(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedule", json=stopping_train_schedule_payload
+    )
+    stopping_train_schedule_response.raise_for_status()
+
     train_schedule_payload = [
         {
             "comfort": "STANDARD",
@@ -84,11 +88,50 @@ def test_conflicts(
             "train_name": "pass",
         }
     ]
-    requests.post(f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedule", json=train_schedule_payload)
-    response = requests.get(f"{EDITOAST_URL}/timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}")
-    assert response.status_code == 200
-    actual_conflicts = {conflict["conflict_type"] for conflict in response.json()}
+    requests.post(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedule", json=train_schedule_payload
+    ).raise_for_status()
+
+    conflicts_response = requests.get(f"{EDITOAST_URL}/timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}")
+    conflicts_response.raise_for_status()
+    actual_conflicts = {conflict["conflict_type"] for conflict in conflicts_response.json()}
     assert actual_conflicts == expected_conflict_types
+
+    # Check GET reservation block starts at the right time for the signal protecting switch.
+    # Train is received on closed (STOP/SHORT_SLIP_STOP) or OPEN signal.
+    # The free-block requirement must start at the same time as the spacing requirement of the switch's zone
+    # (signal sight for OPEN reception, or 20s before restart for STOP/SHORT_SLIP_STOP reception).
+    train_id = stopping_train_schedule_response.json()[0]["id"]
+    simu_response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={small_infra.id}")
+    simu_response.raise_for_status()
+    simu_response_json = simu_response.json()
+    switch_zone_spacing_requirement = [
+        r
+        for r in simu_response_json["final_output"]["spacing_requirements"]
+        if r["zone"] == "zone.[DC4:INCREASING, DC5:INCREASING, DD0:DECREASING]"
+    ]
+    assert len(switch_zone_spacing_requirement) == 1
+    path_response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/path/?infra_id={small_infra.id}")
+    path_response.raise_for_status()
+    path_response_json = path_response.json()
+    project_path_payload = {
+        "ids": [train_id],
+        "infra_id": small_infra.id,
+        "path": {
+            "blocks": path_response_json["blocks"],
+            "routes": path_response_json["routes"],
+            "track_section_ranges": path_response_json["track_section_ranges"],
+        },
+    }
+    response_project_path = requests.post(f"{EDITOAST_URL}/train_schedule/project_path", json=project_path_payload)
+    response_project_path.raise_for_status()
+    switch_signal_free_block_update = [
+        u
+        for u in response_project_path.json()[str(train_id)]["signal_updates"]
+        if (u["signal_id"] == "SC4" and u["aspect_label"] == "VL")
+    ]
+    assert len(switch_signal_free_block_update) == 1
+    assert switch_signal_free_block_update[0]["time_start"] == switch_zone_spacing_requirement[0]["begin_time"]
 
 
 def test_scheduled_points_with_incompatible_margins(


### PR DESCRIPTION
Fix #8814

This is done by amending signal-sightings with stop-ending (minus margin) when stop is on closed signal

Also:
* Adds corresponding integration test

A complete comment up-to-date is also worth reading: https://github.com/OpenRailAssociation/osrd/pull/9661#issuecomment-2491886171

🔍 review by commit is probably easier