### PR TITLE
editoast: remove InternalError usage in Delete and Create Model API

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "postgis_diesel",
  "postgres-openssl",
+ "regex",
  "thiserror 2.0.11",
  "tokio",
  "tokio-postgres",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -70,6 +70,7 @@ rangemap = "1.5.1"
 opentelemetry = { version = "0.27.1", default-features = false, features = [
   "trace",
 ] }
+regex = "1.11"
 reqwest = { version = "0.11.27", features = ["json"] }
 rstest = { version = "0.19.0", default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }
@@ -170,7 +171,7 @@ redis = { version = "0.28", default-features = false, features = [
   "tokio-comp",
   "tokio-native-tls-comp",
 ] }
-regex = "1.11.1"
+regex.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/editoast/editoast_derive/src/model/args.rs
+++ b/editoast/editoast_derive/src/model/args.rs
@@ -20,6 +20,8 @@ pub(super) struct ModelArgs {
     pub(super) row: GeneratedTypeArgs,
     #[darling(default)]
     pub(super) changeset: GeneratedTypeArgs,
+    #[darling(default)]
+    pub(super) error: Option<syn::Path>,
     #[darling(multiple, rename = "identifier")]
     pub(super) identifiers: Vec<RawIdentifier>,
     #[darling(rename = "gen")]

--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -137,6 +137,7 @@ impl ModelConfig {
             model: self.model.clone(),
             row: self.row.ident(),
             changeset: self.changeset.ident(),
+            error: self.error.clone(),
             table: self.table.clone(),
         }
     }

