### PR TITLE
Minor improvements of AppState management in editoast

### DIFF
--- a/editoast/editoast_models/src/lib.rs
+++ b/editoast/editoast_models/src/lib.rs
@@ -1,18 +1,12 @@
-use diesel_async::pooled_connection::deadpool::Pool;
-use diesel_async::AsyncPgConnection;
-
 pub mod db_connection_pool;
 pub mod tables;
 
 pub use db_connection_pool::DbConnection;
 pub use db_connection_pool::DbConnectionPoolV2;
 
-type DieselConnection = AsyncPgConnection;
-pub type DbConnectionPool = Pool<DieselConnection>;
-
 /// Generic error type to forward errors from the database
 ///
 /// Useful for functions which only points of failure are the DB calls.
 #[derive(Debug, thiserror::Error)]
-#[error("an error occured while querying the database: {0}")]
+#[error("an error occurred while querying the database: {0}")]
 pub struct DatabaseError(#[from] diesel::result::Error);

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10072,7 +10072,7 @@ components:
               enum:
               - pathfinding_not_found
       - type: object
-        description: An error has occured during pathfinding
+        description: An error has occurred during pathfinding
         required:
         - core_error
         - status
@@ -10084,7 +10084,7 @@ components:
             enum:
             - pathfinding_failure
       - type: object
-        description: An error has occured during computing
+        description: An error has occurred during computing
         required:
         - error_type
         - status

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -4,7 +4,7 @@ use std::ops::DerefMut;
 
 use chrono::Utc;
 use editoast_models::DbConnection;
-use editoast_models::DbConnectionPool;
+
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -67,7 +67,7 @@ async fn attached(
     Path(InfraAttachedParams { infra_id, track_id }): Path<InfraAttachedParams>,
     State(AppState {
         infra_caches,
-        db_pool_v2: db_pool,
+        db_pool,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -87,7 +87,7 @@ async fn list_auto_fixes(
     Path(infra_id): Path<i64>,
     State(AppState {
         infra_caches,
-        db_pool_v2: db_pool,
+        db_pool,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -129,7 +129,7 @@ async fn delimited_area(
     Extension(auth): AuthenticationExt,
     State(AppState {
         infra_caches,
-        db_pool_v2: db_pool,
+        db_pool,
         ..
     }): State<AppState>,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -71,7 +71,7 @@ crate::routes! {
 async fn edit<'a>(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
-        db_pool_v2: db_pool,
+        db_pool,
         infra_caches,
         valkey,
         map_layers,
@@ -126,7 +126,7 @@ async fn edit<'a>(
 pub async fn split_track_section<'a>(
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(AppState {
-        db_pool_v2: db_pool,
+        db_pool,
         infra_caches,
         valkey,
         map_layers,

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -45,7 +45,7 @@ async fn get_line_bbox(
     Path((infra_id, line_code)): Path<(i64, i64)>,
     State(AppState {
         infra_caches,
-        db_pool_v2: db_pool,
+        db_pool,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -135,7 +135,7 @@ async fn refresh(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let valkey_client = app_state.valkey.clone();
     let infra_caches = app_state.infra_caches.clone();
     let map_layers = app_state.map_layers.clone();
@@ -212,7 +212,7 @@ async fn list(
     if !authorized {
         return Err(AuthorizationError::Unauthorized.into());
     }
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let osrdyne_client = app_state.osrdyne_client.clone();
 
     let settings = pagination_params
@@ -307,7 +307,7 @@ async fn get(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let osrdyne_client = app_state.osrdyne_client.clone();
 
     let infra_id = infra.infra_id;
@@ -433,7 +433,7 @@ async fn delete(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let infra_caches = app_state.infra_caches.clone();
     let infra_id = infra.infra_id;
     if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
@@ -513,7 +513,7 @@ async fn get_switch_types(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
     let infra_caches = app_state.infra_caches.clone();
 
@@ -724,7 +724,7 @@ async fn load(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let core_client = app_state.core_client.clone();
 
     let infra_id = path.infra_id;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -207,7 +207,7 @@ async fn list(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    pagination_params: Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams>,
 ) -> Result<Json<InfraListResponse>> {
     let authorized = auth
         .check_roles([BuiltinRole::InfraRead].into())
@@ -430,7 +430,7 @@ async fn delete(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    infra: Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([BuiltinRole::InfraWrite].into())
@@ -440,7 +440,6 @@ async fn delete(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let infra_id = infra.infra_id;
     if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
         infra_caches.remove(&infra_id);
         Ok(StatusCode::NO_CONTENT)

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -110,7 +110,7 @@ async fn pathfinding_view(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let infra_caches = app_state.infra_caches.clone();
 
     // Parse and check input

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -96,7 +96,11 @@ struct QueryParam {
     )
 )]
 async fn pathfinding_view(
-    app_state: State<AppState>,
+    State(AppState {
+        db_pool,
+        infra_caches,
+        ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(infra): Path<InfraIdParam>,
     Query(params): Query<QueryParam>,
@@ -109,9 +113,6 @@ async fn pathfinding_view(
     if !authorized {
         return Err(AuthorizationError::Unauthorized.into());
     }
-
-    let db_pool = app_state.db_pool.clone();
-    let infra_caches = app_state.infra_caches.clone();
 
     // Parse and check input
     let infra_id = infra.infra_id;

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -181,7 +181,7 @@ async fn post_railjson(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let infra_caches = app_state.infra_caches.clone();
     if railjson.version != RAILJSON_VERSION {
         return Err(ListErrorsRailjson::WrongRailjsonVersionProvided.into());

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -55,7 +55,7 @@ enum ListErrorsRailjson {
 )]
 async fn get_railjson(
     Path(infra): Path<InfraIdParam>,
-    db_pool: State<DbConnectionPoolV2>,
+    State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
@@ -168,7 +168,11 @@ struct PostRailjsonResponse {
     )
 )]
 async fn post_railjson(
-    app_state: State<AppState>,
+    State(AppState {
+        db_pool,
+        infra_caches,
+        ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Query(params): Query<PostRailjsonQueryParams>,
     Json(railjson): Json<RailJson>,
@@ -181,8 +185,6 @@ async fn post_railjson(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool.clone();
-    let infra_caches = app_state.infra_caches.clone();
     if railjson.version != RAILJSON_VERSION {
         return Err(ListErrorsRailjson::WrongRailjsonVersionProvided.into());
     }

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -158,7 +158,7 @@ async fn get_routes_track_ranges(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let infra_caches = app_state.infra_caches.clone();
     let infra_id = infra;
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
@@ -219,7 +219,7 @@ async fn get_routes_nodes(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let infra_caches = app_state.infra_caches.clone();
 
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, params.infra_id, || {

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -179,7 +179,7 @@ struct TileParams {
 async fn cache_and_get_mvt_tile(
     State(AppState {
         map_layers,
-        db_pool_v2: db_pool,
+        db_pool,
         valkey,
         ..
     }): State<AppState>,

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -334,11 +334,7 @@ async fn version() -> Json<Version> {
         (status = 200, description = "Return the core service version", body = Version),
     ),
 )]
-async fn core_version(
-    State(AppState {
-        core_client: core, ..
-    }): State<AppState>,
-) -> Json<Version> {
+async fn core_version(State(core): State<Arc<CoreClient>>) -> Json<Version> {
     let response = CoreVersionRequest {}.fetch(&core).await;
     let response = response.unwrap_or(Version { git_describe: None });
     Json(response)
@@ -401,6 +397,12 @@ pub struct AppState {
 impl FromRef<AppState> for DbConnectionPoolV2 {
     fn from_ref(input: &AppState) -> Self {
         (*input.db_pool).clone()
+    }
+}
+
+impl FromRef<AppState> for Arc<CoreClient> {
+    fn from_ref(input: &AppState) -> Self {
+        input.core_client.clone()
     }
 }
 

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -334,8 +334,11 @@ async fn version() -> Json<Version> {
         (status = 200, description = "Return the core service version", body = Version),
     ),
 )]
-async fn core_version(app_state: State<AppState>) -> Json<Version> {
-    let core = app_state.core_client.clone();
+async fn core_version(
+    State(AppState {
+        core_client: core, ..
+    }): State<AppState>,
+) -> Json<Version> {
     let response = CoreVersionRequest {}.fetch(&core).await;
     let response = response.unwrap_or(Version { git_describe: None });
     Json(response)

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -158,7 +158,7 @@ pub enum PathfindingFailure {
 )]
 async fn post(
     State(AppState {
-        db_pool_v2: db_pool,
+        db_pool,
         valkey,
         core_client,
         ..

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -164,7 +164,7 @@ type Properties = EnumSet<Property>;
 )]
 async fn post(
     State(AppState {
-        db_pool_v2: db_pool,
+        db_pool,
         valkey,
         core_client,
         ..

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -118,7 +118,7 @@ async fn overwrite(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
 
     let changeset: Changeset<StdcmSearchEnvironment> = form.into();
@@ -146,7 +146,7 @@ async fn retrieve_latest(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
 
     let search_env = StdcmSearchEnvironment::retrieve_latest(conn).await;

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -285,7 +285,7 @@ async fn conflicts(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let valkey_client = app_state.valkey.clone();
     let core_client = app_state.core_client.clone();
 

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -120,7 +120,7 @@ struct TimetableIdParam {
     ),
 )]
 async fn get(
-    db_pool: State<DbConnectionPoolV2>,
+    State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(timetable_id): Path<TimetableIdParam>,
 ) -> Result<Json<TimetableDetailedResult>> {
@@ -154,7 +154,7 @@ async fn get(
     ),
 )]
 async fn post(
-    db_pool: State<DbConnectionPoolV2>,
+    State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<TimetableResult>> {
     let authorized = auth
@@ -183,7 +183,7 @@ async fn post(
     ),
 )]
 async fn delete(
-    db_pool: State<DbConnectionPoolV2>,
+    State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     timetable_id: Path<TimetableIdParam>,
 ) -> Result<impl IntoResponse> {
@@ -215,7 +215,7 @@ async fn delete(
     )
 )]
 async fn train_schedule(
-    db_pool: State<DbConnectionPoolV2>,
+    State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(timetable_id): Path<TimetableIdParam>,
     Json(train_schedules): Json<Vec<TrainScheduleBase>>,
@@ -271,7 +271,12 @@ pub struct ElectricalProfileSetIdQueryParam {
     ),
 )]
 async fn conflicts(
-    app_state: State<AppState>,
+    State(AppState {
+        db_pool,
+        valkey: valkey_client,
+        core_client,
+        ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(timetable_id): Path<TimetableIdParam>,
     Query(infra_id_query): Query<InfraIdQueryParam>,
@@ -284,10 +289,6 @@ async fn conflicts(
     if !authorized {
         return Err(AuthorizationError::Unauthorized.into());
     }
-
-    let db_pool = app_state.db_pool.clone();
-    let valkey_client = app_state.valkey.clone();
-    let core_client = app_state.core_client.clone();
 
     let timetable_id = timetable_id.id;
     let infra_id = infra_id_query.infra_id;

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -134,7 +134,7 @@ async fn stdcm(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
 
     let valkey_client = app_state.valkey.clone();

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -120,7 +120,12 @@ struct InfraIdQueryParam {
     )
 )]
 async fn stdcm(
-    app_state: State<AppState>,
+    State(AppState {
+        db_pool,
+        valkey: valkey_client,
+        core_client,
+        ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Path(id): Path<i64>,
     Query(query): Query<InfraIdQueryParam>,
@@ -134,11 +139,8 @@ async fn stdcm(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
 
-    let valkey_client = app_state.valkey.clone();
-    let core_client = app_state.core_client.clone();
     let timetable_id = id;
     let infra_id = query.infra;
 

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -179,7 +179,7 @@ async fn get(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let train_schedule_id = train_schedule_id.id;
     let conn = &mut db_pool.get().await?;
 
@@ -217,7 +217,7 @@ async fn get_batch(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
     let train_schedules: Vec<TrainSchedule> =
         TrainSchedule::retrieve_batch_or_fail(conn, train_ids, |missing| {
@@ -251,7 +251,7 @@ async fn delete(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
 
     use crate::models::DeleteBatch;
     let conn = &mut db_pool.get().await?;
@@ -339,7 +339,7 @@ async fn simulation(
 
     let valkey_client = app_state.valkey.clone();
     let core_client = app_state.core_client.clone();
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
 
     let infra_id = infra_id_query.infra_id;
     let electrical_profile_set_id = electrical_profile_set_id_query.electrical_profile_set_id;
@@ -673,7 +673,7 @@ async fn simulation_summary(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let conn = &mut db_pool.get().await?;
     let valkey_client = app_state.valkey.clone();
     let core = app_state.core_client.clone();
@@ -774,7 +774,7 @@ async fn get_path(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let valkey_client = app_state.valkey.clone();
     let core = app_state.core_client.clone();
 

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -126,7 +126,12 @@ struct CachedProjectPathTrainResult {
     ),
 )]
 async fn project_path(
-    app_state: State<AppState>,
+    State(AppState {
+        db_pool,
+        valkey: valkey_client,
+        core_client,
+        ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Json(ProjectPathForm {
         infra_id,
@@ -149,10 +154,6 @@ async fn project_path(
     if !authorized {
         return Err(AuthorizationError::Unauthorized.into());
     }
-
-    let db_pool = app_state.db_pool.clone();
-    let valkey_client = app_state.valkey.clone();
-    let core_client = app_state.core_client.clone();
 
     let ProjectPathInput {
         track_section_ranges: path_track_ranges,

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -288,11 +288,11 @@ async fn project_path(
         let cached_value = CachedProjectPathTrainResult {
             space_time_curves: space_time_curves
                 .get(id)
-                .expect("Space time curves not availabe for train")
+                .expect("Space time curves not available for train")
                 .clone(),
             signal_updates: signal_updates
                 .get(id)
-                .expect("Signal update not availabe for train")
+                .expect("Signal update not available for train")
                 .clone(),
         };
         hit_cache.insert(*id, cached_value.clone());

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -150,7 +150,7 @@ async fn project_path(
         return Err(AuthorizationError::Unauthorized.into());
     }
 
-    let db_pool = app_state.db_pool_v2.clone();
+    let db_pool = app_state.db_pool.clone();
     let valkey_client = app_state.valkey.clone();
     let core_client = app_state.core_client.clone();
 


### PR DESCRIPTION
- **editoast: deprecate DbPool V1 and remove it from the AppState**
- **editoast: destructure AppState early in handlers for consistency**
- **editoast: fix minor destructuration inconsistencies**

> TIP
> Rapidly reviewable commit by commit
