### PR TITLE
editoast: work-schedules: add endpoints for easier edition and viewing

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3095,7 +3095,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WorkScheduleCreateForm'
+              type: object
+              description: This structure is used by the post endpoint to create a work schedule
+              required:
+              - work_schedule_group_name
+              - work_schedules
+              properties:
+                work_schedule_group_name:
+                  type: string
+                work_schedules:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/WorkScheduleItemForm'
         required: true
       responses:
         '201':
@@ -3103,7 +3114,151 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkScheduleCreateResponse'
+                type: object
+                required:
+                - work_schedule_group_id
+                properties:
+                  work_schedule_group_id:
+                    type: integer
+                    format: int64
+  /work_schedules/group:
+    get:
+      tags:
+      - work_schedules
+      responses:
+        '201':
+          description: The existing work schedule group ids
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+    post:
+      tags:
+      - work_schedules
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                work_schedule_group_name:
+                  type: string
+                  nullable: true
+        required: true
+      responses:
+        '200':
+          description: The id of the created work schedule group
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - work_schedule_group_id
+                properties:
+                  work_schedule_group_id:
+                    type: integer
+                    format: int64
+  /work_schedules/group/{id}:
+    get:
+      tags:
+      - work_schedules
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 25
+          nullable: true
+          minimum: 1
+      - name: id
+        in: path
+        description: A work schedule group ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: ordering
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/Ordering'
+      responses:
+        '200':
+          description: The work schedules in the group
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginationStats'
+                - type: object
+                  required:
+                  - results
+                  properties:
+                    results:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/WorkSchedule'
+        '404':
+          description: Work schedule group not found
+    put:
+      tags:
+      - work_schedules
+      parameters:
+      - name: id
+        in: path
+        description: A work schedule group ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/WorkScheduleItemForm'
+        required: true
+      responses:
+        '200':
+          description: The work schedules have been created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkSchedule'
+        '404':
+          description: Work schedule group not found
+    delete:
+      tags:
+      - work_schedules
+      parameters:
+      - name: id
+        in: path
+        description: A work schedule group ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: The work schedule group has been deleted
+        '404':
+          description: The work schedule group does not exist
   /work_schedules/project_path:
     post:
       tags:
@@ -4375,6 +4530,7 @@ components:
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorNameAlreadyUsed'
+      - $ref: '#/components/schemas/EditoastWorkScheduleErrorWorkScheduleGroupNotFound'
       description: Generated error type for Editoast
       discriminator:
         propertyName: type
@@ -5793,6 +5949,30 @@ components:
           type: string
           enum:
           - editoast:work_schedule:NameAlreadyUsed
+    EditoastWorkScheduleErrorWorkScheduleGroupNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - id
+          properties:
+            id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:work_schedule:WorkScheduleGroupNotFound
     EffortCurve:
       type: object
       required:
@@ -10873,27 +11053,37 @@ components:
             type: string
             enum:
             - Detector
-    WorkScheduleCreateForm:
-      type: object
-      description: This structure is used by the post endpoint to create a work schedule
-      required:
-      - work_schedule_group_name
-      - work_schedules
-      properties:
-        work_schedule_group_name:
-          type: string
-        work_schedules:
-          type: array
-          items:
-            $ref: '#/components/schemas/WorkScheduleItemForm'
-    WorkScheduleCreateResponse:
+    WorkSchedule:
       type: object
       required:
+      - id
+      - start_date_time
+      - end_date_time
+      - track_ranges
+      - obj_id
+      - work_schedule_type
       - work_schedule_group_id
       properties:
+        end_date_time:
+          type: string
+          format: date-time
+        id:
+          type: integer
+          format: int64
+        obj_id:
+          type: string
+        start_date_time:
+          type: string
+          format: date-time
+        track_ranges:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrackRange'
         work_schedule_group_id:
           type: integer
           format: int64
+        work_schedule_type:
+          $ref: '#/components/schemas/WorkScheduleType'
     WorkScheduleItemForm:
       type: object
       required:
@@ -10920,6 +11110,11 @@ components:
           enum:
           - CATENARY
           - TRACK
+    WorkScheduleType:
+      type: string
+      enum:
+      - CATENARY
+      - TRACK
     ZoneUpdate:
       type: object
       required:

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -29,9 +29,9 @@ pub enum WorkScheduleType {
     Track,
 }
 
-#[derive(Debug, Default, Clone, Model)]
+#[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema)]
 #[model(table = editoast_models::tables::work_schedule)]
