### PR TITLE
front: fix font weight in input timestop table

### DIFF
--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -49,15 +49,15 @@
       margin-inline: 10px;
       background-color: var(--grey20);
     }
+
+    .active {
+      color: var(--grey90);
+      font-weight: 600;
+    }
   }
 
   .micro-macro-buttons:hover {
     background-color: var(--white100);
-  }
-
-  .active {
-    color: var(--grey90);
-    font-weight: 600;
   }
 
   .scenario-timetable-collapsed {


### PR DESCRIPTION
Close #9732

Bug introduced in https://github.com/OpenRailAssociation/osrd/pull/8861, looking at the pr it stands to reason that .active is supposed to be specialized to micro macro buttons. Inspecting the page, it does not seem that any other element affected by the pr was using the .active class.