### PR TITLE
python: fix missing flake8-formatter-junit-xml dependency

### DIFF
--- a/python/osrd_schemas/poetry.lock
+++ b/python/osrd_schemas/poetry.lock
@@ -118,6 +118,21 @@ pycodestyle = ">=2.11.0,<2.12.0"
 pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
+name = "flake8-formatter-junit-xml"
+version = "0.0.6"
+description = "JUnit XML Formatter for flake8"
+optional = false
+python-versions = "*"
+files = [
+    {file = "flake8_formatter_junit_xml-0.0.6-py2.py3-none-any.whl", hash = "sha256:6358a44ecafdf0f9c8ee5314859b8d6f553dc2e55e946a24c538185e1eba7ce6"},
+    {file = "flake8_formatter_junit_xml-0.0.6.tar.gz", hash = "sha256:1ddd9356bb30ba736c3f14c769c837cfacf4f79c3d383ab963ef9d38eea05a9c"},
+]
+
+[package.dependencies]
+flake8 = ">3.0.0"
+junit-xml = ">=1.8"
+
+[[package]]
 name = "geojson-pydantic"
 version = "1.0.2"
 description = "Pydantic data models for the GeoJSON spec."
@@ -180,6 +195,20 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "junit-xml"
+version = "1.9"
+description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins"
+optional = false
+python-versions = "*"
+files = [
+    {file = "junit-xml-1.9.tar.gz", hash = "sha256:de16a051990d4e25a3982b2dd9e89d671067548718866416faec14d9de56db9f"},
+    {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
+]
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "libcst"
@@ -683,6 +712,17 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
@@ -747,4 +787,4 @@ typing-extensions = ">=3.7.4"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "ff66481d03f881b30719c264142ec793c44dbb2d121139f95878ddef5f10e9cd"
+content-hash = "b8fc2b213787f5c2a48c51aff2ef327ef7453fe62215740a4df214ee53143629"

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -15,6 +15,7 @@ python = ">=3.9,<3.13"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"
+flake8-formatter-junit-xml = "^0.0.6"
 isort = "^5.12.0"
 pyproject-flake8 = "^6.0.0.post1"
 pytype = { platform = "linux", version = "^2023.10.17" }

--- a/python/railjson_generator/poetry.lock
+++ b/python/railjson_generator/poetry.lock
@@ -199,6 +199,21 @@ pycodestyle = ">=2.11.0,<2.12.0"
 pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
+name = "flake8-formatter-junit-xml"
+version = "0.0.6"
+description = "JUnit XML Formatter for flake8"
+optional = false
+python-versions = "*"
+files = [
+    {file = "flake8_formatter_junit_xml-0.0.6-py2.py3-none-any.whl", hash = "sha256:6358a44ecafdf0f9c8ee5314859b8d6f553dc2e55e946a24c538185e1eba7ce6"},
+    {file = "flake8_formatter_junit_xml-0.0.6.tar.gz", hash = "sha256:1ddd9356bb30ba736c3f14c769c837cfacf4f79c3d383ab963ef9d38eea05a9c"},
+]
+
+[package.dependencies]
+flake8 = ">3.0.0"
+junit-xml = ">=1.8"
+
+[[package]]
 name = "geojson-pydantic"
 version = "1.0.2"
 description = "Pydantic data models for the GeoJSON spec."
@@ -272,6 +287,20 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "junit-xml"
+version = "1.9"
+description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins"
+optional = false
+python-versions = "*"
+files = [
+    {file = "junit-xml-1.9.tar.gz", hash = "sha256:de16a051990d4e25a3982b2dd9e89d671067548718866416faec14d9de56db9f"},
+    {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
+]
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "libcst"
@@ -453,7 +482,7 @@ test = ["codecov (>=2.0.5)", "coverage (>=4.2)", "flake8 (>=3.0.4)", "pytest (>=
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.15"
+version = "0.8.16"
 description = ""
 optional = false
 python-versions = ">=3.9,<3.13"
@@ -847,6 +876,17 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
@@ -911,4 +951,4 @@ typing-extensions = ">=3.7.4"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "5f5cbde1c767a19aaa8db905ca3509903880964d92319ac50b916a9241e5eee8"
+content-hash = "c9c3d89247ec19ae3c2402ca9dc08d4365d81f062648dc34c9165114351781e5"

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -16,6 +16,7 @@ python = ">=3.9,<3.13"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"
+flake8-formatter-junit-xml = "^0.0.6"
 isort = "^5.12.0"
 pyproject-flake8 = "^6.0.0.post1"
 pytype = { platform = "linux", version = "^2023.10.17" }


### PR DESCRIPTION
In CI we use the following command:

    poetry run pflake8 --config ./pyproject.toml --output-file flake8.xml --format junit-xml

Unfortunately, when flake8 doesn't recognize a predefined format, it silently interprets it as a format string. As a result the output file flake8.xml contained a single line with the raw string "junit-xml".

Example: https://github.com/OpenRailAssociation/osrd/actions/runs/12713432631/job/35441321986?pr=10325#step:6:3