### PR TITLE
front: fix flaky test 012 and 006

### DIFF
--- a/front/tests/012-op-simulation-settings-tab.spec.ts
+++ b/front/tests/012-op-simulation-settings-tab.spec.ts
@@ -30,9 +30,6 @@ test.describe('Simulation Settings Tab Verification', () => {
   // Set viewport to avoid scrolling issues and ensure elements are attached to the DOM
   test.use({ viewport: { width: 1920, height: 1080 } });
 
-  // TODO: Remove the skip when bug #9344 is fixed
-  test.skip(({ browserName }) => browserName === 'webkit', 'Skip this test on Safari');
-
   const expectedCellDataElectricalProfileON: StationData[] = readJsonFile(
     './tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileON.json'
   );
@@ -64,6 +61,7 @@ test.describe('Simulation Settings Tab Verification', () => {
   let infra: Infra;
   let OSRDLanguage: string;
   type TranslationKeys = keyof typeof enTranslations;
+  let stabilityTimeout: number;
 
   // Define CellData interface for table cell data
   interface CellData {
@@ -85,7 +83,8 @@ test.describe('Simulation Settings Tab Verification', () => {
 
   test.beforeEach(
     'Navigate to Times and Stops tab with rolling stock and route set',
-    async ({ page }) => {
+    async ({ page, browserName }) => {
+      stabilityTimeout = browserName === 'webkit' ? 2000 : 500;
       const [operationalStudiesPage, routePage, rollingStockPage, homePage] = [
         new OperationalStudiesPage(page),
         new RoutePage(page),
@@ -165,9 +164,9 @@ test.describe('Simulation Settings Tab Verification', () => {
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTrainSchedule();
     await operationalStudiesPage.returnSimulationResult();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('11:53');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataElectricalProfileON, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -176,11 +175,10 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.clickOnSimulationSettingsTab();
     await opSimulationSettingsPage.deactivateElectricalProfile();
     await opTimetablePage.clickOnEditTrainSchedule();
-    // TODO: Remove the reload when bug #8854 (UI not updating after modification) is fixed
-    await page.reload({ timeout: 30000, waitUntil: 'networkidle' });
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await page.waitForTimeout(stabilityTimeout); // Waiting for the timetable to update due to a slight latency
     await opTimetablePage.getTrainArrivalTime('11:52');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataElectricalProfileOFF, OSRDLanguage);
   });
   test('Activate composition code', async ({ page }) => {
@@ -220,9 +218,9 @@ test.describe('Simulation Settings Tab Verification', () => {
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTrainSchedule();
     await operationalStudiesPage.returnSimulationResult();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('12:03');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataCodeCompoON, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -231,11 +229,10 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.clickOnSimulationSettingsTab();
     await opSimulationSettingsPage.selectCodeCompoOption('__PLACEHOLDER__');
     await opTimetablePage.clickOnEditTrainSchedule();
-    // TODO: Remove the reload when bug #8854 (UI not updating after modification) is fixed
-    await page.reload({ timeout: 30000, waitUntil: 'networkidle' });
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await page.waitForTimeout(stabilityTimeout);
     await opTimetablePage.getTrainArrivalTime('11:52');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataCodeCompoOFF, OSRDLanguage);
   });
   test('Activate linear and mareco margin', async ({ page }) => {
@@ -284,9 +281,9 @@ test.describe('Simulation Settings Tab Verification', () => {
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTrainSchedule();
     await operationalStudiesPage.returnSimulationResult();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('11:54');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataLinearMargin, OSRDLanguage);
     await opTimetablePage.clickOnTimetableCollapseButton();
@@ -295,11 +292,10 @@ test.describe('Simulation Settings Tab Verification', () => {
     await operationalStudiesPage.clickOnSimulationSettingsTab();
     await opSimulationSettingsPage.activateMarecoMargin();
     await opTimetablePage.clickOnEditTrainSchedule();
-    // TODO: Remove the reload when bug #8854 (UI not updating after modification) is fixed
-    await page.reload({ timeout: 30000, waitUntil: 'networkidle' });
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
+    await page.waitForTimeout(stabilityTimeout);
     await opTimetablePage.getTrainArrivalTime('11:54');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opOutputTablePage.getOutputTableData(expectedCellDataMarecoMargin, OSRDLanguage);
   });
   test('Add all the simulation settings', async ({ page }) => {
@@ -349,9 +345,9 @@ test.describe('Simulation Settings Tab Verification', () => {
     // Add the train schedule and verify output results
     await operationalStudiesPage.addTrainSchedule();
     await operationalStudiesPage.returnSimulationResult();
-    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await opTimetablePage.getTrainArrivalTime('12:06');
     await opTimetablePage.clickOnScenarioCollapseButton();
+    await opOutputTablePage.verifyTimeStopsDataSheetVisibility();
     await scrollContainer(page, '.time-stop-outputs .time-stops-datasheet .dsg-container');
     await opOutputTablePage.getOutputTableData(expectedCellDataForAllSettings, OSRDLanguage);
   });

--- a/front/tests/pages/op-output-table-page-model.ts
+++ b/front/tests/pages/op-output-table-page-model.ts
@@ -15,12 +15,11 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
     this.columnHeaders = page.locator(
       '.dsg-cell.dsg-cell-header:not(.dsg-cell-gutter) .dsg-cell-header-container'
     );
-    this.tableRows = page.locator('.time-stop-outputs .time-stops-datasheet .dsg-row');
+    this.tableRows = page.locator('.time-stops-datasheet .dsg-row');
   }
 
   // Retrieve the cell value based on the locator type
   static async getCellValue(cell: Locator, isInput: boolean = true): Promise<string> {
-    await cell.waitFor({ state: 'visible', timeout: 30 * 1000 });
     return isInput
       ? (await cell.locator('input').getAttribute('value'))?.trim() || ''
       : (await cell.textContent())?.trim() || '';
@@ -28,7 +27,6 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
 
   // Extract the column index for each header name
   async getHeaderIndexMap(): Promise<Record<string, number>> {
-    await this.columnHeaders.first().waitFor({ state: 'visible', timeout: 30 * 1000 });
     const headers = await this.columnHeaders.allTextContents();
     const headerMap: Record<string, number> = {};
     headers.forEach((header, index) => {
@@ -67,48 +65,46 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
         calculatedArrival,
         calculatedDeparture,
       ] = await Promise.all([
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.name]),
           false
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
-          cells.nth(headerIndexMap[translations.ch])
-        ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(cells.nth(headerIndexMap[translations.ch])),
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.arrivalTime]),
           false
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.departureTime]),
           false
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.stopTime])
         ),
-        await cells
+        cells
           .nth(headerIndexMap[translations.receptionOnClosedSignal])
           .locator('input.dsg-checkbox')
           .isChecked(),
-        await cells
+        cells
           .nth(headerIndexMap[translations.shortSlipDistance])
           .locator('input.dsg-checkbox')
           .isChecked(),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.theoreticalMargin])
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.theoreticalMarginSeconds])
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.realMargin])
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.diffMargins])
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.calculatedArrivalTime])
         ),
