### PR TITLE
front: add version parameter to translations load path

### DIFF
--- a/front/src/i18n.ts
+++ b/front/src/i18n.ts
@@ -6,6 +6,8 @@ import { initReactI18next } from 'react-i18next';
 // Official languages codes to use from IANA
 // https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
 
+const version = encodeURIComponent(import.meta.env.VITE_OSRD_GIT_DESCRIBE);
+
 i18n
   .use(Backend)
   .use(initReactI18next)
@@ -19,6 +21,9 @@ i18n
     },
     react: {
       useSuspense: false,
+    },
+    backend: {
+      loadPath: `/locales/{{lng}}/{{ns}}.json?v=${version}`,
     },
   });
 


### PR DESCRIPTION
That way, every time we release a new OSRD version, we force browsers to refresh translation files. This is similar to the hash inserted in JS/CSS filenames by vite.

Docs: https://github.com/i18next/i18next-xhr-backend?tab=readme-ov-file#backend-options

Closes: https://github.com/OpenRailAssociation/osrd/issues/9965