### PR TITLE
editoast: 'OtelAxumLayer' act as 'INFO' level

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -94,7 +94,9 @@ axum-extra = { version = "0.9.6", default-features = false, features = [
   "typed-header",
 ] }
 axum-test = { version = "16.4.1", default-features = false }
-axum-tracing-opentelemetry = { version = "0.24.1", default-features = false }
+axum-tracing-opentelemetry = { version = "0.24.1", default-features = false, features = [
+  "tracing_level_info",
+] }
 chrono.workspace = true
 clap = { version = "4.5.23", features = ["derive", "env"] }
 colored = "2.2.0"


### PR DESCRIPTION
By default, the 'OtelAxumLayer' only creates span at 'TRACE' level. That means that if you try `tracing::Span::current()` in a handler, you will get a `Span::none()` in response. This span is useless (it doesn't have a subscriber, no metadata): it can't be used with OpenTelemetry since all interactions between 'tracing' and 'opentelemetry' happens through `Span::with_subscriber()`.