### PR TITLE
front: upgrade node to v23, nivo to v0.88

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -5,7 +5,7 @@ COPY docker/exec-as.c .
 RUN gcc -std=c99 -static -o /exec-as exec-as.c
 
 
-FROM node:20
+FROM node:23
 
 # Install dependencies
 RUN apt-get update -yqq && \

--- a/front/docker/Dockerfile.nginx
+++ b/front/docker/Dockerfile.nginx
@@ -1,6 +1,6 @@
 ### BUILD STAGE
 
-FROM node:20-bookworm AS build
+FROM node:23-bookworm AS build
 
 WORKDIR /app
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-media/react-pdf-table": "^2.0.1",
-        "@nivo/core": "^0.80.0",
-        "@nivo/line": "^0.80.0",
+        "@nivo/core": "^0.88.0",
+        "@nivo/line": "^0.88.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
         "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
         "@osrd-project/ui-core": "^0.0.62",
@@ -1617,142 +1617,160 @@
       }
     },
     "node_modules/@nivo/annotations": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.80.0.tgz",
-      "integrity": "sha512-bC9z0CLjU07LULTMWsqpjovRtHxP7n8oJjqBQBLmHOGB4IfiLbrryBfu9+aEZH3VN2jXHhdpWUz+HxeZzOzsLg==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.88.0.tgz",
+      "integrity": "sha512-NXE+1oIUn+EGWMQpnpeRMLgi2wyuzhGDoJQY4OUHissCUiNotid2oNQ/PXJwN0toiu+/j9SyhzI32xr70OPi7Q==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/colors": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/axes": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.80.0.tgz",
-      "integrity": "sha512-AsUyaSHGwQVSEK8QXpsn8X+poZxvakLMYW7crKY1xTGPNw+SU4SSBohPVumm2jMH3fTSLNxLhAjWo71GBJXfdA==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.88.0.tgz",
+      "integrity": "sha512-jF7aIxzTNayV5cI1J/b9Q1FfpMBxTXGk3OwSigXMSfYWlliskDn2u0qGRLiYhuXFdQAWIp4oXsO1GcAQ0eRVdg==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/scales": "0.80.0",
-        "@react-spring/web": "9.4.5",
+        "@nivo/core": "0.88.0",
+        "@nivo/scales": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
         "d3-format": "^1.4.4",
         "d3-time-format": "^3.0.0"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
+    "node_modules/@nivo/axes/node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/axes/node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg==",
+      "license": "MIT"
+    },
     "node_modules/@nivo/colors": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.80.0.tgz",
