### PR TITLE
editoast: skip serializing empty TrackSection extensions

### DIFF
--- a/editoast/editoast_schemas/src/infra/track_section_extensions.rs
+++ b/editoast/editoast_schemas/src/infra/track_section_extensions.rs
@@ -9,7 +9,9 @@ use crate::infra::TrackSectionSourceExtension;
 #[serde(deny_unknown_fields)]
 pub struct TrackSectionExtensions {
     #[schema(inline)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sncf: Option<TrackSectionSncfExtension>,
     #[schema(inline)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<TrackSectionSourceExtension>,
 }


### PR DESCRIPTION
This causes osrd_schemas pydantic validator to complain when an extension isn't in use (for example, when trying to parse small infra tracksections).