### PR TITLE
core: stdcm: increase max length to test for engineering allowances

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -43,7 +43,7 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
         if (affectedEdges.isEmpty()) return false // No space to try the allowance
 
         val length = affectedEdges.map { it.length.distance }.sumDistances()
-        if (length > 20_000.meters) {
+        if (length > 50_000.meters) {
             // If the allowance area is large enough to reasonably stop and accelerate again, we
             // just accept the solution. This avoids computation on very large paths
             // (which can be quite time expensive)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope.part.EnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.constraints.EnvelopeConstraint
 import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
+import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeAcceleration
@@ -117,7 +118,7 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
                 ConstrainedEnvelopePartBuilder(
                     speedupPartBuilder,
                     SpeedConstraint(0.0, EnvelopePartConstraintType.FLOOR),
-                    EnvelopeConstraint(maxEffort, EnvelopePartConstraintType.CEILING)
+                    PositionConstraint(maxEffort.beginPos, maxEffort.endPos),
                 )
             EnvelopeAcceleration.accelerate(
                 context,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -194,6 +194,25 @@ private fun initFixedPoints(
     }
     if (hasStandardAllowance && res.none { it.offset == length })
         res.add(makeFixedPoint(res, edges, length, length, updatedTimeData, 0.0))
+
+    // Add points at the end of each engineering allowance
+    var prevEdgeLength = 0.meters
+    for (edge in edges) {
+        if (edge.afterEngineeringAllowance) {
+            if (res.none { it.offset.distance == prevEdgeLength }) {
+                res.add(
+                    makeFixedPoint(
+                        res,
+                        edges,
+                        Offset(prevEdgeLength),
+                        length,
+                        updatedTimeData,
+                    )
+                )
+            }
+        }
+        prevEdgeLength += edge.length.distance
+    }
     return res
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -34,6 +34,9 @@ data class STDCMEdge(
     // How long it takes to go from the beginning to the end of the block, taking the
     // standard allowance into account
     val totalTime: Double,
+    // Set to true if a conflict in the current edge required an engineering allowance.
+    // Used for initial placement of fixed time points in post-processing.
+    val afterEngineeringAllowance: Boolean,
 ) {
     val block = infraExplorer.getCurrentBlock()
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdgeBuilder.kt
@@ -158,7 +158,9 @@ internal constructor(
 
         var maximumDelay = 0.0
         var departureTimeShift = delayNeeded
-        if (delayNeeded > prevNode.timeData.maxDepartureDelayingWithoutConflict) {
+        val needEngineeringAllowance =
+            delayNeeded > prevNode.timeData.maxDepartureDelayingWithoutConflict
+        if (needEngineeringAllowance) {
             // We can't just shift the departure time, we need an engineering allowance
             // It's not computed yet, we just check that it's possible
             if (!graph.allowanceManager.checkEngineeringAllowance(prevNode, actualStartTime))
@@ -212,6 +214,7 @@ internal constructor(
                 envelope!!.endSpeed,
                 Length(fromMeters(envelope!!.endPos)),
                 envelope!!.totalTime / standardAllowanceSpeedRatio,
+                needEngineeringAllowance,
             )
         res = graph.backtrackingManager.backtrack(res!!, envelope!!)
         return if (res == null || graph.delayManager.isRunTimeTooLong(res)) null else res

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -252,7 +252,8 @@ class STDCMHeuristicTests {
                 0.0,
                 0.0,
                 Length(0.meters),
-                0.0
+                0.0,
+                false,
             )
         return heuristic.invoke(defaultEdge, nodeOffsetOnEdge?.let { Offset(it) }, nbPassedSteps)
     }


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/10385 (at least the few cases I've seen recently, I'll re-check if it still happens afterwards)

So apparently even 20km isn't always enough to add any amount of delay, because sometimes we barely have the traction to maintain the current speed. Ideally we should remove that check altogether, but it would still cause performance issues (repeatedly computing margins over potentially thousands of kilometers would certainly cause timeouts). We should look into https://github.com/OpenRailAssociation/osrd/issues/7136 for a proper solution. 

EDIT: this version is better but it's still not enough. I've found a case with a **300km long** allowance section that was still impossible. We may need to rework some stuff. 

---

So there's two extra fixes:

1. Small bugfix on how we compute the "slowest envelope": we'd stop early if the max speed envelope ended with a speedup (we'd "intersect" right away)
2. In post-processing, prefill the fixed time point list with the end of every engineering allowance. This avoids some unnecessary and constraining extra fixed points at the wrong places. 