### PR TITLE
core: add ETCS SVL logic to ETCS braking simulator

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/EnvelopeSimPath.java
@@ -111,6 +111,10 @@ public final class EnvelopeSimPath implements PhysicsPath {
         // TODO: Optimise method by adding in a cache.
         int indexBegin = getIndexBeforePos(begin);
         int indexEnd = getIndexBeforePos(end);
+        // TODO: Remove if we extend path properties until last SvL > path.length.
+        if (indexBegin == indexEnd && indexBegin == gradePositions.length - 1)
+            // Take last grade value in this case
+            return gradeValues[gradeValues.length - 1];
         var lowestGradient = gradeValues[indexBegin];
         for (int i = indexBegin; i < indexEnd; i++) {
             var grad = gradeValues[i];

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/PhysicsRollingStock.java
@@ -1,8 +1,8 @@
 package fr.sncf.osrd.envelope_sim;
 
 import static fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.GRAVITY_ACCELERATION;
-import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.mRotatingMax;
-import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.mRotatingMin;
+import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.M_ROTATING_MAX;
+import static fr.sncf.osrd.envelope_sim.etcs.ConstantsKt.M_ROTATING_MIN;
 
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
 
@@ -64,7 +64,7 @@ public interface PhysicsRollingStock {
      * mRotating (Max or Min) is in %, as seen in ERA braking curves simulation tool v5.1.
      */
     static double getGradientAcceleration(double grade) {
-        var mRotating = grade >= 0 ? mRotatingMax : mRotatingMin;
+        var mRotating = grade >= 0 ? M_ROTATING_MAX : M_ROTATING_MIN;
         return -GRAVITY_ACCELERATION * grade / (1000.0 + 10.0 * mRotating);
     }
 

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/Constants.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/Constants.kt
@@ -11,43 +11,49 @@ package fr.sncf.osrd.envelope_sim.etcs
  * National Default Value: permission to inhibit the compensation of the speed measurement accuracy.
  * See Subset 026: table in Appendix A.3.2.
  */
-const val qNvinhsmicperm = false
+const val Q_NVINHSMICPERM = false
+
+/**
+ * National Default Value: permission to follow release speed at 40km/h near the EoA. See Subset
+ * 026: table in Appendix A.3.2.
+ */
+const val NATIONAL_RELEASE_SPEED = 40.0 / 3.6 // m/s
 
 /**
  * Estimated acceleration during tBerem, worst case scenario (aEst2 is between 0 and 0.4), expressed
  * in m/s². See Subset 026: §3.13.9.3.2.9.
  */
-const val aEst2 = 0.4
+const val A_EST_2 = 0.4
 
 /** See Subset 026: table in Appendix A.3.1. */
-const val dvEbiMin = 7.5 / 3.6 // m/s
-const val dvEbiMax = 15.0 / 3.6 // m/s
-const val vEbiMin = 110.0 / 3.6 // m/s
-const val vEbiMax = 210.0 / 3.6 // m/s
-const val tWarning = 2.0 // s
-const val tDriver = 4.0 // s
-const val mRotatingMax = 15.0 // %
-const val mRotatingMin = 2.0 // %
+const val DV_EBI_MIN = 7.5 / 3.6 // m/s
+const val DV_EBI_MAX = 15.0 / 3.6 // m/s
+const val V_EBI_MIN = 110.0 / 3.6 // m/s
+const val V_EBI_MAX = 210.0 / 3.6 // m/s
+const val T_WARNING = 2.0 // s
+const val T_DRIVER = 4.0 // s
+const val M_ROTATING_MIN = 2.0 // %
+const val M_ROTATING_MAX = 15.0 // %
 
 /** See Subset 041: §5.3.1.2. */
-const val vUraMinLimit = 30 / 3.6 // m/s
-const val vUraMaxLimit = 500 / 3.6 // m/s
-const val vUraMin = 2 / 3.6 // m/s
-const val vUraMax = 12 / 3.6 // m/s
+const val V_URA_MIN_LIMIT = 30 / 3.6 // m/s
+const val V_URA_MAX_LIMIT = 500 / 3.6 // m/s
+const val V_URA_MIN = 2 / 3.6 // m/s
+const val V_URA_MAX = 12 / 3.6 // m/s
 
 /** See Subset 041: §5.3.1.2. */
 fun vUra(speed: Double): Double {
-    return interpolateLinearSpeed(speed, vUraMinLimit, vUraMaxLimit, vUraMin, vUraMax)
+    return interpolateLinearSpeed(speed, V_URA_MIN_LIMIT, V_URA_MAX_LIMIT, V_URA_MIN, V_URA_MAX)
 }
 
 /** See Subset 026: §3.13.9.3.2.10. */
 fun vDelta0(speed: Double): Double {
-    return if (!qNvinhsmicperm) vUra(speed) else 0.0
+    return if (!Q_NVINHSMICPERM) vUra(speed) else 0.0
 }
 
 /** See Subset 026: §3.13.9.2.3. */
 fun dvEbi(speed: Double): Double {
-    return interpolateLinearSpeed(speed, vEbiMin, vEbiMax, dvEbiMin, dvEbiMax)
+    return interpolateLinearSpeed(speed, V_EBI_MIN, V_EBI_MAX, DV_EBI_MIN, DV_EBI_MAX)
 }
 
 /**

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -47,56 +47,40 @@ fun addBrakingCurvesAtEOAs(
 ): Envelope {
     val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
     var beginPos = envelope.beginPos
+    val maxSpeedEnvelope = envelope.maxSpeed
     val builder = OverlayEnvelopeBuilder.forward(envelope)
     for (endOfAuthority in sortedEndsOfAuthority) {
         val targetPosition = endOfAuthority.offsetEOA.distance.meters
         assert(targetPosition > 0.0)
         val targetSpeed = 0.0
-        val maxSpeedEnvelope = envelope.maxSpeed
-        val overhead =
-            Envelope.make(
-                EnvelopePart.generateTimes(
-                    listOf(EnvelopeProfile.CONSTANT_SPEED),
-                    doubleArrayOf(0.0, targetPosition),
-                    doubleArrayOf(maxSpeedEnvelope, maxSpeedEnvelope)
-                )
-            )
-        val sbdCurve =
-            computeBrakingCurve(
-                context,
-                overhead,
-                targetPosition,
-                targetSpeed,
-                BrakingType.ETCS_SBD
-            )
-        assert(sbdCurve.beginPos >= 0 && sbdCurve.endPos == targetPosition)
-        assert(sbdCurve.endSpeed == targetSpeed)
-        val guiCurve =
-            computeBrakingCurve(
-                context,
-                overhead,
-                targetPosition,
-                targetSpeed,
-                BrakingType.ETCS_GUI
-            )
-        assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
-        assert((guiCurve.beginSpeed == maxSpeedEnvelope || guiCurve.beginPos == 0.0))
-        assert(guiCurve.endSpeed == targetSpeed)
+        val fullIndicationCurveEoa =
+            computeSbdFullIndicationCurve(context, targetPosition, maxSpeedEnvelope)
+        var fullIndicationCurveStop = Envelope.make(fullIndicationCurveEoa)
 
-        val fullIndicationCurve =
-            computeIndicationBrakingCurveFromRef(context, sbdCurve, BrakingCurveType.SBD, guiCurve)
-        assert(fullIndicationCurve.endPos == targetPosition)
-        assert(fullIndicationCurve.endSpeed == targetSpeed)
+        if (endOfAuthority.offsetSVL != null) {
+            val targetPositionSvl = endOfAuthority.offsetSVL.distance.meters
+            val fullIndicationCurveSvl =
+                computeEbdFullIndicationCurve(
+                    context,
+                    targetPositionSvl,
+                    targetSpeed,
+                    maxSpeedEnvelope
+                )
+            fullIndicationCurveStop =
+                computeMinSvlEoaIndCurve(
+                    fullIndicationCurveEoa,
+                    fullIndicationCurveSvl,
+                    targetPosition
+                )
+        }
 
         val indicationCurve =
-            keepBrakingCurveUnderOverlay(Envelope.make(fullIndicationCurve), envelope, beginPos)
-                ?: continue
+            keepBrakingCurveUnderOverlay(fullIndicationCurveStop, envelope, beginPos) ?: continue
         assert(indicationCurve.beginPos >= beginPos && indicationCurve.endPos == targetPosition)
         assert(
             indicationCurve.beginSpeed <= maxSpeedEnvelope &&
                 indicationCurve.endSpeed == targetSpeed
         )
-
         builder.addPart(indicationCurve)
 
         // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so, we
@@ -104,6 +88,95 @@ fun addBrakingCurvesAtEOAs(
         beginPos = targetPosition
     }
     return builder.build()
+}
+
+private fun computeMinSvlEoaIndCurve(
+    fullIndicationCurveEoa: EnvelopePart,
+    fullIndicationCurveSvl: EnvelopePart,
+    targetPosition: Double
+): Envelope {
+    // SvL indication curve should have positions before target position, and speeds above the
+    // release speed. Otherwise, follow EoA indication curve.
+    if (
+        fullIndicationCurveSvl.beginPos >= targetPosition ||
+            fullIndicationCurveSvl.maxSpeed <= NATIONAL_RELEASE_SPEED
+    ) {
+        return Envelope.make(fullIndicationCurveEoa)
+    }
+    val releaseSpeedPositionEoa = fullIndicationCurveEoa.interpolatePosition(NATIONAL_RELEASE_SPEED)
+    val releaseSpeedPositionSvl = fullIndicationCurveSvl.interpolatePosition(NATIONAL_RELEASE_SPEED)
+    val lastIndicationPart =
+        fullIndicationCurveEoa.sliceWithSpeeds(
+            releaseSpeedPositionEoa,
+            NATIONAL_RELEASE_SPEED,
+            fullIndicationCurveEoa.endPos,
+            fullIndicationCurveEoa.endSpeed
+        )
+    val slicedIndicationCurveEoa =
+        fullIndicationCurveEoa.sliceWithSpeeds(
+            fullIndicationCurveEoa.beginPos,
+            fullIndicationCurveEoa.beginSpeed,
+            releaseSpeedPositionEoa,
+            NATIONAL_RELEASE_SPEED
+        )
+    val slicedIndicationCurveSvl =
+        fullIndicationCurveSvl.sliceWithSpeeds(
+            fullIndicationCurveSvl.beginPos,
+            fullIndicationCurveSvl.beginSpeed,
+            releaseSpeedPositionSvl,
+            NATIONAL_RELEASE_SPEED
+        )
+    val startIntersectingRange =
+        max(slicedIndicationCurveEoa.beginPos, slicedIndicationCurveSvl.beginPos)
+    var refCurve = slicedIndicationCurveEoa
+    var otherCurve = slicedIndicationCurveSvl
+    if (
+        slicedIndicationCurveEoa.interpolateSpeed(startIntersectingRange) >
+            slicedIndicationCurveSvl.interpolateSpeed(startIntersectingRange)
+    ) {
+        refCurve = slicedIndicationCurveSvl
+        otherCurve = slicedIndicationCurveEoa
+    }
+    val pointCount = refCurve.pointCount()
+    var indicationPositions = DoubleArray(pointCount)
+    var indicationSpeeds = DoubleArray(pointCount)
+    for (i in 0 until pointCount) {
+        val newPos = refCurve.getPointPos(i)
+        val newSpeed = refCurve.getPointSpeed(i)
+        if (newPos < otherCurve.beginPos) {
+            indicationPositions[i] = newPos
+            indicationSpeeds[i] = newSpeed
+        } else if (newPos <= otherCurve.endPos) {
+            val otherSpeed = slicedIndicationCurveSvl.interpolateSpeed(newPos)
+            indicationPositions[i] = newPos
+            // TODO: unneeded for now: interpolate to not approximate position at intersection.
+            indicationSpeeds[i] = min(otherSpeed, newSpeed)
+        } else {
+            indicationPositions[i] = otherCurve.endPos
+            indicationSpeeds[i] = otherCurve.endSpeed
+            // Clean up the last unneeded points in the arrays before exiting the loop.
+            indicationPositions = indicationPositions.dropLast(pointCount - 1 - i).toDoubleArray()
+            indicationSpeeds = indicationSpeeds.dropLast(pointCount - 1 - i).toDoubleArray()
+            break
+        }
+    }
+    val firstIndicationPart =
+        EnvelopePart.generateTimes(
+            listOf(EnvelopeProfile.BRAKING),
+            indicationPositions,
+            indicationSpeeds
+        )
+    if (releaseSpeedPositionSvl < releaseSpeedPositionEoa) {
+        val maintainReleaseSpeedPart =
+            EnvelopePart.generateTimes(
+                listOf(EnvelopeProfile.CONSTANT_SPEED),
+                doubleArrayOf(releaseSpeedPositionSvl, releaseSpeedPositionEoa),
+                doubleArrayOf(NATIONAL_RELEASE_SPEED, NATIONAL_RELEASE_SPEED)
+            )
+        return Envelope.make(firstIndicationPart, maintainReleaseSpeedPart, lastIndicationPart)
+    } else {
+        return Envelope.make(firstIndicationPart, lastIndicationPart)
+    }
 }
 
 /** Compute braking curves at every limit of authority. */
@@ -114,58 +187,19 @@ fun addBrakingCurvesAtLOAs(
 ): Envelope {
     val sortedLimitsOfAuthority = limitsOfAuthority.sortedBy { it.offset }
     val beginPos = envelope.beginPos
+    val maxSpeedEnvelope = envelope.maxSpeed
     var envelopeWithLoaBrakingCurves = envelope
     var builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
-
-    val maxSpeedEnvelope = envelopeWithLoaBrakingCurves.maxSpeed
-    // Add maxBecDeltaSpeed to EBD curve overhead so it reaches a sufficiently high speed to
-    // guarantee that, after the speed translation, the corresponding EBI curve does intersect
-    // with envelope max speed.
-    val maxBecDeltaSpeed = maxBecDeltaSpeed()
-    val maxSpeedEbd = maxSpeedEnvelope + maxBecDeltaSpeed
-    val overhead =
-        Envelope.make(
-            EnvelopePart.generateTimes(
-                listOf(EnvelopeProfile.CONSTANT_SPEED),
-                doubleArrayOf(0.0, context.path.length),
-                doubleArrayOf(maxSpeedEbd, maxSpeedEbd)
-            )
-        )
 
     for (limitOfAuthority in sortedLimitsOfAuthority) {
         val targetPosition = limitOfAuthority.offset.distance.meters
         assert(targetPosition > 0.0)
         val targetSpeed = limitOfAuthority.speed
         assert(targetSpeed > 0.0)
-
-        val ebdCurve =
-            computeBrakingCurve(
-                context,
-                overhead,
-                targetPosition,
-                targetSpeed,
-                BrakingType.ETCS_EBD
-            )
-        assert(ebdCurve.beginPos >= 0.0 && ebdCurve.endPos >= targetPosition)
-        val guiCurve =
-            computeBrakingCurve(
-                context,
-                overhead,
-                targetPosition,
-                targetSpeed,
-                BrakingType.ETCS_GUI
-            )
-        assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
-        assert((guiCurve.beginSpeed == maxSpeedEbd || guiCurve.beginPos == 0.0))
-
-        val ebiCurve = computeEbiBrakingCurveFromEbd(context, ebdCurve, targetSpeed)
-        assert(ebiCurve.endSpeed == targetSpeed)
-
         val fullIndicationCurve =
-            computeIndicationBrakingCurveFromRef(context, ebiCurve, BrakingCurveType.EBI, guiCurve)
+            computeEbdFullIndicationCurve(context, targetPosition, targetSpeed, maxSpeedEnvelope)
         val endOfIndicationCurve = fullIndicationCurve.endPos
         assert(endOfIndicationCurve <= targetPosition)
-        assert(fullIndicationCurve.endSpeed == targetSpeed)
 
         val fullIndCurveWithMaintain: Envelope
         if (endOfIndicationCurve < targetPosition) {
@@ -203,6 +237,80 @@ fun addBrakingCurvesAtLOAs(
     return envelopeWithLoaBrakingCurves
 }
 
+/** Compute SBD-based full indication curve. */
+private fun computeSbdFullIndicationCurve(
+    context: EnvelopeSimContext,
+    targetPosition: Double,
+    maxSpeedEnvelope: Double
+): EnvelopePart {
+    val targetSpeed = 0.0
+    val overhead =
+        Envelope.make(
+            EnvelopePart.generateTimes(
+                listOf(EnvelopeProfile.CONSTANT_SPEED),
+                doubleArrayOf(0.0, targetPosition),
+                doubleArrayOf(maxSpeedEnvelope, maxSpeedEnvelope)
+            )
+        )
+    val sbdCurve =
+        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_SBD)
+    assert(sbdCurve.beginPos >= 0 && sbdCurve.endPos == targetPosition)
+    assert(sbdCurve.endSpeed == targetSpeed)
+
+    val guiCurve =
+        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_GUI)
+    assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
+    assert((guiCurve.beginSpeed == maxSpeedEnvelope || guiCurve.beginPos == 0.0))
+    assert(guiCurve.endSpeed == targetSpeed)
+
+    val fullIndicationCurve =
+        computeIndicationBrakingCurveFromRef(context, sbdCurve, BrakingCurveType.SBD, guiCurve)
+    assert(fullIndicationCurve.endPos == targetPosition)
+    assert(fullIndicationCurve.endSpeed == targetSpeed)
+    return fullIndicationCurve
+}
+
+/** Compute EBD-based full indication curve. */
+private fun computeEbdFullIndicationCurve(
+    context: EnvelopeSimContext,
+    targetPosition: Double,
+    targetSpeed: Double,
+    maxSpeedEnvelope: Double
+): EnvelopePart {
+    // Add maxBecDeltaSpeed to EBD curve overhead so it reaches a sufficiently high speed to
+    // guarantee that, after the speed translation, the corresponding EBI curve does intersect
+    // with envelope max speed.
+    val maxBecDeltaSpeed = maxBecDeltaSpeed()
+    val maxSpeedEbd = maxSpeedEnvelope + maxBecDeltaSpeed
+    val overhead =
+        Envelope.make(
+            EnvelopePart.generateTimes(
+                listOf(EnvelopeProfile.CONSTANT_SPEED),
+                doubleArrayOf(0.0, max(context.path.length, targetPosition)),
+                doubleArrayOf(maxSpeedEbd, maxSpeedEbd)
+            )
+        )
+
+    val ebdCurve =
+        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_EBD)
+    assert(ebdCurve.beginPos >= 0.0 && ebdCurve.endPos >= targetPosition)
+    // TODO: uncomment once ebd is not shifted anymore for an LoA
+    // assert((ebdCurve.beginSpeed == maxSpeedEbd || ebdCurve.beginPos == 0.0))
+
+    val guiCurve =
+        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_GUI)
+    assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
+    assert((guiCurve.beginSpeed == maxSpeedEbd || guiCurve.beginPos == 0.0))
+
+    val ebiCurve = computeEbiBrakingCurveFromEbd(context, ebdCurve, targetSpeed)
+    assert(ebiCurve.endSpeed == targetSpeed)
+
+    val fullIndicationCurve =
+        computeIndicationBrakingCurveFromRef(context, ebiCurve, BrakingCurveType.EBI, guiCurve)
+    assert(fullIndicationCurve.endSpeed == targetSpeed)
+    return fullIndicationCurve
+}
+
 /** Compute braking curve: used to compute EBD, SBD or GUI. */
 private fun computeBrakingCurve(
     context: EnvelopeSimContext,
@@ -217,10 +325,10 @@ private fun computeBrakingCurve(
             brakingType == BrakingType.ETCS_GUI
     )
     // If the stopPosition is after the end of the path, the input is invalid except if it is an
-    // SVL, i.e. the target speed is 0 and the curve to compute is an EBD.
+    // SVL, i.e. the target speed is 0 and the curve to compute is not an SBD.
     if (
         (targetPosition > context.path.length &&
-            !(targetSpeed == 0.0 && brakingType == BrakingType.ETCS_EBD))
+            (targetSpeed != 0.0 || brakingType == BrakingType.ETCS_SBD))
     )
         throw RuntimeException(
             String.format(
@@ -282,15 +390,22 @@ private fun computeEbiBrakingCurveFromEbd(
     targetSpeed: Double
 ): EnvelopePart {
     val pointCount = ebdCurve.pointCount()
-    val newPositions = DoubleArray(pointCount)
-    val newSpeeds = DoubleArray(pointCount)
-    for (i in 0 until ebdCurve.pointCount()) {
+    var newPositions = DoubleArray(pointCount)
+    var newSpeeds = DoubleArray(pointCount)
+    for (i in 0 until pointCount) {
         val speed = ebdCurve.getPointSpeed(i)
         val becParams = computeBecParams(context, ebdCurve, speed, targetSpeed)
         val newPos = ebdCurve.getPointPos(i) - becParams.dBec
         val newSpeed = speed - becParams.deltaBecSpeed
         newPositions[i] = newPos
-        newSpeeds[i] = newSpeed
+        // TODO: unneeded for now: interpolate to not approximate position at 0 m/s.
+        newSpeeds[i] = max(newSpeed, 0.0)
+        if (newSpeed <= 0.0 && i < pointCount - 1) {
+            // Clean up the last unneeded points in the arrays before exiting the loop.
+            newPositions = newPositions.dropLast(pointCount - 1 - i).toDoubleArray()
+            newSpeeds = newSpeeds.dropLast(pointCount - 1 - i).toDoubleArray()
+            break
+        }
     }
 
     val fullBrakingCurve =
@@ -353,10 +468,23 @@ private fun keepBrakingCurveUnderOverlay(
     overlay: Envelope,
     beginPos: Double
 ): EnvelopePart? {
-    if (fullBrakingCurve.endPos <= beginPos) {
+    if (fullBrakingCurve.beginPos >= overlay.endPos || fullBrakingCurve.endPos <= beginPos) {
         etcsBrakingCurvesLogger.warn(
-            "The position-range of the ETCS braking curve ending at ($beginPos, ${fullBrakingCurve.endSpeed}) does not intersect with the overlay envelope's position-range."
+            "The position-range of the ETCS braking curve starting at (${fullBrakingCurve.beginPos}, ${fullBrakingCurve.beginSpeed}) and ending at (${fullBrakingCurve.endPos}, ${fullBrakingCurve.endSpeed}) does not intersect with the overlay envelope's position-range."
         )
+        return null
+    }
+    if (
+        fullBrakingCurve.minSpeed >
+            Envelope.make(
+                    *overlay.slice(
+                        max(fullBrakingCurve.beginPos, beginPos),
+                        min(fullBrakingCurve.endPos, overlay.endPos)
+                    )
+                )
+                .maxSpeed
+    ) {
+        // The full braking curve is above the overlay envelope: nothing to do here.
         return null
     }
 
@@ -376,21 +504,44 @@ private fun keepBrakingCurveUnderOverlay(
                 mergedArray + currentArray.drop(1).toDoubleArray()
             }
     val timeDeltas = fullBrakingCurve.flatMap { it.cloneTimes().asList() }
-    val nbPoints = positions.size
 
     val partBuilder = EnvelopePartBuilder()
     partBuilder.setAttr(EnvelopeProfile.BRAKING)
     val overlayBuilder =
         ConstrainedEnvelopePartBuilder(
             partBuilder,
-            PositionConstraint(beginPos, overlay.endPos),
+            PositionConstraint(max(beginPos, fullBrakingCurve.beginPos), overlay.endPos),
             EnvelopeConstraint(overlay, EnvelopePartConstraintType.CEILING)
         )
-    overlayBuilder.initEnvelopePart(positions[nbPoints - 1], speeds[nbPoints - 1], -1.0)
-    for (i in nbPoints - 2 downTo 0) {
+    val lastIndex = getIndexOfLastPointBeneathOverlay(positions, speeds, overlay)
+    // To create a braking curve with overlay builder, we need at least 2 positions.
+    if (lastIndex <= 0) return null
+    overlayBuilder.initEnvelopePart(positions[lastIndex], speeds[lastIndex], -1.0)
+    for (i in lastIndex - 1 downTo 0) {
         if (!overlayBuilder.addStep(positions[i], speeds[i], timeDeltas[i])) break
     }
     return partBuilder.build()
+}
+
+/**
+ * Find the index of the last point which is located beneath the overlay envelope, -1 if none exist.
+ */
+private fun getIndexOfLastPointBeneathOverlay(
+    positions: DoubleArray,
+    speeds: DoubleArray,
+    overlay: Envelope
+): Int {
+    var lastIndex = positions.size - 1
+    while (
+        lastIndex >= 0 &&
+            speeds[lastIndex] >
+                overlay
+                    .get(overlay.findRightDir(positions[lastIndex], -1.0))
+                    .interpolateSpeed(positions[lastIndex])
+    ) {
+        lastIndex--
+    }
+    return lastIndex
 }
 
 private data class BecParams(val dBec: Double, val vBec: Double, val speed: Double) {
@@ -418,7 +569,7 @@ private fun computeBecParams(
     val tTraction =
         max(
             rollingStock.rjsEtcsBrakeParams.tTractionCutOff -
-                (tWarning + rollingStock.rjsEtcsBrakeParams.tBs2),
+                (T_WARNING + rollingStock.rjsEtcsBrakeParams.tBs2),
             0.0
         )
     // Estimated acceleration during tTraction, worst case scenario (the train accelerates as much
@@ -429,7 +580,12 @@ private fun computeBecParams(
             rollingStock.getRollingResistance(speed),
             weightForce,
             speed,
-            PhysicsRollingStock.getMaxEffort(speed, context.tractiveEffortCurveMap.get(position)),
+            PhysicsRollingStock.getMaxEffort(
+                speed,
+                // TODO: have a tractive effort curve map which extends until the last SvL instead
+                // of the end of the path.
+                context.tractiveEffortCurveMap.get(min(position, context.path.length))
+            ),
             1.0
         )
     // Speed correction due to the traction staying active during tTraction. See Subset:
@@ -440,7 +596,7 @@ private fun computeBecParams(
     // §3.13.9.3.2.6.
     val tBerem = max(rollingStock.rjsEtcsBrakeParams.tBe - tTraction, 0.0)
     // Speed correction due to the braking system not being active yet. See Subset: §3.13.9.3.2.10.
-    val vDelta2 = aEst2 * tBerem
+    val vDelta2 = A_EST_2 * tBerem
 
     // Compute dBec and vBec. See Subset: §3.13.9.3.2.10.
     val maxV = max(speed + vDelta0 + vDelta1, targetSpeed)
@@ -463,7 +619,7 @@ private fun getSbiPosition(ebiOrSbdPosition: Double, speed: Double, tbs: Double)
 
 /** See Subset 026: §3.13.9.3.5.1. */
 private fun getPermittedSpeedPosition(sbiPosition: Double, speed: Double): Double {
-    return getPreviousPosition(sbiPosition, speed, tDriver)
+    return getPreviousPosition(sbiPosition, speed, T_DRIVER)
 }
 
 /** See Subset 026: §3.13.9.3.5.4. */
@@ -488,7 +644,7 @@ private fun getIndicationPosition(
     speed: Double,
     tBs: Double
 ): Double {
-    val tIndication = max((0.8 * tBs), 5.0) + tDriver
+    val tIndication = max((0.8 * tBs), 5.0) + T_DRIVER
     return getPreviousPosition(permittedSpeedPosition, speed, tIndication)
 }
 

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -20,6 +20,7 @@ SPEED_LIMIT_142 = kph2ms(141.9984)
 SPEED_LIMIT_112 = kph2ms(111.9996)
 SAFE_SPEED_30 = kph2ms(29.9988)
 SHORT_SLIP_SPEED_10 = kph2ms(10.0008)
+RELEASE_SPEED_40 = kph2ms(40)
 
 
 def _update_simulation_with_mareco_allowances(editoast_url, train_Schedule_id):
@@ -299,6 +300,213 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(etcs_scenario: Scenario, etcs
         _get_current_or_next_speed_at(simulation_final_output, offset_start_second_brake + 1)
         < speed_before_second_brake
     )
+
+
+def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenario: Scenario, etcs_rolling_stock: int):
+    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = requests.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "brake from MRSP: max_speed + EoA and SvL at same location",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 862_000},
+                    {"id": "first", "track": "TH0", "offset": 1_000_000},
+                    {"id": "last", "track": "TH1", "offset": 3_922_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "first", "stop_for": "PT10S"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # This case hits an LoA curve (slowdown of the MRSP), but it's not the point to test it here.
+
+    # Check that the curves respect the EoA + SvL (EoA = stops), and that there is an
+    # acceleration then deceleration in between (maintain speed when reach the MRSP).
+    first_stop_offset = 41_138_000
+    final_stop_offset = 45_060_000
+    stop_offsets = [
+        0,
+        first_stop_offset,
+        final_stop_offset,
+    ]
+
+    # Check null speed at stops
+    for stop_offset in stop_offsets:
+        assert _get_current_or_next_speed_at(simulation_final_output, stop_offset) == 0
+
+    # Check only one acceleration then only one deceleration between stops
+    for offset_index in range(1, len(stop_offsets) - 1):
+        accelerating = True
+        prev_speed = 0
+        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
+        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        for pos_index in range(start_pos_index, end_pos_index):
+            current_speed = simulation_final_output["speeds"][pos_index]
+            if accelerating:
+                if prev_speed > current_speed:
+                    accelerating = False
+            else:
+                assert prev_speed >= current_speed
+            prev_speed = current_speed
+
+    # Check that the braking curve starts and ends at the expected offsets.
+    offset_start_first_brake = 33_461_530
+    speed_before_first_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake)
+    _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
+    assert (
+        _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake + 1) < speed_before_first_brake
+    )
+    # Check a bending point for the first stop's braking curve (where the Guidance curve's influence stops).
+    offset_bending_guidance_point = 37_210_507
+    speed_at_bending_guidance_point = _get_current_or_next_speed_at(
+        simulation_final_output, offset_bending_guidance_point
+    )
+    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(218.919_495_5))
+    # Check that the release part (where the speed stays at 40km/h) starts and ends at the expected offsets.
+    offset_start_release_speed = 40_827_882
+    speed_at_start_release_speed = _get_current_or_next_speed_at(simulation_final_output, offset_start_release_speed)
+    _assert_equal_speeds(speed_at_start_release_speed, RELEASE_SPEED_40)
+    offset_end_release_speed = 40_892_792
+    speed_at_end_release_speed = _get_current_or_next_speed_at(simulation_final_output, offset_end_release_speed)
+    _assert_equal_speeds(speed_at_end_release_speed, RELEASE_SPEED_40)
+
+
+def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
+    etcs_scenario: Scenario, etcs_rolling_stock: int
+):
+    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+    etcs_rolling_stock_name = rolling_stock_response.json()["name"]
+    ts_response = requests.post(
+        f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
+        json=[
+            {
+                "train_name": "brake from MRSP: max_speed + EoA and SvL 100m after EoA",
+                "labels": [],
+                "rolling_stock_name": etcs_rolling_stock_name,
+                "start_time": "2024-01-01T07:00:00Z",
+                "path": [
+                    {"id": "zero", "track": "TA0", "offset": 862_000},
+                    {"id": "first", "track": "TH0", "offset": 900_000},
+                    {"id": "last", "track": "TH1", "offset": 3_922_000},
+                ],
+                "schedule": [
+                    {"at": "zero", "stop_for": "P0D"},
+                    {"at": "first", "stop_for": "PT10S"},
+                    {"at": "last", "stop_for": "P0D"},
+                ],
+                "margins": {"boundaries": [], "values": ["0%"]},
+                "initial_speed": 0,
+                "comfort": "STANDARD",
+                "constraint_distribution": "STANDARD",
+                "speed_limit_tag": "foo",
+                "power_restrictions": [],
+            }
+        ],
+    )
+
+    schedule = ts_response.json()[0]
+    schedule_id = schedule["id"]
+    ts_id_response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
+    ts_id_response.raise_for_status()
+    simu_response = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={etcs_scenario.infra}"
+    )
+    simulation_final_output = simu_response.json()["final_output"]
+
+    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+
+    # To debug this test: please add a breakpoint then use front to display speed-space chart
+    # (activate Context for Slopes and Speed limits).
+
+    # This case hits an LoA curve (slowdown of the MRSP), but it's not the point to test it here.
+
+    # Check that the curves respect the EoA + SvL (EoA = stops), and that there is an
+    # acceleration then deceleration in between (maintain speed when reach the MRSP).
+    # Here, the stop (EoA) is 100m before the PH1 switch (SvL).
+    svl_ph1_offset = 41_138_000
+    first_stop_offset = svl_ph1_offset - 100_000
+    final_stop_offset = 45_060_000
+    stop_offsets = [
+        0,
+        first_stop_offset,
+        final_stop_offset,
+    ]
+
+    # Check null speed at stops
+    for stop_offset in stop_offsets:
+        assert _get_current_or_next_speed_at(simulation_final_output, stop_offset) == 0
+
+    # Check only one acceleration then only one deceleration between stops
+    for offset_index in range(1, len(stop_offsets) - 1):
+        accelerating = True
+        prev_speed = 0
+        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
+        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        for pos_index in range(start_pos_index, end_pos_index):
+            current_speed = simulation_final_output["speeds"][pos_index]
+            if accelerating:
+                if prev_speed > current_speed:
+                    accelerating = False
+            else:
+                assert prev_speed >= current_speed
+            prev_speed = current_speed
+
+    # Check that the braking curve starts and ends at the expected offsets.
+    offset_start_first_brake = 33_361_530
+    speed_before_first_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake)
+    _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
+    assert (
+        _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake + 1) < speed_before_first_brake
+    )
+    # Check the first bending point for the first stop's braking curve (where the Guidance curve's influence stops).
+    offset_bending_guidance_point = 37_240_601
+    speed_at_bending_guidance_point = _get_current_or_next_speed_at(
+        simulation_final_output, offset_bending_guidance_point
+    )
+    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(219.751_941_6))
+    # Check the second bending point for the first stop's braking curve, where the indication curve followed switches
+    # from the EoA indication curve to the SvL indication curve.
+    offset_bending_point_eoa_to_svl = 39_101_733
+    speed_at_start_release_speed = _get_current_or_next_speed_at(
+        simulation_final_output, offset_bending_point_eoa_to_svl
+    )
+    _assert_equal_speeds(speed_at_start_release_speed, kph2ms(155.175_955_2))
+    # Check the third bending point for the first stop's braking curve, where the indication curve followed switches
+    # back from the SvL indication curve to the EoA indication curve.
+    offset_bending_point_svl_to_eoa = 40_589_456
+    speed_at_start_release_speed = _get_current_or_next_speed_at(
+        simulation_final_output, offset_bending_point_svl_to_eoa
+    )
+    _assert_equal_speeds(speed_at_start_release_speed, kph2ms(62.492_266_11))
 
 
 def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_stock: int):


### PR DESCRIPTION
Fixes #10404.
Add SVL logic to ETCS braking simulator.
How: compute svl and eoa indications, compute minimum curve, and compare it against overlay.
Limit: approximate braking curves' calculation when SvL is after the end of the path, due to the missing tractive effort and slopes post path.