### PR TITLE
front: stop putting path step IDs in SuggestedOP.opId

### DIFF
--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -136,7 +136,7 @@ export function getOperationalPointsWithTimes(
     const stopEndTime = computeStopDepartureTime(formattedTime, durationToString);
 
     return {
-      opId: op.opId,
+      opId: op.opId!,
       positionOnPath: op.positionOnPath,
       time: formattedTime,
       name: op.name,

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -94,7 +94,7 @@ export const upsertPathStepsInOPs = (ops: SuggestedOP[], pathSteps: PathStep[]):
     // We check only for pathSteps added by map click
     if ('track' in step) {
       const formattedStep: SuggestedOP = {
-        opId: step.id,
+        pathStepId: step.id,
         positionOnPath: step.positionOnPath!,
         offsetOnTrack: step.offset,
         track: step.track,
@@ -124,6 +124,7 @@ export const upsertPathStepsInOPs = (ops: SuggestedOP[], pathSteps: PathStep[]):
         if (matchPathStepAndOp(step, op) && op.kp === step.kp) {
           return {
             ...op,
+            pathStepId: step.id,
             stopFor,
             arrival,
             receptionSignal,
@@ -141,14 +142,12 @@ export const pathStepMatchesOp = (
   pathStep: PathStep,
   op: Pick<
     SuggestedOP,
-    'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
+    'pathStepId' | 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
   >,
   withKP = false
 ) => {
   if (!matchPathStepAndOp(pathStep, op)) {
-    // TODO: we abuse the PathStep.id field here, the backend also sets it to an
-    // ID which has nothing to do with OPs
-    return pathStep.id === op.opId;
+    return pathStep.id === op.pathStepId;
   }
   if ('uic' in pathStep) {
     return withKP ? pathStep.kp === op.kp : pathStep.name === op.name;
@@ -168,7 +167,7 @@ export const isVia = (
   vias: PathStep[],
   op: Pick<
     SuggestedOP,
-    'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
+    'pathStepId' | 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
   >,
   { withKP = false } = {}
 ) => vias.some((via) => pathStepMatchesOp(via, op, withKP));

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -26,9 +26,7 @@ import { TableType, type TimeExtraDays, type TimesStopsInputRow } from '../types
 
 const matchPathStepAndOpWithKP = (step: PathStep, op: SuggestedOP) => {
   if (!matchPathStepAndOp(step, op)) {
-    // TODO: we abuse the PathStep.id field here, the backend also sets it to an
-    // ID which has nothing to do with OPs
-    return step.id === op.opId;
+    return step.id === op.pathStepId;
   }
   // We match the kp in case two OPs have the same uic+ch (can happen when the
   // infra is imported)
@@ -101,7 +99,7 @@ export const formatSuggestedViasToRowVias = (
       arrival: formattedArrival,
       departure: formattedDeparture,
       onStopSignal,
-      name: name || t('waypoint', { id: filteredOp.opId }),
+      name: name || t('waypoint', { id: filteredOp.pathStepId }),
       shortSlipDistance,
       stopFor,
       theoreticalMargin,

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -84,7 +84,7 @@ const useOutputTableData = (
         : false;
 
       return {
-        opId: pathStep.id,
+        pathStepId: pathStep.id,
         name: t('waypoint', { id: pathStep.id }),
         ch: undefined,
         isWaypoint: true,

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -10,7 +10,8 @@ export type TimeExtraDays = {
 };
 
 export type TimesStopsRow = {
-  opId: string;
+  pathStepId?: string;
+  opId?: string;
   name?: string;
   ch?: string;
   trackName?: string;

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/types.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/types.ts
@@ -4,7 +4,8 @@ import type { ReceptionSignal, TrainScheduleBase } from 'common/api/osrdEditoast
 import type { IsoDurationString } from 'common/types';
 
 export type SuggestedOP = {
-  opId: string;
+  pathStepId?: string;
+  opId?: string;
   name?: string;
   uic?: number;
   ch?: string;

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/utils.ts
@@ -417,7 +417,7 @@ const testCommonConfReducers = (slice: OperationalStudiesConfSlice | StdcmConfSl
       });
 
       const newVia: SuggestedOP = {
-        opId: 'lemans',
+        pathStepId: 'lemans',
         track: '60ca8dda-6667-11e3-81ff-01f464e0362d',
         offsetOnTrack: 426.443,
         positionOnPath: 200,


### PR DESCRIPTION
The opId field was (ab)used for track offset waypoints: we were putting path step IDs in there. Instead, make opId optional and add a new field for the path step ID.

This paves the way for simplifying SuggestedOP/PathStep matching: we'll be able to use pathStepId instead of trying to match with a random subset of uic/trigram/secondary_code/kp/positionOnPath and friends.