### PR TITLE
core: avoid recomputing unnecessary coastings, which sometimes crashed

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/allowances/mareco_impl/CoastingGenerator.java
@@ -67,8 +67,11 @@ public final class CoastingGenerator {
 
         assert constrainedBuilder.getLastPos() < endPos;
 
-        if (!reachedLowLimit && constrainedBuilder.getLastPos() != envelope.getBeginPos())
+        if (!reachedLowLimit) {
             return backwardPartBuilder.build();
+            // We only need to recompute a coasting going forward if the low speed limit has been reached,
+            // as we'd need to add accelerations in places where we've clipped the speed
+        }
 
         var resultCoast = coastFromBeginning(
                 envelope, context, constrainedBuilder.getLastPos(), constrainedBuilder.getLastSpeed());


### PR DESCRIPTION
The forward coasting would sometimes not intersect with the base curve, which causes some weirdness and 0-length steps.

That coasting would only happen if there's no intersection with min speed limit. In that case, it's not actually necessary to compute it (it's supposed to give the same result as the backwards one).