### PR TITLE
front: repair npm start

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -157,7 +157,7 @@
   },
   "scripts": {
     "compile": "tsc -b",
-    "start": "exec scripts/start-dev.sh",
+    "start": "vite",
     "start-container": "vite --host",
     "build": "vite build",
     "test": "vitest",


### PR DESCRIPTION
sh was removed in https://github.com/OpenRailAssociation/osrd/pull/10320 and script left untouched