### PR TITLE
dependabot: use area:ci instead of area:actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,4 +100,4 @@ updates:
     open-pull-requests-limit: 100
     labels:
       - "dependencies"
-      - "area:actions"
+      - "area:ci"


### PR DESCRIPTION
The area:actions label doesn't exist