### PR TITLE
front: harmonize timesstops component name in scenario

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next';
 
 import { Loader } from 'common/Loaders/Loader';
 
-import { useTimeStopsColumns } from './hooks/useTimeStopsColumns';
-import { type TableType, type TimeStopsRow } from './types';
+import { useTimesStopsColumns } from './hooks/useTimesStopsColumns';
+import { type TableType, type TimesStopsRow } from './types';
 
-type TimesStopsProps<T extends TimeStopsRow> = {
+type TimesStopsProps<T extends TimesStopsRow> = {
   rows: T[];
   tableType: TableType;
   cellClassName?: DataSheetGridProps['cellClassName'];
@@ -18,7 +18,7 @@ type TimesStopsProps<T extends TimeStopsRow> = {
   dataIsLoading: boolean;
 };
 
-const TimesStops = <T extends TimeStopsRow>({
+const TimesStops = <T extends TimesStopsRow>({
   rows,
   tableType,
   cellClassName,
@@ -29,7 +29,7 @@ const TimesStops = <T extends TimeStopsRow>({
 }: TimesStopsProps<T>) => {
   const { t } = useTranslation('timesStops');
 
-  const columns = useTimeStopsColumns(tableType, rows);
+  const columns = useTimesStopsColumns(tableType, rows);
 
   if (dataIsLoading) {
     return (

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -10,7 +10,7 @@ import { NO_BREAK_SPACE } from 'utils/strings';
 
 import useOutputTableData from './hooks/useOutputTableData';
 import TimesStops from './TimesStops';
-import { TableType, type TimeStopsRow } from './types';
+import { TableType, type TimesStopsRow } from './types';
 
 type TimesStopsOutputProps = {
   simulatedTrain: SimulationResponseSuccess;
@@ -41,7 +41,7 @@ const TimesStopsOutput = ({
       rows={enrichedOperationalPoints}
       tableType={TableType.Output}
       cellClassName={({ rowData: rowData_, columnId }) => {
-        const rowData = rowData_ as TimeStopsRow;
+        const rowData = rowData_ as TimesStopsRow;
         const arrivalScheduleNotRespected = rowData.arrival?.time
           ? rowData.calculatedArrival !== rowData.arrival.time
           : false;

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -18,7 +18,7 @@ import { ARRIVAL_TIME_ACCEPTABLE_ERROR_MS } from '../consts';
 import { computeInputDatetimes } from '../helpers/arrivalTime';
 import computeMargins, { getTheoreticalMargins } from '../helpers/computeMargins';
 import { formatSchedule } from '../helpers/scheduleData';
-import { type ScheduleEntry, type TimeStopsRow } from '../types';
+import { type ScheduleEntry, type TimesStopsRow } from '../types';
 
 const useOutputTableData = (
   { final_output: simulatedTrain }: SimulationResponseSuccess,
@@ -26,11 +26,11 @@ const useOutputTableData = (
   operationalPoints?: PathPropertiesFormatted['operationalPoints'],
   selectedTrainSchedule?: TrainScheduleResult,
   path?: PathfindingResultSuccess
-): TimeStopsRow[] => {
+): TimesStopsRow[] => {
   const { t } = useTranslation('timesStops');
   const { getTrackSectionsByIds } = useScenarioContext();
 
-  const [rows, setRows] = useState<TimeStopsRow[]>([]);
+  const [rows, setRows] = useState<TimesStopsRow[]>([]);
 
   const scheduleByAt: Record<string, ScheduleEntry> = keyBy(selectedTrainSchedule?.schedule, 'at');
   const theoreticalMargins = selectedTrainSchedule && getTheoreticalMargins(selectedTrainSchedule);

--- a/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
+++ b/front/src/modules/timesStops/hooks/useTimesStopsColumns.tsx
@@ -11,7 +11,7 @@ import { marginRegExValidation } from '../consts';
 import { disabledTextColumn } from '../helpers/utils';
 import ReadOnlyTime from '../ReadOnlyTime';
 import TimeInput from '../TimeInput';
-import { TableType, type TimeExtraDays, type TimeStopsRow } from '../types';
+import { TableType, type TimeExtraDays, type TimesStopsRow } from '../types';
 
 const timeColumn = (isOutputTable: boolean) =>
   ({
@@ -33,7 +33,7 @@ function headerWithTitleTagIfShortened(shortenedHeader: string, fullHeader: stri
   return <span title={fullHeader}> {shortenedHeader} </span>;
 }
 
-export const useTimeStopsColumns = <T extends TimeStopsRow>(
+export const useTimesStopsColumns = <T extends TimesStopsRow>(
   tableType: TableType,
   allWaypoints: T[] = []
 ) => {

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -9,7 +9,7 @@ export type TimeExtraDays = {
   dayDisplayed?: boolean;
 };
 
-export type TimeStopsRow = {
+export type TimesStopsRow = {
   opId: string;
   name?: string;
   ch?: string;
@@ -33,7 +33,7 @@ export type TimeStopsRow = {
   isMarginValid?: boolean;
 };
 
-export type TimesStopsInputRow = Omit<SuggestedOP, 'arrival' | 'departure'> & TimeStopsRow;
+export type TimesStopsInputRow = Omit<SuggestedOP, 'arrival' | 'departure'> & TimesStopsRow;
 
 export enum TableType {
   Input = 'Input',

--- a/front/tests/011-op-times-and-stops-tab.spec.ts
+++ b/front/tests/011-op-times-and-stops-tab.spec.ts
@@ -173,7 +173,7 @@ test.describe('Times and Stops Tab Verification', () => {
     // Add train schedule, verify results and output table data
     await operationalStudiesPage.addTrainSchedule();
     await operationalStudiesPage.returnSimulationResult();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
 
     // Scroll and extract output table data for verification
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');

--- a/front/tests/012-op-simulation-settings-tab.spec.ts
+++ b/front/tests/012-op-simulation-settings-tab.spec.ts
@@ -166,7 +166,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.returnSimulationResult();
     await opTimetablePage.getTrainArrivalTime('11:53');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataElectricalProfileON, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -178,7 +178,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await page.waitForTimeout(stabilityTimeout); // Waiting for the timetable to update due to a slight latency
     await opTimetablePage.getTrainArrivalTime('11:52');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataElectricalProfileOFF, OSRDLanguage);
   });
   test('Activate composition code', async ({ page }) => {
@@ -220,7 +220,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.returnSimulationResult();
     await opTimetablePage.getTrainArrivalTime('12:03');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataCodeCompoON, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -232,7 +232,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await page.waitForTimeout(stabilityTimeout);
     await opTimetablePage.getTrainArrivalTime('11:52');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataCodeCompoOFF, OSRDLanguage);
   });
   test('Activate linear and mareco margin', async ({ page }) => {
@@ -283,7 +283,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.returnSimulationResult();
     await opTimetablePage.getTrainArrivalTime('11:54');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataLinearMargin, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -295,7 +295,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await page.waitForTimeout(stabilityTimeout);
     await opTimetablePage.getTrainArrivalTime('11:54');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataMarecoMargin, OSRDLanguage);
   });
   test('Add all the simulation settings', async ({ page }) => {
@@ -347,7 +347,7 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.returnSimulationResult();
     await opTimetablePage.getTrainArrivalTime('12:06');
     await opTimetablePage.clickOnScenarioCollapseButton();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await opOutputTablePage.verifyTimesStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataForAllSettings, OSRDLanguage);
   });

--- a/front/tests/pages/op-output-table-page-model.ts
+++ b/front/tests/pages/op-output-table-page-model.ts
@@ -143,10 +143,10 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
   }
 
   // Wait for the Times and Stops simulation data sheet to be fully loaded with a specified timeout (default: 60 seconds)
-  async verifyTimeStopsDataSheetVisibility(timeout = 60 * 1000): Promise<void> {
-    await this.timeStopsDataSheet.waitFor({ state: 'visible', timeout });
+  async verifyTimesStopsDataSheetVisibility(timeout = 60 * 1000): Promise<void> {
+    await this.timesStopsDataSheet.waitFor({ state: 'visible', timeout });
     await this.page.waitForTimeout(100); // Short delay for stabilization
-    await this.timeStopsDataSheet.scrollIntoViewIfNeeded({ timeout });
+    await this.timesStopsDataSheet.scrollIntoViewIfNeeded({ timeout });
   }
 }
 

--- a/front/tests/pages/op-timetable-page-model.ts
+++ b/front/tests/pages/op-timetable-page-model.ts
@@ -22,7 +22,7 @@ class OperationalStudiesTimetablePage {
 
   readonly speedSpaceChart: Locator;
 
-  readonly timeStopsDataSheet: Locator;
+  readonly timesStopsDataSheet: Locator;
 
   readonly simulationMap: Locator;
 
@@ -52,7 +52,7 @@ class OperationalStudiesTimetablePage {
     this.manchetteSpaceTimeChart = page.locator('.manchette-space-time-chart-wrapper');
     this.speedSpaceChart = page.locator('#container-SpeedSpaceChart');
     this.spaceTimeChart = page.locator('.space-time-chart-container');
-    this.timeStopsDataSheet = page.locator('.time-stops-datasheet');
+    this.timesStopsDataSheet = page.locator('.time-stops-datasheet');
     this.simulationMap = page.locator('.simulation-map');
     this.timetableFilterButton = page.getByTestId('timetable-filter-button');
     this.timetableFilterButtonClose = page.getByTestId('timetable-filter-button-close');
@@ -104,7 +104,7 @@ class OperationalStudiesTimetablePage {
       this.speedSpaceChart,
       this.spaceTimeChart,
       this.simulationMap,
-      this.timeStopsDataSheet,
+      this.timesStopsDataSheet,
     ];
     await Promise.all(
       simulationResultsLocators.map((simulationResultsLocator) =>
@@ -211,10 +211,10 @@ class OperationalStudiesTimetablePage {
     }
   }
 
-  async verifyTimeStopsDataSheetVisibility(timeout = 60 * 1000): Promise<void> {
+  async verifyTimesStopsDataSheetVisibility(timeout = 60 * 1000): Promise<void> {
     // Wait for the Times and Stops simulation dataSheet to be fully loaded with a specified timeout (default: 60 seconds)
-    await expect(this.timeStopsDataSheet).toBeVisible({ timeout });
-    await this.timeStopsDataSheet.scrollIntoViewIfNeeded();
+    await expect(this.timesStopsDataSheet).toBeVisible({ timeout });
+    await this.timesStopsDataSheet.scrollIntoViewIfNeeded();
   }
 
   async clickOnEditTrain() {


### PR DESCRIPTION
Turn all occurences of timeStops to timesStops

There were more occurences of timesStops than timeStops hence the change in this sense, but I'm fine with the other way too, as long as we make a single choice.