### PR TITLE
core: log execution time when processing messages

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -175,6 +175,7 @@ class WorkerCommand : CliCommand {
             val channel = connection.createChannel()
             val callback =
                 fun(message: Delivery) {
+                    val startTimeMS = System.currentTimeMillis()
                     reportActivity(activityChannel, "request-received")
 
                     val replyTo = message.properties.replyTo
@@ -281,7 +282,12 @@ class WorkerCommand : CliCommand {
                     }
 
                     channel.basicAck(message.envelope.deliveryTag, false)
-                    logger.info("request for path {} processed", path)
+                    val executionTimeMS = System.currentTimeMillis() - startTimeMS
+                    logger.info(
+                        "request for path {} processed in {}s",
+                        path,
+                        executionTimeMS / 1_000.0
+                    )
                 }
             channel.basicConsume(
                 WORKER_REQUESTS_QUEUE,


### PR DESCRIPTION
Tiny improvement that can sometimes be useful

```
[14:43:14,052] [INFO]          [WorkerCommand] request for path /v2/stdcm processed in 11.221s
[14:43:14,717] [INFO]          [WorkerCommand] received request for path /v2/path_properties
[14:43:14,718] [INFO]          [WorkerCommand] received request for path /v2/path_properties
[14:43:14,738] [INFO]          [WorkerCommand] request for path /v2/path_properties processed in 0.021s
[14:43:14,740] [INFO]          [WorkerCommand] request for path /v2/path_properties processed in 0.022s
```