-      "integrity": "sha512-T695Zr411FU4RPo7WDINOAn8f79DPP10SFJmDdEqELE+cbzYVTpXqLGZ7JMv88ko7EOf9qxLQgcBqY69rp9tHQ==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.88.0.tgz",
+      "integrity": "sha512-IZ+leYIqAlo7dyLHmsQwujanfRgXyoQ5H7PU3RWLEn1PP0zxDKLgEjFEDADpDauuslh2Tx0L81GNkWR6QSP0Mw==",
       "license": "MIT",
       "dependencies": {
-        "d3-color": "^2.0.0",
-        "d3-scale": "^3.2.3",
-        "d3-scale-chromatic": "^2.0.0",
-        "lodash": "^4.17.21"
+        "@nivo/core": "0.88.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "@types/prop-types": "^15.7.2",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/core": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.80.0.tgz",
-      "integrity": "sha512-6caih0RavXdWWSfde+rC2pk17WrX9YQlqK26BrxIdXzv3Ydzlh5SkrC7dR2TEvMGBhunzVeLOfiC2DWT1S8CFg==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.88.0.tgz",
+      "integrity": "sha512-XjUkA5MmwjLP38bdrJwn36Gj7T5SYMKD55LYQp/1nIJPdxqJ38dUfE4XyBDfIEgfP6yrHOihw3C63cUdnUBoiw==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/recompose": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "d3-color": "^2.0.0",
+        "@nivo/tooltip": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
         "d3-format": "^1.4.4",
-        "d3-interpolate": "^2.0.1",
-        "d3-scale": "^3.2.3",
-        "d3-scale-chromatic": "^2.0.0",
-        "d3-shape": "^1.3.5",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
         "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
-        "@nivo/tooltip": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/core/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
     "node_modules/@nivo/legends": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.80.0.tgz",
-      "integrity": "sha512-h0IUIPGygpbKIZZZWIxkkxOw4SO0rqPrqDrykjaoQz4CvL4HtLIUS3YRA4akKOVNZfS5agmImjzvIe0s3RvqlQ==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.88.0.tgz",
+      "integrity": "sha512-d4DF9pHbD8LmGJlp/Gp1cF4e8y2wfQTcw3jVhbZj9zkb7ZWB7JfeF60VHRfbXNux9bjQ9U78/SssQqueVDPEmg==",
       "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
       "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/line": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.80.0.tgz",
-      "integrity": "sha512-6UAD/y74qq3DDRnVb+QUPvXYojxMtwXMipGSNvCGk8omv1QZNTaUrbV+eQacvn9yh//a0yZcWipnpq0tGJyJCA==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.88.0.tgz",
+      "integrity": "sha512-hFTyZ3BdAZvq2HwdwMj2SJGUeodjEW+7DLtFMIIoVIxmjZlAs3z533HcJ9cJd3it928fDm8SF/rgHs0TztYf9Q==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/annotations": "0.80.0",
-        "@nivo/axes": "0.80.0",
-        "@nivo/colors": "0.80.0",
-        "@nivo/legends": "0.80.0",
-        "@nivo/scales": "0.80.0",
-        "@nivo/tooltip": "0.80.0",
-        "@nivo/voronoi": "0.80.0",
-        "@react-spring/web": "9.4.5",
-        "d3-shape": "^1.3.5"
-      },
-      "peerDependencies": {
-        "@nivo/core": "0.80.0",
-        "prop-types": ">= 15.5.10 < 16.0.0",
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/recompose": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/recompose/-/recompose-0.80.0.tgz",
-      "integrity": "sha512-iL3g7j3nJGD9+mRDbwNwt/IXDXH6E29mhShY1I7SP91xrfusZV9pSFf4EzyYgruNJk/2iqMuaqn+e+TVFra44A==",
-      "license": "MIT",
-      "dependencies": {
-        "react-lifecycles-compat": "^3.0.4"
+        "@nivo/annotations": "0.88.0",
+        "@nivo/axes": "0.88.0",
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
+        "@nivo/legends": "0.88.0",
+        "@nivo/scales": "0.88.0",
+        "@nivo/tooltip": "0.88.0",
+        "@nivo/voronoi": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "d3-shape": "^3.2.0"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/scales": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.80.0.tgz",
-      "integrity": "sha512-4y2pQdCg+f3n4TKXC2tYuq71veZM+xPRQbOTgGYJpuBvMc7pQsXF9T5z7ryeIG9hkpXkrlyjecU6XcAG7tLSNg==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.88.0.tgz",
+      "integrity": "sha512-HbpxkQp6tHCltZ1yDGeqdLcaJl5ze54NPjurfGtx/Uq+H5IQoBd4Tln49bUar5CsFAMsXw8yF1HQvASr7I1SIA==",
       "license": "MIT",
       "dependencies": {
-        "d3-scale": "^3.2.3",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-scale": "^4.0.2",
         "d3-time": "^1.0.11",
         "d3-time-format": "^3.0.0",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g==",
+      "license": "MIT"
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg==",
+      "license": "MIT"
     },
     "node_modules/@nivo/scales/node_modules/d3-time": {
       "version": "1.1.0",
@@ -1761,45 +1779,34 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@nivo/tooltip": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.80.0.tgz",
-      "integrity": "sha512-qGmrreRwnCsYjn/LAuwBtxBn/tvG8y+rwgd4gkANLBAoXd3bzJyvmkSe+QJPhUG64bq57ibDK+lO2pC48a3/fw==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
+      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/web": "9.4.5"
+        "@nivo/core": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
       },
       "peerDependencies": {
-        "@nivo/core": "0.80.0"
-      }
-    },
-    "node_modules/@nivo/voronoi": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.80.0.tgz",
-      "integrity": "sha512-zaJV3I3cRu1gHpsXCIEvp6GGlGY8P7D9CwAVCjYDGrz3W/+GKN0kA7qGyHTC97zVxJtfefxSPlP/GtOdxac+qw==",
-      "license": "MIT",
-      "dependencies": {
-        "d3-delaunay": "^5.3.0",
-        "d3-scale": "^3.2.3"
-      },
-      "peerDependencies": {
-        "@nivo/core": "0.80.0",
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/voronoi/node_modules/d3-delaunay": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
-      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
-      "license": "ISC",
+    "node_modules/@nivo/voronoi": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.88.0.tgz",
+      "integrity": "sha512-MyiNLvODthFoMjQ7Wjp693nogbTmVEx8Yn/7QkJhyPQbFyyA37TF/D1a/ox4h2OslXtP6K9QFN+42gB/zu7ixw==",
+      "license": "MIT",
       "dependencies": {
-        "delaunator": "4"
+        "@nivo/core": "0.88.0",
+        "@nivo/tooltip": "0.88.0",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "d3-delaunay": "^6.0.4",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
       }
-    },
-    "node_modules/@nivo/voronoi/node_modules/delaunator": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
-      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
-      "license": "ISC"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5422,7 +5429,6 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-dispatch": {
@@ -5510,7 +5516,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-polygon": {
@@ -5538,7 +5543,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
       "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
@@ -5548,7 +5552,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
       "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-selection": {
@@ -5561,7 +5564,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
       "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -5571,7 +5573,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
       "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-time-format": {
@@ -9446,10 +9447,13 @@
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
-      "license": "BSD-3-Clause"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-contour": {
       "version": "4.0.2",
@@ -9605,15 +9609,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-interpolate/node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
@@ -9651,75 +9646,33 @@
       }
     },
     "node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-      "license": "BSD-3-Clause",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
       "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-scale-chromatic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
-      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
-      "license": "BSD-3-Clause",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
       "dependencies": {
-        "d3-color": "1 - 2",
-        "d3-interpolate": "1 - 2"
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
-    },
-    "node_modules/d3-scale-chromatic/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-scale/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "2"
-      }
-    },
-    "node_modules/d3-scale/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
@@ -9731,19 +9684,16 @@
       }
     },
     "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "license": "BSD-3-Clause",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
       "dependencies": {
-        "d3-path": "1"
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
-    },
-    "node_modules/d3-shape/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
@@ -9818,15 +9768,6 @@
         "d3-selection": "2 - 3"
       }
     },
