### PR TITLE
core: stdcm: set a min speed for engineering allowance check

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -407,10 +407,13 @@ private fun handlePostProcessingConflict(
     updatedTimeData: TimeData,
     fixedPoints: TreeSet<FixedTimePoint>,
     conflictOffset: Offset<TravelledPath>,
-    isMareco: Boolean
+    isMareco: Boolean,
 ): Envelope {
     postProcessingLogger.error(
         "Conflicts detected in post-processing, mismatch with the exploration data"
+    )
+    postProcessingLogger.error(
+        "NOTE: look through the logs for allowance issues, they may cause mismatches."
     )
     val conflictTime = fixedPoints.first { it.offset == conflictOffset }.time
     postProcessingLogger.info(


### PR DESCRIPTION
We used to consider that we can add any amount of time if the train can basically stop, but this was too optimistic

Fix https://github.com/OpenRailAssociation/osrd/issues/9023 (at least some cases, I'll run the fuzzer to look for any other bug)