### PR TITLE
docker: bump to 'jaeger:2'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       OSRDYNE_API_URL: "http://osrd-osrdyne:4242/"
       TELEMETRY_KIND: "opentelemetry"
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
+      OTEL_SERVICE_NAME: "osrd-editoast"
       OSRD_MQ_URL: "amqp://osrd:password@osrd-rabbitmq:5672/%2f"
     command:
       - /bin/sh
@@ -184,7 +185,7 @@ services:
       OSRDYNE__OPENTELEMETRY__SERVICE_NAME: "osrdyne"
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/jaeger:latest
     container_name: osrd-jaeger
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Jaeger v1 will be deprecated at the end of 2025.

<details>
<summary>warning message in Jaeger 1</summary>

```
osrd-jaeger    | *******************************************************************************
osrd-jaeger    | 
osrd-jaeger    | 🛑  WARNING: End-of-life Notice for Jaeger v1
osrd-jaeger    | 
osrd-jaeger    | You are currently running a v1 version of Jaeger, which is deprecated and will
osrd-jaeger    | reach end-of-life on December 31st, 2025. This means there will be no further
osrd-jaeger    | development, bug fixes, or security patches for v1 after this date.
osrd-jaeger    | 
osrd-jaeger    | We strongly recommend migrating to Jaeger v2 for continued support and access
osrd-jaeger    | to new features.
osrd-jaeger    | 
osrd-jaeger    | For detailed migration instructions, please refer to the official Jaeger
osrd-jaeger    | documentation:  https://www.jaegertracing.io/docs/latest/migration/
osrd-jaeger    | 
osrd-jaeger    | Tracking issue: https://github.com/jaegertracing/jaeger/issues/6321
osrd-jaeger    | 
osrd-jaeger    | 🛑  WARNING: End-of-life Notice for Jaeger v1
osrd-jaeger    | 
osrd-jaeger    | *******************************************************************************
```

</details>