### PR TITLE
docker: fix default network name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
+name: osrd
+
 volumes:
   psql_data:
   valkey_data:
   rabbitmq_data:
-
 
 services:
   postgres:


### PR DESCRIPTION
If omitted, the project name is automatically deduced from the parent directory name. This was working fine for container names because we were explicitly defining their names, but the network name was left unspecified. osrdyne default config depends on the network name being "osrd_default", but that wasn't the case when the parent directory wasn't named "osrd".

Explicitly set the project name to fix this. Drop explicit names for container names, since the default values should be fine now.