### PR TITLE
front: use matchPathStepAndOp() in upsertPathStepsInOPs()

### DIFF
--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -121,9 +121,9 @@ export const upsertPathStepsInOPs = (ops: SuggestedOP[], pathSteps: PathStep[]):
       } else {
         updatedOPs.push(formattedStep);
       }
-    } else if ('uic' in step) {
+    } else {
       updatedOPs = updatedOPs.map((op) => {
-        if (op.uic === step.uic && op.ch === step.ch && op.kp === step.kp) {
+        if (matchPathStepAndOp(step, op) && op.kp === step.kp) {
           return {
             ...op,
             stopFor,


### PR DESCRIPTION
matchPathStepAndOp() is more general than special-casing UICs. It should make upsertPathStepsInOPs() work even if steps are defined in terms of trigrams or OP IDs.