### PR TITLE
front: leave ch code null when unspecified in XML import

### DIFF
--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -49,7 +49,7 @@ export type TrainScheduleImportConfig = {
 };
 
 export type CichDictValue = {
-  ciCode: number | string;
+  ciCode: number;
   chCode?: string;
 };
 

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -157,10 +157,9 @@ const ImportTrainScheduleConfig = ({
       } as TrainScheduleImportConfig);
     }
   }
-  // EXTRACT-CI-CH-CODE
   const extractCiChCode = (code: string) => {
     const [ciCode, chCode] = code.split('/');
-    return { ciCode: ciCode || '', chCode: chCode || '' };
+    return { ciCode, chCode };
   };
 
   const cleanTimeFormat = (time: string): string => time.replace(/\.0$/, ''); // Remove the '.0' if it's at the end of the time string

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -159,7 +159,7 @@ const ImportTrainScheduleConfig = ({
   }
   const extractCiChCode = (code: string) => {
     const [ciCode, chCode] = code.split('/');
-    return { ciCode, chCode };
+    return { ciCode: Number(ciCode), chCode };
   };
 
   const cleanTimeFormat = (time: string): string => time.replace(/\.0$/, ''); // Remove the '.0' if it's at the end of the time string


### PR DESCRIPTION
An empty string will specifically select OPs without any secondary
code. However that's very unlikely that's what the user wants: in
the French infrastructure, all OPs have a secondary code. Instead,
use undefined to match any secondary code.

While at it, drop the empty string default for ciCode: this is
always guaranteed to be a string (because split() always returns
an array with at least one element) so it's dead code.

To test: edit an XML file to remove a ch code (e.g. replace `SG/BV` with `SG`), then import it.

Also includes a cleanup commit.