-#[model(gen(batch_ops = c, list))]
+#[model(gen(batch_ops = cd, list))]
 pub struct WorkSchedule {
     pub id: i64,
     pub start_date_time: DateTime<Utc>,

--- a/editoast/src/views/operational_studies.rs
+++ b/editoast/src/views/operational_studies.rs
@@ -1,4 +1,5 @@
 use crate::models::prelude::*;
+use crate::models::work_schedules::WorkSchedule;
 use crate::models::Project;
 use crate::models::Scenario;
 use crate::models::Study;
@@ -56,6 +57,14 @@ impl Ordering {
             Ordering::CreationDateDesc => Scenario::CREATION_DATE.desc(),
             Ordering::LastModifiedAsc => Scenario::LAST_MODIFICATION.asc(),
             Ordering::LastModifiedDesc => Scenario::LAST_MODIFICATION.desc(),
+        }
+    }
+
+    pub fn as_work_schedule_ordering(&self) -> SortSetting<WorkSchedule> {
+        match *self {
+            Ordering::NameAsc => WorkSchedule::OBJ_ID.asc(),
+            Ordering::NameDesc => WorkSchedule::OBJ_ID.desc(),
+            _ => WorkSchedule::OBJ_ID.asc(),
         }
     }
 }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -220,7 +220,8 @@
       "InvalidUrl": "Invalid url '{{url}}'"
     },
     "work_schedule": {
-      "NameAlreadyUsed": "A group of work schedules with '{{name}}' already exists"
+      "NameAlreadyUsed": "A group of work schedules with '{{name}}' already exists",
+      "WorkScheduleGroupNotFound": "No such work schedule group with id '{{id}}'"
     },
     "temporary_speed_limit": {
       "NameAlreadyUsed": "A group of temporary speed limits with '{{name}}' already exists"

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -217,7 +217,8 @@
       "InvalidUrl": "Url invalide '{{url}}'"
     },
     "work_schedule": {
-      "NameAlreadyUsed": "Un groupe de planches travaux avec le nom '{{name}}' existe déjà"
+      "NameAlreadyUsed": "Un groupe de planches travaux avec le nom '{{name}}' existe déjà",
+      "WorkScheduleGroupNotFound": "Le groupe de planche travaux avec l'id {{id}} n'existe pas"
     },
     "temporary_speed_limit": {
       "NameAlreadyUsed": "Un groupe de limites temporaires de vitesse avec le nom '{{name}} existe déjà"

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -911,11 +911,57 @@ const injectedRtkApi = api
         query: () => ({ url: `/version/core` }),
       }),
       postWorkSchedules: build.mutation<PostWorkSchedulesApiResponse, PostWorkSchedulesApiArg>({
+        query: (queryArg) => ({ url: `/work_schedules`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['work_schedules'],
+      }),
+      getWorkSchedulesGroup: build.query<
+        GetWorkSchedulesGroupApiResponse,
+        GetWorkSchedulesGroupApiArg
+      >({
+        query: () => ({ url: `/work_schedules/group` }),
+        providesTags: ['work_schedules'],
+      }),
+      postWorkSchedulesGroup: build.mutation<
+        PostWorkSchedulesGroupApiResponse,
+        PostWorkSchedulesGroupApiArg
+      >({
         query: (queryArg) => ({
-          url: `/work_schedules`,
+          url: `/work_schedules/group`,
           method: 'POST',
-          body: queryArg.workScheduleCreateForm,
+          body: queryArg.body,
         }),
+        invalidatesTags: ['work_schedules'],
+      }),
+      getWorkSchedulesGroupById: build.query<
+        GetWorkSchedulesGroupByIdApiResponse,
+        GetWorkSchedulesGroupByIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/work_schedules/group/${queryArg.id}`,
+          params: {
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+            ordering: queryArg.ordering,
+          },
+        }),
+        providesTags: ['work_schedules'],
+      }),
+      putWorkSchedulesGroupById: build.mutation<
+        PutWorkSchedulesGroupByIdApiResponse,
+        PutWorkSchedulesGroupByIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/work_schedules/group/${queryArg.id}`,
+          method: 'PUT',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['work_schedules'],
+      }),
+      deleteWorkSchedulesGroupById: build.mutation<
+        DeleteWorkSchedulesGroupByIdApiResponse,
+        DeleteWorkSchedulesGroupByIdApiArg
+      >({
+        query: (queryArg) => ({ url: `/work_schedules/group/${queryArg.id}`, method: 'DELETE' }),
         invalidatesTags: ['work_schedules'],
       }),
       postWorkSchedulesProjectPath: build.query<
