### PR TITLE
editoast: fix all units about rolling resistance

### DIFF
--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -10,6 +10,7 @@ pub use effort_curves::ModeEffortCurves;
 
 mod rolling_resistance;
 pub use rolling_resistance::RollingResistance;
+pub use rolling_resistance::RollingResistancePerWeight;
 
 mod energy_source;
 pub use energy_source::EnergySource;

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
@@ -5,6 +5,7 @@ use utoipa::ToSchema;
 
 editoast_common::schemas! {
     RollingResistance,
+    RollingResistancePerWeight,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
@@ -14,13 +15,31 @@ editoast_common::schemas! {
 pub struct RollingResistance {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
-    /// Solid friction in kN
+    /// Solid friction in N
     #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
     pub A: f64,
-    /// Viscosity friction in kN/(km/h)
+    /// Viscosity friction in N/(m/s)
     #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
     pub B: f64,
-    /// Aerodynamic drag in kN/(km/h)²
+    /// Aerodynamic drag in N/(m/s)²
+    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    pub C: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
+#[derivative(Hash)]
+#[serde(deny_unknown_fields)]
+#[allow(non_snake_case)]
+pub struct RollingResistancePerWeight {
+    #[serde(rename = "type")]
+    pub rolling_resistance_type: String,
+    /// Solid friction in N/kg
+    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    pub A: f64,
+    /// Viscosity friction in (N/kg)/(m/s)
+    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    pub B: f64,
+    /// Aerodynamic drag in (N/kg)/(m/s)²
     #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
     pub C: f64,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -1,5 +1,5 @@
 use super::Gamma;
-use super::RollingResistance;
+use super::RollingResistancePerWeight;
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TowedRollingStock {
@@ -15,6 +15,6 @@ pub struct TowedRollingStock {
     /// In m/s²
     pub startup_acceleration: f64,
     pub inertia_coefficient: f64,
-    pub rolling_resistance: RollingResistance,
+    pub rolling_resistance: RollingResistancePerWeight,
     pub gamma: Gamma,
 }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8260,15 +8260,38 @@ components:
         A:
           type: number
           format: double
-          description: Solid friction in kN
+          description: Solid friction in N
         B:
           type: number
           format: double
-          description: Viscosity friction in kN/(km/h)
+          description: Viscosity friction in N/(m/s)
         C:
           type: number
           format: double
-          description: Aerodynamic drag in kN/(km/h)²
+          description: Aerodynamic drag in N/(m/s)²
+        type:
+          type: string
+      additionalProperties: false
+    RollingResistancePerWeight:
+      type: object
+      required:
+      - type
+      - A
+      - B
+      - C
+      properties:
+        A:
+          type: number
+          format: double
+          description: Solid friction in N/kg
+        B:
+          type: number
+          format: double
+          description: Viscosity friction in (N/kg)/(m/s)
+        C:
+          type: number
+          format: double
+          description: Aerodynamic drag in (N/kg)/(m/s)²
         type:
           type: string
       additionalProperties: false
@@ -10330,7 +10353,7 @@ components:
         railjson_version:
           type: string
         rolling_resistance:
-          $ref: '#/components/schemas/RollingResistance'
+          $ref: '#/components/schemas/RollingResistancePerWeight'
         startup_acceleration:
           type: number
           format: double
@@ -10380,7 +10403,7 @@ components:
         name:
           type: string
         rolling_resistance:
-          $ref: '#/components/schemas/RollingResistance'
+          $ref: '#/components/schemas/RollingResistancePerWeight'
         startup_acceleration:
           type: number
           format: double

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -61,10 +61,10 @@ pub struct PhysicsConsist {
     /// Mapping of power restriction code to power class
     #[serde(default)]
     pub power_restrictions: BTreeMap<String, String>,
-    /// The time the train takes before actually using electrical power (in miliseconds).
+    /// The time the train takes before actually using electrical power (in milliseconds).
     /// Is null if the train is not electric or the value not specified.
     pub electrical_power_startup_time: Option<u64>,
-    /// The time it takes to raise this train's pantograph in miliseconds.
+    /// The time it takes to raise this train's pantograph in milliseconds.
     /// Is null if the train is not electric or the value not specified.
     pub raise_pantograph_time: Option<u64>,
 }
@@ -180,18 +180,18 @@ impl PhysicsConsistParameters {
 
             let towed_mass = total_mass - traction_engine_mass; // kg
 
-            let traction_engine_solid_friction_a = traction_engine_rr.A * 1000.0; // convert from kN to N
-            let traction_engine_viscosity_friction_b = traction_engine_rr.B * 1000.0 * 3.6; // convert from kN/(km/h) to N/(m/s)
-            let traction_engine_aerodynamic_drag_c = traction_engine_rr.C * 1000.0 * 3.6 * 3.6; // convert from kN/(km/h)² to N/(m/s)²
+            let traction_engine_solid_friction_a = traction_engine_rr.A; // N
+            let traction_engine_viscosity_friction_b = traction_engine_rr.B; // N/(m/s)
+            let traction_engine_aerodynamic_drag_c = traction_engine_rr.C; // N/(m/s)²
 
-            let towed_solid_friction_a = towed_rs_rr.A * 1e-2 * towed_mass; // convert from daN/t to N
-            let towed_viscosity_friction_b = towed_rs_rr.B * 1e-2 * towed_mass * 3.6; // convert from (daN/t)/(km/h) to N/(m/s)
-            let towed_aerodynamic_drag_c = towed_rs_rr.C * 1e-2 * towed_mass * 3.6 * 3.6; // convert from (daN/t)/(km/h)² to N/(m/s)²
+            let towed_solid_friction_a = towed_rs_rr.A * towed_mass; // N
+            let towed_viscosity_friction_b = towed_rs_rr.B * towed_mass; // N/(m/s)
+            let towed_aerodynamic_drag_c = towed_rs_rr.C * towed_mass; // N/(m/s)²
 
-            let solid_friction_a = traction_engine_solid_friction_a + towed_solid_friction_a;
+            let solid_friction_a = traction_engine_solid_friction_a + towed_solid_friction_a; // N
             let viscosity_friction_b =
-                traction_engine_viscosity_friction_b + towed_viscosity_friction_b;
-            let aerodynamic_drag_c = traction_engine_aerodynamic_drag_c + towed_aerodynamic_drag_c;
+                traction_engine_viscosity_friction_b + towed_viscosity_friction_b; // N/(m/s)
+            let aerodynamic_drag_c = traction_engine_aerodynamic_drag_c + towed_aerodynamic_drag_c; // N/(m/s)²
 
             RollingResistance {
                 rolling_resistance_type: traction_engine_rr.rolling_resistance_type.clone(),
@@ -592,9 +592,9 @@ mod tests {
             physics_consist.compute_rolling_resistance(),
             RollingResistance {
                 rolling_resistance_type: "davis".to_string(),
-                A: 1350.0,
-                B: 48.6,
-                C: 7.387200000000001
+                A: 35001.0,
+                B: 350.01,
+                C: 7.0005,
             }
         );
 

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -15,6 +15,7 @@ use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::Gamma;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::rolling_stock::RollingResistance;
+use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::RollingStock;
 use editoast_schemas::rolling_stock::RollingStockSupportedSignalingSystems;
 use editoast_schemas::rolling_stock::TowedRollingStock;
@@ -230,11 +231,11 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
         comfort_acceleration: 0.2, // In m/s²
         startup_acceleration: 0.06,
         inertia_coefficient: 1.05,
-        rolling_resistance: RollingResistance {
+        rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,    // In kN
-            B: 0.01,   // In kN/(km/h)
-            C: 0.0002, // In kN/(km/h)²
+            A: 1.0,    // In N
+            B: 0.01,   // In N/(m/s)
+            C: 0.0002, // In N/(m/s)²
         },
         gamma: Gamma {
             gamma_type: "CONST".to_string(),
@@ -268,9 +269,9 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,    // In kN
-            B: 0.01,   // In kN/(km/h)
-            C: 0.0005, // In kN/(km/h)²
+            A: 1.0,    // In N
+            B: 0.01,   // In N/(m/s)
+            C: 0.0005, // In N/(m/s)²
         },
         length: 140.0,   // m
         mass: 15000.0,   // kg

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -1,6 +1,6 @@
 use editoast_derive::Model;
 use editoast_schemas::rolling_stock::Gamma;
-use editoast_schemas::rolling_stock::RollingResistance;
+use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::TowedRollingStock;
 use serde::Deserialize;
 use serde::Serialize;
@@ -29,7 +29,7 @@ pub struct TowedRollingStockModel {
     pub startup_acceleration: f64,
     pub inertia_coefficient: f64,
     #[model(json)]
-    pub rolling_resistance: RollingResistance,
+    pub rolling_resistance: RollingResistancePerWeight,
     #[model(json)]
     pub gamma: Gamma,
 

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -18,7 +18,7 @@ use editoast_authz::BuiltinRole;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::rolling_stock::Gamma;
-use editoast_schemas::rolling_stock::RollingResistance;
+use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::ROLLING_STOCK_RAILJSON_VERSION;
 use serde::Deserialize;
 use serde::Serialize;
@@ -59,7 +59,7 @@ struct TowedRollingStock {
     comfort_acceleration: f64,
     startup_acceleration: f64,
     inertia_coefficient: f64,
-    rolling_resistance: RollingResistance,
+    rolling_resistance: RollingResistancePerWeight,
     gamma: Gamma,
 }
 
@@ -104,7 +104,7 @@ pub struct TowedRollingStockForm {
     pub comfort_acceleration: f64,
     pub startup_acceleration: f64,
     pub inertia_coefficient: f64,
-    pub rolling_resistance: RollingResistance,
+    pub rolling_resistance: RollingResistancePerWeight,
     pub gamma: Gamma,
 }
 

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -901,9 +901,9 @@ mod tests {
             physics_consist.rolling_resistance,
             RollingResistance {
                 rolling_resistance_type: "davis".to_string(),
-                A: 2000.0,
-                B: 72.0,
-                C: 9.072000000000001
+                A: 100001.0,
+                B: 1000.01,
+                C: 20.0005
             }
         );
     }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2589,11 +2589,11 @@ export type RollingStockMetadata = {
   unit: string;
 };
 export type RollingResistance = {
-  /** Solid friction in kN */
+  /** Solid friction in N */
   A: number;
-  /** Viscosity friction in kN/(km/h) */
+  /** Viscosity friction in N/(m/s) */
   B: number;
-  /** Aerodynamic drag in kN/(km/h)² */
+  /** Aerodynamic drag in N/(m/s)² */
   C: number;
   type: string;
 };
@@ -3241,6 +3241,15 @@ export type TrainScheduleResult = TrainScheduleBase & {
   id: number;
   timetable_id: number;
 };
+export type RollingResistancePerWeight = {
+  /** Solid friction in N/kg */
+  A: number;
+  /** Viscosity friction in (N/kg)/(m/s) */
+  B: number;
+  /** Aerodynamic drag in (N/kg)/(m/s)² */
+  C: number;
+  type: string;
+};
 export type TowedRollingStock = {
   comfort_acceleration: number;
   gamma: Gamma;
@@ -3252,7 +3261,7 @@ export type TowedRollingStock = {
   mass: number;
   name: string;
   railjson_version: string;
-  rolling_resistance: RollingResistance;
+  rolling_resistance: RollingResistancePerWeight;
   startup_acceleration: number;
 };
 export type TowedRollingStockForm = {
@@ -3264,7 +3273,7 @@ export type TowedRollingStockForm = {
   locked: boolean;
   mass: number;
   name: string;
-  rolling_resistance: RollingResistance;
+  rolling_resistance: RollingResistancePerWeight;
   startup_acceleration: number;
 };
 export type TowedRollingStockLockedForm = {


### PR DESCRIPTION
Fixes #9657 (or we hope it does at least).

The database is populated with SI units, which means Newton, kg, meter and seconds.

Another important piece of information is:
- Units of rolling resistance for traction engines (also named rolling stocks) are in N, N/(m/s) and N/(m/s)²
- Units of rolling resistance for towed rolling stocks are in (N/kg), (N/kg)/(m/s) and (N/kg)/(m/s)².

Therefore, we need 2 different `struct` for storing those, hence the introduction of `RollingResistancePerWeight`.