### PR TITLE
core: stdcm: add comment to clarify earliest conflict operation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/TimeData.kt
@@ -90,8 +90,13 @@ data class TimeData(
         val nextEarliestReachableTime =
             earliestReachableTime + extraTravelTime + (extraStopTime ?: 0.0)
         var timeOfNextConflict = timeOfNextConflictAtLocation
-        if (maxAdditionalStopTime != null)
+        if (maxAdditionalStopTime != null) {
+            // We could have added a `min(timeOfNextConflict, ...)`,
+            // but we're specifically not interested in what happens before
+            // the stop. Engineering margins and other delay constraints
+            // would stop at the stop and ignore anything before.
             timeOfNextConflict = nextEarliestReachableTime + maxAdditionalStopTime
+        }
         if (extraStopTime != null) {
             val stopDataCopy = newStopData.toMutableList()
             stopDataCopy.add(


### PR DESCRIPTION
Follow up of https://github.com/OpenRailAssociation/osrd/pull/10126 after @bougue-pe's input. 

The logic doesn't change, we just add a clarifying comment. 