### PR TITLE
front: avoid unecessary path finding call in stdcm

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -147,7 +147,7 @@ const StdcmConfig = ({
       );
       setFormErrors(formErrorsStatus);
     }
-  }, [pathfinding]);
+  }, [pathfinding, pathSteps, t]);
 
   useEffect(() => {
     if (!isDebugMode) {


### PR DESCRIPTION
fix #10144

Adding a state for `pathStepsLocations` and only changes its value when there is a deep diff