### PR TITLE
front: drop StdcmResultsOperationalPoint.departureTime

### DIFF
--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -68,7 +68,6 @@ export type StdcmResultsOperationalPoint = {
   ch?: string;
   stop?: string | null;
   duration: number;
-  departureTime: string;
   stopEndTime: string;
   trackName?: string;
 };

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -136,7 +136,6 @@ export function getOperationalPointsWithTimes(
       name: op.name,
       ch: op.ch,
       duration: durationInSeconds,
-      departureTime,
       stopEndTime,
       trackName: op.metadata?.trackName,
     };


### PR DESCRIPTION
This is unused, and always set to the same constant value for all operational points.