### PR TITLE
editoast: optimize build scripts and macros for dev

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -220,3 +220,6 @@ debug = "full"
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
+
+[profile.dev.build-override]
+opt-level = 3


### PR DESCRIPTION
In https://corrode.dev/blog/tips-for-faster-rust-compile-times/#avoid-procedural-macro-crates, it's suggested to compile macro and build scripts with maximum optimization level, since they themselves will be used for code generation during the compilation.

We can also find some information on the official Rust documentation. https://doc.rust-lang.org/cargo/reference/profiles.html#build-dependencies

Note that I tried to measure that and the results are interesting. A full rebuild is significantly slower (the time it takes to optimize these macros is not win later when using them).

<details>
<summary>Full rebuild: 232s -> 372s (unfold for details)</summary>

```
❯ hyperfine \
    --parameter-list branch 'dev,wsl/editoast/fast-macros' \
    --setup 'git switch {branch}' \
    --max-runs 3 \
    --prepare 'cargo clean' \
    'cargo build'

Benchmark 1: cargo build (branch = dev)
  Time (mean ± σ):     232.396 s ±  6.294 s    [User: 1125.013 s, System: 65.498 s]
  Range (min … max):   227.123 s … 239.363 s    3 runs

Benchmark 2: cargo build (branch = wsl/editoast/fast-macros)
  Time (mean ± σ):     372.540 s ±  5.647 s    [User: 2581.742 s, System: 72.775 s]
  Range (min … max):   366.605 s … 377.845 s    3 runs

Summary
  cargo build (branch = dev) ran
    1.60 ± 0.05 times faster than cargo build (branch = wsl/editoast/fast-macros)
```

</details>

However, when only touching the crates that are interesting to us, it seems that the compilation times improve.

<details>
<summary>Only `editoast_*` crates rebuild 26.6s -> 24.5s (unfold for details)</summary>

```
❯ hyperfine \
    --parameter-list branch 'dev,wsl/editoast/fast-macros' \
    --setup 'git switch {branch} && cargo clean && cargo build' \
    --prepare 'touch src/main.rs && touch editoast_{authz,common,models,osrdyne_client,schemas,search}/src/lib.rs' \
    'cargo build'

Benchmark 1: cargo build (branch = dev)
  Time (mean ± σ):     26.636 s ±  0.915 s    [User: 29.259 s, System: 3.293 s]
  Range (min … max):   25.292 s … 28.020 s    10 runs

Benchmark 2: cargo build (branch = wsl/editoast/fast-macros)
  Time (mean ± σ):     24.478 s ±  0.428 s    [User: 26.830 s, System: 3.254 s]
  Range (min … max):   24.039 s … 25.425 s    10 runs

Summary
  cargo build (branch = wsl/editoast/fast-macros) ran
    1.09 ± 0.04 times faster than cargo build (branch = dev)

```

</details>

I would argue that as developers, we are most of the time in the second case than in the first, therefore, it might be a good idea to merge this PR? What do you think?