### PR TITLE
front: update top positon of compass in map buttons

### DIFF
--- a/front/src/styles/scss/common/map/_map.scss
+++ b/front/src/styles/scss/common/map/_map.scss
@@ -63,7 +63,7 @@
     .compass-needle,
     .compass-cardinal {
       position: absolute;
-      top: 16px;
+      top: 12px;
       left: 18px;
       transform: translate(-40%, 0);
     }


### PR DESCRIPTION
closes https://github.com/osrd-project/osrd-confidential/issues/670

Check that the last button and the compass button are centered.

The 4px shift is that in the previous PR we used a 4px margin block and now simply an 8px margin bottom.