### PR TITLE
front: edit timetable trains in macro mode

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
@@ -24,12 +24,14 @@ type AddTrainScheduleButtonProps = {
   infraState?: InfraState;
   setIsWorking: (isWorking: boolean) => void;
   upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void;
+  dtoImport: () => void;
 };
 
 const AddTrainScheduleButton = ({
   infraState,
   setIsWorking,
   upsertTrainSchedules,
+  dtoImport,
 }: AddTrainScheduleButtonProps) => {
   const [postTrainSchedule] =
     osrdEditoastApi.endpoints.postTimetableByIdTrainSchedule.useMutation();
@@ -83,6 +85,7 @@ const AddTrainScheduleButton = ({
           })
         );
         setIsWorking(false);
+        dtoImport();
         upsertTrainSchedules(newTrainSchedules);
       } catch (e) {
         setIsWorking(false);

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/TimetableManageTrainSchedule.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/TimetableManageTrainSchedule.tsx
@@ -18,6 +18,7 @@ type TimetableManageTrainScheduleProps = {
   upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void;
   infraState?: InfraState;
   setTrainIdToEdit: (trainIdToEdit?: number) => void;
+  dtoImport: () => void;
 };
 
 const TimetableManageTrainSchedule = ({
@@ -27,6 +28,7 @@ const TimetableManageTrainSchedule = ({
   infraState,
   trainIdToEdit,
   setTrainIdToEdit,
+  dtoImport,
 }: TimetableManageTrainScheduleProps) => {
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');
   const [isWorking, setIsWorking] = useState(false);
@@ -41,9 +43,9 @@ const TimetableManageTrainSchedule = ({
     setDisplayTrainScheduleManagement,
     upsertTrainSchedules,
     setTrainIdToEdit,
+    dtoImport,
     trainIdToEdit
   );
-
   return (
     <div className="scenario-timetable-managetrainschedule">
       <div className="scenario-timetable-managetrainschedule-header">
@@ -77,6 +79,7 @@ const TimetableManageTrainSchedule = ({
                 infraState={infraState}
                 setIsWorking={setIsWorking}
                 upsertTrainSchedules={upsertTrainSchedules}
+                dtoImport={dtoImport}
               />
             )}
             <TrainAddingSettings />

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -19,6 +19,7 @@ const useUpdateTrainSchedule = (
   setDisplayTrainScheduleManagement: (type: string) => void,
   upsertTrainSchedules: (trainSchedules: TrainScheduleResult[]) => void,
   setTrainIdToEdit: (trainIdToEdit?: number) => void,
+  dtoImport: () => void,
   trainIdToEdit?: number
 ) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
@@ -50,8 +51,8 @@ const useUpdateTrainSchedule = (
           id: trainIdToEdit,
           trainScheduleForm: trainSchedule,
         }).unwrap();
-
         upsertTrainSchedules([trainScheduleResult]);
+        dtoImport();
         dispatch(
           setSuccess({
             title: t('trainUpdated'),

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -28,6 +28,7 @@ type TimetableProps = {
   trainIdToEdit?: number;
   trainSchedules?: TrainScheduleResult[];
   trainSchedulesWithDetails: TrainScheduleWithDetails[];
+  dtoImport: () => void;
 };
 
 const formatDepartureDate = (d: Date) => dayjs(d).locale(i18n.language).format('dddd D MMMM YYYY');
@@ -43,6 +44,7 @@ const Timetable = ({
   trainIdToEdit,
   trainSchedules = [],
   trainSchedulesWithDetails,
+  dtoImport,
 }: TimetableProps) => {
   const { t } = useTranslation(['operationalStudies/scenario', 'common/itemTypes']);
 
@@ -160,6 +162,7 @@ const Timetable = ({
               projectionPathIsUsed={
                 infraState === 'CACHED' && trainIdUsedForProjection === train.id
               }
+              dtoImport={dtoImport}
             />
           </div>
         ))}

--- a/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableTrainCard.tsx
@@ -34,6 +34,7 @@ type TimetableTrainCardProps = {
   setTrainIdToEdit: (trainIdToEdit?: number) => void;
   removeTrains: (trainIds: number[]) => void;
   projectionPathIsUsed: boolean;
+  dtoImport: () => void;
 };
 
 const formatFullDate = (d: Date) => dayjs(d).format('D/MM/YYYY HH:mm:ss');
@@ -50,6 +51,7 @@ const TimetableTrainCard = ({
   setTrainIdToEdit,
   removeTrains,
   projectionPathIsUsed,
+  dtoImport,
 }: TimetableTrainCardProps) => {
   const { t } = useTranslation(['operationalStudies/scenario']);
   const dispatch = useAppDispatch();
@@ -81,6 +83,7 @@ const TimetableTrainCard = ({
       .unwrap()
       .then(() => {
         removeTrains([train.id]);
+        dtoImport();
         dispatch(
           setSuccess({
             title: t('timetable.trainDeleted', { name: train.trainName }),
@@ -125,6 +128,7 @@ const TimetableTrainCard = ({
           body: [newTrain],
         }).unwrap();
         upsertTrainSchedules([trainScheduleResult]);
+        dtoImport();
         dispatch(
           setSuccess({
             title: t('timetable.trainAdded'),


### PR DESCRIPTION
Part 2 of https://github.com/osrd-project/osrd-confidential/issues/840

We can now : 
- edit trains from the timetable in macro mode and see the update
- edit trains from NGE and see the updates in the timetable train card
