### PR TITLE
front, editoast: add set -x option to the bash scripts

### DIFF
--- a/docker/gateway-entrypoint.sh
+++ b/docker/gateway-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 >/tmp/front_config jq -rn '{
     OSRD_GIT_DESCRIBE: env.OSRD_GIT_DESCRIBE,
 } | @json | "      globalThis.import_meta_env = \(.);"'

--- a/editoast/assets/signal_sprites/generate-atlas.sh
+++ b/editoast/assets/signal_sprites/generate-atlas.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 # This script should be used to generate signaling systems atlas given svg.
 # First add all your svg in a subfolder named to the signaling system (eg: `BAL`)
 # Then run this script. You will need docker.

--- a/front/docker/dev-entrypoint.sh
+++ b/front/docker/dev-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 # This script changes the user and group of the dev server
 # process to match the owner of the project's files.

--- a/front/docker/nginx-entrypoint.sh
+++ b/front/docker/nginx-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 : "${FRONT_PORT:=80}"
 
 sed -i "s|%FRONT_PORT%|${FRONT_PORT}|g" /etc/nginx/conf.d/nginx.conf

--- a/front/scripts/generate-types.sh
+++ b/front/scripts/generate-types.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -x
+
 if ! npx @rtk-query/codegen-openapi src/config/openapi-editoast-config.ts; then
     echo "npx @rtk-query/codegen-openapi src/config/openapi-editoast-config.ts command failed. Exit the script"
     exit 1

--- a/front/scripts/start-dev.sh
+++ b/front/scripts/start-dev.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+set -x
 (sleep 3; xdg-open 'http://localhost:4000') &
 import-meta-env-prepare -x .env.example && vite

--- a/scripts/build-core.sh
+++ b/scripts/build-core.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 docker compose \
     -p "osrd" \
     -f "docker-compose.yml" \

--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -7,6 +7,7 @@
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
+set -x
 
 # Check arguments
 if [ "$#" -ne 0 ]; then

--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -7,6 +7,7 @@
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
+set -x
 
 OUTPUT_DIR="."
 if [ "$#" -eq 1 ]; then

--- a/scripts/drop-core.sh
+++ b/scripts/drop-core.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 docker rm -f "dyn-osrd-core-$1"
 
 docker compose \

--- a/scripts/host-compose.sh
+++ b/scripts/host-compose.sh
@@ -4,6 +4,7 @@
 # By design, this script is not meant to be run on Windows since it relies exclusively on network_mode: host.
 
 set -e
+set -x
 
 # We override the default docker-compose file with the "host" version in the docker folder
 docker compose \

--- a/scripts/load-backup.sh
+++ b/scripts/load-backup.sh
@@ -7,6 +7,7 @@
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
+set -x
 
 # Check arguments
 if [ "$#" -ne 1 ]; then

--- a/scripts/load-railjson-infra.sh
+++ b/scripts/load-railjson-infra.sh
@@ -7,6 +7,7 @@
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
+set -x
 
 infra_name="${1:?missing infrastructure name}"
 infra_path="${2:?missing path to RailJSON infrastructure}"

--- a/scripts/load-railjson-rolling-stock.sh
+++ b/scripts/load-railjson-rolling-stock.sh
@@ -7,6 +7,7 @@
 # As a workaround, use relative paths: container:tmp/foo instead of container://tmp/foo
 
 set -e
+set -x
 
 if [ "$#" = 0 ]; then
 	echo "Missing path to RailJSON rolling stock"

--- a/scripts/pr-tests-compose.sh
+++ b/scripts/pr-tests-compose.sh
@@ -6,6 +6,7 @@
 
 
 set -e
+set -x
 
 # For Macos ARM chip users set a postgis image compiled to run on ARM, it makes their DB runs faster as their computer don't have to emulate x86_64's architecture.
 case "$(uname -s)" in
@@ -22,12 +23,12 @@ if  {
     {
         [ "$#" -eq 2 ] &&
             [ "$2" != "up" ]
-    } || 
+    } ||
     {
         [ "$#" -eq 1 ] &&
             [ "$1" != "down" ] &&
             [ "$1" != "down-and-clean" ]
-    } || 
+    } ||
     {
         [ "$#" -ne 1 ] &&
             [ "$#" -ne 2 ] &&

--- a/scripts/run-front-playwright-container.sh
+++ b/scripts/run-front-playwright-container.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 # Open the base osrd folder, assuming the script is located in osrd/scripts
 cd "$(realpath "$(dirname "$0")"/..)"

--- a/scripts/single-worker-compose.sh
+++ b/scripts/single-worker-compose.sh
@@ -4,6 +4,7 @@
 # By design, this script is not meant to be run on Windows since it relies exclusively on network_mode: host.
 
 set -e
+set -x
 
 # We override the default docker-compose file with "host" and "single-worker" versions in the docker folder
 docker compose \

--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 root_path="$(realpath "$(dirname "$0")"/..)"
 


### PR DESCRIPTION
It is useful when not knowing well the commands executed inside a script and their expected output to be able to see immediately which command failed and with which arguments it was called.