### PR TITLE
Rename header to skip authorization

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ApiServerCommand.java
@@ -42,7 +42,7 @@ public final class ApiServerCommand implements CliCommand {
     @Parameter(
             names = {"--editoast-authorization"},
             description = "The HTTP Authorization header sent to editoast")
-    private String editoastAuthorization = "x-osrd-core";
+    private String editoastAuthorization = "x-osrd-skip-authz";
 
     @Parameter(
             names = {"-j", "--threads"},

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -38,7 +38,7 @@ class WorkerCommand : CliCommand {
         names = ["--editoast-authorization"],
         description = "The HTTP Authorization header sent to editoast"
     )
-    private var editoastAuthorization: String = "x-osrd-core"
+    private var editoastAuthorization: String = "x-osrd-skip-authz"
 
     val WORKER_ID: String?
     val WORKER_ID_USE_HOSTNAME: Boolean

--- a/gateway/gateway.toml
+++ b/gateway/gateway.toml
@@ -14,7 +14,7 @@ endpoint = "http://localhost:4317"
 prefix = "/api"
 upstream = "http://localhost:8090"
 require_auth = true
-blocked_headers = ["x-osrd-core"]
+blocked_headers = ["x-osrd-skip-authz"]
 
 [[targets]]
 upstream = "http://localhost:3000"


### PR DESCRIPTION
Core is not the only service that should bypass the authorization

osrd-chart PR: https://github.com/OpenRailAssociation/osrd-chart/pull/39