### PR TITLE
front: update e2e study date check

### DIFF
--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -37,7 +37,7 @@ test.describe('Validate the Study creation workflow', () => {
     const translations = OSRDLanguage === 'English' ? enTranslations : frTranslations;
     const studyName = `${studyData.name} ${uuidv4()}`; // Unique study name
     const todayDateISO = new Date().toISOString().split('T')[0]; // Get today's date in ISO format
-    const expectedDate = formatDateToDayMonthYear(todayDateISO);
+    const expectedDate = formatDateToDayMonthYear(todayDateISO, OSRDLanguage);
     // Create a new study using the study page model
     await studyPage.createStudy({
       name: studyName,
@@ -79,7 +79,7 @@ test.describe('Validate the Study creation workflow', () => {
     await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
     const translations = OSRDLanguage === 'English' ? enTranslations : frTranslations;
     const tomorrowDateISO = new Date(Date.now() + 86400000).toISOString().split('T')[0]; // Get tomorrow's date in ISO format
-    const expectedDate = formatDateToDayMonthYear(tomorrowDateISO);
+    const expectedDate = formatDateToDayMonthYear(tomorrowDateISO, OSRDLanguage);
     // Update the study with new values
     await studyPage.updateStudy({
       name: `${study.name} (updated)`,

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -92,20 +92,18 @@ export async function clickWithDelay(element: Locator, delay = 500): Promise<voi
 /**
  * Convert a date string from YYYY-MM-DD format to "DD mmm YYYY" format.
  * @param dateString - The input date string in YYYY-MM-DD format.
+ * @param OSRDLanguage - The current language of the application
  * @returns The formatted date string in "DD mmm YYYY" format.
  */
-export function formatDateToDayMonthYear(dateString: string): string {
+export function formatDateToDayMonthYear(dateString: string, OSRDLanguage: string): string {
+  const locale = OSRDLanguage === 'English' ? 'en-GB' : 'fr-FR';
   const date = new Date(dateString);
-
-  // Format the date to "15 Oct 2024" using toLocaleDateString
-  const formattedDate = date.toLocaleDateString('en-GB', {
+  const formattedDate = date.toLocaleDateString(locale, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
   });
-
-  // Convert the short month (first letter capitalized) to lowercase
-  return formattedDate.replace(/([A-Z])/g, (match) => match.toLowerCase());
+  return formattedDate.replace('.', '');
 }
 /**
  * Waits until the infrastructure state becomes 'CACHED' before proceeding to the next step.


### PR DESCRIPTION
The test is failing as the check didn't account for the french language.
```
Expected string: "2 dec 2024"
Received string: "2 déc 2024"
```