### PR TITLE
front: remove webkit from e2e tests

### DIFF
--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -71,15 +71,5 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
-    {
-      name: 'webkit',
-      use: {
-        browserName: 'webkit',
-        launchOptions: {
-          slowMo: 150, // Slows down WebKit interactions by 150 milliseconds
-        },
-      },
-      dependencies: ['setup'],
-    },
   ],
 });

--- a/front/tests/009-rollingstock-editor.spec.ts
+++ b/front/tests/009-rollingstock-editor.spec.ts
@@ -39,8 +39,7 @@ test.describe('Rollingstock editor page tests', () => {
   );
 
   /** *************** Test 1 **************** */
-  test('Create a new rolling stock', async ({ page, browserName }) => {
-    test.slow(browserName === 'webkit', 'This test is slow on Safari');
+  test('Create a new rolling stock', async ({ page }) => {
     const rollingStockEditorPage = new RollingstockEditorPage(page);
 
     // Start the rolling stock creation process
@@ -104,8 +103,7 @@ test.describe('Rollingstock editor page tests', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Duplicate and modify a rolling stock', async ({ page, browserName }) => {
-    test.slow(browserName === 'webkit', 'This test is slow on Safari');
+  test('Duplicate and modify a rolling stock', async ({ page }) => {
     const rollingStockEditorPage = new RollingstockEditorPage(page);
 
     // Select the existing electric rolling stock and duplicate it

--- a/front/tests/012-op-simulation-settings-tab.spec.ts
+++ b/front/tests/012-op-simulation-settings-tab.spec.ts
@@ -86,8 +86,8 @@ test.describe('Simulation Settings Tab Verification', () => {
 
   test.beforeEach(
     'Navigate to Times and Stops tab with rolling stock and route set',
-    async ({ page, browserName }) => {
-      stabilityTimeout = browserName === 'webkit' ? 2000 : 1000;
+    async ({ page }) => {
+      stabilityTimeout = 1000;
       const [operationalStudiesPage, routePage, rollingStockPage, homePage] = [
         new OperationalStudiesPage(page),
         new RoutePage(page),


### PR DESCRIPTION
Remove WebKit from e2e tests as it slows down the test execution