### PR TITLE
front: fix selectableSlot in useLinkedTrainSearch

### DIFF
--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -29,7 +29,6 @@ const useLinkedTrainSearch = () => {
 
   const selectableSlot = useMemo(() => {
     const startDate = searchDatetimeWindow ? new Date(searchDatetimeWindow.begin) : new Date();
-    startDate.setUTCHours(0, 0, 0);
     return {
       start: startDate,
       end: searchDatetimeWindow?.end || startDate,


### PR DESCRIPTION
For this stdcm environment search window  :
```
{
    "id": 55,
    "infra_id": 2,
    "timetable_id": 1,
    "search_window_begin": "2024-09-16T22:00:00Z",
    "search_window_end": "2024-09-18T21:59:59Z"
}
```
we should only have the 17th and the 18th displayed in the `DatePicker`.

But we have the wrong dates for the linked train search:
![image](https://github.com/user-attachments/assets/679aa116-2986-4d0a-ad82-c8d092de9f0d)

