### PR TITLE
STDCM: linked path search adjustments

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedPathSearch.tsx
@@ -90,6 +90,7 @@ const StdcmLinkedPathSearch = ({
               selectableSlot={selectableSlot}
               value={linkedPathDate}
               onDateChange={(date) => {
+                setDisplaySearchButton(true);
                 setLinkedPathDate(date);
               }}
             />

--- a/front/src/applications/stdcm/hooks/useLinkedPathSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedPathSearch.ts
@@ -109,6 +109,7 @@ const useLinkedPathSearch = () => {
 
       if (!filteredResults.length) {
         setDisplaySearchButton(true);
+        setLinkedPathResults([]);
         return;
       }
 

--- a/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
+++ b/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
@@ -31,7 +31,7 @@ export default function useStdcmEnvironment() {
           workScheduleGroupId: data.work_schedule_group_id,
           temporarySpeedLimitGroupId: data.temporary_speed_limit_group_id,
           searchDatetimeWindow: {
-            begin: new Date(data.search_window_begin),
+            begin: new Date(`${data.search_window_begin}Z`), // TODO: Remove this temporary fix when editoast returns the date in UTC
             end: new Date(data.search_window_end),
           },
         })

--- a/front/src/styles/scss/applications/stdcm/_linkedPath.scss
+++ b/front/src/styles/scss/applications/stdcm/_linkedPath.scss
@@ -58,9 +58,11 @@
         }
 
         .train-name {
+          font-weight: 500;
           font-size: 1rem;
           padding-top: 4px;
           margin-bottom: 4px;
+          text-align: start;
         }
         .opDetails {
           font-size: 0.875rem;


### PR DESCRIPTION
This PR will close some small issues we have on the linked path search: 
Closes [STDCM: No results displayed for linked path search](https://github.com/OpenRailAssociation/osrd/issues/9925)
Closes [STDCM: The train name is centered when there is one result in the linked path search](https://github.com/OpenRailAssociation/osrd/issues/9926) 
Closes [STDCM: Unable to perform a new search after changing the date for the linked path](https://github.com/OpenRailAssociation/osrd/issues/9927)