### PR TITLE
core: stdcm: optimize incremental conflict detection

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/conflicts/Conflicts.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/Conflicts.kt
@@ -7,10 +7,6 @@ import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult.Confli
 import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult.ConflictRequirement
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
-import kotlin.math.max
-import kotlin.math.min
-
-const val DEFAULT_WORK_SCHEDULE_ID: Long = -1
 
 interface SpacingTrainRequirement {
     val trainId: Long
@@ -54,75 +50,24 @@ enum class RequirementType {
     WORK_SCHEDULE
 }
 
-data class ConflictProperties(
-    // If there are conflicts, minimum delay that should be added to the train so that there are no
-    // conflicts anymore
-    val minDelayWithoutConflicts: Double,
-    // If there are no conflicts, maximum delay that can be added to the train without creating any
-    // conflict
-    val maxDelayWithoutConflicts: Double,
-    // If there are no conflicts, minimum begin time of the next requirement that could conflict
-    val timeOfNextConflict: Double
-)
-
 fun detectConflicts(trainRequirements: List<TrainRequirements>): List<Conflict> {
     return detectRequirementConflicts(convertTrainRequirements(trainRequirements))
 }
 
 fun detectRequirementConflicts(requirements: List<Requirements>): List<Conflict> {
-    val res = incrementalConflictDetectorFromRequirements(requirements).checkConflicts()
+    val res = conflictDetectorFromRequirements(requirements).checkConflicts()
     return mergeConflicts(res)
 }
 
-interface IncrementalConflictDetector {
+interface ConflictDetector {
     fun checkConflicts(): List<Conflict>
-
-    fun checkConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): List<Conflict>
-
-    /** Only check the given new spacing requirement against the scheduled requirements */
-    fun checkSpacingRequirement(req: SpacingRequirement): List<Conflict>
-
-    /** Only check the given new routing requirement against the scheduled requirements */
-    fun checkRoutingRequirement(req: RoutingRequirement): List<Conflict>
-
-    fun minDelayWithoutConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double
-
-    fun maxDelayWithoutConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double
-
-    fun timeOfNextConflict(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double
-
-    fun analyseConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): ConflictProperties
 }
 
-fun incrementalConflictDetector(
-    trainRequirements: List<TrainRequirements>
-): IncrementalConflictDetector {
-    return IncrementalConflictDetectorImpl(convertTrainRequirements(trainRequirements))
+fun conflictDetectorFromRequirements(requirements: List<Requirements>): ConflictDetector {
+    return ConflictDetectorImpl(requirements)
 }
 
-fun incrementalConflictDetectorFromRequirements(
-    requirements: List<Requirements>
-): IncrementalConflictDetector {
-    return IncrementalConflictDetectorImpl(requirements)
-}
-
-class IncrementalConflictDetectorImpl(requirements: List<Requirements>) :
-    IncrementalConflictDetector {
+class ConflictDetectorImpl(requirements: List<Requirements>) : ConflictDetector {
     private val spacingZoneRequirements =
         mutableMapOf<String, MutableList<SpacingZoneRequirement>>()
     private val routingZoneRequirements =
@@ -249,201 +194,13 @@ class IncrementalConflictDetectorImpl(requirements: List<Requirements>) :
         }
         return res
     }
-
-    override fun checkConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): List<Conflict> {
-        val res = mutableListOf<Conflict>()
-        for (spacingRequirement in spacingRequirements) {
-            res.addAll(checkSpacingRequirement(spacingRequirement))
-        }
-        for (routingRequirement in routingRequirements) {
-            res.addAll(checkRoutingRequirement(routingRequirement))
-        }
-        return res
-    }
-
-    override fun checkSpacingRequirement(req: SpacingRequirement): List<Conflict> {
-        val requirements = spacingZoneRequirements[req.zone] ?: return listOf()
-
-        val res = mutableListOf<Conflict>()
-        for (otherReq in requirements) {
-            val beginTime = max(req.beginTime, otherReq.beginTime)
-            val endTime = min(req.endTime, otherReq.endTime)
-            if (beginTime < endTime) {
-                val trainIds = mutableListOf<Long>()
-                val workScheduleIds = mutableListOf<Long>()
-                if (otherReq.id.type == RequirementType.WORK_SCHEDULE)
-                    workScheduleIds.add(otherReq.id.id)
-                else trainIds.add(otherReq.id.id)
-                val conflictReq = ConflictRequirement(req.zone, beginTime, endTime)
-                res.add(
-                    Conflict(
-                        trainIds,
-                        workScheduleIds,
-                        beginTime,
-                        endTime,
-                        ConflictType.SPACING,
-                        listOf(conflictReq)
-                    )
-                )
-            }
-        }
-
-        return res
-    }
-
-    override fun checkRoutingRequirement(req: RoutingRequirement): List<Conflict> {
-        val res = mutableListOf<Conflict>()
-        for (zoneReq in req.zones) {
-            val zoneReqConfig =
-                RoutingZoneConfig(zoneReq.entryDetector, zoneReq.exitDetector, zoneReq.switches!!)
-            val requirements = routingZoneRequirements[zoneReq.zone!!] ?: continue
-
-            for (otherReq in requirements) {
-                if (otherReq.config == zoneReqConfig) continue
-                val beginTime = max(req.beginTime, otherReq.beginTime)
-                val endTime = min(zoneReq.endTime, otherReq.endTime)
-                val conflictReq = ConflictRequirement(zoneReq.zone, beginTime, endTime)
-                if (beginTime < endTime)
-                    res.add(
-                        Conflict(
-                            listOf(otherReq.trainId),
-                            beginTime,
-                            endTime,
-                            ConflictType.ROUTING,
-                            listOf(conflictReq)
-                        )
-                    )
-            }
-        }
-        return res
-    }
-
-    override fun analyseConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): ConflictProperties {
-        val minDelayWithoutConflicts =
-            minDelayWithoutConflicts(spacingRequirements, routingRequirements)
-        if (minDelayWithoutConflicts != 0.0) { // There are initial conflicts
-            return ConflictProperties(minDelayWithoutConflicts, 0.0, 0.0)
-        } else { // There are no initial conflicts
-            var maxDelay = Double.POSITIVE_INFINITY
-            var timeOfNextConflict = Double.POSITIVE_INFINITY
-            for (spacingRequirement in spacingRequirements) {
-                if (spacingZoneRequirements[spacingRequirement.zone!!] != null) {
-                    val endTime = spacingRequirement.endTime
-                    for (requirement in spacingZoneRequirements[spacingRequirement.zone!!]!!) {
-                        if (endTime <= requirement.beginTime) {
-                            maxDelay = min(maxDelay, requirement.beginTime - endTime)
-                            timeOfNextConflict = min(timeOfNextConflict, requirement.beginTime)
-                        }
-                    }
-                }
-            }
-            for (routingRequirement in routingRequirements) {
-                for (zoneReq in routingRequirement.zones) {
-                    if (routingZoneRequirements[zoneReq.zone!!] != null) {
-                        val endTime = zoneReq.endTime
-                        val config =
-                            RoutingZoneConfig(
-                                zoneReq.entryDetector,
-                                zoneReq.exitDetector,
-                                zoneReq.switches!!
-                            )
-                        for (requirement in routingZoneRequirements[zoneReq.zone!!]!!) {
-                            if (endTime <= requirement.beginTime && config != requirement.config) {
-                                maxDelay = min(maxDelay, requirement.beginTime - endTime)
-                                timeOfNextConflict = min(timeOfNextConflict, requirement.beginTime)
-                            }
-                        }
-                    }
-                }
-            }
-            return ConflictProperties(minDelayWithoutConflicts, maxDelay, timeOfNextConflict)
-        }
-    }
-
-    override fun minDelayWithoutConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double {
-        var globalMinDelay = 0.0
-        while (globalMinDelay.isFinite()) {
-            var minDelay = 0.0
-            for (spacingRequirement in spacingRequirements) {
-                if (spacingZoneRequirements[spacingRequirement.zone!!] != null) {
-                    val conflictingRequirements =
-                        spacingZoneRequirements[spacingRequirement.zone!!]!!.filter {
-                            !(spacingRequirement.beginTime >= it.endTime ||
-                                spacingRequirement.endTime <= it.beginTime)
-                        }
-                    if (conflictingRequirements.isNotEmpty()) {
-                        val latestEndTime = conflictingRequirements.maxOf { it.endTime }
-                        minDelay = max(minDelay, latestEndTime - spacingRequirement.beginTime)
-                    }
-                }
-            }
-            for (routingRequirement in routingRequirements) {
-                for (zoneReq in routingRequirement.zones) {
-                    if (routingZoneRequirements[zoneReq.zone!!] != null) {
-                        val config =
-                            RoutingZoneConfig(
-                                zoneReq.entryDetector,
-                                zoneReq.exitDetector,
-                                zoneReq.switches!!
-                            )
-                        val conflictingRequirements =
-                            routingZoneRequirements[zoneReq.zone!!]!!.filter {
-                                !(routingRequirement.beginTime >= it.endTime ||
-                                    zoneReq.endTime <= it.beginTime) && config != it.config
-                            }
-                        if (conflictingRequirements.isNotEmpty()) {
-                            val latestEndTime = conflictingRequirements.maxOf { it.endTime }
-                            minDelay = max(minDelay, latestEndTime - routingRequirement.beginTime)
-                        }
-                    }
-                }
-            }
-            // No new conflicts
-            if (minDelay == 0.0) return globalMinDelay
-
-            // Check for conflicts with newly added delay
-            globalMinDelay += minDelay
-            spacingRequirements.onEach {
-                it.beginTime += minDelay
-                it.endTime += minDelay
-            }
-            routingRequirements.onEach { routingRequirement ->
-                routingRequirement.beginTime += minDelay
-                routingRequirement.zones.onEach { it.endTime += minDelay }
-            }
-        }
-        return Double.POSITIVE_INFINITY
-    }
-
-    override fun maxDelayWithoutConflicts(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double {
-        return analyseConflicts(spacingRequirements, routingRequirements).maxDelayWithoutConflicts
-    }
-
-    override fun timeOfNextConflict(
-        spacingRequirements: List<SpacingRequirement>,
-        routingRequirements: List<RoutingRequirement>
-    ): Double {
-        return analyseConflicts(spacingRequirements, routingRequirements).timeOfNextConflict
-    }
 }
 
 /**
  * Return a list of requirement conflict groups. If requirements pairs (A, B) and (B, C) are
  * conflicting, then (A, B, C) are part of the same conflict group.
  */
