### PR TITLE
[superseded, on-hold before closing] editoast: remove 'validator' dependency

### DIFF
--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -31,7 +31,6 @@ use strum::Display;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
-use validator::Validate;
 
 use crate::error::InternalError;
 use crate::error::Result;
@@ -323,7 +322,6 @@ async fn create(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    rolling_stock_form.validate()?;
     let conn = &mut db_pool.get().await?;
     let rolling_stock_name = rolling_stock_form.name.clone();
     let rolling_stock_changeset: Changeset<RollingStockModel> = rolling_stock_form.into();
@@ -361,7 +359,6 @@ async fn update(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    rolling_stock_form.validate()?;
     let name = rolling_stock_form.name.clone();
 
     let new_rolling_stock = db_pool


### PR DESCRIPTION
⚠️ Superseded for one part by https://github.com/OpenRailAssociation/osrd/pull/12904 and for the other part by https://github.com/OpenRailAssociation/osrd/issues/13333

---

After https://github.com/OpenRailAssociation/osrd/pull/10147#discussion_r1905598946

TODO:
- [ ] fix tests
- [ ] use Changeset<RollingStock> and #[serde(remote = "Self")] if possible
- [ ] maybe change error type returned by the free function
- [ ] remove any 'validator' use