### PR TITLE
github: group osrd-ui dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,9 @@ updates:
       nivo:
         patterns:
           - "@nivo/*"
+      osrd-ui:
+        patterns:
+          - "@osrd-project/ui-*"
       rjsf:
         patterns:
           - "@rjsf/*"


### PR DESCRIPTION
osrd-ui has an unusual versioning scheme: it uses 0.0.x and all releases may contain breaking changes.