### PR TITLE
Fix incorrect input saving when switching simulations during a running calculation

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -5,11 +5,17 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
+import useStdcmForm from 'applications/stdcm/hooks/useStdcmForm';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
 import { useOsrdConfSelectors } from 'common/osrdContext';
 import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
-import { resetMargins, restoreStdcmConfig, updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
+import {
+  resetMargins,
+  restoreStdcmConfig,
+  updateStdcmPathStep,
+  addStdcmSimulation,
+} from 'reducers/osrdconf/stdcmConf';
 import {
   getStdcmDestination,
   getStdcmOrigin,
@@ -44,19 +50,23 @@ declare global {
 type StdcmConfigProps = {
   isDebugMode: boolean;
   isPending: boolean;
-  launchStdcmRequest: () => Promise<void>;
   retainedSimulationIndex?: number;
   showBtnToLaunchSimulation: boolean;
+  skipPathfindingStatusMessage: boolean;
+  launchStdcmRequest: () => Promise<void>;
   cancelStdcmRequest: () => void;
+  setSkipPathfindingStatusMessage: (value: boolean) => void;
 };
 
 const StdcmConfig = ({
   isDebugMode,
   isPending,
-  launchStdcmRequest,
   retainedSimulationIndex,
   showBtnToLaunchSimulation,
+  skipPathfindingStatusMessage,
+  setSkipPathfindingStatusMessage,
   cancelStdcmRequest,
+  launchStdcmRequest,
 }: StdcmConfigProps) => {
   const { t } = useTranslation('stdcm');
   const launchButtonRef = useRef<HTMLDivElement>(null);
@@ -81,13 +91,16 @@ const StdcmConfig = ({
 
   const [formErrors, setFormErrors] = useState<StdcmConfigErrors>();
 
+  const currentSimulationInputs = useStdcmForm();
+
   const disabled = isPending || retainedSimulationIndex !== undefined;
 
   const markersInfo = useMemo(() => extractMarkersInfo(pathSteps), [pathSteps]);
 
-  const startSimulation = () => {
+  const startSimulation = async () => {
     const formErrorsStatus = checkStdcmConfigErrors(pathSteps, t, pathfinding?.status);
     if (pathfinding?.status === 'success' && !formErrorsStatus) {
+      dispatch(addStdcmSimulation(currentSimulationInputs));
       launchStdcmRequest();
     } else {
       // The console error is only for debugging the user tests (temporary)
@@ -101,11 +114,14 @@ const StdcmConfig = ({
       updateStdcmPathStep({ id: origin.id, updates: { arrivalType: ArrivalTimeTypes.ASAP } })
     );
   };
+
   const removeDestinationArrivalTime = () => {
     dispatch(
       updateStdcmPathStep({ id: destination.id, updates: { arrivalType: ArrivalTimeTypes.ASAP } })
     );
   };
+
+  const onItineraryChange = () => setSkipPathfindingStatusMessage(false);
 
   const getStatusMessage = () => {
     if (isPathFindingLoading) {
@@ -141,14 +157,14 @@ const StdcmConfig = ({
   }, []);
 
   useEffect(() => {
-    if (isPathFindingLoading) {
+    if (!skipPathfindingStatusMessage && isPathFindingLoading) {
       setShowMessage(true);
     }
 
     if (pathfinding?.status === 'failure') {
       setShowMessage(false);
     }
-  }, [isPathFindingLoading, pathfinding?.status]);
+  }, [isPathFindingLoading, pathfinding?.status, skipPathfindingStatusMessage]);
 
   useLayoutEffect(() => {
     const handleAnimationEnd = () => {
@@ -185,9 +201,13 @@ const StdcmConfig = ({
             </div>
             <div className="stdcm__separator" />
             <div ref={formRef} className="stdcm-simulation-itinerary">
-              <StdcmOrigin disabled={disabled} />
-              <StdcmVias disabled={disabled} />
-              <StdcmDestination disabled={disabled} />
+              <StdcmOrigin disabled={disabled} onItineraryChange={onItineraryChange} />
+              <StdcmVias
+                disabled={disabled}
+                skipAnimation={skipPathfindingStatusMessage}
+                onItineraryChange={onItineraryChange}
+              />
+              <StdcmDestination disabled={disabled} onItineraryChange={onItineraryChange} />
               <StdcmLinkedTrainSearch
                 disabled={disabled}
                 linkedTrainType="posterior"

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmDestination.tsx
@@ -7,9 +7,9 @@ import { getStdcmDestination } from 'reducers/osrdconf/stdcmConf/selectors';
 import StdcmCard from './StdcmCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmOpSchedule from './StdcmOpSchedule';
-import type { StdcmConfigCardProps } from '../../types';
+import type { StdcmItineraryProps } from '../../types';
 
-const StdcmDestination = ({ disabled = false }: StdcmConfigCardProps) => {
+const StdcmDestination = ({ disabled = false, onItineraryChange }: StdcmItineraryProps) => {
   const { t } = useTranslation('stdcm');
 
   const destination = useSelector(getStdcmDestination);
@@ -26,6 +26,7 @@ const StdcmDestination = ({ disabled = false }: StdcmConfigCardProps) => {
         location={destination.location}
         pathStepId={destination.id}
         disabled={disabled}
+        onItineraryChange={onItineraryChange}
       />
       <StdcmOpSchedule pathStep={destination} disabled={disabled} opId="destination-arrival" />
     </StdcmCard>

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -14,6 +14,7 @@ type StdcmOperationalPointProps = {
   location?: StdcmPathStep['location'];
   pathStepId: string;
   disabled?: boolean;
+  onItineraryChange: () => void;
 };
 
 type CIOption = StdcmPathStep['location'] & { label: string };
@@ -37,7 +38,12 @@ const extractChCodes = (searchResults: SearchResultItemOperationalPoint[], selec
       return acc;
     }, [] as CHOption[]);
 
-const StdcmOperationalPoint = ({ location, pathStepId, disabled }: StdcmOperationalPointProps) => {
+const StdcmOperationalPoint = ({
+  location,
+  pathStepId,
+  disabled,
+  onItineraryChange,
+}: StdcmOperationalPointProps) => {
   const { t } = useTranslation('stdcm');
   const dispatch = useAppDispatch();
 
@@ -106,6 +112,7 @@ const StdcmOperationalPoint = ({ location, pathStepId, disabled }: StdcmOperatio
 
   const handleCiSelect = async (selectedSuggestion?: CIOption) => {
     dispatch(updateStdcmPathStep({ id: pathStepId, updates: { location: selectedSuggestion } }));
+    onItineraryChange();
     if (selectedSuggestion) {
       const operationalPointParts = await searchOperationalPointsByTrigram(
         selectedSuggestion.trigram
@@ -131,6 +138,7 @@ const StdcmOperationalPoint = ({ location, pathStepId, disabled }: StdcmOperatio
           },
         })
       );
+      onItineraryChange();
     }
   };
 

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOrigin.tsx
@@ -7,9 +7,9 @@ import { getStdcmOrigin } from 'reducers/osrdconf/stdcmConf/selectors';
 import StdcmCard from './StdcmCard';
 import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmOpSchedule from './StdcmOpSchedule';
-import type { StdcmConfigCardProps } from '../../types';
+import type { StdcmItineraryProps } from '../../types';
 
-const StdcmOrigin = ({ disabled = false }: StdcmConfigCardProps) => {
+const StdcmOrigin = ({ disabled = false, onItineraryChange }: StdcmItineraryProps) => {
   const { t } = useTranslation('stdcm');
 
   const origin = useSelector(getStdcmOrigin);
@@ -26,6 +26,7 @@ const StdcmOrigin = ({ disabled = false }: StdcmConfigCardProps) => {
         location={origin.location}
         pathStepId={origin.id}
         disabled={disabled}
+        onItineraryChange={onItineraryChange}
       />
       <StdcmOpSchedule pathStep={origin} disabled={disabled} opId="origin-arrival" isOrigin />
     </StdcmCard>

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmVias.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useMemo, useState } from 'react';
 
 import { Location } from '@osrd-project/ui-icons';
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -16,9 +17,13 @@ import StdcmOperationalPoint from './StdcmOperationalPoint';
 import StdcmStopType from './StdcmStopType';
 import StopDurationInput from './StopDurationInput';
 import { StdcmStopTypes } from '../../types';
-import type { StdcmConfigCardProps } from '../../types';
+import type { StdcmItineraryProps } from '../../types';
 
-const StdcmVias = ({ disabled = false }: StdcmConfigCardProps) => {
+type StdcmViasProps = StdcmItineraryProps & {
+  skipAnimation: boolean;
+};
+
+const StdcmVias = ({ disabled = false, skipAnimation, onItineraryChange }: StdcmViasProps) => {
   const { t } = useTranslation('stdcm');
   const dispatch = useAppDispatch();
   const pathSteps = useSelector(getStdcmPathSteps);
@@ -89,11 +94,13 @@ const StdcmVias = ({ disabled = false }: StdcmConfigCardProps) => {
 
   const deleteViaOnClick = (pathStepId: string) => {
     dispatch(deleteStdcmVia(pathStepId));
+    onItineraryChange();
   };
 
   const addViaOnClick = (pathStepIndex: number) => {
     dispatch(addStdcmVia(pathStepIndex));
     setNewIntermediateOpIndex(pathStepIndex);
+    onItineraryChange();
   };
 
   return (
@@ -102,7 +109,12 @@ const StdcmVias = ({ disabled = false }: StdcmConfigCardProps) => {
         if (!pathStep.isVia) return null;
         const pathStepIndex = index + 1;
         return (
-          <div className="stdcm-vias-bundle" key={pathStep.id}>
+          <div
+            className={cx('stdcm-vias-bundle', {
+              animated: pathStepIndex === newIntermediateOpIndex && !skipAnimation,
+            })}
+            key={pathStep.id}
+          >
             <StdcmDefaultCard
               hasTip
               text={t('trainPath.addVia')}
@@ -135,6 +147,7 @@ const StdcmVias = ({ disabled = false }: StdcmConfigCardProps) => {
                 location={pathStep.location}
                 pathStepId={pathStep.id}
                 disabled={disabled}
+                onItineraryChange={onItineraryChange}
               />
               <StdcmStopType
                 stopTypes={pathStep.stopType}

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -45,7 +45,6 @@ const StcdmResults = ({
   showStatusBanner,
 }: StcdmResultsProps) => {
   const infraId = useInfraID();
-
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const { stdcmName } = useDeploymentSettings();
 
@@ -89,103 +88,107 @@ const StcdmResults = ({
         onSelectSimulation={onSelectSimulation}
         retainedSimulationIndex={retainedSimulationIndex}
       />
-      <div className="simulation-results">
-        {hasSimulationResults && !hasConflictResults ? (
-          <div className="results-and-sheet">
-            <StcdmResultsTable
-              stdcmData={outputs.results}
-              consist={selectedSimulation.inputs.consist}
-              isSimulationRetained={isSelectedSimulationRetained}
-              operationalPointsList={operationalPointsList}
-              simulationIndex={selectedSimulation.index}
-            />
-            {isSelectedSimulationRetained && (
-              <div className="get-simulation">
-                <div className="download-simulation">
-                  <PDFDownloadLink
-                    document={
-                      <SimulationReportSheet
-                        stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
-                        stdcmData={outputs.results}
-                        consist={selectedSimulation.inputs.consist}
-                        simulationReportSheetNumber={simulationReportSheetNumber}
-                        operationalPointsList={operationalPointsList}
-                      />
-                    }
-                    fileName={`${stdcmName}-${simulationReportSheetNumber}.pdf`}
-                  >
+      {outputs && (
+        <>
+          <div className="simulation-results">
+            {hasSimulationResults && !hasConflictResults ? (
+              <div className="results-and-sheet">
+                <StcdmResultsTable
+                  stdcmData={outputs.results}
+                  consist={selectedSimulation.inputs.consist}
+                  isSimulationRetained={isSelectedSimulationRetained}
+                  operationalPointsList={operationalPointsList}
+                  simulationIndex={selectedSimulation.index}
+                />
+                {isSelectedSimulationRetained && (
+                  <div className="get-simulation">
+                    <div className="download-simulation">
+                      <PDFDownloadLink
+                        document={
+                          <SimulationReportSheet
+                            stdcmLinkedTrains={selectedSimulation.inputs.linkedTrains}
+                            stdcmData={outputs.results}
+                            consist={selectedSimulation.inputs.consist}
+                            simulationReportSheetNumber={simulationReportSheetNumber}
+                            operationalPointsList={operationalPointsList}
+                          />
+                        }
+                        fileName={`${stdcmName}-${simulationReportSheetNumber}.pdf`}
+                      >
+                        <Button
+                          data-testid="download-simulation-button"
+                          label={t('downloadSimulationSheet')}
+                          onClick={() => {}}
+                        />
+                      </PDFDownloadLink>
+                    </div>
+                    <div className="gesico-text">{t('gesicoRequest')}</div>
+                  </div>
+                )}
+                {retainedSimulationIndex !== undefined && buttonsVisible && (
+                  <div className="start-new-query">
                     <Button
-                      data-testid="download-simulation-button"
-                      label={t('downloadSimulationSheet')}
-                      onClick={() => {}}
+                      data-testid="start-new-query-button"
+                      variant="Primary"
+                      label={t('startNewQuery')}
+                      onClick={onStartNewQuery}
                     />
-                  </PDFDownloadLink>
-                </div>
-                <div className="gesico-text">{t('gesicoRequest')}</div>
+                    <Button
+                      className="start-new-query-with-data"
+                      data-testid="start-new-query-with-data-button"
+                      variant="Normal"
+                      label={t('startNewQueryFromCurrent')}
+                      onClick={onStartNewQueryWithData}
+                    />
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="simulation-failure">
+                <span className="title">{t('notFound')}</span>
+                <span className="change-criteria">{t('conflictsTitle')}</span>
+
+                {trackConflicts.length > 0 && (
+                  <ul>
+                    {trackConflicts.map((message, index) => (
+                      <li key={index}>
+                        <span>
+                          <Trans>&bull; {message}</Trans>
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {trackConflicts.length > 0 && workConflicts.length > 0 && <br />}
+
+                {workConflicts.length > 0 && (
+                  <ul>
+                    {workConflicts.map((message, index) => (
+                      <li key={index}>
+                        <span>
+                          <Trans>&bull; {message}</Trans>
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <span>{t('changeSearchCriteria')}</span>
               </div>
             )}
-            {retainedSimulationIndex !== undefined && buttonsVisible && (
-              <div className="start-new-query">
-                <Button
-                  data-testid="start-new-query-button"
-                  variant="Primary"
-                  label={t('startNewQuery')}
-                  onClick={onStartNewQuery}
-                />
-                <Button
-                  className="start-new-query-with-data"
-                  data-testid="start-new-query-with-data-button"
-                  variant="Normal"
-                  label={t('startNewQueryFromCurrent')}
-                  onClick={onStartNewQueryWithData}
-                />
-              </div>
-            )}
+            <div className="osrd-config-item-container osrd-config-item-container-map map-results">
+              <DefaultBaseMap
+                mapId="stdcm-map-result"
+                infraId={infraId}
+                geometry={outputs?.pathProperties?.geometry}
+                pathStepMarkers={markersInfo}
+                isFeasible={!hasConflictResults}
+              />
+            </div>
           </div>
-        ) : (
-          <div className="simulation-failure">
-            <span className="title">{t('notFound')}</span>
-            <span className="change-criteria">{t('conflictsTitle')}</span>
-
-            {trackConflicts.length > 0 && (
-              <ul>
-                {trackConflicts.map((message, index) => (
-                  <li key={index}>
-                    <span>
-                      <Trans>&bull; {message}</Trans>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {trackConflicts.length > 0 && workConflicts.length > 0 && <br />}
-
-            {workConflicts.length > 0 && (
-              <ul>
-                {workConflicts.map((message, index) => (
-                  <li key={index}>
-                    <span>
-                      <Trans>&bull; {message}</Trans>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <span>{t('changeSearchCriteria')}</span>
-          </div>
-        )}
-        <div className="osrd-config-item-container osrd-config-item-container-map map-results">
-          <DefaultBaseMap
-            mapId="stdcm-map-result"
-            infraId={infraId}
-            geometry={outputs?.pathProperties?.geometry}
-            pathStepMarkers={markersInfo}
-            isFeasible={!hasConflictResults}
-          />
-        </div>
-      </div>
-      {isDebugMode && <StdcmDebugResults simulationOutputs={outputs} />}
+          {isDebugMode && <StdcmDebugResults simulationOutputs={outputs} />}
+        </>
+      )}
     </>
   );
 };

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmSimulationNavigator.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmSimulationNavigator.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 
 import useHorizontalScroll from 'applications/stdcm/hooks/useHorizontalScroll';
 import { hasConflicts, hasResults } from 'applications/stdcm/utils/simulationOutputUtils';
-import { getStdcmSimulations } from 'reducers/osrdconf/stdcmConf/selectors';
+import { getStdcmCompletedSimulations } from 'reducers/osrdconf/stdcmConf/selectors';
 import { formatDateToString, formatTimeDifference } from 'utils/date';
 import { mmToKm } from 'utils/physics';
 
@@ -29,7 +29,7 @@ const StdcmSimulationNavigator = ({
 }: StdcmSimulationNavigatorProps) => {
   const { t } = useTranslation();
 
-  const simulationsList = useSelector(getStdcmSimulations);
+  const completedSimulations = useSelector(getStdcmCompletedSimulations);
 
   const { scrollableRef, showLeftBtn, showRightBtn, scrollLeft, scrollRight } = useHorizontalScroll(
     SIMULATION_ITEM_CLASSNAME,
@@ -42,91 +42,95 @@ const StdcmSimulationNavigator = ({
         'with-error-status': showStatusBanner && isCalculationFailed,
       })}
     >
-      <div className="simulation-list-wrapper">
-        {showLeftBtn && (
-          <div
-            className="scroll-btn left"
-            role="button"
-            tabIndex={0}
-            aria-label="Scroll left"
-            onClick={scrollLeft}
-          >
-            <ChevronLeft size="lg" />
-          </div>
-        )}
-        <div className="simulation-list" ref={scrollableRef}>
-          {simulationsList.map(({ index, creationDate, outputs }) => {
-            let formatedTotalLength = '';
-            let formatedTripDuration = '';
-
-            if (hasResults(outputs)) {
-              const { results } = outputs;
-              const lastPointTime = results.simulation.final_output.times.at(-1)!;
-              const departureTimeInMs = new Date(results.departure_time).getTime();
-
-              formatedTotalLength = `${Math.round(mmToKm(results.path.length))} ${t('common.units.km', { ns: 'translation' })} `;
-              formatedTripDuration = formatTimeDifference(
-                departureTimeInMs,
-                lastPointTime + departureTimeInMs
-              );
-            }
-
-            return (
+      {completedSimulations.length > 0 && (
+        <>
+          <div className="simulation-list-wrapper">
+            {showLeftBtn && (
               <div
+                className="scroll-btn left"
                 role="button"
                 tabIndex={0}
-                key={index}
-                className={cx(SIMULATION_ITEM_CLASSNAME, {
-                  retained: retainedSimulationIndex === index,
-                  selected: selectedSimulationIndex === index,
-                  anyRetained: retainedSimulationIndex !== undefined,
-                })}
-                onClick={() => onSelectSimulation(index)}
+                aria-label="Scroll left"
+                onClick={scrollLeft}
               >
-                <div className="simulation-name">
-                  <span>
-                    {outputs && !hasConflicts(outputs)
-                      ? t('simulation.results.simulationName.withOutputs', {
-                          id: index + 1,
-                          ns: 'stdcm',
-                        })
-                      : t('simulation.results.simulationName.withoutOutputs', {
+                <ChevronLeft size="lg" />
+              </div>
+            )}
+            <div className="simulation-list" ref={scrollableRef}>
+              {completedSimulations.map(({ index, creationDate, outputs }) => {
+                let formatedTotalLength = '';
+                let formatedTripDuration = '';
+
+                if (hasResults(outputs)) {
+                  const { results } = outputs;
+                  const lastPointTime = results.simulation.final_output.times.at(-1)!;
+                  const departureTimeInMs = new Date(results.departure_time).getTime();
+
+                  formatedTotalLength = `${Math.round(mmToKm(results.path.length))} ${t('common.units.km', { ns: 'translation' })} `;
+                  formatedTripDuration = formatTimeDifference(
+                    departureTimeInMs,
+                    lastPointTime + departureTimeInMs
+                  );
+                }
+
+                return (
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    key={index}
+                    className={cx(SIMULATION_ITEM_CLASSNAME, {
+                      retained: retainedSimulationIndex === index,
+                      selected: selectedSimulationIndex === index,
+                      anyRetained: retainedSimulationIndex !== undefined,
+                    })}
+                    onClick={() => onSelectSimulation(index)}
+                  >
+                    <div className="simulation-name">
+                      <span>
+                        {outputs && !hasConflicts(outputs)
+                          ? t('simulation.results.simulationName.withOutputs', {
+                              id: index + 1,
+                              ns: 'stdcm',
+                            })
+                          : t('simulation.results.simulationName.withoutOutputs', {
+                              ns: 'stdcm',
+                            })}
+                      </span>
+                      {retainedSimulationIndex === index && (
+                        <CheckCircle className="check-circle" variant="fill" />
+                      )}
+                    </div>
+                    <div className="simulation-metadata" key={index}>
+                      <span className="creation-date">
+                        {t('simulation.results.formatCreationDate', {
+                          ...formatDateToString(creationDate, true),
                           ns: 'stdcm',
                         })}
-                  </span>
-                  {retainedSimulationIndex === index && (
-                    <CheckCircle className="check-circle" variant="fill" />
-                  )}
-                </div>
-                <div className="simulation-metadata" key={index}>
-                  <span className="creation-date">
-                    {t('simulation.results.formatCreationDate', {
-                      ...formatDateToString(creationDate, true),
-                      ns: 'stdcm',
-                    })}
-                  </span>
-                  <span className="total-length-trip-duration">{`${formatedTotalLength}— ${formatedTripDuration}`}</span>
-                </div>
-                {selectedSimulationIndex === index && (
-                  <div className="selected-simulation-indicator" />
-                )}
+                      </span>
+                      <span className="total-length-trip-duration">{`${formatedTotalLength}— ${formatedTripDuration}`}</span>
+                    </div>
+                    {selectedSimulationIndex === index && (
+                      <div className="selected-simulation-indicator" />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            {showRightBtn && (
+              <div
+                className="scroll-btn right"
+                role="button"
+                tabIndex={0}
+                aria-label="Scroll right"
+                onClick={scrollRight}
+              >
+                <ChevronRight size="lg" />
               </div>
-            );
-          })}
-        </div>
-        {showRightBtn && (
-          <div
-            className="scroll-btn right"
-            role="button"
-            tabIndex={0}
-            aria-label="Scroll right"
-            onClick={scrollRight}
-          >
-            <ChevronRight size="lg" />
+            )}
           </div>
-        )}
-      </div>
-      <div className="separator" />
+          <div className="separator" />
+        </>
+      )}
     </div>
   );
 };

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -159,12 +159,17 @@ export type StdcmSimulation = {
   outputs?: StdcmSimulationOutputs;
 };
 
-/** This type is used for StdcmConsist, StdcmOrigin, StdcmDestination and StdcmVias components */
+/** This type is used for StdcmConsist component */
 export type StdcmConfigCardProps = {
   disabled?: boolean;
   consistErrors?: ConsistErrors;
   isDebugMode?: boolean;
 };
+
+/* This type is used for StdcmOrigin, StdcmDestination and StdcmVias component */
+export type StdcmItineraryProps = {
+  onItineraryChange: () => void;
+} & StdcmConfigCardProps;
 
 export enum ArrivalTimeTypes {
   PRECISE_TIME = 'preciseTime',

--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -1,18 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, useLayoutEffect } from 'react';
 
 import { isEqual, isNil } from 'lodash';
 import { useSelector } from 'react-redux';
 
 import useStdcm from 'applications/stdcm/hooks/useStdcm';
 import { LoaderFill } from 'common/Loaders';
-import {
-  addNewStdcmResult,
-  selectSimulation,
-  updateLastStdcmResult,
-} from 'reducers/osrdconf/stdcmConf';
+import { selectSimulation, updateLastStdcmResult } from 'reducers/osrdconf/stdcmConf';
 import {
   getRetainedSimulationIndex,
   getSelectedSimulationIndex,
+  getStdcmCompletedSimulations,
   getStdcmConf,
   getStdcmSimulations,
 } from 'reducers/osrdconf/stdcmConf/selectors';
@@ -33,6 +30,7 @@ const StdcmView = () => {
   const currentSimulationInputs = useStdcmForm();
   const stdcmConf = useSelector(getStdcmConf);
   const simulationsList = useSelector(getStdcmSimulations);
+  const completedSimulations = useSelector(getStdcmCompletedSimulations);
   const selectedSimulationIndex = useSelector(getSelectedSimulationIndex);
   const retainedSimulationIndex = useSelector(getRetainedSimulationIndex);
 
@@ -41,6 +39,10 @@ const StdcmView = () => {
   const [isDebugMode, setIsDebugMode] = useState(false);
   const [showHelpModule, setShowHelpModule] = useState(false);
   const [buttonsVisible, setButtonsVisible] = useState(true);
+  const [skipPathfindingStatusMessage, setSkipPathfindingStatusMessage] = useState(false);
+
+  const resultSectionRef = useRef<HTMLDivElement | null>(null);
+  const previousResultSectionOffsetRef = useRef<number | null>(null);
 
   const {
     launchStdcmRequest,
@@ -62,7 +64,12 @@ const StdcmView = () => {
 
   const handleSelectSimulation = (index: number) => {
     if (retainedSimulationIndex === undefined) {
+      if (resultSectionRef.current) {
+        previousResultSectionOffsetRef.current =
+          resultSectionRef.current.getBoundingClientRect().top;
+      }
       dispatch(selectSimulation(index));
+      setSkipPathfindingStatusMessage(true);
       setShowBtnToLaunchSimulation(false);
     }
   };
@@ -102,7 +109,7 @@ const StdcmView = () => {
       selectedSimulationIndex === undefined ||
         !isEqual(currentSimulationInputs, simulationsList[selectedSimulationIndex].inputs)
     );
-  }, [currentSimulationInputs]);
+  }, [currentSimulationInputs, selectedSimulationIndex]);
 
   useEffect(() => {
     if (isPending) {
@@ -129,20 +136,13 @@ const StdcmView = () => {
      * listed in the simulations list. This helps us determine whether to add a new simulation or update
      * the existing one.
      */
-    const lastSimulation = simulationsList.at(simulationsList.length - 1);
-    const isSimulationAlreadyListed = isEqual(lastSimulation?.inputs, currentSimulationInputs);
-    const isSimulationOutputsComplete = stdcmResults?.stdcmResponse ?? hasConflicts;
+    const lastSimulation = simulationsList.at(-1);
+    const isSimulationOutputsComplete = stdcmResults?.stdcmResponse || hasConflicts;
 
-    if (isSimulationOutputsComplete) {
-      const newSimulation = {
-        ...(isSimulationAlreadyListed
-          ? { ...lastSimulation }
-          : {
-              index: simulationsList.length,
-              creationDate: new Date(),
-              inputs: currentSimulationInputs,
-            }),
-        ...(pathProperties && {
+    if (lastSimulation && isSimulationOutputsComplete && pathProperties) {
+      dispatch(
+        updateLastStdcmResult({
+          ...lastSimulation,
           outputs: {
             pathProperties,
             ...(stdcmResults?.stdcmResponse &&
@@ -154,14 +154,9 @@ const StdcmView = () => {
               conflicts: stdcmTrainConflicts,
             }),
           },
-        }),
-      };
+        } as StdcmSimulation)
+      );
 
-      if (isSimulationAlreadyListed) {
-        dispatch(updateLastStdcmResult(newSimulation as StdcmSimulation));
-      } else {
-        dispatch(addNewStdcmResult(newSimulation as StdcmSimulation));
-      }
       setShowStatusBanner(true);
     }
   }, [
@@ -176,6 +171,20 @@ const StdcmView = () => {
       setShowStatusBanner(true);
     }
   }, [isRejected]);
+
+  /*
+   * After the new content is rendered, this effect adjusts the scroll to compensate for any shift in the stdcmResult section.
+   * It compares the stdcmResult section position before the change (stored in previousResultSectionOffsetRef)
+   * with its current position after rendering. The calculated difference is used to perform a window.scrollBy,
+   *  ensuring that the section remains at the same relative position in the viewport, thus avoiding any visual jump.
+   */
+  useLayoutEffect(() => {
+    if (resultSectionRef.current && previousResultSectionOffsetRef.current) {
+      const newOffset = resultSectionRef.current.getBoundingClientRect().top;
+      const diff = newOffset - previousResultSectionOffsetRef.current;
+      window.scrollBy({ top: diff, behavior: 'auto' });
+    }
+  }, [selectedSimulationIndex]);
 
   // If we've got an error during the loading of the stdcm env which is not the "no config error" message,
   // we let the error boundary manage it
@@ -199,14 +208,16 @@ const StdcmView = () => {
             isDebugMode={isDebugMode}
             showBtnToLaunchSimulation={showBtnToLaunchSimulation}
             retainedSimulationIndex={retainedSimulationIndex}
+            skipPathfindingStatusMessage={skipPathfindingStatusMessage}
+            setSkipPathfindingStatusMessage={setSkipPathfindingStatusMessage}
             launchStdcmRequest={launchStdcmRequest}
             cancelStdcmRequest={cancelStdcmRequest}
           />
 
           {showStatusBanner && <StdcmStatusBanner isFailed={isCalculationFailed} />}
 
-          {simulationsList.length && (
-            <div className="stdcm-results">
+          {completedSimulations.length > 0 && (
+            <div ref={resultSectionRef} className="stdcm-results">
               <StdcmResults
                 isCalculationFailed={isCalculationFailed}
                 isDebugMode={isDebugMode}

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -8,6 +8,7 @@ import {
   type ExtremityPathStepType,
   type StdcmLinkedTrainExtremity,
   type StdcmSimulation,
+  type StdcmSimulationInputs,
 } from 'applications/stdcm/types';
 import { defaultCommonConf, buildCommonConfReducers } from 'reducers/osrdconf/osrdConfCommon';
 import type { OsrdStdcmConfState, StdcmPathStep } from 'reducers/osrdconf/types';
@@ -47,6 +48,19 @@ export const stdcmConfInitialState: OsrdStdcmConfState = {
     posteriorTrain: undefined,
   },
   simulations: [],
+};
+
+const updateSimulationState = (state: Draft<OsrdStdcmConfState>, simulation: StdcmSimulation) => {
+  const {
+    inputs: { consist, pathSteps },
+  } = simulation;
+  state.rollingStockID = consist?.tractionEngine?.id;
+  state.towedRollingStockID = consist?.towedRollingStock?.id;
+  state.totalLength = consist?.totalLength;
+  state.totalMass = consist?.totalMass;
+  state.maxSpeed = consist?.maxSpeed;
+  state.speedLimitByTag = consist?.speedLimitByTag;
+  state.stdcmPathSteps = pathSteps;
 };
 
 export const stdcmConfSlice = createSlice({
@@ -232,10 +246,15 @@ export const stdcmConfSlice = createSlice({
       );
       state.stdcmPathSteps = newPathSteps;
     },
-    // temporary solution to add a new simulation, only 1 action should remain after the refactoring
-    addNewStdcmResult(state: Draft<OsrdStdcmConfState>, action: PayloadAction<StdcmSimulation>) {
-      state.simulations.push(action.payload);
-      state.selectedSimulationIndex = state.simulations.length - 1;
+    addStdcmSimulation(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<StdcmSimulationInputs>
+    ) {
+      state.simulations.push({
+        index: state.simulations.length,
+        inputs: action.payload,
+        creationDate: new Date(),
+      });
     },
     updateLastStdcmResult(
       state: Draft<OsrdStdcmConfState>,
@@ -247,20 +266,11 @@ export const stdcmConfSlice = createSlice({
         action.payload
       );
       state.selectedSimulationIndex = state.simulations.length - 1;
+      updateSimulationState(state, action.payload);
     },
     selectSimulation(state: Draft<OsrdStdcmConfState>, action: PayloadAction<number>) {
       state.selectedSimulationIndex = action.payload;
-
-      const {
-        inputs: { consist, pathSteps },
-      } = state.simulations[action.payload];
-      state.rollingStockID = consist?.tractionEngine?.id;
-      state.towedRollingStockID = consist?.towedRollingStock?.id;
-      state.totalLength = consist?.totalLength;
-      state.totalMass = consist?.totalMass;
-      state.maxSpeed = consist?.maxSpeed;
-      state.speedLimitByTag = consist?.speedLimitByTag;
-      state.stdcmPathSteps = pathSteps;
+      updateSimulationState(state, state.simulations[action.payload]);
     },
     retainSimulation(state: Draft<OsrdStdcmConfState>, action: PayloadAction<number>) {
       state.retainedSimulationIndex = action.payload;
@@ -285,10 +295,10 @@ export const {
   addStdcmVia,
   deleteStdcmVia,
   updateLinkedTrainExtremity,
-  addNewStdcmResult,
   updateLastStdcmResult,
   selectSimulation,
   retainSimulation,
+  addStdcmSimulation,
 } = stdcmConfSlice.actions;
 
 export type StdcmConfSlice = typeof stdcmConfSlice;

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -32,6 +32,10 @@ const buildStdcmConfSelectors = () => {
     }
   );
 
+  const getStdcmCompletedSimulations = createSelector([getStdcmSimulations], (simulations) =>
+    simulations.filter((simulation) => simulation.outputs)
+  );
+
   return {
     ...commonConfSelectors,
     getStdcmConf,
@@ -62,6 +66,7 @@ const buildStdcmConfSelectors = () => {
     getLinkedTrains: makeOsrdConfSelector('linkedTrains'),
 
     getStdcmSimulations,
+    getStdcmCompletedSimulations,
     getSelectedSimulationIndex,
     getSelectedSimulation,
     getRetainedSimulationIndex: makeOsrdConfSelector('retainedSimulationIndex'),
@@ -83,6 +88,7 @@ export const {
   getStdcmDestination,
   getLinkedTrains,
   getStdcmSimulations,
+  getStdcmCompletedSimulations,
   getSelectedSimulationIndex,
   getSelectedSimulation,
   getRetainedSimulationIndex,

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { ArrivalTimeTypes, StdcmStopTypes } from 'applications/stdcm/types';
+import {
+  ArrivalTimeTypes,
+  StdcmStopTypes,
+  type LinkedTrains,
+  type StdcmSimulation,
+} from 'applications/stdcm/types';
 import {
   stdcmConfInitialState,
   stdcmConfSlice,
@@ -14,9 +19,9 @@ import {
   updateTotalLength,
   updateTotalMass,
   updateTowedRollingStockID,
-  addNewStdcmResult,
   retainSimulation,
   selectSimulation,
+  addStdcmSimulation,
 } from 'reducers/osrdconf/stdcmConf';
 import type { OsrdStdcmConfState, StandardAllowance, StdcmPathStep } from 'reducers/osrdconf/types';
 import { createStoreWithoutMiddleware } from 'store';
@@ -42,6 +47,22 @@ function stdcmConfTestDataBuilder() {
       value,
       type: 'time',
     }),
+    buildLinkedTrains(value?: Partial<LinkedTrains>): LinkedTrains {
+      return {
+        anteriorTrain: {
+          date: '2025-02-06',
+          time: '12:00',
+          trainName: 'anterior train',
+          ...value?.anteriorTrain,
+        },
+        posteriorTrain: {
+          date: '2025-02-08',
+          time: '12:00',
+          trainName: 'posterior train',
+          ...value?.posteriorTrain,
+        },
+      };
+    },
   };
 }
 
@@ -201,35 +222,32 @@ describe('stdcmConfReducers', () => {
   });
 
   describe('StdcmResults updates', () => {
-    const simulation = {
-      index: 0,
-      creationDate: new Date(),
-      inputs: {
-        pathSteps: stdcmPathSteps,
-        linkedTrains: { anteriorTrain: undefined, posteriorTrain: undefined },
+    const simulationInputs = {
+      pathSteps: stdcmPathSteps,
+      linkedTrains: { anteriorTrain: undefined, posteriorTrain: undefined },
+      consist: {
+        totalMass: 100,
+        totalLength: 50,
+        maxSpeed: 25,
+        speedLimitByTag: 'new-tag',
       },
     };
 
-    it('should handle adding new simulations', () => {
+    const simulation = {
+      index: 0,
+      creationDate: new Date(),
+      inputs: simulationInputs,
+    };
+
+    it('should add a new simulation', () => {
       const store = createStore();
       const { simulations } = store.getState()[stdcmConfSlice.name];
       expect(simulations.length).toBe(0);
 
-      store.dispatch(addNewStdcmResult(simulation));
-      let state = store.getState()[stdcmConfSlice.name];
+      store.dispatch(addStdcmSimulation(simulationInputs));
+      const state = store.getState()[stdcmConfSlice.name];
       expect(state.simulations.length).toEqual(1);
-      expect(state.simulations.at(0)).toEqual(simulation);
-
-      const newSimulation = {
-        ...simulation,
-        index: 1,
-      };
-
-      store.dispatch(addNewStdcmResult(newSimulation));
-      state = store.getState()[stdcmConfSlice.name];
-      expect(state.simulations.length).toEqual(2);
-      expect(state.simulations.at(0)).toEqual(simulation);
-      expect(state.simulations.at(1)).toEqual(newSimulation);
+      expect(state.simulations.at(0)!.inputs).toEqual(simulationInputs);
     });
 
     it('should handle updating last simulation', () => {
@@ -237,15 +255,29 @@ describe('stdcmConfReducers', () => {
       const { simulations } = store.getState()[stdcmConfSlice.name];
       expect(simulations.length).toBe(1);
 
-      const newSimulation = {
+      const newSimulation: StdcmSimulation = {
         ...simulation,
-        index: 1,
+        inputs: {
+          ...simulation.inputs,
+          consist: {
+            totalMass: 75,
+            totalLength: 20,
+            maxSpeed: 10,
+            speedLimitByTag: 'new-tag',
+          },
+        },
       };
 
       store.dispatch(updateLastStdcmResult(newSimulation));
       const state = store.getState()[stdcmConfSlice.name];
       expect(state.simulations.length).toEqual(1);
       expect(state.simulations.at(0)).toEqual(newSimulation);
+      expect(state.selectedSimulationIndex).toEqual(0);
+      expect(state.totalLength).toEqual(newSimulation.inputs.consist!.totalLength);
+      expect(state.totalMass).toEqual(newSimulation.inputs.consist!.totalMass);
+      expect(state.maxSpeed).toEqual(newSimulation.inputs.consist!.maxSpeed);
+      expect(state.speedLimitByTag).toEqual(newSimulation.inputs.consist!.speedLimitByTag);
+      expect(state.stdcmPathSteps).toEqual(newSimulation.inputs.pathSteps);
     });
 
     it('should handle selecting a simulation', () => {
@@ -253,6 +285,11 @@ describe('stdcmConfReducers', () => {
       store.dispatch(selectSimulation(0));
       const state = store.getState()[stdcmConfSlice.name];
       expect(state.selectedSimulationIndex).toEqual(0);
+      expect(state.totalLength).toEqual(simulation.inputs.consist.totalLength);
+      expect(state.totalMass).toEqual(simulation.inputs.consist.totalMass);
+      expect(state.maxSpeed).toEqual(simulation.inputs.consist.maxSpeed);
+      expect(state.speedLimitByTag).toEqual(simulation.inputs.consist.speedLimitByTag);
+      expect(state.stdcmPathSteps).toEqual(simulation.inputs.pathSteps);
     });
 
     it('should handle retaining a simulation', () => {

--- a/front/src/styles/scss/applications/stdcm/_home.scss
+++ b/front/src/styles/scss/applications/stdcm/_home.scss
@@ -107,7 +107,9 @@
         }
 
         .stdcm-vias-bundle {
-          animation: bouncin-in 0.75s cubic-bezier(0.567, -0.475, 0, 1);
+          &.animated {
+            animation: bouncin-in 0.75s cubic-bezier(0.567, -0.475, 0, 1);
+          }
 
           .stdcm-card {
             scroll-margin-bottom: 15px;
@@ -299,6 +301,7 @@
       }
 
       .pathfinding-status {
+        z-index: 1;
         left: -8px;
         position: absolute;
         bottom: -95px;


### PR DESCRIPTION
closes #10480 
When a different simulation is selected while a calculation is still running, the new simulation’s inputs overwrite the inputs of the ongoing calculation. This causes a mismatch between the inputs used for the calculation and the results.
