### PR TITLE
timetable performance

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -101,7 +101,8 @@
         "remark-gfm": "^4.0.0",
         "reselect": "^5.1.0",
         "uuid": "^11.0.5",
-        "viewport-mercator-project": "^7.0.4"
+        "viewport-mercator-project": "^7.0.4",
+        "virtua": "^0.39.3"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
@@ -14691,6 +14692,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -15774,6 +15776,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
       "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
@@ -15787,6 +15790,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -21500,6 +21504,35 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/virtua": {
+      "version": "0.39.3",
+      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.39.3.tgz",
+      "integrity": "sha512-Ep3aiJXSGPm1UUniThr5mGDfG0upAleP7pqQs5mvvCgM1wPhII1ZKa7eNCWAJRLkC+InpXKokKozyaaj/aMYOQ==",
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "solid-js": ">=1.0",
+        "svelte": ">=5.0",
+        "vue": ">=3.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/front/package.json
+++ b/front/package.json
@@ -96,7 +96,8 @@
     "remark-gfm": "^4.0.0",
     "reselect": "^5.1.0",
     "uuid": "^11.0.5",
-    "viewport-mercator-project": "^7.0.4"
+    "viewport-mercator-project": "^7.0.4",
+    "virtua": "^0.39.3"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -151,7 +151,7 @@ const Timetable = ({
         />
         <Virtualizer overscan={15}>
           {displayedTrainSchedules.map((train: TrainScheduleWithDetails, index) => (
-            <div key={`timetable-train-card-${train.id}-${train.trainName}`}>
+            <div key={`timetable-train-card-${train.id}`}>
               {showDepartureDates[index] && (
                 <div className="scenario-timetable-departure-date">
                   {currentDepartureDates[index]}

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 
 import cx from 'classnames';
 import dayjs from 'dayjs';
@@ -64,28 +64,31 @@ const Timetable = ({
     setShowTrainDetails(!showTrainDetails);
   };
 
-  const removeAndUnselectTrains = (trainIds: number[]) => {
+  const removeAndUnselectTrains = useCallback((trainIds: number[]) => {
     removeTrains(trainIds);
     setSelectedTrainIds([]);
     dtoImport();
-  };
+  }, []);
 
   const toggleConflictsListExpanded = () => {
     setConflictsListExpanded(!conflictsListExpanded);
   };
 
-  const handleSelectTrain = (id: number) => {
-    const currentSelectedTrainIds = [...selectedTrainIds];
-    const index = currentSelectedTrainIds.indexOf(id);
+  const handleSelectTrain = useCallback(
+    (id: number) => {
+      const currentSelectedTrainIds = [...selectedTrainIds];
+      const index = currentSelectedTrainIds.indexOf(id);
 
-    if (index === -1) {
-      currentSelectedTrainIds.push(id);
-    } else {
-      currentSelectedTrainIds.splice(index, 1);
-    }
+      if (index === -1) {
+        currentSelectedTrainIds.push(id);
+      } else {
+        currentSelectedTrainIds.splice(index, 1);
+      }
 
-    setSelectedTrainIds(currentSelectedTrainIds);
-  };
+      setSelectedTrainIds(currentSelectedTrainIds);
+    },
+    [selectedTrainIds]
+  );
 
   const handleConflictClick = (conflict: Conflict) => {
     if (conflict.train_ids.length > 0) {

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { Virtualizer } from 'virtua';
 
 import { MANAGE_TRAIN_SCHEDULE_TYPES } from 'applications/operationalStudies/consts';
 import type { Conflict, InfraState, TrainScheduleResult } from 'common/api/osrdEditoastApi';
@@ -145,30 +146,32 @@ const Timetable = ({
           trainSchedules={trainSchedules}
           isInSelection={selectedTrainIds.length > 0}
         />
-        {displayedTrainSchedules.map((train: TrainScheduleWithDetails, index) => (
-          <div key={`timetable-train-card-${train.id}-${train.trainName}`}>
-            {showDepartureDates[index] && (
-              <div className="scenario-timetable-departure-date">
-                {currentDepartureDates[index]}
-              </div>
-            )}
-            <TimetableTrainCard
-              isInSelection={selectedTrainIds.includes(train.id)}
-              handleSelectTrain={handleSelectTrain}
-              train={train}
-              isSelected={infraState === 'CACHED' && selectedTrainId === train.id}
-              isModified={train.id === trainIdToEdit}
-              setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
-              upsertTrainSchedules={upsertTrainSchedules}
-              setTrainIdToEdit={setTrainIdToEdit}
-              removeTrains={removeAndUnselectTrains}
-              projectionPathIsUsed={
-                infraState === 'CACHED' && trainIdUsedForProjection === train.id
-              }
-              dtoImport={dtoImport}
-            />
-          </div>
-        ))}
+        <Virtualizer overscan={15}>
+          {displayedTrainSchedules.map((train: TrainScheduleWithDetails, index) => (
+            <div key={`timetable-train-card-${train.id}-${train.trainName}`}>
+              {showDepartureDates[index] && (
+                <div className="scenario-timetable-departure-date">
+                  {currentDepartureDates[index]}
+                </div>
+              )}
+              <TimetableTrainCard
+                isInSelection={selectedTrainIds.includes(train.id)}
+                handleSelectTrain={handleSelectTrain}
+                train={train}
+                isSelected={infraState === 'CACHED' && selectedTrainId === train.id}
+                isModified={train.id === trainIdToEdit}
+                setDisplayTrainScheduleManagement={setDisplayTrainScheduleManagement}
+                upsertTrainSchedules={upsertTrainSchedules}
+                setTrainIdToEdit={setTrainIdToEdit}
+                removeTrains={removeAndUnselectTrains}
+                projectionPathIsUsed={
+                  infraState === 'CACHED' && trainIdUsedForProjection === train.id
+                }
+                dtoImport={dtoImport}
+              />
+            </div>
+          ))}
+        </Virtualizer>
         <div
           className={cx('bottom-timetables-trains', {
             'empty-list': trainSchedulesWithDetails.length === 0,


### PR DESCRIPTION
closes #10377


Performance improvement with a 1000 trains timetable on a short path. Every single train was being re-rendered on every single frame.

improvements: 
- virtualizing list of trains to only have elements that are actually displayed in the DOM.
- using useCallback on two props to prevent of re-renders on `TimetableTrainCard`
![Screenshot_20250113_210147](https://github.com/user-attachments/assets/f1569844-81a6-496b-821b-a263530db4a9)

the 2 `useCallback`s on their own prevent any re-render of `TimetableTrainCard` that are already painted.

adding `VList` on top of the 2 `useCallback`s makes an anonymous wrapper of `TimetableTrainCard` re-render (internal stuff of the library (z prop)) but it’s still an improvement from using useCallback alone.

### Timing

|  case |  timer |   |
|---|---|---|
|  base |  4:27 | https://github.com/user-attachments/assets/23e89906-72c4-43d3-81dc-3336af39c6f6  |
|  VList only | 1:13  |  https://github.com/user-attachments/assets/36366f06-c0ce-46c4-aaca-b61f1ea29984 | 
|  useCallback only |  1:25 | https://github.com/user-attachments/assets/238d8dc5-a106-4904-a7b3-a0f23671c068 | 
|  Both |  1:00 | https://github.com/user-attachments/assets/bbb3e9d6-fa5a-4816-b6d3-432d2a064cd6 | 


a bit of improvement for #8575, but still slow on a click



