### PR TITLE
front: center text on stdcm error

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_home.scss
+++ b/front/src/styles/scss/applications/stdcm/_home.scss
@@ -288,10 +288,11 @@
       }
 
       .error-message {
-        padding-top: 22px;
-        max-width: 546px;
+        padding: 22px 8px 0 8px;
+        width: 466px;
         color: rgba(49, 46, 43, 1);
         line-height: 24px;
+        text-align: center;
       }
     }
   }


### PR DESCRIPTION
fix #10135 for the text alignment

![image](https://github.com/user-attachments/assets/6a8e426e-ffd4-4396-ad2d-9b58ee2d662b)
