### PR TITLE
front: remove now-unnecessary cast to HTMLInputElement in RadioButton

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedTrainResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmLinkedTrainResults.tsx
@@ -45,7 +45,7 @@ const StdcmLinkedTrainResults = ({
               value={`${index}`}
               name={`linked-train-radio-buttons-${extremityType}`}
               onClick={({ target }) => {
-                const resultIndex = Number((target as HTMLInputElement).value);
+                const resultIndex = Number(target.value);
                 dispatch(
                   updateLinkedTrainExtremity({
                     linkedTrainExtremity: extremityType,


### PR DESCRIPTION
References: https://github.com/OpenRailAssociation/osrd-ui/pull/762