### PR TITLE
schemas: allow extensions to be specified but None

### DIFF
--- a/front/src/reducers/osrdconf/infra_schema.json
+++ b/front/src/reducers/osrdconf/infra_schema.json
@@ -187,9 +187,12 @@
         "BufferStopExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/BufferStopSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -331,9 +334,12 @@
         "DetectorExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/DetectorSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -761,9 +767,12 @@
         "NeutralSectionExtensions": {
             "properties": {
                 "neutral_sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/NeutralSectionNeutralSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -852,17 +861,23 @@
         "OperationalPointExtensions": {
             "properties": {
                 "identifier": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/OperationalPointIdentifierExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
                 },
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/OperationalPointSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -927,9 +942,12 @@
         "OperationalPointPartExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/OperationalPointPartSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -1220,9 +1238,12 @@
         "SignalExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/SignalSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -1376,9 +1397,12 @@
         "SpeedSectionExtensions": {
             "properties": {
                 "psl_sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/SpeedSectionPslSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -1474,9 +1498,12 @@
         "SwitchExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/SwitchSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
@@ -1662,17 +1689,23 @@
         "TrackSectionExtensions": {
             "properties": {
                 "sncf": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/TrackSectionSncfExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null
                 },
                 "source": {
-                    "allOf": [
+                    "anyOf": [
                         {
                             "$ref": "#/$defs/TrackSectionSourceExtension"
+                        },
+                        {
+                            "type": "null"
                         }
                     ],
                     "default": null

--- a/python/osrd_schemas/osrd_schemas/infra.py
+++ b/python/osrd_schemas/osrd_schemas/infra.py
@@ -545,7 +545,7 @@ def register_extension(object: Type[BaseModel], name):
             raise RuntimeError(f"Extension '{name}' already registered for {object.__name__}")
 
         extensions_field.annotation.model_fields[name] = FieldInfo(
-            annotation=extension,
+            annotation=Optional[extension],
             default=None,
         )
         return extension

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "osrd_schemas"
-version = "0.8.13"
+version = "0.8.14"
 
 [tool.poetry]
 name = "osrd_schemas"
-version = "0.8.13"
+version = "0.8.14"
 description = ""
 authors = ["OSRD <contact@osrd.fr>"]
 


### PR DESCRIPTION
Editoast serialize *all* extensions, even when not present. The pydantic validation should thus allow None