### PR TITLE
front: setting power restrictions don't remove pathSteps

### DIFF
--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -75,6 +75,7 @@ const createPathStep = (
     ...trackOffset,
     // TODO: we should return the offset in mm once it is stored in mm in the store
     offset: mmToM(trackOffset.offset),
+    isFromPowerRestriction: true,
   };
 };
 
@@ -124,6 +125,7 @@ export const createCutAtPathStep = (
     id: nextId(),
     positionOnPath: cutAtPosition,
     coordinates: coordinatesAtCut,
+    isFromPowerRestriction: true,
     ...trackOffset,
     // TODO: we should return the offset in mm once it is stored in mm in the store
     offset: mmToM(trackOffset.offset),

--- a/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/utils.ts
@@ -95,7 +95,7 @@ export const cleanPathSteps = (
   powerRestrictions: PowerRestriction[]
 ): PathStep[] =>
   pathSteps.reduce((acc, pathStep, index) => {
-    if (index === 0 || index === pathSteps.length - 1) {
+    if (index === 0 || index === pathSteps.length - 1 || !pathStep.isFromPowerRestriction) {
       acc.push(pathStep);
       return acc;
     }

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -89,6 +89,14 @@ export type PathStep = PathItemLocation & {
     trackNumber: number;
   };
   isInvalid?: boolean;
+  /** Flag specifying whether the pathStep was created from the power restriction selector or not
+   *
+   * If true, the pathStep might be cleaned if its power restriction is removed (except if it has time, stop or margin constraints)
+   *
+   * This flag will only work if the user has not saved their change. Once the change is saved, the flag will be removed and the pathStep
+   * will become permanent.
+   */
+  isFromPowerRestriction?: boolean;
 };
 
 export type StdcmPathStep = {


### PR DESCRIPTION
closes #9361 

When manipulating power restrictions, the pathSteps without any constraints (stop, arrival time or margin) were cleaned. This was the expected behaviour before, because we could not have pathSteps without constraints.

As the expected behaviour changed (we now authorize pathSteps without constraints), the pathSteps created from the power restrictions selector have a new flag and may be cleaned if they are not linked anymore to a power restriction and have no constraints. The other pathSteps will not be cleaned.

:warning: There is currently another bug which resets automatically the power restrictions when editing a train (#9902). It should be fixed in another PR (#9924).

To test:
- create a train between PE and SG (select a rolling stock with power restrictions)
- add some via on the path (don't add any stop, arrival times or margins)
- add some power restrictions: cut a range in 2 and select a value
- check in the itinerary tab that a new via has appeared (or 2) for the power restriction range, but the other vias should still be there
- remove the power restriction range
- check in the itinerary tab that the vias linked to the power restriction range have disappeared, but not the other ones.