### PR TITLE
editoast, front: allow providing etcs_brake_params to rolling-stock web api

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9410,6 +9410,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EnergySource'
+        etcs_brake_params:
+          allOf:
+          - $ref: '#/components/schemas/EtcsBrakeParams'
+          nullable: true
         inertia_coefficient:
           type: number
           format: double

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use editoast_common::units::{quantities::*, *};
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
+use editoast_schemas::rolling_stock::EtcsBrakeParams;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::rolling_stock::RollingResistance;
 use editoast_schemas::rolling_stock::RollingStockMetadata;
@@ -55,6 +56,7 @@ pub struct RollingStockForm {
     #[schema(example = 5.0)]
     #[serde(default, with = "second::option")]
     pub electrical_power_startup_time: Option<Time>,
+    pub etcs_brake_params: Option<EtcsBrakeParams>,
     /// The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
     #[schema(example = 15.0)]
     #[serde(default, with = "second::option")]
@@ -79,6 +81,7 @@ impl From<RollingStockForm> for Changeset<RollingStockModel> {
             .startup_acceleration(rolling_stock.startup_acceleration)
             .comfort_acceleration(rolling_stock.comfort_acceleration)
             .const_gamma(rolling_stock.const_gamma)
+            .etcs_brake_params(rolling_stock.etcs_brake_params)
             .inertia_coefficient(rolling_stock.inertia_coefficient)
             .mass(rolling_stock.mass)
             .rolling_resistance(rolling_stock.rolling_resistance)
@@ -115,6 +118,7 @@ impl From<RollingStockModel> for RollingStockForm {
             startup_acceleration: value.startup_acceleration,
             comfort_acceleration: value.comfort_acceleration,
             const_gamma: value.const_gamma,
+            etcs_brake_params: value.etcs_brake_params,
             inertia_coefficient: value.inertia_coefficient,
             mass: value.mass,
             rolling_resistance: value.rolling_resistance,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3109,6 +3109,7 @@ export type RollingStockForm = {
     Duration in s */
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
+  etcs_brake_params?: EtcsBrakeParams | null;
   /** Ratio 1:1 */
   inertia_coefficient: number;
   /** Length in m */

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorForm.tsx
@@ -190,7 +190,10 @@ const RollingStockEditorForm = ({
     }
 
     setErrorMessage('');
-    const payload = rollingStockEditorQueryArg(validRollingStockForm, effortCurves!);
+    const payload: RollingStockForm = {
+      ...rollingStockEditorQueryArg(validRollingStockForm, effortCurves!),
+      etcs_brake_params: rollingStockData?.etcs_brake_params,
+    };
     openModal(
       <RollingStockEditorFormModal
         setAddOrEditState={setAddOrEditState}


### PR DESCRIPTION
front: persist etcs params when editing a rollingstock handling etcs (without this, etcs_brake_params are emptied when updating a RS with the front).

Follow-up on #10147 

AC:
* ability to create a RS with etcs_brake_params via editoast's web API:
  * `curl 'http://localhost:4000/api/rolling_stock?locked=false' -X POST -H 'content-type: application/json' -H 'Cookie: gateway=<blabliblo>' --data '@/<path/to>/osrd/tests/data/rolling_stocks/etcs_level2_rolling_stock.json'`
  * check in PG that `etcs_brake_params` column is filled
* ability to update given RS without erasing etcs_brake_params:
  * change some field of the RS using the front (i.e. name, details)
  * check in PG that `etcs_brake_params` column is still filled
