### PR TITLE
core: stdcm: fix post-processing when arrival time is set

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMNode.kt
@@ -134,12 +134,26 @@ data class STDCMNode(
         return relativeMaxTimeDiff
     }
 
+    /** Returns true if there's no stop between the start and this node (excluded). */
+    private fun isBeforeFirstStop(): Boolean {
+        var edge = previousEdge
+        while (true) {
+            if (edge == null) return true
+            val node = edge.previousNode
+            if (node.stopDuration != null) return false
+            edge = node.previousEdge
+        }
+    }
+
     /**
      * Compute how much delay we can add to the current node, given some elements about what happens
      * further down the path. The tricky part is identifying how stop durations may be adjusted to
      * locally change passage times without conflict.
      */
     private fun computeMaxAddedDelay(updatedTimeData: TimeData): Double {
+        if (isBeforeFirstStop()) {
+            return updatedTimeData.maxFirstDepartureDelaying
+        }
         var maxAddedDelay = Double.POSITIVE_INFINITY
 
         // List of stops that haven't been reached on this node

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -169,6 +169,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 node,
                 nodes.subList(firstPlannedNodeIndex + 1, nodes.size),
                 mutableStopData,
+                timeData,
             )
         var actualStopAddedTime = min(maxAddedTime, timeDiff)
 
@@ -231,7 +232,9 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         node: STDCMNode,
         nextNodes: List<STDCMNode>,
         mutableStopData: MutableList<StopTimeData>,
+        lastTimeData: TimeData,
     ): Double {
+        if (lastStopIndexBeforeNode == 0) return lastTimeData.maxFirstDepartureDelaying
         var maxTimeDiff = Double.POSITIVE_INFINITY
         var nextStopIndex = lastStopIndexBeforeNode
         if (node.stopDuration != null) nextStopIndex++

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -254,6 +254,7 @@ class FullSTDCMTests {
         } else {
             assertEquals(expectedPassageTime, res.departureTime + res.envelope.totalTime, timeStep)
         }
+        assertTrue(res.departureTime <= 12_000.0) // Max departure delay
     }
 
     /** Check that the result we find doesn't cause a conflict */
@@ -379,6 +380,14 @@ class FullSTDCMTests {
                 null,
                 PlannedTimingData(10_000.seconds, 300.seconds, 300.seconds),
                 10_000.0,
+                true,
+            ),
+            Arguments.of(
+                start,
+                end,
+                null,
+                PlannedTimingData(20_000.seconds, 1_000.seconds, 1_000.seconds),
+                19_000.0, // We'd need more than max departure delay to reach 20_000
                 true,
             ),
         )


### PR DESCRIPTION
We'd add too much delay to the departure time, resulting in inconsistencies. Includes a regression unit test. 

Fix https://github.com/OpenRailAssociation/osrd/issues/9872

Helps with https://github.com/OpenRailAssociation/osrd/issues/9023 as well, but it still happens, just much less often