### PR TITLE
front: fix nge import when there is only one step

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -242,7 +242,9 @@ const importTimetable = async (
       body: { ids: train_ids },
     })
   );
-  const trainSchedules = await trainSchedulesPromise.unwrap();
+  const trainSchedules = (await trainSchedulesPromise.unwrap()).filter(
+    (trainSchedule) => trainSchedule.path.length >= 2
+  );
 
   const searchPayload = buildOpQuery(infraId, trainSchedules);
   const searchResults = searchPayload ? await executeSearch(searchPayload, dispatch) : [];


### PR DESCRIPTION
closes #9610 

When importing a train, it can happen that the train only has 1 step, which was resulting in the origin and destination being the same step. 
We check the length of the steps, if it's less than 2, we skip. 