-        await OperationalStudiesOutputTablePage.getCellValue(
+        OperationalStudiesOutputTablePage.getCellValue(
           cells.nth(headerIndexMap[translations.calculatedDepartureTime])
         ),
       ]);
@@ -141,8 +137,8 @@ class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage 
 
   // Wait for the Times and Stops simulation data sheet to be fully loaded with a specified timeout (default: 60 seconds)
   async verifyTimeStopsDataSheetVisibility(timeout = 60 * 1000): Promise<void> {
-    await this.timeStopsDataSheet.waitFor({ state: 'attached', timeout });
-    await expect(this.timeStopsDataSheet).toBeVisible({ timeout });
+    await this.timeStopsDataSheet.waitFor({ state: 'visible', timeout });
+    await this.page.waitForTimeout(100); // Short delay for stabilization
     await this.timeStopsDataSheet.scrollIntoViewIfNeeded({ timeout });
   }
 }

--- a/front/tests/pages/stdcm-page-model.ts
+++ b/front/tests/pages/stdcm-page-model.ts
@@ -493,6 +493,7 @@ class STDCMPage {
 
   async downloadSimulation(browserName: string) {
     // Wait for the download event
+    await this.page.waitForTimeout(500);
     const downloadPromise = this.page.waitForEvent('download', { timeout: 120000 });
     await this.downloadSimulationButton.click({ force: true });
     const download = await downloadPromise.catch(() => {


### PR DESCRIPTION
This PR addresses the flakiness in tests 006 and 012.
The Playwright runner is very fast, which sometimes prevents the results from being updated in time. To resolve this, I added timeouts