### PR TITLE
front: fix via deletion from timestop table

### DIFF
--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -64,7 +64,7 @@ type TimesStopsInputProps = {
 const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInputProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('timesStops');
-  const { updatePathSteps, upsertSeveralViasFromSuggestedOP } = useOsrdConfActions();
+  const { deleteVia, upsertSeveralViasFromSuggestedOP } = useOsrdConfActions();
 
   const [rows, setRows] = useState<TimesStopsInputRow[]>([]);
 
@@ -88,19 +88,7 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
 
     if (index === -1) return;
 
-    const updatedPathSteps = pathSteps.map((step, i) => {
-      if (i === index) {
-        return {
-          ...step,
-          stopFor: undefined,
-          theoreticalMargin: undefined,
-          arrival: undefined,
-          receptionSignal: undefined,
-        };
-      }
-      return step;
-    });
-    dispatch(updatePathSteps({ pathSteps: updatedPathSteps }));
+    dispatch(deleteVia(index - 1));
   };
 
   const onChange = useCallback(


### PR DESCRIPTION
Would close #9026

Vias are now actually deleted from the path steps list when clearing a line in the input table. 

However, input table deletion also deletes vias added via pathfinding. We probably only want to delete vias added from the input table, but once added we lack the information to distinguish them.

We probably want to add a flag to the pathsteplist to distinguish steps added from constraints from steps added from pathfinding.