### PR TITLE
core, editoast: rename rolling stock to physics consist

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/RollingStockParser.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/RollingStockParser.kt
@@ -10,17 +10,17 @@ import fr.sncf.osrd.train.RollingStock.*
 
 /** Parse the rolling stock model into something the backend can work with */
 fun parseRawRollingStock(
-    rawRollingStock: PhysicsRollingStockModel,
+    rawPhysicsConsist: PhysicsConsistModel,
     loadingGaugeType: RJSLoadingGaugeType = RJSLoadingGaugeType.G1,
     rollingStockSupportedSignalingSystems: List<String> = listOf(),
 ): RollingStock {
     // Parse effort_curves
-    val rawModes = rawRollingStock.effortCurves.modes
+    val rawModes = rawPhysicsConsist.effortCurves.modes
 
-    if (!rawModes.containsKey(rawRollingStock.effortCurves.defaultMode))
+    if (!rawModes.containsKey(rawPhysicsConsist.effortCurves.defaultMode))
         throw OSRDError.newInvalidRollingStockError(
             ErrorType.InvalidRollingStockDefaultModeNotFound,
-            rawRollingStock.effortCurves.defaultMode
+            rawPhysicsConsist.effortCurves.defaultMode
         )
 
     // Parse tractive effort curves modes
@@ -29,28 +29,28 @@ fun parseRawRollingStock(
         modes[key] = parseModeEffortCurves(value, "effort_curves.modes.$key")
     }
 
-    val rollingResistance = parseRollingResistance(rawRollingStock.rollingResistance)
+    val rollingResistance = parseRollingResistance(rawPhysicsConsist.rollingResistance)
 
     return RollingStock(
         "placeholder_name",
-        rawRollingStock.length.distance.meters,
-        rawRollingStock.mass.toDouble(),
-        rawRollingStock.inertiaCoefficient,
+        rawPhysicsConsist.length.distance.meters,
+        rawPhysicsConsist.mass.toDouble(),
+        rawPhysicsConsist.inertiaCoefficient,
         rollingResistance.A,
         rollingResistance.B,
         rollingResistance.C,
-        rawRollingStock.maxSpeed,
-        rawRollingStock.startupTime.seconds,
-        rawRollingStock.startupAcceleration,
-        rawRollingStock.comfortAcceleration,
-        rawRollingStock.constGamma,
+        rawPhysicsConsist.maxSpeed,
+        rawPhysicsConsist.startupTime.seconds,
+        rawPhysicsConsist.startupAcceleration,
+        rawPhysicsConsist.comfortAcceleration,
+        rawPhysicsConsist.constGamma,
         loadingGaugeType,
         modes,
-        rawRollingStock.effortCurves.defaultMode,
-        rawRollingStock.basePowerClass,
-        rawRollingStock.powerRestrictions,
-        rawRollingStock.electricalPowerStartupTime?.seconds,
-        rawRollingStock.raisePantographTime?.seconds,
+        rawPhysicsConsist.effortCurves.defaultMode,
+        rawPhysicsConsist.basePowerClass,
+        rawPhysicsConsist.powerRestrictions,
+        rawPhysicsConsist.electricalPowerStartupTime?.seconds,
+        rawPhysicsConsist.raisePantographTime?.seconds,
         rollingStockSupportedSignalingSystems.toTypedArray(),
     )
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
@@ -45,7 +45,7 @@ class SimulationEndpoint(
                 electricalProfileSetManager.getProfileMap(request.electricalProfileSetId)
 
             // Parse rolling stocks
-            val rollingStock = parseRawRollingStock(request.rollingStock)
+            val rollingStock = parseRawRollingStock(request.physicsConsist)
 
             // Parse path
             val chunkPath = makeChunkPath(infra.rawInfra, request.path.trackSectionRanges)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
@@ -30,7 +30,7 @@ class SimulationRequest(
     @Json(name = "speed_limit_tag") val speedLimitTag: String?,
     @Json(name = "power_restrictions") val powerRestrictions: List<SimulationPowerRestrictionItem>,
     val options: TrainScheduleOptions,
-    @Json(name = "rolling_stock") val rollingStock: PhysicsRollingStockModel,
+    @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
     @Json(name = "electrical_profile_set_id") val electricalProfileSetId: String?
 ) {
     companion object {
@@ -57,7 +57,7 @@ enum class AllowanceDistribution {
     }
 }
 
-class PhysicsRollingStockModel(
+class PhysicsConsistModel(
     @Json(name = "effort_curves") val effortCurves: EffortCurve,
     @Json(name = "base_power_class") val basePowerClass: String?,
     val length: Length<RollingStock>,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -87,7 +87,7 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
                 buildTemporarySpeedLimitManager(infra, request.temporarySpeedLimits)
             val rollingStock =
                 parseRawRollingStock(
-                    request.rollingStock,
+                    request.physicsConsist,
                     request.rollingStockLoadingGauge,
                     request.rollingStockSupportedSignalingSystems
                 )

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMRequestV2.kt
@@ -10,7 +10,7 @@ import fr.sncf.osrd.api.api_v2.WorkSchedule
 import fr.sncf.osrd.api.api_v2.conflicts.TrainRequirementsRequest
 import fr.sncf.osrd.api.api_v2.standalone_sim.MarginValue
 import fr.sncf.osrd.api.api_v2.standalone_sim.MarginValueAdapter
-import fr.sncf.osrd.api.api_v2.standalone_sim.PhysicsRollingStockModel
+import fr.sncf.osrd.api.api_v2.standalone_sim.PhysicsConsistModel
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
@@ -25,7 +25,7 @@ class STDCMRequestV2(
     @Json(name = "expected_version") var expectedVersion: String,
 
     // Rolling stock
-    @Json(name = "rolling_stock") val rollingStock: PhysicsRollingStockModel,
+    @Json(name = "physics_consist") val physicsConsist: PhysicsConsistModel,
 
     // Pathfinding inputs
     /// List of waypoints. Each waypoint is a list of track offsets

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -428,7 +428,7 @@ pub struct SimulationRequest {
     pub speed_limit_tag: Option<String>,
     pub power_restrictions: Vec<SimulationPowerRestrictionItem>,
     pub options: TrainScheduleOptions,
-    pub rolling_stock: PhysicsConsist,
+    pub physics_consist: PhysicsConsist,
     pub electrical_profile_set_id: Option<i64>,
 }
 

--- a/editoast/src/core/stdcm.rs
+++ b/editoast/src/core/stdcm.rs
@@ -38,7 +38,7 @@ pub struct Request {
     /// The comfort of the train
     pub comfort: Comfort,
     pub speed_limit_tag: Option<String>,
-    pub rolling_stock: PhysicsConsist,
+    pub physics_consist: PhysicsConsist,
 
     // STDCM search parameters
     pub trains_requirements: HashMap<i64, TrainRequirements>,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -216,7 +216,7 @@ async fn stdcm(
         rolling_stock_supported_signaling_systems: rolling_stock
             .supported_signaling_systems
             .clone(),
-        rolling_stock: PhysicsConsistParameters {
+        physics_consist: PhysicsConsistParameters {
             max_speed: stdcm_request.max_speed,
             total_length: stdcm_request.total_length,
             total_mass: stdcm_request.total_mass,

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -590,7 +590,8 @@ fn build_simulation_request(
         speed_limit_tag: train_schedule.speed_limit_tag.clone(),
         power_restrictions,
         options: train_schedule.options.clone(),
-        rolling_stock: PhysicsConsistParameters::with_traction_engine(rolling_stock.into()).into(),
+        physics_consist: PhysicsConsistParameters::with_traction_engine(rolling_stock.into())
+            .into(),
         electrical_profile_set_id,
     }
 }


### PR DESCRIPTION
Now that consists are supported instead of a single traction engine (named rolling stock in the entire application), it's reasonable to rename all along up to `core`.

It's a follow up of https://github.com/OpenRailAssociation/osrd/pull/9106.

❓ In `core`, I changed `PhysicsRollingStockModel` into `PhysicsConsistModel`. But there is also `RollingStockParser` which converts a `PhysicsConsistModel` into a `RollingStock`: I'm not sure how far I should push the renaming. Is `RollingStock` only about physics? Because `RollingStock` contains also information about identifier, or `supportedSignalingSystems` which not really be about the physics of the rolling stock?