### PR TITLE
front: disable get the simulation button when infra is not loaded

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -172,7 +172,11 @@ const StdcmConfig = ({
                   })}
                   label={t('simulation.getSimulation')}
                   onClick={startSimulation}
-                  isDisabled={disabled || !showBtnToLaunchSimulation}
+                  isDisabled={
+                    disabled ||
+                    !showBtnToLaunchSimulation ||
+                    formErrors?.errorType === StdcmConfigErrorTypes.INFRA_NOT_LOADED
+                  }
                 />
                 {formErrors && (
                   <StdcmWarningBox


### PR DESCRIPTION
closes #9452 