### PR TITLE
front: fix stdcm add via scroll

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -75,12 +75,19 @@ const StdcmVias = ({ disabled = false }: StdcmConfigCardProps) => {
 
     requestId = requestAnimationFrame(scrollWithAnimation);
 
-    const cancelListener = () => cancelAnimationFrame(requestId);
+    const newElementCIInput: HTMLInputElement | null = newElement.querySelector('.ci-input input');
 
-    newElement.parentElement!.addEventListener('animationend', cancelListener);
+    if (newElementCIInput) newElementCIInput.focus({ preventScroll: true });
+
+    const handleAnimationEnd = () => {
+      cancelAnimationFrame(requestId);
+      setNewIntermediateOpIndex(undefined);
+    };
+
+    newElement.parentElement!.addEventListener('animationend', handleAnimationEnd);
     return () => {
-      newElement.parentElement!.removeEventListener('animationend', cancelListener);
-      cancelListener();
+      newElement.parentElement!.removeEventListener('animationend', handleAnimationEnd);
+      cancelAnimationFrame(requestId);
     };
   }, [newIntermediateOpIndex]);
 


### PR DESCRIPTION
- Focus the CI input of the new added via
- Reset the state giving the via index to scroll to after the action to enable the animation even when the user adds 2 vias in a row at the same index

close #9713 (see last comment in the issue)