### PR TITLE
core: sim: add speed limit anticipation back

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import com.google.common.collect.TreeRangeMap
+import fr.sncf.osrd.DriverBehaviour
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.api_v2.RangeValues
 import fr.sncf.osrd.api.api_v2.standalone_sim.ElectricalProfileValue
@@ -60,11 +61,13 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-    pathItemPositions: List<Offset<Path>>
+    pathItemPositions: List<Offset<Path>>,
+    driverBehaviour: DriverBehaviour = DriverBehaviour()
 ): SimulationSuccess {
     // MRSP & SpeedLimits
     val safetySpeedRanges = makeSafetySpeedRanges(infra, chunkPath, routes, schedule)
-    val mrsp = computeMRSP(pathProps, rollingStock, true, speedLimitTag, null, safetySpeedRanges)
+    var mrsp = computeMRSP(pathProps, rollingStock, true, speedLimitTag, null, safetySpeedRanges)
+    mrsp = driverBehaviour.applyToMRSP(mrsp)
     // We don't use speed safety ranges in the MRSP displayed in the front
     // (just like we don't add the train length)
     val speedLimits =

--- a/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulationTest.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.standalone_sim
 
 import com.google.common.collect.ImmutableRangeMap
+import fr.sncf.osrd.DriverBehaviour
 import fr.sncf.osrd.api.api_v2.RangeValues
 import fr.sncf.osrd.api.api_v2.standalone_sim.MarginValue
 import fr.sncf.osrd.api.api_v2.standalone_sim.ReportTrain
@@ -229,6 +230,7 @@ class StandaloneSimulationTest {
                 testCase.startSpeed,
                 testCase.margins,
                 listOf(),
+                DriverBehaviour(0.0, 0.0),
             )
 
         // Test scheduled points

--- a/front/tests/assets/operationStudies/simulationSettings/allSettings.json
+++ b/front/tests/assets/operationStudies/simulationSettings/allSettings.json
@@ -9,8 +9,8 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "5 %",
-      "theoreticalS": "85 s",
-      "actual": "85 s",
+      "theoreticalS": "86 s",
+      "actual": "86 s",
       "difference": "0 s"
     },
     "calculatedArrival": "11:22:40",
@@ -30,7 +30,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:44:13",
+    "calculatedArrival": "11:44:19",
     "calculatedDeparture": ""
   },
   {
@@ -47,8 +47,8 @@
       "actual": "32 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:52:55",
-    "calculatedDeparture": "11:54:59"
+    "calculatedArrival": "11:53:04",
+    "calculatedDeparture": "11:55:08"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "12:06:18",
-    "calculatedDeparture": "12:06:18"
+    "calculatedArrival": "12:06:27",
+    "calculatedDeparture": "12:06:27"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoOFF.json
+++ b/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoOFF.json
@@ -47,8 +47,8 @@
       "actual": "0 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:39:55",
-    "calculatedDeparture": "11:41:59"
+    "calculatedArrival": "11:39:56",
+    "calculatedDeparture": "11:42:00"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:52:11",
-    "calculatedDeparture": "11:52:11"
+    "calculatedArrival": "11:52:12",
+    "calculatedDeparture": "11:52:12"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoON.json
+++ b/front/tests/assets/operationStudies/simulationSettings/codeCompo/codeCompoON.json
@@ -30,7 +30,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:42:48",
+    "calculatedArrival": "11:42:55",
     "calculatedDeparture": ""
   },
   {
@@ -47,8 +47,8 @@
       "actual": "0 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:50:48",
-    "calculatedDeparture": "11:52:52"
+    "calculatedArrival": "11:50:58",
+    "calculatedDeparture": "11:53:02"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "12:03:04",
-    "calculatedDeparture": "12:03:04"
+    "calculatedArrival": "12:03:14",
+    "calculatedDeparture": "12:03:14"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileOFF.json
+++ b/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileOFF.json
@@ -47,8 +47,8 @@
       "actual": "0 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:39:55",
-    "calculatedDeparture": "11:41:59"
+    "calculatedArrival": "11:39:56",
+    "calculatedDeparture": "11:42:00"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:52:11",
-    "calculatedDeparture": "11:52:11"
+    "calculatedArrival": "11:52:12",
+    "calculatedDeparture": "11:52:12"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileON.json
+++ b/front/tests/assets/operationStudies/simulationSettings/electricalProfiles/electricalProfileON.json
@@ -47,8 +47,8 @@
       "actual": "0 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:40:27",
-    "calculatedDeparture": "11:42:31"
+    "calculatedArrival": "11:40:28",
+    "calculatedDeparture": "11:42:32"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:53:19",
-    "calculatedDeparture": "11:53:19"
+    "calculatedArrival": "11:53:20",
+    "calculatedDeparture": "11:53:20"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/margin/linearMargin.json
+++ b/front/tests/assets/operationStudies/simulationSettings/margin/linearMargin.json
@@ -47,8 +47,8 @@
       "actual": "62 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:41:40",
-    "calculatedDeparture": "11:43:44"
+    "calculatedArrival": "11:41:41",
+    "calculatedDeparture": "11:43:45"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:54:58",
-    "calculatedDeparture": "11:54:58"
+    "calculatedArrival": "11:54:59",
+    "calculatedDeparture": "11:54:59"
   }
 ]

--- a/front/tests/assets/operationStudies/simulationSettings/margin/marecoMargin.json
+++ b/front/tests/assets/operationStudies/simulationSettings/margin/marecoMargin.json
@@ -9,9 +9,9 @@
     "signalReceptionClosed": false,
     "margin": {
       "theoretical": "10 %",
-      "theoreticalS": "104 s",
+      "theoreticalS": "103 s",
       "actual": "105 s",
-      "difference": "1 s"
+      "difference": "2 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -47,8 +47,8 @@
       "actual": "62 s",
       "difference": "0 s"
     },
-    "calculatedArrival": "11:41:40",
-    "calculatedDeparture": "11:43:44"
+    "calculatedArrival": "11:41:41",
+    "calculatedDeparture": "11:43:45"
   },
   {
     "stationName": "South_East_station",
@@ -64,7 +64,7 @@
       "actual": "",
       "difference": ""
     },
-    "calculatedArrival": "11:54:58",
-    "calculatedDeparture": "11:54:58"
+    "calculatedArrival": "11:54:59",
+    "calculatedDeparture": "11:54:59"
   }
 ]

--- a/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
+++ b/front/tests/assets/operationStudies/timesAndStops/expectedOutputsCellsData.json
@@ -10,8 +10,8 @@
     "margin": {
       "theoretical": "5 %",
       "theoreticalS": "29 s",
-      "actual": "922 s",
-      "difference": "893 s"
+      "actual": "920 s",
+      "difference": "891 s"
     },
     "calculatedArrival": "11:22:40",
     "calculatedDeparture": ""
@@ -28,11 +28,11 @@
     "margin": {
       "theoretical": "1 min/100km",
       "theoreticalS": "9 s",
-      "actual": "291 s",
-      "difference": "282 s"
+      "actual": "253 s",
+      "difference": "244 s"
     },
     "calculatedArrival": "11:47:40",
-    "calculatedDeparture": "11:52:40"
+    "calculatedDeparture": "11:52:39"
   },
   {
     "stationName": "Mid_East_station",


### PR DESCRIPTION
It was used in v1 but not v2. Includes margins before max speed drops and after it goes up.

Fix https://github.com/OpenRailAssociation/osrd/issues/10136

![image](https://github.com/user-attachments/assets/495be942-bfe9-4226-98c6-e228599a088b)

Note: this is not applied in STDCM context.
