### PR TITLE
front: fix stdcm consist length and mass minimum values

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -144,7 +144,7 @@ const StdcmConsist = ({ isDebugMode, consistErrors = {}, disabled = false }: Std
                   status: 'error',
                   tooltip: 'left',
                   message: t(consistErrors.totalMass, {
-                    low: Math.floor(
+                    low: Math.ceil(
                       kgToT((rollingStock?.mass ?? 0) + (towedRollingStock?.mass ?? 0))
                     ),
                     high: CONSIST_TOTAL_MASS_MAX,
@@ -168,7 +168,7 @@ const StdcmConsist = ({ isDebugMode, consistErrors = {}, disabled = false }: Std
                   status: 'error',
                   tooltip: 'left',
                   message: t(consistErrors.totalLength, {
-                    low: Math.floor((rollingStock?.length ?? 0) + (towedRollingStock?.length ?? 0)),
+                    low: Math.ceil((rollingStock?.length ?? 0) + (towedRollingStock?.length ?? 0)),
                     high: CONSIST_TOTAL_LENGTH_MAX,
                   }),
                 }

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -51,12 +51,12 @@ const useStdcmConsist = () => {
     maxSpeedTag?: string | null
   ) => {
     if (!totalMassChanged) {
-      const consistMass = Math.floor(kgToT((rollingStock?.mass ?? 0) + (towed?.mass ?? 0)));
+      const consistMass = Math.ceil(kgToT((rollingStock?.mass ?? 0) + (towed?.mass ?? 0)));
       dispatch(updateTotalMass(consistMass > 0 ? consistMass : undefined));
     }
 
     if (!totalLengthChanged) {
-      const consistLength = Math.floor((rollingStock?.length ?? 0) + (towed?.length ?? 0));
+      const consistLength = Math.ceil((rollingStock?.length ?? 0) + (towed?.length ?? 0));
       dispatch(updateTotalLength(consistLength > 0 ? consistLength : undefined));
     }
 

--- a/front/src/applications/stdcm/utils/consistValidation.ts
+++ b/front/src/applications/stdcm/utils/consistValidation.ts
@@ -22,7 +22,7 @@ export const validateTotalMass = ({
   }
 
   const tractionMassInTons = kgToT(tractionEngineMass);
-  const consistMassInTons = Math.floor(kgToT(tractionEngineMass + towedMass));
+  const consistMassInTons = Math.ceil(kgToT(tractionEngineMass + towedMass));
   const massLimit = towedMass ? consistMassInTons : tractionMassInTons;
 
   if (totalMass < massLimit || totalMass > CONSIST_TOTAL_MASS_MAX) {
@@ -49,7 +49,7 @@ export const validateTotalLength = ({
     return 'consist.errors.totalLength.negative';
   }
 
-  const consistLength = Math.floor(tractionEngineLength + towedLength);
+  const consistLength = Math.ceil(tractionEngineLength + towedLength);
 
   if (totalLength < consistLength || totalLength > CONSIST_TOTAL_LENGTH_MAX) {
     return 'consist.errors.totalLength.range';

--- a/front/tests/006-stdcm.spec.ts
+++ b/front/tests/006-stdcm.spec.ts
@@ -35,7 +35,7 @@ test.describe('Verify train schedule elements and filters', () => {
   };
   const fastRollingStockPrefilledValues = {
     tonnage: '190',
-    length: '45',
+    length: '46',
     maxSpeed: '220',
   };
   const towedRollingStockPrefilledValues = {


### PR DESCRIPTION
The sum of the rolling stock and towed rolling stock mass was previously rounded down (instead of up) resulting to some invalid values send to the form. If a total mass was 80.7t, the user was allowed to send 80t.

fix #10306 