### PR TITLE
front: drop unused package overrides

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -153,9 +153,6 @@
     "vitest": "^2.0.0"
   },
   "overrides": {
-    "react-error-overlay": "6.0.9",
-    "@nivo/line": "^0.80.0",
-    "@nivo/core": "^0.80.0",
     "oazapfts": "osrd-project/oazapfts#master"
   },
   "scripts": {


### PR DESCRIPTION
Running `npm install` after removing these indicates that all dependencies were already up-to-date and remain unchanged.