### PR TITLE
front: fix lazy loading for rolling stock images

### DIFF
--- a/front/src/common/api/documentApi.ts
+++ b/front/src/common/api/documentApi.ts
@@ -1,8 +1,11 @@
 import type { NewDocumentResponse } from 'common/api/osrdEditoastApi';
 import mainConfig from 'config/config';
 
+export const getDocumentUrl = (documentKey: number) =>
+  `${mainConfig.proxy_editoast}/documents/${documentKey}`;
+
 export const getDocument = async (documentKey: number): Promise<Blob> => {
-  const res = await fetch(`${mainConfig.proxy_editoast}/documents/${documentKey}`);
+  const res = await fetch(getDocumentUrl(documentKey));
   return res.blob();
 };
 

--- a/front/src/modules/rollingStock/components/RollingStock2Img.tsx
+++ b/front/src/modules/rollingStock/components/RollingStock2Img.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import placeholderRollingStockElectric from 'assets/pictures/placeholder_rollingstock_elec.gif';
 import placeholderRollingStockThermal from 'assets/pictures/placeholder_rollingstock_thermal.gif';
-import { getDocument } from 'common/api/documentApi';
+import { getDocumentUrl } from 'common/api/documentApi';
 import type {
   LightRollingStockWithLiveries,
   RollingStockWithLiveries,
@@ -13,14 +13,14 @@ type RollingStock2ImgProps = {
 };
 
 const RollingStock2Img = ({ rollingStock }: RollingStock2ImgProps) => {
-  // as the image is stored in the database and can be fetched only through api (authentication needed),
-  // the direct url can not be given to the <img /> directly. Thus the image is fetched, and a new
-  // url is generated and stored in imageUrl (then used in <img />).
   const [imageUrl, setImageUrl] = useState('');
 
-  const getRollingStockImage = async () => {
+  useEffect(() => {
     const { liveries } = rollingStock;
-    if (!rollingStock || !Array.isArray(liveries)) return;
+    if (!Array.isArray(liveries)) {
+      setImageUrl('');
+      return;
+    }
 
     const defaultLivery = liveries.find((livery) => livery.name === 'default');
     const mode = Object.keys(rollingStock.effort_curves.modes)[0];
@@ -30,25 +30,14 @@ const RollingStock2Img = ({ rollingStock }: RollingStock2ImgProps) => {
           ? placeholderRollingStockElectric
           : placeholderRollingStockThermal
       );
-      return;
+    } else {
+      setImageUrl(getDocumentUrl(defaultLivery.compound_image_id));
     }
-
-    try {
-      const image = await getDocument(defaultLivery.compound_image_id);
-      if (image) setImageUrl(URL.createObjectURL(image));
-    } catch (e: unknown) {
-      console.error(e instanceof Error ? e.message : e);
-    }
-  };
-
-  useEffect(() => {
-    setImageUrl('');
-    getRollingStockImage();
   }, [rollingStock]);
 
   if (!imageUrl) return null;
 
-  return <img src={imageUrl} alt={rollingStock?.name} />;
+  return <img src={imageUrl} alt={rollingStock?.name} loading="lazy" />;
 };
 
 export default React.memo(RollingStock2Img);


### PR DESCRIPTION
We were unconditionally fetching the rolling stock image via getDocument(). Instead, side-step getDocument() entirely, and directly use the document URL as the image source. That way, the loading="lazy" attribute can be used and the image is only fetched if it's visible.

The deleted comment is wrong: authentication is required, but is performed via a cookie. Cookies are always sent for same-origin image requests.