### PR TITLE
core: use physics path in etcs braking simulator

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -1,13 +1,13 @@
 package fr.sncf.osrd.envelope_sim.etcs
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.envelope_sim.PhysicsPath
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.sim_infra.api.Path
-import fr.sncf.osrd.sim_infra.api.PathProperties
 import fr.sncf.osrd.utils.units.Offset
 
 interface ETCSBrakingSimulator {
-    val trainPath: PathProperties
+    val path: PhysicsPath
     val rollingStock: PhysicsRollingStock
     val timeStep: Double
 
@@ -38,7 +38,7 @@ data class EndOfAuthority(
 }
 
 class ETCSBrakingSimulatorImpl(
-    override val trainPath: PathProperties,
+    override val path: PhysicsPath,
     override val rollingStock: PhysicsRollingStock,
     override val timeStep: Double
 ) : ETCSBrakingSimulator {


### PR DESCRIPTION
`PhysicsPath` gives access to gradient AND can be accessed in this part of the code.