### PR TITLE
front: lmr reset prefilled values changed by the user

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { min } from 'lodash';
 import { useSelector } from 'react-redux';
@@ -44,6 +44,18 @@ const useStdcmConsist = () => {
     setMaxSpeedChanged(true);
     dispatch(updateMaxSpeed(totalMaxSpeed === 0 ? undefined : totalMaxSpeed));
   };
+
+  useEffect(() => {
+    if (!totalMass) {
+      setTotalMassChanged(false);
+    }
+    if (!totalLength) {
+      setTotalLengthChanged(false);
+    }
+    if (!maxSpeed) {
+      setMaxSpeedChanged(false);
+    }
+  }, [maxSpeed, totalLength, totalMass]);
 
   const prefillConsist = (
     rollingStock?: LightRollingStockWithLiveries,


### PR DESCRIPTION
fix [#10270](https://github.com/OpenRailAssociation/osrd/issues/10270)
When the user modifies or enters a value, it disables the prefill for mass, length, and max speed. This PR re-enables the prefill if the user removes the value.