### PR TITLE
core: pathfinding: filter out paths with repeated tracks during exploration

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlySet.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlySet.kt
@@ -1,0 +1,36 @@
+package fr.sncf.osrd.utils
+
+/**
+ * Append-only set implementation. The internal structure is a linked list. Used to store data on
+ * diverging paths while minimizing copies. See also `AppendOnlyLinkedList`.
+ */
+class AppendOnlySet<T>(
+    private val list: AppendOnlyLinkedList<T>,
+    private val keyFilter: BloomFilter<T>,
+) {
+
+    /** Add the given value to the set. O(1). */
+    fun add(k: T) {
+        keyFilter.add(k)
+        list.add(k)
+    }
+
+    /** Returns a copy of the set. The underlying structure is *not* copied. O(1). */
+    fun shallowCopy(): AppendOnlySet<T> {
+        return AppendOnlySet(list.shallowCopy(), keyFilter.copy())
+    }
+
+    /**
+     * Returns true if the value is in the set. O(n) in worst case, O(1) if the value is near the
+     * end. Pre-filtered using a bloom filter.
+     */
+    fun contains(key: T): Boolean {
+        if (!keyFilter.mayContain(key)) return false
+        return list.findLast { it == key } != null
+    }
+}
+
+/** Returns a new empty set */
+fun <T> appendOnlySetOf(): AppendOnlySet<T> {
+    return AppendOnlySet(appendOnlyLinkedListOf(), emptyBloomFilter())
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -391,7 +391,7 @@ class DummyInfra : RawInfra, BlockInfra {
     }
 
     override fun getTrackFromChunk(trackChunk: TrackChunkId): TrackSectionId {
-        TODO("Not yet implemented")
+        return convertId(trackChunk)
     }
 
     override fun getTrackChunkSlope(trackChunk: DirTrackChunkId): DistanceRangeMap<Double> {


### PR DESCRIPTION
Prevents issues where the post-processing fails because of "repeated tracks in the path".

The result changes to "no path found" in most cases, but this time with some more details (such as constraints). It finds *some* new paths, but they make some extreme detours. 

It does come with a mild performance hit (roughly +10% computation time).