### PR TITLE
front: fix stdcm cards display

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_card.scss
+++ b/front/src/styles/scss/applications/stdcm/_card.scss
@@ -7,9 +7,6 @@
   background-color: rgba(255, 255, 255, 1);
   height: fit-content;
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
 
   .stdcm-default-card-icon {
     color: #1844ef;
@@ -92,9 +89,13 @@
     }
 
     .feed-back {
-      --field-wrapper-padding-bottom: 9px;
-      padding-top: 3px;
-      padding-bottom: 3px;
+      padding: 0;
+      &.error {
+        --field-wrapper-padding-bottom: 5px;
+        .status-message-wrapper-tooltip.tooltip-left {
+          left: -4px;
+        }
+      }
     }
 
     .date-picker {
@@ -126,8 +127,7 @@
 
     // cards styles
     &.consist {
-      padding-left: 11px;
-      padding-right: 11px;
+      padding-left: 24px;
       padding-bottom: 15px;
 
       .towed-rolling-stock {
@@ -136,8 +136,9 @@
 
       .stdcm-consist__properties {
         display: grid;
-        grid-template-columns: 139px 147px;
+        grid-template-columns: 119px 127px;
         justify-content: space-between;
+        padding-block: 8px;
 
         .osrd-config-item {
           padding-right: 3px;


### PR DESCRIPTION
The layout of stdcm card fields no longer matches the mock-ups

![image](https://github.com/user-attachments/assets/445b294d-2df1-4bf5-9e16-fb9822bd0e5b)

