### PR TITLE
front: fix scroll in stdcm result table

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_results.scss
+++ b/front/src/styles/scss/applications/stdcm/_results.scss
@@ -150,11 +150,12 @@
       .table-container {
         width: 804px;
         margin-right: 32px;
-
+        height: calc(100vh - 180px);
+        overflow-y: auto;
+        scrollbar-width: none;
         .table-results {
           border-radius: 6px;
           background-color: rgba(0, 0, 0, 0.05);
-
           thead {
             position: sticky;
             top: 0;


### PR DESCRIPTION
close #9625 

Decided to put a max height of 80vh to prevent the results from increasing page size too much. 
Can be changed for lesser / higher value if you think it's better to. 