### PR TITLE
front: drop pathfinding error message bubble

### DIFF
--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -90,7 +90,6 @@ const usePathfinding = (
       launchPathfinding(updatedPathSteps);
     } else {
       setError(t('missingPathSteps'));
-      dispatch(setFailure({ name: t('pathfindingError'), message: t('missingPathSteps') }));
     }
   };
 


### PR DESCRIPTION
The "pathfindingError" translation needs an "errorMessage" property, so it's not displayed properly.
    
Since the error is already displayed to the user in a different way, we can just drop the bubble.

To reproduce:

- Select a train in small_infra
- Switch to another infra (e.g. France)
- Open the "Create new train" modal