-    "node_modules/d3-transition/node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
@@ -9843,61 +9784,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3/node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3/node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
       "engines": {
         "node": ">=12"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@ag-media/react-pdf-table": "^2.0.1",
-    "@nivo/core": "^0.80.0",
-    "@nivo/line": "^0.80.0",
+    "@nivo/core": "^0.88.0",
+    "@nivo/line": "^0.88.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
     "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
     "@osrd-project/ui-core": "^0.0.62",


### PR DESCRIPTION
A newer node version [is required][1] to make require() work with
modules. This is necessary for a nivo upgrade, otherwise CI fails
with:

     FAIL  src/modules/rollingStock/components/RollingStockEditor/__tests__/RollingStockEditorForm.spec.ts [ src/modules/rollingStock/components/RollingStockEditor/__tests__/RollingStockEditorForm.spec.ts ]
    Error: require() of ES Module /app/node_modules/d3-interpolate/src/index.js from /app/node_modules/@nivo/core/dist/nivo-core.cjs.js not supported.
    Instead change the require of index.js in /app/node_modules/@nivo/core/dist/nivo-core.cjs.js to a dynamic import() which is available in all CommonJS modules.
     ❯ Object.<anonymous> node_modules/@nivo/core/dist/nivo-core.cjs.js:1:164

[1]: https://github.com/plouc/nivo/issues/2310#issuecomment-2495916321

See also: https://github.com/OpenRailAssociation/osrd/pull/10256