### PR TITLE
editoast: refactor of projection algorithm

### DIFF
--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -172,6 +172,7 @@ pub struct TrackRange {
 
 impl From<editoast_schemas::infra::DirectionalTrackRange> for TrackRange {
     fn from(value: editoast_schemas::infra::DirectionalTrackRange) -> Self {
+        assert!(value.begin <= value.end);
         TrackRange {
             track_section: value.track,
             begin: (value.begin * 1000.).round() as u64,
@@ -201,6 +202,7 @@ impl std::str::FromStr for TrackRange {
         let Ok(end) = end.parse() else {
             return Err(format!("{end} in track range should be an integer"));
         };
+        assert!(begin != end); // Impossible to determine direction in this case
         let (begin, end, direction) = if begin < end {
             (begin, end, Direction::StartToStop)
         } else {
@@ -224,6 +226,7 @@ impl TrackRange {
         end: u64,
         direction: Direction,
     ) -> Self {
+        assert!(begin <= end);
         Self {
             track_section: track_section.as_ref().into(),
             begin,

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -157,7 +157,7 @@ pub enum PathfindingNotFound {
 
 /// An oriented range on a track section.
 /// `begin` is always less than `end`.
-#[derive(Serialize, Deserialize, Clone, Debug, ToSchema, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, ToSchema, Hash, PartialEq, Eq)]
 pub struct TrackRange {
     /// The track section identifier.
     #[schema(inline)]
@@ -178,6 +178,17 @@ impl From<editoast_schemas::infra::DirectionalTrackRange> for TrackRange {
             begin: (value.begin * 1000.).round() as u64,
             end: (value.end * 1000.).round() as u64,
             direction: value.direction,
+        }
+    }
+}
+
+impl std::fmt::Debug for TrackRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "'{}+", self.track_section)?;
+        if matches!(self.direction, Direction::StartToStop) {
+            write!(f, "{}-{}'", self.begin, self.end)
+        } else {
+            write!(f, "{}-{}'", self.end, self.begin)
         }
     }
 }

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -9,6 +9,7 @@ use utoipa::ToSchema;
 
 use crate::core::{AsCoreRequest, Json};
 use crate::error::InternalError;
+use crate::views::path::projection::Intersection;
 
 editoast_common::schemas! {
     IncompatibleConstraints,
@@ -260,6 +261,23 @@ impl TrackRange {
 
     pub fn length(&self) -> u64 {
         self.end - self.begin
+    }
+
+    // Check if the 2 track ranges overlap.
+    // Intersection have non-null length and are offsets from the beginning
+    // of the `self` track range.
+    pub fn overlap(&self, track_range: &TrackRange) -> Option<Intersection> {
+        if self.track_section != track_range.track_section {
+            return None;
+        }
+        let begin = std::cmp::max(self.begin, track_range.begin);
+        let end = std::cmp::min(self.end, track_range.end);
+        // In case of equality, we don't consider it an overlap
+        if begin < self.end && end > self.begin {
+            Some(Intersection::from((begin, end)))
+        } else {
+            None
+        }
     }
 }
 

--- a/editoast/src/views/path/projection.rs
+++ b/editoast/src/views/path/projection.rs
@@ -28,7 +28,7 @@ impl<'a> PathProjection<'a> {
     /// Retrieve a track range from the path given the track section identifier.
     fn get_track_range(&self, track_section: &Identifier) -> Option<&TrackRange> {
         let index = *self.track_index.get(track_section)?;
-        Some(&self.path[index])
+        self.path.get(index)
     }
 
     /// Create a new projection from a path.

--- a/editoast/src/views/path/projection.rs
+++ b/editoast/src/views/path/projection.rs
@@ -482,7 +482,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn projection_get_invalid_location() {
+    fn projection_get_out_of_bound_location() {
         let path = vec![TrackRange::new("A", 50, 100, Direction::StartToStop)];
 
         let projection = PathProjection::new(&path);


### PR DESCRIPTION
fixes #9686

This is a complete rewrite of the projection algorithm. The idea is to support the case when multiple track ranges with the same track section identifier are projected on an axis. `PathProjection` can't support that use case since the constructor assert for no duplicate identifiers.

In order to minimize the modifications, we decided to not change the constructor of `PathProjection`. The important change is the inversion of the semantic for the function `get_intersection()`: before, `self` was projected on `track_ranges`, now, we project `track_ranges` on `self`. Since we will always project on a continuous path, we can then keep the constructor of `PathProjection` with it assertions about no duplicate identifiers.

> [!WARNING]
> There is still a bunch of things to do.
> - [ ] must be merged after #10137 
> - [ ] all callers of `PathProjection::get_intersection()` needs to be inverted (remember, now, `track_ranges` is projected on `path`, not the other way around)
> - [ ] a reminding problem about intersections that are merged and shouldn't be merged (see below)
> - [ ] minor: do we want to keep the custom implementation of `Debug` for `TrackRange` (or maybe it should be a `Display` implementation instead?)

# The ones that shouldn't be merged

When you have a projection path `A+0-100`, `B+0-100` and you want to project the following track ranges on it, `A+0-150` and `B+0-100`, the result should be 2 intersections, `(0, 100)` and `(100, 200)` and you don't want to merge them (or do we?). Indeed, the train path you're trying to project is moving in space but also in time on `A+100-150` which means that between `A+100` and `B+0`, there will be a hole in the Space-Time Chart.

An attempt to solve this problem has been done by introducing the `is_exhaustive` in the `TrackRangeEvent`: the idea is to keep the information that the overlap is exhaustive on the track range being projected, or not. It does work for `Begin` where it can be used... but I didn't find an obvious way to use the `is_exhaustive` from `End` 🤷 

## Unsolved questions about this merge strategy
- Should we actually not merge them? The idea makes sense if you're trying to project a train path, but does it still make sense for a work schedule which doesn't move in space or time.
- Could we always merge (would simplify the algorithm) and separate later in the post-processing (trying to get the time of these locations) ?
- 💡Maybe we don’t want to merge anything at all? The impact would be producing more payload (is that really that much), but it would probably drastically simplify the algorithm (that would mean that there would be at least one intersection per track section).