### PR TITLE
front: remove high speed train from stdcm

### DIFF
--- a/front/src/assets/rollingStock/freightRollingStocks.ts
+++ b/front/src/assets/rollingStock/freightRollingStocks.ts
@@ -63,7 +63,6 @@ const FREIGHT_ROLLING_STOCKS = [
   '67300AG',
   '68000B',
   '71000A',
-  '72000TGV',
   '72001BG',
   '7200GS',
   '7200PH',


### PR DESCRIPTION
Remove this high-speed train that sneaked among the freight locomotives.
It's just a kick fix i haven't checked that it actually works cause i can't deploy locally, but i assume this small fix should work. If you can try it quickly at the review i'd be great :)
Thanks !