### PR TITLE
front: do not persist STDCM configuration

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -18,6 +18,7 @@ import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/compon
 import NewMap from 'modules/trainschedule/components/ManageTrainSchedule/NewMap';
 import { type StdcmConfSliceActions, resetMargins } from 'reducers/osrdconf/stdcmConf';
 import type { StdcmConfSelectors } from 'reducers/osrdconf/stdcmConf/selectors';
+import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 
 import StdcmConsist from './StdcmConsist';
@@ -32,6 +33,12 @@ import { ArrivalTimeTypes, StdcmConfigErrorTypes } from '../../types';
 import checkStdcmConfigErrors from '../../utils/checkStdcmConfigErrors';
 import StdcmLoader from '../StdcmLoader';
 import StdcmWarningBox from '../StdcmWarningBox';
+
+declare global {
+  interface Window {
+    osrdStdcmConfState?: OsrdStdcmConfState;
+  }
+}
 
 /**
  * Inputs in different cards inside the StdcmConfig component come from the stdcm redux store.
@@ -59,7 +66,7 @@ const StdcmConfig = ({
 
   const { infra } = useInfraStatus();
   const dispatch = useAppDispatch();
-  const { updateStdcmPathStep, resetStdcmConfig } = useOsrdConfActions() as StdcmConfSliceActions;
+  const { updateStdcmPathStep, restoreStdcmConfig } = useOsrdConfActions() as StdcmConfSliceActions;
 
   const {
     getStdcmOrigin,
@@ -164,12 +171,9 @@ const StdcmConfig = ({
   }, [infra]);
 
   useEffect(() => {
-    const keepForm = localStorage.getItem('keepForm');
-
-    if (!keepForm) {
-      dispatch(resetStdcmConfig());
-    } else {
-      localStorage.removeItem('keepForm');
+    const state = window.osrdStdcmConfState;
+    if (state) {
+      dispatch(restoreStdcmConfig(state));
     }
   }, []);
 

--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 
 import { isEqual, isNil } from 'lodash';
+import { useSelector } from 'react-redux';
 
 import useStdcm from 'applications/stdcm/hooks/useStdcm';
 import { LoaderFill } from 'common/Loaders';
 import { useOsrdConfActions } from 'common/osrdContext';
 import type { StdcmConfSliceActions } from 'reducers/osrdconf/stdcmConf';
+import { getStdcmConf } from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
 import { replaceElementAtIndex } from 'utils/array';
 
@@ -22,6 +24,7 @@ import type { StdcmSimulation } from '../types';
 const StdcmView = () => {
   // TODO : refacto. state useStdcm. Maybe we can merge some state together in order to reduce the number of refresh
   const currentSimulationInputs = useStdcmForm();
+  const stdcmConf = useSelector(getStdcmConf);
   const [simulationsList, setSimulationsList] = useState<StdcmSimulation[]>([]);
   const [selectedSimulationIndex, setSelectedSimulationIndex] = useState(-1);
   const [showStatusBanner, setShowStatusBanner] = useState(false);
@@ -62,9 +65,12 @@ const StdcmView = () => {
     }
   };
 
-  const openNewWindow = () => {
+  const openNewWindow = (keepForm: boolean) => {
     const newWindow = window.open(window.location.href, '_blank');
     if (newWindow) {
+      if (keepForm) {
+        newWindow.osrdStdcmConfState = stdcmConf;
+      }
       newWindow.onload = () => {
         newWindow.focus();
       };
@@ -75,14 +81,13 @@ const StdcmView = () => {
     setButtonsVisible(false);
     resetStdcmState();
 
-    openNewWindow();
+    openNewWindow(false);
   };
 
   const handleStartNewQueryWithData = () => {
     setButtonsVisible(false);
-    localStorage.setItem('keepForm', 'true');
 
-    openNewWindow();
+    openNewWindow(true);
   };
 
   const toggleHelpModule = () => setShowHelpModule((show) => !show);

--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -61,17 +61,6 @@ const saveUserFilter = createFilter('user', userWhiteList);
 const saveMainFilter = createFilter('main', mainWhiteList);
 
 // Deserialize date strings coming from local storage
-const stdcmPathStepsDateTransform = createTransform(
-  null,
-  (outboundState: { arrival?: string }[]) =>
-    outboundState.map(({ arrival, ...step }) => {
-      if (arrival) {
-        return { ...step, arrival: new Date(arrival) };
-      }
-      return step;
-    }),
-  { whitelist: ['stdcmPathSteps'] }
-);
 const operationalStudiesDateTransform = createTransform(
   null,
   ({ startTime, ...outboundState }: { startTime: string }) => ({
@@ -96,7 +85,7 @@ const buildOsrdConfPersistConfig = <T extends OperationalStudiesConfState | Osrd
 ): PersistConfig<T> => ({
   key: slice.name,
   storage,
-  transforms: [stdcmPathStepsDateTransform, operationalStudiesDateTransform, pathStepsTransform],
+  transforms: [operationalStudiesDateTransform, pathStepsTransform],
 });
 
 export const persistConfig = {
@@ -153,10 +142,7 @@ export const rootReducer: ReducersMapObject<RootState> = {
   [mapViewerSlice.name]: mapViewerReducer,
   [editorSlice.name]: editorReducer as Reducer<EditorState, AnyAction>,
   [mainSlice.name]: mainReducer,
-  [stdcmConfSlice.name]: persistReducer(
-    buildOsrdConfPersistConfig<OsrdStdcmConfState>(stdcmConfSlice),
-    stdcmConfReducer
-  ) as unknown as Reducer<OsrdStdcmConfState, AnyAction>,
+  [stdcmConfSlice.name]: stdcmConfReducer,
   [operationalStudiesConfSlice.name]: persistReducer(
     buildOsrdConfPersistConfig<OperationalStudiesConfState>(operationalStudiesConfSlice),
     operationalStudiesConfReducer

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -62,6 +62,12 @@ export const stdcmConfSlice = createSlice({
       state.speedLimitByTag = stdcmConfInitialState.speedLimitByTag;
       state.linkedTrains = stdcmConfInitialState.linkedTrains;
     },
+    restoreStdcmConfig(
+      _state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState>
+    ) {
+      return action.payload;
+    },
     updateTotalMass(
       state: Draft<OsrdStdcmConfState>,
       action: PayloadAction<OsrdStdcmConfState['totalMass']>


### PR DESCRIPTION
@thibautsailly has confirmed that restoring the STDCM form values wasn't desirable when opening a new STDCM window.

Fixes crashes when reading an old local storage with data which doesn't conform to the new types.