### PR TITLE
front: add a second button in lmr for new request with prefill form

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -68,6 +68,7 @@
       },
       "simulationSelected": "You have selected this simulation",
       "startNewQuery": "Start a new query",
+      "startNewQueryFromCurrent": "Start a new query from the current one",
       "status": {
         "completed": "Calculation completed",
         "errorMessage": "We are sorry that we could not process your request. The LMR team has been notified and will be aware of the situation as soon as possible.",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -68,6 +68,7 @@
       },
       "simulationSelected": "Vous avez retenu cette simulation",
       "startNewQuery": "Démarrez une nouvelle requête",
+      "startNewQueryFromCurrent": "Démarrez une nouvelle requête à partir de celle-ci",
       "status": {
         "completed": "Calcul terminé",
         "errorMessage": "Nous sommes désolés de ne pas avoir pu traiter votre demande. L’équipe LMR a été notifiée et prendra connaissance de la situation dès que possible.",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -127,7 +127,13 @@ const StdcmConfig = ({
   }, [infra]);
 
   useEffect(() => {
-    dispatch(resetStdcmConfig());
+    const keepForm = localStorage.getItem('keepForm');
+
+    if (!keepForm) {
+      dispatch(resetStdcmConfig());
+    } else {
+      localStorage.removeItem('keepForm');
+    }
   }, []);
 
   return (

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -26,6 +26,8 @@ type StcdmResultsProps = {
   onRetainSimulation: () => void;
   onSelectSimulation: (simulationIndex: number) => void;
   onStartNewQuery: () => void;
+  onStartNewQueryWithData: () => void;
+  buttonsVisible: boolean;
   retainedSimulationIndex: number;
   selectedSimulationIndex: number;
   showStatusBanner: boolean;
@@ -39,6 +41,8 @@ const StcdmResults = ({
   onRetainSimulation,
   onSelectSimulation,
   onStartNewQuery,
+  onStartNewQueryWithData,
+  buttonsVisible,
   retainedSimulationIndex,
   selectedSimulationIndex,
   showStatusBanner,
@@ -120,13 +124,20 @@ const StcdmResults = ({
                 <div className="gesico-text">{t('gesicoRequest')}</div>
               </div>
             )}
-            {retainedSimulationIndex > -1 && (
+            {retainedSimulationIndex > -1 && buttonsVisible && (
               <div className="start-new-query">
                 <Button
                   data-testid="start-new-query-button"
-                  variant="Normal"
+                  variant="Primary"
                   label={t('startNewQuery')}
                   onClick={onStartNewQuery}
+                />
+                <Button
+                  className="start-new-query-with-data"
+                  data-testid="start-new-query-with-data-button"
+                  variant="Normal"
+                  label={t('startNewQueryFromCurrent')}
+                  onClick={onStartNewQueryWithData}
                 />
               </div>
             )}

--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -29,6 +29,7 @@ const StdcmView = () => {
   const [showBtnToLaunchSimulation, setShowBtnToLaunchSimulation] = useState(false);
   const [isDebugMode, setIsDebugMode] = useState(false);
   const [showHelpModule, setShowHelpModule] = useState(false);
+  const [buttonsVisible, setButtonsVisible] = useState(true);
 
   const {
     launchStdcmRequest,
@@ -47,8 +48,7 @@ const StdcmView = () => {
   const { loading, error, loadStdcmEnvironment } = useStdcmEnvironment();
 
   const dispatch = useAppDispatch();
-  const { resetStdcmConfig, updateStdcmConfigWithData } =
-    useOsrdConfActions() as StdcmConfSliceActions;
+  const { updateStdcmConfigWithData } = useOsrdConfActions() as StdcmConfSliceActions;
 
   const selectedSimulation = simulationsList[selectedSimulationIndex];
   const showResults = showStatusBanner || simulationsList.length > 0 || hasConflicts;
@@ -62,12 +62,27 @@ const StdcmView = () => {
     }
   };
 
+  const openNewWindow = () => {
+    const newWindow = window.open(window.location.href, '_blank');
+    if (newWindow) {
+      newWindow.onload = () => {
+        newWindow.focus();
+      };
+    }
+  };
+
   const handleStartNewQuery = () => {
-    setSimulationsList([]);
+    setButtonsVisible(false);
     resetStdcmState();
-    setSelectedSimulationIndex(-1);
-    setRetainedSimulationIndex(-1);
-    dispatch(resetStdcmConfig());
+
+    openNewWindow();
+  };
+
+  const handleStartNewQueryWithData = () => {
+    setButtonsVisible(false);
+    localStorage.setItem('keepForm', 'true');
+
+    openNewWindow();
   };
 
   const toggleHelpModule = () => setShowHelpModule((show) => !show);
@@ -215,6 +230,8 @@ const StdcmView = () => {
                   onRetainSimulation={handleRetainSimulation}
                   onSelectSimulation={handleSelectSimulation}
                   onStartNewQuery={handleStartNewQuery}
+                  onStartNewQueryWithData={handleStartNewQueryWithData}
+                  buttonsVisible={buttonsVisible}
                   retainedSimulationIndex={retainedSimulationIndex}
                   selectedSimulationIndex={selectedSimulationIndex}
                   showStatusBanner={showStatusBanner}

--- a/front/src/styles/scss/applications/stdcm/_results.scss
+++ b/front/src/styles/scss/applications/stdcm/_results.scss
@@ -324,8 +324,12 @@
       .start-new-query {
         margin-top: 76px;
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
+        .start-new-query-with-data {
+          margin-top: 48px;
+        }
       }
     }
 

--- a/front/tests/pages/stdcm-page-model.ts
+++ b/front/tests/pages/stdcm-page-model.ts
@@ -137,6 +137,8 @@ class STDCMPage {
 
   readonly startNewQueryButton: Locator;
 
+  readonly startNewQueryWithDataButton: Locator;
+
   readonly originMarker: Locator;
 
   readonly destinationMarker: Locator;
@@ -222,6 +224,7 @@ class STDCMPage {
     this.retainSimulationButton = page.getByTestId('retain-simulation-button');
     this.downloadSimulationButton = page.getByTestId('download-simulation-button');
     this.startNewQueryButton = page.getByTestId('start-new-query-button');
+    this.startNewQueryWithDataButton = page.getByTestId('start-new-query-with-data-button');
     this.originMarker = this.mapContainer.locator('img[alt="origin"]');
     this.destinationMarker = this.mapContainer.locator('img[alt="destination"]');
     this.viaMarker = this.mapContainer.locator('img[alt="via"]');
@@ -671,6 +674,7 @@ class STDCMPage {
     await expect(this.downloadSimulationButton).toBeVisible();
     await expect(this.downloadSimulationButton).toBeEnabled();
     await expect(this.startNewQueryButton).toBeVisible();
+    await expect(this.startNewQueryWithDataButton).toBeVisible();
   }
 
   async downloadSimulation(browserName: string) {


### PR DESCRIPTION
close #9695

Edit: seen with @axrolld, now we withdraw the two buttons in the initial page when one of them is clicked. 