### PR TITLE
front: fix stdcm consist unwanted warning

### DIFF
--- a/front/src/applications/stdcm/utils/consistValidation.ts
+++ b/front/src/applications/stdcm/utils/consistValidation.ts
@@ -22,7 +22,7 @@ export const validateTotalMass = ({
   }
 
   const tractionMassInTons = kgToT(tractionEngineMass);
-  const consistMassInTons = kgToT(tractionEngineMass + towedMass);
+  const consistMassInTons = Math.floor(kgToT(tractionEngineMass + towedMass));
   const massLimit = towedMass ? consistMassInTons : tractionMassInTons;
 
   if (totalMass < massLimit || totalMass >= CONSIST_TOTAL_MASS_MAX) {


### PR DESCRIPTION
Round to bottom the conversion to ton of the sum of the rolling stock and towed rolling stock mass to match the behavior of the tonnage input.

fix #10306 