### PR TITLE
Revert "front: deactivate marker check for e2e tests"

### DIFF
--- a/front/tests/006-stdcm.spec.ts
+++ b/front/tests/006-stdcm.spec.ts
@@ -73,17 +73,15 @@ test.describe('Verify train schedule elements and filters', () => {
     await stdcmPage.fillDestinationDetailsLight();
     await stdcmPage.fillAndVerifyViaDetails(1, 'mid_west');
     // Verify input map markers in Chromium
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   await stdcmPage.mapMarkerVisibility();
-    // }
+    if (browserName === 'chromium') {
+      await stdcmPage.mapMarkerVisibility();
+    }
     // Launch simulation and verify output data matches expected results
     await stdcmPage.launchSimulation();
     // Verify map results markers in Chromium
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   await stdcmPage.mapMarkerResultVisibility();
-    // }
+    if (browserName === 'chromium') {
+      await stdcmPage.mapMarkerResultVisibility();
+    }
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmWithoutAllVia.json');
     await stdcmPage.clickOnAllViaButton();
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmWithAllVia.json');

--- a/front/tests/010-op-route-tab.spec.ts
+++ b/front/tests/010-op-route-tab.spec.ts
@@ -58,7 +58,7 @@ test.describe('Route Tab Verification', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('Select a route for operational study', async ({ page }) => {
+  test('Select a route for operational study', async ({ page, browserName }) => {
     const operationalStudiesPage = new OperationalStudiesPage(page);
     const routePage = new RoutePage(page);
 
@@ -67,18 +67,17 @@ test.describe('Route Tab Verification', () => {
 
     // Perform pathfinding by station trigrams and verify map markers in Chromium
     await routePage.performPathfindingByTrigram('WS', 'NES', 'MES');
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   const expectedMapMarkersValues = ['West_station', 'North_East_station', 'Mid_East_station'];
-    //   await routePage.verifyMapMarkers(...expectedMapMarkersValues);
-    // }
+    if (browserName === 'chromium') {
+      const expectedMapMarkersValues = ['West_station', 'North_East_station', 'Mid_East_station'];
+      await routePage.verifyMapMarkers(...expectedMapMarkersValues);
+    }
 
     // Verify that tab warnings are absent
     await operationalStudiesPage.verifyTabWarningAbsence();
   });
 
   /** *************** Test 2 **************** */
-  test('Adding waypoints to a route for operational study', async ({ page }) => {
+  test('Adding waypoints to a route for operational study', async ({ page, browserName }) => {
     const operationalStudiesPage = new OperationalStudiesPage(page);
     const routePage = new RoutePage(page);
 
@@ -93,40 +92,40 @@ test.describe('Route Tab Verification', () => {
     await routePage.addNewWaypoints(2, ['Mid_West_station', 'Mid_East_station'], expectedViaValues);
 
     // Verify map markers in Chromium
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   const expectedMapMarkersValues = [
-    //     'West_station',
-    //     'Mid_West_station',
-    //     'Mid_East_station',
-    //     'North_East_station',
-    //   ];
-    //   await routePage.verifyMapMarkers(...expectedMapMarkersValues);
-    // }
+    if (browserName === 'chromium') {
+      const expectedMapMarkersValues = [
+        'West_station',
+        'Mid_West_station',
+        'Mid_East_station',
+        'North_East_station',
+      ];
+      await routePage.verifyMapMarkers(...expectedMapMarkersValues);
+    }
 
     // Verify that tab warnings are absent
     await operationalStudiesPage.verifyTabWarningAbsence();
   });
 
   /** *************** Test 3 **************** */
-  test('Reversing and deleting waypoints in a route for operational study', async ({ page }) => {
+  test('Reversing and deleting waypoints in a route for operational study', async ({
+    page,
+    browserName,
+  }) => {
     const routePage = new RoutePage(page);
 
     // Perform pathfinding by station trigrams and verify map markers in Chromium
     await routePage.performPathfindingByTrigram('WS', 'SES', 'MWS');
-    // TODO: Uncomment this part when osm server is up again
-    // const expectedMapMarkersValues = ['West_station', 'South_East_station', 'Mid_West_station'];
-    // if (browserName === 'chromium') {
-    //   await routePage.verifyMapMarkers(...expectedMapMarkersValues);
-    // }
+    const expectedMapMarkersValues = ['West_station', 'South_East_station', 'Mid_West_station'];
+    if (browserName === 'chromium') {
+      await routePage.verifyMapMarkers(...expectedMapMarkersValues);
+    }
 
     // Reverse the itinerary and verify the map markers
     await routePage.clickOnReverseItinerary();
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   const reversedMapMarkersValues = [...expectedMapMarkersValues].reverse();
-    //   await routePage.verifyMapMarkers(...reversedMapMarkersValues);
-    // }
+    if (browserName === 'chromium') {
+      const reversedMapMarkersValues = [...expectedMapMarkersValues].reverse();
+      await routePage.verifyMapMarkers(...reversedMapMarkersValues);
+    }
 
     // Delete operational points and verify no selected route
     await routePage.clickOnDeleteOPButtons(OSRDLanguage);
@@ -134,10 +133,9 @@ test.describe('Route Tab Verification', () => {
 
     // Perform pathfinding again and verify map markers in Chromium
     await routePage.performPathfindingByTrigram('WS', 'SES', 'MWS');
-    // TODO: Uncomment this part when osm server is up again
-    // if (browserName === 'chromium') {
-    //   await routePage.verifyMapMarkers(...expectedMapMarkersValues);
-    // }
+    if (browserName === 'chromium') {
+      await routePage.verifyMapMarkers(...expectedMapMarkersValues);
+    }
 
     // Delete the itinerary and verify no selected route
     await routePage.clickDeleteItineraryButton();


### PR DESCRIPTION
This reverts commit c66903323307900202f0c9a2ddcf129b020e27d6.

The bug was fixed in 8e9c6d43b117 ("front: show map markers/itinerary when OSM map is unavailable").