--- a/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
@@ -42,23 +42,25 @@ impl ToTokens for CreateBatchImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
-                    .await?
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_ok(<#model as Model>::from_row)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
-            impl crate::models::CreateBatch<#changeset> for #model {
+            impl crate::models::CreateBatch for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch<
-                    I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #changeset> + Send,
                     C: Default + std::iter::Extend<Self> + Send + std::fmt::Debug,
                 >(
                     conn: &mut editoast_models::DbConnection,
                     values: I,
-                ) -> crate::error::Result<C> {
+                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;

--- a/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
@@ -47,29 +47,28 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map(|s| {
-                        s.map_ok(|row| {
-                            let model = <#model as Model>::from_row(row);
-                            (model.get_id(), model)
-                        })
-                        .try_collect::<Vec<_>>()
-                    })?
-                    .await?
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_ok(|row| {
+                        let model = <#model as Model>::from_row(row);
+                        (model.get_id(), model)
+                    })
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
-            impl crate::models::CreateBatchWithKey<#changeset, #ty> for #model {
+            impl crate::models::CreateBatchWithKey<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch_with_key<
-                    I: std::iter::IntoIterator<Item = #changeset> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #changeset> + Send,
                     C: Default + std::iter::Extend<(#ty, Self)> + Send + std::fmt::Debug,
                 >(
                     conn: &mut editoast_models::DbConnection,
                     values: I,
-                ) -> crate::error::Result<C> {
+                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use std::ops::DerefMut;

--- a/editoast/editoast_derive/src/model/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_impl.rs
@@ -22,13 +22,12 @@ impl ToTokens for CreateImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::Create<#model> for #changeset {
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create(
                     self,
                     conn: &mut editoast_models::DbConnection,
-                ) -> crate::error::Result<#model> {
+                ) -> std::result::Result<#model, <#model as crate::models::Model>::Error> {
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;
@@ -38,7 +37,7 @@ impl ToTokens for CreateImpl {
                         .get_result::<#row>(conn.write().await.deref_mut())
                         .await
                         .map(Into::into)
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_batch_impl.rs
@@ -40,19 +40,21 @@ impl ToTokens for DeleteBatchImpl {
                 for #id_ident in chunk.into_iter() {
                     query = query.or_filter(#filters);
                 }
-                query.execute(conn.write().await.deref_mut()).await?
+                query
+                    .execute(conn.write().await.deref_mut())
+                    .await
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::DeleteBatch<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
-                async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait>(
+                async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send>(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<usize> {
+                ) -> std::result::Result<usize, <#model as crate::models::Model>::Error> {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;

--- a/editoast/editoast_derive/src/model/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_impl.rs
@@ -18,13 +18,12 @@ impl ToTokens for DeleteImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::Delete for #model {
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id = ?self.#primary_key))]
                 async fn delete(
                     &self,
                     conn: &mut editoast_models::DbConnection,
-                ) -> crate::error::Result<bool> {
+                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
@@ -34,7 +33,7 @@ impl ToTokens for DeleteImpl {
                         .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_static_impl.rs
@@ -26,13 +26,12 @@ impl ToTokens for DeleteStaticImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::DeleteStatic<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn delete_static(
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> crate::error::Result<bool> {
+                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -42,7 +41,7 @@ impl ToTokens for DeleteStaticImpl {
                         .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/model_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/model_impl.rs
@@ -4,6 +4,7 @@ pub(crate) struct ModelImpl {
     pub(super) model: syn::Ident,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
+    pub(super) error: syn::Path,
     pub(super) table: syn::Path,
 }
 
@@ -13,6 +14,7 @@ impl ToTokens for ModelImpl {
             model,
             row,
             changeset,
+            error,
             table,
         } = self;
         tokens.extend(quote! {
@@ -21,6 +23,7 @@ impl ToTokens for ModelImpl {
                 type Row = #row;
                 type Changeset = #changeset;
                 type Table = #table::table;
+                type Error = #error;
             }
         });
     }

--- a/editoast/editoast_derive/src/model/config.rs
+++ b/editoast/editoast_derive/src/model/config.rs
@@ -19,6 +19,7 @@ pub(crate) struct ModelConfig {
     pub(crate) fields: Fields,
     pub(crate) row: GeneratedTypeArgs,
     pub(crate) changeset: GeneratedTypeArgs,
+    pub(crate) error: syn::Path,
     pub(crate) identifiers: BTreeSet<Identifier>, // identifiers ⊆ fields
     pub(crate) preferred_identifier: Identifier,  // preferred_identifier ∈ identifiers
     pub(crate) primary_identifier: Identifier,    // primary_identifier ∈ identifiers

--- a/editoast/editoast_derive/src/model/parsing.rs
+++ b/editoast/editoast_derive/src/model/parsing.rs
@@ -138,6 +138,9 @@ impl ModelConfig {
             fields,
             row,
             changeset,
+            error: options
+                .error
+                .unwrap_or(syn::parse_quote! { editoast_models::model::Error }),
             identifiers: typed_identifiers,
             preferred_identifier: preferred_typed_identifier,
             primary_identifier: primary_typed_identifier,

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -25,6 +25,7 @@ impl crate::models::Model for Document {
     type Row = DocumentRow;
     type Changeset = DocumentChangeset;
     type Table = editoast_models::tables::osrd_infra_document::table;
+    type Error = editoast_models::model::Error;
 }
 paste::paste! {
     impl Document { pub const [< id_ : snake : upper >] : crate ::models::ModelField <
@@ -486,7 +487,6 @@ impl crate::models::Create<Document> for DocumentChangeset {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Delete for Document {
     #[tracing::instrument(
         name = "model:delete<Document>",
@@ -498,7 +498,7 @@ impl crate::models::Delete for Document {
     async fn delete(
         &self,
         conn: &mut editoast_models::DbConnection,
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -508,7 +508,9 @@ impl crate::models::Delete for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -611,13 +611,15 @@ impl crate::models::prelude::Count for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
-impl crate::models::CreateBatch<DocumentChangeset> for Document {
+impl crate::models::CreateBatch for Document {
     #[tracing::instrument(name = "model:create_batch<Document>", skip_all, err)]
     async fn create_batch<
-        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
         C: Default + std::iter::Extend<Self> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, values: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        values: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
@@ -638,12 +640,15 @@ impl crate::models::CreateBatch<DocumentChangeset> for Document {
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Document as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Document as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -652,13 +657,15 @@ impl crate::models::CreateBatch<DocumentChangeset> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
-impl crate::models::CreateBatchWithKey<DocumentChangeset, (String)> for Document {
+impl crate::models::CreateBatchWithKey<(String)> for Document {
     #[tracing::instrument(name = "model:create_batch_with_key<Document>", skip_all, err)]
     async fn create_batch_with_key<
-        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
         C: Default + std::iter::Extend<((String), Self)> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, values: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        values: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use std::ops::DerefMut;
@@ -680,14 +687,18 @@ impl crate::models::CreateBatchWithKey<DocumentChangeset, (String)> for Document
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -696,13 +707,15 @@ impl crate::models::CreateBatchWithKey<DocumentChangeset, (String)> for Document
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
-impl crate::models::CreateBatchWithKey<DocumentChangeset, (i64)> for Document {
+impl crate::models::CreateBatchWithKey<(i64)> for Document {
     #[tracing::instrument(name = "model:create_batch_with_key<Document>", skip_all, err)]
     async fn create_batch_with_key<
-        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
         C: Default + std::iter::Extend<((i64), Self)> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, values: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        values: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use std::ops::DerefMut;
@@ -724,14 +737,18 @@ impl crate::models::CreateBatchWithKey<DocumentChangeset, (i64)> for Document {
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -469,13 +469,12 @@ impl crate::models::DeleteStatic<(i64)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Create<Document> for DocumentChangeset {
     #[tracing::instrument(name = "model:create<Document>", skip_all, err)]
     async fn create(
         self,
         conn: &mut editoast_models::DbConnection,
-    ) -> crate::error::Result<Document> {
+    ) -> std::result::Result<Document, <Document as crate::models::Model>::Error> {
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
@@ -485,7 +484,9 @@ impl crate::models::Create<Document> for DocumentChangeset {
             .get_result::<DocumentRow>(conn.write().await.deref_mut())
             .await
             .map(Into::into)
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -1167,7 +1167,6 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::DeleteBatch<(String)> for Document {
     #[tracing::instrument(
         name = "model:delete_batch<Document>",
@@ -1176,9 +1175,10 @@ impl crate::models::DeleteBatch<(String)> for Document {
         err,
         fields(query_ids)
     )]
-    async fn delete_batch<
-        I: std::iter::IntoIterator<Item = (String)> + Send + 'async_trait,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<usize> {
+    async fn delete_batch<I: std::iter::IntoIterator<Item = (String)> + Send>(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<usize, <Document as crate::models::Model>::Error> {
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
@@ -1198,7 +1198,12 @@ impl crate::models::DeleteBatch<(String)> for Document {
                     for content_type in chunk.into_iter() {
                         query = query.or_filter(dsl::content_type.eq(content_type));
                     }
-                    query.execute(conn.write().await.deref_mut()).await?
+                    query
+                        .execute(conn.write().await.deref_mut())
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.push(chunk_result);
             }
@@ -1208,7 +1213,6 @@ impl crate::models::DeleteBatch<(String)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::DeleteBatch<(i64)> for Document {
     #[tracing::instrument(
         name = "model:delete_batch<Document>",
@@ -1217,9 +1221,10 @@ impl crate::models::DeleteBatch<(i64)> for Document {
         err,
         fields(query_ids)
     )]
-    async fn delete_batch<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<usize> {
+    async fn delete_batch<I: std::iter::IntoIterator<Item = (i64)> + Send>(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<usize, <Document as crate::models::Model>::Error> {
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
@@ -1239,7 +1244,12 @@ impl crate::models::DeleteBatch<(i64)> for Document {
                     for id_ in chunk.into_iter() {
                         query = query.or_filter(dsl::id.eq(id_));
                     }
-                    query.execute(conn.write().await.deref_mut()).await?
+                    query
+                        .execute(conn.write().await.deref_mut())
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.push(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -412,7 +412,6 @@ impl crate::models::Update<(i64), Document> for DocumentChangeset {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::DeleteStatic<(String)> for Document {
     #[tracing::instrument(
         name = "model:delete_static<Document>",
@@ -424,7 +423,7 @@ impl crate::models::DeleteStatic<(String)> for Document {
     async fn delete_static(
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -437,11 +436,12 @@ impl crate::models::DeleteStatic<(String)> for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::DeleteStatic<(i64)> for Document {
     #[tracing::instrument(
         name = "model:delete_static<Document>",
@@ -453,7 +453,7 @@ impl crate::models::DeleteStatic<(i64)> for Document {
     async fn delete_static(
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -463,7 +463,9 @@ impl crate::models::DeleteStatic<(i64)> for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_models/Cargo.toml
+++ b/editoast/editoast_models/Cargo.toml
@@ -17,6 +17,7 @@ openssl.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 postgis_diesel.workspace = true
 postgres-openssl.workspace = true
+regex.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true

--- a/editoast/editoast_models/src/lib.rs
+++ b/editoast/editoast_models/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod db_connection_pool;
+pub mod model;
 pub mod tables;
 
 pub use db_connection_pool::DbConnection;

--- a/editoast/editoast_models/src/model.rs
+++ b/editoast/editoast_models/src/model.rs
@@ -1,0 +1,83 @@
+use std::sync::LazyLock;
+
+use diesel::result::{DatabaseErrorInformation, DatabaseErrorKind};
+use regex::Regex;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unique constraint violation \"{constraint}\" on column \"{column}\" with value \"{value}\"")]
+    UniqueViolation {
+        constraint: String,
+        column: String,
+        value: String,
+    },
+    #[error("check constraint violation of \"{constraint}\"")]
+    CheckViolation { constraint: String },
+    #[error(transparent)]
+    DatabaseError(diesel::result::Error),
+}
+
+fn try_parse_unique_violation(e: &(dyn DatabaseErrorInformation + Send + Sync)) -> Option<Error> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"duplicate key value violates unique constraint"#).unwrap());
+    if RE.is_match(e.message()) {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"Key \(([^)]+)\)=\(([^)]+)\) already exists\."#).unwrap()
+        });
+        RE.captures(e.details().expect("PostgreSQL should provide details"))
+            .map(|captures| Error::UniqueViolation {
+                constraint: e
+                    .constraint_name()
+                    .expect("PostgreSQL should provide the constraint name")
+                    .to_owned(),
+                column: captures.get(1).unwrap().as_str().to_owned(),
+                value: captures.get(2).unwrap().as_str().to_owned(),
+            })
+    } else {
+        None
+    }
+}
+
+fn try_parse_check_violation(e: &(dyn DatabaseErrorInformation + Send + Sync)) -> Option<Error> {
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"new row for relation .* violates check constraint"#).unwrap()
+    });
+    if RE.is_match(e.message()) {
+        Some(Error::CheckViolation {
+            constraint: e
+                .constraint_name()
+                .expect("PostgreSQL should provide the constraint name")
+                .to_owned(),
+        })
+    } else {
+        None
+    }
+}
+
+impl From<diesel::result::Error> for Error {
+    fn from(e: diesel::result::Error) -> Self {
+        match &e {
+            diesel::result::Error::DatabaseError(DatabaseErrorKind::UniqueViolation, inner) => {
+                try_parse_unique_violation(inner.as_ref()).unwrap_or_else(move || {
+                    // falling back to the generic error — since it's still semantically correct, logging the error is enough
+                    tracing::error!(
+                        error = %e,
+                        "failed to parse PostgreSQL details message"
+                    );
+                    Self::DatabaseError(e)
+                })
+            }
+            diesel::result::Error::DatabaseError(DatabaseErrorKind::CheckViolation, inner) => {
+                try_parse_check_violation(inner.as_ref()).unwrap_or_else(|| {
+                    // falling back to the generic error — since it's still semantically correct, logging the error is enough
+                    tracing::error!(
+                        error = %e,
+                        "failed to parse PostgreSQL details message"
+                    );
+                    Self::DatabaseError(e)
+                })
+            }
+            _ => Self::DatabaseError(e),
+        }
+    }
+}

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4769,6 +4769,7 @@ components:
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
       - $ref: '#/components/schemas/EditoastListErrorsRailjsonWrongRailjsonVersionProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
+      - $ref: '#/components/schemas/EditoastModelError'
       - $ref: '#/components/schemas/EditoastMqClientErrorConnectionDoesNotExist'
       - $ref: '#/components/schemas/EditoastMqClientErrorLapin'
       - $ref: '#/components/schemas/EditoastMqClientErrorPoolChannelFail'
@@ -5109,6 +5110,25 @@ components:
           type: string
           enum:
           - editoast:macro_node:NotFound
+    EditoastModelError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:model:ModelError
     EditoastMqClientErrorConnectionDoesNotExist:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4836,6 +4836,7 @@ components:
       - $ref: '#/components/schemas/EditoastStudyErrorDatabase'
       - $ref: '#/components/schemas/EditoastStudyErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorStartDateAfterEndDate'
+      - $ref: '#/components/schemas/EditoastTemporarySpeedLimitErrorDatabase'
       - $ref: '#/components/schemas/EditoastTemporarySpeedLimitErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastTimetableErrorDatabase'
       - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotFound'
@@ -6261,6 +6262,25 @@ components:
           type: string
           enum:
           - editoast:study:StartDateAfterEndDate
+    EditoastTemporarySpeedLimitErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:temporary_speed_limit:Database
     EditoastTemporarySpeedLimitErrorNameAlreadyUsed:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2327,10 +2327,6 @@ paths:
           description: The requested rolling stock was not found
         '409':
           description: The requested rolling stock is used
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RollingStockError'
     patch:
       tags:
       - rolling_stock
@@ -4599,6 +4595,25 @@ components:
           type: string
           enum:
           - editoast:delimited_area:InvalidLocations
+    EditoastDocumentErrorsDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:document:Database
     EditoastDocumentErrorsNotFound:
       type: object
       required:
@@ -4752,6 +4767,7 @@ components:
       - $ref: '#/components/schemas/EditoastCoreErrorUnparsableErrorOutput'
       - $ref: '#/components/schemas/EditoastDatabaseAccessErrorDatabaseAccessError'
       - $ref: '#/components/schemas/EditoastDelimitedAreaErrorInvalidLocations'
+      - $ref: '#/components/schemas/EditoastDocumentErrorsDatabase'
       - $ref: '#/components/schemas/EditoastDocumentErrorsNotFound'
       - $ref: '#/components/schemas/EditoastEditionErrorInfraIsLocked'
       - $ref: '#/components/schemas/EditoastEditionErrorSplitTrackSectionBadOffset'
@@ -4794,11 +4810,13 @@ components:
       - $ref: '#/components/schemas/EditoastRollingStockErrorBasePowerClassEmpty'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotCreateCompoundImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotReadImage'
+      - $ref: '#/components/schemas/EditoastRollingStockErrorDatabase'
       - $ref: '#/components/schemas/EditoastRollingStockErrorIsLocked'
       - $ref: '#/components/schemas/EditoastRollingStockErrorIsUsed'
       - $ref: '#/components/schemas/EditoastRollingStockErrorKeyNotFound'
       - $ref: '#/components/schemas/EditoastRollingStockErrorLiveryMultipartError'
       - $ref: '#/components/schemas/EditoastRollingStockErrorNameAlreadyUsed'
+      - $ref: '#/components/schemas/EditoastScenarioErrorDatabase'
       - $ref: '#/components/schemas/EditoastScenarioErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastScenarioErrorNotFound'
       - $ref: '#/components/schemas/EditoastScenarioErrorTimetableNotFound'
@@ -4815,16 +4833,20 @@ components:
       - $ref: '#/components/schemas/EditoastStdcmLogErrorMissingIdAndTraceId'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorNotFound'
       - $ref: '#/components/schemas/EditoastStdcmLogErrorTraceIdNotFound'
+      - $ref: '#/components/schemas/EditoastStudyErrorDatabase'
       - $ref: '#/components/schemas/EditoastStudyErrorNotFound'
       - $ref: '#/components/schemas/EditoastStudyErrorStartDateAfterEndDate'
       - $ref: '#/components/schemas/EditoastTemporarySpeedLimitErrorNameAlreadyUsed'
+      - $ref: '#/components/schemas/EditoastTimetableErrorDatabase'
       - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorNotFound'
       - $ref: '#/components/schemas/EditoastTowedRollingStockErrorIdNotFound'
       - $ref: '#/components/schemas/EditoastTowedRollingStockErrorIsLocked'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorBatchTrainScheduleNotFound'
+      - $ref: '#/components/schemas/EditoastTrainScheduleErrorDatabase'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorNotFound'
+      - $ref: '#/components/schemas/EditoastWorkScheduleErrorDatabase'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorNameAlreadyUsed'
       - $ref: '#/components/schemas/EditoastWorkScheduleErrorWorkScheduleGroupNotFound'
       description: Generated error type for Editoast
@@ -5652,6 +5674,25 @@ components:
           type: string
           enum:
           - editoast:rollingstocks:CannotReadImage
+    EditoastRollingStockErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:rollingstocks:Database
     EditoastRollingStockErrorIsLocked:
       type: object
       required:
@@ -5770,6 +5811,25 @@ components:
           type: string
           enum:
           - editoast:rollingstocks:NameAlreadyUsed
+    EditoastScenarioErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:scenario:Database
     EditoastScenarioErrorInfraNotFound:
       type: object
       required:
@@ -6139,6 +6199,25 @@ components:
           type: string
           enum:
           - editoast:stdcm_log:TraceIdNotFound
+    EditoastStudyErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:study:Database
     EditoastStudyErrorNotFound:
       type: object
       required:
@@ -6206,6 +6285,25 @@ components:
           type: string
           enum:
           - editoast:temporary_speed_limit:NameAlreadyUsed
+    EditoastTimetableErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:timetable:Database
     EditoastTimetableErrorInfraNotFound:
       type: object
       required:
@@ -6326,6 +6424,25 @@ components:
           type: string
           enum:
           - editoast:train_schedule:BatchTrainScheduleNotFound
+    EditoastTrainScheduleErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:train_schedule:Database
     EditoastTrainScheduleErrorInfraNotFound:
       type: object
       required:
@@ -6374,6 +6491,25 @@ components:
           type: string
           enum:
           - editoast:train_schedule:NotFound
+    EditoastWorkScheduleErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:work_schedule:Database
     EditoastWorkScheduleErrorNameAlreadyUsed:
       type: object
       required:
@@ -9336,68 +9472,6 @@ components:
         version:
           type: integer
           format: int64
-    RollingStockError:
-      oneOf:
-      - type: string
-        enum:
-        - CannotReadImage
-      - type: string
-        enum:
-        - CannotCreateCompoundImage
-      - type: object
-        required:
-        - KeyNotFound
-        properties:
-          KeyNotFound:
-            type: object
-            required:
-            - rolling_stock_key
-            properties:
-              rolling_stock_key:
-                $ref: '#/components/schemas/RollingStockKey'
-      - type: object
-        required:
-        - NameAlreadyUsed
-        properties:
-          NameAlreadyUsed:
-            type: object
-            required:
-            - name
-            properties:
-              name:
-                type: string
-      - type: object
-        required:
-        - IsLocked
-        properties:
-          IsLocked:
-            type: object
-            required:
-            - rolling_stock_id
-            properties:
-              rolling_stock_id:
-                type: integer
-                format: int64
-      - type: object
-        required:
-        - IsUsed
-        properties:
-          IsUsed:
-            type: object
-            required:
-            - rolling_stock_id
-            - usage
-            properties:
-              rolling_stock_id:
-                type: integer
-                format: int64
-              usage:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ScenarioReference'
-      - type: string
-        enum:
-        - BasePowerClassEmpty
     RollingStockForm:
       type: object
       required:
@@ -9499,31 +9573,6 @@ components:
           description: Duration in s
         supported_signaling_systems:
           $ref: '#/components/schemas/RollingStockSupportedSignalingSystems'
-    RollingStockKey:
-      oneOf:
-      - type: object
-        required:
-        - type
-        - key
-        properties:
-          key:
-            type: integer
-            format: int64
-          type:
-            type: string
-            enum:
-            - Id
-      - type: object
-        required:
-        - type
-        - key
-        properties:
-          key:
-            type: string
-          type:
-            type: string
-            enum:
-            - Name
     RollingStockLivery:
       type: object
       required:

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -265,6 +265,19 @@ impl EditoastError for editoast_schemas::errors::GeometryError {
     }
 }
 
+inventory::submit! {
+    ErrorDefinition::new("editoast:model:ModelError", "", "ModelError", 500u16, r#"{}"#)
+}
+impl EditoastError for editoast_models::model::Error {
+    fn get_status(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn get_type(&self) -> &str {
+        "editoast:ModelError"
+    }
+}
+
 // error definition : uses by the macro EditoastError to generate
 // the list of error and share it with the openAPI generator
 #[derive(Debug)]

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -246,7 +246,7 @@ impl Infra {
     }
 
     /// Clear generated data of the infra
-    /// This function will update `generated_version` acordingly.
+    /// This function will update `generated_version` accordingly.
     pub async fn clear(&mut self, conn: &mut DbConnection) -> Result<bool> {
         // TODO: lock self for update
         generated_data::clear_all(conn, self.id).await?;
@@ -301,6 +301,7 @@ impl Infra {
             })
         })
         .await
+        .map_err(Into::into)
     }
 }
 
@@ -386,7 +387,7 @@ pub mod tests {
     }
 
     #[rstest]
-    // The fixture leaks the persisted infra because we explicitely opened a
+    // The fixture leaks the persisted infra because we explicitly opened a
     // connection. This should be fixed by the testing utils rework. The ignore
     // should be removed after.
     #[ignore]

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -61,13 +61,17 @@ mod tests {
     use super::prelude::*;
 
     #[derive(Debug, Default, Clone, Model, PartialEq, Eq)]
-    #[model(table = editoast_models::tables::document)]
+    #[model(table = editoast_models::tables::document, error = DocError)]
     #[model(gen(ops = crud, batch_ops = crud, list))]
     struct Document {
         id: i64,
         content_type: String,
         data: Vec<u8>,
     }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("oh no {0}")]
+    struct DocError(#[from] editoast_models::model::Error);
 
     #[rstest]
     async fn test_batch() {

--- a/editoast/src/models/prelude/create.rs
+++ b/editoast/src/models/prelude/create.rs
@@ -1,14 +1,14 @@
 use std::fmt::Debug;
+use std::result::Result;
 
 use editoast_models::model;
 use editoast_models::DbConnection;
 
 use crate::error::EditoastError;
-use crate::error::Result;
 
 use super::Model;
 
-/// Describes how a [Model](super::Model) can be created in the database
+/// Describes how a [Model] can be created in the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
@@ -30,15 +30,11 @@ pub trait Create<M: Model>: Sized {
     }
 }
 
-/// Describes how a [Model](super::Model) can be created in the database given a batch of its changesets
+/// Describes how a [Model] can be created in the database given a batch of its changesets
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait CreateBatch<Cs>: Sized
-where
-    Cs: Send,
-{
+pub trait CreateBatch: Model {
     /// Creates a batch of rows in the database given an iterator of changesets
     ///
     /// Returns a collection of the created rows.
@@ -52,15 +48,15 @@ where
     /// assert_eq!(docs.len(), 5);
     /// ```
     async fn create_batch<
-        I: IntoIterator<Item = Cs> + Send + 'async_trait,
+        I: IntoIterator<Item = Self::Changeset> + Send,
         C: Default + std::iter::Extend<Self> + Send + Debug,
     >(
         conn: &mut DbConnection,
         values: I,
-    ) -> Result<C>;
+    ) -> Result<C, Self::Error>;
 }
 
-/// Describes how a [Model](super::Model) can be created in the database given a batch of its changesets
+/// Describes how a [Model] can be created in the database given a batch of its changesets
 ///
 /// This trait is similar to [CreateBatch] but the returned models are paired with their key.
 /// There is two different traits because Rust cannot infer the type of the key when using
@@ -68,18 +64,16 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait CreateBatchWithKey<Cs, K>: Sized
+pub trait CreateBatchWithKey<K>: Model
 where
-    Cs: Send,
     K: Send + Clone,
 {
     /// Just like [CreateBatch::create_batch] but the returned models are paired with their key
     async fn create_batch_with_key<
-        I: IntoIterator<Item = Cs> + Send + 'async_trait,
+        I: IntoIterator<Item = Self::Changeset> + Send,
         C: Default + std::iter::Extend<(K, Self)> + Send + Debug,
     >(
         conn: &mut DbConnection,
         values: I,
-    ) -> Result<C>;
+    ) -> Result<C, Self::Error>;
 }

--- a/editoast/src/models/prelude/create.rs
+++ b/editoast/src/models/prelude/create.rs
@@ -1,29 +1,31 @@
 use std::fmt::Debug;
 
+use editoast_models::model;
 use editoast_models::DbConnection;
 
 use crate::error::EditoastError;
 use crate::error::Result;
 
+use super::Model;
+
 /// Describes how a [Model](super::Model) can be created in the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait Create<Row: Send>: Sized {
+pub trait Create<M: Model>: Sized {
     /// Creates a new row in the database with the values of the changeset and
     /// returns the created model instance
-    async fn create(self, conn: &mut DbConnection) -> Result<Row>;
+    async fn create(self, conn: &mut DbConnection) -> std::result::Result<M, M::Error>;
 
     /// Just like [Create::create] but discards the error if any and returns `Err(fail())` instead
-    async fn create_or_fail<E: EditoastError, F: FnOnce() -> E + Send>(
+    async fn create_or_fail<E: From<M::Error>, F: FnOnce() -> E + Send>(
         self,
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         fail: F,
-    ) -> Result<Row> {
+    ) -> std::result::Result<M, E> {
         match self.create(conn).await {
             Ok(obj) => Ok(obj),
-            Err(_) => Err(fail().into()),
+            Err(_) => Err(fail()),
         }
     }
 }

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -40,24 +40,26 @@ pub trait Delete: Model {
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait DeleteStatic<K>: Sized
+pub trait DeleteStatic<K>: Model
 where
-    for<'async_trait> K: Send + 'async_trait,
+    K: Send,
 {
     /// Deletes the row #`id` from the database
-    async fn delete_static(conn: &mut DbConnection, id: K) -> Result<bool>;
+    async fn delete_static(
+        conn: &mut DbConnection,
+        id: K,
+    ) -> std::result::Result<bool, Self::Error>;
 
     /// Just like [DeleteStatic::delete_static] but returns `Err(fail())` if the row didn't exist
-    async fn delete_static_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<()>
+    async fn delete_static_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<(), E>
     where
-        E: EditoastError,
-        F: FnOnce() -> E + Send + 'async_trait,
+        E: From<Self::Error>,
+        F: FnOnce() -> E + Send,
     {
         match Self::delete_static(conn, id).await {
             Ok(true) => Ok(()),
-            Ok(false) => Err(fail().into()),
-            Err(e) => Err(e),
+            Ok(false) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -1,11 +1,12 @@
-use editoast_models::DbConnection;
+use std::result::Result;
+
+use editoast_models::{model, DbConnection};
 
 use crate::error::EditoastError;
-use crate::error::Result;
 
 use super::Model;
 
-/// Describes how a [Model](super::Model) can be deleted from the database
+/// Describes how a [Model] can be deleted from the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
@@ -16,11 +17,7 @@ pub trait Delete: Model {
     async fn delete(&self, conn: &mut DbConnection) -> std::result::Result<bool, Self::Error>;
 
     /// Just like [Delete::delete] but returns `Err(fail())` if the row didn't exist
-    async fn delete_or_fail<E, F>(
-        &self,
-        conn: &mut DbConnection,
-        fail: F,
-    ) -> std::result::Result<(), E>
+    async fn delete_or_fail<E, F>(&self, conn: &mut DbConnection, fail: F) -> Result<(), E>
     where
         E: From<Self::Error>,
         F: FnOnce() -> E + Send,
@@ -33,7 +30,7 @@ pub trait Delete: Model {
     }
 }
 
-/// Describes how a [Model](super::Model) can be deleted from the database
+/// Describes how a [Model] can be deleted from the database
 ///
 /// This trait is similar to [Delete] but it doesn't take a reference to the model
 /// instance. This is useful for models that don't have to be retrieved before deletion.
@@ -64,36 +61,39 @@ where
     }
 }
 
-/// Describes how a [Model](super::Model) can be deleted from the database given a batch of keys
+/// Describes how a [Model] can be deleted from the database given a batch of keys
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait DeleteBatch<K>: Sized
+pub trait DeleteBatch<K>: Model
 where
-    for<'async_trait> K: Send + 'async_trait,
+    K: Send,
 {
     /// Deletes a batch of rows from the database given an iterator of keys
     ///
     /// Returns the number of rows deleted.
-    async fn delete_batch<I: IntoIterator<Item = K> + Send + 'async_trait>(
+    async fn delete_batch<I: IntoIterator<Item = K> + Send>(
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<usize>;
+    ) -> Result<usize, Self::Error>;
 
     /// Just like [DeleteBatch::delete_batch] but returns `Err(fail(missing))` where `missing`
     /// is the number of rows that were not deleted
-    async fn delete_batch_or_fail<I, E, F>(conn: &mut DbConnection, ids: I, fail: F) -> Result<()>
+    async fn delete_batch_or_fail<I, E, F>(
+        conn: &mut DbConnection,
+        ids: I,
+        fail: F,
+    ) -> Result<(), E>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
-        E: EditoastError,
-        F: FnOnce(usize) -> E + Send + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
+        E: From<Self::Error>,
+        F: FnOnce(usize) -> E + Send,
     {
         let ids = ids.into_iter().collect::<Vec<_>>();
         let expected_count = ids.len();
         let count = Self::delete_batch(conn, ids).await?;
         if count != expected_count {
-            Err(fail(expected_count - count).into())
+            Err(fail(expected_count - count))
         } else {
             Ok(())
         }

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -3,27 +3,32 @@ use editoast_models::DbConnection;
 use crate::error::EditoastError;
 use crate::error::Result;
 
+use super::Model;
+
 /// Describes how a [Model](super::Model) can be deleted from the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
-pub trait Delete: Sized {
+pub trait Delete: Model {
     /// Deletes the row corresponding to this model instance
     ///
     /// Returns `true` if the row was deleted, `false` if it didn't exist
-    async fn delete(&self, conn: &mut DbConnection) -> Result<bool>;
+    async fn delete(&self, conn: &mut DbConnection) -> std::result::Result<bool, Self::Error>;
 
     /// Just like [Delete::delete] but returns `Err(fail())` if the row didn't exist
-    async fn delete_or_fail<E, F>(&self, conn: &mut DbConnection, fail: F) -> Result<()>
+    async fn delete_or_fail<E, F>(
+        &self,
+        conn: &mut DbConnection,
+        fail: F,
+    ) -> std::result::Result<(), E>
     where
-        E: EditoastError,
-        F: FnOnce() -> E + Send + 'async_trait,
+        E: From<Self::Error>,
+        F: FnOnce() -> E + Send,
     {
         match self.delete(conn).await {
             Ok(true) => Ok(()),
-            Ok(false) => Err(fail().into()),
-            Err(e) => Err(e),
+            Ok(false) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }

--- a/editoast/src/models/prelude/mod.rs
+++ b/editoast/src/models/prelude/mod.rs
@@ -31,6 +31,7 @@ pub trait Model: std::fmt::Debug + Clone + Sized + Send {
     type Row: Into<Self> + Send;
     type Changeset: Default + From<Self> + Send;
     type Table: diesel::Table + Send;
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
 
     /// Returns an empty changeset for this model
     fn changeset() -> Self::Changeset {
@@ -56,15 +57,19 @@ pub trait Model: std::fmt::Debug + Clone + Sized + Send {
 
 /// A type alias for the [Model::Row] associated type
 ///
-/// Helps silent compiler errors about type amibiguity.
+/// Helps silent compiler errors about type ambiguity.
 #[allow(unused)]
 pub type Row<M> = <M as Model>::Row;
 
 /// A type alias for the [Model::Changeset] associated type
 ///
-/// Helps silent compiler errors about type amibiguity.
-#[allow(unused)]
+/// Helps silent compiler errors about type ambiguity.
 pub type Changeset<M> = <M as Model>::Changeset;
+
+/// A type alias for the [Model::Error] associated type
+///
+/// Helps silent compiler errors about type ambiguity.
+pub type ModelError<M> = <M as Model>::Error;
 
 /// A struct persisting the column and type information of each model field
 ///

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -7,6 +7,7 @@ use editoast_common::units::quantities::{
     Acceleration, Deceleration, Length, Mass, Ratio, Time, Velocity,
 };
 use editoast_derive::Model;
+use editoast_models::model;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
 use editoast_schemas::rolling_stock::EtcsBrakeParams;
@@ -35,7 +36,7 @@ editoast_common::schemas! {
 
 #[editoast_derive::annotate_units]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Model, ToSchema)]
-#[model(table = editoast_models::tables::rolling_stock)]
+#[model(table = editoast_models::tables::rolling_stock, error = Error)]
 #[model(gen(ops = crud, batch_ops = r, list))]
 #[model(changeset(derive(Deserialize), public))]
 #[schema(as = RollingStock)]
@@ -99,6 +100,36 @@ pub struct RollingStockModel {
     #[schema(value_type = Vec<String>)]
     #[model(remote = "Vec<Option<String>>")]
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Rolling stock name already used: {name}")]
+    NameAlreadyUsed { name: String },
+    #[error("Rolling stock base power class cannot be an empty string")]
+    BasePowerClassEmpty,
+    #[error(transparent)]
+    Database(editoast_models::model::Error),
+}
+
+impl From<model::Error> for Error {
+    fn from(e: model::Error) -> Self {
+        match e {
+            model::Error::UniqueViolation {
+                constraint,
+                column,
+                value,
+            } if constraint == "rolling_stock_name_key" && column == "name" => {
+                Self::NameAlreadyUsed { name: value }
+            }
+            model::Error::CheckViolation { constraint }
+                if constraint == "base_power_class_null_or_non_empty" =>
+            {
+                Self::BasePowerClassEmpty
+            }
+            e => Self::Database(e),
+        }
+    }
 }
 
 impl RollingStockModelChangeset {

--- a/editoast/src/models/stdcm_search_environment.rs
+++ b/editoast/src/models/stdcm_search_environment.rs
@@ -4,13 +4,14 @@ use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use editoast_models::model;
 use editoast_models::DbConnection;
 use serde::Serialize;
 use std::ops::DerefMut;
+use std::result::Result;
 use utoipa::ToSchema;
 
-use crate::error::Result;
-use crate::models::prelude::{Create, Row};
+use crate::models::prelude::*;
 
 #[cfg(test)]
 use serde::Deserialize;
@@ -48,7 +49,7 @@ impl StdcmSearchEnvironment {
             .ok()
     }
 
-    pub async fn delete_all(conn: &mut DbConnection) -> Result<()> {
+    pub async fn delete_all(conn: &mut DbConnection) -> Result<(), model::Error> {
         use editoast_models::tables::stdcm_search_environment::dsl::*;
         diesel::delete(stdcm_search_environment)
             .execute(conn.write().await.deref_mut())
@@ -58,7 +59,10 @@ impl StdcmSearchEnvironment {
 }
 
 impl StdcmSearchEnvironmentChangeset {
-    pub async fn overwrite(self, conn: &mut DbConnection) -> Result<StdcmSearchEnvironment> {
+    pub async fn overwrite(
+        self,
+        conn: &mut DbConnection,
+    ) -> Result<StdcmSearchEnvironment, model::Error> {
         StdcmSearchEnvironment::delete_all(conn).await?;
         self.create(conn).await
     }

--- a/editoast/src/models/temporary_speed_limits.rs
+++ b/editoast/src/models/temporary_speed_limits.rs
@@ -1,13 +1,16 @@
 use chrono::NaiveDateTime;
 use editoast_derive::Model;
-use editoast_models::tables::{temporary_speed_limit, temporary_speed_limit_group};
+use editoast_models::{
+    model,
+    tables::{temporary_speed_limit, temporary_speed_limit_group},
+};
 use editoast_schemas::infra::DirectionalTrackRange;
 use serde::Serialize;
 
 use crate::core::stdcm::TemporarySpeedLimit as CoreTemporarySpeedLimit;
 
 #[derive(Debug, Clone, Model)]
-#[model(table = temporary_speed_limit_group)]
+#[model(table = temporary_speed_limit_group, error = TslGroupError)]
 #[model(gen(ops = crd, batch_ops = c, list))]
 pub struct TemporarySpeedLimitGroup {
     pub id: i64,
@@ -15,8 +18,31 @@ pub struct TemporarySpeedLimitGroup {
     pub name: String,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum TslGroupError {
+    #[error("Temporary speed limit group name already used: {name}")]
+    NameAlreadyUsed { name: String },
+    #[error(transparent)]
+    Database(model::Error),
+}
+
+impl From<model::Error> for TslGroupError {
+    fn from(e: model::Error) -> Self {
+        match e {
+            model::Error::UniqueViolation {
+                constraint,
+                column,
+                value,
+            } if constraint == "temporary_speed_limit_group_name_key" && column == "name" => {
+                Self::NameAlreadyUsed { name: value }
+            }
+            e => Self::Database(e),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Clone, Model)]
-#[model(table = temporary_speed_limit)]
+#[model(table = temporary_speed_limit, error = Error)]
 #[model(gen(ops = cr, batch_ops = c, list))]
 pub struct TemporarySpeedLimit {
     pub id: i64,
@@ -28,6 +54,10 @@ pub struct TemporarySpeedLimit {
     pub obj_id: String,
     pub temporary_speed_limit_group_id: i64,
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(#[from] model::Error);
 
 impl From<TemporarySpeedLimit> for CoreTemporarySpeedLimit {
     fn from(value: TemporarySpeedLimit) -> Self {

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -24,6 +24,19 @@ pub struct Timetable {
     pub id: i64,
 }
 
+impl crate::models::Model for Timetable {
+    type Row = Self;
+    type Changeset = Option<i64>;
+    type Table = editoast_models::tables::timetable::table;
+    type Error = editoast_models::model::Error;
+}
+
+impl From<Timetable> for Option<i64> {
+    fn from(timetable: Timetable) -> Self {
+        Some(timetable.id)
+    }
+}
+
 impl Timetable {
     #[tracing::instrument(name = "model:create<Timetable>", skip_all, err)]
     pub async fn create(conn: &mut DbConnection) -> Result<Self> {
@@ -84,22 +97,21 @@ impl Timetable {
     }
 }
 
-#[async_trait::async_trait]
 impl DeleteStatic<i64> for Timetable {
-    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
     #[tracing::instrument(name = "model:delete_static<Timetable>", skip_all, ret, err)]
-    async fn delete_static(conn: &mut DbConnection, id: i64) -> Result<bool> {
-        diesel::delete(dsl::timetable.filter(dsl::id.eq(id)))
+    async fn delete_static(
+        conn: &mut DbConnection,
+        id: i64,
+    ) -> Result<bool, editoast_models::model::Error> {
+        let n = diesel::delete(dsl::timetable.filter(dsl::id.eq(id)))
             .execute(conn.write().await.deref_mut())
-            .await
-            .map(|n| n == 1)
-            .map_err(Into::into)
+            .await?;
+        Ok(n == 1)
     }
 }
 
 #[async_trait::async_trait]
 impl Retrieve<i64> for Timetable {
-    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
     #[tracing::instrument(name = "model:retrieve<Timetable>", skip_all, err)]
     async fn retrieve(
         conn: &mut editoast_models::DbConnection,
@@ -116,7 +128,6 @@ impl Retrieve<i64> for Timetable {
 
 #[async_trait::async_trait]
 impl Exists<i64> for Timetable {
-    #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
     #[tracing::instrument(name = "model:exists<Timetable>", skip_all, ret, err)]
     async fn exists(conn: &mut DbConnection, id: i64) -> Result<bool> {
         Self::retrieve(conn, id)

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -31,7 +31,7 @@ pub enum WorkScheduleType {
 
 #[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema)]
 #[model(table = editoast_models::tables::work_schedule)]
-#[model(gen(batch_ops = cd, list))]
+#[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {
     pub id: i64,
     pub start_date_time: DateTime<Utc>,

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use chrono::DateTime;
 use chrono::Utc;
 use editoast_derive::Model;
+use editoast_models::model;
 use editoast_schemas::infra::TrackRange;
 use strum::FromRepr;
 
@@ -13,12 +14,35 @@ use utoipa::ToSchema;
 use crate::core::stdcm::UndirectedTrackRange;
 
 #[derive(Debug, Clone, Model)]
-#[model(table = editoast_models::tables::work_schedule_group)]
+#[model(table = editoast_models::tables::work_schedule_group, error = WsGroupError)]
 #[model(gen(ops = crd, batch_ops = c, list))]
 pub struct WorkScheduleGroup {
     pub id: i64,
     pub creation_date: DateTime<Utc>,
     pub name: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WsGroupError {
+    #[error("Work schedule group name already used: {name}")]
+    NameAlreadyUsed { name: String },
+    #[error(transparent)]
+    Database(model::Error),
+}
+
+impl From<model::Error> for WsGroupError {
+    fn from(e: model::Error) -> Self {
+        match e {
+            model::Error::UniqueViolation {
+                constraint,
+                column,
+                value,
+            } if constraint == "work_schedule_group_name_key" && column == "name" => {
+                Self::NameAlreadyUsed { name: value }
+            }
+            e => Self::Database(e),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, FromRepr, ToSchema, PartialEq)]
@@ -30,7 +54,7 @@ pub enum WorkScheduleType {
 }
 
 #[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema)]
-#[model(table = editoast_models::tables::work_schedule)]
+#[model(table = editoast_models::tables::work_schedule, error = Error)]
 #[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {
     pub id: i64,
@@ -43,6 +67,10 @@ pub struct WorkSchedule {
     pub work_schedule_type: WorkScheduleType,
     pub work_schedule_group_id: i64,
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(#[from] model::Error);
 
 impl WorkSchedule {
     pub fn as_core_work_schedule(

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -39,6 +39,9 @@ pub enum DocumentErrors {
     #[error("Document '{document_key}' not found")]
     #[editoast_error(status = 404)]
     NotFound { document_key: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 /// Returns a document of any type

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -67,8 +67,6 @@ editoast_common::schemas! {
     DeleteRollingStockQueryParams,
     RollingStockLockedUpdateForm,
     RollingStockLiveryCreateForm,
-    RollingStockError,
-    RollingStockKey,
     RollingStockWithLiveries,
     ScenarioReference,
     light::schemas(),
@@ -102,14 +100,14 @@ impl RollingStockWithLiveries {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Display, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Display, Serialize)]
 #[serde(tag = "type", content = "key")]
 pub enum RollingStockKey {
     Id(i64),
     Name(String),
 }
 
-#[derive(Debug, Error, EditoastError, ToSchema, Serialize)] // serde is required in order to skip variants
+#[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "rollingstocks")]
 pub enum RollingStockError {
     #[error("Impossible to read the separated image")]
@@ -121,8 +119,7 @@ pub enum RollingStockError {
     CannotCreateCompoundImage,
 
     #[error("Invalid livery import payload: {0}")]
-    #[editoast_error(status = 400, no_context)]
-    #[serde(skip)]
+    #[editoast_error(status = 400)]
     LiveryMultipartError(#[from] LiveryMultipartError),
 
     #[error("Rolling stock '{rolling_stock_key}' could not be found")]
@@ -147,6 +144,10 @@ pub enum RollingStockError {
     #[error("Base power class is an empty string")]
     #[editoast_error(status = 400)]
     BasePowerClassEmpty,
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(Debug, Error)]
@@ -424,7 +425,7 @@ struct DeleteRollingStockQueryParams {
         (status = 204, description = "The rolling stock was deleted successfully"),
         (status = 404, description = "The requested rolling stock is locked"),
         (status = 404, description = "The requested rolling stock was not found"),
-        (status = 409, description = "The requested rolling stock is used", body = RollingStockError),
+        (status = 409, description = "The requested rolling stock is used"),
     )
 )]
 async fn delete(
@@ -811,7 +812,7 @@ pub mod tests {
         let mut form = serde_json::from_str::<RollingStockForm>(include_str!(
             "../tests/example_rolling_stock_1.json"
         ))
-        .expect("Unable to parse exemple rolling stock");
+        .expect("Unable to parse example rolling stock");
         form.name = name.to_owned();
         form
     }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -2,6 +2,7 @@ pub mod form;
 pub mod light;
 mod towed;
 
+use editoast_models::model;
 pub use form::RollingStockForm;
 
 use std::io::Cursor;
@@ -37,6 +38,7 @@ use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::prelude::*;
 use crate::models::rolling_stock_livery::RollingStockLiveryModel;
+use crate::models::rolling_stock_model;
 use crate::models::rolling_stock_model::ScenarioReference;
 use crate::models::Document;
 use crate::models::RollingStockModel;
@@ -147,7 +149,7 @@ pub enum RollingStockError {
 
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    Database(#[from] editoast_models::model::Error),
+    Database(model::Error),
 }
 
 #[derive(Debug, Error)]
@@ -178,6 +180,7 @@ pub(crate) enum LiveryMultipartError {
     },
 }
 
+// Still used to parse the error of `Update` and `Save`. Will be removed soon.
 pub fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalError {
     if e.message
         .contains(r#"duplicate key value violates unique constraint "rolling_stock_name_key""#)
@@ -187,6 +190,17 @@ pub fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalErro
         RollingStockError::BasePowerClassEmpty.into()
     } else {
         e
+    }
+}
+
+// This implementation could be generated rather trivially...
+impl From<rolling_stock_model::Error> for RollingStockError {
+    fn from(e: rolling_stock_model::Error) -> Self {
+        match e {
+            rolling_stock_model::Error::NameAlreadyUsed { name } => Self::NameAlreadyUsed { name },
+            rolling_stock_model::Error::BasePowerClassEmpty => Self::BasePowerClassEmpty,
+            rolling_stock_model::Error::Database(error) => Self::Database(error),
+        }
     }
 }
 
@@ -326,7 +340,6 @@ async fn create(
     }
     rolling_stock_form.validate()?;
     let conn = &mut db_pool.get().await?;
-    let rolling_stock_name = rolling_stock_form.name.clone();
     let rolling_stock_changeset: Changeset<RollingStockModel> = rolling_stock_form.into();
 
     let rolling_stock = rolling_stock_changeset
@@ -334,7 +347,7 @@ async fn create(
         .version(0)
         .create(conn)
         .await
-        .map_err(|e| map_diesel_error(e, rolling_stock_name))?;
+        .map_err(RollingStockError::from)?;
 
     Ok(Json(rolling_stock))
 }

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -134,6 +134,10 @@ pub enum ScenarioError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -65,6 +65,9 @@ pub enum StudyError {
     #[error("The study start date must be before the end date")]
     #[editoast_error(status = 400)]
     StartDateAfterEndDate,
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -505,13 +508,13 @@ pub mod tests {
         let response: StudyListResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        let studies_retreived = response
+        let studies_retrieved = response
             .results
             .iter()
             .find(|r| r.study.id == created_study.id)
             .expect("Study not found");
 
-        assert_eq!(studies_retreived.study, created_study);
+        assert_eq!(studies_retrieved.study, created_study);
     }
 
     #[rstest]

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -173,7 +173,9 @@ async fn create_temporary_speed_limit_group(
         .into_iter()
         .map(|speed_limit| speed_limit.into_temporary_speed_limit_changeset(group_id))
         .collect::<Vec<_>>();
-    let _: Vec<_> = TemporarySpeedLimit::create_batch(conn, speed_limits_changesets).await?;
+    let _: Vec<_> = TemporarySpeedLimit::create_batch(conn, speed_limits_changesets)
+        .await
+        .map_err(TemporarySpeedLimitError::from)?;
 
     Ok(Json(TemporarySpeedLimitCreateResponse { group_id }))
 }

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -6,14 +6,15 @@ use chrono::Utc;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::DirectionalTrackRange;
+use itertools::Either;
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Serialize};
 use std::result::Result as StdResult;
 use thiserror::Error;
 use utoipa::ToSchema;
 
-use crate::error::InternalError;
 use crate::error::Result;
+use crate::models::temporary_speed_limits;
 use crate::models::temporary_speed_limits::TemporarySpeedLimit;
 use crate::models::temporary_speed_limits::TemporarySpeedLimitGroup;
 use crate::models::Changeset;
@@ -111,18 +112,25 @@ enum TemporarySpeedLimitError {
     #[error("Name '{name}' already used")]
     #[editoast_error(status = 400)]
     NameAlreadyUsed { name: String },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(Either<temporary_speed_limits::Error, temporary_speed_limits::TslGroupError>),
 }
 
-fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalError {
-    if e.message.contains(
-        r#"duplicate key value violates unique constraint "temporary_speed_limit_group_name_key""#,
-    ) {
-        TemporarySpeedLimitError::NameAlreadyUsed {
-            name: name.as_ref().to_string(),
+impl From<temporary_speed_limits::Error> for TemporarySpeedLimitError {
+    fn from(e: temporary_speed_limits::Error) -> Self {
+        Self::Database(Either::Left(e))
+    }
+}
+
+impl From<temporary_speed_limits::TslGroupError> for TemporarySpeedLimitError {
+    fn from(e: temporary_speed_limits::TslGroupError) -> Self {
+        match e {
+            temporary_speed_limits::TslGroupError::NameAlreadyUsed { name } => {
+                Self::NameAlreadyUsed { name }
+            }
+            e => Self::Database(Either::Right(e)),
         }
-        .into()
-    } else {
-        e
     }
 }
 
@@ -158,7 +166,7 @@ async fn create_temporary_speed_limit_group(
         .creation_date(Utc::now().naive_utc())
         .create(conn)
         .await
-        .map_err(|e| map_diesel_error(e, speed_limit_group_name))?;
+        .map_err(TemporarySpeedLimitError::from)?;
 
     // Create the speed limits
     let speed_limits_changesets = speed_limits

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -69,6 +69,9 @@ enum TimetableError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 /// Creation result for a Timetable

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -102,6 +102,9 @@ pub enum TrainScheduleError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(IntoParams, Deserialize)]

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -73,6 +73,9 @@ enum WorkScheduleError {
     #[error("Work schedule group '{id}' not found")]
     #[editoast_error(status = 404)]
     WorkScheduleGroupNotFound { id: i64 },
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 pub fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalError {

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -202,8 +202,9 @@ async fn create(
             work_schedule.into_work_schedule_changeset(work_schedule_group.work_schedule_group_id)
         })
         .collect::<Vec<_>>();
-    let _work_schedules: Vec<_> =
-        WorkSchedule::create_batch(conn, work_schedules_changesets).await?;
+    let _work_schedules: Vec<_> = WorkSchedule::create_batch(conn, work_schedules_changesets)
+        .await
+        .map_err(WorkScheduleError::from)?;
 
     Ok(Json(WorkScheduleCreateResponse {
         work_schedule_group_id: work_schedule_group.work_schedule_group_id,
@@ -454,7 +455,9 @@ async fn put_in_group(
                 .map(|work_schedule| work_schedule.into_work_schedule_changeset(group_id))
                 .collect::<Vec<_>>();
             let work_schedules =
-                WorkSchedule::create_batch(&mut conn.clone(), work_schedules_changesets).await?;
+                WorkSchedule::create_batch(&mut conn.clone(), work_schedules_changesets)
+                    .await
+                    .map_err(WorkScheduleError::from)?;
 
             Ok(Json(work_schedules))
         })

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -1,8 +1,8 @@
 use super::pagination::PaginatedList;
 use crate::core::pathfinding::TrackRange as CoreTrackRange;
-use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::prelude::*;
+use crate::models::work_schedules;
 use crate::models::work_schedules::WorkSchedule;
 use crate::models::work_schedules::WorkScheduleGroup;
 use crate::models::work_schedules::WorkScheduleType;
@@ -27,6 +27,7 @@ use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::TrackRange;
+use itertools::Either;
 use serde::de::Error as SerdeError;
 use serde::Deserialize;
 use serde::Serialize;
@@ -75,19 +76,23 @@ enum WorkScheduleError {
     WorkScheduleGroupNotFound { id: i64 },
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    Database(#[from] editoast_models::model::Error),
+    Database(Either<work_schedules::Error, work_schedules::WsGroupError>),
 }
 
-pub fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalError {
-    if e.message.contains(
-        r#"duplicate key value violates unique constraint "work_schedule_group_name_key""#,
-    ) {
-        WorkScheduleError::NameAlreadyUsed {
-            name: name.as_ref().to_string(),
+impl From<work_schedules::Error> for WorkScheduleError {
+    fn from(e: work_schedules::Error) -> Self {
+        WorkScheduleError::Database(Either::Left(e))
+    }
+}
+
+impl From<work_schedules::WsGroupError> for WorkScheduleError {
+    fn from(e: work_schedules::WsGroupError) -> Self {
+        match e {
+            work_schedules::WsGroupError::NameAlreadyUsed { name } => {
+                WorkScheduleError::NameAlreadyUsed { name }
+            }
+            e => WorkScheduleError::Database(Either::Right(e)),
         }
-        .into()
-    } else {
-        e
     }
 }
 
@@ -339,8 +344,9 @@ async fn create_group(
         .name(group_name.clone())
         .creation_date(Utc::now())
         .create(conn)
-        .await;
-    let work_schedule_group = work_schedule_group.map_err(|e| map_diesel_error(e, group_name))?;
+        .await
+        .map_err(WorkScheduleError::from)?;
+
     Ok(Json(WorkScheduleGroupCreateResponse {
         work_schedule_group_id: work_schedule_group.id,
     }))
@@ -611,7 +617,7 @@ pub mod tests {
         let work_schedule_response = app
             .fetch(request)
             .assert_status(StatusCode::BAD_REQUEST)
-            .json_into::<InternalError>();
+            .json_into::<crate::error::InternalError>();
 
         assert_eq!(
             &work_schedule_response.error_type,

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -106,6 +106,9 @@
     "macro_node": {
       "NotFound": "Node {{node_id}} not found."
     },
+    "model": {
+      "ModelError": "Internal error (database query)"
+    },
     "operation": {
       "EmptyId": "Empty string id is forbidden",
       "InvalidPatch": "A Json Patch error occurred",
@@ -166,7 +169,7 @@
       "EmptyArray": "Empty arrays are invalid syntax",
       "IntegerConversion": "Could not convert to i64",
       "InvalidColumnName": "Invalid column name",
-      "InvalidFunctionIdentifier": "Function identifer must be a string",
+      "InvalidFunctionIdentifier": "Function identifier must be a string",
       "InvalidSyntax": "Invalid syntax",
       "ObjectType": "Object type is invalid",
       "QueryAst": "Query Boolean type is expected",

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -55,6 +55,7 @@
       "InvalidLocations": "Some locations are invalid"
     },
     "document": {
+      "Database": "Internal error (database)",
       "NotFound": "Document '{{document_key}}' not found"
     },
     "electrical_profiles": {
@@ -149,6 +150,7 @@
       "BasePowerClassEmpty": "Base power class is an empty string",
       "CannotCreateCompoundImage": "Impossible to copy the separated image on the compound image",
       "CannotReadImage": "Impossible to read the separated image",
+      "Database": "Internal error (database)",
       "NameAlreadyUsed": "Name '{{name}}' already used",
       "KeyNotFound": "Rolling stock '{{rolling_stock_key.key}}' could not be found",
       "LiveryMultipartError": "Invalid multipart request while uploading livery",
@@ -160,6 +162,7 @@
       "IsLocked": "Towed rolling stock '{{towed_rolling_stock_id}}' is locked"
     },
     "scenario": {
+      "Database": "Internal error (database)",
       "NotFound": "Scenario not found"
     },
     "search": {
@@ -208,10 +211,12 @@
       "TimetableNotFound": "Timetable '{{timetable_id}}' does not exist"
     },
     "study": {
+      "Database": "Internal error (database)",
       "NotFound": "Study '{{study_id}}' could not be found",
       "StartDateAfterEndDate": "The study start date must be before the end date"
     },
     "timetable": {
+      "Database": "Internal error (database)",
       "InfraNotLoaded": "Infrastructure '{{infra_id}}' is not loaded",
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
       "NotFound": "Timetable '{{timetable_id}}' could not be found"
@@ -219,6 +224,7 @@
     "train_schedule": {
       "BatchShouldHaveSameTimetable": "Batch should have the same timetable",
       "BatchTrainScheduleNotFound": "Some Train Schedules could not be found",
+      "Database": "Internal error (database)",
       "NoSimulation": "No simulation given",
       "NoTrainSchedules": "No train schedules given",
       "NotFound": "Train Schedule '{{train_schedule_id}}' could not be found",
@@ -237,6 +243,7 @@
       "InvalidUrl": "Invalid url '{{url}}'"
     },
     "work_schedule": {
+      "Database": "Internal error (database)",
       "NameAlreadyUsed": "A group of work schedules with '{{name}}' already exists",
       "WorkScheduleGroupNotFound": "No such work schedule group with id '{{id}}'"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -54,6 +54,7 @@
       "InvalidLocations": "Certaines localisations sont invalides"
     },
     "document": {
+      "Database": "Erreur interne (base de données)",
       "NotFound": "Document '{{document_key}}' non trouvé"
     },
     "DatabaseAccessError": "Erreur fatale d'accès à la base de données",
@@ -149,6 +150,7 @@
       "BasePowerClassEmpty": "La classe de puissance par défaut ne peut être vide",
       "CannotCreateCompoundImage": "Impossible de créer l'image composée",
       "CannotReadImage": "Impossible de lire l'image",
+      "Database": "Erreur interne (base de données)",
       "NameAlreadyUsed": "Un matériel roulant avec le nom '{{name}}' existe déjà",
       "KeyNotFound": "Matériel roulant '{{rolling_stock_key.key}}' non trouvé",
       "LiveryMultipartError": "Requête multipart invalide pour upload de livrée",
@@ -160,6 +162,7 @@
       "IsLocked": "Matériel remorqué '{{towed_rolling_stock_id}}' est verrouillé"
     },
     "scenario": {
+      "Database": "Erreur interne (base de données)",
       "NotFound": "Scénario non trouvé",
       "InfraNotFound": "Infrastructure {{infra_id}} non trouvée",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée"
@@ -210,10 +213,12 @@
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée"
     },
     "study": {
+      "Database": "Erreur interne (base de données)",
       "NotFound": "Etude '{{study_id}}' non trouvée",
       "StartDateAfterEndDate": "La date de début de l'étude doit commencer avant sa date de fin"
     },
     "timetable": {
+      "Database": "Erreur interne (base de données)",
       "InfraNotLoaded": "L'infrastructure '{{infra_id}}' n'est pas chargée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Grille horaire '{{timetable_id}}' non trouvée"
@@ -221,6 +226,7 @@
     "train_schedule": {
       "BatchShouldHaveSameTimetable": "Le lot doit avoir une grille horaire identique",
       "BatchTrainScheduleNotFound": "Certaines circulations sont introuvables",
+      "Database": "Erreur interne (base de données)",
       "NoSimulation": "Aucune simulation fournie",
       "NoTrainSchedules": "Aucune circulation de train fournie",
       "NotFound": "Circulation '{{train_schedule_id}}' non trouvée",
@@ -234,6 +240,7 @@
       "InvalidUrl": "Url invalide '{{url}}'"
     },
     "work_schedule": {
+      "Database": "Erreur interne (base de données)",
       "NameAlreadyUsed": "Un groupe de planches travaux avec le nom '{{name}}' existe déjà",
       "WorkScheduleGroupNotFound": "Le groupe de planche travaux avec l'id {{id}} n'existe pas"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -106,6 +106,9 @@
     "macro_node": {
       "NotFound": "Noeud {{node_id}} non trouvé."
     },
+    "model": {
+      "ModelError": "Erreur interne (requêtage base de données)"
+    },
     "operation": {
       "EmptyId": "Une chaine de caractères vide est interdit comme identifiant",
       "InvalidPatch": "Une erreur de correctif JSON est survenue",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -245,6 +245,7 @@
       "WorkScheduleGroupNotFound": "Le groupe de planche travaux avec l'id {{id}} n'existe pas"
     },
     "temporary_speed_limit": {
+      "Database": "Erreur interne (base de données)",
       "NameAlreadyUsed": "Un groupe de limites temporaires de vitesse avec le nom '{{name}} existe déjà"
     },
     "app_health": {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1596,8 +1596,7 @@ export type GetRollingStockByRollingStockIdApiResponse =
 export type GetRollingStockByRollingStockIdApiArg = {
   rollingStockId: number;
 };
-export type DeleteRollingStockByRollingStockIdApiResponse =
-  /** status 204 The rolling stock was deleted successfully */ void;
+export type DeleteRollingStockByRollingStockIdApiResponse = unknown;
 export type DeleteRollingStockByRollingStockIdApiArg = {
   rollingStockId: number;
   /** force the deletion even if it's used */
@@ -3169,48 +3168,6 @@ export type RollingStockForm = {
 export type RollingStockWithLiveries = RollingStock & {
   liveries: RollingStockLivery[];
 };
-export type RollingStockKey =
-  | {
-      key: number;
-      type: 'Id';
-    }
-  | {
-      key: string;
-      type: 'Name';
-    };
-export type ScenarioReference = {
-  project_id: number;
-  project_name: string;
-  scenario_id: number;
-  scenario_name: string;
-  study_id: number;
-  study_name: string;
-};
-export type RollingStockError =
-  | 'CannotReadImage'
-  | 'CannotCreateCompoundImage'
-  | {
-      KeyNotFound: {
-        rolling_stock_key: RollingStockKey;
-      };
-    }
-  | {
-      NameAlreadyUsed: {
-        name: string;
-      };
-    }
-  | {
-      IsLocked: {
-        rolling_stock_id: number;
-      };
-    }
-  | {
-      IsUsed: {
-        rolling_stock_id: number;
-        usage: ScenarioReference[];
-      };
-    }
-  | 'BasePowerClassEmpty';
 export type RollingStockLiveryCreateForm = {
   images: Blob[];
   name: string;
@@ -3218,6 +3175,14 @@ export type RollingStockLiveryCreateForm = {
 export type RollingStockLockedUpdateForm = {
   /** New locked value */
   locked: boolean;
+};
+export type ScenarioReference = {
+  project_id: number;
+  project_name: string;
+  scenario_id: number;
+  scenario_name: string;
+  study_id: number;
+  study_name: string;
 };
 export type SearchResultItemTrack = {
   infra_id: number;


### PR DESCRIPTION
* Creates a custom error type wrapping `diesel::result::Error` in `editoast_models`
* Adapt the API of deletion and creation traits (the rest will come in another PR(s))
* Propagate the API change in `views` (mostly)
    * new error variants are created to accommodate some (valid) typing constraints, bringing us closer to our target error management structure
    * simplified a few `map_diesel_error` here and there
* The traits will be moved into `editoast_models::model` later

> [!TIP]
> Review commit by commit 