### PR TITLE
core: reduce the amount of logs for repeated events

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -116,6 +116,7 @@ class STDCMPathfinding(
         assert(stops.isNotEmpty())
         starts = getStartNodes(stops, listOf(constraints))
         val path = findPathImpl()
+        graph.stdcmSimulations.logWarnings()
         if (path == null) {
             logger.info("Failed to find a path")
             return null

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/BacktrackingTests.kt
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/DepartureTimeShiftTests.kt
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.stdcm.graph.simulateBlock
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/STDCMHelpers.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMultimap
 import fr.sncf.osrd.DriverBehaviour
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.makeChunkPath
+import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
 import fr.sncf.osrd.graph.GraphAdapter
 import fr.sncf.osrd.graph.Pathfinding
@@ -15,10 +16,11 @@ import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.standalone_sim.StandaloneSim
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
-import fr.sncf.osrd.stdcm.graph.simulateBlock
+import fr.sncf.osrd.stdcm.graph.STDCMSimulations
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorer
 import fr.sncf.osrd.stdcm.preprocessing.OccupancySegment
+import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.StandaloneTrainSchedule
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.train.TrainStop
@@ -118,6 +120,36 @@ fun getBlocksRunTime(infra: FullInfra, blocks: List<BlockId>): Double {
     }
     return time
 }
+
+/** Helper function to call `simulateBlock` without instantiating an `STDCMSimulations` */
+fun simulateBlock(
+    rawInfra: RawSignalingInfra,
+    infraExplorer: InfraExplorer,
+    initialSpeed: Double,
+    start: Offset<Block>,
+    rollingStock: RollingStock,
+    comfort: Comfort?,
+    timeStep: Double,
+    stopPosition: Offset<Block>?,
+    trainTag: String?
+): Envelope? {
+    val sim = STDCMSimulations()
+    val res =
+        sim.simulateBlock(
+            rawInfra,
+            infraExplorer,
+            initialSpeed,
+            start,
+            rollingStock,
+            comfort,
+            timeStep,
+            stopPosition,
+            trainTag
+        )
+    sim.logWarnings()
+    return res
+}
+
 /**
  * Checks that the result doesn't cross an occupied section, with a certain tolerance for binary
  * search inaccuracies


### PR DESCRIPTION
Reduces the amount of logs in two cases:

1. Invalid work schedules: we only log the amount that were invalid and a few "samples"
2. Impossible simulations in stdcm search: we only log the first actual error, then just the number of failures