### PR TITLE
editoast: extract osm_to_railjson in separate binary

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1324,7 +1324,6 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "ordered-float",
- "osm_to_railjson",
  "paste",
  "pathfinding",
  "postgis_diesel",
@@ -3066,6 +3065,7 @@ dependencies = [
 name = "osm_to_railjson"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "editoast_schemas",
  "geo-types",
  "geos",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -26,6 +26,7 @@ license = "LGPL-3.0"
 
 [workspace.dependencies]
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
+clap = { version = "4.5.23", features = ["derive", "env"] }
 derivative = "2.2.0"
 diesel = { version = "2.2", default-features = false, features = [
   "32-column-tables",
@@ -158,7 +159,6 @@ opentelemetry-otlp = { version = "0.27.0", default-features = false, features = 
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
 ordered-float = { version = "4.6.0", features = ["serde"] }
-osm_to_railjson = { path = "./osm_to_railjson" }
 paste.workspace = true
 pathfinding = "4.13.0"
 postgis_diesel.workspace = true

--- a/editoast/osm_to_railjson/Cargo.toml
+++ b/editoast/osm_to_railjson/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+clap.workspace = true
 editoast_schemas.workspace = true
 geo-types = "0.7.14"
 geos.workspace = true

--- a/editoast/osm_to_railjson/README.md
+++ b/editoast/osm_to_railjson/README.md
@@ -9,7 +9,7 @@ Example for Germany:
 2. Launch conversion (release build of editoast and conversion can be long):
     ```sh
     cd ../../editoast
-    cargo run --release -- osm-to-railjson <path/to/germany-latest.osm.pbf> <path/to/germany_railjson.json>
+    cargo run --release -p osm_to_railjson -- <path/to/germany-latest.osm.pbf> <path/to/germany_railjson.json>
     ```
 3. Load railjson (also possible through [a script](../../scripts/load-railjson-infra.sh) or OSRD's web interface):
     ```sh

--- a/editoast/osm_to_railjson/src/main.rs
+++ b/editoast/osm_to_railjson/src/main.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(about, long_about = "Extracts a railjson from OpenStreetMap data")]
+pub struct OsmToRailjsonArgs {
+    /// Input file in the OSM PBF format
+    pub osm_pbf_in: PathBuf,
+    /// Output file in Railjson format
+    pub railjson_out: PathBuf,
+}
+
+fn main() {
+    let args = OsmToRailjsonArgs::parse();
+    osm_to_railjson::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
+        .expect("Could not convert osm to railjson");
+}

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -16,7 +16,6 @@ mod valkey_config;
 use std::env;
 use std::path::PathBuf;
 
-use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 use clap::ValueEnum;
@@ -77,7 +76,6 @@ pub enum Commands {
     ElectricalProfiles(electrical_profiles_commands::ElectricalProfilesCommands),
     ImportRollingStock(ImportRollingStockArgs),
     ImportTowedRollingStock(ImportRollingStockArgs),
-    OsmToRailjson(OsmToRailjsonArgs),
     #[command(about, long_about = "Prints the OpenApi of the service")]
     Openapi,
     #[command(subcommand, about, long_about = "Search engine related commands")]
@@ -100,15 +98,6 @@ pub enum Commands {
     User(UserCommand),
     #[command(about, long_about = "Healthcheck")]
     Healthcheck(CoreArgs),
-}
-
-#[derive(Args, Debug)]
-#[command(about, long_about = "Extracts a railjson from OpenStreetMap data")]
-pub struct OsmToRailjsonArgs {
-    /// Input file in the OSM PBF format
-    pub osm_pbf_in: PathBuf,
-    /// Output file in Railjson format
-    pub railjson_out: PathBuf,
 }
 
 /// Prints the OpenApi to stdout

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -138,9 +138,6 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
         Commands::ImportTowedRollingStock(args) => {
             import_towed_rolling_stock(args, db_pool.into()).await
         }
-        Commands::OsmToRailjson(args) => {
-            osm_to_railjson::osm_to_railjson(args.osm_pbf_in, args.railjson_out)
-        }
         Commands::Openapi => {
             print_openapi();
             Ok(())


### PR DESCRIPTION
This is more to open a discussion:

As compile time are unbearable, we could split the editoast binary into smaller ones. As we already started separating crates, this could be quite simple.

In this pull request, osm-to-railjson in separated.

It now must be called as `cargo run -p osm_to_railjson`

The improvement are not spectacular:

```
Now:
- 541 units
- total build time: 175.5s
- editoast bin: 109s
- minor change build time: 25s
- binary size (debug): 312Mb

Before:
- 561 units
- total build time: 182.4s
- editoast bin: 109s
- minor change build time: 26secs
- binary size (debug): 314Mb
```

I’m not sure if it would make sens to extract the other commands that are more close to the editoast core?