### PR TITLE
front: revert tolerances! in StdcmOrigin and StdcmDestination

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
@@ -31,8 +31,8 @@ const StdcmDestination = ({ disabled = false }: StdcmConfigCardProps) => {
         ? extractDateAndTimefromISO(destination.arrival)
         : undefined,
       destinationToleranceValues: {
-        arrivalToleranceBefore: destination.tolerances!.before,
-        arrivalToleranceAfter: destination.tolerances!.after,
+        arrivalToleranceBefore: destination.tolerances?.before || 0,
+        arrivalToleranceAfter: destination.tolerances?.after || 0,
       },
     }),
     [destination]

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
@@ -28,8 +28,8 @@ const StdcmOrigin = ({ disabled = false }: StdcmConfigCardProps) => {
     () => ({
       originArrival: origin.arrival ? extractDateAndTimefromISO(origin.arrival) : undefined,
       originToleranceValues: {
-        arrivalToleranceBefore: origin.tolerances!.before,
-        arrivalToleranceAfter: origin.tolerances!.after,
+        arrivalToleranceBefore: origin.tolerances?.before || 0,
+        arrivalToleranceAfter: origin.tolerances?.after || 0,
       },
     }),
     [origin]


### PR DESCRIPTION
tolerances are stored in the store and in the local storage. For some users, this field is still undefined in their local storage. However, since https://github.com/OpenRailAssociation/osrd/pull/9977, we assume that tolerances can not be undefined, which is not true if the users have not reset their store (=clean their cookies) or manullaly filled it.

To prevent the app from crashing when a user without tolerances opens the stdcm page, I revert the changes in StdcmOrigin and StdcmDestination for now.