### PR TITLE
front: cancel fetch request when user cancels simulation in lmr

### DIFF
--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -35,6 +35,7 @@ const StdcmView = () => {
     cancelStdcmRequest,
     isPending,
     isRejected,
+    isCanceled,
     stdcmResults,
     pathProperties,
     stdcmTrainConflicts,
@@ -106,6 +107,12 @@ const StdcmView = () => {
       setShowBtnToLaunchSimulation(true);
     }
   }, [isDebugMode]);
+
+  useEffect(() => {
+    if (isCanceled) {
+      setShowBtnToLaunchSimulation(true);
+    }
+  }, [isCanceled]);
 
   useEffect(() => {
     /*


### PR DESCRIPTION
close #9779 

Also, had a minor bug where the button to launch the simulation disappeared after canceling a request, added a fix. 