### PR TITLE
script: docker: remove docker images of the tested PR when cleaning

### DIFF
--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -23,7 +23,7 @@ OSRD_VALKEY="osrd-valkey"
 OSRD_VALKEY_VOLUME="osrd_valkey_data"
 OSRD_POSTGRES_PORT=5432
 OSRD_VALKEY_PORT=6379
-if [ "$PR_TEST" -eq 1 ]; then
+if [ "$PR_TEST" = 1 ]; then
   OSRD_POSTGRES="osrd-postgres-pr-tests"
   OSRD_EDITOAST="osrd-editoast-pr-tests"
   OSRD_VALKEY="osrd-valkey-pr-tests"

--- a/scripts/load-backup.sh
+++ b/scripts/load-backup.sh
@@ -41,7 +41,7 @@ fi
 # These variables are necessary to load the infra on the correct instance (the pr-infra or the dev one)
 OSRD_POSTGRES="osrd-postgres"
 OSRD_POSTGRES_PORT=5432
-if [ "$PR_TEST" -eq 1 ]; then
+if [ "$PR_TEST" = 1 ]; then
   OSRD_POSTGRES="osrd-postgres-pr-tests"
   OSRD_POSTGRES_PORT=5433
 fi

--- a/scripts/pr-tests-compose.sh
+++ b/scripts/pr-tests-compose.sh
@@ -74,10 +74,20 @@ elif [ "$1" = "down" ]; then
 
 else
 
-    # Shutdown and clean the docker instance
+    # Shutdown and clean the docker instance (remove "osrd" images too)
+    osrd_images=$(docker compose \
+        -p "osrd-pr-tests" \
+        -f "docker/docker-compose.pr-tests.yml" \
+        images --format json \
+        core editoast osrdyne gateway front \
+        | jq --raw-output '.[].ID')
+
     docker compose \
         -p "osrd-pr-tests" \
         -f "docker/docker-compose.pr-tests.yml" \
         down -v
+
+    # shellcheck disable=SC2086
+    docker rmi ${osrd_images}
 
 fi


### PR DESCRIPTION
Saves disk resources (and forces re-pull, which may be useful for new version)