### PR TITLE
core: fix typo in initFixedPoints, with unit test

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/PostProcessingSimulation.kt
@@ -216,7 +216,7 @@ private fun initFixedPoints(
             val engineeringAllowanceStart = prevEdgeLength - engineeringAllowanceLength
             // Edges can have overlapping engineering allowance, only the last one is relevant.
             // So we remove any point in the current allowance range.
-            res.removeIf { it.offset.distance > engineeringAllowanceStart && it.stopTime != null }
+            res.removeIf { it.offset.distance > engineeringAllowanceStart && it.stopTime == null }
 
             addFixedPointAvoidingDuplicates(prevEdgeLength)
             addFixedPointAvoidingDuplicates(engineeringAllowanceStart)

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -404,6 +404,58 @@ class EngineeringAllowanceTests {
         Assertions.assertNull(res)
     }
 
+    @Test
+    fun testOverwrittenEngineeringAllowance() {
+        /*
+        a --> b --> c --> d --> e --> f
+
+        space
+          ^                    end
+        f |###################### /
+          |#################x####/
+        e |#############  _/    /
+          |#############_/   __/
+        d |           _/  __/
+          |         _/ __/
+        c |       _/__/
+          |     _/_/
+        b |   _/
+          |  /#######################
+        a |_/_#######################> time
+
+        First engineering allowance to avoid the conflict at d->e,
+        which is then overwritten by the allowance to avoid the
+        conflict at e->f
+
+         */
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b", 1000.meters),
+                infra.addBlock("b", "c", 50_000.meters),
+                infra.addBlock("c", "d", 20_000.meters),
+                infra.addBlock("d", "e", 1000.meters),
+                infra.addBlock("e", "f", 1000.meters),
+            )
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                blocks[0],
+                OccupancySegment(600.0, Double.POSITIVE_INFINITY, 0.meters, 1000.meters),
+                blocks[3],
+                OccupancySegment(0.0, 2900.0, 0.meters, 1000.meters),
+                blocks[4],
+                OccupancySegment(0.0, 3000.0, 0.meters, 1000.meters),
+            )
+        STDCMPathfindingBuilder()
+            .setInfra(infra.fullInfra())
+            .setStartLocations(setOf(EdgeLocation(blocks[0], Offset(0.meters))))
+            .setEndLocations(setOf(EdgeLocation(blocks[4], Offset(1000.meters))))
+            .setUnavailableTimes(occupancyGraph)
+            .setMaxDepartureDelay(Double.POSITIVE_INFINITY)
+            .setMaxRunTime(Double.POSITIVE_INFINITY)
+            .run()!!
+    }
+
     /** Test that we return the fastest path even if there are some engineering allowances */
     @Test
     fun testReturnTheFastestPathWithAllowance() {


### PR DESCRIPTION
While trying to reproduce the bug seen in https://github.com/OpenRailAssociation/osrd/pull/10488, I ended up with a unit test that failed, which led me to this typo (introduced in the previous PR)