### PR TITLE
front: align compute margin to spec in timestops table

### DIFF
--- a/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
+++ b/front/src/modules/timesStops/helpers/__tests__/computeMargins.spec.ts
@@ -1,8 +1,10 @@
+import { keyBy } from 'lodash';
 import { describe, it, expect } from 'vitest';
 
 import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { ScheduleEntry } from 'modules/timesStops/types';
 
-import computeMargins from '../computeMargins';
+import computeMargins, { getTheoreticalMargins } from '../computeMargins';
 
 describe('computeMargins', () => {
   const path = [
@@ -18,33 +20,92 @@ describe('computeMargins', () => {
       id: 'c',
       uic: 3,
     },
+    {
+      id: 'd',
+      uic: 4,
+    },
+    {
+      id: 'e',
+      uic: 5,
+    },
   ];
-  const margins = { boundaries: ['c'], values: ['10%', '0%'] };
+  const margins = { boundaries: ['c'], values: ['10%', '5%'] };
   const pathItemTimes = {
-    base: [0, 100 * 1000, 200 * 1000],
-    provisional: [0, 110 * 1000, 220 * 1000],
-    final: [0, 115 * 1000, 230 * 1000],
+    base: [0, 100 * 1000, 200 * 1000, 400 * 1000, 500 * 1000],
+    provisional: [0, 110 * 1000, 220 * 1000, 430 * 1000, 535 * 1000],
+    final: [0, 115 * 1000, 230 * 1000, 440 * 1000, 545 * 1000],
   };
+  const schedule = [
+    {
+      at: 'a',
+    },
+    {
+      at: 'c',
+    },
+    {
+      at: 'd',
+    },
+    {
+      at: 'e',
+    },
+  ];
 
   it('should compute simple margin', () => {
-    const train = { path, margins } as TrainScheduleResult;
-    expect(computeMargins(train, 0, pathItemTimes)).toEqual({
+    const train = { path, margins, schedule } as TrainScheduleResult;
+    const scheduleByAt: Record<string, ScheduleEntry> = keyBy(train.schedule, 'at');
+    const theoreticalMargins = getTheoreticalMargins(train);
+    expect(computeMargins(theoreticalMargins, train, scheduleByAt, 0, pathItemTimes)).toEqual({
       theoreticalMargin: '10 %',
-      theoreticalMarginSeconds: '10 s',
-      calculatedMargin: '15 s',
-      diffMargins: '5 s',
-    });
-    expect(computeMargins(train, 1, pathItemTimes)).toEqual({
-      theoreticalMargin: '',
+      isTheoreticalMarginBoundary: true,
       theoreticalMarginSeconds: '20 s',
       calculatedMargin: '30 s',
       diffMargins: '10 s',
     });
-    expect(computeMargins(train, 2, pathItemTimes)).toEqual({
+    expect(computeMargins(theoreticalMargins, train, scheduleByAt, 1, pathItemTimes)).toEqual({
       theoreticalMargin: undefined,
+      isTheoreticalMarginBoundary: undefined,
       theoreticalMarginSeconds: undefined,
       calculatedMargin: undefined,
       diffMargins: undefined,
+    });
+    expect(computeMargins(theoreticalMargins, train, scheduleByAt, 2, pathItemTimes)).toEqual({
+      theoreticalMargin: '5 %',
+      isTheoreticalMarginBoundary: true,
+      theoreticalMarginSeconds: '10 s',
+      calculatedMargin: '10 s',
+      diffMargins: '0 s',
+    });
+    expect(computeMargins(theoreticalMargins, train, scheduleByAt, 3, pathItemTimes)).toEqual({
+      theoreticalMargin: '5 %',
+      isTheoreticalMarginBoundary: false,
+      theoreticalMarginSeconds: '5 s',
+      calculatedMargin: '5 s',
+      diffMargins: '0 s',
+    });
+    expect(computeMargins(theoreticalMargins, train, scheduleByAt, 4, pathItemTimes)).toEqual({
+      theoreticalMargin: undefined,
+      isTheoreticalMarginBoundary: undefined,
+      theoreticalMarginSeconds: undefined,
+      calculatedMargin: undefined,
+      diffMargins: undefined,
+    });
+  });
+});
+
+describe('getTheoreticalMargins', () => {
+  it('should compute theoretical margins with boundaries correctly', () => {
+    const path = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }];
+    const margins = { boundaries: ['c', 'd'], values: ['10%', '0%', '10 min/100km'] };
+    const trainSchedule = { path, margins } as TrainScheduleResult;
+
+    const theoreticalMargins = getTheoreticalMargins(trainSchedule);
+
+    expect(theoreticalMargins).toEqual({
+      a: { theoreticalMargin: '10%', isBoundary: true },
+      b: { theoreticalMargin: '10%', isBoundary: false },
+      c: { theoreticalMargin: '0%', isBoundary: true },
+      d: { theoreticalMargin: '10 min/100km', isBoundary: true },
+      e: { theoreticalMargin: '10 min/100km', isBoundary: false },
     });
   });
 });

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -114,7 +114,7 @@ const getDigits = (unit: string | undefined) =>
   unit === MarginUnit.second || unit === MarginUnit.percent ? 0 : 1;
 
 export function formatDigitsAndUnit(fullValue: string | number | undefined, unit?: string) {
-  if (fullValue === undefined || fullValue === '0%') {
+  if (fullValue === undefined) {
     return '';
   }
   if (typeof fullValue === 'number') {

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -15,7 +15,7 @@ import { calculateTimeDifferenceInSeconds } from 'utils/timeManipulation';
 
 import { ARRIVAL_TIME_ACCEPTABLE_ERROR_MS } from '../consts';
 import { computeInputDatetimes } from '../helpers/arrivalTime';
-import computeMargins from '../helpers/computeMargins';
+import computeMargins, { getTheoreticalMargins } from '../helpers/computeMargins';
 import { formatSchedule } from '../helpers/scheduleData';
 import { type ScheduleEntry, type TimeStopsRow } from '../types';
 
@@ -29,6 +29,8 @@ const useOutputTableData = (
   const { t } = useTranslation('timesStops');
 
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrainSchedule?.schedule, 'at');
+  const theoreticalMargins = selectedTrainSchedule && getTheoreticalMargins(selectedTrainSchedule);
+
   const startDatetime = selectedTrainSchedule
     ? new Date(selectedTrainSchedule.start_time)
     : undefined;
@@ -48,8 +50,19 @@ const useOutputTableData = (
         computedArrival,
         schedule
       );
-      const { theoreticalMargin, theoreticalMarginSeconds, calculatedMargin, diffMargins } =
-        computeMargins(selectedTrainSchedule, index, pathItemTimes);
+      const {
+        theoreticalMargin,
+        isTheoreticalMarginBoundary,
+        theoreticalMarginSeconds,
+        calculatedMargin,
+        diffMargins,
+      } = computeMargins(
+        theoreticalMargins,
+        selectedTrainSchedule,
+        scheduleByAt,
+        index,
+        pathItemTimes
+      );
 
       const { theoreticalArrival, arrival, departure, refDate } = computeInputDatetimes(
         startDatetime,
@@ -78,6 +91,7 @@ const useOutputTableData = (
         onStopSignal,
         shortSlipDistance,
         theoreticalMargin,
+        isTheoreticalMarginBoundary,
 
         theoreticalMarginSeconds,
         calculatedMargin,

--- a/front/src/modules/timesStops/hooks/useTimeStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimeStopsColumns.tsx
@@ -158,7 +158,7 @@ export const useTimeStopsColumns = <T extends TimeStopsRow>(
             continuousUpdates: false,
             placeholder: !isOutputTable ? t('theoreticalMarginPlaceholder') : '',
             formatBlurredInput: (value) => {
-              if (!value || value === '0%') return '';
+              if (!value) return '';
               if (!isOutputTable && !marginRegExValidation.test(value)) {
                 return `${value}${t('theoreticalMarginPlaceholder')}`;
               }
@@ -168,7 +168,10 @@ export const useTimeStopsColumns = <T extends TimeStopsRow>(
           })
         ),
         cellClassName: ({ rowData }) =>
-          cx({ invalidCell: !isOutputTable && !rowData.isMarginValid }),
+          cx({
+            invalidCell: !isOutputTable && !rowData.isMarginValid,
+            repeatedValue: rowData.isTheoreticalMarginBoundary === false, // the class should be added on false but not undefined
+          }),
         title: t('theoreticalMargin'),
         headerClassName: 'padded-header',
         minWidth: 100,

--- a/front/src/modules/timesStops/hooks/useTimeStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimeStopsColumns.tsx
@@ -5,6 +5,8 @@ import { keyColumn, type Column, checkboxColumn, createTextColumn } from 'react-
 import type { CellComponent } from 'react-datasheet-grid/dist/types';
 import { useTranslation } from 'react-i18next';
 
+import { NO_BREAK_SPACE } from 'utils/strings';
+
 import { marginRegExValidation } from '../consts';
 import { disabledTextColumn } from '../helpers/utils';
 import ReadOnlyTime from '../ReadOnlyTime';
@@ -167,6 +169,27 @@ export const useTimeStopsColumns = <T extends TimeStopsRow>(
             alignRight: true,
           })
         ),
+        ...(isOutputTable && {
+          component: ({ rowData }) => {
+            if (!rowData.theoreticalMargin) return null;
+            const [digits, unit] = rowData.theoreticalMargin.split(NO_BREAK_SPACE);
+            return (
+              <span className="dsg-input dsg-input-align-right self-center text-nowrap">
+                {digits}
+                {NO_BREAK_SPACE}
+                {unit === 'min/100km' ? (
+                  <span className="small-unit-container">
+                    <span>min/</span>
+                    <br />
+                    <span>100km</span>
+                  </span>
+                ) : (
+                  unit
+                )}
+              </span>
+            );
+          },
+        }),
         cellClassName: ({ rowData }) =>
           cx({
             invalidCell: !isOutputTable && !rowData.isMarginValid,
@@ -174,8 +197,7 @@ export const useTimeStopsColumns = <T extends TimeStopsRow>(
           }),
         title: t('theoreticalMargin'),
         headerClassName: 'padded-header',
-        minWidth: 100,
-        maxWidth: 130,
+        ...fixedWidth(isOutputTable ? 75 : 110),
         disabled: ({ rowIndex }) => isOutputTable || rowIndex === allWaypoints.length - 1,
       },
       ...extraOutputColumns,

--- a/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
@@ -23,6 +23,10 @@
     color: red !important;
   }
 
+  .repeatedValue {
+    color: var(--grey30);
+  }
+
   .warning-schedule {
     background: var(--warning30);
   }

--- a/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
+++ b/front/src/modules/timesStops/styles/_timesStopsDatasheet.scss
@@ -11,6 +11,10 @@
   --dsg-header-text-color: var(--grey50);
   --dsg-header-active-text-color: var(--black100);
 
+  .invalidCell {
+    color: red !important;
+  }
+
   .padded-header > * {
     padding-inline: 8px 16px;
   }
@@ -19,8 +23,16 @@
     color: var(--grey50);
   }
 
-  .invalidCell {
-    color: red !important;
+  .self-center {
+    align-self: center;
+  }
+
+  .small-unit-container {
+    display: inline-block;
+    font-size: 0.5rem;
+    line-height: 8px;
+    text-align: left;
+    vertical-align: -10%;
   }
 
   .repeatedValue {

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -21,6 +21,7 @@ export type TimeStopsRow = {
   onStopSignal?: boolean;
   shortSlipDistance?: boolean;
   theoreticalMargin?: string; // value asked by user
+  isTheoreticalMarginBoundary?: boolean; // tells whether the theoreticalMargin value was inputted for this line or if it is repeated from a previous line
 
   theoreticalMarginSeconds?: string;
   calculatedMargin?: string;
@@ -39,3 +40,8 @@ export enum TableType {
 }
 
 export type ScheduleEntry = ArrayElement<TrainScheduleResult['schedule']>;
+
+export type TheoreticalMarginsRecord = Record<
+  string,
+  { theoreticalMargin: string; isBoundary: boolean }
+>;

--- a/front/tests/assets/operationStudies/simulationSettings/allSettings.json
+++ b/front/tests/assets/operationStudies/simulationSettings/allSettings.json
@@ -8,8 +8,8 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "5 %",
-      "theoreticalS": "61 s",
-      "actual": "61 s",
+      "theoreticalS": "85 s",
+      "actual": "85 s",
       "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
@@ -24,9 +24,9 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "",
-      "theoreticalS": "85 s",
-      "actual": "85 s",
-      "difference": "0 s"
+      "theoreticalS": "",
+      "actual": "",
+      "difference": ""
     },
     "calculatedArrival": "11:44:13",
     "calculatedDeparture": ""
@@ -39,9 +39,9 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "117 s",
-      "actual": "117 s",
+      "theoretical": "5 %",
+      "theoreticalS": "32 s",
+      "actual": "32 s",
       "difference": "0 s"
     },
     "calculatedArrival": "11:52:55",

--- a/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoOFF.json
+++ b/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoOFF.json
@@ -7,10 +7,10 @@
     "stopTime": "",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -39,10 +39,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:39:55",
     "calculatedDeparture": "11:41:59"

--- a/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoON.json
+++ b/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoON.json
@@ -7,10 +7,10 @@
     "stopTime": "",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -39,10 +39,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:50:48",
     "calculatedDeparture": "11:52:52"

--- a/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileOFF.json
+++ b/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileOFF.json
@@ -7,10 +7,10 @@
     "stopTime": "",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -39,10 +39,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:39:55",
     "calculatedDeparture": "11:41:59"

--- a/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileON.json
+++ b/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileON.json
@@ -7,10 +7,10 @@
     "stopTime": "",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -39,10 +39,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "",
-      "actual": "",
-      "difference": ""
+      "theoretical": "0 %",
+      "theoreticalS": "0 s",
+      "actual": "0 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:40:27",
     "calculatedDeparture": "11:42:31"

--- a/front/tests/assets/operationStudies/simulationSettings/margin/linearMargin.json
+++ b/front/tests/assets/operationStudies/simulationSettings/margin/linearMargin.json
@@ -8,8 +8,8 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "10 %",
-      "theoreticalS": "60 s",
-      "actual": "60 s",
+      "theoreticalS": "105 s",
+      "actual": "105 s",
       "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
@@ -24,9 +24,9 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "",
-      "theoreticalS": "105 s",
-      "actual": "105 s",
-      "difference": "0 s"
+      "theoreticalS": "",
+      "actual": "",
+      "difference": ""
     },
     "calculatedArrival": "11:33:33",
     "calculatedDeparture": ""
@@ -39,9 +39,9 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "167 s",
-      "actual": "167 s",
+      "theoretical": "10 %",
+      "theoreticalS": "62 s",
+      "actual": "62 s",
       "difference": "0 s"
     },
     "calculatedArrival": "11:41:40",

--- a/front/tests/assets/operationStudies/simulationSettings/margin/marecoMargin.json
+++ b/front/tests/assets/operationStudies/simulationSettings/margin/marecoMargin.json
@@ -8,9 +8,9 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "10 %",
-      "theoreticalS": "0 s",
-      "actual": "0 s",
-      "difference": "0 s"
+      "theoreticalS": "104 s",
+      "actual": "105 s",
+      "difference": "1 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -24,9 +24,9 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "",
-      "theoreticalS": "104 s",
-      "actual": "105 s",
-      "difference": "1 s"
+      "theoreticalS": "",
+      "actual": "",
+      "difference": ""
     },
     "calculatedArrival": "11:32:33",
     "calculatedDeparture": ""
@@ -39,10 +39,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "165 s",
-      "actual": "167 s",
-      "difference": "1 s"
+      "theoretical": "10 %",
+      "theoreticalS": "62 s",
+      "actual": "62 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "11:41:40",
     "calculatedDeparture": "11:43:44"

--- a/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
+++ b/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
@@ -25,9 +25,9 @@
     "shortSlipDistance": true,
     "margin": {
       "theoretical": "1 min/100km",
-      "theoreticalS": "37 s",
-      "actual": "1213 s",
-      "difference": "1176 s"
+      "theoreticalS": "9 s",
+      "actual": "291 s",
+      "difference": "282 s"
     },
     "calculatedArrival": "11:47:40",
     "calculatedDeparture": "11:52:40"
@@ -40,10 +40,10 @@
     "stopTime": "124",
     "signalReceptionClosed": false,
     "margin": {
-      "theoretical": "",
-      "theoreticalS": "20 s",
-      "actual": "303 s",
-      "difference": "283 s"
+      "theoretical": "1 min/100km",
+      "theoreticalS": "12 s",
+      "actual": "12 s",
+      "difference": "0 s"
     },
     "calculatedArrival": "12:05:21",
     "calculatedDeparture": "12:07:24"

--- a/front/tests/pages/op-output-table-page-model.ts
+++ b/front/tests/pages/op-output-table-page-model.ts
@@ -90,7 +90,8 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
           .locator('input.dsg-checkbox')
           .isChecked(),
         OperationalStudiesOutputTablePage.getCellValue(
-          cells.nth(headerIndexMap[translations.theoreticalMargin])
+          cells.nth(headerIndexMap[translations.theoreticalMargin]),
+          false
         ),
         OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.theoreticalMarginSeconds])


### PR DESCRIPTION
Close #9737
Also partially fix #8959 

Depend on https://github.com/OpenRailAssociation/osrd/pull/9642