### PR TITLE
front: use clean oazapfts master branch

### DIFF
--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -7989,7 +7989,7 @@ oas-validator@^5.0.8:
 
 oazapfts@^4.8.0, oazapfts@osrd-project/oazapfts#master:
   version "0.0.0-development"
-  resolved "https://codeload.github.com/osrd-project/oazapfts/tar.gz/3cdfac73c2615b923ba1cde9027ea096bc56ac54"
+  resolved "https://codeload.github.com/osrd-project/oazapfts/tar.gz/ce86de04f9590074ce701fd2bb4e902bbd7ae565"
   dependencies:
     "@apidevtools/swagger-parser" "^10.1.0"
     lodash "^4.17.21"


### PR DESCRIPTION
cleaned up master branch on [oazapfts](https://github.com/osrd-project/oazapfts/tree/master). no change in behavior

------
Maintainer of main repo taking time off, so this might be here for a while

https://github.com/oazapfts/oazapfts/pull/671 on hold