### PR TITLE
github: only group patch upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
       nivo:
         patterns:
           - "@nivo/*"
@@ -50,6 +46,9 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+      patch:
+        update-types:
+          - "patch"
     commit-message:
       prefix: "front:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
The idea behind minor-and-patch was to group all uninteresting upgrades together. Indeed, with SemVer, patch and minor upgrades are not supposed to include API breaks, and grouping these together should be a good idea in theory as explained in the [GitHub docs][1].

However, in practice this doesn't seem to work well. First, some packages are at version 0.x.y, and minor upgrades often contain breaking changes. Unfortunately there's no way to ask dependabot to not group these unstable dependencies. Another issue is that some minor upgrades do contain some breaking changes (e.g. typescript).

Fix these issues by only grouping patch updates, which shoudl still keep the number of PRs to a reasonable number and not include any breaking upgrade.

While at it, move the group to the end of the list so that it's only used if none of the other groups match the package which need updating. Indeed, dependabot [picks the first group which matches the package][2].

[1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-updates-into-one-pull-request
[2]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups