### PR TITLE
editoast: rename `Unauthenticated` to `Unauthorized`, `Unauthorized` to `Forbidden`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4133,26 +4133,7 @@ components:
           type: string
           enum:
           - editoast:authz:DbError
-    EditoastAuthorizationErrorUnauthenticated:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 401
-        type:
-          type: string
-          enum:
-          - editoast:authz:Unauthenticated
-    EditoastAuthorizationErrorUnauthorized:
+    EditoastAuthorizationErrorForbidden:
       type: object
       required:
       - type
@@ -4167,6 +4148,25 @@ components:
           type: integer
           enum:
           - 403
+        type:
+          type: string
+          enum:
+          - editoast:authz:Forbidden
+    EditoastAuthorizationErrorUnauthorized:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 401
         type:
           type: string
           enum:
@@ -4665,7 +4665,7 @@ components:
       - $ref: '#/components/schemas/EditoastAttachedErrorTrackNotFound'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorAuthError'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorDbError'
-      - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthenticated'
+      - $ref: '#/components/schemas/EditoastAuthorizationErrorForbidden'
       - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthorized'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthz'
       - $ref: '#/components/schemas/EditoastAuthzErrorDriver'

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -104,7 +104,7 @@ async fn list_user_roles(
         .await
         .map_err(AuthorizationError::from)?
     {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let authorizer = auth.authorizer()?;
@@ -142,7 +142,7 @@ async fn grant_roles(
         .await
         .map_err(AuthorizationError::from)?
     {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let mut authorizer = auth.authorizer()?;
@@ -174,7 +174,7 @@ async fn strip_roles(
         .await
         .map_err(AuthorizationError::from)?
     {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let mut authorizer = auth.authorizer()?;

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -63,7 +63,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let doc = Document::retrieve_or_fail(conn, document_id, || DocumentErrors::NotFound {
@@ -108,7 +108,7 @@ async fn post(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let content_type = content_type.to_string();
 
@@ -151,7 +151,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     Document::delete_static_or_fail(conn, document_id, || DocumentErrors::NotFound {

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -66,7 +66,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let mut conn = db_pool.get().await?;
     Ok(Json(ElectricalProfileSet::list_light(&mut conn).await?))
@@ -92,7 +92,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
@@ -131,7 +131,7 @@ async fn get_level_order(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
@@ -163,7 +163,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let deleted = ElectricalProfileSet::delete_static(conn, electrical_profile_set_id).await?;
@@ -201,7 +201,7 @@ async fn post_electrical_profile(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let ep_set = ElectricalProfileSet::changeset()
         .name(ep_set_name.name)

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -77,7 +77,7 @@ async fn attached(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let mut conn = db_pool.get().await?;

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -97,7 +97,7 @@ async fn list_auto_fixes(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -142,7 +142,7 @@ async fn delimited_area(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // Retrieve the infra

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -85,7 +85,7 @@ async fn edit<'a>(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // TODO: lock for update
@@ -140,7 +140,7 @@ pub async fn split_track_section<'a>(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     info!(

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -86,7 +86,7 @@ async fn list_errors(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let (page, page_size) = pagination_params

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -55,7 +55,7 @@ async fn get_line_bbox(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let line_code: i32 = line_code.try_into().unwrap();

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -138,7 +138,7 @@ async fn refresh(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // Use a transaction to give scope to infra list lock
@@ -214,7 +214,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let settings = pagination_params
@@ -310,7 +310,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra_id = infra.infra_id;
@@ -356,7 +356,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra: Changeset<Infra> = infra_form.into();
@@ -392,7 +392,7 @@ async fn clone(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -437,7 +437,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
@@ -482,7 +482,7 @@ async fn put(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra_cs: Changeset<Infra> = patch.into();
@@ -518,7 +518,7 @@ async fn get_switch_types(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -559,7 +559,7 @@ async fn get_speed_limit_tags(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -603,7 +603,7 @@ async fn get_voltages(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
@@ -637,7 +637,7 @@ async fn get_all_voltages(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let voltages = Infra::get_all_voltages(&mut db_pool.get().await?).await?;
@@ -673,7 +673,7 @@ async fn lock(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     set_locked(infra.infra_id, true, db_pool).await?;
@@ -700,7 +700,7 @@ async fn unlock(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     set_locked(infra.infra_id, false, db_pool).await?;
@@ -731,7 +731,7 @@ async fn load(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra_id = path.infra_id;

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -67,7 +67,7 @@ async fn get_objects(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra_id = infra_id_param.infra_id;

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -111,7 +111,7 @@ async fn pathfinding_view(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // Parse and check input

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -63,7 +63,7 @@ async fn get_railjson(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra_id = infra.infra_id;
@@ -182,7 +182,7 @@ async fn post_railjson(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     if railjson.version != RAILJSON_VERSION {

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -75,7 +75,7 @@ async fn get_routes_from_waypoint(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -159,7 +159,7 @@ async fn get_routes_track_ranges(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let db_pool = db_pool.clone();
@@ -224,7 +224,7 @@ async fn get_routes_nodes(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, params.infra_id, || {

--- a/editoast/src/views/layers.rs
+++ b/editoast/src/views/layers.rs
@@ -124,7 +124,7 @@ async fn layer_view(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let layer = match map_layers.layers.get(&layer_slug) {
@@ -192,7 +192,7 @@ async fn cache_and_get_mvt_tile(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let layer = match map_layers.layers.get(&layer_slug) {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -179,7 +179,7 @@ impl Authentication {
         match self {
             Authentication::Authenticated(authorizer) => Ok(authorizer),
             Authentication::Unauthenticated | Authentication::SkipAuthorization => {
-                Err(AuthorizationError::Unauthenticated)
+                Err(AuthorizationError::Unauthorized)
             }
         }
     }
@@ -241,12 +241,12 @@ async fn authentication_middleware(
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "authz")]
 pub enum AuthorizationError {
-    #[error("Unauthenticated")]
+    #[error("Unauthorized — user must be authenticated")]
     #[editoast_error(status = 401)]
-    Unauthenticated,
-    #[error("Unauthorized")]
-    #[editoast_error(status = 403)]
     Unauthorized,
+    #[error("Forbidden — user has insufficient privileges")]
+    #[editoast_error(status = 403)]
+    Forbidden,
     #[error(transparent)]
     #[editoast_error(status = 500)]
     AuthError(

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -172,7 +172,7 @@ async fn post(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/projects.rs
+++ b/editoast/src/views/projects.rs
@@ -155,7 +155,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     if let Some(image) = project_create_form.image {
@@ -197,7 +197,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let ordering = ordering_params.ordering;
@@ -249,7 +249,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let project =
@@ -278,7 +278,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     if Project::delete_and_prune_document(conn, project_id).await? {
@@ -345,7 +345,7 @@ async fn patch(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     if let Some(image) = form.image {

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -220,7 +220,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let rolling_stock = retrieve_existing_rolling_stock(
         &mut db_pool.get().await?,
@@ -251,7 +251,7 @@ async fn get_by_name(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let rolling_stock = retrieve_existing_rolling_stock(
@@ -281,7 +281,7 @@ async fn get_power_restrictions(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let power_restrictions = RollingStockModel::get_power_restrictions(conn).await?;
@@ -321,7 +321,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     rolling_stock_form.validate()?;
     let conn = &mut db_pool.get().await?;
@@ -359,7 +359,7 @@ async fn update(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     rolling_stock_form.validate()?;
     let name = rolling_stock_form.name.clone();
@@ -438,7 +438,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
 
@@ -505,7 +505,7 @@ async fn update_locked(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -587,7 +587,7 @@ async fn create_livery(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
 

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -113,7 +113,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
         .validate(1000)?
@@ -156,7 +156,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let rolling_stock = RollingStockModel::retrieve_or_fail(
         &mut db_pool.get().await?,
@@ -190,7 +190,7 @@ async fn get_by_name(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let rolling_stock = RollingStockModel::retrieve_or_fail(
         &mut db_pool.get().await?,

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -147,7 +147,7 @@ async fn post(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
     let rolling_stock_changeset: Changeset<TowedRollingStockModel> =
@@ -185,7 +185,7 @@ async fn get_list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
         .validate(50)?
@@ -228,7 +228,7 @@ async fn get_by_id(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let towed_rolling_stock = TowedRollingStockModel::retrieve_or_fail(
@@ -264,7 +264,7 @@ async fn patch_by_id(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let new_towed_rolling_stock = db_pool
@@ -336,7 +336,7 @@ async fn patch_by_id_locked(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -200,7 +200,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let timetable_id = data.timetable_id;
@@ -281,7 +281,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     db_pool
@@ -368,7 +368,7 @@ async fn patch(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let scenarios_response = db_pool
@@ -443,7 +443,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -495,7 +495,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -148,7 +148,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -194,7 +194,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let created = db_pool
@@ -248,7 +248,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // Check for project / study / scenario
@@ -282,7 +282,7 @@ async fn update(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let updated = db_pool
@@ -336,7 +336,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     db_pool

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -367,7 +367,7 @@ async fn search(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let (page, per_page) = query_params.validate(1000)?.warn_page_size(100).unpack();

--- a/editoast/src/views/speed_limit_tags.rs
+++ b/editoast/src/views/speed_limit_tags.rs
@@ -32,7 +32,7 @@ async fn speed_limit_tags(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     Ok(Json(speed_limit_tag_ids.as_ref().clone()))

--- a/editoast/src/views/sprites.rs
+++ b/editoast/src/views/sprites.rs
@@ -47,7 +47,7 @@ async fn signaling_systems(Extension(auth): AuthenticationExt) -> Result<Json<Ve
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let sprite_configs = SpriteConfig::load();
@@ -78,7 +78,7 @@ async fn sprites(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let sprite_configs = SpriteConfig::load();

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -115,7 +115,7 @@ async fn overwrite(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -140,7 +140,7 @@ async fn retrieve_latest(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -144,7 +144,7 @@ async fn create(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let connection = db_pool.get().await?;
@@ -209,7 +209,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     // Check if project exists
     let conn = &mut db_pool.get().await?;
@@ -246,7 +246,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     // Check if project exists
     let conn = &mut db_pool.get().await?;
@@ -330,7 +330,7 @@ async fn patch(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
     let connection = db_pool.get().await?;
     let (study_scenarios, project) = connection
@@ -413,7 +413,7 @@ async fn list(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let ordering = ordering_params.ordering;

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -147,7 +147,7 @@ async fn create_temporary_speed_limit_group(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -129,7 +129,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -158,7 +158,7 @@ async fn post(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -188,7 +188,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -220,7 +220,7 @@ async fn train_schedule(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -283,7 +283,7 @@ async fn conflicts(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // 1. Retrieve Timetable / Infra / Trains / Simultion

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -138,7 +138,7 @@ async fn stdcm(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     stdcm_request.validate()?;

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -178,7 +178,7 @@ async fn get(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -213,7 +213,7 @@ async fn get_batch(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -246,7 +246,7 @@ async fn delete(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     use crate::models::DeleteBatch;
@@ -282,7 +282,7 @@ async fn put(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -338,7 +338,7 @@ async fn simulation(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // Retrieve infra or fail
@@ -671,7 +671,7 @@ async fn simulation_summary(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -774,7 +774,7 @@ async fn get_path(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/train_schedule/projection.rs
+++ b/editoast/src/views/train_schedule/projection.rs
@@ -152,7 +152,7 @@ async fn project_path(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let ProjectPathInput {

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -251,7 +251,7 @@ async fn project_path(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     // get all work_schedule of the group
@@ -325,7 +325,7 @@ async fn create_group(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -362,7 +362,7 @@ async fn delete_group(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -390,7 +390,7 @@ async fn list_groups(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -426,7 +426,7 @@ async fn put_in_group(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
@@ -490,7 +490,7 @@ async fn get_group(
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
-        return Err(AuthorizationError::Unauthorized.into());
+        return Err(AuthorizationError::Forbidden.into());
     }
 
     let ordering = ordering_params.ordering;

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -22,8 +22,8 @@
       "DbError": "Database access fatal error",
       "Driver": "Authentication/authorization internal error, try again or contact support",
       "NoSuchUser": "Unknown user",
-      "Unauthenticated": "Unauthenticated user",
-      "Unauthorized": "Access denied"
+      "Unauthorized": "Unauthenticated user",
+      "Forbidden": "Access denied"
     },
     "auto_fixes": {
       "ConflictingFixesOnSameObject": "Conflicting fixes for the same object on the same fix-iteration",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -22,8 +22,8 @@
       "DbError": "Erreur interne de base de données, veuillez réessayer ou contacter le support",
       "Driver": "Erreur interne d'authentification ou d'autorisation, veuillez réessayer ou contacter le support",
       "NoSuchUser": "Utilisateur inconnu",
-      "Unauthenticated": "Utilisateur non authentifié",
-      "Unauthorized": "Accès refusé"
+      "Unauthorized": "Utilisateur non authentifié",
+      "Forbidden": "Accès refusé"
     },
     "auto_fixes": {
       "ConflictingFixesOnSameObject": "Correctifs conflictuels pour le même objet sur la même itération de correctif",


### PR DESCRIPTION
This PR updates the error messages to better align with HTTP status codes. Specifically, it renames the `Unauthenticated` error to `Unauthorized` and the `Unauthorized` error to `Forbidden`. This change improves clarity and consistency in our error handling.