### PR TITLE
editoast, front: forbid zero-length paths in pathfinding endpoint

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8435,6 +8435,14 @@ components:
             - rolling_stock_not_found
           rolling_stock_name:
             type: string
+      - type: object
+        required:
+        - error_type
+        properties:
+          error_type:
+            type: string
+            enum:
+            - zero_length_path
     PathfindingItem:
       type: object
       required:

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -133,6 +133,7 @@ pub enum PathfindingInputError {
     RollingStockNotFound {
         rolling_stock_name: String,
     },
+    ZeroLengthPath,
 }
 
 // Enum for not-found results and incompatible constraints

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -262,7 +262,7 @@ mod tests {
             blocks: vec![],
             routes: vec![],
             track_section_ranges: vec![],
-            length: 0,
+            length: 1,
             path_item_positions: vec![0, 10],
         }
     }

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -668,7 +668,7 @@ mod tests {
             blocks: vec![],
             routes: vec![],
             track_section_ranges: vec![],
-            length: 0,
+            length: 1,
             path_item_positions: vec![0, 10],
         }
     }

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -945,7 +945,7 @@ mod tests {
                 "routes": [],
                 "track_section_ranges": [],
                 "path_item_positions": [0,1,2,3],
-                "length": 0,
+                "length": 1,
                 "status": "success"
             }))
             .finish();

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -91,6 +91,11 @@
         "WrongRailjsonVersionProvided": "Wrong railjson version provided"
       }
     },
+    "core": {
+      "pathfinding": {
+        "ZeroLengthPath": "Path length cannot be null."
+      }
+    },
     "infra_state": {
       "FetchError": "Error while fetching the infrastructure loading status"
     },

--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -114,7 +114,8 @@
     "noResults": "No path found",
     "noScheduledPoint": "The calculation requires either the origin or destination schedule.",
     "pathfindingFailed": "No path have been found for these waypoints.",
-    "requestFailed": "Calculation error for last minute train path"
+    "requestFailed": "Calculation error for last minute train path",
+    "zeroLengthPath": "The path cannot have a null length."
   },
   "stdcmResults": "Results",
   "stdcmSimulationReport": "Path simulation report",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -91,6 +91,11 @@
         "WrongRailjsonVersionProvided": "Mauvaise version de railjson fournie"
       }
     },
+    "core": {
+      "pathfinding": {
+        "ZeroLengthPath": "La longueur d'un chemin ne peut pas être nulle."
+      }
+    },
     "infra_state": {
       "FetchError": "Erreur de récupération de l'état de chargement de l'infrastructure"
     },

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -114,7 +114,8 @@
     "noResults": "Aucun sillon trouvé",
     "noScheduledPoint": "Le calcul a besoin de l'horaire d'origine ou de celui de la destination.",
     "pathfindingFailed": "Aucun chemin n'a été trouvé pour ces points de jalonnement.",