@@ -1686,9 +1732,49 @@ export type GetVersionApiArg = void;
 export type GetVersionCoreApiResponse = /** status 200 Return the core service version */ Version;
 export type GetVersionCoreApiArg = void;
 export type PostWorkSchedulesApiResponse =
-  /** status 201 The id of the created work schedule group */ WorkScheduleCreateResponse;
+  /** status 201 The id of the created work schedule group */ {
+    work_schedule_group_id: number;
+  };
 export type PostWorkSchedulesApiArg = {
-  workScheduleCreateForm: WorkScheduleCreateForm;
+  body: {
+    work_schedule_group_name: string;
+    work_schedules: WorkScheduleItemForm[];
+  };
+};
+export type GetWorkSchedulesGroupApiResponse =
+  /** status 201 The existing work schedule group ids */ number[];
+export type GetWorkSchedulesGroupApiArg = void;
+export type PostWorkSchedulesGroupApiResponse =
+  /** status 200 The id of the created work schedule group */ {
+    work_schedule_group_id: number;
+  };
+export type PostWorkSchedulesGroupApiArg = {
+  body: {
+    work_schedule_group_name?: string | null;
+  };
+};
+export type GetWorkSchedulesGroupByIdApiResponse =
+  /** status 200 The work schedules in the group */ PaginationStats & {
+    results: WorkSchedule[];
+  };
+export type GetWorkSchedulesGroupByIdApiArg = {
+  page?: number;
+  pageSize?: number | null;
+  /** A work schedule group ID */
+  id: number;
+  ordering?: Ordering;
+};
+export type PutWorkSchedulesGroupByIdApiResponse =
+  /** status 200 The work schedules have been created */ WorkSchedule[];
+export type PutWorkSchedulesGroupByIdApiArg = {
+  /** A work schedule group ID */
+  id: number;
+  body: WorkScheduleItemForm[];
+};
+export type DeleteWorkSchedulesGroupByIdApiResponse = unknown;
+export type DeleteWorkSchedulesGroupByIdApiArg = {
+  /** A work schedule group ID */
+  id: number;
 };
 export type PostWorkSchedulesProjectPathApiResponse =
   /** status 201 Returns a list of work schedules whose track ranges intersect the given path */ {
@@ -3389,9 +3475,6 @@ export type TrainScheduleForm = TrainScheduleBase & {
 export type Version = {
   git_describe: string | null;
 };
-export type WorkScheduleCreateResponse = {
-  work_schedule_group_id: number;
-};
 export type WorkScheduleItemForm = {
   end_date_time: string;
   obj_id: string;
@@ -3399,9 +3482,15 @@ export type WorkScheduleItemForm = {
   track_ranges: TrackRange[];
   work_schedule_type: 'CATENARY' | 'TRACK';
 };
-export type WorkScheduleCreateForm = {
-  work_schedule_group_name: string;
-  work_schedules: WorkScheduleItemForm[];
+export type WorkScheduleType = 'CATENARY' | 'TRACK';
+export type WorkSchedule = {
+  end_date_time: string;
+  id: number;
+  obj_id: string;
+  start_date_time: string;
+  track_ranges: TrackRange[];
+  work_schedule_group_id: number;
+  work_schedule_type: WorkScheduleType;
 };
 export type Intersection = {
   /** Distance of the end of the intersection relative to the beginning of the path */


### PR DESCRIPTION
Would fix 2/3 of https://github.com/osrd-project/osrd-confidential/issues/838, the rest is changing the etl for batched imports.

I've added a few more endpoints than just what was in the ticket, to have a complete workflow:

1. `POST /work_schedules/group`: create a new group (name can be empty and autofilled (the unique name thing is just painful))
1. `GET /work_schedules/group`: lists all the group ids
2. `PUT /work_schedules/group/42`: insets a work schedule into an existing group
3. `GET /work_schedules/group/42`: lists all the work schedules in the group
4. `DELETE /workçschedules/group/42`: deletes the group and its work schedules


What I **have not** added but could have been nice:

1. More details in `GET /work_schedules/group` (name, creation date, ...)
2. `GET /work_schedules` to list them all
3. Any kind of endpoint dealing with individual work schedules