### PR TITLE
Fix speed limit tags for stdcm

### DIFF
--- a/front/src/applications/stdcm/consts.ts
+++ b/front/src/applications/stdcm/consts.ts
@@ -19,14 +19,6 @@ export const COMPOSITION_CODES = [
   'ME140',
   'MV160',
   'MVGV',
-  'Marchandise',
-  'Marchandise - MA100',
-  'Marchandise - MA80',
-  'Marchandise - MA90',
-  'Messagerie - ME100',
-  'Messagerie - ME120',
-  'Messagerie - ME140',
-  'Messagerie - MVGV',
 ];
 
 export const DEFAULT_TOLERANCE = 1800; // 30min


### PR DESCRIPTION
The list of speed limits was invalid for STDCM.

close https://github.com/OpenRailAssociation/osrd/issues/9682