### PR TITLE
fron: lmr consist prefill mass length max speed

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -52,6 +52,7 @@ const StdcmConsist = ({ disabled = false }: StdcmConfigCardProps) => {
     onTotalLengthChange,
     maxSpeed,
     onMaxSpeedChange,
+    prefillConsist,
   } = useStdcmConsist();
 
   const { filters, searchRollingStock, searchRollingStockById, filteredRollingStockList } =
@@ -91,6 +92,7 @@ const StdcmConsist = ({ disabled = false }: StdcmConfigCardProps) => {
   };
 
   const onSelectSuggestion = (option?: LightRollingStockWithLiveries) => {
+    prefillConsist(option, towedRollingStock);
     dispatch(updateRollingStockID(option?.id));
   };
 
@@ -144,6 +146,7 @@ const StdcmConsist = ({ disabled = false }: StdcmConfigCardProps) => {
           suggestions={filteredTowedRollingStockList}
           getSuggestionLabel={(suggestion: TowedRollingStock) => suggestion.name}
           onSelectSuggestion={(towed) => {
+            prefillConsist(rollingStock, towed);
             dispatch(updateTowedRollingStockID(towed?.id));
           }}
         />

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -1,12 +1,21 @@
+import { useState } from 'react';
+
 import { useSelector } from 'react-redux';
 
+import type { LightRollingStockWithLiveries, TowedRollingStock } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
 import { type StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
 import type { StdcmConfSelectors } from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
+import { kgToT } from 'utils/physics';
 
 const useStdcmConsist = () => {
   const dispatch = useAppDispatch();
+
+  const [totalMassChanged, setTotalMassChanged] = useState(false);
+  const [totalLengthChanged, setTotalLengthChanged] = useState(false);
+  const [maxSpeedChanged, setMaxSpeedChanged] = useState(false);
+
   const { getTotalMass, getTotalLength, getMaxSpeed } =
     useOsrdConfSelectors() as StdcmConfSelectors;
   const { updateTotalMass, updateTotalLength, updateMaxSpeed } =
@@ -15,19 +24,43 @@ const useStdcmConsist = () => {
   const totalMass = useSelector(getTotalMass);
   const onTotalMassChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMassValue = Number(e.target.value);
+    setTotalMassChanged(true);
     dispatch(updateTotalMass(totalMassValue === 0 ? undefined : totalMassValue));
   };
 
   const totalLength = useSelector(getTotalLength);
   const onTotalLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalLengthValue = Number(e.target.value);
+    setTotalLengthChanged(true);
     dispatch(updateTotalLength(totalLengthValue === 0 ? undefined : totalLengthValue));
   };
 
   const maxSpeed = useSelector(getMaxSpeed);
   const onMaxSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const totalMaxSpeed = Number(e.target.value);
+    setMaxSpeedChanged(true);
     dispatch(updateMaxSpeed(totalMaxSpeed === 0 ? undefined : totalMaxSpeed));
+  };
+
+  const prefillConsist = (
+    rollingStock?: LightRollingStockWithLiveries,
+    towed?: TowedRollingStock
+  ) => {
+    if (!totalMassChanged) {
+      const consistMass = Math.floor(kgToT((rollingStock?.mass ?? 0) + (towed?.mass ?? 0)));
+      dispatch(updateTotalMass(consistMass > 0 ? consistMass : undefined));
+    }
+
+    if (!totalLengthChanged) {
+      const consistLength = Math.floor((rollingStock?.length ?? 0) + (towed?.length ?? 0));
+      dispatch(updateTotalLength(consistLength > 0 ? consistLength : undefined));
+    }
+
+    if (!maxSpeedChanged) {
+      dispatch(
+        updateMaxSpeed(rollingStock?.max_speed ? Math.floor(rollingStock.max_speed) : undefined)
+      );
+    }
   };
 
   return {
@@ -37,6 +70,7 @@ const useStdcmConsist = () => {
     onTotalLengthChange,
     maxSpeed,
     onMaxSpeedChange,
+    prefillConsist,
   };
 };
 

--- a/front/src/applications/stdcm/hooks/useStdcmTowedRollingStock.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmTowedRollingStock.ts
@@ -8,7 +8,7 @@ const useStdcmTowedRollingStock = () => {
   const { getTowedRollingStockID } = useOsrdConfSelectors() as StdcmConfSelectors;
   const towedRollingStockId = useSelector(getTowedRollingStockID);
 
-  const { data: towedRollingStock } =
+  const { currentData: towedRollingStock } =
     osrdEditoastApi.endpoints.getTowedRollingStockByTowedRollingStockId.useQuery(
       {
         towedRollingStockId: towedRollingStockId!,

--- a/front/src/utils/physics.ts
+++ b/front/src/utils/physics.ts
@@ -101,3 +101,11 @@ export function decimalToPercentage(value: number) {
 export function tToKg(value: number) {
   return value * 1000;
 }
+
+/**
+ * ex: converts 12000kg to 12t
+ * @param value in kg
+ */
+export function kgToT(value: number) {
+  return value / 1000;
+}


### PR DESCRIPTION
part of #9712

Prefill the consist values based on the rolling stock and towed rolling stock selection.
Do not update the value if the user has manually changed it.