### PR TITLE
core: aggregate errors that happen too often during infra loading

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/LogAggregator.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/LogAggregator.kt
@@ -1,0 +1,32 @@
+package fr.sncf.osrd.utils
+
+/**
+ * This class can be used to aggregate logs: when a specific error/warning happens thousands of time
+ * in a row, we only report the first $n and only log the total error number afterward. The class
+ * must be initialized once before the loop, errors should be logged with `logError`, and then
+ * `logAggregatedSummary` should be called once at the end.
+ */
+data class LogAggregator(
+    /** Function to use to log anything (e.g. `{ logger.warn(it) }` ). */
+    val logFunction: (str: String) -> Unit,
+    /** String to be used for collapsed errors, using %d and .format for the remaining number. */
+    val summaryErrorMessage: String = "... and %d other similar errors",
+    /** Max number of errors before collapsing the rest. */
+    val maxReportedErrors: Int = 3,
+) {
+    private var nErrors = 0
+    private var savedErrors = mutableListOf<String>()
+
+    /** Registers an error. Does not log anything before the `reportSummary` call. */
+    fun registerError(msg: String) {
+        nErrors++
+        if (savedErrors.size < maxReportedErrors) savedErrors.add(msg)
+    }
+
+    /** Logs the errors, collapsing the ones after `maxReportedErrors`. */
+    fun logAggregatedSummary() {
+        for (err in savedErrors) logFunction(err)
+        val remainingErrors = nErrors - savedErrors.size
+        if (remainingErrors > 0) logFunction(summaryErrorMessage.format(remainingErrors))
+    }
+}


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/8773

After:

```
[15:46:49,574] [INFO]          [ValidateInfra] parsing json
[15:46:52,963] [INFO]          [ValidateInfra] parsing RailJSON
[15:46:57,358] [WARN]      [RawInfraRJSParser] Electrification conflict on track-range TRACK_ID[53m, 1168m]: 25000V != 3000V
[15:46:57,358] [WARN]      [RawInfraRJSParser] Electrification conflict on track-range TRACK_ID[23m, 487m]: 25000V != 3000V
[15:46:57,358] [WARN]      [RawInfraRJSParser] Electrification conflict on track-range TRACK_ID[487m, 974m]: 25000V != 3000V
[15:46:57,371] [WARN]      [RawInfraRJSParser] ... and 90 other similar errors
[15:47:10,282] [INFO]          [ValidateInfra] loading signals
[15:47:10,502] [INFO]          [ValidateInfra] building blocks
[15:47:12,318] [DEBUG]          [BlockBuilder] no signal at non buffer stop detector.DETECTOR_ID:DECREASING
[15:47:12,318] [DEBUG]          [BlockBuilder] no signal at non buffer stop detector.DETECTOR_ID:INCREASING
[15:47:12,318] [DEBUG]          [BlockBuilder] no signal at non buffer stop detector.DETECTOR_ID:INCREASING
[15:47:12,328] [DEBUG]          [BlockBuilder] ... and 1256 other similar errors
[15:47:12,536] [DEBUG] [SignalingSimulatorImpl] error in block BLOCK_ID: too_few_signals
[15:47:12,536] [DEBUG] [SignalingSimulatorImpl] error in block BLOCK_ID: too_few_signals
[15:47:12,536] [DEBUG] [SignalingSimulatorImpl] error in block BLOCK_ID: too_few_signals
[15:47:12,537] [DEBUG] [SignalingSimulatorImpl] ... and 955 other similar errors
[15:47:12,537] [INFO]          [ValidateInfra] done
```

Before: same thing but over 2k2 lines