### PR TITLE
core: stdcm: limit the loop where we look for possible delays

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -132,7 +132,7 @@ internal constructor(
     private fun getDelaysPerOpening(): Set<Double> {
         return graph.delayManager.minimumDelaysPerOpening(
             getExplorerWithNewEnvelope()!!,
-            prevNode.timeData.earliestReachableTime,
+            prevNode.timeData,
             envelope!!,
             startOffset,
         )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPathfinding.kt
@@ -25,6 +25,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
 import java.time.Instant
 import java.util.*
+import kotlin.Double.Companion.POSITIVE_INFINITY
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -272,7 +273,7 @@ class STDCMPathfinding(
                             earliestReachableTime = startTime,
                             maxDepartureDelayingWithoutConflict = maxDepartureDelay,
                             departureTime = startTime,
-                            timeOfNextConflictAtLocation = 0.0,
+                            timeOfNextConflictAtLocation = POSITIVE_INFINITY,
                             totalRunningTime = 0.0,
                             stopTimeData = listOf(),
                             maxFirstDepartureDelaying = maxDepartureDelay,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -89,6 +89,9 @@ data class TimeData(
         var maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict
         val nextEarliestReachableTime =
             earliestReachableTime + extraTravelTime + (extraStopTime ?: 0.0)
+        var timeOfNextConflict = timeOfNextConflictAtLocation
+        if (maxAdditionalStopTime != null)
+            timeOfNextConflict = nextEarliestReachableTime + maxAdditionalStopTime
         if (extraStopTime != null) {
             val stopDataCopy = newStopData.toMutableList()
             stopDataCopy.add(
@@ -108,6 +111,7 @@ data class TimeData(
             maxDepartureDelayingWithoutConflict = maxDepartureDelayingWithoutConflict,
             maxFirstDepartureDelaying =
                 min(maxFirstDepartureDelaying, (maxAdditionalStopTime ?: POSITIVE_INFINITY)),
+            timeOfNextConflictAtLocation = timeOfNextConflict,
         )
     }
 


### PR DESCRIPTION
We would keep looking for different "openings" even very far in the future. This limits both conflict detection calls and the early steps of edge building.

The speedup is actually *really good* (roughly dividing the computation time by 2).

In the previous version, we would do something like that: we look for "openings" infinitely far in the future, and it's only when checking for conflicts and engineering allowances that we would discard them. In this case (and in fact in most case), there's only one "opening" available without clear conflicts.

![image](https://github.com/user-attachments/assets/fe792a54-fb21-43ec-9279-71f27027be15)
