### PR TITLE
front: fix margin and improve stopfor input in timesstops table

### DIFF
--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -103,26 +103,21 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
       if (!updatedRows[operation.fromRowIndex].isMarginValid) {
         newRows[operation.fromRowIndex].isMarginValid = false;
         setRows(newRows);
-      } else if (
-        !rows[operation.fromRowIndex].isMarginValid &&
-        updatedRows[operation.fromRowIndex].isMarginValid
-      ) {
-        newRows[operation.fromRowIndex].isMarginValid = true;
-        setRows(newRows);
-      } else {
-        const newVias = updatedRows
-          .filter(
-            (row, index) =>
-              !isEqual(normalizeNullablesInRow(row), normalizeNullablesInRow(rows[index]))
-          )
-          .map(({ shortSlipDistance, onStopSignal, arrival, departure, ...row }) => ({
-            ...row,
-            arrival: durationSinceStartTime(startTime, arrival),
-            departure: durationSinceStartTime(startTime, departure),
-            receptionSignal: onStopSignalToReceptionSignal(onStopSignal, shortSlipDistance),
-          }));
-        dispatch(upsertSeveralViasFromSuggestedOP(newVias));
+        return;
       }
+
+      const newVias = updatedRows
+        .filter(
+          (row, index) =>
+            !isEqual(normalizeNullablesInRow(row), normalizeNullablesInRow(rows[index]))
+        )
+        .map(({ shortSlipDistance, onStopSignal, arrival, departure, ...row }) => ({
+          ...row,
+          arrival: durationSinceStartTime(startTime, arrival),
+          departure: durationSinceStartTime(startTime, departure),
+          receptionSignal: onStopSignalToReceptionSignal(onStopSignal, shortSlipDistance),
+        }));
+      dispatch(upsertSeveralViasFromSuggestedOP(newVias));
     },
     [rows, startTime]
   );

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -214,6 +214,10 @@ export function updateRowTimesAndMargin(
       newRowData.theoreticalMargin = '0%';
     }
   }
+  // Remove second unit in stopFor if inputted by mistake
+  if (newRowData.stopFor && /^[0-9]+ *s$/i.test(newRowData.stopFor)) {
+    newRowData.stopFor = newRowData.stopFor.replace(/ *s$/i, '');
+  }
   return newRowData;
 }
 


### PR DESCRIPTION
First commit : fix bug where setting an invalid margin, then a valid margin, would not register the valid margin in the path
Close #9882

Second commit : enable the user to input timestops with second unit, which were otherwise silently discarded upon saving the table