### PR TITLE
front: move allWaypoints to ManageTrainScheduleContextType

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
+++ b/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
@@ -23,7 +23,7 @@ type ManageTrainScheduleContextType = {
   pathfindingState: PathfindingState;
   infraInfo: { infra?: InfraWithState; reloadCount: number };
   /** Operational points along the path (including origin and destination) and vias added by clicking on map */
-  allWaypoints?: SuggestedOP[];
+  pathStepsAndSuggestedOPs?: SuggestedOP[];
 } | null;
 
 const ManageTrainScheduleContext = createContext<ManageTrainScheduleContextType>(null);
@@ -45,7 +45,7 @@ export const ManageTrainScheduleContextProvider = ({
     [pathProperties]
   );
 
-  const allWaypoints = useMemo(() => {
+  const pathStepsAndSuggestedOPs = useMemo(() => {
     if (!pathProperties) return undefined;
     return upsertPathStepsInOPs(pathProperties.suggestedOperationalPoints, compact(pathSteps));
   }, [pathProperties?.suggestedOperationalPoints, pathSteps]);
@@ -58,7 +58,7 @@ export const ManageTrainScheduleContextProvider = ({
       launchPathfinding,
       pathfindingState,
       infraInfo,
-      allWaypoints,
+      pathStepsAndSuggestedOPs,
     }),
     [
       pathProperties,
@@ -67,7 +67,7 @@ export const ManageTrainScheduleContextProvider = ({
       launchPathfinding,
       pathfindingState,
       infraInfo,
-      allWaypoints,
+      pathStepsAndSuggestedOPs,
     ]
   );
 

--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -15,11 +15,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
 import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQuery';
-import {
-  formatSuggestedOperationalPoints,
-  matchPathStepAndOp,
-  upsertPathStepsInOPs,
-} from 'modules/pathfinding/utils';
+import { formatSuggestedOperationalPoints, matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { getSupportedElectrification, isThermal } from 'modules/rollingStock/helpers/electric';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import computeBasePathStep from 'modules/trainschedule/helpers/computeBasePathStep';
@@ -213,14 +209,11 @@ const useSetupItineraryForTrainUpdate = (trainIdToEdit: number) => {
         });
       }
 
-      const allWaypoints = upsertPathStepsInOPs(suggestedOperationalPoints, updatedPathSteps);
-
       return {
         pathProperties: {
           electrifications,
           geometry,
           suggestedOperationalPoints,
-          allWaypoints,
           length: pathfindingResult.length,
           trackSectionRanges: pathfindingResult.track_section_ranges,
         },

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -74,8 +74,6 @@ export type ManageTrainSchedulePathProperties = {
   electrifications: NonNullable<PathProperties['electrifications']>;
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
-  /** Operational points along the path (including origin and destination) and vias added by clicking on map */
-  allWaypoints: SuggestedOP[];
   length: number;
   trackSectionRanges: NonNullable<PathfindingResultSuccess['track_section_ranges']>;
   incompatibleConstraints?: IncompatibleConstraints;

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -31,7 +31,8 @@ type ManageTrainScheduleProps = {
 
 const ManageTrainSchedule = ({ trainIdToEdit }: ManageTrainScheduleProps) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const { pathProperties, voltageRanges, allWaypoints } = useManageTrainScheduleContext();
+  const { pathProperties, voltageRanges, pathStepsAndSuggestedOPs } =
+    useManageTrainScheduleContext();
 
   const { getOrigin, getDestination, getPathSteps, getConstraintDistribution, getStartTime } =
     useOsrdConfSelectors();
@@ -117,7 +118,7 @@ const ManageTrainSchedule = ({ trainIdToEdit }: ManageTrainScheduleProps) => {
     // If pathProperties is defined we know that pathSteps won't have any null values
     content: (
       <TimesStopsInput
-        allWaypoints={allWaypoints}
+        pathStepsAndSuggestedOPs={pathStepsAndSuggestedOPs}
         startTime={new Date(startTime)}
         pathSteps={compact(pathSteps)}
       />

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -31,7 +31,7 @@ type ManageTrainScheduleProps = {
 
 const ManageTrainSchedule = ({ trainIdToEdit }: ManageTrainScheduleProps) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const { pathProperties, voltageRanges } = useManageTrainScheduleContext();
+  const { pathProperties, voltageRanges, allWaypoints } = useManageTrainScheduleContext();
 
   const { getOrigin, getDestination, getPathSteps, getConstraintDistribution, getStartTime } =
     useOsrdConfSelectors();
@@ -117,7 +117,7 @@ const ManageTrainSchedule = ({ trainIdToEdit }: ManageTrainScheduleProps) => {
     // If pathProperties is defined we know that pathSteps won't have any null values
     content: (
       <TimesStopsInput
-        allWaypoints={pathProperties?.allWaypoints}
+        allWaypoints={allWaypoints}
         startTime={new Date(startTime)}
         pathSteps={compact(pathSteps)}
       />

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -38,7 +38,8 @@ const Itinerary = () => {
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');
   const { openModal } = useModal();
 
-  const { pathProperties, setPathProperties, launchPathfinding } = useManageTrainScheduleContext();
+  const { pathProperties, setPathProperties, launchPathfinding, allWaypoints } =
+    useManageTrainScheduleContext();
 
   const zoomToFeaturePoint = (lngLat?: Position) => {
     if (lngLat) {
@@ -118,7 +119,7 @@ const Itinerary = () => {
           >
             <Route />
           </button>
-          {pathProperties && pathProperties.suggestedOperationalPoints && (
+          {allWaypoints && (
             <button
               data-testid="add-waypoints-button"
               className="col ml-1 my-1 text-white btn bg-info btn-sm"
@@ -126,7 +127,7 @@ const Itinerary = () => {
               onClick={() =>
                 openModal(
                   <ModalSuggestedVias
-                    suggestedVias={pathProperties.allWaypoints}
+                    suggestedVias={allWaypoints}
                     launchPathfinding={launchPathfinding}
                   />
                 )

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -38,7 +38,7 @@ const Itinerary = () => {
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');
   const { openModal } = useModal();
 
-  const { pathProperties, setPathProperties, launchPathfinding, allWaypoints } =
+  const { pathProperties, setPathProperties, launchPathfinding, pathStepsAndSuggestedOPs } =
     useManageTrainScheduleContext();
 
   const zoomToFeaturePoint = (lngLat?: Position) => {
@@ -119,7 +119,7 @@ const Itinerary = () => {
           >
             <Route />
           </button>
-          {allWaypoints && (
+          {pathStepsAndSuggestedOPs && (
             <button
               data-testid="add-waypoints-button"
               className="col ml-1 my-1 text-white btn bg-info btn-sm"
@@ -127,7 +127,7 @@ const Itinerary = () => {
               onClick={() =>
                 openModal(
                   <ModalSuggestedVias
-                    suggestedVias={allWaypoints}
+                    suggestedVias={pathStepsAndSuggestedOPs}
                     launchPathfinding={launchPathfinding}
                   />
                 )

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { compact, isObject } from 'lodash';
+import { isObject } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -18,7 +18,6 @@ import {
   formatSuggestedOperationalPoints,
   getPathfindingQuery,
   matchPathStepAndOp,
-  upsertPathStepsInOPs,
 } from 'modules/pathfinding/utils';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
@@ -161,16 +160,10 @@ const usePathfinding = (
     }
     dispatch(updatePathSteps(updatedPathSteps));
 
-    const allWaypoints = upsertPathStepsInOPs(
-      suggestedOperationalPoints,
-      compact(updatedPathSteps)
-    );
-
     setPathProperties({
       electrifications,
       geometry,
       suggestedOperationalPoints,
-      allWaypoints,
       length: pathResult.length,
       trackSectionRanges: pathResult.track_section_ranges,
       incompatibleConstraints,

--- a/front/src/modules/timesStops/TimesStopsInput.tsx
+++ b/front/src/modules/timesStops/TimesStopsInput.tsx
@@ -28,7 +28,7 @@ type ClearButtonProps = {
   removeVia: () => void;
   rowIndex: number;
   rowData: TimesStopsInputRow;
-  allWaypoints?: SuggestedOP[];
+  pathStepsAndSuggestedOPs?: SuggestedOP[];
   pathSteps: PathStep[];
 };
 
@@ -36,13 +36,13 @@ const createClearViaButton = ({
   removeVia,
   rowIndex,
   rowData,
-  allWaypoints,
+  pathStepsAndSuggestedOPs,
   pathSteps,
 }: ClearButtonProps) => {
   const isClearBtnShown =
-    allWaypoints &&
+    pathStepsAndSuggestedOPs &&
     rowIndex > 0 &&
-    rowIndex < allWaypoints.length - 1 &&
+    rowIndex < pathStepsAndSuggestedOPs.length - 1 &&
     isVia(pathSteps || [], rowData, { withKP: true }) &&
     (!isNil(rowData.stopFor) ||
       rowData.theoreticalMargin !== undefined ||
@@ -59,12 +59,16 @@ const createClearViaButton = ({
 };
 
 type TimesStopsInputProps = {
-  allWaypoints?: SuggestedOP[];
+  pathStepsAndSuggestedOPs?: SuggestedOP[];
   startTime: Date;
   pathSteps: PathStep[];
 };
 
-const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInputProps) => {
+const TimesStopsInput = ({
+  pathStepsAndSuggestedOPs,
+  startTime,
+  pathSteps,
+}: TimesStopsInputProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation('timesStops');
   const { updatePathSteps, upsertSeveralViasFromSuggestedOP } =
@@ -128,10 +132,10 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
 
   useEffect(() => {
     const fetchAndFormatRows = async () => {
-      if (allWaypoints) {
-        const trackIds = allWaypoints.map((op) => op.track);
+      if (pathStepsAndSuggestedOPs) {
+        const trackIds = pathStepsAndSuggestedOPs.map((op) => op.track);
         const trackSections = await getTrackSectionsByIds(trackIds);
-        const suggestedOPsWithTrackNames = allWaypoints.map((op) => ({
+        const suggestedOPsWithTrackNames = pathStepsAndSuggestedOPs.map((op) => ({
           ...op,
           trackName: trackSections[op.track]?.extensions?.sncf?.track_name,
         }));
@@ -147,7 +151,7 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
     };
 
     fetchAndFormatRows();
-  }, [allWaypoints, pathSteps, startTime]);
+  }, [pathStepsAndSuggestedOPs, pathSteps, startTime]);
 
   return (
     <TimesStops
@@ -159,7 +163,7 @@ const TimesStopsInput = ({ allWaypoints, startTime, pathSteps }: TimesStopsInput
             removeVia: () => clearPathStep(rowData),
             rowIndex,
             rowData,
-            allWaypoints,
+            pathStepsAndSuggestedOPs,
             pathSteps,
           }),
       }}

--- a/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/__tests__/commonConfBuilder.ts
@@ -61,7 +61,6 @@ export default function commonConfBuilder() {
         ],
       },
       suggestedOperationalPoints: [],
-      allWaypoints: [],
       length: 1169926000,
       trackSectionRanges: [],
     }),


### PR DESCRIPTION
This value should be updated every time pathSteps or suggestedOperationalPoints change. Instead of manually updating it when touching these two values, memoize it.