### PR TITLE
front: nge language synchro + Remove SBB header + bump NGE version 2.9.9

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.6d049b7244241254c33afc3818f40ec57ab57217",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528",
     "@osrd-project/ui-core": "^0.0.53",
     "@osrd-project/ui-icons": "^0.0.53",
     "@osrd-project/ui-manchette": "^0.0.53",

--- a/front/public/locales/de/home/navbar.json
+++ b/front/public/locales/de/home/navbar.json
@@ -2,8 +2,11 @@
   "about": "Über OSRD",
   "attributions": "Zuweisungen",
   "disconnect": "Abmelden",
+  "help": "Hilfe",
   "informations": {
     "application": "Anwendung",
+    "collaborations": "Kooperationen",
+    "dataSources": "Datenquellen",
     "librairies": "Versionsinformationen",
     "version": "Version"
   },

--- a/front/public/locales/en/home/navbar.json
+++ b/front/public/locales/en/home/navbar.json
@@ -5,6 +5,7 @@
   "help": "Help",
   "informations": {
     "application": "Application",
+    "collaborations": "Collaborations",
     "dataSources": "Data sources",
     "librairies": "Libraries & licenses",
     "version": "Version"

--- a/front/public/locales/fr/home/navbar.json
+++ b/front/public/locales/fr/home/navbar.json
@@ -5,6 +5,7 @@
   "help": "Aide",
   "informations": {
     "application": "Application",
+    "collaborations": "Collaborations",
     "dataSources": "Sources de données",
     "librairies": "Librairies & licences",
     "version": "Version"

--- a/front/src/applications/operationalStudies/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/NGE/NGE.tsx
@@ -8,9 +8,12 @@ import ngeStyles from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-fronten
 import ngeVendor from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-frontend/vendor.js?url';
 /* eslint-enable import/extensions, import/no-unresolved */
 
+import i18n from 'i18n';
+
 import type { NetzgrafikDto, NGEEvent } from './types';
 
 interface NGEElement extends HTMLElement {
+  language: string;
   netzgrafikDto: NetzgrafikDto;
 }
 
@@ -68,6 +71,12 @@ const NGE = ({ dto, onOperation }: NGEProps) => {
       frame.removeEventListener('load', handleFrameLoad);
     };
   }, []);
+
+  useEffect(() => {
+    if (ngeRootElement && i18n.language) {
+      ngeRootElement.language = i18n.language;
+    }
+  }, [i18n.language, ngeRootElement]);
 
   useEffect(() => {
     if (ngeRootElement && dto) {

--- a/front/src/common/ReleaseInformations/LicenseAttributions.tsx
+++ b/front/src/common/ReleaseInformations/LicenseAttributions.tsx
@@ -11,6 +11,17 @@ type AttributionLicense = {
   license: string;
 };
 
+const COLLABORATIONS: AttributionLicense[] = [
+  {
+    license: 'Apache-2.0',
+    publisher: 'Apache',
+    copyright: '© 2024 Swiss Federal Railways SBB AG',
+    version: '',
+    name: 'Netzgrafik-Editor',
+    url: 'https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend',
+  },
+];
+
 // Libs which are not in the package.json, so we add it statically
 const DATA_SOURCES: AttributionLicense[] = [
   {
@@ -78,7 +89,13 @@ const LicenseAttributions = () => {
 
   return (
     <div className="col-md-6 h-100 d-flex flex-column">
-      <h2 className="text-center mb-4">{t('informations.dataSources')}</h2>
+      <h2 className="text-center mb-4">{t('informations.collaborations')}</h2>
+      <div className="license-attributions">
+        {COLLABORATIONS.map((dataSource) => (
+          <LicenseCard attribution={dataSource} key={dataSource.name} />
+        ))}
+      </div>
+      <h2 className="text-center my-4">{t('informations.dataSources')}</h2>
       <div className="license-attributions">
         {DATA_SOURCES.map((dataSource) => (
           <LicenseCard attribution={dataSource} key={dataSource.name} />

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1142,10 +1142,10 @@
     openapi-typescript "^5.4.1"
     yargs "^17.7.2"
 
-"@osrd-project/netzgrafik-frontend@0.0.0-snapshot.6d049b7244241254c33afc3818f40ec57ab57217":
-  version "0.0.0-snapshot.6d049b7244241254c33afc3818f40ec57ab57217"
-  resolved "https://registry.yarnpkg.com/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.6d049b7244241254c33afc3818f40ec57ab57217.tgz#40e507bb3e05be9c6dc07f6ed5533c3db5426d24"
-  integrity sha512-lK/r4qYPeibUtoumN/oaj1spoL7S7lK0J3ZLIf2pm/xCjbK/Gx+8QLNDz6PMoKlG19RUbFc765qybzADo3e3pg==
+"@osrd-project/netzgrafik-frontend@0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528":
+  version "0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528"
+  resolved "https://registry.yarnpkg.com/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528.tgz#b6970f0c9ee230f83f6f6b37853a2c01ee4e63b5"
+  integrity sha512-aaLaR3LGU6tyyz27/tzba1F9Yj+V2rkcSjerr856Q4yAc2xYH53eFU/LK6mcfieqPZFfSwJu1bfIgJ+hA8tLJg==
 
 "@osrd-project/ui-core@^0.0.53":
   version "0.0.53"


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/9694

- Allow language synchronization
- Remove sbb header
- Credit sbb
- bump forked NGE version to 2.9.9

![image](https://github.com/user-attachments/assets/0bd94a20-074f-4261-821b-d3a713a2fbbc)

note to myself : remember to squash before merge