### PR TITLE
front: fix typing of TrainScheduleImportConfig.{from,to}

### DIFF
--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -40,9 +40,22 @@ export type ImportedTrainSchedule = {
   transilienName?: string;
 };
 
+export type ImportStation = {
+  trigram?: string;
+  name?: string;
+  yardname?: string;
+  town?: string;
+  department?: string;
+  region?: string;
+  uic?: number;
+  linename?: string;
+  pk?: string;
+  linecode?: string;
+};
+
 export type TrainScheduleImportConfig = {
-  from: string;
-  to: string;
+  from: ImportStation;
+  to: ImportStation;
   date: string;
   startTime: string;
   endTime: string;

--- a/front/src/common/StationCard.tsx
+++ b/front/src/common/StationCard.tsx
@@ -1,19 +1,7 @@
 import cx from 'classnames';
 
+import type { ImportStation } from 'applications/operationalStudies/types';
 import { formatUicToCi } from 'utils/strings';
-
-export interface ImportStation {
-  trigram?: string;
-  name?: string;
-  yardname?: string;
-  town?: string;
-  department?: string;
-  region?: string;
-  uic?: number;
-  linename?: string;
-  pk?: string;
-  linecode?: string;
-}
 
 type Props = {
   station: ImportStation;

--- a/front/src/common/api/graouApi.ts
+++ b/front/src/common/api/graouApi.ts
@@ -1,5 +1,7 @@
-import type { TrainScheduleImportConfig } from 'applications/operationalStudies/types';
-import type { ImportStation } from 'common/StationCard';
+import type {
+  ImportStation,
+  TrainScheduleImportConfig,
+} from 'applications/operationalStudies/types';
 
 export const GRAOU_URL = 'https://graou.info';
 

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleConfig.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import nextId from 'react-id-generator';
 
 import type {
+  ImportStation,
   ImportedTrainSchedule,
   TrainScheduleImportConfig,
   Step,
@@ -15,7 +16,7 @@ import { getGraouTrainSchedules } from 'common/api/graouApi';
 import { type TrainScheduleBase } from 'common/api/osrdEditoastApi';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import StationCard, { type ImportStation } from 'common/StationCard';
+import StationCard from 'common/StationCard';
 import UploadFileModal from 'common/uploadFileModal';
 import StationSelector from 'modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleStationSelector';
 import { setFailure } from 'reducers/main';
@@ -154,7 +155,7 @@ const ImportTrainScheduleConfig = ({
         date,
         startTime,
         endTime,
-      } as TrainScheduleImportConfig);
+      });
     }
   }
   // EXTRACT-CI-CH-CODE

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleStationSelector.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleStationSelector.tsx
@@ -3,10 +3,11 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import nextId from 'react-id-generator';
 
+import type { ImportStation } from 'applications/operationalStudies/types';
 import { searchGraouStations } from 'common/api/graouApi';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import { Loader } from 'common/Loaders';
-import StationCard, { type ImportStation } from 'common/StationCard';
+import StationCard from 'common/StationCard';
 import { useDebounce } from 'utils/helpers';
 
 interface ImportTrainScheduleStationSelectorProps {


### PR DESCRIPTION
These are defined as strings, but we were passing ImportStation objects. The type error was silenced with a "as" keyword.

We need to move the ImportStation type from StationCard to src/applications/operationalStudies/types.ts to use it in TrainScheduleImportConfig.

No functional change - only typing changes.