### PR TITLE
editoast: use uom to type units

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1282,6 +1282,7 @@ name = "editoast"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "async-std",
  "async-trait",
  "axum 0.8.1",

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uom",
  "url",
  "utoipa",
  "uuid",
@@ -1384,6 +1385,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uom",
  "url",
  "utoipa",
 ]
@@ -1445,6 +1447,7 @@ dependencies = [
  "chrono",
  "derivative",
  "editoast_common",
+ "editoast_derive",
  "enum-map",
  "geojson",
  "iso8601",
@@ -1453,6 +1456,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror 2.0.11",
+ "uom",
  "utoipa",
  "uuid",
 ]
@@ -4945,6 +4949,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -86,6 +86,7 @@ tracing-opentelemetry = { version = "0.28.0", default-features = false, features
   "tracing-log",
 ] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uom = { version = "0.36.0", default-features = false, features = ["f64", "si"] }
 url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1.3"
 utoipa = { version = "4.2.3", features = ["chrono", "uuid"] }
@@ -194,6 +195,7 @@ tower-http = { version = "0.6.2", features = [
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
+uom.workspace = true
 url.workspace = true
 utoipa.workspace = true
 uuid.workspace = true

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -94,6 +94,7 @@ uuid = { version = "1.11.1", features = ["serde", "v4"] }
 
 [dependencies]
 anyhow = "1.0"
+approx = "0.5.1"
 async-trait = "0.1.85"
 axum = { version = "0.8.1", default-features = false, features = [
   "multipart",

--- a/editoast/editoast_common/Cargo.toml
+++ b/editoast/editoast_common/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
+uom.workspace = true
 url.workspace = true
 utoipa.workspace = true
 

--- a/editoast/editoast_common/src/lib.rs
+++ b/editoast/editoast_common/src/lib.rs
@@ -3,6 +3,7 @@ mod hash_rounded_float;
 pub mod rangemap_utils;
 pub mod schemas;
 pub mod tracing;
+pub mod units;
 
 pub use hash_rounded_float::hash_float;
 pub use hash_rounded_float::hash_float_slice;

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -167,3 +167,4 @@ define_unit!(kilogram_per_meter, AerodynamicDrag);
 define_unit!(per_meter, AerodynamicDragPerWeight);
 define_unit!(second, Time);
 define_unit!(millisecond, Time);
+define_unit!(basis_point, Ratio);

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -43,6 +43,7 @@ pub type ViscosityFriction = uom::si::f64::MassRate;
 pub type ViscosityFrictionPerWeight = uom::si::f64::Frequency;
 pub type AerodynamicDrag = uom::si::f64::LinearMassDensity;
 pub type AerodynamicDragPerWeight = uom::si::f64::LinearNumberDensity;
+pub type Deceleration = uom::si::f64::Acceleration;
 
 macro_rules! quantity_to_path {
     (Length, $unit:ident) => {

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -35,10 +35,14 @@
 //! ```
 
 /// Re-export the Quantities that are used in OSRD
-pub use uom::si::f64::{
-    Acceleration, Force, Frequency, Length, LinearMassDensity, LinearNumberDensity, Mass, MassRate,
-    Time, Velocity,
-};
+pub use uom::si::f64::{Acceleration, Length, Mass, Ratio, Time, Velocity};
+
+pub type SolidFriction = uom::si::f64::Force;
+pub type SolidFrictionPerWeight = uom::si::f64::Acceleration;
+pub type ViscosityFriction = uom::si::f64::MassRate;
+pub type ViscosityFrictionPerWeight = uom::si::f64::Frequency;
+pub type AerodynamicDrag = uom::si::f64::LinearMassDensity;
+pub type AerodynamicDragPerWeight = uom::si::f64::LinearNumberDensity;
 
 macro_rules! quantity_to_path {
     (Length, $unit:ident) => {
@@ -53,19 +57,19 @@ macro_rules! quantity_to_path {
     (Mass, $unit:ident) => {
         uom::si::mass::$unit
     };
-    (Force, $unit:ident) => {
+    (SolidFriction, $unit:ident) => {
         uom::si::force::$unit
     };
-    (MassRate, $unit:ident) => {
+    (ViscosityFriction, $unit:ident) => {
         uom::si::mass_rate::$unit
     };
-    (Frequency, $unit:ident) => {
+    (ViscosityFrictionPerWeight, $unit:ident) => {
         uom::si::frequency::$unit
     };
-    (LinearMassDensity, $unit:ident) => {
+    (AerodynamicDrag, $unit:ident) => {
         uom::si::linear_mass_density::$unit
     };
-    (LinearNumberDensity, $unit:ident) => {
+    (AerodynamicDragPerWeight, $unit:ident) => {
         uom::si::linear_number_density::$unit
     };
     (Time, $unit:ident) => {
@@ -79,8 +83,8 @@ macro_rules! quantity_to_path {
 macro_rules! define_unit {
     ($unit:ident, $quantity:ident) => {
         pub mod $unit {
+            use super::*;
             use serde::{Deserialize, Deserializer, Serialize, Serializer};
-            use uom::si::f64::*;
             type Unit = quantity_to_path!($quantity, $unit);
             pub type ReprType = f64;
 
@@ -155,10 +159,10 @@ define_unit!(millimeter, Length);
 define_unit!(meter_per_second, Velocity);
 define_unit!(meter_per_second_squared, Acceleration);
 define_unit!(kilogram, Mass);
-define_unit!(newton, Force);
-define_unit!(kilogram_per_second, MassRate);
-define_unit!(hertz, Frequency);
-define_unit!(kilogram_per_meter, LinearMassDensity);
-define_unit!(per_meter, LinearNumberDensity);
+define_unit!(newton, SolidFriction);
+define_unit!(kilogram_per_second, ViscosityFriction);
+define_unit!(hertz, ViscosityFrictionPerWeight);
+define_unit!(kilogram_per_meter, AerodynamicDrag);
+define_unit!(per_meter, AerodynamicDragPerWeight);
 define_unit!(second, Time);
 define_unit!(millisecond, Time);

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -1,0 +1,164 @@
+//! Module to allow the use of serde with uom quantities
+//!
+//! The serde feature of uom doesn’t allow to specify in which unit the value will be serialized.
+//!
+//! Two helpers are provided for convenience:
+//! * `unit::new` (e.g. `meter::new(32)`) to build a new quantity from a f64 in the given unit
+//! * `unit::from` (e.g. `millimeter::from(length)`) to have the quantity as f64 in the given unit
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use editoast_model::units::*;
+//! #[derive(Debug, Serialize, Derivative)]
+//! struct Train {
+//!     // This means that serde with read and write the velocity in meters per second
+//!     #[serde(with="meter_per_second")]
+//!     max_speed: Velocity,
+//!     // When using optional values, we must add `default` and use ::option unit
+//!     // See https://stackoverflow.com/a/44303505
+//!     #[serde(default, with="meter::option")]
+//!     length: Option<Length>,
+//! }
+//!
+//! impl Train {
+//!     fn from_meter_per_seconds(mps: f64) -> Self {
+//!         Self {
+//!             max_speed: meter_per_second::new(mps),
+//!         }
+//!     }
+//!
+//!     fn print(&self) {
+//!         println!("The max speed is: {} km/h", kilometer_per_hour::from(self.max_speed));
+//!     }
+//! }
+//! ```
+
+/// Re-export the Quantities that are used in OSRD
+pub use uom::si::f64::{
+    Acceleration, Force, Frequency, Length, LinearMassDensity, LinearNumberDensity, Mass, MassRate,
+    Time, Velocity,
+};
+
+macro_rules! quantity_to_path {
+    (Length, $unit:ident) => {
+        uom::si::length::$unit
+    };
+    (Velocity, $unit:ident) => {
+        uom::si::velocity::$unit
+    };
+    (Acceleration, $unit:ident) => {
+        uom::si::acceleration::$unit
+    };
+    (Mass, $unit:ident) => {
+        uom::si::mass::$unit
+    };
+    (Force, $unit:ident) => {
+        uom::si::force::$unit
+    };
+    (MassRate, $unit:ident) => {
+        uom::si::mass_rate::$unit
+    };
+    (Frequency, $unit:ident) => {
+        uom::si::frequency::$unit
+    };
+    (LinearMassDensity, $unit:ident) => {
+        uom::si::linear_mass_density::$unit
+    };
+    (LinearNumberDensity, $unit:ident) => {
+        uom::si::linear_number_density::$unit
+    };
+    (Time, $unit:ident) => {
+        uom::si::time::$unit
+    };
+    (Ratio, $unit:ident) => {
+        uom::si::ratio::$unit
+    };
+}
+
+macro_rules! define_unit {
+    ($unit:ident, $quantity:ident) => {
+        pub mod $unit {
+            use serde::{Deserialize, Deserializer, Serialize, Serializer};
+            use uom::si::f64::*;
+            type Unit = quantity_to_path!($quantity, $unit);
+            pub type ReprType = f64;
+
+            pub fn serialize<S>(value: &$quantity, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                value.get::<Unit>().serialize(serializer)
+            }
+
+            pub fn deserialize<'de, D>(deserializer: D) -> Result<$quantity, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = ReprType::deserialize(deserializer)?;
+                Ok($quantity::new::<Unit>(value))
+            }
+
+            pub fn new(value: ReprType) -> $quantity {
+                $quantity::new::<Unit>(value)
+            }
+
+            pub fn from(qty: $quantity) -> ReprType {
+                qty.get::<Unit>()
+            }
+
+            pub fn hash<H: std::hash::Hasher>(value: &$quantity, state: &mut H) {
+                crate::hash_float::<5, H>(&from(*value), state);
+            }
+
+            pub mod option {
+                use super::*;
+                pub type ReprType = Option<super::ReprType>;
+
+                pub fn serialize<S>(
+                    value: &Option<$quantity>,
+                    serializer: S,
+                ) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    value.map(|value| value.get::<Unit>()).serialize(serializer)
+                }
+
+                pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<$quantity>, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    let value = Option::deserialize(deserializer)?;
+                    Ok(value.map(|value| $quantity::new::<Unit>(value)))
+                }
+
+                pub fn new(value: ReprType) -> Option<$quantity> {
+                    value.map(|v| $quantity::new::<Unit>(v))
+                }
+
+                pub fn from(qty: Option<$quantity>) -> ReprType {
+                    qty.map(|q| q.get::<Unit>())
+                }
+
+                pub fn hash<H: std::hash::Hasher>(value: &Option<$quantity>, state: &mut H) {
+                    super::hash(&value.unwrap_or_default(), state);
+                }
+            }
+        }
+    };
+}
+
+// Any new value here must also be added in editoast_derive/src/annotate_units.rs
+define_unit!(meter, Length);
+define_unit!(millimeter, Length);
+define_unit!(meter_per_second, Velocity);
+define_unit!(meter_per_second_squared, Acceleration);
+define_unit!(kilogram, Mass);
+define_unit!(newton, Force);
+define_unit!(kilogram_per_second, MassRate);
+define_unit!(hertz, Frequency);
+define_unit!(kilogram_per_meter, LinearMassDensity);
+define_unit!(per_meter, LinearNumberDensity);
+define_unit!(second, Time);
+define_unit!(millisecond, Time);

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -35,15 +35,16 @@
 //! ```
 
 /// Re-export the Quantities that are used in OSRD
-pub use uom::si::f64::{Acceleration, Length, Mass, Ratio, Time, Velocity};
-
-pub type SolidFriction = uom::si::f64::Force;
-pub type SolidFrictionPerWeight = uom::si::f64::Acceleration;
-pub type ViscosityFriction = uom::si::f64::MassRate;
-pub type ViscosityFrictionPerWeight = uom::si::f64::Frequency;
-pub type AerodynamicDrag = uom::si::f64::LinearMassDensity;
-pub type AerodynamicDragPerWeight = uom::si::f64::LinearNumberDensity;
-pub type Deceleration = uom::si::f64::Acceleration;
+pub mod quantities {
+    pub use uom::si::f64::{Acceleration, Length, Mass, Ratio, Time, Velocity};
+    pub type SolidFriction = uom::si::f64::Force;
+    pub type SolidFrictionPerWeight = uom::si::f64::Acceleration;
+    pub type ViscosityFriction = uom::si::f64::MassRate;
+    pub type ViscosityFrictionPerWeight = uom::si::f64::Frequency;
+    pub type AerodynamicDrag = uom::si::f64::LinearMassDensity;
+    pub type AerodynamicDragPerWeight = uom::si::f64::LinearNumberDensity;
+    pub type Deceleration = uom::si::f64::Acceleration;
+}
 
 macro_rules! quantity_to_path {
     (Length, $unit:ident) => {
@@ -199,6 +200,7 @@ macro_rules! define_unit {
 }
 
 // Any new value here must also be added in editoast_derive/src/annotate_units.rs
+use quantities::*;
 define_unit!(meter, Length);
 define_unit!(millimeter, Length);
 define_unit!(meter_per_second, Velocity);

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -150,6 +150,50 @@ macro_rules! define_unit {
                     super::hash(&value.unwrap_or_default(), state);
                 }
             }
+
+            pub mod u64 {
+                use super::*;
+
+                pub fn serialize<S>(value: &$quantity, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    (value.get::<Unit>() as u64).serialize(serializer)
+                }
+
+                pub fn deserialize<'de, D>(deserializer: D) -> Result<$quantity, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    super::deserialize(deserializer)
+                }
+
+                pub mod option {
+                    use super::*;
+                    pub type ReprType = Option<super::ReprType>;
+
+                    pub fn serialize<S>(
+                        value: &Option<$quantity>,
+                        serializer: S,
+                    ) -> Result<S::Ok, S::Error>
+                    where
+                        S: Serializer,
+                    {
+                        value
+                            .map(|value| value.get::<Unit>() as u64)
+                            .serialize(serializer)
+                    }
+
+                    pub fn deserialize<'de, D>(
+                        deserializer: D,
+                    ) -> Result<Option<$quantity>, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        super::super::option::deserialize(deserializer)
+                    }
+                }
+            }
         }
     };
 }

--- a/editoast/editoast_derive/src/annotate_units.rs
+++ b/editoast/editoast_derive/src/annotate_units.rs
@@ -39,6 +39,7 @@ fn get_abbreviation(value: &str) -> Option<&'static str> {
         "kilogram_per_meter" => Some("Aerodynamic drag in kg·m⁻¹"),
         "kilogram_per_second" => Some("Viscosity friction in kg·s⁻¹"),
         "per_meter" => Some("Aerodynamic drag per kg in m⁻¹"),
+        "basis_point" => Some("Ratio 1:1"),
         _ => None,
     }
 }

--- a/editoast/editoast_derive/src/annotate_units.rs
+++ b/editoast/editoast_derive/src/annotate_units.rs
@@ -1,0 +1,75 @@
+use darling::Result;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, DeriveInput, LitStr};
+
+const OPTIONAL_SUFFIX: &str = "::option";
+struct UnitType {
+    unit: String,
+    optional: bool,
+}
+
+impl UnitType {
+    fn new(path: LitStr) -> Self {
+        let path = path.value();
+        let optional = path.ends_with(OPTIONAL_SUFFIX);
+        let unit = path
+            .strip_suffix(OPTIONAL_SUFFIX)
+            .unwrap_or(&path)
+            .rsplit("::")
+            .next()
+            .expect("String::split to return at least an empty string")
+            .to_owned();
+        Self { unit, optional }
+    }
+}
+
+fn get_abbreviation(value: &str) -> Option<&'static str> {
+    // Any new value here must also be added in editoast_common/src/units.rs
+    match value {
+        "second" => Some("Duration in s"),
+        "millisecond" => Some("Duration in ms"),
+        "meter" => Some("Length in m"),
+        "millimeter" => Some("Length in mm"),
+        "meter_per_second" => Some("Velocity in m·s⁻¹"),
+        "meter_per_second_squared" => Some("Acceleration in m·s⁻²"),
+        "kilogram" => Some("Mass in kg"),
+        "newton" => Some("Solid Friction in N"),
+        "hertz" => Some("Viscosity friction per weight in s⁻¹"),
+        "kilogram_per_meter" => Some("Aerodynamic drag in kg·m⁻¹"),
+        "kilogram_per_second" => Some("Viscosity friction in kg·s⁻¹"),
+        "per_meter" => Some("Aerodynamic drag per kg in m⁻¹"),
+        _ => None,
+    }
+}
+
+pub fn annotate_units(input: &mut DeriveInput) -> Result<TokenStream> {
+    // We look for fields that have #[sered(with="meter")] attributes
+    // and we push two new attributes to it to improve the OpenAPI
+    if let syn::Data::Struct(s) = &mut input.data {
+        for f in s.fields.iter_mut() {
+            for attr in f.attrs.clone() {
+                if attr.path().is_ident("serde") {
+                    let _ = attr.parse_nested_meta(|meta| {
+                        if meta.path.is_ident("with") {
+                            let value = meta.value()?;
+                            let s: LitStr = value.parse()?;
+                            let unit = UnitType::new(s);
+                            if let Some(abbreviation) = get_abbreviation(&unit.unit) {
+                                if unit.optional {
+                                    f.attrs
+                                        .push(parse_quote! {#[schema(value_type = Option<f64>)]});
+                                } else {
+                                    f.attrs.push(parse_quote! {#[schema(value_type = f64)]});
+                                }
+                                f.attrs.push(parse_quote! {#[doc = #abbreviation]});
+                            }
+                        }
+                        Ok(())
+                    });
+                }
+            }
+        }
+    }
+    Ok(quote! {#input})
+}

--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate proc_macro;
 
+mod annotate_units;
 mod error;
 mod model;
 mod search;
@@ -269,3 +270,20 @@ mod test_utils {
 
 #[cfg(test)]
 use test_utils::assert_macro_expansion;
+/// Annotates fields of a structs with documentation and value_type for a better utoipa schema
+///
+/// It must be used on structs that use #[derive(ToSchema)]
+///
+/// On every field that has an attribute such as #[serde(with="millimeter")]
+/// It will add:
+/// * #[schema(value_type = f64)]
+/// * /// Length in mm
+#[proc_macro_attribute]
+pub fn annotate_units(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    // We are using a macro attribute to modify in place the attributes of fields to annotate
+    // This requires to mutate the input
+    let mut input = parse_macro_input!(input as DeriveInput);
+    annotate_units::annotate_units(&mut input)
+        .unwrap_or_else(darling::Error::write_errors)
+        .into()
+}

--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -218,6 +218,7 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// * `#[model(to_string)]`: calls `to_string()` before writing the field to the database and calls `String::from` after reading (diesel column type: String)
 /// * `#[model(to_enum)]`: is converted as `u8` before writing the field to the database and calls `FromRepr::from_repr` after reading (diesel column type: TinyInt)
 /// * `#[model(remote = "T")]`: calls `Into::<T>::into` before writing the field to the database and calls `T::from` after reading (diesel column type: T)
+/// * `#[model(uom_unit = "path::to::unit")]`: the value is the path to an unit defined in editoast_common, e.g. `"editoast_common::units::meter"`
 /// * `#[model(geo)]` **TODO**: TBD
 ///
 /// #### A note on identifiers

--- a/editoast/editoast_derive/src/model/args.rs
+++ b/editoast/editoast_derive/src/model/args.rs
@@ -79,6 +79,8 @@ pub(super) struct ModelFieldArgs {
     pub(super) to_enum: bool,
     #[darling(default)]
     pub(super) remote: Option<syn::Type>,
+    #[darling(default)]
+    pub(super) uom_unit: Option<syn::Path>,
 }
 
 impl GeneratedTypeArgs {

--- a/editoast/editoast_derive/src/model/config.rs
+++ b/editoast/editoast_derive/src/model/config.rs
@@ -45,6 +45,7 @@ pub(crate) enum FieldTransformation {
     Geo,
     ToString,
     ToEnum(syn::Type),
+    UomUnit(syn::Path),
 }
 
 #[derive(Debug, PartialEq)]
@@ -132,6 +133,9 @@ impl ModelField {
             Some(FieldTransformation::ToEnum(_)) => {
                 parse_quote! { #expr as i16 }
             }
+            Some(FieldTransformation::UomUnit(ref unit)) => {
+                parse_quote! { #unit::from(#expr) }
+            }
             None => parse_quote! { #expr },
         }
     }
@@ -146,6 +150,9 @@ impl ModelField {
             Some(FieldTransformation::ToEnum(ref ty)) => {
                 parse_quote! { #ty::from_repr(#expr as usize).expect("Invalid variant repr") }
             }
+            Some(FieldTransformation::UomUnit(ref unit)) => {
+                parse_quote! { #unit::new(#expr) }
+            }
             None => parse_quote! { #expr },
         }
     }
@@ -158,6 +165,7 @@ impl ModelField {
             Some(FieldTransformation::Geo) => unimplemented!("to be designed"),
             Some(FieldTransformation::ToString) => parse_quote! { String },
             Some(FieldTransformation::ToEnum(_)) => parse_quote! { i16 },
+            Some(FieldTransformation::UomUnit(ref unit)) => parse_quote! { #unit::ReprType },
             None => ty.clone(),
         }
     }

--- a/editoast/editoast_derive/src/model/parsing.rs
+++ b/editoast/editoast_derive/src/model/parsing.rs
@@ -165,6 +165,7 @@ impl ModelField {
             value.geo,
             value.to_string,
             to_enum,
+            value.uom_unit,
         )
         .map_err(|e| e.with_span(&ident))?;
         Ok(Self {
@@ -188,16 +189,18 @@ impl FieldTransformation {
         geo: bool,
         to_string: bool,
         to_enum: Option<syn::Type>,
+        uom_unit: Option<syn::Path>,
     ) -> darling::Result<Option<Self>> {
-        match (remote, json, geo, to_string, to_enum) {
-            (Some(ty), false, false, false, None) => Ok(Some(Self::Remote(ty))),
-            (None, true, false, false, None) => Ok(Some(Self::Json)),
-            (None, false, true, false, None) => Ok(Some(Self::Geo)),
-            (None, false, false, true, None) => Ok(Some(Self::ToString)),
-            (None, false, false, false, Some(ty)) => Ok(Some(Self::ToEnum(ty))),
-            (None, false, false, false, None) => Ok(None),
+        match (remote, json, geo, to_string, to_enum, uom_unit) {
+            (Some(ty), false, false, false, None, None) => Ok(Some(Self::Remote(ty))),
+            (None, true, false, false, None, None) => Ok(Some(Self::Json)),
+            (None, false, true, false, None, None) => Ok(Some(Self::Geo)),
+            (None, false, false, true, None, None) => Ok(Some(Self::ToString)),
+            (None, false, false, false, Some(ty), None) => Ok(Some(Self::ToEnum(ty))),
+            (None, false, false, false, None, Some(ty)) => Ok(Some(Self::UomUnit(ty))),
+            (None, false, false, false, None, None) => Ok(None),
             _ => Err(Error::custom(
-                "Model: remote, json, geo, to_string and to_enum attributes are mutually exclusive",
+                "Model: remote, json, geo, to_string, to_enum and uom_unit attributes are mutually exclusive",
             )),
         }
     }

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 chrono.workspace = true
 derivative.workspace = true
 editoast_common.workspace = true
+editoast_derive.workspace = true
 enum-map.workspace = true
 geojson.workspace = true
 iso8601 = "0.6.1"
@@ -16,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+uom.workspace = true
 utoipa.workspace = true
 uuid.workspace = true
 

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -76,8 +76,8 @@ pub struct RollingStock {
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     #[serde(with = "kilogram")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -36,7 +36,10 @@ pub use rolling_stock_livery::RollingStockLiveryMetadata;
 mod towed_rolling_stock;
 pub use towed_rolling_stock::TowedRollingStock;
 
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Time, Velocity,
+};
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -61,24 +64,24 @@ pub struct RollingStock {
     pub locked: bool,
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
-    #[serde(with = "meter")]
+    #[serde(with = "units::meter")]
     pub length: Length,
-    #[serde(with = "meter_per_second")]
+    #[serde(with = "units::meter_per_second")]
     pub max_speed: Velocity,
-    #[serde(with = "second")]
+    #[serde(with = "units::second")]
     pub startup_time: Time,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
     // The constant gamma braking coefficient used when NOT circulating
     // under ETCS/ERTMS signaling system
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "basis_point")]
+    #[serde(with = "units::basis_point")]
     pub inertia_coefficient: Ratio,
-    #[serde(with = "kilogram")]
+    #[serde(with = "units::kilogram")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,
     pub loading_gauge: LoadingGaugeType,
@@ -89,11 +92,11 @@ pub struct RollingStock {
     pub energy_sources: Vec<EnergySource>,
     /// The time the train takes before actually using electrical power (in seconds).
     /// Is null if the train is not electric.
-    #[serde(default, with = "second::option")]
+    #[serde(default, with = "units::second::option")]
     pub electrical_power_startup_time: Option<Time>,
     /// The time it takes to raise this train's pantograph in seconds.
     /// Is null if the train is not electric.
-    #[serde(default, with = "second::option")]
+    #[serde(default, with = "units::second::option")]
     pub raise_pantograph_time: Option<Time>,
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub railjson_version: String,

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -36,6 +36,7 @@ pub use rolling_stock_livery::RollingStockLiveryMetadata;
 mod towed_rolling_stock;
 pub use towed_rolling_stock::TowedRollingStock;
 
+use editoast_common::units::*;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -60,22 +61,25 @@ pub struct RollingStock {
     pub locked: bool,
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
-    /// In m
-    pub length: f64,
-    /// In m/s
-    pub max_speed: f64,
-    pub startup_time: f64,
-    /// In m/s²
-    pub startup_acceleration: f64,
-    /// In m/s²
-    pub comfort_acceleration: f64,
+    #[serde(with = "meter")]
+    pub length: Length,
+    #[serde(with = "meter_per_second")]
+    pub max_speed: Velocity,
+    #[serde(with = "second")]
+    pub startup_time: Time,
+    #[serde(with = "meter_per_second_squared")]
+    pub startup_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub comfort_acceleration: Acceleration,
     // The constant gamma braking coefficient used when NOT circulating
-    // under ETCS/ERTMS signaling system in m/s^2
-    pub const_gamma: f64,
+    // under ETCS/ERTMS signaling system
+    #[serde(with = "meter_per_second_squared")]
+    pub const_gamma: Acceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    pub inertia_coefficient: f64,
-    /// In kg
-    pub mass: f64,
+    #[serde(with = "meter_per_second_squared")]
+    pub inertia_coefficient: Acceleration,
+    #[serde(with = "kilogram")]
+    pub mass: Mass,
     pub rolling_resistance: RollingResistance,
     pub loading_gauge: LoadingGaugeType,
     /// Mapping of power restriction code to power class
@@ -85,11 +89,12 @@ pub struct RollingStock {
     pub energy_sources: Vec<EnergySource>,
     /// The time the train takes before actually using electrical power (in seconds).
     /// Is null if the train is not electric.
-    pub electrical_power_startup_time: Option<f64>,
+    #[serde(default, with = "second::option")]
+    pub electrical_power_startup_time: Option<Time>,
     /// The time it takes to raise this train's pantograph in seconds.
     /// Is null if the train is not electric.
-    #[serde(default)]
-    pub raise_pantograph_time: Option<f64>,
+    #[serde(default, with = "second::option")]
+    pub raise_pantograph_time: Option<Time>,
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub railjson_version: String,
     #[serde(default)]

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -74,7 +74,7 @@ pub struct RollingStock {
     // The constant gamma braking coefficient used when NOT circulating
     // under ETCS/ERTMS signaling system
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
     #[serde(with = "meter_per_second_squared")]
     pub inertia_coefficient: Acceleration,

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
@@ -1,5 +1,9 @@
 use derivative::Derivative;
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    AerodynamicDrag, AerodynamicDragPerWeight, SolidFriction, SolidFrictionPerWeight,
+    ViscosityFriction, ViscosityFrictionPerWeight,
+};
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -18,16 +22,16 @@ pub struct RollingResistance {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
     /// Solid friction
-    #[derivative(Hash(hash_with = "newton::hash"))]
-    #[serde(with = "newton")]
+    #[derivative(Hash(hash_with = "units::newton::hash"))]
+    #[serde(with = "units::newton")]
     pub A: SolidFriction,
     /// Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "kilogram_per_second::hash"))]
-    #[serde(with = "kilogram_per_second")]
+    #[derivative(Hash(hash_with = "units::kilogram_per_second::hash"))]
+    #[serde(with = "units::kilogram_per_second")]
     pub B: ViscosityFriction,
     /// Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "kilogram_per_meter::hash"))]
-    #[serde(with = "kilogram_per_meter")]
+    #[derivative(Hash(hash_with = "units::kilogram_per_meter::hash"))]
+    #[serde(with = "units::kilogram_per_meter")]
     pub C: AerodynamicDrag,
 }
 
@@ -40,15 +44,15 @@ pub struct RollingResistancePerWeight {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
     /// Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "meter_per_second_squared::hash"))]
-    #[serde(with = "meter_per_second_squared")]
+    #[derivative(Hash(hash_with = "units::meter_per_second_squared::hash"))]
+    #[serde(with = "units::meter_per_second_squared")]
     pub A: SolidFrictionPerWeight,
     /// Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "hertz::hash"))]
-    #[serde(with = "hertz")]
+    #[derivative(Hash(hash_with = "units::hertz::hash"))]
+    #[serde(with = "units::hertz")]
     pub B: ViscosityFrictionPerWeight,
     /// Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "per_meter::hash"))]
-    #[serde(with = "per_meter")]
+    #[derivative(Hash(hash_with = "units::per_meter::hash"))]
+    #[serde(with = "units::per_meter")]
     pub C: AerodynamicDragPerWeight,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
@@ -1,4 +1,5 @@
 use derivative::Derivative;
+use editoast_common::units::*;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -8,6 +9,7 @@ editoast_common::schemas! {
     RollingResistancePerWeight,
 }
 
+#[editoast_derive::annotate_units]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
 #[derivative(Hash)]
 #[serde(deny_unknown_fields)]
@@ -15,17 +17,21 @@ editoast_common::schemas! {
 pub struct RollingResistance {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
-    /// Solid friction in N
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub A: f64,
-    /// Viscosity friction in N/(m/s)
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub B: f64,
-    /// Aerodynamic drag in N/(m/s)²
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub C: f64,
+    /// Solid friction
+    #[derivative(Hash(hash_with = "newton::hash"))]
+    #[serde(with = "newton")]
+    pub A: SolidFriction,
+    /// Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+    #[derivative(Hash(hash_with = "kilogram_per_second::hash"))]
+    #[serde(with = "kilogram_per_second")]
+    pub B: ViscosityFriction,
+    /// Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
+    #[derivative(Hash(hash_with = "kilogram_per_meter::hash"))]
+    #[serde(with = "kilogram_per_meter")]
+    pub C: AerodynamicDrag,
 }
 
+#[editoast_derive::annotate_units]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
 #[derivative(Hash)]
 #[serde(deny_unknown_fields)]
@@ -33,13 +39,16 @@ pub struct RollingResistance {
 pub struct RollingResistancePerWeight {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
-    /// Solid friction in N/kg
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub A: f64,
-    /// Viscosity friction in (N/kg)/(m/s)
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub B: f64,
-    /// Aerodynamic drag in (N/kg)/(m/s)²
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
-    pub C: f64,
+    /// Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
+    #[derivative(Hash(hash_with = "meter_per_second_squared::hash"))]
+    #[serde(with = "meter_per_second_squared")]
+    pub A: SolidFrictionPerWeight,
+    /// Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+    #[derivative(Hash(hash_with = "hertz::hash"))]
+    #[serde(with = "hertz")]
+    pub B: ViscosityFrictionPerWeight,
+    /// Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
+    #[derivative(Hash(hash_with = "per_meter::hash"))]
+    #[serde(with = "per_meter")]
+    pub C: AerodynamicDragPerWeight,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -1,22 +1,26 @@
 use super::RollingResistancePerWeight;
+use editoast_common::units::*;
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TowedRollingStock {
     pub name: String,
     pub label: String,
     pub railjson_version: String,
-    /// In kg
-    pub mass: f64,
-    /// In m
-    pub length: f64,
-    /// In m/s²
-    pub comfort_acceleration: f64,
-    /// In m/s²
-    pub startup_acceleration: f64,
-    pub inertia_coefficient: f64,
+    #[serde(with = "kilogram")]
+    pub mass: Mass,
+    #[serde(with = "meter")]
+    pub length: Length,
+    #[serde(with = "meter_per_second_squared")]
+    pub comfort_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub startup_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub inertia_coefficient: Acceleration,
     pub rolling_resistance: RollingResistancePerWeight,
     /// The constant gamma braking coefficient used when NOT circulating
-    /// under ETCS/ERTMS signaling system in m/s^2
-    pub const_gamma: f64,
-    pub max_speed: Option<f64>,
+    /// under ETCS/ERTMS signaling system
+    #[serde(with = "meter_per_second_squared")]
+    pub const_gamma: Acceleration,
+    #[serde(default, with = "meter_per_second::option")]
+    pub max_speed: Option<Velocity>,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -20,7 +20,7 @@ pub struct TowedRollingStock {
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     #[serde(default, with = "meter_per_second::option")]
     pub max_speed: Option<Velocity>,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -1,26 +1,29 @@
 use super::RollingResistancePerWeight;
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Velocity,
+};
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TowedRollingStock {
     pub name: String,
     pub label: String,
     pub railjson_version: String,
-    #[serde(with = "kilogram")]
+    #[serde(with = "units::kilogram")]
     pub mass: Mass,
-    #[serde(with = "meter")]
+    #[serde(with = "units::meter")]
     pub length: Length,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "basis_point")]
+    #[serde(with = "units::basis_point")]
     pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
-    #[serde(default, with = "meter_per_second::option")]
+    #[serde(default, with = "units::meter_per_second::option")]
     pub max_speed: Option<Velocity>,
 }

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -14,8 +14,8 @@ pub struct TowedRollingStock {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2793,7 +2793,9 @@ paths:
                 max_speed:
                   type: number
                   format: double
-                  description: Maximum speed of the consist in km/h
+                  description: |-
+                    Maximum speed of the consist in km/h
+                    Velocity in m·s⁻¹
                   nullable: true
                 maximum_departure_delay:
                   type: integer
@@ -2852,12 +2854,16 @@ paths:
                 total_length:
                   type: number
                   format: double
-                  description: Total length of the consist in meters
+                  description: |-
+                    Total length of the consist in meters
+                    Length in m
                   nullable: true
                 total_mass:
                   type: number
                   format: double
-                  description: Total mass of the consist in kg
+                  description: |-
+                    Total mass of the consist
+                    Mass in kg
                   nullable: true
                 towed_rolling_stock_id:
                   type: integer
@@ -7270,9 +7276,11 @@ components:
         comfort_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         const_gamma:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         effort_curves:
           $ref: '#/components/schemas/LightEffortCurves'
         energy_sources:
@@ -7289,9 +7297,11 @@ components:
         inertia_coefficient:
           type: number
           format: double
+          description: Ratio 1:1
         length:
           type: number
           format: double
+          description: Length in m
         loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
         locked:
@@ -7299,9 +7309,11 @@ components:
         mass:
           type: number
           format: double
+          description: Mass in kg
         max_speed:
           type: number
           format: double
+          description: Velocity in m·s⁻¹
         metadata:
           allOf:
           - $ref: '#/components/schemas/RollingStockMetadata'
@@ -7319,9 +7331,11 @@ components:
         startup_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         startup_time:
           type: number
           format: double
+          description: Duration in s
         supported_signaling_systems:
           $ref: '#/components/schemas/RollingStockSupportedSignalingSystems'
     LightRollingStockWithLiveries:
@@ -8978,7 +8992,9 @@ components:
         max_speed:
           type: number
           format: double
-          description: Maximum speed of the consist in km/h
+          description: |-
+            Maximum speed of the consist in km/h
+            Velocity in m·s⁻¹
           nullable: true
         maximum_departure_delay:
           type: integer
@@ -9037,12 +9053,16 @@ components:
         total_length:
           type: number
           format: double
-          description: Total length of the consist in meters
+          description: |-
+            Total length of the consist in meters
+            Length in m
           nullable: true
         total_mass:
           type: number
           format: double
-          description: Total mass of the consist in kg
+          description: |-
+            Total mass of the consist
+            Mass in kg
           nullable: true
         towed_rolling_stock_id:
           type: integer
@@ -9125,15 +9145,21 @@ components:
         A:
           type: number
           format: double
-          description: Solid friction in N
+          description: |-
+            Solid friction
+            Solid Friction in N
         B:
           type: number
           format: double
-          description: Viscosity friction in N/(m/s)
+          description: |-
+            Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+            Viscosity friction in kg·s⁻¹
         C:
           type: number
           format: double
-          description: Aerodynamic drag in N/(m/s)²
+          description: |-
+            Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
+            Aerodynamic drag in kg·m⁻¹
         type:
           type: string
       additionalProperties: false
@@ -9148,15 +9174,21 @@ components:
         A:
           type: number
           format: double
-          description: Solid friction in N/kg
+          description: |-
+            Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
+            Acceleration in m·s⁻²
         B:
           type: number
           format: double
-          description: Viscosity friction in (N/kg)/(m/s)
+          description: |-
+            Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+            Viscosity friction per weight in s⁻¹
         C:
           type: number
           format: double
-          description: Aerodynamic drag in (N/kg)/(m/s)²
+          description: |-
+            Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
+            Aerodynamic drag per kg in m⁻¹
         type:
           type: string
       additionalProperties: false
@@ -9194,14 +9226,17 @@ components:
         comfort_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         const_gamma:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         effort_curves:
           $ref: '#/components/schemas/EffortCurves'
         electrical_power_startup_time:
           type: number
           format: double
+          description: Duration in s
           nullable: true
         energy_sources:
           type: array
@@ -9217,9 +9252,11 @@ components:
         inertia_coefficient:
           type: number
           format: double
+          description: Ratio 1:1
         length:
           type: number
           format: double
+          description: Length in m
         loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
         locked:
@@ -9227,9 +9264,11 @@ components:
         mass:
           type: number
           format: double
+          description: Mass in kg
         max_speed:
           type: number
           format: double
+          description: Velocity in m·s⁻¹
         metadata:
           allOf:
           - $ref: '#/components/schemas/RollingStockMetadata'
@@ -9245,15 +9284,18 @@ components:
         raise_pantograph_time:
           type: number
           format: double
+          description: Duration in s
           nullable: true
         rolling_resistance:
           $ref: '#/components/schemas/RollingResistance'
         startup_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         startup_time:
           type: number
           format: double
+          description: Duration in s
         supported_signaling_systems:
           type: array
           items:
@@ -9349,15 +9391,19 @@ components:
         comfort_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         const_gamma:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         effort_curves:
           $ref: '#/components/schemas/EffortCurves'
         electrical_power_startup_time:
           type: number
           format: double
-          description: The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
+          description: |-
+            The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
+            Duration in s
           example: 5.0
           nullable: true
         energy_sources:
@@ -9367,9 +9413,11 @@ components:
         inertia_coefficient:
           type: number
           format: double
+          description: Ratio 1:1
         length:
           type: number
           format: double
+          description: Length in m
         loading_gauge:
           $ref: '#/components/schemas/LoadingGaugeType'
         locked:
@@ -9378,9 +9426,11 @@ components:
         mass:
           type: number
           format: double
+          description: Mass in kg
         max_speed:
           type: number
           format: double
+          description: Velocity in m·s⁻¹
         metadata:
           allOf:
           - $ref: '#/components/schemas/RollingStockMetadata'
@@ -9395,7 +9445,9 @@ components:
         raise_pantograph_time:
           type: number
           format: double
-          description: The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
+          description: |-
+            The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
+            Duration in s
           example: 15.0
           nullable: true
         rolling_resistance:
@@ -9403,9 +9455,11 @@ components:
         startup_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         startup_time:
           type: number
           format: double
+          description: Duration in s
         supported_signaling_systems:
           $ref: '#/components/schemas/RollingStockSupportedSignalingSystems'
     RollingStockKey:
@@ -11163,32 +11217,39 @@ components:
       - inertia_coefficient
       - rolling_resistance
       - const_gamma
+      - max_speed
       properties:
         comfort_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         const_gamma:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         id:
           type: integer
           format: int64
         inertia_coefficient:
           type: number
           format: double
+          description: Ratio 1:1
         label:
           type: string
         length:
           type: number
           format: double
+          description: Length in m
         locked:
           type: boolean
         mass:
           type: number
           format: double
+          description: Mass in kg
         max_speed:
           type: number
           format: double
+          description: Velocity in m·s⁻¹
           nullable: true
         name:
           type: string
@@ -11199,6 +11260,7 @@ components:
         startup_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
     TowedRollingStockCountList:
       allOf:
       - $ref: '#/components/schemas/PaginationStats'
@@ -11227,25 +11289,31 @@ components:
         comfort_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         const_gamma:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
         inertia_coefficient:
           type: number
           format: double
+          description: Ratio 1:1
         label:
           type: string
         length:
           type: number
           format: double
+          description: Length in m
         locked:
           type: boolean
         mass:
           type: number
           format: double
+          description: Mass in kg
         max_speed:
           type: number
           format: double
+          description: Velocity in m·s⁻¹
           nullable: true
         name:
           type: string
@@ -11254,6 +11322,7 @@ components:
         startup_acceleration:
           type: number
           format: double
+          description: Acceleration in m·s⁻²
     TowedRollingStockLockedForm:
       type: object
       required:

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -41,8 +41,8 @@ pub struct PhysicsConsist {
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
     /// Length of the rolling stock
-    #[derivative(Hash(hash_with = "meter::hash"))]
-    #[serde(with = "meter")]
+    #[derivative(Hash(hash_with = "millimeter::hash"))]
+    #[serde(with = "millimeter::u64")]
     pub length: Length,
     /// Maximum speed of the rolling stock
     #[derivative(Hash(hash_with = "meter_per_second::hash"))]
@@ -68,7 +68,7 @@ pub struct PhysicsConsist {
     pub inertia_coefficient: Ratio,
     /// Mass of the rolling stock
     #[derivative(Hash(hash_with = "kilogram::hash"))]
-    #[serde(with = "kilogram")]
+    #[serde(with = "kilogram::u64")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,
     /// Mapping of power restriction code to power class
@@ -77,12 +77,12 @@ pub struct PhysicsConsist {
     /// The time the train takes before actually using electrical power.
     /// Is null if the train is not electric or the value not specified.
     #[derivative(Hash(hash_with = "millisecond::option::hash"))]
-    #[serde(default, with = "millisecond::option")]
+    #[serde(default, with = "millisecond::u64::option")]
     pub electrical_power_startup_time: Option<Time>,
     /// The time it takes to raise this train's pantograph.
     /// Is null if the train is not electric or the value not specified.
     #[derivative(Hash(hash_with = "millisecond::option::hash"))]
-    #[serde(default, with = "millisecond::option")]
+    #[serde(default, with = "millisecond::u64::option")]
     pub raise_pantograph_time: Option<Time>,
 }
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -63,9 +63,9 @@ pub struct PhysicsConsist {
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[derivative(Hash(hash_with = "meter_per_second_squared::hash"))]
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[derivative(Hash(hash_with = "basis_point::hash"))]
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     /// Mass of the rolling stock
     #[derivative(Hash(hash_with = "kilogram::hash"))]
     #[serde(with = "kilogram")]
@@ -156,7 +156,7 @@ impl PhysicsConsistParameters {
             .unwrap_or(self.traction_engine.comfort_acceleration)
     }
 
-    pub fn compute_inertia_coefficient(&self) -> Acceleration {
+    pub fn compute_inertia_coefficient(&self) -> Ratio {
         if let (Some(towed_rolling_stock), Some(total_mass)) =
             (self.towed_rolling_stock.as_ref(), self.total_mass)
         {
@@ -662,15 +662,15 @@ mod tests {
     fn physics_consist_compute_inertia_coefficient() {
         let mut physics_consist = create_physics_consist();
 
-        assert_eq!(
-            physics_consist.compute_inertia_coefficient(),
-            meter_per_second_squared::new(1.065)
+        approx::assert_relative_eq!(
+            basis_point::from(physics_consist.compute_inertia_coefficient()),
+            1.065
         );
 
         physics_consist.towed_rolling_stock = None;
         assert_eq!(
             physics_consist.compute_inertia_coefficient(),
-            meter_per_second_squared::new(1.10,)
+            basis_point::new(1.10,)
         );
     }
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -61,7 +61,7 @@ pub struct PhysicsConsist {
     /// under ETCS/ERTMS signaling system
     #[derivative(Hash(hash_with = "meter_per_second_squared::hash"))]
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
     #[derivative(Hash(hash_with = "meter_per_second_squared::hash"))]
     #[serde(with = "meter_per_second_squared")]

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -5,7 +5,7 @@ use std::ops::DerefMut;
 use chrono::Utc;
 use editoast_models::DbConnection;
 
-use editoast_common::units::*;
+use editoast_common::units;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
@@ -228,21 +228,21 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
     TowedRollingStock {
         name: "TOWED_ROLLING_STOCK".to_string(),
         label: "towed".to_string(),
-        mass: kilogram::new(50000.0),
-        length: meter::new(30.0),
-        comfort_acceleration: meter_per_second_squared::new(0.2),
-        startup_acceleration: meter_per_second_squared::new(0.06),
-        inertia_coefficient: basis_point::new(1.05),
+        mass: units::kilogram::new(50000.0),
+        length: units::meter::new(30.0),
+        comfort_acceleration: units::meter_per_second_squared::new(0.2),
+        startup_acceleration: units::meter_per_second_squared::new(0.06),
+        inertia_coefficient: units::basis_point::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
             // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight
             // We should use more realistic values and fix the tests
-            A: meter_per_second_squared::new(1.0),
-            B: hertz::new(0.01),
-            C: per_meter::new(0.0002),
+            A: units::meter_per_second_squared::new(1.0),
+            B: units::hertz::new(0.01),
+            C: units::per_meter::new(0.0002),
         },
-        const_gamma: meter_per_second_squared::new(0.5),
-        max_speed: Some(meter_per_second::new(35.0)),
+        const_gamma: units::meter_per_second_squared::new(0.5),
+        max_speed: Some(units::meter_per_second::new(35.0)),
         railjson_version: "3.4".to_string(),
     }
 }
@@ -253,15 +253,15 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         loading_gauge: LoadingGaugeType::G1,
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
-        comfort_acceleration: meter_per_second_squared::new(0.1),
-        inertia_coefficient: basis_point::new(1.10),
-        startup_acceleration: meter_per_second_squared::new(0.04),
-        startup_time: second::new(1.0),
+        comfort_acceleration: units::meter_per_second_squared::new(0.1),
+        inertia_coefficient: units::basis_point::new(1.10),
+        startup_acceleration: units::meter_per_second_squared::new(0.04),
+        startup_time: units::second::new(1.0),
         effort_curves: EffortCurves::default(),
         electrical_power_startup_time: None,
         raise_pantograph_time: None,
         energy_sources: vec![],
-        const_gamma: meter_per_second_squared::new(1.0),
+        const_gamma: units::meter_per_second_squared::new(1.0),
         etcs_brake_params: None,
         locked: false,
         metadata: None,
@@ -271,13 +271,13 @@ pub fn create_simple_rolling_stock() -> RollingStock {
             rolling_resistance_type: "davis".to_string(),
             // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
             // We should use more realistic values and fix the tests
-            A: newton::new(1.0),
-            B: kilogram_per_second::new(0.01),
-            C: kilogram_per_meter::new(0.0005),
+            A: units::newton::new(1.0),
+            B: units::kilogram_per_second::new(0.01),
+            C: units::kilogram_per_meter::new(0.0005),
         },
-        length: meter::new(140.0),
-        mass: kilogram::new(15000.0),
-        max_speed: meter_per_second::new(20.0),
+        length: units::meter::new(140.0),
+        mass: units::kilogram::new(15000.0),
+        max_speed: units::meter_per_second::new(20.0),
     }
 }
 

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -235,9 +235,6 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
         inertia_coefficient: basis_point::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
-            A: meter_per_second_squared::new(1.0), // In N/kg
-            B: hertz::new(0.01),                   // In N/kg/(m/s)
-            C: per_meter::new(0.0002),             // In N/kg/(m/s)²
         },
         const_gamma: meter_per_second_squared::new(0.5),
         max_speed: Some(meter_per_second::new(35.0)),
@@ -267,9 +264,6 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: newton::new(1.0),                // In N
-            B: kilogram_per_second::new(0.01),  // In N/(m/s)
-            C: kilogram_per_meter::new(0.0005), // In N/(m/s)²
         },
         length: meter::new(140.0),
         mass: kilogram::new(15000.0),

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -232,7 +232,7 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
         length: meter::new(30.0),
         comfort_acceleration: meter_per_second_squared::new(0.2),
         startup_acceleration: meter_per_second_squared::new(0.06),
-        inertia_coefficient: meter_per_second_squared::new(1.05),
+        inertia_coefficient: basis_point::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
             A: meter_per_second_squared::new(1.0), // In N/kg
@@ -252,7 +252,7 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
         comfort_acceleration: meter_per_second_squared::new(0.1),
-        inertia_coefficient: meter_per_second_squared::new(1.10),
+        inertia_coefficient: basis_point::new(1.10),
         startup_acceleration: meter_per_second_squared::new(0.04),
         startup_time: second::new(1.0),
         effort_curves: EffortCurves::default(),

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -5,6 +5,7 @@ use std::ops::DerefMut;
 use chrono::Utc;
 use editoast_models::DbConnection;
 
+use editoast_common::units::*;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
@@ -227,19 +228,19 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
     TowedRollingStock {
         name: "TOWED_ROLLING_STOCK".to_string(),
         label: "towed".to_string(),
-        mass: 50000.0,             // kg
-        length: 30.0,              // m
-        comfort_acceleration: 0.2, // In m/s²
-        startup_acceleration: 0.06,
-        inertia_coefficient: 1.05,
+        mass: kilogram::new(50000.0),
+        length: meter::new(30.0),
+        comfort_acceleration: meter_per_second_squared::new(0.2),
+        startup_acceleration: meter_per_second_squared::new(0.06),
+        inertia_coefficient: meter_per_second_squared::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,    // In N
-            B: 0.01,   // In N/(m/s)
-            C: 0.0002, // In N/(m/s)²
+            A: meter_per_second_squared::new(1.0), // In N/kg
+            B: hertz::new(0.01),                   // In N/kg/(m/s)
+            C: per_meter::new(0.0002),             // In N/kg/(m/s)²
         },
-        const_gamma: 0.5,
-        max_speed: Some(35.0),
+        const_gamma: meter_per_second_squared::new(0.5),
+        max_speed: Some(meter_per_second::new(35.0)),
         railjson_version: "3.4".to_string(),
     }
 }
@@ -250,15 +251,15 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         loading_gauge: LoadingGaugeType::G1,
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
-        comfort_acceleration: 0.1, // In m/s²
-        inertia_coefficient: 1.10,
-        startup_acceleration: 0.04, // In m/s²
-        startup_time: 1.0,
+        comfort_acceleration: meter_per_second_squared::new(0.1),
+        inertia_coefficient: meter_per_second_squared::new(1.10),
+        startup_acceleration: meter_per_second_squared::new(0.04),
+        startup_time: second::new(1.0),
         effort_curves: EffortCurves::default(),
         electrical_power_startup_time: None,
         raise_pantograph_time: None,
         energy_sources: vec![],
-        const_gamma: 1.0,
+        const_gamma: meter_per_second_squared::new(1.0),
         etcs_brake_params: None,
         locked: false,
         metadata: None,
@@ -266,13 +267,13 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: 1.0,    // In N
-            B: 0.01,   // In N/(m/s)
-            C: 0.0005, // In N/(m/s)²
+            A: newton::new(1.0),                // In N
+            B: kilogram_per_second::new(0.01),  // In N/(m/s)
+            C: kilogram_per_meter::new(0.0005), // In N/(m/s)²
         },
-        length: 140.0,   // m
-        mass: 15000.0,   // kg
-        max_speed: 20.0, // m/s
+        length: meter::new(140.0),
+        mass: kilogram::new(15000.0),
+        max_speed: meter_per_second::new(20.0),
     }
 }
 

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -235,6 +235,11 @@ pub fn create_towed_rolling_stock() -> TowedRollingStock {
         inertia_coefficient: basis_point::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
+            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight
+            // We should use more realistic values and fix the tests
+            A: meter_per_second_squared::new(1.0),
+            B: hertz::new(0.01),
+            C: per_meter::new(0.0002),
         },
         const_gamma: meter_per_second_squared::new(0.5),
         max_speed: Some(meter_per_second::new(35.0)),
@@ -264,6 +269,11 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         railjson_version: "12".to_string(),
         rolling_resistance: RollingResistance {
             rolling_resistance_type: "davis".to_string(),
+            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
+            // We should use more realistic values and fix the tests
+            A: newton::new(1.0),
+            B: kilogram_per_second::new(0.01),
+            C: kilogram_per_meter::new(0.0005),
         },
         length: meter::new(140.0),
         mass: kilogram::new(15000.0),

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -2,7 +2,10 @@ mod power_restrictions;
 
 use std::collections::HashMap;
 
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Time, Velocity,
+};
 use editoast_derive::Model;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
@@ -46,34 +49,34 @@ pub struct RollingStockModel {
     #[model(json)]
     #[schema(required)]
     pub metadata: Option<RollingStockMetadata>,
-    #[serde(with = "meter")]
-    #[model(uom_unit = "meter")]
+    #[serde(with = "units::meter")]
+    #[model(uom_unit = "units::meter")]
     pub length: Length,
-    #[serde(with = "meter_per_second")]
-    #[model(uom_unit = "meter_per_second")]
+    #[serde(with = "units::meter_per_second")]
+    #[model(uom_unit = "units::meter_per_second")]
     pub max_speed: Velocity,
-    #[serde(with = "second")]
-    #[model(uom_unit = "second")]
+    #[serde(with = "units::second")]
+    #[model(uom_unit = "units::second")]
     pub startup_time: Time,
-    #[serde(with = "meter_per_second_squared")]
-    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
-    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
-    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
     #[model(json)]
     #[schema(required)]
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "basis_point")]
-    #[model(uom_unit = "basis_point")]
+    #[serde(with = "units::basis_point")]
+    #[model(uom_unit = "units::basis_point")]
     pub inertia_coefficient: Ratio,
     #[schema(required)]
     pub base_power_class: Option<String>,
-    #[serde(with = "kilogram")]
-    #[model(uom_unit = "kilogram")]
+    #[serde(with = "units::kilogram")]
+    #[model(uom_unit = "units::kilogram")]
     pub mass: Mass,
     #[model(json)]
     pub rolling_resistance: RollingResistance,
@@ -85,12 +88,12 @@ pub struct RollingStockModel {
     pub energy_sources: Vec<EnergySource>,
     pub locked: bool,
     #[schema(required)]
-    #[serde(default, with = "second::option")]
-    #[model(uom_unit = "second::option")]
+    #[serde(default, with = "units::second::option")]
+    #[model(uom_unit = "units::second::option")]
     pub electrical_power_startup_time: Option<Time>,
     #[schema(required)]
-    #[serde(default, with = "second::option")]
-    #[model(uom_unit = "second::option")]
+    #[serde(default, with = "units::second::option")]
+    #[model(uom_unit = "units::second::option")]
     pub raise_pantograph_time: Option<Time>,
     pub version: i64,
     #[schema(value_type = Vec<String>)]
@@ -105,8 +108,8 @@ impl RollingStockModelChangeset {
                 effort_curves,
                 self.electrical_power_startup_time
                     .flatten()
-                    .map(second::new),
-                self.raise_pantograph_time.flatten().map(second::new),
+                    .map(units::second::new),
+                self.raise_pantograph_time.flatten().map(units::second::new),
             )
             .map_err(|e| {
                 let mut err = ValidationErrors::new();

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -67,9 +67,9 @@ pub struct RollingStockModel {
     #[model(json)]
     #[schema(required)]
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "meter_per_second_squared")]
-    #[model(uom_unit = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    #[model(uom_unit = "basis_point")]
+    pub inertia_coefficient: Ratio,
     #[schema(required)]
     pub base_power_class: Option<String>,
     #[serde(with = "kilogram")]

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -63,7 +63,7 @@ pub struct RollingStockModel {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     #[model(uom_unit = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     #[model(json)]
     #[schema(required)]
     pub etcs_brake_params: Option<EtcsBrakeParams>,

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -1,4 +1,7 @@
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Velocity,
+};
 use editoast_derive::Model;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::TowedRollingStock;
@@ -22,29 +25,29 @@ pub struct TowedRollingStockModel {
     pub railjson_version: String,
     pub locked: bool,
 
-    #[serde(with = "kilogram")]
-    #[model(uom_unit = "kilogram")]
+    #[serde(with = "units::kilogram")]
+    #[model(uom_unit = "units::kilogram")]
     pub mass: Mass,
-    #[serde(with = "meter")]
-    #[model(uom_unit = "meter")]
+    #[serde(with = "units::meter")]
+    #[model(uom_unit = "units::meter")]
     pub length: Length,
     #[schema(required)]
-    #[serde(default, with = "meter_per_second::option")]
-    #[model(uom_unit = "meter_per_second::option")]
+    #[serde(default, with = "units::meter_per_second::option")]
+    #[model(uom_unit = "units::meter_per_second::option")]
     pub max_speed: Option<Velocity>,
-    #[model(uom_unit = "meter_per_second_squared")]
-    #[serde(with = "meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
-    #[model(uom_unit = "meter_per_second_squared")]
-    #[serde(with = "meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[model(uom_unit = "basis_point")]
-    #[serde(with = "basis_point")]
+    #[model(uom_unit = "units::basis_point")]
+    #[serde(with = "units::basis_point")]
     pub inertia_coefficient: Ratio,
     #[model(json)]
     pub rolling_resistance: RollingResistancePerWeight,
-    #[model(uom_unit = "meter_per_second_squared")]
-    #[serde(with = "meter_per_second_squared")]
+    #[model(uom_unit = "units::meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
 
     pub version: i64,

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -1,3 +1,4 @@
+use editoast_common::units::*;
 use editoast_derive::Model;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::TowedRollingStock;
@@ -7,6 +8,7 @@ use utoipa::ToSchema;
 
 use crate::models::prelude::*;
 
+#[editoast_derive::annotate_units]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Model, ToSchema)]
 #[model(table = editoast_models::tables::towed_rolling_stock)]
 #[model(gen(ops = crud, batch_ops = r, list))]
@@ -20,18 +22,30 @@ pub struct TowedRollingStockModel {
     pub railjson_version: String,
     pub locked: bool,
 
-    /// In kg
-    pub mass: f64,
-    /// In m
-    pub length: f64,
-    /// In km/h
-    pub max_speed: Option<f64>,
-    pub comfort_acceleration: f64,
-    pub startup_acceleration: f64,
-    pub inertia_coefficient: f64,
+    #[serde(with = "kilogram")]
+    #[model(uom_unit = "kilogram")]
+    pub mass: Mass,
+    #[serde(with = "meter")]
+    #[model(uom_unit = "meter")]
+    pub length: Length,
+    #[schema(required)]
+    #[serde(default, with = "meter_per_second::option")]
+    #[model(uom_unit = "meter_per_second::option")]
+    pub max_speed: Option<Velocity>,
+    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "meter_per_second_squared")]
+    pub comfort_acceleration: Acceleration,
+    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "meter_per_second_squared")]
+    pub startup_acceleration: Acceleration,
+    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "meter_per_second_squared")]
+    pub inertia_coefficient: Acceleration,
     #[model(json)]
     pub rolling_resistance: RollingResistancePerWeight,
-    pub const_gamma: f64,
+    #[model(uom_unit = "meter_per_second_squared")]
+    #[serde(with = "meter_per_second_squared")]
+    pub const_gamma: Acceleration,
 
     pub version: i64,
 }

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -45,7 +45,7 @@ pub struct TowedRollingStockModel {
     pub rolling_resistance: RollingResistancePerWeight,
     #[model(uom_unit = "meter_per_second_squared")]
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
 
     pub version: i64,
 }

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -38,9 +38,9 @@ pub struct TowedRollingStockModel {
     #[model(uom_unit = "meter_per_second_squared")]
     #[serde(with = "meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[model(uom_unit = "meter_per_second_squared")]
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[model(uom_unit = "basis_point")]
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     #[model(json)]
     pub rolling_resistance: RollingResistancePerWeight,
     #[model(uom_unit = "meter_per_second_squared")]

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -9,6 +9,7 @@ use axum::extract::Path;
 use axum::extract::State;
 use axum::Extension;
 use editoast_authz::BuiltinRole;
+use editoast_common::units::*;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::rolling_stock::RollingStock;
 use editoast_schemas::train_schedule::PathItemLocation;
@@ -395,8 +396,10 @@ pub async fn pathfinding_from_train_batch(
                 .supported_signaling_systems
                 .0
                 .clone(),
-            rolling_stock_maximum_speed: OrderedFloat(rolling_stock.max_speed),
-            rolling_stock_length: OrderedFloat(rolling_stock.length),
+            rolling_stock_maximum_speed: OrderedFloat(meter_per_second::from(
+                rolling_stock.max_speed,
+            )),
+            rolling_stock_length: OrderedFloat(meter::from(rolling_stock.length)),
             path_items: train_schedule
                 .path
                 .clone()

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -9,7 +9,7 @@ use axum::extract::Path;
 use axum::extract::State;
 use axum::Extension;
 use editoast_authz::BuiltinRole;
-use editoast_common::units::*;
+use editoast_common::units;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::rolling_stock::RollingStock;
 use editoast_schemas::train_schedule::PathItemLocation;
@@ -396,10 +396,10 @@ pub async fn pathfinding_from_train_batch(
                 .supported_signaling_systems
                 .0
                 .clone(),
-            rolling_stock_maximum_speed: OrderedFloat(meter_per_second::from(
+            rolling_stock_maximum_speed: OrderedFloat(units::meter_per_second::from(
                 rolling_stock.max_speed,
             )),
-            rolling_stock_length: OrderedFloat(meter::from(rolling_stock.length)),
+            rolling_stock_length: OrderedFloat(units::meter::from(rolling_stock.length)),
             path_items: train_schedule
                 .path
                 .clone()

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -38,7 +38,7 @@ pub struct RollingStockForm {
     #[serde(with = "meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     #[serde(with = "meter_per_second_squared")]
     pub inertia_coefficient: Acceleration,
     #[serde(with = "kilogram")]

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use editoast_common::units::*;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
@@ -18,6 +19,7 @@ use crate::models::Changeset;
 use crate::models::Model;
 use crate::models::RollingStockModel;
 
+#[editoast_derive::annotate_units]
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate)]
 #[validate(schema(function = "validate_rolling_stock_form"))]
 pub struct RollingStockForm {
@@ -25,14 +27,22 @@ pub struct RollingStockForm {
     pub effort_curves: EffortCurves,
     #[schema(example = "5", required)]
     pub base_power_class: Option<String>,
-    pub length: f64,
-    pub max_speed: f64,
-    pub startup_time: f64,
-    pub startup_acceleration: f64,
-    pub comfort_acceleration: f64,
-    pub const_gamma: f64,
-    pub inertia_coefficient: f64,
-    pub mass: f64,
+    #[serde(with = "meter")]
+    pub length: Length,
+    #[serde(with = "meter_per_second")]
+    pub max_speed: Velocity,
+    #[serde(with = "second")]
+    pub startup_time: Time,
+    #[serde(with = "meter_per_second_squared")]
+    pub startup_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub comfort_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub const_gamma: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    pub inertia_coefficient: Acceleration,
+    #[serde(with = "kilogram")]
+    pub mass: Mass,
     pub rolling_resistance: RollingResistance,
     pub loading_gauge: LoadingGaugeType,
     /// Mapping of power restriction code to power class
@@ -43,10 +53,12 @@ pub struct RollingStockForm {
     pub energy_sources: Vec<EnergySource>,
     /// The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
     #[schema(example = 5.0)]
-    pub electrical_power_startup_time: Option<f64>,
+    #[serde(default, with = "second::option")]
+    pub electrical_power_startup_time: Option<Time>,
     /// The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
     #[schema(example = 15.0)]
-    pub raise_pantograph_time: Option<f64>,
+    #[serde(default, with = "second::option")]
+    pub raise_pantograph_time: Option<Time>,
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub locked: Option<bool>,
     pub metadata: Option<RollingStockMetadata>,

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use editoast_common::units::*;
+use editoast_common::units::{quantities::*, *};
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
 use editoast_schemas::rolling_stock::LoadingGaugeType;

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -39,8 +39,8 @@ pub struct RollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     #[serde(with = "kilogram")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -4,7 +4,10 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::Extension;
 use editoast_authz::BuiltinRole;
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Time, Velocity,
+};
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::rolling_stock::EffortCurves;
@@ -218,23 +221,23 @@ struct LightRollingStock {
     effort_curves: LightEffortCurves,
     #[schema(required)]
     base_power_class: Option<String>,
-    #[serde(with = "meter")]
+    #[serde(with = "units::meter")]
     length: Length,
-    #[serde(with = "meter_per_second")]
+    #[serde(with = "units::meter_per_second")]
     max_speed: Velocity,
-    #[serde(with = "second")]
+    #[serde(with = "units::second")]
     startup_time: Time,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     comfort_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     const_gamma: Deceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "basis_point")]
+    #[serde(with = "units::basis_point")]
     inertia_coefficient: Ratio,
-    #[serde(with = "kilogram")]
+    #[serde(with = "units::kilogram")]
     mass: Mass,
     rolling_resistance: RollingResistance,
     loading_gauge: LoadingGaugeType,

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -229,7 +229,7 @@ struct LightRollingStock {
     #[serde(with = "meter_per_second_squared")]
     comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
-    const_gamma: Acceleration,
+    const_gamma: Deceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
     #[serde(with = "meter_per_second_squared")]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -4,6 +4,7 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::Extension;
 use editoast_authz::BuiltinRole;
+use editoast_common::units::*;
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::rolling_stock::EffortCurves;
@@ -206,6 +207,7 @@ async fn get_by_name(
     Ok(Json(light_rolling_stock_with_liveries))
 }
 
+#[editoast_derive::annotate_units]
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(Deserialize))]
 struct LightRollingStock {
@@ -216,16 +218,24 @@ struct LightRollingStock {
     effort_curves: LightEffortCurves,
     #[schema(required)]
     base_power_class: Option<String>,
-    length: f64,
-    max_speed: f64,
-    startup_time: f64,
-    startup_acceleration: f64,
-    comfort_acceleration: f64,
-    const_gamma: f64,
+    #[serde(with = "meter")]
+    length: Length,
+    #[serde(with = "meter_per_second")]
+    max_speed: Velocity,
+    #[serde(with = "second")]
+    startup_time: Time,
+    #[serde(with = "meter_per_second_squared")]
+    startup_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    comfort_acceleration: Acceleration,
+    #[serde(with = "meter_per_second_squared")]
+    const_gamma: Acceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
-    inertia_coefficient: f64,
-    mass: f64,
+    #[serde(with = "meter_per_second_squared")]
+    inertia_coefficient: Acceleration,
+    #[serde(with = "kilogram")]
+    mass: Mass,
     rolling_resistance: RollingResistance,
     loading_gauge: LoadingGaugeType,
     #[schema(required)]

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -232,8 +232,8 @@ struct LightRollingStock {
     const_gamma: Deceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "meter_per_second_squared")]
-    inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    inertia_coefficient: Ratio,
     #[serde(with = "kilogram")]
     mass: Mass,
     rolling_resistance: RollingResistance,

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -15,7 +15,10 @@ use axum::Extension;
 use axum::Json;
 use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_authz::BuiltinRole;
-use editoast_common::units::*;
+use editoast_common::units;
+use editoast_common::units::quantities::{
+    Acceleration, Deceleration, Length, Mass, Ratio, Velocity,
+};
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
@@ -55,21 +58,21 @@ struct TowedRollingStock {
     railjson_version: String,
     locked: bool,
 
-    #[serde(with = "kilogram")]
+    #[serde(with = "units::kilogram")]
     mass: Mass,
-    #[serde(with = "meter")]
+    #[serde(with = "units::meter")]
     length: Length,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     comfort_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     startup_acceleration: Acceleration,
-    #[serde(with = "basis_point")]
+    #[serde(with = "units::basis_point")]
     inertia_coefficient: Ratio,
     rolling_resistance: RollingResistancePerWeight,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     const_gamma: Deceleration,
     #[schema(required)]
-    #[serde(default, with = "meter_per_second::option")]
+    #[serde(default, with = "units::meter_per_second::option")]
     max_speed: Option<Velocity>,
 }
 
@@ -111,20 +114,20 @@ pub struct TowedRollingStockForm {
     pub label: String,
     pub locked: bool,
 
-    #[serde(with = "kilogram")]
+    #[serde(with = "units::kilogram")]
     pub mass: Mass,
-    #[serde(with = "meter")]
+    #[serde(with = "units::meter")]
     pub length: Length,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub comfort_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "basis_point")]
+    #[serde(with = "units::basis_point")]
     pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
-    #[serde(with = "meter_per_second_squared")]
+    #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
-    #[serde(default, with = "meter_per_second::option")]
+    #[serde(default, with = "units::meter_per_second::option")]
     pub max_speed: Option<Velocity>,
 }
 
@@ -378,7 +381,7 @@ mod tests {
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
     use axum::http::StatusCode;
-    use editoast_common::units::*;
+    use editoast_common::units;
     use rstest::rstest;
     use serde_json::json;
     use uuid::Uuid;
@@ -482,7 +485,7 @@ mod tests {
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, UNLOCKED);
 
         let id = towed_rolling_stock.id;
-        towed_rolling_stock.mass = kilogram::new(13000.0);
+        towed_rolling_stock.mass = units::kilogram::new(13000.0);
         let updated_towed_rolling_stock: TowedRollingStock = app
             .fetch(
                 app.patch(&format!("/towed_rolling_stock/{id}"))
@@ -492,7 +495,10 @@ mod tests {
             .json_into();
 
         assert_eq!(updated_towed_rolling_stock.name, name);
-        assert_eq!(updated_towed_rolling_stock.mass, kilogram::new(13000.0));
+        assert_eq!(
+            updated_towed_rolling_stock.mass,
+            units::kilogram::new(13000.0)
+        );
     }
 
     #[rstest]
@@ -515,7 +521,7 @@ mod tests {
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
 
         let id = towed_rolling_stock.id;
-        towed_rolling_stock.mass = kilogram::new(13000.0);
+        towed_rolling_stock.mass = units::kilogram::new(13000.0);
         app.fetch(
             app.patch(&format!("/towed_rolling_stock/{id}"))
                 .json(&towed_rolling_stock),
@@ -531,7 +537,7 @@ mod tests {
         let mut towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
 
         let id = towed_rolling_stock.id;
-        towed_rolling_stock.mass = kilogram::new(13000.0);
+        towed_rolling_stock.mass = units::kilogram::new(13000.0);
         app.fetch(
             app.patch(&format!("/towed_rolling_stock/{id}/locked"))
                 .json(&json!({ "locked": false })),

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -63,8 +63,8 @@ struct TowedRollingStock {
     comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
-    inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    inertia_coefficient: Ratio,
     rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "meter_per_second_squared")]
     const_gamma: Deceleration,
@@ -119,8 +119,8 @@ pub struct TowedRollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "meter_per_second_squared")]
-    pub inertia_coefficient: Acceleration,
+    #[serde(with = "basis_point")]
+    pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -67,7 +67,7 @@ struct TowedRollingStock {
     inertia_coefficient: Acceleration,
     rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "meter_per_second_squared")]
-    const_gamma: Acceleration,
+    const_gamma: Deceleration,
     #[schema(required)]
     #[serde(default, with = "meter_per_second::option")]
     max_speed: Option<Velocity>,
@@ -123,7 +123,7 @@ pub struct TowedRollingStockForm {
     pub inertia_coefficient: Acceleration,
     pub rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "meter_per_second_squared")]
-    pub const_gamma: Acceleration,
+    pub const_gamma: Deceleration,
     #[serde(default, with = "meter_per_second::option")]
     pub max_speed: Option<Velocity>,
 }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -575,7 +575,7 @@ mod tests {
         let mut rolling_stock = create_simple_rolling_stock();
         rolling_stock.mass = kilogram::new(100000.0);
         rolling_stock.length = meter::new(20.0);
-        rolling_stock.inertia_coefficient = meter_per_second_squared::new(1.10);
+        rolling_stock.inertia_coefficient = basis_point::new(1.10);
         rolling_stock.comfort_acceleration = meter_per_second_squared::new(0.1);
         rolling_stock.startup_acceleration = meter_per_second_squared::new(0.04);
         rolling_stock.rolling_resistance = RollingResistance {
@@ -601,10 +601,7 @@ mod tests {
 
         assert_eq!(physics_consist.mass, total_mass);
 
-        assert_eq!(
-            physics_consist.inertia_coefficient,
-            meter_per_second_squared::new(1.075)
-        );
+        assert_eq!(physics_consist.inertia_coefficient, basis_point::new(1.075));
 
         assert_eq!(
             physics_consist.rolling_resistance,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -27,7 +27,6 @@ use thiserror::Error;
 use tracing::Instrument;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
-use validator::Validate;
 
 use crate::core::conflict_detection::Conflict;
 use crate::core::conflict_detection::TrainRequirements;
@@ -143,7 +142,6 @@ async fn stdcm(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    stdcm_request.validate()?;
     let mut conn = db_pool.get().await?;
 
     let timetable_id = id;

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -541,7 +541,7 @@ fn build_single_margin(margin: Option<MarginValue>) -> Margins {
 mod tests {
     use axum::http::StatusCode;
     use chrono::DateTime;
-    use editoast_common::units::*;
+    use editoast_common::units;
     use editoast_models::DbConnectionPoolV2;
     use editoast_schemas::rolling_stock::RollingResistance;
     use pretty_assertions::assert_eq;
@@ -573,21 +573,21 @@ mod tests {
     #[test]
     fn simulation_with_towed_rolling_stock_parameters() {
         let mut rolling_stock = create_simple_rolling_stock();
-        rolling_stock.mass = kilogram::new(100000.0);
-        rolling_stock.length = meter::new(20.0);
-        rolling_stock.inertia_coefficient = basis_point::new(1.10);
-        rolling_stock.comfort_acceleration = meter_per_second_squared::new(0.1);
-        rolling_stock.startup_acceleration = meter_per_second_squared::new(0.04);
+        rolling_stock.mass = units::kilogram::new(100000.0);
+        rolling_stock.length = units::meter::new(20.0);
+        rolling_stock.inertia_coefficient = units::basis_point::new(1.10);
+        rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.1);
+        rolling_stock.startup_acceleration = units::meter_per_second_squared::new(0.04);
         rolling_stock.rolling_resistance = RollingResistance {
             rolling_resistance_type: "davis".to_string(),
-            A: newton::new(1.0),
-            B: kilogram_per_second::new(0.01),
-            C: kilogram_per_meter::new(0.0005),
+            A: units::newton::new(1.0),
+            B: units::kilogram_per_second::new(0.01),
+            C: units::kilogram_per_meter::new(0.0005),
         };
 
         let towed_rolling_stock = create_towed_rolling_stock();
 
-        let total_mass = kilogram::new(200000.0);
+        let total_mass = units::kilogram::new(200000.0);
 
         let simulation_parameters = PhysicsConsistParameters {
             total_length: None,
@@ -601,15 +601,18 @@ mod tests {
 
         assert_eq!(physics_consist.mass, total_mass);
 
-        assert_eq!(physics_consist.inertia_coefficient, basis_point::new(1.075));
+        assert_eq!(
+            physics_consist.inertia_coefficient,
+            units::basis_point::new(1.075)
+        );
 
         assert_eq!(
             physics_consist.rolling_resistance,
             RollingResistance {
                 rolling_resistance_type: "davis".to_string(),
-                A: newton::new(100001.0),
-                B: kilogram_per_second::new(1000.01),
-                C: kilogram_per_meter::new(20.0005),
+                A: units::newton::new(100001.0),
+                B: units::kilogram_per_second::new(1000.01),
+                C: units::kilogram_per_meter::new(20.0005),
             }
         );
     }
@@ -617,18 +620,21 @@ mod tests {
     #[test]
     fn simulation_with_parameters() {
         let simulation_parameters = PhysicsConsistParameters {
-            total_mass: Some(kilogram::new(123.0)),
-            total_length: Some(meter::new(455.0)),
-            max_speed: Some(meter_per_second::new(10.0)),
+            total_mass: Some(units::kilogram::new(123.0)),
+            total_length: Some(units::meter::new(455.0)),
+            max_speed: Some(units::meter_per_second::new(10.0)),
             towed_rolling_stock: None,
             traction_engine: create_simple_rolling_stock(),
         };
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
 
-        assert_eq!(physics_consist.mass, kilogram::new(123.0));
-        assert_eq!(physics_consist.length, millimeter::new(455000.0)); // It should be converted in mm
-        assert_eq!(physics_consist.max_speed, meter_per_second::new(10_f64)); // It should be in m/s
+        assert_eq!(physics_consist.mass, units::kilogram::new(123.0));
+        assert_eq!(physics_consist.length, units::millimeter::new(455000.0)); // It should be converted in mm
+        assert_eq!(
+            physics_consist.max_speed,
+            units::meter_per_second::new(10_f64)
+        ); // It should be in m/s
     }
 
     #[test]
@@ -638,17 +644,20 @@ mod tests {
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
 
-        assert_eq!(physics_consist.mass, kilogram::new(15000.0));
-        assert_eq!(physics_consist.length, millimeter::new(140000.)); // It should be converted in mm
-        assert_eq!(physics_consist.max_speed, meter_per_second::new(20_f64));
+        assert_eq!(physics_consist.mass, units::kilogram::new(15000.0));
+        assert_eq!(physics_consist.length, units::millimeter::new(140000.)); // It should be converted in mm
+        assert_eq!(
+            physics_consist.max_speed,
+            units::meter_per_second::new(20_f64)
+        );
     }
 
     #[test]
     fn new_physics_rolling_stock_keeps_the_smallest_available_comfort_acceleration() {
         let mut rolling_stock = create_simple_rolling_stock();
         let mut towed_rolling_stock = create_towed_rolling_stock();
-        rolling_stock.comfort_acceleration = meter_per_second_squared::new(0.2);
-        towed_rolling_stock.comfort_acceleration = meter_per_second_squared::new(0.1);
+        rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.2);
+        towed_rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.1);
 
         let mut simulation_parameters = PhysicsConsistParameters {
             max_speed: None,
@@ -662,19 +671,19 @@ mod tests {
 
         assert_eq!(
             physics_consist.comfort_acceleration,
-            meter_per_second_squared::new(0.1)
+            units::meter_per_second_squared::new(0.1)
         );
 
         simulation_parameters.traction_engine.comfort_acceleration =
-            meter_per_second_squared::new(0.2);
-        towed_rolling_stock.comfort_acceleration = meter_per_second_squared::new(0.67);
+            units::meter_per_second_squared::new(0.2);
+        towed_rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.67);
         simulation_parameters.towed_rolling_stock = Some(towed_rolling_stock);
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
 
         assert_eq!(
             physics_consist.comfort_acceleration,
-            meter_per_second_squared::new(0.2)
+            units::meter_per_second_squared::new(0.2)
         );
     }
 
@@ -689,29 +698,29 @@ mod tests {
         };
 
         simulation_parameters.traction_engine.startup_acceleration =
-            meter_per_second_squared::new(0.3);
+            units::meter_per_second_squared::new(0.3);
         if let Some(trs) = simulation_parameters.towed_rolling_stock.as_mut() {
-            trs.startup_acceleration = meter_per_second_squared::new(0.45);
+            trs.startup_acceleration = units::meter_per_second_squared::new(0.45);
         }
 
         let physics_consist: PhysicsConsist = simulation_parameters.clone().into();
 
         assert_eq!(
             physics_consist.startup_acceleration,
-            meter_per_second_squared::new(0.45)
+            units::meter_per_second_squared::new(0.45)
         );
 
         if let Some(trs) = simulation_parameters.towed_rolling_stock.as_mut() {
-            trs.startup_acceleration = meter_per_second_squared::new(0.4);
+            trs.startup_acceleration = units::meter_per_second_squared::new(0.4);
         }
         simulation_parameters.traction_engine.startup_acceleration =
-            meter_per_second_squared::new(0.88);
+            units::meter_per_second_squared::new(0.88);
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
 
         assert_eq!(
             physics_consist.startup_acceleration,
-            meter_per_second_squared::new(0.88)
+            units::meter_per_second_squared::new(0.88)
         );
     }
 
@@ -720,14 +729,17 @@ mod tests {
         let simulation_parameters = PhysicsConsistParameters {
             total_mass: None,
             total_length: None,
-            max_speed: Some(meter_per_second::new(30.0)),
+            max_speed: Some(units::meter_per_second::new(30.0)),
             towed_rolling_stock: None,
             traction_engine: create_simple_rolling_stock(),
         };
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
 
-        assert_eq!(physics_consist.max_speed, meter_per_second::new(20_f64));
+        assert_eq!(
+            physics_consist.max_speed,
+            units::meter_per_second::new(20_f64)
+        );
     }
 
     fn pathfinding_result_success() -> PathfindingResult {

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -1,6 +1,7 @@
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use editoast_common::units::*;
 use editoast_models::DbConnection;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::train_schedule::Comfort;
@@ -66,6 +67,7 @@ struct StepTimingData {
 }
 
 /// An STDCM request
+#[editoast_derive::annotate_units]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Validate, ToSchema)]
 pub(super) struct Request {
     /// Deprecated, first step arrival time should be used instead
@@ -102,15 +104,16 @@ pub(super) struct Request {
     #[serde(default)]
     #[schema(value_type = Option<String>, example = json!(["5%", "2min/100km"]))]
     pub(super) margin: Option<MarginValue>,
-    /// Total mass of the consist in kg
-    #[validate(range(exclusive_min = 0.0))]
-    pub(super) total_mass: Option<f64>,
+    /// Total mass of the consist
+    //#[validate(range(exclusive_min = 0.0))] TODOUOM
+    #[serde(default, with = "kilogram::option")]
+    pub(super) total_mass: Option<Mass>,
     /// Total length of the consist in meters
-    #[validate(range(exclusive_min = 0.0))]
-    pub(super) total_length: Option<f64>,
+    #[serde(default, with = "meter::option")]
+    pub(super) total_length: Option<Length>,
     /// Maximum speed of the consist in km/h
-    #[validate(range(exclusive_min = 0.0))]
-    pub(super) max_speed: Option<f64>,
+    #[serde(default, with = "meter_per_second::option")]
+    pub(super) max_speed: Option<Velocity>,
     pub(super) loading_gauge_type: Option<LoadingGaugeType>,
 }
 

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -1,7 +1,7 @@
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
-use editoast_common::units::*;
+use editoast_common::units;
 use editoast_models::DbConnection;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::train_schedule::Comfort;
@@ -12,6 +12,8 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
+use serde::Serializer;
+use units::quantities;
 use utoipa::ToSchema;
 
 use crate::core::pathfinding::PathfindingInputError;
@@ -106,14 +108,14 @@ pub(super) struct Request {
     #[schema(value_type = Option<String>, example = json!(["5%", "2min/100km"]))]
     pub(super) margin: Option<MarginValue>,
     /// Total mass of the consist
-    #[serde(default, with = "kilogram::option")]
-    pub(super) total_mass: Option<Mass>,
+    #[serde(default, with = "units::kilogram::option")]
+    pub(super) total_mass: Option<quantities::Mass>,
     /// Total length of the consist in meters
-    #[serde(default, with = "meter::option")]
-    pub(super) total_length: Option<Length>,
+    #[serde(default, with = "units::meter::option")]
+    pub(super) total_length: Option<quantities::Length>,
     /// Maximum speed of the consist in km/h
-    #[serde(default, with = "meter_per_second::option")]
-    pub(super) max_speed: Option<Velocity>,
+    #[serde(default, with = "units::meter_per_second::option")]
+    pub(super) max_speed: Option<quantities::Velocity>,
     pub(super) loading_gauge_type: Option<LoadingGaugeType>,
 }
 
@@ -300,7 +302,7 @@ impl<'de> Deserialize<'de> for Request {
     {
         let request = Request::deserialize(deserializer)?;
         if let Some(mass) = request.total_mass {
-            if mass <= kilogram::new(0.0) {
+            if mass <= units::kilogram::new(0.0) {
                 return Err(serde::de::Error::custom(
                     "the total mass must be strictly positive",
                 ));
@@ -308,7 +310,7 @@ impl<'de> Deserialize<'de> for Request {
         }
 
         if let Some(total_length) = request.total_length {
-            if total_length <= meter::new(0.0) {
+            if total_length <= units::meter::new(0.0) {
                 return Err(serde::de::Error::custom(
                     "the length mass must be strictly positive",
                 ));
@@ -316,7 +318,7 @@ impl<'de> Deserialize<'de> for Request {
         }
 
         if let Some(max_speed) = request.max_speed {
-            if max_speed <= meter_per_second::new(0.0) {
+            if max_speed <= units::meter_per_second::new(0.0) {
                 return Err(serde::de::Error::custom(
                     "the max_speed must be strictly positive",
                 ));

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -4,6 +4,7 @@ use axum::Extension;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_authz::BuiltinRole;
+use editoast_common::units::*;
 use editoast_schemas::primitives::Identifier;
 use futures::join;
 use itertools::izip;
@@ -317,7 +318,7 @@ async fn project_path(
             train_id,
             ProjectPathTrainResult {
                 departure_time: train.start_time,
-                rolling_stock_length: (length * 1000.).round() as u64,
+                rolling_stock_length: millimeter::from(*length) as u64,
                 cached,
             },
         );

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -4,7 +4,7 @@ use axum::Extension;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_authz::BuiltinRole;
-use editoast_common::units::*;
+use editoast_common::units;
 use editoast_schemas::primitives::Identifier;
 use futures::join;
 use itertools::izip;
@@ -318,7 +318,7 @@ async fn project_path(
             train_id,
             ProjectPathTrainResult {
                 departure_time: train.start_time,
-                rolling_stock_length: millimeter::from(*length) as u64,
+                rolling_stock_length: units::millimeter::from(*length) as u64,
                 cached,
             },
         );

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1700,7 +1700,8 @@ export type PostTimetableByIdStdcmApiArg = {
     loading_gauge_type?: LoadingGaugeType | null;
     /** Can be a percentage `X%`, a time in minutes per 100 kilometer `Xmin/100km` */
     margin?: string | null;
-    /** Maximum speed of the consist in km/h */
+    /** Maximum speed of the consist in km/h
+        Velocity in m·s⁻¹ */
     max_speed?: number | null;
     /** By how long we can shift the departure time in milliseconds
         Deprecated, first step data should be used instead */
@@ -1725,9 +1726,11 @@ export type PostTimetableByIdStdcmApiArg = {
         Enforces that the path used by the train should be free and
         available at least that many milliseconds before its passage. */
     time_gap_before?: number;
-    /** Total length of the consist in meters */
+    /** Total length of the consist in meters
+        Length in m */
     total_length?: number | null;
-    /** Total mass of the consist in kg */
+    /** Total mass of the consist
+        Mass in kg */
     total_mass?: number | null;
     towed_rolling_stock_id?: number | null;
     work_schedule_group_id?: number | null;
@@ -2826,28 +2829,37 @@ export type RollingStockMetadata = {
   unit: string;
 };
 export type RollingResistance = {
-  /** Solid friction in N */
+  /** Solid friction
+    Solid Friction in N */
   A: number;
-  /** Viscosity friction in N/(m/s) */
+  /** Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+    Viscosity friction in kg·s⁻¹ */
   B: number;
-  /** Aerodynamic drag in N/(m/s)² */
+  /** Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
+    Aerodynamic drag in kg·m⁻¹ */
   C: number;
   type: string;
 };
 export type RollingStockSupportedSignalingSystems = string[];
 export type LightRollingStock = {
   base_power_class: string | null;
+  /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
+  /** Acceleration in m·s⁻² */
   const_gamma: number;
   effort_curves: LightEffortCurves;
   energy_sources: EnergySource[];
   etcs_brake_params: EtcsBrakeParams | null;
   id: number;
+  /** Ratio 1:1 */
   inertia_coefficient: number;
+  /** Length in m */
   length: number;
   loading_gauge: LoadingGaugeType;
   locked: boolean;
+  /** Mass in kg */
   mass: number;
+  /** Velocity in m·s⁻¹ */
   max_speed: number;
   metadata: RollingStockMetadata | null;
   name: string;
@@ -2856,7 +2868,9 @@ export type LightRollingStock = {
   };
   railjson_version: string;
   rolling_resistance: RollingResistance;
+  /** Acceleration in m·s⁻² */
   startup_acceleration: number;
+  /** Duration in s */
   startup_time: number;
   supported_signaling_systems: RollingStockSupportedSignalingSystems;
 };
@@ -3048,18 +3062,25 @@ export type EffortCurves = {
 };
 export type RollingStock = {
   base_power_class: string | null;
+  /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
+  /** Acceleration in m·s⁻² */
   const_gamma: number;
   effort_curves: EffortCurves;
+  /** Duration in s */
   electrical_power_startup_time: number | null;
   energy_sources: EnergySource[];
   etcs_brake_params: EtcsBrakeParams | null;
   id: number;
+  /** Ratio 1:1 */
   inertia_coefficient: number;
+  /** Length in m */
   length: number;
   loading_gauge: LoadingGaugeType;
   locked: boolean;
+  /** Mass in kg */
   mass: number;
+  /** Velocity in m·s⁻¹ */
   max_speed: number;
   metadata: RollingStockMetadata | null;
   name: string;
@@ -3067,26 +3088,36 @@ export type RollingStock = {
     [key: string]: string;
   };
   railjson_version: string;
+  /** Duration in s */
   raise_pantograph_time: number | null;
   rolling_resistance: RollingResistance;
+  /** Acceleration in m·s⁻² */
   startup_acceleration: number;
+  /** Duration in s */
   startup_time: number;
   supported_signaling_systems: string[];
   version: number;
 };
 export type RollingStockForm = {
   base_power_class: string | null;
+  /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
+  /** Acceleration in m·s⁻² */
   const_gamma: number;
   effort_curves: EffortCurves;
-  /** The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric. */
+  /** The time the train takes before actually using electrical power (in seconds). Is null if the train is not electric.
+    Duration in s */
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
+  /** Ratio 1:1 */
   inertia_coefficient: number;
+  /** Length in m */
   length: number;
   loading_gauge: LoadingGaugeType;
   locked?: boolean | null;
+  /** Mass in kg */
   mass: number;
+  /** Velocity in m·s⁻¹ */
   max_speed: number;
   metadata?: RollingStockMetadata | null;
   name: string;
@@ -3094,10 +3125,13 @@ export type RollingStockForm = {
   power_restrictions: {
     [key: string]: string;
   };
-  /** The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric. */
+  /** The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
+    Duration in s */
   raise_pantograph_time?: number | null;
   rolling_resistance: RollingResistance;
+  /** Acceleration in m·s⁻² */
   startup_acceleration: number;
+  /** Duration in s */
   startup_time: number;
   supported_signaling_systems: RollingStockSupportedSignalingSystems;
 };
@@ -3505,40 +3539,57 @@ export type TrainScheduleResult = TrainScheduleBase & {
   timetable_id: number;
 };
 export type RollingResistancePerWeight = {
-  /** Solid friction in N/kg */
+  /** Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
+    Acceleration in m·s⁻² */
   A: number;
-  /** Viscosity friction in (N/kg)/(m/s) */
+  /** Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
+    Viscosity friction per weight in s⁻¹ */
   B: number;
-  /** Aerodynamic drag in (N/kg)/(m/s)² */
+  /** Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
+    Aerodynamic drag per kg in m⁻¹ */
   C: number;
   type: string;
 };
 export type TowedRollingStock = {
+  /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
+  /** Acceleration in m·s⁻² */
   const_gamma: number;
   id: number;
+  /** Ratio 1:1 */
   inertia_coefficient: number;
   label: string;
+  /** Length in m */
   length: number;
   locked: boolean;
+  /** Mass in kg */
   mass: number;
-  max_speed?: number | null;
+  /** Velocity in m·s⁻¹ */
+  max_speed: number | null;
   name: string;
   railjson_version: string;
   rolling_resistance: RollingResistancePerWeight;
+  /** Acceleration in m·s⁻² */
   startup_acceleration: number;
 };
 export type TowedRollingStockForm = {
+  /** Acceleration in m·s⁻² */
   comfort_acceleration: number;
+  /** Acceleration in m·s⁻² */
   const_gamma: number;
+  /** Ratio 1:1 */
   inertia_coefficient: number;
   label: string;
+  /** Length in m */
   length: number;
   locked: boolean;
+  /** Mass in kg */
   mass: number;
+  /** Velocity in m·s⁻¹ */
   max_speed?: number | null;
   name: string;
   rolling_resistance: RollingResistancePerWeight;
+  /** Acceleration in m·s⁻² */
   startup_acceleration: number;
 };
 export type TowedRollingStockLockedForm = {


### PR DESCRIPTION
Refs [#9431](https://github.com/OpenRailAssociation/osrd/issues/9431)

This pull request isn’t ready, and was made to be a base for discussions. There are many values that still need to be typed

The models are hard to convert (I’m struggling with `derive(Model)`. But maybe it’s the right level of separation? In the database they are stored as floats, so maybe building the unit values in `impl From<RollingStockModel> for LightRollingStock` is actually the right place?

We get very long lines, such as `Acceleration::new::<meter_per_second_squared>(startup_acceleration)`. But I think it’s a good thing to have very explicit units.

In general I like that the units are now very explicit, and we no longer need comments to indicate what to do, and we can even remove them completly.

What do you think in general?