-private fun <ReqT : ResourceRequirement> detectRequirementConflicts(
+internal fun <ReqT : ResourceRequirement> detectRequirementConflicts(
     requirements: MutableList<ReqT>,
     conflicting: (ReqT, ReqT) -> Boolean,
 ): List<List<ReqT>> {
@@ -581,7 +338,7 @@ fun mergeConflicts(conflicts: List<Conflict>): List<Conflict> {
     return mergedConflicts
 }
 
-private fun convertTrainRequirements(
+internal fun convertTrainRequirements(
     trainRequirements: List<TrainRequirements>
 ): List<Requirements> {
     val res = mutableListOf<Requirements>()

--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalConflictDetector.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalConflictDetector.kt
@@ -1,0 +1,291 @@
+package fr.sncf.osrd.conflicts
+
+import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult.Conflict
+import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult.Conflict.ConflictType
+import fr.sncf.osrd.api.ConflictDetectionEndpoint.ConflictDetectionResult.ConflictRequirement
+import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
+import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
+import kotlin.math.max
+import kotlin.math.min
+
+const val DEFAULT_WORK_SCHEDULE_ID: Long = -1
+
+data class ConflictProperties(
+    // If there are conflicts, minimum delay that should be added to the train so that there are no
+    // conflicts anymore
+    val minDelayWithoutConflicts: Double,
+    // If there are no conflicts, maximum delay that can be added to the train without creating any
+    // conflict
+    val maxDelayWithoutConflicts: Double,
+    // If there are no conflicts, minimum begin time of the next requirement that could conflict
+    val timeOfNextConflict: Double,
+)
+
+fun incrementalConflictDetectorFromTrainReq(
+    requirements: List<TrainRequirements>
+): IncrementalConflictDetector {
+    return IncrementalConflictDetectorImpl(convertTrainRequirements(requirements))
+}
+
+fun incrementalConflictDetectorFromReq(
+    requirements: List<Requirements>
+): IncrementalConflictDetector {
+    return IncrementalConflictDetectorImpl(requirements)
+}
+
+interface IncrementalConflictDetector {
+    fun checkConflicts(
+        spacingRequirements: List<SpacingRequirement>,
+        routingRequirements: List<RoutingRequirement>
+    ): List<Conflict>
+
+    fun analyseConflicts(
+        spacingRequirements: List<SpacingRequirement>,
+        routingRequirements: List<RoutingRequirement>
+    ): ConflictProperties
+}
+
+class IncrementalConflictDetectorImpl(requirements: List<Requirements>) :
+    IncrementalConflictDetector {
+    private val spacingZoneRequirements =
+        mutableMapOf<String, MutableList<SpacingZoneRequirement>>()
+    private val routingZoneRequirements =
+        mutableMapOf<String, MutableList<RoutingZoneRequirement>>()
+
+    init {
+        generateSpacingRequirements(requirements)
+        generateRoutingRequirements(requirements)
+    }
+
+    data class SpacingZoneRequirement(
+        val id: RequirementId,
+        override val beginTime: Double,
+        override val endTime: Double,
+    ) : ResourceRequirement
+
+    private fun generateSpacingRequirements(requirements: List<Requirements>) {
+        // organize requirements by zone
+        for (req in requirements) {
+            for (spacingReq in req.spacingRequirements) {
+                val zoneReq =
+                    SpacingZoneRequirement(req.id, spacingReq.beginTime, spacingReq.endTime)
+                spacingZoneRequirements.getOrPut(spacingReq.zone!!) { mutableListOf() }.add(zoneReq)
+            }
+        }
+    }
+
+    data class RoutingZoneConfig(
+        val entryDet: String,
+        val exitDet: String,
+        val switches: Map<String, String>
+    )
+
+    data class RoutingZoneRequirement(
+        val trainId: Long,
+        val route: String,
+        override val beginTime: Double,
+        override val endTime: Double,
+        val config: RoutingZoneConfig,
+    ) : ResourceRequirement
+
+    private fun generateRoutingRequirements(requirements: List<Requirements>) {
+        // reorganize requirements by zone
+        for (trainRequirements in requirements) {
+            val trainId = trainRequirements.id.id
+            for (routeRequirements in trainRequirements.routingRequirements) {
+                val route = routeRequirements.route!!
+                var beginTime = routeRequirements.beginTime
+                // TODO: make it a parameter
+                if (routeRequirements.zones.any { it.switches.isNotEmpty() }) beginTime -= 5.0
+                for (zoneRequirement in routeRequirements.zones) {
+                    val endTime = zoneRequirement.endTime
+                    val config =
+                        RoutingZoneConfig(
+                            zoneRequirement.entryDetector,
+                            zoneRequirement.exitDetector,
+                            zoneRequirement.switches!!
+                        )
+                    val requirement =
+                        RoutingZoneRequirement(trainId, route, beginTime, endTime, config)
+                    routingZoneRequirements
+                        .getOrPut(zoneRequirement.zone) { mutableListOf() }
+                        .add(requirement)
+                }
+            }
+        }
+    }
+
+    override fun checkConflicts(
+        spacingRequirements: List<SpacingRequirement>,
+        routingRequirements: List<RoutingRequirement>
+    ): List<Conflict> {
+        val res = mutableListOf<Conflict>()
+        for (spacingRequirement in spacingRequirements) {
+            res.addAll(checkSpacingRequirement(spacingRequirement))
+        }
+        for (routingRequirement in routingRequirements) {
+            res.addAll(checkRoutingRequirement(routingRequirement))
+        }
+        return res
+    }
+
+    fun checkSpacingRequirement(req: SpacingRequirement): List<Conflict> {
+        val requirements = spacingZoneRequirements[req.zone] ?: return listOf()
+
+        val res = mutableListOf<Conflict>()
+        for (otherReq in requirements) {
+            val beginTime = max(req.beginTime, otherReq.beginTime)
+            val endTime = min(req.endTime, otherReq.endTime)
+            if (beginTime < endTime) {
+                val trainIds = mutableListOf<Long>()
+                val workScheduleIds = mutableListOf<Long>()
+                if (otherReq.id.type == RequirementType.WORK_SCHEDULE)
+                    workScheduleIds.add(otherReq.id.id)
+                else trainIds.add(otherReq.id.id)
+                val conflictReq = ConflictRequirement(req.zone, beginTime, endTime)
+                res.add(
+                    Conflict(
+                        trainIds,
+                        workScheduleIds,
+                        beginTime,
+                        endTime,
+                        ConflictType.SPACING,
+                        listOf(conflictReq)
+                    )
+                )
+            }
+        }
+
+        return res
+    }
+
+    fun checkRoutingRequirement(req: RoutingRequirement): List<Conflict> {
+        val res = mutableListOf<Conflict>()
+        for (zoneReq in req.zones) {
+            val zoneReqConfig =
+                RoutingZoneConfig(zoneReq.entryDetector, zoneReq.exitDetector, zoneReq.switches!!)
+            val requirements = routingZoneRequirements[zoneReq.zone!!] ?: continue
+
+            for (otherReq in requirements) {
+                if (otherReq.config == zoneReqConfig) continue
+                val beginTime = max(req.beginTime, otherReq.beginTime)
+                val endTime = min(zoneReq.endTime, otherReq.endTime)
+                val conflictReq = ConflictRequirement(zoneReq.zone, beginTime, endTime)
+                if (beginTime < endTime)
+                    res.add(
+                        Conflict(
+                            listOf(otherReq.trainId),
+                            beginTime,
+                            endTime,
+                            ConflictType.ROUTING,
+                            listOf(conflictReq)
+                        )
+                    )
+            }
+        }
+        return res
+    }
+
+    override fun analyseConflicts(
+        spacingRequirements: List<SpacingRequirement>,
+        routingRequirements: List<RoutingRequirement>
+    ): ConflictProperties {
+        val minDelayWithoutConflicts =
+            minDelayWithoutConflicts(spacingRequirements, routingRequirements)
+        if (minDelayWithoutConflicts != 0.0) { // There are initial conflicts
+            return ConflictProperties(minDelayWithoutConflicts, 0.0, 0.0)
+        } else { // There are no initial conflicts
+            var maxDelay = Double.POSITIVE_INFINITY
+            var timeOfNextConflict = Double.POSITIVE_INFINITY
+            for (spacingRequirement in spacingRequirements) {
+                if (spacingZoneRequirements[spacingRequirement.zone!!] != null) {
+                    val endTime = spacingRequirement.endTime
+                    for (requirement in spacingZoneRequirements[spacingRequirement.zone!!]!!) {
+                        if (endTime <= requirement.beginTime) {
+                            maxDelay = min(maxDelay, requirement.beginTime - endTime)
+                            timeOfNextConflict = min(timeOfNextConflict, requirement.beginTime)
+                        }
+                    }
+                }
+            }
+            for (routingRequirement in routingRequirements) {
+                for (zoneReq in routingRequirement.zones) {
+                    if (routingZoneRequirements[zoneReq.zone!!] != null) {
+                        val endTime = zoneReq.endTime
+                        val config =
+                            RoutingZoneConfig(
+                                zoneReq.entryDetector,
+                                zoneReq.exitDetector,
+                                zoneReq.switches!!
+                            )
+                        for (requirement in routingZoneRequirements[zoneReq.zone!!]!!) {
+                            if (endTime <= requirement.beginTime && config != requirement.config) {
+                                maxDelay = min(maxDelay, requirement.beginTime - endTime)
+                                timeOfNextConflict = min(timeOfNextConflict, requirement.beginTime)
+                            }
+                        }
+                    }
+                }
+            }
+            return ConflictProperties(minDelayWithoutConflicts, maxDelay, timeOfNextConflict)
+        }
+    }
+
+    fun minDelayWithoutConflicts(
+        spacingRequirements: List<SpacingRequirement>,
+        routingRequirements: List<RoutingRequirement>
+    ): Double {
+        var globalMinDelay = 0.0
+        while (globalMinDelay.isFinite()) {
+            var minDelay = 0.0
+            for (spacingRequirement in spacingRequirements) {
+                if (spacingZoneRequirements[spacingRequirement.zone!!] != null) {
+                    val conflictingRequirements =
+                        spacingZoneRequirements[spacingRequirement.zone!!]!!.filter {
+                            !(spacingRequirement.beginTime >= it.endTime ||
+                                spacingRequirement.endTime <= it.beginTime)
+                        }
+                    if (conflictingRequirements.isNotEmpty()) {
+                        val latestEndTime = conflictingRequirements.maxOf { it.endTime }
+                        minDelay = max(minDelay, latestEndTime - spacingRequirement.beginTime)
+                    }
+                }
+            }
+            for (routingRequirement in routingRequirements) {
+                for (zoneReq in routingRequirement.zones) {
+                    if (routingZoneRequirements[zoneReq.zone!!] != null) {
+                        val config =
+                            RoutingZoneConfig(
+                                zoneReq.entryDetector,
+                                zoneReq.exitDetector,
+                                zoneReq.switches!!
+                            )
+                        val conflictingRequirements =
+                            routingZoneRequirements[zoneReq.zone!!]!!.filter {
+                                !(routingRequirement.beginTime >= it.endTime ||
+                                    zoneReq.endTime <= it.beginTime) && config != it.config
+                            }
+                        if (conflictingRequirements.isNotEmpty()) {
+                            val latestEndTime = conflictingRequirements.maxOf { it.endTime }
+                            minDelay = max(minDelay, latestEndTime - routingRequirement.beginTime)
+                        }
+                    }
+                }
+            }
+            // No new conflicts
+            if (minDelay == 0.0) return globalMinDelay
+
+            // Check for conflicts with newly added delay
+            globalMinDelay += minDelay
+            spacingRequirements.onEach {
+                it.beginTime += minDelay
+                it.endTime += minDelay
+            }
+            routingRequirements.onEach { routingRequirement ->
+                routingRequirement.beginTime += minDelay
+                routingRequirement.zones.onEach { it.endTime += minDelay }
+            }
+        }
+        return Double.POSITIVE_INFINITY
+    }
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -355,8 +355,8 @@ private fun checkForConflicts(
         }
     val conflictDetector = incrementalConflictDetectorFromReq(timetableTrainRequirements)
     val spacingRequirements = parseSpacingRequirements(newTrainSpacingRequirement)
-    val conflicts = conflictDetector.checkConflicts(spacingRequirements, listOf())
-    assert(conflicts.isEmpty()) { "STDCM result is conflicting with the scheduled timetable" }
+    val conflicts = conflictDetector.analyseConflicts(spacingRequirements, listOf())
+    assert(!conflicts.hasConflict) { "STDCM result is conflicting with the scheduled timetable" }
 }
 
 private fun findWaypointBlocks(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -355,8 +355,10 @@ private fun checkForConflicts(
         }
     val conflictDetector = incrementalConflictDetectorFromReq(timetableTrainRequirements)
     val spacingRequirements = parseSpacingRequirements(newTrainSpacingRequirement)
-    val conflicts = conflictDetector.analyseConflicts(spacingRequirements, listOf())
-    assert(!conflicts.hasConflict) { "STDCM result is conflicting with the scheduled timetable" }
+    val conflicts = conflictDetector.analyseConflicts(spacingRequirements)
+    assert(conflicts is NoConflictResponse) {
+        "STDCM result is conflicting with the scheduled timetable"
+    }
 }
 
 private fun findWaypointBlocks(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -49,7 +49,6 @@ import java.time.Duration.ofMillis
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import kotlin.Throws
 import org.takes.Request
 import org.takes.Response
 import org.takes.Take
@@ -354,7 +353,7 @@ private fun checkForConflicts(
                 it.endTime + departureTime.seconds
             )
         }
-    val conflictDetector = incrementalConflictDetectorFromRequirements(timetableTrainRequirements)
+    val conflictDetector = incrementalConflictDetectorFromReq(timetableTrainRequirements)
     val spacingRequirements = parseSpacingRequirements(newTrainSpacingRequirement)
     val conflicts = conflictDetector.checkConflicts(spacingRequirements, listOf())
     assert(conflicts.isEmpty()) { "STDCM result is conflicting with the scheduled timetable" }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -163,7 +163,7 @@ private fun checkForConflicts(
     val requirements = TrainRequirements(0, spacingRequirements, listOf())
     val conflictDetector = incrementalConflictDetectorFromTrainReq(listOf(requirements))
     val conflicts =
-        conflictDetector.checkConflicts(
+        conflictDetector.analyseConflicts(
             simResult.spacingRequirements.map {
                 ResultTrain.SpacingRequirement(
                     it.zone,
@@ -176,5 +176,5 @@ private fun checkForConflicts(
                 ResultTrain.RoutingRequirement(it.route, it.beginTime + departureTime, it.zones)
             }
         )
-    assert(conflicts.isEmpty()) { "STDCM result is conflicting with the scheduled timetable" }
+    assert(!conflicts.hasConflict) { "STDCM result is conflicting with the scheduled timetable" }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -172,9 +172,8 @@ private fun checkForConflicts(
                     it.isComplete
                 )
             },
-            simResult.routingRequirements.map {
-                ResultTrain.RoutingRequirement(it.route, it.beginTime + departureTime, it.zones)
-            }
         )
-    assert(!conflicts.hasConflict) { "STDCM result is conflicting with the scheduled timetable" }
+    assert(conflicts is NoConflictResponse) {
+        "STDCM result is conflicting with the scheduled timetable"
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -161,7 +161,7 @@ private fun checkForConflicts(
     departureTime: Double
 ) {
     val requirements = TrainRequirements(0, spacingRequirements, listOf())
-    val conflictDetector = incrementalConflictDetector(listOf(requirements))
+    val conflictDetector = incrementalConflictDetectorFromTrainReq(listOf(requirements))
     val conflicts =
         conflictDetector.checkConflicts(
             simResult.spacingRequirements.map {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -261,11 +261,9 @@ data class BlockAvailability(
                     )
                 }
                 .filter { it.beginTime < it.endTime }
-        val conflicts =
-            incrementalConflictDetector.checkConflicts(shiftedSpacingRequirements, listOf())
         val conflictProperties =
             incrementalConflictDetector.analyseConflicts(shiftedSpacingRequirements, listOf())
-        if (conflicts.isEmpty()) {
+        if (!conflictProperties.hasConflict) {
             return BlockAvailabilityInterface.Available(
                 conflictProperties.maxDelayWithoutConflicts,
                 conflictProperties.timeOfNextConflict
@@ -274,7 +272,7 @@ data class BlockAvailability(
             val firstConflictOffset =
                 getEnvelopeOffsetFromTime(
                     infraExplorer,
-                    conflicts.first().startTime - pathStartTime
+                    conflictProperties.firstConflictTime!! - pathStartTime
                 )
             return BlockAvailabilityInterface.Unavailable(
                 conflictProperties.minDelayWithoutConflicts,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.stdcm.preprocessing.implementation
 import fr.sncf.osrd.conflicts.IncrementalConflictDetector
 import fr.sncf.osrd.conflicts.TrainRequirements
 import fr.sncf.osrd.conflicts.TravelledPath
-import fr.sncf.osrd.conflicts.incrementalConflictDetector
+import fr.sncf.osrd.conflicts.incrementalConflictDetectorFromTrainReq
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
 import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
@@ -372,7 +372,7 @@ fun makeBlockAvailability(
     // Only keep steps with planned timing data
     val plannedSteps = steps.filter { it.plannedTimingData != null }
     return BlockAvailability(
-        incrementalConflictDetector(trainRequirements),
+        incrementalConflictDetectorFromTrainReq(trainRequirements),
         plannedSteps,
         gridMarginBeforeTrain,
         gridMarginAfterTrain,

--- a/core/src/test/kotlin/fr/sncf/osrd/conflicts/IncrementalConflictDetectorTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/conflicts/IncrementalConflictDetectorTests.kt
@@ -1,0 +1,63 @@
+package fr.sncf.osrd.conflicts
+
+import fr.sncf.osrd.standalone_sim.result.ResultTrain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IncrementalConflictDetectorTests {
+    data class SimpleRequirement(
+        val zoneId: Int,
+        val start: Double,
+        val end: Double,
+    )
+
+    @Test
+    fun simpleAvailableTest() {
+        val detector =
+            makeDetector(
+                SimpleRequirement(0, 0.0, 1_000.0),
+                SimpleRequirement(0, 2_000.0, 3_000.0),
+            )
+        val res =
+            checkConflict(detector, SimpleRequirement(0, 1_200.0, 1_400.0)) as NoConflictResponse
+        assertEquals(600.0, res.maxDelayWithoutConflicts)
+        assertEquals(2_000.0, res.timeOfNextConflict)
+    }
+
+    @Test
+    fun simpleNoAvailableTest() {
+        val detector =
+            makeDetector(
+                SimpleRequirement(0, 0.0, 900.0),
+                SimpleRequirement(0, 1_100.0, 2_000.0),
+            )
+        val res = checkConflict(detector, SimpleRequirement(0, 200.0, 450.0)) as ConflictResponse
+        assertEquals(200.0, res.firstConflictTime)
+        assertEquals(1_800.0, res.minDelayWithoutConflicts)
+    }
+
+    fun makeDetector(vararg requirements: SimpleRequirement): IncrementalConflictDetector {
+        return IncrementalConflictDetector(
+            listOf(
+                Requirements(
+                    RequirementId(0, RequirementType.TRAIN),
+                    requirements.map {
+                        ResultTrain.SpacingRequirement(it.zoneId.toString(), it.start, it.end, true)
+                    },
+                    listOf()
+                )
+            )
+        )
+    }
+
+    fun checkConflict(
+        detector: IncrementalConflictDetector,
+        vararg requirements: SimpleRequirement
+    ): IncrementalConflictResponse {
+        return detector.analyseConflicts(
+            requirements.map {
+                ResultTrain.SpacingRequirement(it.zoneId.toString(), it.start, it.end, true)
+            },
+        )
+    }
+}


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/9801
Helps with https://github.com/OpenRailAssociation/osrd/issues/10034 without entirely fixing it

Possible review by commit (though it's possible to just ignore the previous version and read the new one on its own):

1. Split "static" and "incremental" conflict detection classes (the uses and possible optimizations differ quite a lot)
2. Remove incremental *routing* conflict detection (wasn't used and brought lots of complexity, we can add it back later)
3. Use range sets / tree maps for zone uses instead of a list of requirements

I haven't run a *proper benchmark* as it requires a pretty specific setup (thousands of trains in a realistic timetable), but I do have some metrics:

* In the profiler, this section of the code goes from ~60% of execution time ~down to 2-5%~
* On the slowest request I've logged (uncapped), execution time goes from 330s down to 190s. Still a timeout but not by much (180s threshold)

This PR also reduces code complexity by quite a lot, and *may* fix some of the "mismatch" crashes. 

---

**edit**: hold on, the new version *still* takes up a lot of time when it timeout (a lot more than 2-5% execution time). On one massive request, the time we spend in the conflict detection methods goes from 71% to 45% execution time: it's much better but still quite a lot. *edit2*: partially fixed by https://github.com/OpenRailAssociation/osrd/pull/10126.