-    "requestFailed": "Erreur de calcul Sillon de dernière minute"
+    "requestFailed": "Erreur de calcul Sillon de dernière minute",
+    "zeroLengthPath": "Le chemin ne peut pas avoir de longueur nulle."
   },
   "stdcmResults": "Résultats",
   "stdcmSimulationReport": "Fiche simulation",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -127,8 +127,7 @@ const StdcmConfig = ({
   const markersInfo = useMemo(() => extractMarkersInfo(pathSteps), [pathSteps]);
 
   const startSimulation = () => {
-    const isPathfindingFailed = !!pathfinding && pathfinding.status !== 'success';
-    const formErrorsStatus = checkStdcmConfigErrors(isPathfindingFailed, pathSteps, t);
+    const formErrorsStatus = checkStdcmConfigErrors(pathSteps, t, pathfinding?.status);
     if (pathfinding?.status === 'success' && !formErrorsStatus) {
       launchStdcmRequest();
     } else {
@@ -157,14 +156,8 @@ const StdcmConfig = ({
   };
 
   useEffect(() => {
-    if (pathfinding) {
-      const formErrorsStatus = checkStdcmConfigErrors(
-        pathfinding.status !== 'success',
-        pathSteps,
-        t
-      );
-      setFormErrors(formErrorsStatus);
-    }
+    const formErrorsStatus = checkStdcmConfigErrors(pathSteps, t, pathfinding?.status);
+    setFormErrors(formErrorsStatus);
   }, [pathfinding, pathSteps, t]);
 
   useEffect(() => {

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -58,6 +58,16 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
         return;
       }
 
+      // Don't run the pathfinding if the origin and destination are the same:
+      const origin = pathSteps.at(0)!;
+      const destination = pathSteps.at(-1)!;
+      if (
+        origin.location!.uic === destination.location!.uic &&
+        origin.location!.secondary_code === destination.location!.secondary_code
+      ) {
+        return;
+      }
+
       const payload = getPathfindingQuery({
         infraId: infra.id,
         rollingStock,

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -168,6 +168,7 @@ export enum StdcmConfigErrorTypes {
   PATHFINDING_FAILED = 'pathfindingFailed',
   BOTH_POINT_SCHEDULED = 'bothPointAreScheduled',
   NO_SCHEDULED_POINT = 'noScheduledPoint',
+  ZERO_LENGTH_PATH = 'zeroLengthPath',
 }
 
 export type StdcmConfigErrors = {

--- a/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
+++ b/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
@@ -23,6 +23,13 @@ const checkStdcmConfigErrors = (
     throw new Error('Last step can not be a via');
   }
 
+  if (
+    origin.location!.uic === destination.location!.uic &&
+    origin.location!.secondary_code === destination.location!.secondary_code
+  ) {
+    return { errorType: StdcmConfigErrorTypes.ZERO_LENGTH_PATH };
+  }
+
   if (pathfindingStateError) {
     return { errorType: StdcmConfigErrorTypes.PATHFINDING_FAILED };
   }

--- a/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
+++ b/front/src/applications/stdcm/utils/checkStdcmConfigErrors.ts
@@ -6,9 +6,9 @@ import { dateToHHMMSS } from 'utils/date';
 import { StdcmConfigErrorTypes, ArrivalTimeTypes, type StdcmConfigErrors } from '../types';
 
 const checkStdcmConfigErrors = (
-  pathfindingStateError: boolean,
   pathSteps: StdcmPathStep[],
-  t: TFunction
+  t: TFunction,
+  pathfindingStatus?: 'success' | 'failure'
 ): StdcmConfigErrors | undefined => {
   if (pathSteps.some((step) => !step.location)) {
     return { errorType: StdcmConfigErrorTypes.MISSING_LOCATION };
@@ -30,7 +30,7 @@ const checkStdcmConfigErrors = (
     return { errorType: StdcmConfigErrorTypes.ZERO_LENGTH_PATH };
   }
 
-  if (pathfindingStateError) {
+  if (pathfindingStatus && pathfindingStatus === 'failure') {
     return { errorType: StdcmConfigErrorTypes.PATHFINDING_FAILED };
   }
 

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2700,6 +2700,9 @@ export type PathfindingInputError =
   | {
       error_type: 'rolling_stock_not_found';
       rolling_stock_name: string;
+    }
+  | {
+      error_type: 'zero_length_path';
     };
 export type OffsetRange = {
   end: number;


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/9444
- ~~Editoast: immediately return a `422 Unprocessable Content` error at deserialization when the endpoint `pathfinding/blocks` is called with the same origin and destination.~~
- Editoast: `pathfinding/blocks`: fail in post-processing with a new `PathfindingInputError::ZeroLengthPath` variant when core returns zero-length paths.
- Front: add a new type of stdcm error type when trying to make an STDCM request with the same origin and destination, update the stdcm inputs validation method.