### PR TITLE
front: show map markers/itinerary when OSM map is unavailable

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
@@ -393,23 +393,19 @@ const Map = ({
             <RenderPopup pathProperties={pathProperties} />
           </>
         )}
-        {mapIsLoaded && (
-          <>
-            <ItineraryLayer
-              layerOrder={LAYER_GROUPS_ORDER[LAYERS.ITINERARY.GROUP]}
-              geometry={pathGeometry}
-              hideItineraryLine={hideItinerary}
-              showStdcmAssets={showStdcmAssets}
-              isFeasible={isFeasible}
-            />
-            {mapRef.current && (
-              <ItineraryMarkers
-                simulationPathSteps={simulationPathSteps}
-                map={mapRef.current.getMap()}
-                showStdcmAssets={showStdcmAssets}
-              />
-            )}
-          </>
+        <ItineraryLayer
+          layerOrder={LAYER_GROUPS_ORDER[LAYERS.ITINERARY.GROUP]}
+          geometry={pathGeometry}
+          hideItineraryLine={hideItinerary}
+          showStdcmAssets={showStdcmAssets}
+          isFeasible={isFeasible}
+        />
+        {mapRef.current && (
+          <ItineraryMarkers
+            simulationPathSteps={simulationPathSteps}
+            map={mapRef.current.getMap()}
+            showStdcmAssets={showStdcmAssets}
+          />
         )}
         {mapSearchMarker && <SearchMarker data={mapSearchMarker} colors={colors[mapStyle]} />}
         {snappedPoint !== undefined && <SnappedMarker geojson={snappedPoint} />}


### PR DESCRIPTION
When the OSM map background is unavailable, we can still display the map markers and itinerary.

Reverts part of b038d3eba049 ("front: display itinerary markers name when editing a train").