### PR TITLE
editoast: improve tests for projection

### DIFF
--- a/editoast/editoast_schemas/src/infra/direction.rs
+++ b/editoast/editoast_schemas/src/infra/direction.rs
@@ -22,3 +22,13 @@ impl From<Direction> for RangeMapDirection {
         }
     }
 }
+
+impl Direction {
+    #[must_use]
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::StartToStop => Self::StopToStart,
+            Self::StopToStart => Self::StartToStop,
+        }
+    }
+}

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -180,6 +180,40 @@ impl From<editoast_schemas::infra::DirectionalTrackRange> for TrackRange {
     }
 }
 
+#[cfg(test)]
+impl std::str::FromStr for TrackRange {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((name, offsets)) = s.split_once('+') else {
+            return Err(String::from(
+                "track range must contain at least a '+' and be of the form \"A+12-25\"",
+            ));
+        };
+        let track_section = Identifier::from(name);
+        let Some((begin, end)) = offsets.split_once('-') else {
+            return Err(String::from("track range must contain '-' to separate the offsets and be of the form \"A+12-25\""));
+        };
+        let Ok(begin) = begin.parse() else {
+            return Err(format!("{begin} in track range should be an integer"));
+        };
+        let Ok(end) = end.parse() else {
+            return Err(format!("{end} in track range should be an integer"));
+        };
+        let (begin, end, direction) = if begin < end {
+            (begin, end, Direction::StartToStop)
+        } else {
+            (end, begin, Direction::StopToStart)
+        };
+        Ok(TrackRange {
+            track_section,
+            begin,
+            end,
+            direction,
+        })
+    }
+}
+
 impl TrackRange {
     #[cfg(test)]
     /// Creates a new `TrackRange`.

--- a/editoast/src/views/path/projection.rs
+++ b/editoast/src/views/path/projection.rs
@@ -411,6 +411,12 @@ mod tests {
     // One track on the path
     #[case::one_path_different_track(&["A+0-100"], &["B+0-100"], &[])]
     #[case::one_path_no_overlap(&["A+0-100"], &["A+100-200"], &[])]
+    #[case::one_path_one_simple_intersection(&["A+120-140"], &["A+100-200"], &[(20, 40)])]
+    #[case::one_path_one_simple_intersection_reverse_on_track_ranges(&["A+140-120"], &["A+100-200"], &[(20, 40)])]
+    #[case::two_path_merged(&["A+180-200", "B+100-120"], &["A+100-200", "B+100-200"], &[(80, 120)])]
+    #[case::two_path_not_merged(&["A+180-220", "B+80-120"], &["A+100-200", "B+100-200"], &[(80, 120)])]
+    #[case::two_path_merged_with_extra_bounds(&["A+180-220", "B+80-120"], &["A+100-200", "B+100-200"], &[(80, 120)])]
+    #[case::three_path_with_hole(&["A+150-200", "C+100-150"], &["A+100-200", "B+100-200", "C+100-200"], &[(50, 100), (200, 250)])]
     // Complex paths with complex track ranges
     #[case::complex_path_one_intersection(
         &["A+50-100", "B+200-0", "C+0-300", "D+250-120"],


### PR DESCRIPTION
We're planning a rework of the projection algorithm to support a case that is not supported today: project multiple times the same track range (possibly different offset). This use case is brought to us by work schedule which might have this pattern.

In order to have a good refactoring without breaking anything, let's have even more tests.

> [!NOTE]
> Review by commit
> 1. first commit just make use of `rstest` cases to express tests in a more concise way
> 2. second commit add more tests
> 3. third commit, automate switching direction of inputs (multiply by 4 the numbers of tests)

> [!WARNING]
> The third commit significantly make the test code harder to read so I'd be happy to discuss it... 