### PR TITLE
front: drop StdcmResultsOperationalPointsList type

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import type {
-  StdcmResultsOperationalPointsList,
+  StdcmResultsOperationalPoint,
   StdcmSimulationInputs,
   StdcmSuccessResponse,
 } from 'applications/stdcm/types';
@@ -15,7 +15,7 @@ type SimulationTableProps = {
   stdcmData: StdcmSuccessResponse;
   consist: StdcmSimulationInputs['consist'];
   isSimulationRetained: boolean;
-  operationalPointsList: StdcmResultsOperationalPointsList;
+  operationalPointsList: StdcmResultsOperationalPoint[];
   onRetainSimulation: () => void;
 };
 

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -57,12 +57,10 @@ export type SimulationReportSheetProps = {
   consist: StdcmSimulationInputs['consist'];
   simulationReportSheetNumber: string;
   mapCanvas?: string;
-  operationalPointsList: StdcmResultsOperationalPointsList;
+  operationalPointsList: StdcmResultsOperationalPoint[];
 };
 
-export type StdcmResultsOperationalPointsList = StdcmResultsOperationalPoint[];
-
-type StdcmResultsOperationalPoint = {
+export type StdcmResultsOperationalPoint = {
   opId: string;
   positionOnPath: number;
   time: string | null;

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -2,7 +2,7 @@ import type { SimulationResponse } from 'common/api/osrdEditoastApi';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 
-import type { StdcmResultsOperationalPointsList } from '../types';
+import type { StdcmResultsOperationalPoint } from '../types';
 
 function generateRandomString(length: number): string {
   return Array.from({ length }, () => Math.floor(Math.random() * 10)).join('');
@@ -113,7 +113,7 @@ export function getOperationalPointsWithTimes(
   operationalPoints: SuggestedOP[],
   simulation: Extract<SimulationResponse, { status: 'success' }>,
   departureTime: string
-): StdcmResultsOperationalPointsList {
+): StdcmResultsOperationalPoint[] {
   const { positions, times } = simulation.final_output;
   const pathDepartureTime = new Date(departureTime).toLocaleTimeString().substring(0, 5);
 


### PR DESCRIPTION
This just adds an unnecessary indirection. Directly use an array to make it clear that we manipulate one (as opposed to an object).