### PR TITLE
front: fix linked path button clickable if retained simulation

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
@@ -47,14 +47,13 @@ const StdcmLinkedPathSearch = ({
   return (
     <div className={`stdcm-linked-path-search-container ${className}`}>
       {!displayLinkedPathSearch ? (
-        <div tabIndex={0} role="button" onClick={() => setShowLinkedPathSearch(true)}>
-          <StdcmDefaultCard
-            disabled={disabled}
-            text={defaultCardText}
-            Icon={cardIcon}
-            className="add-linked-path"
-          />
-        </div>
+        <StdcmDefaultCard
+          disabled={disabled}
+          text={defaultCardText}
+          Icon={cardIcon}
+          className="add-linked-path"
+          onClick={() => setShowLinkedPathSearch(true)}
+        />
       ) : (
         <StdcmCard
           disabled={disabled}


### PR DESCRIPTION
Remove the unnecessary div wrapper for the card

fix #9807 