### PR TITLE
front: match PathStep and SuggestedOP with pathStepId

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -99,7 +99,13 @@ const useStdcm = ({
       path: response.status === 'conflicts' ? response.pathfinding_result : response.path,
     } as StdcmResponse;
 
-    const pathProperties = await fetchPathProperties(formattedResponse.path, infraId, dispatch);
+    const pathSteps = payload.body.steps.map((step) => ({ ...step.location, id: nextId() }));
+    const pathProperties = await fetchPathProperties(
+      formattedResponse.path,
+      pathSteps,
+      infraId,
+      dispatch
+    );
 
     // If the response is successful compute the chart data, otherwise only include conflicts.
     let outputs;
@@ -109,7 +115,7 @@ const useStdcm = ({
         timetable_id: timetableId,
         comfort: payload.body.comfort,
         constraint_distribution: 'MARECO',
-        path: payload.body.steps.map((step) => ({ ...step.location, id: nextId() })),
+        path: pathSteps,
         rolling_stock_name: stdcmRollingStock!.name,
         start_time: formattedResponse.departure_time,
         train_name: 'stdcm',

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -8,6 +8,7 @@ import type {
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
+import type { PathStep } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 
 /**
@@ -15,6 +16,7 @@ import type { AppDispatch } from 'store';
  */
 const fetchPathProperties = async (
   path: PathfindingResultSuccess,
+  pathSteps: PathStep[],
   infraId: number,
   dispatch: AppDispatch
 ): Promise<StdcmPathProperties> => {
@@ -65,6 +67,7 @@ const fetchPathProperties = async (
 
     const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
       operationalPointsWithMetadata,
+      pathSteps,
       result.geometry,
       path.length
     );

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -1,5 +1,4 @@
 import type { SimulationResponse } from 'common/api/osrdEditoastApi';
-import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { interpolateValue } from 'modules/simulationResult/SimulationResultExport/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
@@ -139,9 +138,7 @@ function formatOperationalPointWithTimes(
 ): StdcmResultsOperationalPoint {
   const partiallyFormattedOp = formatMinimalOperationalPointWithTimes(op, train);
   // Find the corresponding stopType from pathSteps
-  const correspondingStep = simulationPathSteps.find(
-    (step) => step.location && matchPathStepAndOp(step.location, op)
-  );
+  const correspondingStep = simulationPathSteps.find((step) => step.id === op.pathStepId);
   let stopType;
   if (correspondingStep) {
     stopType = correspondingStep.isVia ? correspondingStep.stopType : StdcmStopTypes.SERVICE_STOP;

--- a/front/src/applications/stdcm/utils/index.ts
+++ b/front/src/applications/stdcm/utils/index.ts
@@ -30,6 +30,7 @@ export const extractMarkersInfo = (pathSteps: StdcmPathStep[]): MarkerInformatio
 
     acc.push({
       pointType,
+      id: step.id,
       uic: step.location.uic,
       secondary_code: step.location.secondary_code,
       coordinates: step.location.coordinates,

--- a/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/ModalSuggestedVias.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import ModalFooterSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalFooterSNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
-import { isVia, matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { upsertViaFromSuggestedOP } from 'reducers/osrdconf/operationalStudiesConf';
 import {
@@ -39,12 +38,12 @@ const ModalSuggestedVias = ({ suggestedVias, launchPathfinding }: ModalSuggested
   );
 
   const removeViaFromPath = (op: SuggestedOP) => {
-    const newPathSteps = pathSteps.filter((step) => !matchPathStepAndOp(step!, op));
+    const newPathSteps = pathSteps.filter((step) => step!.id !== op.pathStepId);
     launchPathfinding(newPathSteps);
   };
 
   const formatOP = (op: SuggestedOP, idx: number, idxTrueVia: number) => {
-    const isInVias = isVia(vias, op);
+    const isInVias = vias.find((step) => step.id === op.pathStepId);
     return (
       <div
         key={`suggested-via-modal-${op.opId}-${idx}`}
@@ -107,7 +106,7 @@ const ModalSuggestedVias = ({ suggestedVias, launchPathfinding }: ModalSuggested
           {suggestedVias.map((via, idx) => {
             if (!isOriginOrDestination(via)) {
               // If name is undefined, we know the op/via has been added by clicking on map
-              if (isVia(vias, via)) idxTrueVia += 1;
+              if (vias.find((step) => step.id === via.pathStepId)) idxTrueVia += 1;
               return formatOP(via, idx, idxTrueVia);
             }
             return null;

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -163,6 +163,7 @@ const usePathfinding = ({
 
     const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
       operational_points,
+      pathStepsInput,
       geometry,
       pathResult.length
     );

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -15,11 +15,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQuery';
-import {
-  formatSuggestedOperationalPoints,
-  getPathfindingQuery,
-  matchPathStepAndOp,
-} from 'modules/pathfinding/utils';
+import { formatSuggestedOperationalPoints, getPathfindingQuery } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { setFailure, setWarning } from 'reducers/main';
 import { replaceItinerary, updatePathSteps } from 'reducers/osrdconf/operationalStudiesConf';
@@ -171,8 +167,8 @@ const usePathfinding = ({
     // We update existing pathsteps with coordinates, positionOnPath and kp corresponding to the new pathfinding result
     const updatedPathSteps: (PathStep | null)[] = pathStepsInput.map((step, i) => {
       if (!step) return step;
-      const correspondingOp = suggestedOperationalPoints.find((suggestedOp) =>
-        matchPathStepAndOp(step, suggestedOp)
+      const correspondingOp = suggestedOperationalPoints.find(
+        (suggestedOp) => step.id === suggestedOp.pathStepId
       );
 
       const theoreticalMargin = i === 0 ? step.theoreticalMargin || '0%' : step.theoreticalMargin;

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -16,10 +16,7 @@ import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import getStepLocation from './helpers/getStepLocation';
 
-export const matchPathStepAndOp = (
-  step: PathItemLocation,
-  op: Pick<SuggestedOP, 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack'>
-) => {
+const matchPathStepAndOp = (step: PathItemLocation, op: SuggestedOP) => {
   if ('operational_point' in step) {
     return step.operational_point === op.opId;
   }

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -154,40 +154,6 @@ export const upsertPathStepsInOPs = (ops: SuggestedOP[], pathSteps: PathStep[]):
   return updatedOPs;
 };
 
-export const pathStepMatchesOp = (
-  pathStep: PathStep,
-  op: Pick<
-    SuggestedOP,
-    'pathStepId' | 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
-  >,
-  withKP = false
-) => {
-  if (!matchPathStepAndOp(pathStep, op)) {
-    return pathStep.id === op.pathStepId;
-  }
-  if ('uic' in pathStep) {
-    return withKP ? pathStep.kp === op.kp : pathStep.name === op.name;
-  }
-  return true;
-};
-
-/**
- * Check if a suggested operational point is a via.
- * Some OPs have same uic so we need to check also the ch (can be still not enough
- * probably because of imports problem).
- * If the vias has no uic, it has been added via map click and we know it has an id.
- * @param withKP - If true, we check the kp compatibility instead of the name.
- * It is used in the times and stops table to check if an operational point is a via.
- */
-export const isVia = (
-  vias: PathStep[],
-  op: Pick<
-    SuggestedOP,
-    'pathStepId' | 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack' | 'name' | 'kp'
-  >,
-  { withKP = false } = {}
-) => vias.some((via) => pathStepMatchesOp(via, op, withKP));
-
 export const isStation = (chCode: string): boolean =>
   chCode === 'BV' || chCode === '00' || chCode === '';
 

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -16,7 +16,10 @@ import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import getStepLocation from './helpers/getStepLocation';
 
-const matchPathStepAndOp = (step: PathItemLocation, op: SuggestedOP) => {
+export const matchPathStepAndOp = (
+  step: PathItemLocation,
+  op: Pick<SuggestedOP, 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack'>
+) => {
   if ('operational_point' in step) {
     return step.operational_point === op.opId;
   }

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -16,29 +16,6 @@ import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import getStepLocation from './helpers/getStepLocation';
 
-export const formatSuggestedOperationalPoints = (
-  operationalPoints: Array<
-    NonNullable<Required<PathProperties['operational_points']>>[number] & {
-      metadata?: NonNullable<SuggestedOP['metadata']>;
-    }
-  >,
-  geometry: GeoJsonLineString,
-  pathLength: number
-): SuggestedOP[] =>
-  operationalPoints.map((op) => ({
-    opId: op.id,
-    name: op.extensions?.identifier?.name,
-    uic: op.extensions?.identifier?.uic,
-    ch: op.extensions?.sncf?.ch,
-    kp: op.part.extensions?.sncf?.kp,
-    trigram: op.extensions?.sncf?.trigram,
-    offsetOnTrack: op.part.position,
-    track: op.part.track,
-    positionOnPath: op.position,
-    coordinates: getPointOnTrackCoordinates(geometry, pathLength, op.position),
-    metadata: op?.metadata,
-  }));
-
 export const matchPathStepAndOp = (
   step: PathItemLocation,
   op: Pick<SuggestedOP, 'opId' | 'uic' | 'ch' | 'trigram' | 'track' | 'offsetOnTrack'>
@@ -53,6 +30,43 @@ export const matchPathStepAndOp = (
     return step.trigram === op.trigram && step.secondary_code === op.ch;
   }
   return step.track === op.track && step.offset === op.offsetOnTrack;
+};
+
+const populatePathStepIdInSuggestedOPs = (
+  suggestedOPs: SuggestedOP[],
+  pathSteps: PathStep[]
+): SuggestedOP[] =>
+  suggestedOPs.map((op) => ({
+    ...op,
+    pathStepId: pathSteps.find(
+      (pathStep) => matchPathStepAndOp(pathStep, op) // TODO: && op.kp === pathStep.kp && step.positionOnPath === op.positionOnPath
+    )?.id,
+  }));
+
+export const formatSuggestedOperationalPoints = (
+  operationalPoints: Array<
+    NonNullable<Required<PathProperties['operational_points']>>[number] & {
+      metadata?: NonNullable<SuggestedOP['metadata']>;
+    }
+  >,
+  pathSteps: PathStep[],
+  geometry: GeoJsonLineString,
+  pathLength: number
+): SuggestedOP[] => {
+  const suggestedOPs = operationalPoints.map((op) => ({
+    opId: op.id,
+    name: op.extensions?.identifier?.name,
+    uic: op.extensions?.identifier?.uic,
+    ch: op.extensions?.sncf?.ch,
+    kp: op.part.extensions?.sncf?.kp,
+    trigram: op.extensions?.sncf?.trigram,
+    offsetOnTrack: op.part.position,
+    track: op.part.track,
+    positionOnPath: op.position,
+    coordinates: getPointOnTrackCoordinates(geometry, pathLength, op.position),
+    metadata: op?.metadata,
+  }));
+  return populatePathStepIdInSuggestedOPs(suggestedOPs, pathSteps);
 };
 
 export const getPathfindingQuery = ({

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -138,14 +138,9 @@ export const upsertPathStepsInOPs = (ops: SuggestedOP[], pathSteps: PathStep[]):
       }
     } else {
       updatedOPs = updatedOPs.map((op) => {
-        if (
-          matchPathStepAndOp(step, op) &&
-          op.kp === step.kp &&
-          step.positionOnPath === op.positionOnPath
-        ) {
+        if (step.id === op.pathStepId) {
           return {
             ...op,
-            pathStepId: step.id,
             stopFor,
             arrival,
             receptionSignal,

--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { PathfindingState } from 'modules/pathfinding/types';
-import { isVia, matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import {
   updatePathSteps,
@@ -48,7 +47,7 @@ const createClearViaButton = ({
     pathStepsAndSuggestedOPs &&
     rowIndex > 0 &&
     rowIndex < pathStepsAndSuggestedOPs.length - 1 &&
-    isVia(pathSteps || [], rowData, { withKP: true }) &&
+    pathSteps.find((step) => step.id === rowData.pathStepId) &&
     (!isNil(rowData.stopFor) ||
       rowData.theoreticalMargin !== undefined ||
       rowData.arrival !== undefined ||
@@ -83,9 +82,7 @@ const TimesStopsInput = ({
   const { getTrackSectionsByIds, trackSectionsLoading } = useScenarioContext();
 
   const clearPathStep = (rowData: TimesStopsInputRow) => {
-    const index = pathSteps.findIndex(
-      (step) => matchPathStepAndOp(step, rowData) && step.positionOnPath === rowData.positionOnPath
-    );
+    const index = pathSteps.findIndex((step) => step.id === rowData.pathStepId);
 
     const updatedPathSteps = pathSteps.map((step, i) => {
       if (i === index) {

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -6,7 +6,6 @@ import { keyColumn, createTextColumn } from 'react-datasheet-grid';
 
 import type { ReceptionSignal } from 'common/api/osrdEditoastApi';
 import type { TimeString } from 'common/types';
-import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { Duration } from 'utils/duration';
@@ -23,18 +22,6 @@ import {
 import { marginRegExValidation, MarginUnit } from '../consts';
 import { TableType, type TimeExtraDays, type TimesStopsInputRow } from '../types';
 
-const matchPathStepAndOpWithKP = (step: PathStep, op: SuggestedOP) => {
-  if (!matchPathStepAndOp(step, op)) {
-    return step.id === op.pathStepId;
-  }
-  // We match the kp in case two OPs have the same uic+ch (can happen when the
-  // infra is imported)
-  if ('uic' in step || 'trigram' in step) {
-    return step.kp === op.kp;
-  }
-  return true;
-};
-
 export const formatSuggestedViasToRowVias = (
   operationalPoints: SuggestedOP[],
   pathSteps: PathStep[],
@@ -48,7 +35,7 @@ export const formatSuggestedViasToRowVias = (
   // to move it to the first position
   const origin = pathSteps[0];
   const originIndexInOps = origin
-    ? operationalPoints.findIndex((op) => matchPathStepAndOpWithKP(origin, op))
+    ? operationalPoints.findIndex((op) => origin.id === op.pathStepId)
     : -1;
   if (originIndexInOps !== -1) {
     [formattedOps[0], formattedOps[originIndexInOps]] = [
@@ -59,9 +46,7 @@ export const formatSuggestedViasToRowVias = (
 
   // Ditto: destination should be last
   const dest = pathSteps[pathSteps.length - 1];
-  const destIndexInOps = dest
-    ? operationalPoints.findIndex((op) => matchPathStepAndOpWithKP(dest, op))
-    : -1;
+  const destIndexInOps = dest ? operationalPoints.findIndex((op) => dest.id === op.pathStepId) : -1;
   if (destIndexInOps !== -1) {
     const lastOpIndex = formattedOps.length - 1;
     [formattedOps[lastOpIndex], formattedOps[destIndexInOps]] = [
@@ -71,7 +56,7 @@ export const formatSuggestedViasToRowVias = (
   }
 
   return formattedOps.map((op, i) => {
-    const pathStep = pathSteps.find((step) => matchPathStepAndOpWithKP(step, op));
+    const pathStep = pathSteps.find((step) => step.id === op.pathStepId);
     const { name } = pathStep || op;
     const objectToUse = tableType === TableType.Input ? pathStep : op;
 

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -124,6 +124,7 @@ const useOutputTableData = (
         if (matchingPathStep) {
           return {
             ...matchingPathStep,
+            pathStepId: matchingPathStep.pathStepId,
             opId: op.id,
             name: op.extensions?.identifier?.name,
             ch: op.extensions?.sncf?.ch,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/ItineraryMarkers.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/ItineraryMarkers.tsx
@@ -12,12 +12,11 @@ import stdcmOrigin from 'assets/pictures/mapMarkers/start.svg';
 import originSVG from 'assets/pictures/origin.svg';
 import viaSVG from 'assets/pictures/via.svg';
 import type { PathItemLocation, TrackSection } from 'common/api/osrdEditoastApi';
-import { matchPathStepAndOp } from 'modules/pathfinding/utils';
 import type { PathStep } from 'reducers/osrdconf/types';
 
 import type { SuggestedOP } from '../types';
 
-export type MarkerInformation = Pick<PathStep, 'name' | 'coordinates' | 'metadata'> &
+export type MarkerInformation = Pick<PathStep, 'id' | 'name' | 'coordinates' | 'metadata'> &
   PathItemLocation & {
     pointType: MARKER_TYPE;
   };
@@ -87,7 +86,7 @@ const extractMarkerInformation = (
       if (!pathStep.coordinates) return null;
 
       const matchingOp = suggestedOP
-        ? suggestedOP.find((op) => matchPathStepAndOp(pathStep, op))
+        ? suggestedOP.find((op) => pathStep.id === op.pathStepId)
         : undefined;
 
       const images = showStdcmAssets ? STDCM_MARKER_IMAGES : MARKER_IMAGES;

--- a/front/src/reducers/osrdconf/helpers.ts
+++ b/front/src/reducers/osrdconf/helpers.ts
@@ -4,7 +4,6 @@ import { v4 as uuidV4 } from 'uuid';
 
 import { calculateDistanceAlongTrack } from 'applications/editor/tools/utils';
 import type { MapPathProperties } from 'applications/operationalStudies/types';
-import { pathStepMatchesOp } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import { addElementAtIndex } from 'utils/array';
 
@@ -85,7 +84,7 @@ export function upsertPathStep(statePathSteps: (PathStep | null)[], op: Suggeste
         }),
   };
 
-  const stepIndex = cleanPathSteps.findIndex((step) => pathStepMatchesOp(step, op));
+  const stepIndex = cleanPathSteps.findIndex((step) => step.id === op.pathStepId);
   if (stepIndex >= 0) {
     // Because of import issues, there can be multiple ops with same position on path
     // To avoid updating the wrong one, we need to find the one that matches the payload


### PR DESCRIPTION
Last episode: https://github.com/OpenRailAssociation/osrd/pull/9967

Matching via uic/trigram/ch/etc is unreliable because:

- Two OPs can have the same trigram/ch.
- The same OP could appear multiple times at different spots in a
  path.

Moreover, we had multiple variants of the matching with slight
differences. Some of the matching logic got adjusted to account
for specific bugs, while others were left alone.

Each path step can be identified with a unique ID stored in
PathStep.id. Use that instead.

(The refactoring has been split into small digestible commits to ease bisecting and make it more obvious why type and test adjustments are necessary.)