### PR TITLE
front: fix typo in classname

### DIFF
--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainDetail.tsx
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/ImportTrainScheduleTrainDetail.tsx
@@ -78,7 +78,7 @@ export default function ImportTrainScheduleTrainDetail({
         </span>
         <span
           className={`import-train-schedule-traindetail-stepnb ${
-            trainData.steps.length <= 2 ? 'import-invalid-stepnb' : 'bg-primary'
+            trainData.steps.length <= 2 ? 'import-invalid-step-nb' : 'bg-primary'
           }`}
         >
           {trainData.steps.length - 2}


### PR DESCRIPTION
close #9594 

I've let a typo in the previous feature fixing it. 