### PR TITLE
front: fix displayed op on manchette

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -53,7 +53,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 7746000,
         },
         position: 9246000,
-        weight: null,
+        weight: 100,
       },
       {
         id: 'Mid_West_station',
@@ -112,7 +112,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 6481000,
         },
         position: 0,
-        weight: null,
+        weight: 100,
       },
       {
         id: 'Mid_West_station',
@@ -142,7 +142,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 679000,
         },
         position: 4198000,
-        weight: null,
+        weight: 100,
       },
       {
         id: '3',
@@ -157,7 +157,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 883000,
         },
         position: 4402000,
-        weight: null,
+        weight: 100,
       },
     ]);
   });
@@ -186,7 +186,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 6481000,
         },
         position: 0,
-        weight: null,
+        weight: 100,
       },
       {
         id: '2',
@@ -201,7 +201,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
           position: 4733000,
         },
         position: 1748000,
-        weight: null,
+        weight: 100,
       },
     ]);
   });

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -190,6 +190,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       position: waypoint.position,
       name: waypoint.extensions?.identifier?.name,
       secondaryCode: waypoint.extensions?.sncf?.ch,
+      weight: waypoint.weight ?? 0,
     }));
   }, [waypointsPanelData, operationalPoints]);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -78,11 +78,12 @@ const useGetProjectedTrainOperationalPoints = (
           >;
         } else {
           // If the manchette hasn't been saved, we want to display by default only
-          // the waypoints with CH BV/00/'' and the ones added by map click
+          // the waypoints with CH BV/00/'' and the path steps (origin, destination, vias)
           operationalPointsWithUniqueIds = operationalPointsWithUniqueIds.filter((op) =>
-            op.extensions?.sncf ? isStation(op.extensions.sncf.ch) : true
+            op.extensions?.sncf ? isStation(op.extensions.sncf.ch) || op.weight === 100 : true
           );
         }
+
         setFilteredOperationalPoints(operationalPointsWithUniqueIds);
       }
     };


### PR DESCRIPTION
Set the weight of the main PRs (origin, arrival and vias) to 100. 
For vias added by hand from the map, they were previously set to “null”, now they're set to 100, so they're displayed on the manchette. 

## Tests : 
- add a waypoint using the functionality, see it displayed on the basic cuff and GEV
- add a waypoint by clicking on the map, and see it displayed on the headline and GEV.
- check PR weights console.log(operationalPoints.weight) and verify that passage PRs have a weight of 100
