### PR TITLE
front: bump nge version to 2.9.11

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,7 +12,7 @@
         "@nivo/core": "^0.80.0",
         "@nivo/line": "^0.80.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
         "@osrd-project/ui-core": "^0.0.55",
         "@osrd-project/ui-icons": "^0.0.55",
         "@osrd-project/ui-manchette": "^0.0.55",
@@ -1925,9 +1925,9 @@
       "license": "MIT"
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528.tgz",
-      "integrity": "sha512-aaLaR3LGU6tyyz27/tzba1F9Yj+V2rkcSjerr856Q4yAc2xYH53eFU/LK6mcfieqPZFfSwJu1bfIgJ+hA8tLJg=="
+      "version": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415.tgz",
+      "integrity": "sha512-lalH7CHnIQfaPLh+dYMLcpIYb7+MnCJWov7wnJ5DUTLTnt7WhrKR+Q+wXRpac4j1ehjEDdoeuy2KViAhVIMTKg=="
     },
     "node_modules/@osrd-project/ui-core": {
       "version": "0.0.55",

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.59a0e23312c449c8fda43c007c91e58745d76528",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
     "@osrd-project/ui-core": "^0.0.55",
     "@osrd-project/ui-icons": "^0.0.55",
     "@osrd-project/ui-manchette": "^0.0.55",


### PR DESCRIPTION
Bumps to 2.9.11



Integrates a [fix](https://github.com/osrd-project/netzgrafik-editor-frontend/pull/6) from fork