### PR TITLE
front: stdcm: fix typo

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -57,7 +57,7 @@
       "remainingWorkConflicts_one": "one other work in conflict",
       "workConflictSameDay": "scheduled work from <strong>{{waypointBefore}}</strong> to <strong>{{waypointAfter}}</strong> on {{startDate}} between {{startTime}} and {{endTime}}",
       "workConflict": "scheduled work from <strong>{{waypointBefore}}</strong> to <strong>{{waypointAfter}}</strong> from {{startDate}} at {{startTime}} to {{endDate}} at {{endTime}}",
-      "changeSearchCriteria": "You can modify your search criteria to find a solution",
+      "changeSearchCriteria": "You can modify your search criteria to find a solution.",
       "retainThisSimulation": "Retain this simulation",
       "simulationName": {
         "withOutputs": "Simulation n°{{id}}",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -57,7 +57,7 @@
       "remainingWorkConflicts_one": "un autre conflit avec des travaux",
       "workConflictSameDay": "travaux de <strong>{{waypointBefore}}</strong> à <strong>{{waypointAfter}}</strong> le {{startDate}} entre {{startTime}} et {{endTime}}",
       "workConflict": "travaux de <strong>{{waypointBefore}}</strong> à <strong>{{waypointAfter}}</strong> du {{startDate}} à {{startTime}} au {{endDate}} à {{endTime}}",
-      "changeSearchCriteria": "Vous pouvez modifier vos critères de recherche pour trouver une solution",
+      "changeSearchCriteria": "Vous pouvez modifier vos critères de recherche pour trouver une solution.",
       "retainThisSimulation": "Retenir cette simulation",
       "simulationName": {
         "withOutputs": "Simulation n°{{id}}",


### PR DESCRIPTION
Fix typo, see Mock-up :

![image](https://github.com/user-attachments/assets/f5477fd0-94c6-4a59-aa04-38f3a5f38157)