### PR TITLE
front: bump import-meta-env

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -105,8 +105,8 @@
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
-        "@import-meta-env/prepare": "^0.1.13",
-        "@import-meta-env/unplugin": "^0.5.1",
+        "@import-meta-env/prepare": "^0.2.1",
+        "@import-meta-env/unplugin": "^0.6.1",
         "@playwright/test": "^1.41.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -129,7 +129,6 @@
         "@vitejs/plugin-react": "^4.3.4",
         "@vitejs/plugin-react-swc": "^3.7.2",
         "@vitest/coverage-v8": "^2.1.8",
-        "dotenv": "^16.4.7",
         "eslint": "^8.56.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.1.0",
@@ -955,15 +954,16 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@import-meta-env/prepare": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@import-meta-env/prepare/-/prepare-0.1.14.tgz",
-      "integrity": "sha512-bkf1U5mEyEd4S4qT0vjIm9IPhxlBWnRjCfVLQW+GCajosh92gjO4bxsenasLeRTwiGi1cKo7LRDBdbugN6EpdA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@import-meta-env/prepare/-/prepare-0.2.1.tgz",
+      "integrity": "sha512-NEP83/y/cnIkPoHD4qddldkRkfnXDfZkrAb/IiICgOCByUMAYs2KunEJGPlhkg24JmGjD5BHMWzQrtHbAfwOIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "12.1.0",
+        "dotenv": "^16.0.0",
         "glob": "11.0.0",
-        "picocolors": "1.0.1",
+        "picocolors": "1.1.1",
         "serialize-javascript": "6.0.2"
       },
       "bin": {
@@ -971,37 +971,27 @@
       },
       "engines": {
         "node": ">= 14"
-      },
-      "peerDependencies": {
-        "dotenv": "^11.0.0 || ^12.0.4 || ^13.0.1 || ^14.3.2 || ^15.0.1 || ^16.0.0"
       }
     },
-    "node_modules/@import-meta-env/prepare/node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@import-meta-env/unplugin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@import-meta-env/unplugin/-/unplugin-0.5.2.tgz",
-      "integrity": "sha512-v4/BBoq9GseABxpBuxmuNsLFkHGr9rhCg5T+t00cGf2q67o8xjn3LrxVa8OiYqN49c5J2OLHj4udL5wzIxrtCQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@import-meta-env/unplugin/-/unplugin-0.6.1.tgz",
+      "integrity": "sha512-LxoU4O49tbLIfDI+w/aVIECzF27pi2qjjUO1hDhLO49mzKDvoK9k4uNJQBV2SJPbTLPcnhJ1Psu6ajo848lGBw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.0.0",
         "magic-string": "^0.30.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "unplugin": "^1.5.0"
+        "unplugin": "^2.0.0"
       },
       "engines": {
         "node": ">= 14"
       },
       "peerDependencies": {
-        "@import-meta-env/cli": "^0.5.1 || ^0.6.0",
-        "dotenv": "^11.0.0 || ^12.0.4 || ^13.0.1 || ^14.3.2 || ^15.0.1 || ^16.0.0"
+        "@import-meta-env/cli": "^0.7.0"
       },
       "peerDependenciesMeta": {
         "@import-meta-env/cli": {
@@ -4683,9 +4673,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -15685,9 +15675,9 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -20912,25 +20902,17 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.14.1.tgz",
-      "integrity": "sha512-lBlHbfSFPToDYp9pjXlUEFVxYLaue9f9T1HC+4OHlmj+HnMDdz9oZY+erXfoCe/5V/7gKUSY2jpXPb9S7f0f/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.1.0.tgz",
+      "integrity": "sha512-us4j03/499KhbGP8BU7Hrzrgseo+KdfJYWcbcajCOqsAyb8Gk0Yn2kiUIcZISYCb1JFaZfIuG3b42HmguVOKCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.12.1",
+        "acorn": "^8.14.0",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "webpack-sources": "^3"
-      },
-      "peerDependenciesMeta": {
-        "webpack-sources": {
-          "optional": true
-        }
+        "node": ">=18.12.0"
       }
     },
     "node_modules/unset-value": {
@@ -22582,18 +22564,6 @@
         "webpack-command": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/front/package.json
+++ b/front/package.json
@@ -100,8 +100,8 @@
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
-    "@import-meta-env/prepare": "^0.1.13",
-    "@import-meta-env/unplugin": "^0.5.1",
+    "@import-meta-env/prepare": "^0.2.1",
+    "@import-meta-env/unplugin": "^0.6.1",
     "@playwright/test": "^1.41.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -124,7 +124,6 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitejs/plugin-react-swc": "^3.7.2",
     "@vitest/coverage-v8": "^2.1.8",
-    "dotenv": "^16.4.7",
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
Bump @import-meta-env/prepare and @import-meta-env/unplugin. Remove the explicit dependency on dotenv since import-meta-env now has an explicit dependency on this package.