### PR TITLE
core: add compatibility for G1 train gauge with FR3.3 track gauge

### DIFF
--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSLoadingGaugeType.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSLoadingGaugeType.java
@@ -27,7 +27,7 @@ public enum RJSLoadingGaugeType {
             case GB1 -> Sets.union(Set.of(GB1), GB.getCompatibleGaugeTypes());
             case GC -> Sets.union(Set.of(GC), GB1.getCompatibleGaugeTypes());
             case G2 -> Sets.union(Set.of(G2, FR3_3_GB_G2), G1.getCompatibleGaugeTypes());
-            case FR3_3 -> Set.of(FR3_3, FR3_3_GB_G2);
+            case FR3_3 -> Sets.union(Set.of(FR3_3, FR3_3_GB_G2), G1.getCompatibleGaugeTypes());
             case GLOTT -> Set.of(GLOTT);
             default -> null;
         };

--- a/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/sim_infra_adapter/PathPropertiesTests.kt
@@ -725,4 +725,16 @@ class PathPropertiesTests {
         }
         return LineString.make(latitudes.toDoubleArray(), longitudes.toDoubleArray())
     }
+
+    @Test
+    fun testG1RollingStockLoadingGaugeCompatibility() {
+        // G1 train is compatible with any track gauge except GLOTT (not sure so default to not
+        // compatible) and FR3.3/GB/G2 that is not a track gauge
+        for (trackGauge in
+            RJSLoadingGaugeType.entries.minus(
+                listOf(RJSLoadingGaugeType.GLOTT, RJSLoadingGaugeType.FR3_3_GB_G2)
+            )) {
+            assert(trackGauge.compatibleGaugeTypes.contains(RJSLoadingGaugeType.G1))
+        }
+    }
 }


### PR DESCRIPTION
Based on:
* G1 (PPI, literally "pass-everywhere international gauge") is the minimal gauge (see https://en.wikipedia.org/wiki/Loading_gauge)
* the description from internal doc: "FR3.3 englobe le G1 pour des paramètres de circulations égaux."

Some doc is referenced in https://github.com/osrd-project/osrd-dags/issues/300