### PR TITLE
core: add warning on route ending on non route delimiting signal in block generation

### DIFF
--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/SignalDriver.kt
@@ -94,6 +94,7 @@ interface SignalingSystemDriver {
     val stateSchema: SigStateSchema
     val settingsSchema: SigSettingsSchema
     val isBlockDelimiterExpr: String
+    val isRouteDelimiterExpr: String
 
     fun checkBlock(reporter: BlockDiagReporter, block: SigBlock)
 

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
@@ -90,4 +90,8 @@ class MockSigSystemManager(
     override fun isBlockDelimiter(sigSystem: SignalingSystemId, settings: SigSettings): Boolean {
         return true
     }
+
+    override fun isRouteDelimiter(sigSystem: SignalingSystemId, settings: SigSettings): Boolean {
+        return true
+    }
 }

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
@@ -95,6 +95,10 @@ class SigSystemManagerImpl : SigSystemManager {
         return evalSigSettings(sigSystemPool[sigSystem].isBlockDelimiterExpr, settings)
     }
 
+    override fun isRouteDelimiter(sigSystem: SignalingSystemId, settings: SigSettings): Boolean {
+        return evalSigSettings(sigSystemPool[sigSystem].isRouteDelimiterExpr, settings)
+    }
+
     override fun checkSignalingSystemBlock(
         reporter: BlockDiagReporter,
         sigSystem: SignalingSystemId,

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -57,6 +57,8 @@ interface InfraSigSystemManager {
     fun getOutputSignalingSystem(driver: SignalDriverId): SignalingSystemId
 
     fun isBlockDelimiter(sigSystem: SignalingSystemId, settings: SigSettings): Boolean
+
+    fun isRouteDelimiter(sigSystem: SignalingSystemId, settings: SigSettings): Boolean
 }
 
 interface LoadedSignalInfra {

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bal/BAL.kt
@@ -12,6 +12,7 @@ object BAL : SignalingSystemDriver {
     override val settingsSchema = SigSettingsSchema { flag("Nf") }
     override val parametersSchema = SigParametersSchema { flag("jaune_cli") }
     override val isBlockDelimiterExpr = "true"
+    override val isRouteDelimiterExpr = "Nf"
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/bapr/BAPR.kt
@@ -15,6 +15,7 @@ object BAPR : SignalingSystemDriver {
     }
     override val parametersSchema = SigParametersSchema {}
     override val isBlockDelimiterExpr = "!distant"
+    override val isRouteDelimiterExpr = "Nf"
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/etcs_level2/ETCS_LEVEL2.kt
@@ -28,6 +28,7 @@ object ETCS_LEVEL2 : SignalingSystemDriver {
     override val parametersSchema = SigParametersSchema {}
 
     override val isBlockDelimiterExpr = "true"
+    override val isRouteDelimiterExpr = "Nf"
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm300/TVM300.kt
@@ -22,6 +22,7 @@ object TVM300 : SignalingSystemDriver {
     override val settingsSchema = SigSettingsSchema { flag("Nf") }
     override val parametersSchema = SigParametersSchema {}
     override val isBlockDelimiterExpr = "true"
+    override val isRouteDelimiterExpr = "Nf"
 
     private fun maxSpeedForState(state: SigState): Speed {
         return when (val aspect = state.getEnum("aspect")) {

--- a/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
+++ b/core/kt-osrd-sncf-signaling/src/main/kotlin/fr/sncf/osrd/signaling/tvm430/TVM430.kt
@@ -20,6 +20,7 @@ object TVM430 : SignalingSystemDriver {
     override val parametersSchema = SigParametersSchema {}
 
     override val isBlockDelimiterExpr = "true"
+    override val isRouteDelimiterExpr = "Nf"
 
     override fun checkBlock(reporter: BlockDiagReporter, block: SigBlock) {
         // Check that we have the correct number of signals


### PR DESCRIPTION
Close #4606

We only check that route ends on Nf signals (or more generally route delimiting signal), not whether they start on it