### PR TITLE
front: remove unused class in stdcm results

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_results.scss
+++ b/front/src/styles/scss/applications/stdcm/_results.scss
@@ -373,9 +373,6 @@
       box-shadow:
         0 0 0 2px rgba(255, 255, 255, 0.75) inset,
         0 0 0 1px rgba(0, 0, 0, 0.25) inset;
-      &.no-pointer-events {
-        pointer-events: none;
-      }
     }
   }
 }


### PR DESCRIPTION
Since a recent PR, this class isn't used anymore.