### PR TITLE
python: fix maximum Python version

### DIFF
--- a/python/osrd_schemas/poetry.lock
+++ b/python/osrd_schemas/poetry.lock
@@ -786,5 +786,5 @@ typing-extensions = ">=3.7.4"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.13"
-content-hash = "b8fc2b213787f5c2a48c51aff2ef327ef7453fe62215740a4df214ee53143629"
+python-versions = ">=3.9,<3.12"
+content-hash = "a93d9517a9561035021101241794f0a9d0154922b6db6704171022c5709223dc"

--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["OSRD <contact@osrd.fr>"]
 [tool.poetry.dependencies]
 geojson-pydantic = "^1.0.0"
 pydantic = "^2.1.1"
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.12"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/python/railjson_generator/poetry.lock
+++ b/python/railjson_generator/poetry.lock
@@ -485,7 +485,7 @@ name = "osrd-schemas"
 version = "0.8.16"
 description = ""
 optional = false
-python-versions = ">=3.9,<3.13"
+python-versions = ">=3.9,<3.12"
 files = []
 develop = false
 
@@ -950,5 +950,5 @@ typing-extensions = ">=3.7.4"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.13"
-content-hash = "c9c3d89247ec19ae3c2402ca9dc08d4365d81f062648dc34c9165114351781e5"
+python-versions = ">=3.9,<3.12"
+content-hash = "2094df8db0fd952c2289918d9f0d6f137a451e85b7b95112d4558672985ab7aa"

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -12,7 +12,7 @@ authors = ["OSRD <contact@osrd.fr>"]
 osrd-schemas = { path = "../osrd_schemas/", develop = false }
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.12"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"


### PR DESCRIPTION
Python 3.12 doesn't work:

    # poetry run pflake8 --config ./pyproject.toml
    Traceback (most recent call last):
      File "/root/.cache/pypoetry/virtualenvs/railjson-generator--f9Ha3Rv-py3.12/bin/pflake8", line 5, in <module>
        from pflake8.__main__ import main
      File "/root/.cache/pypoetry/virtualenvs/railjson-generator--f9Ha3Rv-py3.12/lib/python3.12/site-packages/pflake8/__init__.py", line 55, in <module>
        class DivertingSafeConfigParser(ConfigParserTomlMixin, configparser.SafeConfigParser):
                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?

See this upstream bug report:
https://github.com/pydata/pandas-datareader/issues/969

Our CI already checks out Python 3.11, so let's align our maximum version with what CI uses.