### PR TITLE
charts & timetable performances

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="utf-8" />
+    <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script>
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useDeferredValue } from 'react';
 
 import { ChevronRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -59,6 +59,7 @@ const ScenarioContent = ({
     removeTimetableItems,
     updateTrainDepartureTime,
   } = useScenarioData(scenario, infra);
+  const deferredTimetableItemsWithDetails = useDeferredValue(timetableItemsWithDetails);
   const macroEditorState = useRef<MacroEditorState>();
   const [ngeDto, setNgeDto] = useState<NetzgrafikDto>();
   const [ngeIsLoading, setNGEIsLoading] = useState(true);
@@ -113,6 +114,10 @@ const ScenarioContent = ({
 
   const handleNGELoad = () => setNGEIsLoading(false);
 
+  const handleCollapseTimetable = useCallback(() => {
+    setCollapsedTimetable(true);
+  }, []);
+
   return (
     <main className="mastcontainer mastcontainer-no-mastnav scenario">
       <div className="row no-gutters h-100">
@@ -128,7 +133,7 @@ const ScenarioContent = ({
               scenario={scenario}
               infra={infra}
               infraReloadCount={reloadCount}
-              collapseTimetable={() => setCollapsedTimetable(true)}
+              collapseTimetable={handleCollapseTimetable}
             />
 
             <MicroMacroSwitch isMacro={isMacro} setIsMacro={toggleMicroMacroButton} />
@@ -156,7 +161,7 @@ const ScenarioContent = ({
                   setItemIdToEdit={setItemIdToEdit}
                   itemIdToEdit={itemIdToEdit}
                   timetableItems={timetableItems}
-                  timetableItemsWithDetails={timetableItemsWithDetails}
+                  timetableItemsWithDetails={deferredTimetableItemsWithDetails}
                   dtoImport={dtoImport}
                 />
               </>

--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioDescription.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioDescription.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, memo } from 'react';
 
 import { Blocked, ChevronLeft, Pencil, X } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
@@ -175,4 +175,4 @@ const ScenarioDescription = ({
   );
 };
 
-export default ScenarioDescription;
+export default memo(ScenarioDescription);

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useDeferredValue, useCallback } from 'react';
 
 import { ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -23,7 +23,7 @@ import type { ProjectionData } from 'modules/simulationResult/types';
 import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
-import type { TimetableItemId, TrainScheduleId } from 'reducers/osrdconf/types';
+import type { TimetableItemId, TrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
@@ -96,6 +96,18 @@ const SimulationResults = ({
     }
   }, [projectionData]);
 
+  const mapTrainSimulation = useMemo(
+    () =>
+      timetableItemSimulation && selectedTimetableItem
+        ? {
+            ...timetableItemSimulation,
+            timetableItemId: selectedTimetableItem.id,
+            startTime: selectedTimetableItem.start_time,
+          }
+        : null,
+    [timetableItemSimulation, selectedTimetableItem]
+  );
+
   const {
     operationalPoints: projectedOperationalPoints,
     filteredOperationalPoints,
@@ -126,24 +138,40 @@ const SimulationResults = ({
   );
 
   // TODO Paced trains : update this in https://github.com/OpenRailAssociation/osrd/issues/10781
-  const handleTrainDrag = async (
-    draggedTrainId: TimetableItemId,
-    newDepartureTime: Date,
-    { stopPanning }: { stopPanning: boolean }
-  ) => {
-    if (stopPanning) {
-      // update in the database
-      dispatch(updateSelectedTrainId(draggedTrainId as TrainScheduleId));
-      updateTrainDepartureTime(draggedTrainId, newDepartureTime);
-    } else {
-      // update in the state
-      setProjectPathTrainResult(
-        projectPathTrainResult.map((train) =>
-          train.id === draggedTrainId ? { ...train, departureTime: newDepartureTime } : train
-        )
-      );
-    }
-  };
+
+  const handleTrainDrag = useCallback(
+    async (
+      draggedTrainId: TimetableItemId,
+      newDepartureTime: Date,
+      { stopPanning }: { stopPanning: boolean }
+    ) => {
+      if (stopPanning) {
+        // update in the database
+        dispatch(updateSelectedTrainId(draggedTrainId as TrainScheduleId));
+        updateTrainDepartureTime(draggedTrainId, newDepartureTime);
+      } else {
+        // update in the state
+        setProjectPathTrainResult(
+          projectPathTrainResult.map((train) =>
+            train.id === draggedTrainId ? { ...train, departureTime: newDepartureTime } : train
+          )
+        );
+      }
+    },
+    []
+  );
+
+  const onTrainClick = useCallback(
+    (trainId: TrainId | undefined) => dispatch(updateSelectedTrainId(trainId)),
+    []
+  );
+
+  const deferredWypointsPanelData = useDeferredValue({
+    filteredWaypoints: filteredOperationalPoints,
+    setFilteredWaypoints: setFilteredOperationalPoints,
+    projectionPath: projectionData.trainSchedule.path,
+    timetableId,
+  });
 
   if ((!selectedTimetableItem || !timetableItemSimulation) && !projectionData) {
     return null;
@@ -207,17 +235,12 @@ const SimulationResults = ({
                           ? selectedTimetableItem.id
                           : undefined
                       }
-                      waypointsPanelData={{
-                        filteredWaypoints: filteredOperationalPoints,
-                        setFilteredWaypoints: setFilteredOperationalPoints,
-                        projectionPath: projectionData.trainSchedule.path,
-                        timetableId,
-                      }}
+                      waypointsPanelData={deferredWypointsPanelData}
                       conflicts={conflictZones}
                       projectionLoaderData={projectionData.projectionLoaderData}
                       height={manchetteWithSpaceTimeChartHeight - MANCHETTE_HEIGHT_DIFF}
                       handleTrainDrag={handleTrainDrag}
-                      onTrainClick={(trainId) => dispatch(updateSelectedTrainId(trainId))}
+                      onTrainClick={onTrainClick}
                       selectedProjectionId={trainIdUsedForProjection}
                     />
                   )}
@@ -228,7 +251,7 @@ const SimulationResults = ({
         </div>
       </ResizableSection>
 
-      {selectedTimetableItem && timetableItemSimulation && (
+      {selectedTimetableItem && timetableItemSimulation && mapTrainSimulation && (
         <>
           {/* SIMULATION : SPEED SPACE CHART */}
           {selectedTimetableItemRollingStock && pathProperties && (
@@ -255,13 +278,10 @@ const SimulationResults = ({
           <div data-testid="simulation-map" className="simulation-map">
             <SimulationResultsMap
               geometry={pathProperties?.geometry}
-              timetableItemSimulation={{
-                ...timetableItemSimulation,
-                timetableItemId: selectedTimetableItem.id,
-                startTime: selectedTimetableItem.start_time,
-              }}
+              timetableItemSimulation={mapTrainSimulation}
               setMapCanvas={setMapCanvas}
               pathfindingResult={path}
+              loading={!projectionData?.projectionLoaderData?.allTrainsProjected}
             />
           </div>
 

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -253,6 +253,12 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     }
   }, [selectedProjectionId, projectPathTrainResult.length]);
 
+  // const deferredSpaceTimeChartProps = useConditionallyDeferredValue(
+  //   spaceTimeChartProps,
+  //   !allTrainsProjected
+  // );
+  // const deferredManchetteProps = useConditionallyDeferredValue(manchetteProps, !allTrainsProjected);
+
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const [settings, setSettings] = useState({
     showConflicts: false,
@@ -272,58 +278,63 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   });
 
   // TODO Paced trains : update this in https://github.com/OpenRailAssociation/osrd/issues/10781
-  const onPanOverloaded: SpaceTimeChartProps['onPan'] = async (payload) => {
-    const { isPanning } = payload;
+  const onPanOverloaded = useCallback<
+    Extract<SpaceTimeChartProps['onPan'], (...args: never) => unknown>
+  >(
+    async (payload) => {
+      const { isPanning } = payload;
 
-    if (!handleTrainDrag) {
-      // if no handleTrainDrag, we pan normally
-      spaceTimeChartProps.onPan(payload);
-      return;
-    }
-
-    // if dragging
-    if (draggingState) {
-      const { draggedTrain, initialDepartureTime } = draggingState;
-      dispatch(updateSelectedTrainId(draggedTrain.id));
-
-      const timeDiff = payload.data.time - payload.initialData.time;
-      const newDeparture = new Date(initialDepartureTime.getTime() + timeDiff);
-
-      await handleTrainDrag(draggedTrain.id as TrainScheduleId, newDeparture, {
-        stopPanning: !isPanning,
-      });
-
-      // stop dragging if necessary
-      if (!isPanning) {
-        setDraggingState(undefined);
+      if (!handleTrainDrag) {
+        // if no handleTrainDrag, we pan normally
+        spaceTimeChartProps.onPan(payload);
+        return;
       }
-      return;
-    }
 
-    // if not dragging, we check if we should start dragging
-    if (
-      !zoomMode &&
-      hoveredItem &&
-      (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
-    ) {
-      const hoveredTrainId = getIdFromTrainPath(hoveredItem.element.pathId);
-      const train = projectPathTrainResult.find(
-        (projectedTrain) => projectedTrain.id === hoveredTrainId
-      );
-      if (train) {
-        setTmpSelectedTrain(train.id);
-        setDraggingState({
-          draggedTrain: train,
-          initialDepartureTime: train.departureTime,
+      // if dragging
+      if (draggingState) {
+        const { draggedTrain, initialDepartureTime } = draggingState;
+        dispatch(updateSelectedTrainId(draggedTrain.id));
+
+        const timeDiff = payload.data.time - payload.initialData.time;
+        const newDeparture = new Date(initialDepartureTime.getTime() + timeDiff);
+
+        await handleTrainDrag(draggedTrain.id as TrainScheduleId, newDeparture, {
+          stopPanning: !isPanning,
         });
-      } else {
-        console.error(`No train found with id ${hoveredTrainId}`);
-      }
-    }
 
-    // if no hovered train, we pan normally
-    spaceTimeChartProps.onPan(payload);
-  };
+        // stop dragging if necessary
+        if (!isPanning) {
+          setDraggingState(undefined);
+        }
+        return;
+      }
+
+      // if not dragging, we check if we should start dragging
+      if (
+        !zoomMode &&
+        hoveredItem &&
+        (isSegmentPickingElement(hoveredItem.element) || isPointPickingElement(hoveredItem.element))
+      ) {
+        const hoveredTrainId = getIdFromTrainPath(hoveredItem.element.pathId);
+        const train = projectPathTrainResult.find(
+          (projectedTrain) => projectedTrain.id === hoveredTrainId
+        );
+        if (train) {
+          setTmpSelectedTrain(train.id);
+          setDraggingState({
+            draggedTrain: train,
+            initialDepartureTime: train.departureTime,
+          });
+        } else {
+          console.error(`No train found with id ${hoveredTrainId}`);
+        }
+      }
+
+      // if no hovered train, we pan normally
+      spaceTimeChartProps.onPan(payload);
+    },
+    [handleTrainDrag, spaceTimeChartProps, draggingState, hoveredItem, projectPathTrainResult]
+  );
 
   const waypointMenuData = useWaypointMenu(waypointsPanelData);
 
@@ -350,7 +361,9 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     [setHoveredItem]
   );
 
-  const handleClick: SpaceTimeChartProps['onClick'] = () => {
+  const handleClick = useCallback<
+    Extract<SpaceTimeChartProps['onClick'], (...args: never) => unknown>
+  >(() => {
     if (
       !draggingState &&
       selectedTrainScheduleId &&
@@ -365,7 +378,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
         onTrainClick?.(trainId);
       }
     }
-  };
+  }, []);
 
   return (
     <div

--- a/front/src/modules/simulationResult/components/SimulationResultsMap/SimulationResultsMap.tsx
+++ b/front/src/modules/simulationResult/components/SimulationResultsMap/SimulationResultsMap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import bbox from '@turf/bbox';
 import { lineString, point } from '@turf/helpers';
@@ -34,6 +34,7 @@ import type { TimetableItemId } from 'reducers/osrdconf/types';
 import { getIsPlaying } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { isoDateWithTimezoneToSec } from 'utils/date';
+import { usePrevious } from 'utils/hooks/state';
 import { kmToM, mmToM, msToKmh } from 'utils/physics';
 
 import getSelectedTrainHoverPositions from './getSelectedTrainHoverPositions';
@@ -51,6 +52,7 @@ type SimulationResultMapProps = {
     startTime: string;
   };
   setMapCanvas?: (mapCanvas: string) => void;
+  loading: boolean;
 };
 
 const SimulationResultMap = ({
@@ -58,8 +60,10 @@ const SimulationResultMap = ({
   geometry,
   timetableItemSimulation,
   setMapCanvas,
+  loading,
 }: SimulationResultMapProps) => {
   const dispatch = useAppDispatch();
+  const previousLoading = usePrevious(loading);
 
   const infraID = useInfraID();
   const { getTrackSectionsByIds } = useScenarioContext();
@@ -71,6 +75,13 @@ const SimulationResultMap = ({
   const [selectedTrainHoverPosition, setSelectedTrainHoverPosition] =
     useState<TimetableItemCurrentInfo>();
 
+  console.log(previousLoading, loading);
+  useEffect(() => {
+    if (previousLoading && !loading) {
+      console.log('capture');
+      captureMap(viewport, MAP_ID, setMapCanvas, geometry);
+    }
+  }, [loading]);
   const geojsonPath = useMemo(() => geometry && lineString(geometry.coordinates), [geometry]);
 
   const [mapMarkers, setMapMarkers] = useState<MapMarker[]>([]);
@@ -198,9 +209,9 @@ const SimulationResultMap = ({
         onClick={() => {
           removeSearchItemMarkersOnMap(dispatch);
         }}
-        onIdle={() => {
-          captureMap(viewport, MAP_ID, setMapCanvas, geometry);
-        }}
+        // onIdle={() => {
+        //   captureMap(viewport, MAP_ID, setMapCanvas, geometry);
+        // }}
         onMouseEnter={onPathHover}
         showOSM={showOSM}
         viewPort={viewport}
@@ -227,4 +238,4 @@ const SimulationResultMap = ({
   );
 };
 
-export default SimulationResultMap;
+export default memo(SimulationResultMap);

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/ManchetteMenuButton.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/ManchetteMenuButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, memo } from 'react';
 
 import { Eye, KebabHorizontal } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -73,4 +73,4 @@ const ManchetteMenuButton = ({ setWaypointsPanelIsOpen }: ManchetteMenuButtonPro
   );
 };
 
-export default ManchetteMenuButton;
+export default memo(ManchetteMenuButton);

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -146,6 +146,7 @@ const useLazyProjectTrains = ({
       timetableItemIdsToProject.size > 0 &&
       requestedProjectedTrainIds.current.size === timetableItemIdsToProject.size
     ) {
+      console.log('new ids');
       setTimetableItemIdsToProject(new Set());
       requestedProjectedTrainIds.current = new Set();
     }
@@ -153,6 +154,7 @@ const useLazyProjectTrains = ({
 
   useEffect(() => {
     if (!moreTrainsToCome && timetableItems && path) {
+      console.log('new projects trains ');
       // project all the trains again
       projectionSeqNum.current += 1;
       requestedProjectedTrainIds.current = new Set();

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { EyeClosed } from '@osrd-project/ui-icons';
 import { omit } from 'lodash';
@@ -42,41 +42,49 @@ const useWaypointMenu = (waypointsPanelData?: WaypointsPanelData) => {
     };
   }, [activeWaypointId]);
 
-  const menuItems: OSRDMenuItem[] = [
-    {
-      title: t('waypointMenu.hide'),
-      icon: <EyeClosed />,
-      disabled: filteredWaypoints ? filteredWaypoints.length <= 2 : false,
-      disabledMessage: t('waypointsPanel.warning'),
-      onClick: () => {
-        closeMenu();
-        setFilteredWaypoints?.((prevFilteredWaypoints) => {
-          const newFilteredWaypoints = prevFilteredWaypoints.filter(
-            (waypoint) => waypoint.id !== activeWaypointId
-          );
+  const menuItems: OSRDMenuItem[] = useMemo(
+    () => [
+      {
+        title: t('waypointMenu.hide'),
+        icon: <EyeClosed />,
+        disabled: filteredWaypoints ? filteredWaypoints.length <= 2 : false,
+        disabledMessage: t('waypointsPanel.warning'),
+        onClick: () => {
+          closeMenu();
+          setFilteredWaypoints?.((prevFilteredWaypoints) => {
+            const newFilteredWaypoints = prevFilteredWaypoints.filter(
+              (waypoint) => waypoint.id !== activeWaypointId
+            );
 
-          // We need to remove the id because it can change for waypoints added by map click
-          const simplifiedPath = projectionPath?.map((waypoint) =>
-            omit(waypoint, ['id', 'deleted'])
-          );
+            // We need to remove the id because it can change for waypoints added by map click
+            const simplifiedPath = projectionPath?.map((waypoint) =>
+              omit(waypoint, ['id', 'deleted'])
+            );
 
-          // TODO : when switching to the manchette back-end manager, remove all logic using
-          // cleanScenarioLocalStorage from projet/study/scenario components (single/multi select)
-          localStorage.setItem(
-            `${timetableId}-${JSON.stringify(simplifiedPath)}`,
-            JSON.stringify(newFilteredWaypoints)
-          );
-          return newFilteredWaypoints;
-        });
+            // TODO : when switching to the manchette back-end manager, remove all logic using
+            // cleanScenarioLocalStorage from projet/study/scenario components (single/multi select)
+            localStorage.setItem(
+              `${timetableId}-${JSON.stringify(simplifiedPath)}`,
+              JSON.stringify(newFilteredWaypoints)
+            );
+            return newFilteredWaypoints;
+          });
+        },
       },
-    },
-  ];
+    ],
+    []
+  );
 
-  const handleWaypointClick = (id: string) => {
+  const handleWaypointClick = useCallback((id: string) => {
     setActiveWaypointId(id);
-  };
+  }, []);
 
-  return { menuRef, menuItems, activeWaypointId, handleWaypointClick };
+  const waypointMenu = useMemo(
+    () => ({ menuRef, menuItems, activeWaypointId, handleWaypointClick }),
+    [menuRef, menuItems, activeWaypointId, handleWaypointClick]
+  );
+
+  return waypointMenu;
 };
 
 export default useWaypointMenu;

--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChartContainer.tsx
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChartContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   SpeedSpaceChart,
@@ -48,33 +48,40 @@ const SpeedSpaceChartContainer = ({
   const root = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number>(root.current?.clientWidth || 0);
 
-  const speedSpaceChartData = formatData(
-    timetableItemSimulation,
-    rollingStock.length,
-    selectedTimetableItemPowerRestrictions,
-    pathProperties
+  const speedSpaceChartData = useMemo(
+    () =>
+      formatData(
+        timetableItemSimulation,
+        rollingStock.length,
+        selectedTimetableItemPowerRestrictions,
+        pathProperties
+      ),
+    [timetableItemSimulation, rollingStock, selectedTimetableItemPowerRestrictions, pathProperties]
   );
 
-  const translations = {
-    detailsBoxDisplay: {
-      reticleInfos: t('speedSpaceSettings.reticleInfos'),
-      energySource: t('speedSpaceSettings.energySource'),
-      tractionStatus: t('speedSpaceSettings.tractionStatus'),
-      declivities: t('speedSpaceSettings.slopes'),
-      electricalProfiles: t('speedSpaceSettings.electricalProfiles'),
-      powerRestrictions: t('speedSpaceSettings.powerRestrictions'),
-    },
-    layersDisplay: {
-      context: t('speedSpaceSettings.context'),
-      steps: t('speedSpaceSettings.steps'),
-      declivities: t('speedSpaceSettings.slopes'),
-      speedLimits: t('speedSpaceSettings.speedLimits'),
-      temporarySpeedLimits: t('speedSpaceSettings.temporarySpeedLimits'),
-      electricalProfiles: t('speedSpaceSettings.electricalProfiles'),
-      powerRestrictions: t('speedSpaceSettings.powerRestrictions'),
-      speedLimitTags: t('speedSpaceSettings.speedLimitTags'),
-    },
-  };
+  const translations = useMemo(
+    () => ({
+      detailsBoxDisplay: {
+        reticleInfos: t('speedSpaceSettings.reticleInfos'),
+        energySource: t('speedSpaceSettings.energySource'),
+        tractionStatus: t('speedSpaceSettings.tractionStatus'),
+        declivities: t('speedSpaceSettings.slopes'),
+        electricalProfiles: t('speedSpaceSettings.electricalProfiles'),
+        powerRestrictions: t('speedSpaceSettings.powerRestrictions'),
+      },
+      layersDisplay: {
+        context: t('speedSpaceSettings.context'),
+        steps: t('speedSpaceSettings.steps'),
+        declivities: t('speedSpaceSettings.slopes'),
+        speedLimits: t('speedSpaceSettings.speedLimits'),
+        temporarySpeedLimits: t('speedSpaceSettings.temporarySpeedLimits'),
+        electricalProfiles: t('speedSpaceSettings.electricalProfiles'),
+        powerRestrictions: t('speedSpaceSettings.powerRestrictions'),
+        speedLimitTags: t('speedSpaceSettings.speedLimitTags'),
+      },
+    }),
+    [t]
+  );
 
   useEffect(() => {
     const updateCanvasSize = () => {
@@ -95,6 +102,14 @@ const SpeedSpaceChartContainer = ({
     };
   }, []);
 
+  const size = useMemo(
+    () => ({
+      width: '100%',
+      height: `${heightOfSpeedSpaceChartContainer + SPEEDSPACECHART_PADDING_BOTTOM}px`,
+    }),
+    []
+  );
+
   return (
     <Rnd
       default={{
@@ -103,10 +118,7 @@ const SpeedSpaceChartContainer = ({
         width: '100%',
         height: `${heightOfSpeedSpaceChartContainer}px`,
       }}
-      size={{
-        width: '100%',
-        height: `${heightOfSpeedSpaceChartContainer + SPEEDSPACECHART_PADDING_BOTTOM}px`,
-      }}
+      size={size}
       minHeight={SPEEDSPACECHART_MIN_HEIGHT}
       disableDragging
       enableResizing={{
@@ -150,4 +162,4 @@ const SpeedSpaceChartContainer = ({
   );
 };
 
-export default SpeedSpaceChartContainer;
+export default memo(SpeedSpaceChartContainer);

--- a/front/src/modules/timesStops/TimesStops.tsx
+++ b/front/src/modules/timesStops/TimesStops.tsx
@@ -7,6 +7,7 @@ import { Loader } from 'common/Loaders/Loader';
 
 import { useTimesStopsColumns } from './hooks/useTimesStopsColumns';
 import { type TableType, type TimesStopsRow } from './types';
+import { useCallback } from 'react';
 
 type TimesStopsProps<T extends TimesStopsRow> = {
   rows: T[];
@@ -31,6 +32,17 @@ const TimesStops = <T extends TimesStopsRow>({
 
   const columns = useTimesStopsColumns(tableType, rows);
 
+  const handleChange = useCallback<Extract<DataSheetGridProps['onChange'], Function>>((newRows: T[], [op]) => {
+    if (onChange) {
+      onChange(newRows, op);
+    }
+  }, [onChange]);
+
+  const rowClassName = useCallback<Extract<DataSheetGridProps['rowClassName'], Function>>(({ rowData, rowIndex }) =>
+  cx({
+    activeRow: Boolean(rowData.pathStepId),
+    oddRow: (rowIndex + 1) % 2,
+  }), [])
   if (dataIsLoading) {
     return (
       <div style={{ height: '600px' }}>
@@ -46,27 +58,18 @@ const TimesStops = <T extends TimesStopsRow>({
       </div>
     );
   }
-
+  
   return (
     <DynamicDataSheetGrid
       className="time-stops-datasheet"
       columns={columns}
       value={rows}
-      onChange={(newRows: T[], [op]) => {
-        if (onChange) {
-          onChange(newRows, op);
-        }
-      }}
+      onChange={handleChange}
       stickyRightColumn={stickyRightColumn}
       lockRows
       height={600}
       headerRowHeight={headerRowHeight}
-      rowClassName={({ rowData, rowIndex }) =>
-        cx({
-          activeRow: Boolean(rowData.pathStepId),
-          oddRow: (rowIndex + 1) % 2,
-        })
-      }
+      rowClassName={rowClassName}
       cellClassName={cellClassName}
     />
   );

--- a/front/src/modules/timesStops/TimesStopsOutput.tsx
+++ b/front/src/modules/timesStops/TimesStopsOutput.tsx
@@ -12,6 +12,8 @@ import { NO_BREAK_SPACE } from 'utils/strings';
 import useOutputTableData from './hooks/useOutputTableData';
 import TimesStops from './TimesStops';
 import { TableType, type TimesStopsRow } from './types';
+import { memo, useCallback } from 'react';
+import type { DataSheetGridProps } from 'react-datasheet-grid';
 
 type TimesStopsOutputProps = {
   simulatedTimetableItem?: SimulationResponseSuccess;
@@ -37,22 +39,25 @@ const TimesStopsOutput = ({
     selectedTimetableItem,
     path
   );
+  const cellClassName = useCallback<
+      Extract<DataSheetGridProps['cellClassName'], Function>
+    >(({ rowData: rowData_, columnId }) => {
+    const rowData = rowData_ as TimesStopsRow;
+    const arrivalScheduleNotRespected = rowData.arrival?.time
+      ? rowData.calculatedArrival !== rowData.arrival.time
+      : false;
+    const negativeDiffMargins = Number(rowData.diffMargins?.split(NO_BREAK_SPACE)[0]) < 0;
+    return cx({
+      'warning-schedule': arrivalScheduleNotRespected,
+      'warning-margin': negativeDiffMargins,
+      'secondary-code-column': columnId === 'ch',
+    });
+  }, [])
   return (
     <TimesStops
       rows={enrichedOperationalPoints}
       tableType={TableType.Output}
-      cellClassName={({ rowData: rowData_, columnId }) => {
-        const rowData = rowData_ as TimesStopsRow;
-        const arrivalScheduleNotRespected = rowData.arrival?.time
-          ? rowData.calculatedArrival !== rowData.arrival.time
-          : false;
-        const negativeDiffMargins = Number(rowData.diffMargins?.split(NO_BREAK_SPACE)[0]) < 0;
-        return cx({
-          'warning-schedule': arrivalScheduleNotRespected,
-          'warning-margin': negativeDiffMargins,
-          'secondary-code-column': columnId === 'ch',
-        });
-      }}
+      cellClassName={cellClassName}
       headerRowHeight={40}
       dataIsLoading={
         dataIsLoading || !timetableItemWithDetails || !operationalPoints || !selectedTimetableItem
@@ -61,4 +66,4 @@ const TimesStopsOutput = ({
   );
 };
 
-export default TimesStopsOutput;
+export default memo(TimesStopsOutput);

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -66,9 +66,9 @@ const Timetable = ({
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
   const dispatch = useAppDispatch();
 
-  const toggleShowTrainDetails = () => {
+  const toggleShowTrainDetails = useCallback(() => {
     setShowTrainDetails(!showTrainDetails);
-  };
+  }, [setShowTrainDetails, showTrainDetails]);
 
   const removeAndUnselectTrains = useCallback((timetableItemIds: TimetableItemId[]) => {
     removeTimetableItems(timetableItemIds);

--- a/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo, memo, useState } from 'react';
 
 import { Button, Checkbox } from '@osrd-project/ui-core';
 import { Alert, Filter } from '@osrd-project/ui-icons';
@@ -388,4 +388,4 @@ const TimetableToolbar = ({
   );
 };
 
-export default TimetableToolbar;
+export default memo(TimetableToolbar);

--- a/front/src/utils/hooks/useConditionallyDeferredValue.ts
+++ b/front/src/utils/hooks/useConditionallyDeferredValue.ts
@@ -1,0 +1,14 @@
+import { useDeferredValue } from 'react';
+
+/**
+ * expends on the behavior of react hook useDeferredValue
+ * returns a deferred value if the condition is met
+ * returns the normal value otherwise
+ */
+export default function useConditionallyDeferredValue<T>(value: T, condition: boolean) {
+  const deferredValue = useDeferredValue(value);
+  if (condition) {
+    return deferredValue;
+  }
+  return value;
+}


### PR DESCRIPTION
- extensive use of `useMemo`, `useCallback` to stabilize props that were constantly changing, trigger constant re-renders
- `useMemo` and `useCallback` are often not enough, and a child might re-render just because the parent did re-render. using `React.memo` on a component prevents these extra re-renders on children.
- using `useDeferredValue` when a value is updated really often, to allow react to render with an old value to avoid a lot of unnecessary recomputation. for example `spaceTimeChartProps` are deferred. the old value is sent to `SpaceTimeChart` which no longer does heavy recomputation on every single value change
- <s>introducing useConditionallyDeferredValue to use normal value when loading is done.</s>. I was previously planning to use a custom hook `useConditionallyDeferredValue` to keep is deferred value until loading is done, but `useTransition` is actually a better solution.  In case of ui updates such as panning/zoom on the space-time chart (which should be immediate), user input are immediately applied, whereas updates made when loading a thousand trains can be deferred.