### PR TITLE
front: add towed rolling stock e2e test

### DIFF
--- a/front/src/assets/rollingStock/freightRollingStocks.ts
+++ b/front/src/assets/rollingStock/freightRollingStocks.ts
@@ -108,10 +108,6 @@ const FREIGHT_ROLLING_STOCKS = [
   'Y8000AP',
   'Y9000US',
   'electric_rolling_stock_test_e2e',
-  'dual-mode_rolling_stock_test_e2e',
-  'slow_rolling_stock_test_e2e',
-  'fast_rolling_stock_test_e2e',
-  'improbable_rolling_stock_test_e2e',
 ];
 
 export default FREIGHT_ROLLING_STOCKS;

--- a/front/tests/006-stdcm.spec.ts
+++ b/front/tests/006-stdcm.spec.ts
@@ -1,10 +1,11 @@
-import type { Infra } from 'common/api/osrdEditoastApi';
+import type { Infra, TowedRollingStock } from 'common/api/osrdEditoastApi';
 
+import { electricRollingStockName } from './assets/project-const';
 import HomePage from './pages/home-page-model';
-import STDCMPage from './pages/stdcm-page-model';
+import STDCMPage, { type ConsistFields } from './pages/stdcm-page-model';
 import test from './test-logger';
-import { waitForInfraStateToBeCached } from './utils';
-import { getInfra } from './utils/api-setup';
+import { handleAndVerifyInput, waitForInfraStateToBeCached } from './utils';
+import { getInfra, setTowedRollingStock } from './utils/api-setup';
 
 test.use({
   launchOptions: {
@@ -18,9 +19,29 @@ test.describe('Verify train schedule elements and filters', () => {
 
   let infra: Infra;
   let OSRDLanguage: string;
+  let createdTowedRollingStock: TowedRollingStock;
+  const UPDATED_TONNAGE = '561';
+  const consistDetails: ConsistFields = {
+    tractionEngine: electricRollingStockName,
+    tonnage: '400',
+    length: '300',
+    maxSpeed: '180',
+    speedLimitTag: 'HLP',
+  };
+  const tractionEnginePrefilledValues = {
+    tonnage: '900',
+    length: '400',
+    maxSpeed: '288',
+  };
+  const towedRollingStockPrefilledValues = {
+    tonnage: '46',
+    length: '26',
+    maxSpeed: '180',
+  };
 
   test.beforeAll('Fetch infrastructure', async () => {
     infra = await getInfra();
+    createdTowedRollingStock = await setTowedRollingStock();
   });
 
   test.beforeEach('Navigate to the STDCM page', async ({ page }) => {
@@ -30,6 +51,7 @@ test.describe('Verify train schedule elements and filters', () => {
     OSRDLanguage = await homePage.getOSRDLanguage();
     await page.goto('/stdcm');
     await page.waitForLoadState('load', { timeout: 30 * 1000 });
+    await homePage.removeViteOverlay();
 
     // Wait for infra to be in 'CACHED' state before proceeding
     await waitForInfraStateToBeCached(infra.id);
@@ -48,19 +70,24 @@ test.describe('Verify train schedule elements and filters', () => {
   test('Launch STDCM simulation with all stops', async ({ page }) => {
     // Populate STDCM page with origin, destination, and via details, then verify
     const stdcmPage = new STDCMPage(page);
-    await stdcmPage.fillConsistDetails();
+
+    await stdcmPage.fillAndVerifyConsistDetails(
+      consistDetails,
+      tractionEnginePrefilledValues.tonnage,
+      tractionEnginePrefilledValues.length,
+      tractionEnginePrefilledValues.maxSpeed
+    );
     await stdcmPage.fillAndVerifyOriginDetails();
     await stdcmPage.fillAndVerifyDestinationDetails(OSRDLanguage);
     const viaDetails = [
-      { viaNumber: 1, ciSearchValue: 'mid_west' },
-      { viaNumber: 2, ciSearchValue: 'mid_east' },
-      { viaNumber: 3, ciSearchValue: 'nS', language: OSRDLanguage },
+      { viaNumber: 1, ciSearchText: 'mid_west' },
+      { viaNumber: 2, ciSearchText: 'mid_east' },
+      { viaNumber: 3, ciSearchText: 'nS', language: OSRDLanguage },
     ];
 
-    for (const { viaNumber, ciSearchValue, language } of viaDetails) {
-      await stdcmPage.fillAndVerifyViaDetails(viaNumber, ciSearchValue, language);
+    for (const viaDetail of viaDetails) {
+      await stdcmPage.fillAndVerifyViaDetails(viaDetail);
     }
-
     // Launch simulation and verify output data matches expected results
     await stdcmPage.launchSimulation();
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmAllStops.json');
@@ -70,10 +97,18 @@ test.describe('Verify train schedule elements and filters', () => {
   test('Verify STDCM stops and simulation sheet', async ({ page, browserName }) => {
     // Populate STDCM page with origin, destination, and via details
     const stdcmPage = new STDCMPage(page);
-    await stdcmPage.fillConsistDetails();
+    await stdcmPage.fillAndVerifyConsistDetails(
+      consistDetails,
+      tractionEnginePrefilledValues.tonnage,
+      tractionEnginePrefilledValues.length,
+      tractionEnginePrefilledValues.maxSpeed
+    );
     await stdcmPage.fillOriginDetailsLight();
     await stdcmPage.fillDestinationDetailsLight();
-    await stdcmPage.fillAndVerifyViaDetails(1, 'mid_west');
+    await stdcmPage.fillAndVerifyViaDetails({
+      viaNumber: 1,
+      ciSearchText: 'mid_west',
+    });
     // Verify input map markers in Chromium
     if (browserName === 'chromium') {
       await stdcmPage.mapMarkerVisibility();
@@ -85,13 +120,54 @@ test.describe('Verify train schedule elements and filters', () => {
       await stdcmPage.mapMarkerResultVisibility();
     }
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmWithoutAllVia.json');
-    await stdcmPage.clickOnAllViaButton();
+    await stdcmPage.displayAllOperationalPoints();
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmWithAllVia.json');
     await stdcmPage.retainSimulation();
     await stdcmPage.downloadSimulation(browserName);
     // Reset and verify empty fields
-    await stdcmPage.clickOnStartNewQueryButton();
+    await stdcmPage.startNewQuery();
     // TODO: Uncomment the check when the bug #9533 is fixed
     // await stdcmPage.verifyAllFieldsEmpty();
+  });
+
+  /** *************** Test 4 **************** */
+  test('Launch simulation with and without capacity for towed rolling stock', async ({ page }) => {
+    const towedConsistDetails: ConsistFields = {
+      tractionEngine: electricRollingStockName,
+      towedRollingStock: createdTowedRollingStock.name,
+    };
+    const stdcmPage = new STDCMPage(page);
+    await stdcmPage.fillAndVerifyConsistDetails(
+      towedConsistDetails,
+      tractionEnginePrefilledValues.tonnage,
+      tractionEnginePrefilledValues.length,
+      tractionEnginePrefilledValues.maxSpeed,
+      towedRollingStockPrefilledValues.tonnage,
+      towedRollingStockPrefilledValues.length,
+      towedRollingStockPrefilledValues.maxSpeed
+    );
+    await stdcmPage.fillOriginDetailsLight();
+    await stdcmPage.fillDestinationDetailsLight();
+    await stdcmPage.fillAndVerifyViaDetails({
+      viaNumber: 1,
+      ciSearchText: 'mid_west',
+    });
+    // Run first simulation without capacity
+    await stdcmPage.launchSimulation();
+    await stdcmPage.verifySimulationDetails({
+      language: OSRDLanguage,
+      simulationNumber: 1,
+    });
+    // Update tonnage and launch a second simulation with capacity
+    await handleAndVerifyInput(stdcmPage.tonnageField, UPDATED_TONNAGE);
+    await stdcmPage.launchSimulation();
+    await stdcmPage.verifySimulationDetails({
+      language: OSRDLanguage,
+      simulationNumber: 2,
+      simulationLengthAndDuration: '51 km — 24min',
+    });
+    await stdcmPage.verifyTableData(
+      './tests/assets/stdcm/towedRollingStock/towedRollingStockTableResult.json'
+    );
   });
 });

--- a/front/tests/assets/stdcm/towedRollingStock/towedRollingStock.json
+++ b/front/tests/assets/stdcm/towedRollingStock/towedRollingStock.json
@@ -1,0 +1,19 @@
+{
+  "name": "Towed-test-e2e",
+  "label": "",
+  "railjson_version": "3.2",
+  "locked": true,
+  "mass": 46000.0,
+  "length": 26.4,
+  "comfort_acceleration": 0.2,
+  "startup_acceleration": 0.05,
+  "inertia_coefficient": 1.038,
+  "rolling_resistance": {
+    "type": "davis",
+    "A": 8.596,
+    "B": 0.27396000000000004,
+    "C": 0.0225504
+  },
+  "const_gamma": 0.8,
+  "max_speed": 50
+}

--- a/front/tests/assets/stdcm/towedRollingStock/towedRollingStockTableResult.json
+++ b/front/tests/assets/stdcm/towedRollingStock/towedRollingStockTableResult.json
@@ -1,0 +1,32 @@
+[
+  {
+    "index": 1,
+    "operationalPoint": "North_West_station",
+    "code": "BV",
+    "endStop": "",
+    "passageStop": "",
+    "startStop": "20:21",
+    "weight": "561t",
+    "refEngine": ""
+  },
+  {
+    "index": 2,
+    "operationalPoint": "Mid_West_station",
+    "code": "BV",
+    "endStop": "",
+    "passageStop": "20:30",
+    "startStop": "",
+    "weight": "=",
+    "refEngine": "="
+  },
+  {
+    "index": 3,
+    "operationalPoint": "South_station",
+    "code": "BV",
+    "endStop": "20:46",
+    "passageStop": "",
+    "startStop": "",
+    "weight": "561t",
+    "refEngine": ""
+  }
+]

--- a/front/tests/global-setup.ts
+++ b/front/tests/global-setup.ts
@@ -4,6 +4,7 @@ import ROLLING_STOCK_NAMES, {
   globalProjectName,
   trainScheduleProjectName,
 } from './assets/project-const';
+import { logger } from './test-logger';
 import { getStdcmEnvironment } from './utils/api-setup';
 import { createDataForTests } from './utils/setup-utils';
 import { deleteProject, deleteRollingStocks } from './utils/teardown-utils';
@@ -14,12 +15,12 @@ setup('setup', async () => {
     process.env.STDCM_ENVIRONMENT = JSON.stringify(stdcmEnvironment);
   }
 
-  console.info('Starting test data setup ...');
+  logger.info('Starting test data setup ...');
 
   await deleteProject(trainScheduleProjectName);
   await deleteProject(globalProjectName);
   await deleteRollingStocks(ROLLING_STOCK_NAMES);
 
   await createDataForTests();
-  console.info('Test data setup completed successfully.');
+  logger.info('Test data setup completed successfully.');
 });

--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -6,12 +6,13 @@ import ROLLING_STOCK_NAMES, {
   globalProjectName,
   trainScheduleProjectName,
 } from './assets/project-const';
+import { logger } from './test-logger';
 import { setStdcmEnvironment } from './utils/api-setup';
 import { deleteProject, deleteRollingStocks } from './utils/teardown-utils';
 
 teardown('teardown', async ({ browser }) => {
   try {
-    console.info('Starting test data teardown...');
+    logger.info('Starting test data teardown...');
 
     // Delete projects and rolling stocks
     await deleteProject(trainScheduleProjectName);
@@ -20,11 +21,11 @@ teardown('teardown', async ({ browser }) => {
 
     // Delete saved files in the results directory
     fs.rmSync('./tests/stdcm-results', { recursive: true, force: true });
-    console.info('All downloaded files have been removed from the results directory.');
+    logger.info('All downloaded files have been removed from the results directory.');
 
     // Close all browser contexts
     await Promise.all(browser.contexts().map((context) => context.close()));
-    console.info('All browser contexts closed successfully.');
+    logger.info('All browser contexts closed successfully.');
 
     // Restore STDCM environment
     const savedEnvironment = process.env.STDCM_ENVIRONMENT
@@ -33,13 +34,13 @@ teardown('teardown', async ({ browser }) => {
 
     if (savedEnvironment) {
       await setStdcmEnvironment(savedEnvironment);
-      console.info('STDCM environment restored successfully.');
+      logger.info('STDCM environment restored successfully.');
     } else {
-      console.warn('No STDCM environment to restore.');
+      logger.warn('No STDCM environment to restore.');
     }
 
-    console.info('Test data teardown completed successfully.');
+    logger.info('Test data teardown completed successfully.');
   } catch (error) {
-    console.error('Error during test data teardown:', error);
+    logger.error('Error during test data teardown:', error);
   }
 });

--- a/front/tests/test-logger.ts
+++ b/front/tests/test-logger.ts
@@ -1,10 +1,10 @@
 import { test as baseTest } from '@playwright/test';
 
 // Simple logger
-const logger = {
+export const logger = {
   // eslint-disable-next-line no-console
   info: (message: string) => console.log(`[INFO] ${message}`),
-  error: (message: string) => console.error(`[ERROR] ${message}`),
+  error: (message: string, error?: unknown) => console.error(`[ERROR] ${message}`, error),
   warn: (message: string) => console.warn(`[WARN] ${message}`),
 };
 

--- a/front/tests/utils/index.ts
+++ b/front/tests/utils/index.ts
@@ -4,6 +4,7 @@ import { type Locator, type Page, expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getInfraById } from './api-setup';
+import { logger } from '../test-logger';
 
 /**
  * Fill the input field identified by ID or TestID with the specified value and verifies it.
@@ -88,7 +89,20 @@ export async function clickWithDelay(element: Locator, delay = 500): Promise<voi
   await element.click();
   await element.page().waitForTimeout(delay);
 }
-
+/**
+ * Generic function to handle input fields.
+ *
+ * @param {Locator} inputField - The locator for the input field to interact with.
+ * @param {string} [value] - The value to input into the field. If not provided, the function will do nothing.
+ * @returns {Promise<void>} A promise that resolves once the input field is filled and verified.
+ */
+export async function handleAndVerifyInput(inputField: Locator, value?: string): Promise<void> {
+  if (value) {
+    await inputField.click();
+    await inputField.fill(value);
+    await expect(inputField).toHaveValue(value);
+  }
+}
 /**
  * Convert a date string from YYYY-MM-DD format to "DD mmm YYYY" format.
  * @param dateString - The input date string in YYYY-MM-DD format.
@@ -123,12 +137,12 @@ export const waitForInfraStateToBeCached = async (infraId: number): Promise<void
     const infra = await getInfraById(infraId); // Retrieve the latest infra object
     if (infra.state === 'CACHED') {
       const totalTime = Date.now() - startTime;
-      console.info(
+      logger.info(
         `Infrastructure state is 'CACHED'. Total time taken: ${totalTime / 1000} seconds.`
       );
       return;
     }
-    console.info(
+    logger.info(
       `Attempt ${attempt + 1}: Infrastructure current state is '${infra.state}', waiting...`
     );
     await new Promise((resolve) => {

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -10,7 +10,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import { readJsonFile } from '.';
-import { getApiRequest, postApiRequest, setStdcmEnvironment } from './api-setup';
+import { getApiRequest, getInfra, postApiRequest, setStdcmEnvironment } from './api-setup';
 import createScenario from './scenario';
 import { sendTrainSchedules } from './trainSchedule';
 import projectData from '../assets/operationStudies/project.json';
@@ -28,6 +28,7 @@ import {
   trainScheduleScenarioName,
   trainScheduleStudyName,
 } from '../assets/project-const';
+import { logger } from '../test-logger';
 
 /**
  * Helper function to create infrastructure using RailJson.
@@ -144,7 +145,8 @@ export async function createDataForTests(): Promise<void> {
   const trainSchedulesJson = readJsonFile('./tests/assets/trainSchedule/train_schedules.json');
   try {
     // Step 1: Create infrastructure
-    const smallInfra = await createInfrastructure();
+    let smallInfra = await getInfra();
+    if (!smallInfra) smallInfra = await createInfrastructure();
 
     // Step 2: Create rolling stocks
     await createRollingStocks();
@@ -182,6 +184,6 @@ export async function createDataForTests(): Promise<void> {
 
     await setStdcmEnvironment(stdcmEnvironment);
   } catch (error) {
-    console.error('Error during test data setup:', error);
+    logger.error('Error during test data setup:', error);
   }
 }

--- a/front/tests/utils/teardown-utils.ts
+++ b/front/tests/utils/teardown-utils.ts
@@ -11,6 +11,7 @@ import {
   getScenario,
   getProject,
 } from './api-setup';
+import { logger } from '../test-logger';
 
 /**
  * Delete infrastructure by name if it exists.
@@ -24,7 +25,7 @@ export async function deleteInfra(infraName: string): Promise<void> {
   if (infra) {
     await deleteApiRequest(`/api/infra/${infra.id}`);
   } else {
-    console.warn(`Infra "${infraName}" not found for deletion.`);
+    logger.warn(`Infra "${infraName}" not found for deletion.`);
   }
 }
 
@@ -39,7 +40,7 @@ export async function deleteProject(projectName: string): Promise<void> {
   if (project) {
     await deleteApiRequest(`/api/projects/${project.id}`);
   } else {
-    console.warn(`Project "${projectName}" not found for deletion.`);
+    logger.warn(`Project "${projectName}" not found for deletion.`);
   }
 }
 
@@ -66,7 +67,7 @@ export async function deleteRollingStocks(rollingStockNames: string[]): Promise<
       rollingStockIds.map((id: number) => deleteApiRequest(`/api/rolling_stock/${id}`))
     );
   } else {
-    console.warn('No matching rolling stocks found for deletion.');
+    logger.warn('No matching rolling stocks found for deletion.');
   }
 }
 
@@ -82,7 +83,7 @@ export async function deleteStudy(projectId: number, studyName: string): Promise
   if (study) {
     await deleteApiRequest(`/api/projects/${projectId}/studies/${study.id}`);
   } else {
-    console.warn(`Study "${studyName}" not found for deletion.`);
+    logger.warn(`Study "${studyName}" not found for deletion.`);
   }
 }
 
@@ -103,6 +104,6 @@ export async function deleteScenario(
       `/api/projects/${projectId}/studies/${studyId}/scenarios/${scenario.id}`
     );
   } else {
-    console.warn(`Scenario "${scenarioName}" not found for deletion.`);
+    logger.warn(`Scenario "${scenarioName}" not found for deletion.`);
   }
 }


### PR DESCRIPTION
Closes #9743 

This PR:  
- Keeps only the required fake train for e2e tests in `freightRollingStocks.ts`.  
- Adjusts the method responsible for filling the consist fields to ensure that selecting a rolling stock or towed rolling stock correctly pre-fills the tonnage, length, and maximum speed fields.  
- Creates two simulations: one without outputs and another with outputs using a towed rolling stock, verifying the table outputs accordingly.  
- Replaces all `console` usage with the appropriate `logger` type.  
- Fixes typos.  
