### PR TITLE
front: fix some issues in stdcm consist errors tooltips

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -218,10 +218,7 @@ const StdcmConfig = ({
                   isDisabled={
                     disabled ||
                     !showBtnToLaunchSimulation ||
-                    formErrors?.errorType === StdcmConfigErrorTypes.INFRA_NOT_LOADED ||
-                    !!consistErrors.totalMass ||
-                    !!consistErrors.totalLength ||
-                    !!consistErrors.maxSpeed
+                    formErrors?.errorType === StdcmConfigErrorTypes.INFRA_NOT_LOADED
                   }
                 />
                 {formErrors && (

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -200,7 +200,7 @@ const StdcmConsist = ({ consistErrors = {}, disabled = false }: StdcmConfigCardP
             consistErrors?.totalLength
               ? {
                   status: 'error',
-                  tooltip: 'right',
+                  tooltip: 'left',
                   message: t(consistErrors.totalLength, {
                     low: Math.floor((rollingStock?.length ?? 0) + (towedRollingStock?.length ?? 0)),
                     high: CONSIST_TOTAL_LENGTH_MAX,
@@ -230,7 +230,7 @@ const StdcmConsist = ({ consistErrors = {}, disabled = false }: StdcmConfigCardP
             consistErrors?.maxSpeed
               ? {
                   status: 'error',
-                  tooltip: 'right',
+                  tooltip: 'left',
                   message: t(consistErrors.maxSpeed, {
                     low: CONSIST_MAX_SPEED_MIN,
                     high: Math.floor(


### PR DESCRIPTION
- Tooltip position in consist form should be always left
- The launch button shouldn't be disabled if a tooltip is displayed