### PR TITLE
front: fix row deletion in timestop input table

### DIFF
--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -15,6 +15,7 @@ import {
   durationSinceStartTime,
   formatSuggestedViasToRowVias,
   onStopSignalToReceptionSignal,
+  normalizeNullablesInRow,
   updateDaySinceDeparture,
   updateRowTimesAndMargin,
 } from './helpers/utils';
@@ -125,7 +126,10 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
         setRows(newRows);
       } else {
         const newVias = updatedRows
-          .filter((row, index) => !isEqual(row, rows[index]))
+          .filter(
+            (row, index) =>
+              !isEqual(normalizeNullablesInRow(row), normalizeNullablesInRow(rows[index]))
+          )
           .map(({ shortSlipDistance, onStopSignal, arrival, departure, ...row }) => ({
             ...row,
             arrival: durationSinceStartTime(startTime, arrival),

--- a/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/utils.spec.ts
@@ -74,7 +74,7 @@ describe('updateRowTimesAndMargin', () => {
         name: 'Gr',
         arrival: undefined,
         isMarginValid: true,
-        onStopSignal: false,
+        onStopSignal: undefined,
         theoreticalMargin: '0%',
       });
     });
@@ -182,7 +182,7 @@ describe('updateRowTimesAndMargin', () => {
         departure: undefined,
         stopFor: undefined,
         isMarginValid: true,
-        onStopSignal: false,
+        onStopSignal: undefined,
       });
     });
   });

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -196,7 +196,11 @@ export function updateRowTimesAndMargin(
       newRowData.stopFor = undefined;
     }
   }
-  if (!newRowData.stopFor && op.fromRowIndex !== allWaypointsLength - 1) {
+  if (
+    !newRowData.stopFor &&
+    newRowData.onStopSignal &&
+    op.fromRowIndex !== allWaypointsLength - 1
+  ) {
     newRowData.onStopSignal = false;
   }
   newRowData.isMarginValid = !(
@@ -211,6 +215,21 @@ export function updateRowTimesAndMargin(
     }
   }
   return newRowData;
+}
+
+/**
+ * This function is called before comparing rows to prevent a change from undefined to null (or the reverse)
+ * from being treated as an actual update of a row (otherwise changes would occur on deletion of an undefined field)
+ */
+export function normalizeNullablesInRow(row: TimesStopsInputRow): TimesStopsInputRow {
+  const normalizedRow = { ...row };
+  if (normalizedRow.stopFor === null) {
+    normalizedRow.stopFor = undefined;
+  }
+  if (normalizedRow.theoreticalMargin === null) {
+    normalizedRow.theoreticalMargin = undefined;
+  }
+  return normalizedRow;
 }
 
 /**


### PR DESCRIPTION
Partial fix of #8959
-> IV. Multi selected fields modification is bugged
-> V. Delete the value of a stopping time field behaves weirdly

Prevents deletion of empty fields from creating a via