### PR TITLE
Add unique constraint on group name

### DIFF
--- a/editoast/migrations/2024-11-22-151624_group-name-unique/down.sql
+++ b/editoast/migrations/2024-11-22-151624_group-name-unique/down.sql
@@ -1,0 +1,1 @@
+DROP CONSTRAINT group_name_unique;

--- a/editoast/migrations/2024-11-22-151624_group-name-unique/up.sql
+++ b/editoast/migrations/2024-11-22-151624_group-name-unique/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE authn_group ADD CONSTRAINT group_name_unique UNIQUE (name);


### PR DESCRIPTION
Without this constraint some commands does not work properly like `editoast group include`.