### PR TITLE
misc: add jetbrain folder .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.backup
 __pycache__
 .vscode
+.idea
 
 # Direnv
 .envrc

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,5 +1,4 @@
 .gradle
-.idea
 .kotlin
 build
 *.iml


### PR DESCRIPTION
Prevent files from jetbrain IDEs (datagrip, intellij, pycharm, webstorm, ...) from being tracked.

Jetbrain actually recommends part of the .idea folder to be shared via git and provides its own .gitignore for this purpose, but I'm not sure enough people use jetbrain in our project to warrant this.