### PR TITLE
core, editoast, python: stop train at end of block instead of OP

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/BenchSTDCM.kt
@@ -156,7 +156,8 @@ class BenchSTDCM : CliCommand {
                                 it != ETCS_LEVEL2.id
                             },
                         )
-                    val steps = parseSteps(infra, request.pathItems, request.startTime)
+                    val steps =
+                        parseSteps(infra, request.pathItems, request.startTime, rollingStock.length)
                     val requirements = getRequirements(request, infra, cacheManager)
                     val allowedTrackSections =
                         parseTrackSectionIds(infra, request.allowedTrackSections)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlockRequest.kt
@@ -18,6 +18,7 @@ class PathfindingBlockRequest(
     @Json(name = "rolling_stock_maximum_speed") val rollingStockMaximumSpeed: Double,
     @Json(name = "rolling_stock_length") val rollingStockLength: Double,
     @Json(name = "speed_limit_tag") val speedLimitTag: String? = null,
+    @Json(name = "stops_at_end_of_block") val stopsAtEndOfBlock: Boolean? = null,
     val timeout: Double?,
     val infra: String,
     @Json(name = "expected_version") val expectedVersion: Int?,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -28,6 +28,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.*
+import fr.sncf.osrd.utils.units.Distance.Companion.min
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -100,10 +101,32 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
 fun runPathfinding(infra: FullInfra, request: PathfindingBlockRequest): PathfindingBlockResponse {
     // Parse the waypoints
     val waypoints = ArrayList<Collection<EdgeLocation<BlockId, Block>>>()
-    for (step in request.pathItems) {
+    val destinationTrack = request.pathItems.last()
+    val destinationBlock = findWaypointBlocks(infra, destinationTrack)
+    request.pathItems.forEachIndexed { stepIndex, step ->
         val allStarts = HashSet<EdgeLocation<BlockId, Block>>()
         for (direction in Direction.entries) {
-            for (waypoint in step) allStarts.addAll(findWaypointBlocks(infra, waypoint, direction))
+            for (waypoint in step) {
+                val waypointBlocks = findDirectedWaypointBlocks(infra, waypoint, direction)
+                if (
+                    request.stopsAtEndOfBlock == true &&
+                        stepIndex != 0 &&
+                        stepIndex != request.pathItems.size - 1
+                ) {
+                    allStarts.addAll(
+                        waypointBlocks.map {
+                            findStopPositionAtEndOfBlockConsideringRollingStock(
+                                it,
+                                destinationBlock,
+                                request.rollingStockLength,
+                                infra,
+                            )
+                        }
+                    )
+                } else {
+                    allStarts.addAll(waypointBlocks)
+                }
+            }
         }
         waypoints.add(allStarts)
     }
@@ -278,7 +301,7 @@ private fun processPathfindingResponse(
  * @param waypoint corresponding waypoint.
  * @return corresponding edge location, containing a block id and its offset from the waypoint.
  */
-fun findWaypointBlocks(
+fun findDirectedWaypointBlocks(
     infra: FullInfra,
     waypoint: TrackLocation,
     direction: Direction,
@@ -305,6 +328,19 @@ fun findWaypointBlocks(
         res.add(EdgeLocation(block, offset))
     }
     return res
+}
+
+fun findWaypointBlocks(
+    infra: FullInfra,
+    waypoints: Collection<TrackLocation>,
+): Set<EdgeLocation<BlockId, Block>> {
+    val waypointBlocks = HashSet<EdgeLocation<BlockId, Block>>()
+    for (waypoint in waypoints) {
+        for (direction in Direction.entries) {
+            waypointBlocks.addAll(findDirectedWaypointBlocks(infra, waypoint, direction))
+        }
+    }
+    return waypointBlocks
 }
 
 private fun getTrackSectionChunkOnWaypoint(
@@ -398,4 +434,37 @@ private fun makeHeuristicsForPathfindingEdges(
         }
     }
     return remainingDistanceEstimators
+}
+
+/**
+ * Given a waypoint block (initial position of a train stop), returns the new stop position of a
+ * train: end of current block, with the constraints of staying in the same block and keeping the
+ * tail of the train on the initial position (waypointBlock). Note that nodes of the infra are not
+ * considered.
+ */
+fun findStopPositionAtEndOfBlockConsideringRollingStock(
+    waypointBlock: EdgeLocation<BlockId, Block>,
+    destinationBlock: Set<EdgeLocation<BlockId, Block>>,
+    rollingStockLength: Double,
+    infra: FullInfra,
+): EdgeLocation<BlockId, Block> {
+    // To ensure that the tail of the rolling stock is not further than the initial operational
+    // point (waypointBlock) position
+    val maxTailOffset = waypointBlock.offset + rollingStockLength.meters
+
+    // Can't go further than the end of the block, which is delimited by a block-delimiting signal
+    val maxHeadOffset = infra.blockInfra.getBlockLength(waypointBlock.edge)
+
+    val newWaypointOffset = Offset.min(maxTailOffset, maxHeadOffset)
+
+    val destinationOffset =
+        destinationBlock
+            .filter { it.edge == waypointBlock.edge && waypointBlock.offset <= it.offset }
+            .minOfOrNull { it.offset }
+
+    // The waypoint offset does not change in the case where the stop is after the destination
+    if (destinationOffset != null && destinationOffset <= newWaypointOffset)
+        return EdgeLocation(waypointBlock.edge, waypointBlock.offset)
+
+    return EdgeLocation(waypointBlock.edge, newWaypointOffset)
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableRangeMap
 import com.google.common.collect.Range
 import com.google.common.collect.TreeRangeSet
 import fr.sncf.osrd.api.*
+import fr.sncf.osrd.api.pathfinding.findStopPositionAtEndOfBlockConsideringRollingStock
 import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.hasDuplicateTracks
 import fr.sncf.osrd.api.pathfinding.runPathfindingBlockPostProcessing
@@ -21,15 +22,12 @@ import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.Percentage
 import fr.sncf.osrd.envelope_sim.allowances.AllowanceValue.TimePerDistance
 import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.pathfinding.Pathfinding
-import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.etcs_level2.ETCS_LEVEL2
-import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.api.TrackSectionId
@@ -114,7 +112,7 @@ class STDCMEndpoint(
                         it != ETCS_LEVEL2.id
                     },
                 )
-            val steps = parseSteps(infra, request.pathItems, request.startTime)
+            val steps = parseSteps(infra, request.pathItems, request.startTime, rollingStock.length)
             val requirements = getRequirements(request, infra, timetableCacheManager)
             val allowedTrackSections = parseTrackSectionIds(infra, request.allowedTrackSections)
 
@@ -306,6 +304,7 @@ fun parseSteps(
     infra: FullInfra,
     pathItems: List<STDCMPathItem>,
     startTime: ZonedDateTime,
+    rollingStockLength: Double,
 ): List<STDCMStep> {
     if (pathItems.last().stopDuration == null) {
         throw OSRDError(ErrorType.MissingLastSTDCMStop)
@@ -324,20 +323,34 @@ fun parseSteps(
     // that it's not a stop.
     pathItems.first().stopDuration = null
 
-    return pathItems.map {
-        STDCMStep(
-            findWaypointBlocks(infra, it.locations),
-            it.stopDuration?.seconds,
-            it.stopDuration != null,
-            if (it.stepTimingData != null)
-                PlannedTimingData(
-                    TimeDelta(between(startTime, it.stepTimingData.arrivalTime).toMillis()),
-                    it.stepTimingData.arrivalTimeToleranceBefore,
-                    it.stepTimingData.arrivalTimeToleranceAfter,
-                )
-            else null,
-        )
-    }
+    return pathItems
+        .mapIndexed { index, it ->
+            STDCMStep(
+                if (index != 0 && index != pathItems.size - 1) {
+                    val destinationBlock = findWaypointBlocks(infra, pathItems.last().locations)
+                    findWaypointBlocks(infra, it.locations).map { waypointBlock ->
+                        findStopPositionAtEndOfBlockConsideringRollingStock(
+                            waypointBlock,
+                            destinationBlock,
+                            rollingStockLength,
+                            infra,
+                        )
+                    }
+                } else {
+                    findWaypointBlocks(infra, it.locations)
+                },
+                it.stopDuration?.seconds,
+                it.stopDuration != null,
+                if (it.stepTimingData != null)
+                    PlannedTimingData(
+                        TimeDelta(between(startTime, it.stepTimingData.arrivalTime).toMillis()),
+                        it.stepTimingData.arrivalTimeToleranceBefore,
+                        it.stepTimingData.arrivalTimeToleranceAfter,
+                    )
+                else null,
+            )
+        }
+        .toList()
 }
 
 /**
@@ -414,19 +427,6 @@ private fun parseSimulationScheduleItems(
             SimulationScheduleItem(Offset(it.position.meters), null, duration, it.receptionSignal)
         }
     )
-}
-
-private fun findWaypointBlocks(
-    infra: FullInfra,
-    waypoints: Collection<TrackLocation>,
-): Set<EdgeLocation<BlockId, Block>> {
-    val waypointBlocks = HashSet<EdgeLocation<BlockId, Block>>()
-    for (waypoint in waypoints) {
-        for (direction in Direction.entries) {
-            waypointBlocks.addAll(findWaypointBlocks(infra, waypoint, direction))
-        }
-    }
-    return waypointBlocks
 }
 
 fun parseTrackSectionIds(infra: FullInfra, trackSectionName: Set<String>?): Set<TrackSectionId>? {

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingBlocksEndpointTest.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.pathfinding
 
 import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.TrackLocation
-import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
+import fr.sncf.osrd.api.pathfinding.findDirectedWaypointBlocks
 import fr.sncf.osrd.pathfinding.Pathfinding.EdgeLocation
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
@@ -31,7 +31,7 @@ class PathfindingBlocksEndpointTest {
         direction: Direction,
         expectedEdgeLocations: Set<EdgeLocation<BlockId, Block>>,
     ) {
-        val blocks = findWaypointBlocks(smallInfra, pathfindingWaypoint, direction)
+        val blocks = findDirectedWaypointBlocks(smallInfra, pathfindingWaypoint, direction)
         Assertions.assertThat(blocks).containsExactlyInAnyOrderElementsOf(expectedEdgeLocations)
     }
 
@@ -40,7 +40,7 @@ class PathfindingBlocksEndpointTest {
         val incoherentWaypoint = TrackLocation("TA3", Offset(100000000.meters))
         val exception =
             assertThrows(OSRDError::class.java) {
-                findWaypointBlocks(smallInfra, incoherentWaypoint, Direction.INCREASING)
+                findDirectedWaypointBlocks(smallInfra, incoherentWaypoint, Direction.INCREASING)
             }
         assertEquals(ErrorType.InvalidWaypointLocation, exception.osrdErrorType)
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertEquals
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.AssertionsForClassTypes
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -27,6 +28,7 @@ fun getPathfindingBlockRequest(
     rs: RollingStock,
     pathItems: List<Collection<TrackLocation>>,
     infra: String = "unused_name",
+    stopsAtEndOfBlock: Boolean? = false,
 ): PathfindingBlockRequest {
     return PathfindingBlockRequest(
         rs.loadingGaugeType,
@@ -36,6 +38,7 @@ fun getPathfindingBlockRequest(
         rs.maxSpeed,
         rs.length,
         null,
+        stopsAtEndOfBlock,
         null,
         infra,
         1,
@@ -60,6 +63,7 @@ fun checkPathfindingSuccess(
             .plus(expectedIntermediatePathItemPosition)
             .plusElement(Offset(pathSuccess.length.distance))
     assertEquals(expectedPathItemsPos, pathSuccess.pathItemPositions)
+    assertEquals(pathSuccess.pathItemPositions.sorted(), pathSuccess.pathItemPositions)
 
     if (expectedBlocks != null) {
         assertEquals(
@@ -600,5 +604,320 @@ class PathfindingTest : ApiTest() {
         val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
         val parsed = pathfindingResponseAdapter.fromJson(response.body())!!
         return parsed
+    }
+}
+
+class PathfindingV2StopsAtEndOfBlock : ApiTest() {
+    fun callPathfindingEndpoint(
+        rs: RollingStock,
+        pathItems: List<Collection<TrackLocation>>,
+        infra: String,
+        stopsAtEndOfBlock: Boolean,
+    ): PathfindingBlockResponse {
+        val requestBody =
+            pathfindingRequestAdapter.toJson(
+                getPathfindingBlockRequest(rs, pathItems, infra, stopsAtEndOfBlock)
+            )
+        val response = PathfindingBlocksEndpoint(infraManager).act(RqFake(requestBody))
+        val parsed = pathfindingResponseAdapter.fromJson(response.body())!!
+        return parsed
+    }
+
+    private lateinit var waypoints: List<List<TrackLocation>>
+    private val firstIntermediateStopDistance = 12050.meters
+    private val secondIntermediateStopDistance = 26500.meters
+    private val reversedFirstIntermediateStopDistance = 19400.meters
+    private val reversedSecondIntermediateStopDistance = 33850.meters
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+        // West_Station
+        val startWaypoint = TrackLocation("TA1", Offset(500.meters))
+        // Mid_West_Station
+        val firstIntermediateWaypoint = TrackLocation("TC1", Offset(550.meters))
+        // Mid_East_Station
+        val secondIntermediateWaypoint = TrackLocation("TD0", Offset(14000.meters))
+        // South_East_Station
+        val endWaypoint = TrackLocation("TH1", Offset(4400.meters))
+        waypoints =
+            listOf(
+                listOf(startWaypoint),
+                listOf(firstIntermediateWaypoint),
+                listOf(secondIntermediateWaypoint),
+                listOf(endWaypoint),
+            )
+    }
+
+    @Test
+    fun nonStopsAtEndOfBlockTest() {
+        // Stops are not moved - nothing to do here
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                false,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(firstIntermediateStopDistance),
+                    Offset(secondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun reversedNonStopsAtEndOfBlockTest() {
+        // Stops are not moved - nothing to do here
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints.reversed(),
+                "small_infra/infra.json",
+                false,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(reversedFirstIntermediateStopDistance),
+                    Offset(reversedSecondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun shortTrainTest() {
+        // Only intermediate stops are moved to the end of their block
+        val recalculatedFirstIntermediateStopDistance =
+            firstIntermediateStopDistance + TestTrains.VERY_SHORT_FAST_TRAIN.length.meters
+        val recalculatedSecondIntermediateStopDistance =
+            secondIntermediateStopDistance + TestTrains.VERY_SHORT_FAST_TRAIN.length.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.VERY_SHORT_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(recalculatedFirstIntermediateStopDistance),
+                    Offset(recalculatedSecondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun reversedShortTrainTest() {
+        // Only intermediate stops are moved to the end of their block
+        val recalculatedFirstIntermediateStopDistance =
+            reversedFirstIntermediateStopDistance + TestTrains.VERY_SHORT_FAST_TRAIN.length.meters
+        val recalculatedSecondIntermediateStopDistance =
+            reversedSecondIntermediateStopDistance + TestTrains.VERY_SHORT_FAST_TRAIN.length.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.VERY_SHORT_FAST_TRAIN,
+                waypoints.reversed(),
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(recalculatedFirstIntermediateStopDistance),
+                    Offset(recalculatedSecondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun longTrainTest() {
+        // The first intermediate stop is moved to the next block-delimiting signal, but the
+        // distance available is less than the length of the train, so it is moved to the end of the
+        // block (270 meters after the first intermediate stop)
+        val recalculatedFirstIntermediateStopDistance = firstIntermediateStopDistance + 270.meters
+        // The second intermediate stop is also moved to the end of the block (at the "DD0_9"
+        // detector's position, 37.5 meters after the second intermediate stop)
+        val recalculatedSecondIntermediateStopDistance =
+            secondIntermediateStopDistance + 37.5.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.VERY_LONG_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(recalculatedFirstIntermediateStopDistance),
+                    Offset(recalculatedSecondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun reversedLongTrainTest() {
+        // The first intermediate stop is moved to the next block-delimiting signal, but the
+        // distance available is less than the length of the train, so it is moved to the end of the
+        // block, the 9th block of the path (1500 meters after the first intermediate stop)
+        val recalculatedFirstIntermediateStopDistance =
+            reversedFirstIntermediateStopDistance + 1500.meters
+        // The second intermediate stop is also moved to the end of the block, the 13th block of the
+        // path (370 meters after the second intermediate stop)
+        val recalculatedSecondIntermediateStopDistance =
+            reversedSecondIntermediateStopDistance + 370.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.VERY_LONG_FAST_TRAIN,
+                waypoints.reversed(),
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            45900.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(
+                    Offset(recalculatedFirstIntermediateStopDistance),
+                    Offset(recalculatedSecondIntermediateStopDistance),
+                ),
+        )
+    }
+
+    @Test
+    fun penultimateCorrectlyMovedJustBeforeDestination() {
+        var waypoints: List<List<TrackLocation>>
+        val startWaypoint = TrackLocation("TC1", Offset(500.meters))
+        val intermediateWaypoint = TrackLocation("TD0", Offset(12550.meters))
+        val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
+        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+
+        val intermediateStopDistance = 13450.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            13500.meters,
+            expectedIntermediatePathItemPosition = listOf(Offset(intermediateStopDistance)),
+        )
+    }
+
+    @Test
+    fun penultimateStopNotMovedExactlyToDestination() {
+        var waypoints: List<List<TrackLocation>>
+        val startWaypoint = TrackLocation("TC1", Offset(500.meters))
+        val intermediateWaypoint = TrackLocation("TD0", Offset(12600.meters))
+        val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
+        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+
+        // The intermediate stop is moved to the next block-delimiting signal, but the
+        // distance available is more than the length of the train, so it would be moved by the
+        // length of the train (400m) but this is also exactly the destination so the intermediate
+        // stop remains the same
+        val intermediateStopDistance = 13100.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            13500.meters,
+            expectedIntermediatePathItemPosition = listOf(Offset(intermediateStopDistance)),
+        )
+    }
+
+    @Test
+    fun penultimateStopTooCloseToDestination() {
+        var waypoints: List<List<TrackLocation>>
+        val startWaypoint = TrackLocation("TC1", Offset(500.meters))
+        val intermediateWaypoint = TrackLocation("TD0", Offset(12990.meters))
+        val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
+        waypoints = listOf(listOf(startWaypoint), listOf(intermediateWaypoint), listOf(endWaypoint))
+
+        // The intermediate stop is moved to the next block-delimiting signal, but the
+        // distance available is more than the length of the train, so it would be moved by the
+        // length of the train, but that is after the destination so the intermediate stop remains
+        // the same
+        val intermediateStopDistance = 13490.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            13500.meters,
+            expectedIntermediatePathItemPosition = listOf(Offset(intermediateStopDistance)),
+        )
+    }
+
+    @Test
+    fun twoPenultimatesStopTooCloseToDestination() {
+        var waypoints: List<List<TrackLocation>>
+        val startWaypoint = TrackLocation("TC1", Offset(500.meters))
+        val intermediateWaypoint = TrackLocation("TD0", Offset(12950.meters))
+        val secondIntermediateWaypoint = TrackLocation("TD0", Offset(12990.meters))
+        val endWaypoint = TrackLocation("TD0", Offset(13000.meters))
+        waypoints =
+            listOf(
+                listOf(startWaypoint),
+                listOf(intermediateWaypoint),
+                listOf(secondIntermediateWaypoint),
+                listOf(endWaypoint),
+            )
+
+        // The intermediate stops are moved to the next block-delimiting signal, but the
+        // distance available is more than the length of the train, so it would be moved by the
+        // length of the train, but that is after the destination so the intermediate stops remains
+        // the same
+        val intermediateStopDistance = 13450.meters
+        val secondIntermediateStopDistance = 13490.meters
+
+        val parsed =
+            callPathfindingEndpoint(
+                TestTrains.REALISTIC_FAST_TRAIN,
+                waypoints,
+                "small_infra/infra.json",
+                true,
+            )
+        checkPathfindingSuccess(
+            parsed,
+            13500.meters,
+            expectedIntermediatePathItemPosition =
+                listOf(Offset(intermediateStopDistance), Offset(secondIntermediateStopDistance)),
+        )
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -446,6 +446,7 @@ fun makeRequirementsFromPath(
                 rollingStock.maxSpeed,
                 rollingStock.length,
                 null,
+                false,
                 null,
                 "",
                 null,

--- a/editoast/core_client/src/pathfinding.rs
+++ b/editoast/core_client/src/pathfinding.rs
@@ -36,6 +36,9 @@ pub struct PathfindingRequest {
     pub rolling_stock_length: OrderedFloat<f64>,
     /// Speed limit tag, used to estimate the max speed and travel time
     pub speed_limit_tag: Option<String>,
+    /// Stops the train at a new stop position: near next block-delimiting signal,
+    /// staying in the same block and keeping the tail on the initial position
+    pub stops_at_end_of_block: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]

--- a/editoast/core_task/src/envs/pathfinding.rs
+++ b/editoast/core_task/src/envs/pathfinding.rs
@@ -391,6 +391,7 @@ fn build_request(
         rolling_stock_maximum_speed: consist.maximum_speed,
         rolling_stock_length: consist.length,
         speed_limit_tag: consist.speed_limit_tag.clone(),
+        stops_at_end_of_block: Some(false),
     }
 }
 

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10953,6 +10953,13 @@ components:
           - string
           - 'null'
           description: Speed limit tag, used to estimate the travel time
+        stops_at_end_of_block:
+          type:
+          - boolean
+          - 'null'
+          description: |-
+            Stop the train at the next block-delimiting signal,
+            staying in the same block and keeping the tail on the initial position
     PathfindingItem:
       type: object
       required:
@@ -14209,6 +14216,8 @@ components:
     TrainScheduleOptions:
       type: object
       properties:
+        stops_at_end_of_block:
+          type: boolean
         use_electrical_profiles:
           type: boolean
         use_speed_limits_for_simulation:

--- a/editoast/schemas/src/train_schedule.rs
+++ b/editoast/schemas/src/train_schedule.rs
@@ -324,6 +324,7 @@ impl TrainSchedule {
             options: TrainScheduleOptions {
                 use_electrical_profiles: true,
                 use_speed_limits_for_simulation: true,
+                stops_at_end_of_block: false,
             },
             category: None,
         }

--- a/editoast/schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/schemas/src/train_schedule/train_schedule_options.rs
@@ -13,6 +13,10 @@ pub struct TrainScheduleOptions {
     #[educe(Default = true)]
     #[serde(default = "default_use_speed_limits_for_simulation")]
     pub use_speed_limits_for_simulation: bool,
+
+    #[educe(Default = false)]
+    #[serde(default)]
+    pub stops_at_end_of_block: bool,
 }
 
 fn default_use_electrical_profiles() -> bool {
@@ -21,4 +25,10 @@ fn default_use_electrical_profiles() -> bool {
 
 fn default_use_speed_limits_for_simulation() -> bool {
     true
+}
+
+impl TrainScheduleOptions {
+    pub fn stops_at_end_of_block(&self) -> bool {
+        self.stops_at_end_of_block
+    }
 }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -65,6 +65,9 @@ pub(in crate::views) struct PathfindingInput {
     rolling_stock_length: OrderedFloat<f64>,
     /// Speed limit tag, used to estimate the travel time
     speed_limit_tag: Option<String>,
+    /// Stop the train at the next block-delimiting signal,
+    /// staying in the same block and keeping the tail on the initial position
+    stops_at_end_of_block: Option<bool>,
 }
 
 impl PathfindingInput {
@@ -389,6 +392,7 @@ fn build_pathfinding_request(
         rolling_stock_maximum_speed: pathfinding_input.rolling_stock_maximum_speed,
         rolling_stock_length: pathfinding_input.rolling_stock_length,
         speed_limit_tag: pathfinding_input.speed_limit_tag.clone(),
+        stops_at_end_of_block: pathfinding_input.stops_at_end_of_block,
     })
 }
 
@@ -479,6 +483,7 @@ pub async fn pathfinding_from_train_batch<T: TrainScheduleLike>(
                 .map(|item| item.location.clone())
                 .collect(),
             speed_limit_tag: train_schedule.speed_limit_tag().cloned(),
+            stops_at_end_of_block: Some(train_schedule.options().stops_at_end_of_block()),
         };
         to_compute.push(path_input);
         to_compute_index.push(index);

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/__tests__/formatTimetableItemPayload.spec.ts
@@ -63,6 +63,7 @@ describe('formatTimetableItemPayload', () => {
     constraintDistribution: 'MARECO',
     usingElectricalProfiles: true,
     usingSpeedLimits: true,
+    stopsAtEndOfBlock: false,
     powerRestriction: [],
     timeWindow: Duration.parse('PT3H'),
     interval: Duration.parse('PT1H'),
@@ -86,6 +87,7 @@ describe('formatTimetableItemPayload', () => {
         values: ['0%'],
       },
       options: {
+        stops_at_end_of_block: false,
         use_electrical_profiles: true,
         use_speed_limits_for_simulation: true,
       },
@@ -206,6 +208,7 @@ describe('formatTimetableItemPayload', () => {
         labels: [],
         margins: { boundaries: [], values: ['0%'] },
         options: {
+          stops_at_end_of_block: false,
           use_electrical_profiles: true,
           use_speed_limits_for_simulation: true,
         },
@@ -297,6 +300,7 @@ describe('formatTimetableItemPayload', () => {
           labels: [],
           margins: { boundaries: [], values: ['0%'] },
           options: {
+            stops_at_end_of_block: false,
             use_electrical_profiles: true,
             use_speed_limits_for_simulation: true,
           },

--- a/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
+++ b/front/src/applications/operationalStudies/views/Scenario/components/ManageTimetableItem/helpers/formatTimetableItemPayload.ts
@@ -40,6 +40,7 @@ export function formatTimetableItemPayload(
     options: {
       use_electrical_profiles: osrdconf.usingElectricalProfiles,
       use_speed_limits_for_simulation: osrdconf.usingSpeedLimits,
+      stops_at_end_of_block: false,
     },
     path: compact(osrdconf.pathSteps).map((step) => ({
       id: step.id,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3586,6 +3586,9 @@ export type PathfindingInput = {
   rolling_stock_supported_signaling_systems: string[];
   /** Speed limit tag, used to estimate the travel time */
   speed_limit_tag?: string | null;
+  /** Stop the train at the next block-delimiting signal,
+    staying in the same block and keeping the tail on the initial position */
+  stops_at_end_of_block?: boolean | null;
 };
 export type RoutePath = {
   switches_directions: {
@@ -3933,6 +3936,7 @@ export type Margins = {
   values: string[];
 };
 export type TrainScheduleOptions = {
+  stops_at_end_of_block?: boolean;
   use_electrical_profiles?: boolean;
   use_speed_limits_for_simulation?: boolean;
 };

--- a/front/src/common/api/osrdRailwayManagerApi.ts
+++ b/front/src/common/api/osrdRailwayManagerApi.ts
@@ -84,6 +84,7 @@ export type Items = {
     values: string[];
   };
   options?: {
+    stops_at_end_of_block?: boolean;
     use_electrical_profiles?: boolean;
     use_speed_limits_for_simulation?: boolean;
   };
@@ -150,6 +151,7 @@ export type Items = {
 };
 export type ConstraintDistribution = 'STANDARD' | 'MARECO';
 export type Options = {
+  stops_at_end_of_block?: boolean;
   use_electrical_profiles?: boolean;
   use_speed_limits_for_simulation?: boolean;
 };
@@ -263,6 +265,7 @@ export type TransformTimetableResponse = {
       values: string[];
     };
     options?: {
+      stops_at_end_of_block?: boolean;
       use_electrical_profiles?: boolean;
       use_speed_limits_for_simulation?: boolean;
     };

--- a/front/src/modules/timetableItem/helpers/pacedTrain.ts
+++ b/front/src/modules/timetableItem/helpers/pacedTrain.ts
@@ -99,6 +99,8 @@ export const extractOccurrenceDetailsFromPacedTrain = <
       exceptionChangeGroups.options.value?.use_electrical_profiles;
     occurrence.options!.use_speed_limits_for_simulation =
       exceptionChangeGroups.options.value?.use_speed_limits_for_simulation;
+    occurrence.options!.stops_at_end_of_block =
+      exceptionChangeGroups.options.value?.stops_at_end_of_block;
   }
   return occurrence;
 };

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -32,6 +32,7 @@ export const operationalStudiesInitialConf: OperationalStudiesConfState = {
   constraintDistribution: 'MARECO',
   usingElectricalProfiles: true,
   usingSpeedLimits: true,
+  stopsAtEndOfBlock: false,
   powerRestriction: [],
   timeWindow: new Duration({ minutes: 120 }),
   interval: new Duration({ minutes: 60 }),
@@ -80,6 +81,7 @@ export const operationalStudiesConfSlice = createSlice({
 
       state.usingElectricalProfiles = options?.use_electrical_profiles ?? true;
       state.usingSpeedLimits = options?.use_speed_limits_for_simulation ?? true;
+      state.stopsAtEndOfBlock = options?.stops_at_end_of_block ?? false;
       state.labels = labels;
       state.speedLimitByTag = speedLimitTag || undefined;
       state.powerRestriction = power_restrictions || [];

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -52,6 +52,7 @@ export type OperationalStudiesConfState = OsrdConfState & {
   constraintDistribution: Distribution;
   usingElectricalProfiles: boolean;
   usingSpeedLimits: boolean;
+  stopsAtEndOfBlock: boolean;
   powerRestriction: PowerRestriction[];
   timeWindow: Duration;
   interval: Duration;

--- a/front/tests/assets/stdcm/linked-train/anterior-linked-train-table.json
+++ b/front/tests/assets/stdcm/linked-train/anterior-linked-train-table.json
@@ -15,7 +15,7 @@
     "operationalPoint": "North_station",
     "code": "BV",
     "track": "V1bis",
-    "endStop": "13:26",
+    "endStop": "13:25",
     "passageStop": "4 min",
     "startStop": "13:30",
     "weight": "=",

--- a/front/tests/assets/stdcm/stdcm-all-stops.json
+++ b/front/tests/assets/stdcm/stdcm-all-stops.json
@@ -39,7 +39,7 @@
     "track": "V1bis",
     "endStop": "00:52",
     "passageStop": "39 min",
-    "startStop": "01:31",
+    "startStop": "01:32",
     "weight": "=",
     "refEngine": "="
   },

--- a/python/osrd_schemas/osrd_schemas/train_schedule.py
+++ b/python/osrd_schemas/osrd_schemas/train_schedule.py
@@ -201,6 +201,8 @@ class TrainScheduleOptions(BaseModel):
     - `use_electrical_profiles` : use the electrical profiles for the standalone simulation
     - `use_speed_limits_for_simulation` : use the speed limits coming from the infrastructure for
        the standalone simulation
+    - `stops_at_end_of_block` : stop the train at the next block-delimiting signal instead of on the waypoint
+
     """
 
     use_electrical_profiles: bool = Field(
@@ -210,6 +212,11 @@ class TrainScheduleOptions(BaseModel):
     use_speed_limits_for_simulation: bool = Field(
         default=True,
         description="If false, the speed limits of the infrastructure are ignored in the standalone simulation",
+    )
+    stops_at_end_of_block: bool = Field(
+        default=False,
+        description="If true, stop positions will be shifted toward the next block-delimiting signal, \
+        staying in the same block and keeping the tail on the initial position",
     )
 
 

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osrd_schemas"
-version = "0.9.0"
+version = "0.9.1"
 description = ""
 authors = [{ name = "OSRD Contributors", email = "contact@osrd.fr" }]
 requires-python = ">= 3.11"

--- a/railway_manager_interface/osrd_railway_manager_interface/models.py
+++ b/railway_manager_interface/osrd_railway_manager_interface/models.py
@@ -408,6 +408,7 @@ class TrainScheduleOptions(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    stops_at_end_of_block: bool | None = None
     use_electrical_profiles: bool | None = None
     use_speed_limits_for_simulation: bool | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,6 +273,7 @@ def west_to_south_east_path(
             ],
             "rolling_stock_maximum_speed": 200,
             "rolling_stock_length": 100000,
+            "stops_at_end_of_block": False,
         },
     )
     yield TrainPath(**response.json())


### PR DESCRIPTION
Closes https://github.com/osrd-project/osrd-confidential/issues/892
Closes https://github.com/osrd-project/osrd-confidential/issues/830

Analysis of the solution, compared to the default behavior can be seen [here](https://github.com/osrd-project/osrd-dags/pull/655)

## Description

Note : the following screenshots are for review visualization only, nothing will be output in the front-end at the end

The trains were previously stopping exactly on the Operational Point Part position, which is often in the middle of the train platform. The position of the train is considered at the head of the train. This is an issue, because in the real life, a train (meaning its head) stops at the end of the platform (at a specific stop panel position), allowing the rest of the train not to overflow of the passed tracks, avoiding unnecessary track occupation. Also, this doesn't take account of the train direction.

The train stops are now shifted the least possible to the next signal position, with a minimal value that would put the tail of the train on the operational point.

This implementation makes the pathfinding algorithm move the stops of these trains closer to the end of the current block, to try to avoid that the tail of the train is on another track, and also never further than the next block-delimiting signal.
⚠️ the first and last stops are not moved ⚠️

- The feature is ✅ hard-enabled for STDCM (for the simulated train), and there is no deactivation possible.
- The feature is ✖️ hard-disabled in front for Operational Studies (trains created from this module cannot enable the feature)
  - however the feature is 🔲 activable in back (disabled by default), so imported trains that have the feature enabled (such as BASIC timetables) can be looked at in Operational Studies, or used in STDCM search environment.
- The feature may (☑️ will) be enabled for all the trains simulated in the STDCM search environment depending on what was parametrized when importing data.

## Examples

#### With a `TGV2N2`, 400m train
![image](https://github.com/user-attachments/assets/f17049a0-03ad-4db8-a88d-ce0277fa7af8)

#### With a `83500`, 109m train
![image](https://github.com/user-attachments/assets/29c3a370-f132-41dd-a773-344406b1a7a9)

#### Also working on STDCM, with a 200m train
![image](https://github.com/user-attachments/assets/60610f4f-ac9c-460c-8691-0b443d5a3cd6)
