### PR TITLE
front: drop TimesStopsRow.isWaypoint

### DIFF
--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -63,7 +63,7 @@ const TimesStops = <T extends TimesStopsRow>({
       headerRowHeight={headerRowHeight}
       rowClassName={({ rowData, rowIndex }) =>
         cx({
-          activeRow: rowData.isWaypoint,
+          activeRow: Boolean(rowData.pathStepId),
           oddRow: (rowIndex + 1) % 2,
         })
       }

--- a/front/src/modules/timesStops/helpers/utils.ts
+++ b/front/src/modules/timesStops/helpers/utils.ts
@@ -37,7 +37,7 @@ const matchPathStepAndOpWithKP = (step: PathStep, op: SuggestedOP) => {
 };
 
 export const formatSuggestedViasToRowVias = (
-  operationalPoints: (SuggestedOP & { isWaypoint?: boolean })[],
+  operationalPoints: SuggestedOP[],
   pathSteps: PathStep[],
   t: TFunction<'timesStops', undefined>,
   startTime?: Date,
@@ -103,7 +103,6 @@ export const formatSuggestedViasToRowVias = (
       shortSlipDistance,
       stopFor,
       theoreticalMargin,
-      isWaypoint: op.isWaypoint || pathStep !== undefined,
     };
   });
 };

--- a/front/src/modules/timesStops/hooks/useOutputTableData.ts
+++ b/front/src/modules/timesStops/hooks/useOutputTableData.ts
@@ -88,7 +88,6 @@ const useOutputTableData = (
         pathStepId: pathStep.id,
         name: t('waypoint', { id: pathStep.id }),
         ch: undefined,
-        isWaypoint: true,
 
         arrival,
         departure,
@@ -144,7 +143,6 @@ const useOutputTableData = (
         const calculatedArrival = new Date(startDatetime.getTime() + time);
 
         return {
-          isWaypoint: false,
           opId: op.id,
           name: op.extensions?.identifier?.name,
           ch: op.extensions?.sncf?.ch,

--- a/front/src/modules/timesStops/types.ts
+++ b/front/src/modules/timesStops/types.ts
@@ -15,7 +15,6 @@ export type TimesStopsRow = {
   name?: string;
   ch?: string;
   trackName?: string;
-  isWaypoint: boolean;
 
   arrival?: TimeExtraDays; // value asked by user
   departure?: TimeExtraDays; // value asked by user


### PR DESCRIPTION
Now we have an unambiguous way to figure out whether a row is a waypoint explicitly selected by the user: if it has a path step ID, then it's a waypoint.

Check the path step ID instead of having to keep a separate field synced up.