### PR TITLE
Change map tiles server and use pmtiles instead of mbtiles

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -72,6 +72,7 @@
         "maplibre-gl": "^4.0.0",
         "openapi-typescript-codegen": "^0.29.0",
         "party-js": "^2.2.0",
+        "pmtiles": "^4.2.1",
         "prop-types": "^15.8.1",
         "rc-slider": "^11.1.8",
         "react": "^18.2.0",
@@ -9954,6 +9955,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -15699,6 +15706,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pmtiles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.2.1.tgz",
+      "integrity": "sha512-Z73aph49f7KpU7JPb+zDWr+62wPv9jF3p+tvvL26/XeECnzUHnQ0nGopXGPYnq+OQXqyaXZPrsNdKxSD+2HlLA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
       }
     },
     "node_modules/point-in-polygon-hao": {

--- a/front/package.json
+++ b/front/package.json
@@ -68,6 +68,7 @@
     "maplibre-gl": "^4.0.0",
     "openapi-typescript-codegen": "^0.29.0",
     "party-js": "^2.2.0",
+    "pmtiles": "^4.2.1",
     "prop-types": "^15.8.1",
     "rc-slider": "^11.1.8",
     "react": "^18.2.0",

--- a/front/src/applications/editor/Map.tsx
+++ b/front/src/applications/editor/Map.tsx
@@ -2,6 +2,8 @@ import { useContext, useMemo, useState, type PropsWithChildren } from 'react';
 
 import type { TFunction } from 'i18next';
 import { isEmpty, isEqual, isNil } from 'lodash';
+import maplibregl from 'maplibre-gl';
+import { Protocol } from 'pmtiles';
 import { withTranslation } from 'react-i18next';
 import ReactMapGL, { AttributionControl, ScaleControl, type MapRef } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
@@ -49,6 +51,9 @@ interface MapState {
   isDragging: boolean;
   isHovering: boolean;
 }
+
+const protocol = new Protocol();
+maplibregl.addProtocol('pmtiles', protocol.tile);
 
 const MapUnplugged = ({
   mapRef,

--- a/front/src/common/Map/Layers/Background.tsx
+++ b/front/src/common/Map/Layers/Background.tsx
@@ -12,7 +12,7 @@ function Background(props: BackgroundProps) {
   const { colors, layerOrder } = props;
 
   const backgroundParams: LayerProps = {
-    id: 'osm/background',
+    id: 'background',
     type: 'background',
     layout: {
       visibility: 'visible',
@@ -23,12 +23,7 @@ function Background(props: BackgroundProps) {
   };
 
   return (
-    <Source
-      id="platform"
-      type="vector"
-      url="https://osm.osrd.fr/data/v3.json"
-      source-layer="transportation"
-    >
+    <Source id="background" type="vector">
       <OrderedLayer {...backgroundParams} layerOrder={layerOrder} />
     </Source>
   );

--- a/front/src/common/Map/Layers/Hillshade.tsx
+++ b/front/src/common/Map/Layers/Hillshade.tsx
@@ -1,6 +1,7 @@
 import { Source, type LayerProps } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
+import { TERRAIN_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import { getTerrain3DExaggeration } from 'reducers/map/selectors';
 
@@ -29,7 +30,7 @@ const Hillshade = ({ mapStyle, layerOrder }: HillshadeProps) => {
       id="hillshade"
       type="raster-dem"
       encoding="terrarium"
-      url="https://osm.osrd.fr/data/terrain.json"
+      url={TERRAIN_URL}
       tileSize={256}
       maxzoom={12}
     >

--- a/front/src/common/Map/Layers/OSM.tsx
+++ b/front/src/common/Map/Layers/OSM.tsx
@@ -83,7 +83,12 @@ function OSM({ mapStyle, layerOrder, mapIsLoaded }: OSMProps) {
 
   if (reload) return null;
   return (
-    <Source id="osm" type="vector" url={OSM_URL}>
+    <Source
+      id="osm"
+      type="vector"
+      url={OSM_URL}
+      attribution='© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    >
       {genOSMLayers(mapStyle, toggledLayers, layerOrder)}
     </Source>
   );

--- a/front/src/common/Map/Layers/Terrain.tsx
+++ b/front/src/common/Map/Layers/Terrain.tsx
@@ -1,12 +1,14 @@
 import { Source } from 'react-map-gl/maplibre';
 
+import { TERRAIN_URL } from 'common/Map/const';
+
 export default function Terrain() {
   return (
     <Source
       id="terrain"
       type="raster-dem"
       encoding="terrarium"
-      url="https://osm.osrd.fr/data/terrain.json"
+      url={TERRAIN_URL}
       tileSize={256}
       maxzoom={12}
     />

--- a/front/src/common/Map/const.ts
+++ b/front/src/common/Map/const.ts
@@ -4,7 +4,9 @@ import config from 'config/config';
 export const MAP_URL = `${config.proxy_editoast}/layers`;
 export const SPRITES_URL = `${config.proxy_editoast}/sprites`;
 export const FONTS_URL = `${config.proxy_editoast}/fonts`;
-export const OSM_URL = 'https://osm.osrd.fr/data/v3.json';
+export const OSM_URL = 'pmtiles://https://osm.nbg1.your-objectstorage.com/planet.pmtiles';
+export const TERRAIN_URL =
+  'pmtiles://https://osm.nbg1.your-objectstorage.com/terrain-europe.pmtiles';
 
 export const MAP_MODES = {
   display: 'display',


### PR DESCRIPTION
Use pmtiles provided by https://tuiles.codeureusesenliberte.fr/

There should be no visible change.

This only concerns the base layer, underneath the infrastructure handled by OSRD.

To make sure everything works fine, try the different styles (including terrain). Make sure that we see everything, look in the console that all the data comes either from osrd, either from https://osm.nbg1.your-objectstorage.com/ (the url of object storage by hetzner).

Make sure that the map loading feels at least as fast as before.

![image](https://github.com/user-attachments/assets/ffd9cc8d-1e59-41d1-87a8-034d4198247b)
