### PR TITLE
OpenFGA client crate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -517,31 +517,6 @@ jobs:
     name: Check editoast tests
     needs:
       - build
-
-    services:
-      postgres:
-        image: postgis/postgis
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      valkey:
-        image: valkey/valkey
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "valkey-cli ping"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -558,13 +533,21 @@ jobs:
         run: |
           docker load --input ./osrd-editoast-test.tar
 
+      - name: Startup the test infrastructure
+        id: start_editoast_tests_infra
+        run: |
+          set -e
+
+          services='valkey openfga'
+          composes='-f docker-compose.yml'
+          docker compose $composes pull --policy missing $services
+          docker compose $composes up --no-build -d $services
+        env:
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+
       - name: Execute tests within container
         run: |
-          docker run --rm --net=host \
-            -v $PWD/docker/init_db.sql:/init_db.sql \
-            postgis/postgis:latest \
-            psql postgresql://postgres:password@localhost:5432 -f /init_db.sql
-
           # snapshot testing library `insta` requires CI=true
           docker run --name=editoast-test --net=host -v $PWD/output:/output \
             -e DATABASE_URL="postgres://osrd:password@localhost:5432/osrd" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,32 @@ services:
       interval: 5s
       retries: 20
 
+  openfga-migrate:
+    depends_on:
+      postgres: { condition: service_healthy }
+    image: openfga/openfga:latest
+    container_name: osrd-openfga-migrate
+    command: migrate
+    environment:
+      OPENFGA_DATASTORE_ENGINE: "postgres"
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5432/osrd?search_path=openfga"
+
+  openfga:
+    depends_on:
+      openfga-migrate:
+        condition: service_completed_successfully
+    image: openfga/openfga:latest
+    container_name: osrd-openfga
+    environment:
+      OPENFGA_DATASTORE_ENGINE: "postgres"
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5432/osrd?search_path=openfga"
+      OPENFGA_HTTP_ADDR: "0.0.0.0:8091"
+      OPENFGA_PLAYGROUND_PORT: 8092
+    command: run
+    ports:
+      - "8091:8091" # http
+      - "8092:8092" # playground
+
   rabbitmq:
     image: rabbitmq:4-management
     container_name: osrd-rabbitmq

--- a/docker/docker-compose.host.yml
+++ b/docker/docker-compose.host.yml
@@ -9,6 +9,18 @@ services:
     ports: !reset []
     network_mode: host
 
+  openfga-migrate:
+    ports: !reset []
+    network_mode: host
+    environment:
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@localhost:5432/osrd?search_path=openfga"
+
+  openfga:
+    ports: !reset []
+    network_mode: host
+    environment:
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@localhost:5432/osrd?search_path=openfga"
+
   editoast:
     ports: !reset []
     network_mode: host

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -119,10 +119,10 @@ services:
       valkey: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
     restart: unless-stopped
-    ports: [ "8091:8091" ]
+    ports: [ "8089:8089" ]
     environment:
-      EDITOAST_PORT: 8091
-      ROOT_URL: "http://localhost:8091"
+      EDITOAST_PORT: 8089
+      ROOT_URL: "http://osrd-editoast-pr-tests:8089"
       VALKEY_URL: "redis://valkey:6380"
       DATABASE_URL: "postgres://osrd:password@postgres:5433/osrd"
       TELEMETRY_KIND: "opentelemetry"
@@ -134,7 +134,7 @@ services:
       - -c
       - "diesel migration run && exec editoast runserver"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8091/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8089/health" ]
       start_period: 4s
       interval: 5s
       retries: 6

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -54,6 +54,31 @@ services:
     networks:
       - pr-tests
 
+  openfga-migrate:
+    image: openfga/openfga:latest
+    container_name: osrd-openfga-migrate-pr-tests
+    command: migrate
+    environment:
+      OPENFGA_DATASTORE_ENGINE: "postgres"
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5433/osrd?search_path=openfga"
+    networks:
+      - pr-tests
+
+  openfga:
+    image: openfga/openfga:latest
+    container_name: osrd-openfga-pr-tests
+    environment:
+      OPENFGA_DATASTORE_ENGINE: "postgres"
+      OPENFGA_DATASTORE_URI: "postgres://osrd:password@postgres:5433/osrd?search_path=openfga"
+      OPENFGA_HTTP_ADDR: "0.0.0.0:8191"
+      OPENFGA_PLAYGROUND_PORT: 8192
+    command: run
+    ports:
+      - "8191:8191" # http
+      - "8192:8192" # playground
+    networks:
+      - pr-tests
+
   rabbitmq:
     image: rabbitmq:4-management
     container_name: osrd-rabbitmq-pr-tests

--- a/docker/gateway.pr-tests.simple.toml
+++ b/docker/gateway.pr-tests.simple.toml
@@ -20,7 +20,7 @@ redirect_404_to_index = true
 [[targets]]
 tracing_name = "editoast"
 prefix = "/api"
-upstream = "http://osrd-editoast-pr-tests:8091"
+upstream = "http://editoast:8089"
 require_auth = true
 
 [[targets]]

--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -6,6 +6,9 @@ create database template_osrd WITH IS_TEMPLATE true;
 -- Connect to template_osrd
 \c template_osrd
 
+-- Create openfga schema
+create schema openfga;
+
 -- Enable required extensions
 create extension postgis;
 create extension pg_trgm;
@@ -13,6 +16,8 @@ create extension unaccent;
 
 -- Grant privileges to user
 grant all privileges on schema public to osrd;
+grant all privileges on schema openfga to osrd;
+
 
 -- Create osrd database using template_osrd
 create database osrd TEMPLATE template_osrd;

--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -865,7 +865,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1150,6 +1150,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1620,6 +1640,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fga"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "fga_derive",
+ "futures 0.3.31",
+ "futures-util",
+ "itertools",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "stdext",
+ "tempfile",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "fga_derive"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2161,7 +2211,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4436,6 +4486,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdext"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af28eeb7c18ac2dbdb255d40bee63f203120e1db6b0024b177746ebec7049c1"
 
 [[package]]
 name = "stringprep"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -13,6 +13,8 @@ members = [
   "editoast_osrdyne_client",
   "editoast_schemas",
   "editoast_search",
+  "fga",
+  "fga_derive",
   "osm_to_railjson",
 ]
 
@@ -27,6 +29,7 @@ license = "LGPL-3.0"
 [workspace.dependencies]
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+darling = "0.20"
 derivative = "2.2.0"
 diesel = { version = "2.2", default-features = false, features = [
   "32-column-tables",
@@ -66,9 +69,12 @@ paste = "1.0.15"
 postgis_diesel = { version = "2.4.1", features = ["serde"] }
 postgres-openssl = "0.5.1"
 pretty_assertions = "1.4.1"
+proc-macro2 = "1.0"
+quote = "1.0"
 rand = "0.9.0"
 rangemap = "1.5.1"
 regex = "1.11"
+syn = "2.0"
 # 0.12.0 to 0.12.4 have weird timeout issues https://github.com/seanmonstar/reqwest/issues/2283
 # This bug was introduced between 0.12.0 and 0.12.3.
 reqwest = { version = "0.11.27", features = ["json"] }

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -40,6 +40,16 @@ RUN rustup component add llvm-tools && \
     rustup component add rustfmt && \
     rustup component add clippy && \
     cargo install grcov
+
+# install `fga` binary used in `crate fga` unit tests
+RUN mkdir install \
+    && cd install \
+    && wget https://github.com/openfga/cli/releases/download/v0.6.4/fga_0.6.4_linux_amd64.tar.gz \
+    && tar xf fga_0.6.4_linux_amd64.tar.gz \
+    && mv fga /usr/local/bin \
+    && cd .. \
+    && rm -rf install
+
 COPY --from=planner /editoast/recipe.json recipe.json
 COPY --from=planner /editoast/editoast_derive/ editoast_derive
 COPY --from=test_data . /tests/data

--- a/editoast/editoast_derive/Cargo.toml
+++ b/editoast/editoast_derive/Cargo.toml
@@ -7,12 +7,12 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-darling = "0.20"
+darling.workspace = true
 paste.workspace = true
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2.workspace = true
+quote.workspace = true
 serde_json.workspace = true
-syn = "2.0"
+syn.workspace = true
 
 [lib]
 proc-macro = true

--- a/editoast/fga/Cargo.toml
+++ b/editoast/fga/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fga"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+fga_derive = { path = "../fga_derive" }
+futures.workspace = true
+futures-util.workspace = true
+itertools.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+derive_more = { version = "2.0.1", features = ["from"] }
+stdext = "0.3.3"
+tracing-subscriber.workspace = true

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -1,0 +1,1005 @@
+mod authorization_models;
+mod queries;
+mod stores;
+mod tuples;
+
+pub use authorization_models::AuthorizationModel;
+pub use authorization_models::StoreAuthorizationModel;
+use itertools::Either;
+use queries::RawUser;
+use queries::UserFilter;
+pub use stores::Store;
+
+use tracing::Instrument;
+use tuples::RawTuple;
+
+use std::future::Future;
+use std::future::{self};
+
+use futures::stream;
+use futures::TryStreamExt as _;
+use itertools::Itertools as _;
+
+use crate::model::AsUser;
+use crate::model::Check;
+use crate::model::Object;
+use crate::model::ParsingError;
+use crate::model::QueryObjects;
+use crate::model::QueryUsers;
+use crate::model::QueryUsersets;
+use crate::model::Relation;
+use crate::model::Tuple;
+use crate::model::Type;
+use crate::model::User;
+use crate::model::Wildcard;
+
+const OPENFGA_WRITES_MAX_TUPLES: usize = 100;
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    store: Store,
+    authorization_model_id: Option<String>,
+    settings: ConnectionSettings,
+    inner: reqwest::Client,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionSettings {
+    address: String,
+    port: u16,
+
+    /// Whether to reset the store on initialization
+    ///
+    /// This parameter is only relevant when using [Client::try_new_store].
+    ///
+    /// It's useful if a store is created for each unit tests and the store name is the same
+    /// for each run. (This typically occurs if the stores are named according to the test name.)
+    reset_store: bool,
+}
+
+impl ConnectionSettings {
+    pub fn new(address: String, port: u16) -> Self {
+        Self {
+            address,
+            port,
+            reset_store: false,
+        }
+    }
+
+    pub fn reset_store(mut self) -> Self {
+        self.reset_store = true;
+        self
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Consistency {
+    MinimizeLatency,
+    HigherConsistency,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP request to OpenFGA failed: {0}")]
+pub struct RequestFailure(#[source] reqwest::Error);
+
+#[derive(Debug, thiserror::Error)]
+pub enum InitializationError {
+    #[error("Store not found: {0}")]
+    NotFound(String),
+    #[error(transparent)]
+    Request(#[from] RequestFailure),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Too many tuples provided ({provided_count}): hard limit set to {max}")]
+pub struct TooManyTuples {
+    max: usize,
+    provided_count: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    #[error(transparent)]
+    Parsing(#[from] ParsingError),
+    #[error(transparent)]
+    Request(#[from] RequestFailure),
+}
+
+impl From<reqwest::Error> for RequestFailure {
+    fn from(error: reqwest::Error) -> Self {
+        #[cfg(any(debug_assertions, test))]
+        let err = RequestFailure(error);
+        #[cfg(all(not(debug_assertions), not(test)))]
+        let err = RequestFailure(error.without_url());
+        err
+    }
+}
+
+// Public API of the client
+// -------------------------
+
+impl Client {
+    #[tracing::instrument(err)]
+    pub async fn try_with_store(
+        store_name: String,
+        settings: ConnectionSettings,
+    ) -> Result<Self, InitializationError> {
+        let mut client = Self {
+            store: Store::default(),
+            authorization_model_id: None,
+            settings,
+            inner: reqwest::Client::new(),
+        };
+
+        client.store = client
+            .find_store(&store_name)
+            .await?
+            .ok_or_else(|| InitializationError::NotFound(store_name))?;
+        client.actualize_authorization_model().await?;
+
+        Ok(client)
+    }
+
+    #[tracing::instrument(err)]
+    pub async fn try_new_store(
+        store_name: String,
+        settings: ConnectionSettings,
+    ) -> Result<Client, InitializationError> {
+        let mut client = Self {
+            store: Store::default(),
+            authorization_model_id: None,
+            settings,
+            inner: reqwest::Client::new(),
+        };
+        if client.settings.reset_store {
+            if let Some(store) = client.find_store(&store_name).await? {
+                tracing::debug!(old = ?store, "removing old store for reset");
+                client.delete_stores(&store.id).await?;
+            }
+        }
+        client.store = client.post_stores(&store_name).await?;
+        Ok(client)
+    }
+
+    pub fn stores(&self) -> impl stream::TryStream<Ok = Store, Error = RequestFailure> + '_ {
+        Continuation::stream(move |continuation| {
+            async move {
+                let (stores, continuation_str) =
+                    self.get_stores(None, continuation.as_option()).await?;
+                Ok((stores, Continuation::from(continuation_str)))
+            }
+            .in_current_span()
+        })
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub async fn find_store(&self, store_name: &str) -> Result<Option<Store>, RequestFailure> {
+        let stream = self
+            .stores()
+            .try_filter(|Store { name, .. }| future::ready(name == store_name));
+        futures::pin_mut!(stream);
+        let store = stream.try_next().await?.into_iter().last();
+        Ok(store)
+    }
+
+    pub fn authorization_models(
+        &self,
+    ) -> impl stream::TryStream<Ok = StoreAuthorizationModel, Error = RequestFailure> + '_ {
+        Continuation::stream(move |continuation| {
+            async move {
+                let (models, continuation_str) = self
+                    .get_stores_authorization_models(&self.store.id, None, continuation.as_option())
+                    .await?;
+                Ok((models, Continuation::from(continuation_str)))
+            }
+            .in_current_span()
+        })
+    }
+
+    pub async fn latest_authorization_model(
+        &self,
+    ) -> Result<Option<StoreAuthorizationModel>, RequestFailure> {
+        let models = &mut self
+            .get_stores_authorization_models(&self.store.id, Some(1), None)
+            .await?
+            .0;
+        debug_assert!(models.len() <= 1);
+        Ok(models.pop())
+    }
+
+    /// Fetches the latest authorization model ID and instructs the [Client] to use it for future API calls
+    ///
+    /// For API calls that use an authorization model, OpenFGA strongly recommends providing an authorization
+    /// model ID so that they don't have to infer it. It helps to improve performance.
+    /// This function is called automatically when a new [Client] is created with [Client::try_with_store].
+    ///
+    /// Note that the [Client] may still not have an authorization model ID configured after calling this function
+    /// if the [Client]'s store doesn't have any authorization model yet.
+    #[tracing::instrument(skip(self), err)]
+    pub async fn actualize_authorization_model(&mut self) -> Result<(), RequestFailure> {
+        self.authorization_model_id = self
+            .latest_authorization_model()
+            .await?
+            .map(|model| model.id);
+        tracing::debug!(
+            id = self.authorization_model_id,
+            "set client authorization model ID"
+        );
+        Ok(())
+    }
+
+    /// Pushes a new authorization model into OpenFGA and configures the client to use it from now on
+    pub async fn update_authorization_model(
+        &mut self,
+        authorization_model: &AuthorizationModel,
+    ) -> Result<String, RequestFailure> {
+        let model_id = self
+            .post_stores_authorization_models(&self.store.id, authorization_model)
+            .await?;
+        self.actualize_authorization_model().await?;
+        Ok(model_id)
+    }
+
+    /// Writes up to 100 tuples in OpenFGA
+    ///
+    /// If the tuple slice is more than 100 elements, an error will be returned.
+    /// If you want them to be chunked into several requests, or if your tuples cannot
+    /// be monomorphized into a single type, use [Client::prepare_writes] instead.
+    pub async fn write_tuples<'a, R: Relation, U: AsUser<User = R::User>>(
+        &self,
+        tuples: &[Tuple<'a, R, U>],
+    ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
+        if tuples.len() > OPENFGA_WRITES_MAX_TUPLES {
+            return Err(Either::Right(TooManyTuples {
+                max: OPENFGA_WRITES_MAX_TUPLES,
+                provided_count: tuples.len(),
+            }));
+        }
+        self.post_stores_write(
+            &self.store.id,
+            &tuples.into_iter().map_into().collect::<Vec<_>>(),
+            &[],
+            self.authorization_model_id.clone(),
+        )
+        .await
+        .map_err(Either::Left)
+    }
+
+    /// Prepares multiple write requests to OpenFGA
+    ///
+    /// OpenFGA Writes API do not accept more than 100 tuples per request.
+    /// The [PreparedWrites] type returned by this function accepts any number
+    /// of tuples through [PreparedWrites::push] and will chunk them into
+    /// requests of 100 tuples each. The requests are sent concurrently when
+    /// [PreparedWrites::execute] is called.
+    ///
+    /// Beware that the tuples injected into [PreparedWrites] cannot be accessed
+    /// after a [PreparedWrites::push]. So any form of post-processing is impossible.
+    /// Likewise, once a [Tuple] is injected into [PreparedWrites], all its typing information
+    /// is lost.
+    pub fn prepare_writes(&self) -> PreparedWrites<'_> {
+        PreparedWrites {
+            writes: Vec::new(),
+            client: self,
+        }
+    }
+
+    pub async fn check<'a, R: Relation>(
+        &self,
+        Check { user, object }: Check<'a, R>,
+    ) -> Result<bool, RequestFailure> {
+        self.post_stores_check(
+            &self.store.id,
+            RawTuple {
+                user: User::fga_user(user),
+                relation: R::NAME.to_string(),
+                object: object.fga_object(),
+            },
+            None,
+            self.authorization_model_id.clone(),
+        )
+        .await
+    }
+
+    pub async fn list_objects<'a, R: Relation, U: AsUser<User = R::User>>(
+        &self,
+        QueryObjects(user, _): QueryObjects<'a, R, U>,
+    ) -> Result<Vec<R::Object>, QueryError> {
+        let objects = self
+            .post_stores_list_objects(
+                &self.store.id,
+                <R::Object as crate::model::Type>::NAMESPACE,
+                R::NAME,
+                &user.fga_user(),
+                None,
+                None,
+            )
+            .await?
+            .into_iter()
+            .map(|ident| R::Object::parse_fga_object(&ident))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(objects)
+    }
+
+    /// Lists the users related to a given object
+    ///
+    /// In case of an heterogeneous relation, only the users of the type represented
+    /// by `R::User` will be returned. The type-bound public access for `R::User` (if any)
+    /// will also be returned.
+    ///
+    /// If you want to query the usersets related to the object instead, use `Client::query_usersets`.
+    pub async fn list_users<'a, R: Relation>(
+        &self,
+        QueryUsers(object): QueryUsers<'a, R>,
+    ) -> Result<UserList<R::User>, RequestFailure> {
+        let raw_users = self
+            .post_stores_list_users(
+                &self.store.id,
+                (<R::Object as crate::model::Type>::NAMESPACE, object.id()),
+                R::NAME,
+                UserFilter::User {
+                    r#type: <R::User as crate::model::Type>::NAMESPACE,
+                },
+                None,
+                self.authorization_model_id.as_ref().map(String::as_str),
+                None,
+            )
+            .await?;
+        Ok({
+            let mut users = Vec::with_capacity(raw_users.len());
+            let mut public_access = None;
+            for raw_user in raw_users {
+                match raw_user {
+                    RawUser::Object { r#type, id } => {
+                        debug_assert_eq!(r#type.as_str(), R::User::NAMESPACE);
+                        let user = R::User::from(id.to_owned());
+                        users.push(user);
+                    }
+                    RawUser::Wildcard { r#type } => {
+                        debug_assert_eq!(r#type.as_str(), R::User::NAMESPACE);
+                        public_access = Some(Wildcard(std::marker::PhantomData));
+                    }
+                    RawUser::UserSet { .. } => {
+                        unreachable!("OpenFGA cannot return usersets when `user_filter` is configured like above")
+                    }
+                }
+            }
+            UserList {
+                users,
+                public_access,
+            }
+        })
+    }
+
+    /// Lists the objects forming a userset which has a relation to a given object
+    ///
+    /// ```
+    /// # include!("doctest_setup.rs");
+    /// # use fga::fga;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let mut client = fga::client::Client::try_new_store("doctest_list_usersets".to_owned(), settings()).await.unwrap();
+    /// # client.update_authorization_model(&fga::compile_model(include_str!("../tests/doctest.fga"))).await.unwrap();
+    /// // define can_read: reader or writer
+    /// client.prepare_writes()
+    ///     .push(&fga!(Document:"budget"#reader@Group:"friends"#member))
+    ///     .push(&fga!(Document:"budget"#writer@Group:"bosses"#member))
+    ///     .execute()
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let groups = client
+    ///     // "I want the Groups which members can_read the Document 'budget'"
+    ///     .list_usersets(Document::can_read().query_usersets(Group::member(), &fga!(Document:"budget")))
+    ///     .await
+    ///     .unwrap();
+    /// assert!(groups.contains(&fga!(Group:"friends")));
+    /// assert!(groups.contains(&fga!(Group:"bosses")));
+    /// # }
+    pub async fn list_usersets<'a, R: Relation, S: Relation>(
+        &self,
+        QueryUsersets(object, _): QueryUsersets<'a, R, S>,
+    ) -> Result<Vec<S::Object>, RequestFailure> {
+        let users = self
+            .post_stores_list_users(
+                &self.store.id,
+                (<R::Object as crate::model::Type>::NAMESPACE, object.id()),
+                R::NAME,
+                UserFilter::UserSet {
+                    r#type: <S::Object as crate::model::Type>::NAMESPACE,
+                    relation: S::NAME,
+                },
+                None,
+                self.authorization_model_id.as_ref().map(String::as_str),
+                None,
+            )
+            .await?;
+        Ok(users
+            .into_iter()
+            .map(|user| match user {
+                RawUser::UserSet { r#type, id, relation } => {
+                    debug_assert_eq!(r#type.as_str(), S::Object::NAMESPACE);
+                    debug_assert_eq!(relation.as_str(), S::NAME);
+                    S::Object::from(id)
+                }
+                _ => {
+                    unreachable!("OpenFGA cannot return anything other than usersets when the `user_filter` is configured like above");
+                }
+            })
+            .collect_vec())
+    }
+}
+
+/// Result of a [Client::list_users] query
+pub struct UserList<U: User> {
+    /// The list of users related to an object
+    pub users: Vec<U>,
+    /// Whether the object has a user type `U` type-bound public access
+    pub public_access: Option<Wildcard<U>>,
+}
+
+pub struct PreparedWrites<'a> {
+    writes: Vec<RawTuple>,
+    client: &'a Client,
+}
+
+impl PreparedWrites<'_> {
+    pub fn push<'a, R: Relation, U: AsUser<User = R::User>>(
+        mut self,
+        tuple: &Tuple<'_, R, U>,
+    ) -> Self {
+        self.writes.push(RawTuple::from(tuple));
+        self
+    }
+
+    /// Concurrently sends write requests to OpenFGA in 100-tuple chunks
+    ///
+    /// /!\ WARNING /!\ No transactional state is set up, so should any request fail,
+    /// the tuples written by other successful requests will remain in OpenFGA.
+    /// This function also returns at the first failing request, so OpenFGA may still
+    /// write some tuples **after** this function exits.
+    pub async fn execute(self) -> Result<(), RequestFailure> {
+        let futs = self
+            .writes
+            .chunks(100)
+            .map(|chunk| {
+                self.client
+                    .post_stores_write(
+                        &self.client.store.id,
+                        chunk,
+                        &[],
+                        self.client.authorization_model_id.clone(),
+                    )
+                    .in_current_span()
+            })
+            .collect_vec();
+        futures::future::try_join_all(futs).await?;
+        Ok(())
+    }
+}
+
+// Mapping of OpenFGA HTTP API
+// ---------------------------
+//
+// Client functions are implemented for each OpenFGA endpoint. The implementations are
+// scattered across different sub-modules, which are defined according to the sections
+// of the OpenFGA API documentation: https://openfga.dev/api/service
+
+impl Client {
+    fn base_url(&self) -> url::Url {
+        url::Url::parse(
+            format!("http://{}:{}/", self.settings.address, self.settings.port).as_str(),
+        )
+        .unwrap()
+    }
+}
+
+/// Convenience trait to query OpenFGA from [crate::model] query types directly
+///
+/// For example:
+///
+/// ```no_run
+/// # include!("doctest_setup.rs");
+/// # fga::relations! { Document { relation: Person }}
+/// # type Object = Document;
+/// # #[tokio::main]
+/// # async fn main() {
+/// # let user = Person("bob".to_owned());
+/// # let object = Document("topsecret".to_owned());
+/// # let client = todo!();
+/// # use fga::client::Request as _;
+/// Object::relation().check(&user, &object).fetch(&client).await.unwrap();
+/// // instead of
+/// client.check(Object::relation().check(&user, &object)).await.unwrap();
+/// # }
+/// ```
+pub trait Request {
+    type Response;
+    type Error: std::error::Error;
+
+    fn fetch(
+        self,
+        client: &Client,
+    ) -> impl future::Future<Output = Result<Self::Response, Self::Error>>;
+}
+
+impl<R: Relation> Request for Check<'_, R> {
+    type Response = bool;
+
+    type Error = RequestFailure;
+
+    async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
+        client.check(self).await
+    }
+}
+
+impl<R, U> Request for QueryObjects<'_, R, U>
+where
+    R: Relation,
+    U: AsUser<User = R::User>,
+{
+    type Response = Vec<R::Object>;
+
+    type Error = QueryError;
+
+    async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
+        client.list_objects(self).await
+    }
+}
+
+impl<R: Relation> Request for QueryUsers<'_, R> {
+    type Response = UserList<R::User>;
+
+    type Error = RequestFailure;
+
+    async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
+        client.list_users(self).await
+    }
+}
+
+impl<R: Relation, S: Relation> Request for QueryUsersets<'_, R, S> {
+    type Response = Vec<S::Object>;
+
+    type Error = RequestFailure;
+
+    async fn fetch(self, client: &Client) -> Result<Self::Response, Self::Error> {
+        client.list_usersets(self).await
+    }
+}
+
+/// Models the three states of a continuation while unfolding paginated API calls
+enum Continuation {
+    /// Initial state, no calls have been made yet
+    None,
+    /// A call response has provided a continuation token
+    Continue(String),
+    /// A call response has provided no continuation token (an empty string) meaning that the pagination ends there
+    Stop,
+}
+
+impl Continuation {
+    fn as_option(&self) -> Option<&str> {
+        match self {
+            Continuation::None | Continuation::Stop => None,
+            Continuation::Continue(continuation) => Some(continuation.as_str()),
+        }
+    }
+}
+
+impl From<String> for Continuation {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            Continuation::Stop
+        } else {
+            Continuation::Continue(s)
+        }
+    }
+}
+
+impl Continuation {
+    /// Unfolds a continuation-based paginated API call into a stream of items
+    ///
+    /// ```ignore
+    /// # internal API, cannot be doc tested
+    /// #
+    /// fn api_call(shift: u64, cont: Option<String>) -> (Vec<u64>, String) {
+    ///     let Some(page) = cont.and_then(|s| s.parse::<u64>().ok()) else {
+    ///         return (vec![shift], "1".to_string());
+    ///     };
+    ///     if page < 3 {
+    ///         (
+    ///             (1..(page + 1)).map(|x| x + shift).collect(),
+    ///             (page + 1).to_string(),
+    ///         )
+    ///     } else {
+    ///         (vec![], "".to_string())
+    ///     }
+    /// }
+    ///
+    /// let stream = Continuation::stream(
+    ///     move |continuation| async move {
+    ///         let (items, continuation_str) = api_call(shift, continuation);
+    ///         Ok((
+    ///             items,
+    ///             Continuation::from(continuation_str),
+    ///         ))
+    ///     },
+    /// );
+    /// assert_eq!(
+    ///     stream.try_collect::<Vec<_>>().await.unwrap(),
+    ///     vec![0, 11, 21, 22]
+    /// );
+    /// ```
+    ///
+    // TODO: rewrite that using async closures once rust 1.85 lands :pepoparty:
+    fn stream<F, Fut, T>(f: F) -> impl stream::TryStream<Ok = T, Error = RequestFailure>
+    where
+        F: Fn(Continuation) -> Fut + Copy,
+        Fut: Future<Output = Result<(Vec<T>, Continuation), RequestFailure>>,
+    {
+        let stream = stream::try_unfold(Continuation::None, move |continuation| {
+            Box::pin(async move {
+                if let Continuation::Stop = continuation {
+                    return Ok::<_, RequestFailure>(None);
+                }
+                let (items, continuation) = f(continuation).await?;
+                Ok(Some((items, Continuation::from(continuation))))
+            })
+        });
+
+        stream
+            .map_ok(|items| stream::iter(items.into_iter().map(Ok)))
+            .try_flatten()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::client::Client;
+    use crate::client::InitializationError;
+    use crate::client::Request as _;
+    use crate::compile_model;
+    use crate::defs::*;
+    use crate::fga;
+    use crate::model::Check;
+    use crate::model::Relation;
+
+    fn setup_tracing() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .without_time()
+            .pretty()
+            .try_init()
+            .ok();
+    }
+
+    macro_rules! test_client {
+        () => {
+            Client::try_new_store(
+                stdext::function_name!()
+                    .split("::")
+                    .filter(|x| *x != "{{closure}}")
+                    .collect::<Vec<_>>()
+                    .join("-"),
+                crate::connection_settings(),
+            )
+            .await
+            .expect("Failed to initialize client")
+        };
+    }
+
+    #[tokio::test]
+    async fn test_try_init_not_found() {
+        setup_tracing();
+        let result =
+            Client::try_with_store("nonexistent_store".to_owned(), crate::connection_settings())
+                .await;
+
+        match result {
+            Err(InitializationError::NotFound(store_name)) => {
+                assert_eq!(store_name, "nonexistent_store");
+            }
+            _ => panic!("Expected InitializationError::NotFound"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_store_with_reset() {
+        setup_tracing();
+        let client = test_client!();
+        assert_eq!(
+            client.store.name,
+            "fga-client-tests-create_store_with_reset"
+        );
+    }
+
+    impl Client {
+        // TODO: comment about tokio::test
+        #[track_caller]
+        fn assert_check<'a, R: Relation>(&self, check: Check<'a, R>) -> &Self {
+            let error = format!("{check:?} doesn't hold, WWWHHHHYYYYY???");
+            let ok = futures::executor::block_on(check.fetch(self)).unwrap();
+            assert!(ok, "{error}");
+            self
+        }
+
+        #[track_caller]
+        fn assert_check_not<'a, R: Relation>(&self, check: Check<'a, R>) -> &Self {
+            let error = format!("{check:?} does hold, it shouldn't tho");
+            let ok = futures::executor::block_on(check.fetch(self)).unwrap();
+            assert!(!ok, "{error}");
+            self
+        }
+    }
+
+    const MODEL: &'static str = include_str!("../tests/model.fga");
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn persisted_auth_model_id_in_client() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        assert_eq!(client.authorization_model_id, None);
+        let id = client.update_authorization_model(&model).await.unwrap();
+        assert_eq!(client.authorization_model_id, Some(id));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn check() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .write_tuples(&[fga!(Infra:"france"#reader@User:"bob")])
+            .await
+            .unwrap();
+
+        client
+            .assert_check(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")))
+            .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn higher_order_users() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .prepare_writes()
+            .push(&fga!(Infra:"france"#reader@User:"alice"))
+            .push(&fga!(Infra:"espagne"#reader@User:*))
+            .execute()
+            .await
+            .unwrap();
+
+        client
+            .assert_check(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
+            .assert_check_not(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")))
+            .assert_check(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"espagne")))
+            .assert_check(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"espagne")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_objects() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .write_tuples(&[
+                Infra::reader().tuple(&fga!(User:"alice"), &fga!(Infra:"france")),
+                Infra::reader().tuple(&fga!(User:"alice"), &fga!(Infra:"espagne")),
+            ])
+            .await
+            .unwrap();
+
+        let mut objects = client
+            .list_objects(Infra::can_read().query_objects(&fga!(User:"alice")))
+            .await
+            .unwrap();
+        objects.sort();
+        assert_eq!(objects, vec![fga!(Infra:"espagne"), fga!(Infra:"france")]);
+
+        let mut same_objects = Infra::can_read()
+            .query_objects(&fga!(User:"alice"))
+            .fetch(&client)
+            .await
+            .unwrap();
+        same_objects.sort();
+        assert_eq!(same_objects, objects);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_objects_unknown_user() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .write_tuples(&[
+                Infra::reader().tuple(&fga!(User:"alice"), &fga!(Infra:"france")),
+                Infra::reader().tuple(&fga!(User:"alice"), &fga!(Infra:"espagne")),
+            ])
+            .await
+            .unwrap();
+
+        // bob has no tuple, so OpenFGA doesn't know about him
+        let objects = client
+            .list_objects(Infra::can_read().query_objects(&fga!(User:"bob")))
+            .await
+            .unwrap();
+        assert!(objects.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_objects_higher_order_users() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .prepare_writes()
+            .push(&fga!(Infra:"france"#reader@User:"alice"))
+            .push(&fga!(Infra:"espagne"#reader@User:*))
+            .push(&fga!(Group:"les_petits_pedestres"#member@User:"alice"))
+            .push(&fga!(Infra:"allemagne"#reader@Group:"les_petits_pedestres"#member))
+            .execute()
+            .await
+            .unwrap();
+
+        let objects = client
+            .list_objects(Infra::can_read().query_objects(&fga!(User:*)))
+            .await
+            .unwrap();
+        assert_eq!(objects.as_slice(), &[fga!(Infra:"espagne")]);
+
+        let objects = client
+            .list_objects(Infra::can_read().query_objects(&fga!(User:"bob")))
+            .await
+            .unwrap();
+        assert_eq!(objects.as_slice(), &[fga!(Infra:"espagne")]);
+
+        let mut objects = client
+            .list_objects(Infra::can_read().query_objects(&fga!(User:"alice")))
+            .await
+            .unwrap();
+        objects.sort();
+        assert_eq!(
+            objects.as_slice(),
+            &[
+                fga!(Infra:"allemagne"),
+                fga!(Infra:"espagne"),
+                fga!(Infra:"france")
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_users() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .prepare_writes()
+            // direct accesses
+            .push(&fga!(Infra:"fr"#reader@User:"alice"))
+            .push(&fga!(Infra:"es"#writer@User:"alice"))
+            .push(&fga!(Infra:"es"#reader@User:"bob"))
+            .push(&fga!(Infra:"de"#reader@User:"alice"))
+            .push(&fga!(Infra:"de"#reader@User:*))
+            .push(&fga!(Infra:"sw"#reader@User:"patrick"))
+            // manager accesses
+            .push(&fga!(Infra:"fr"#reader@User:"alice"#manager))
+            .push(&fga!(Infra:"es"#writer@User:"alice"#manager))
+            .push(&fga!(Infra:"es"#reader@User:"bob"#manager))
+            .push(&fga!(Infra:"de"#reader@User:"alice"#manager))
+            .push(&fga!(Infra:"sw"#reader@User:"patrick"#manager))
+            // group accesses
+            .push(&fga!(Group:"company"#member@User:"patrick"))
+            .push(&fga!(User:"patrick"#group@Group:"company"))
+            .push(&fga!(Group:"company"#manager@User:"alice"))
+            .execute()
+            .await
+            .unwrap();
+
+        let fr_users = client
+            .list_users(Infra::can_read().query_users(&fga!(Infra:"fr")))
+            .await
+            .unwrap();
+        assert!(fr_users.public_access.is_none());
+        assert_eq!(fr_users.users, vec![fga!(User:"alice")]);
+
+        let mut es_users = client
+            .list_users(Infra::can_read().query_users(&fga!(Infra:"es")))
+            .await
+            .unwrap();
+        es_users.users.sort();
+        assert!(es_users.public_access.is_none());
+        assert_eq!(es_users.users, vec![fga!(User:"alice"), fga!(User:"bob")]);
+
+        let es_users = client
+            .list_users(Infra::can_write().query_users(&fga!(Infra:"es")))
+            .await
+            .unwrap();
+        assert!(es_users.public_access.is_none());
+        assert_eq!(es_users.users, vec![fga!(User:"alice")]);
+
+        let de_users = client
+            .list_users(Infra::can_read().query_users(&fga!(Infra:"de")))
+            .await
+            .unwrap();
+        assert!(de_users.public_access.is_some());
+        assert_eq!(de_users.users, vec![fga!(User:"alice")]);
+
+        let mut sw_users = client
+            .list_users(Infra::can_read().query_users(&fga!(Infra:"sw")))
+            .await
+            .unwrap();
+        sw_users.users.sort();
+        assert!(sw_users.public_access.is_none());
+        assert_eq!(
+            sw_users.users,
+            vec![fga!(User:"alice"), fga!(User:"patrick")]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn list_usersets() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .prepare_writes()
+            // direct accesses
+            .push(&fga!(Infra:"fr"#reader@User:"alice"))
+            // manager accesses
+            .push(&fga!(Infra:"fr"#reader@User:"alice"#manager))
+            // groups
+            .push(&fga!(Group:"company"#member@User:"patrick"))
+            .push(&fga!(User:"patrick"#group@Group:"company"))
+            .push(&fga!(Group:"company"#manager@User:"alice"))
+            .push(&fga!(Group:"competitor"#member@User:"bob"))
+            .push(&fga!(User:"bob"#group@Group:"competitor"))
+            // groups accesses
+            .push(&fga!(Infra:"fr"#reader@Group:"company"#member))
+            .push(&fga!(Infra:"fr"#writer@Group:"company"#manager))
+            .push(&fga!(Infra:"eu"#reader@Group:"company"#member))
+            .push(&fga!(Infra:"eu"#writer@Group:"competitor"#member))
+            .execute()
+            .await
+            .unwrap();
+
+        let groups = Infra::reader()
+            .query_usersets(Group::member(), &fga!(Infra:"fr"))
+            .fetch(&client)
+            .await
+            .unwrap();
+        assert_eq!(groups, vec![fga!(Group:"company")]);
+
+        let groups = Infra::writer()
+            .query_usersets(Group::member(), &fga!(Infra:"fr"))
+            .fetch(&client)
+            .await
+            .unwrap();
+        assert!(groups.is_empty());
+
+        let mut groups = Infra::can_read()
+            .query_usersets(Group::member(), &fga!(Infra:"eu"))
+            .fetch(&client)
+            .await
+            .unwrap();
+        groups.sort();
+        assert_eq!(
+            groups,
+            vec![fga!(Group:"company"), fga!(Group:"competitor")]
+        );
+    }
+}

--- a/editoast/fga/src/client/authorization_models.rs
+++ b/editoast/fga/src/client/authorization_models.rs
@@ -1,0 +1,77 @@
+use super::Client;
+use super::RequestFailure;
+
+pub type AuthorizationModel = serde_json::Value;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct StoreAuthorizationModel {
+    pub id: String,
+    pub type_definitions: AuthorizationModel,
+}
+
+impl Client {
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn get_stores_authorization_models(
+        &self,
+        store_id: &str,
+        page_size: Option<usize>,
+        continuation: Option<&str>,
+    ) -> Result<(Vec<StoreAuthorizationModel>, String), RequestFailure> {
+        #[derive(serde::Deserialize)]
+        struct Response {
+            authorization_models: Vec<StoreAuthorizationModel>,
+            #[serde(default)]
+            continuation_token: String,
+        }
+
+        let mut url = self
+            .base_url()
+            .join(format!("/stores/{store_id}/authorization-models").as_str())
+            .unwrap();
+        if let Some(continuation) = continuation {
+            url.query_pairs_mut()
+                .append_pair("continuation_token", continuation);
+        }
+        if let Some(page_size) = page_size {
+            url.query_pairs_mut()
+                .append_pair("page_size", page_size.to_string().as_str());
+        }
+
+        let response = self.inner.get(url).send().await?.error_for_status()?;
+        let Response {
+            authorization_models,
+            continuation_token,
+        } = response.json().await?;
+
+        Ok((authorization_models, continuation_token))
+    }
+
+    #[tracing::instrument(skip(self, authorization_model), ret(level = "debug"), err)]
+    pub(super) async fn post_stores_authorization_models(
+        &self,
+        store_id: &str,
+        authorization_model: &AuthorizationModel,
+    ) -> Result<String, RequestFailure> {
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/authorization-models").as_str())
+            .unwrap();
+        let response = self
+            .inner
+            .post(url)
+            .json(authorization_model)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            authorization_model_id: String,
+        }
+        let Response {
+            authorization_model_id,
+        } = response.json().await?;
+
+        Ok(authorization_model_id)
+    }
+}

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -1,0 +1,193 @@
+use crate::model::AsUser;
+use crate::model::Relation;
+use crate::model::Tuple;
+
+use super::Client;
+use super::Consistency;
+use super::RawTuple;
+use super::RequestFailure;
+
+#[derive(Debug, serde::Serialize)]
+pub(super) struct ContextualTuples {
+    tuple_keys: Vec<RawTuple>,
+}
+
+impl<'a, R: Relation, U: AsUser<User = R::User>> FromIterator<&'a Tuple<'a, R, U>>
+    for ContextualTuples
+{
+    fn from_iter<I: IntoIterator<Item = &'a Tuple<'a, R, U>>>(iter: I) -> Self {
+        Self {
+            tuple_keys: iter.into_iter().map(RawTuple::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(untagged)]
+pub(super) enum UserFilter<'a> {
+    User { r#type: &'a str },
+    UserSet { r#type: &'a str, relation: &'a str },
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum RawUser {
+    Object {
+        r#type: String,
+        id: String,
+    },
+    UserSet {
+        r#type: String,
+        id: String,
+        relation: String,
+    },
+    Wildcard {
+        r#type: String,
+    },
+}
+
+impl Client {
+    #[tracing::instrument(skip(self), ret(level = "debug") err)]
+    pub(super) async fn post_stores_check(
+        &self,
+        store_id: &str,
+        tuple: RawTuple,
+        contextual_tuples: Option<ContextualTuples>,
+        authorization_model_id: Option<String>,
+    ) -> Result<bool, RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request {
+            tuple_key: RawTuple,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            contextual_tuples: Option<ContextualTuples>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            authorization_model_id: Option<String>,
+        }
+
+        let request = Request {
+            tuple_key: tuple,
+            contextual_tuples,
+            authorization_model_id,
+        };
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/check").as_str())
+            .unwrap();
+        let response = self.inner.post(url).json(&request).send().await?;
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            allowed: bool,
+            #[expect(dead_code)]
+            resolution: String,
+        }
+
+        let Response { allowed, .. } = response.error_for_status()?.json::<Response>().await?;
+
+        Ok(allowed)
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn post_stores_list_objects(
+        &self,
+        store_id: &str,
+        type_: &str,
+        relation: &str,
+        user: &str,
+        contextual_tuples: Option<ContextualTuples>,
+        consistency: Option<Consistency>,
+    ) -> Result<Vec<String>, RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request {
+            #[serde(rename = "type")]
+            type_: String,
+            relation: String,
+            user: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            contextual_tuples: Option<ContextualTuples>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            consistency: Option<Consistency>,
+        }
+
+        let request = Request {
+            type_: type_.to_string(),
+            relation: relation.to_string(),
+            user: user.to_string(),
+            contextual_tuples,
+            consistency,
+        };
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/list-objects").as_str())
+            .unwrap();
+        let response = self.inner.post(url).json(&request).send().await?;
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            objects: Vec<String>,
+        }
+
+        let Response { objects } = response.error_for_status()?.json::<Response>().await?;
+
+        tracing::debug!(count = objects.len(), "objects found");
+        Ok(objects)
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn post_stores_list_users(
+        &self,
+        store_id: &str,
+        (object_type, object_id): (&str, &str),
+        relation: &str,
+        user_filter: UserFilter<'_>,
+        contextual_tuples: Option<ContextualTuples>,
+        authorization_model_id: Option<&str>,
+        consistency: Option<Consistency>,
+    ) -> Result<Vec<RawUser>, RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            authorization_model_id: Option<String>,
+            object: Object<'a>,
+            relation: String,
+            user_filters: Vec<UserFilter<'a>>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            contextual_tuples: Option<ContextualTuples>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            consistency: Option<Consistency>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct Object<'a> {
+            r#type: &'a str,
+            id: &'a str,
+        }
+
+        let request = Request {
+            authorization_model_id: authorization_model_id.map(String::from),
+            object: Object {
+                r#type: object_type,
+                id: object_id,
+            },
+            relation: relation.to_owned(),
+            user_filters: vec![user_filter],
+            contextual_tuples,
+            consistency,
+        };
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/list-users").as_str())
+            .unwrap();
+        let response = self.inner.post(url).json(&request).send().await?;
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            users: Vec<RawUser>,
+        }
+
+        let Response { users } = response.error_for_status()?.json().await?;
+        Ok(users)
+    }
+}

--- a/editoast/fga/src/client/stores.rs
+++ b/editoast/fga/src/client/stores.rs
@@ -1,0 +1,73 @@
+use super::Client;
+use super::RequestFailure;
+
+#[derive(Debug, Default, Clone, serde::Deserialize)]
+pub struct Store {
+    pub id: String,
+    pub name: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+impl Client {
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn get_stores(
+        &self,
+        page_size: Option<usize>,
+        continuation: Option<&str>,
+    ) -> Result<(Vec<Store>, String), RequestFailure> {
+        #[derive(serde::Deserialize)]
+        struct Response {
+            stores: Vec<Store>,
+            #[serde(default)]
+            continuation_token: String,
+        }
+
+        let mut url = self.base_url().join("stores").unwrap();
+        if let Some(continuation) = continuation {
+            url.query_pairs_mut()
+                .append_pair("continuation_token", continuation);
+        }
+        if let Some(page_size) = page_size {
+            url.query_pairs_mut()
+                .append_pair("page_size", page_size.to_string().as_str());
+        }
+        let response = self.inner.get(url).send().await?;
+
+        let Response {
+            stores,
+            continuation_token,
+        } = response.error_for_status()?.json::<Response>().await?;
+
+        Ok((stores, continuation_token))
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn post_stores(&self, name: &str) -> Result<Store, RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request {
+            name: String,
+        }
+
+        let request = Request {
+            name: name.to_owned(),
+        };
+
+        let url = self.base_url().join("stores").unwrap();
+        let response = self.inner.post(url).json(&request).send().await?;
+
+        let store = response.error_for_status()?.json().await?;
+        Ok(store)
+    }
+
+    #[tracing::instrument(skip(self), err)]
+    pub(super) async fn delete_stores(&self, store_id: &str) -> Result<(), RequestFailure> {
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}").as_str())
+            .unwrap();
+        self.inner.delete(url).send().await?.error_for_status()?;
+        Ok(())
+    }
+}

--- a/editoast/fga/src/client/tuples.rs
+++ b/editoast/fga/src/client/tuples.rs
@@ -1,0 +1,95 @@
+use crate::model::AsUser;
+use crate::model::Object as _;
+use crate::model::Relation;
+use crate::model::Tuple;
+
+use super::Client;
+use super::RequestFailure;
+
+#[derive(Debug, serde::Serialize)]
+pub(super) struct RawTuple {
+    pub(super) user: String,
+    pub(super) relation: String,
+    pub(super) object: String,
+}
+
+impl<'a, R: Relation, U: AsUser<User = R::User>> From<&Tuple<'a, R, U>> for RawTuple {
+    fn from(tuple: &Tuple<'a, R, U>) -> Self {
+        RawTuple {
+            user: tuple.user.fga_user(),
+            relation: R::NAME.to_string(),
+            object: tuple.object.fga_object(),
+        }
+    }
+}
+
+impl Client {
+    // It's fine to request tuples to be mapped into `RawTuple` as OpenFGA
+    // doesn't support more than 100 tuples in the request. So mapping 100 objects
+    // max is fine—we'll always be bounded by the network call.
+    #[tracing::instrument(skip(self, writes, deletes), err)]
+    pub(super) async fn post_stores_write<'a>(
+        &self,
+        store_id: &str,
+        writes: &[RawTuple],
+        deletes: &[RawTuple],
+        authorization_model_id: Option<String>,
+    ) -> Result<(), RequestFailure> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            #[serde(skip_serializing_if = "Writes::is_empty")]
+            writes: Writes<'a>,
+            #[serde(skip_serializing_if = "Deletes::is_empty")]
+            deletes: Deletes<'a>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            authorization_model_id: Option<String>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct Writes<'a> {
+            tuple_keys: &'a [RawTuple],
+        }
+
+        impl<'a> Writes<'a> {
+            fn is_empty(&self) -> bool {
+                self.tuple_keys.is_empty()
+            }
+        }
+
+        #[derive(serde::Serialize)]
+        struct Deletes<'a> {
+            tuple_keys: &'a [RawTuple],
+        }
+
+        impl<'a> Deletes<'a> {
+            fn is_empty(&self) -> bool {
+                self.tuple_keys.is_empty()
+            }
+        }
+
+        if writes.len() > 0 {
+            tracing::debug!(writes = writes.len(), "writing tuples");
+        }
+        if deletes.len() > 0 {
+            tracing::debug!(deletes = deletes.len(), "deleting tuples");
+        }
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/write").as_str())
+            .unwrap();
+        self.inner
+            .post(url)
+            .json(&Request {
+                writes: Writes { tuple_keys: writes },
+                deletes: Deletes {
+                    tuple_keys: deletes,
+                },
+                authorization_model_id,
+            })
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}

--- a/editoast/fga/src/doctest_setup.rs
+++ b/editoast/fga/src/doctest_setup.rs
@@ -1,0 +1,27 @@
+use fga::model::Relation as _;
+
+#[derive(Debug, PartialEq, Eq, fga::Type, fga::User, derive_more::From)]
+struct Person(String);
+
+#[derive(Debug, PartialEq, Eq, fga::Type, fga::User, fga::Object, derive_more::From)]
+struct Group(String);
+
+#[derive(Debug, PartialEq, Eq, fga::Type, fga::Object, derive_more::From)]
+struct Document(String);
+
+fga::relations! {
+    Group {
+        member: Person
+    },
+    Document {
+        reader: Person,
+        writer: Person,
+
+        can_read: Person,
+        can_write: Person
+    }
+}
+
+fn settings() -> fga::client::ConnectionSettings {
+    fga::client::ConnectionSettings::new("localhost".to_string(), 8091).reset_store()
+}

--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -1,0 +1,552 @@
+//! OpenFGA client library with type-safe types and relations
+//!
+//! # Content
+//!
+//! This library mainly provides two things:
+//!
+//! 1. A way to modelize OpenFGA objects and relations in a type-safe way. Types are regular Rust structures
+//!     and relations are any type implementing the trait [model::Relation]. Are also provided a few macros
+//!     to define and manipulate relations in a declarative way, close to OpenFGA syntax.
+//! 2. A [client::Client] allowing to interact with an OpenFGA server **over HTTP only**. It doesn't cover all the
+//!     OpenFGA API at the moment but the most common operations are implemented. This client supports the setup
+//!     of stores and authorization models, writing tuples, performing queries such as permission checks, and more.
+//!     The high-level API interfaces with the high-level modelization of OpenFGA objects and relations
+//!     available in this library through the [model] module.
+//!
+//! # High-level modelization of OpenFGA objects
+//!
+//! Available in the [model] module, this part of the library provides a way to modelize OpenFGA objects and
+//! relations in a type-safe way.
+//!
+//! OpenFGA types are any Rust type that can store an ID as a string, corresponding to the second part of
+//! OpenFGA identifiers such as `document:2021-budget`. If a type implements the [model::Object] trait, it can
+//! appear in the OBJECT part of an OpenFGA tuple. If it implements the [model::User] trait, it can appear
+//! in the USER part of an OpenFGA tuple. Both can be implemented for any given type.
+//!
+//! OpenFGA relations are any type implementing the [model::Relation] trait. Everything is set up using
+//! the associated types of this trait: [model::Relation::User] and [model::Relation::Object]. The trait
+//! provides default methods to use the relation in various ways, such as checking permissions, querying
+//! related objects, and more.
+//!
+//! To help with the definition of OpenFGA relations, this library provides a few macros to define relations.
+//! Derive macros [`User`] and [`Object`] are useful to define types, while [`relations!()`] helps generate
+//! the relations implementations for several types at once. Finally, the [`fga!()`] macro helps manipulating
+//! OpenFGA objects and tuples in a concise way, as having concise literals in tests is valuable.
+//!
+//! ## Minimal example
+//!
+//! As an example, lets consider the following simple OpenFGA authorization model:
+//!
+//! ```custom
+//! type person
+//!
+//! type document
+//!     relations
+//!         define reader: [person, person:*] # a document can be publicly available for consultation
+//!         define can_read: reader
+//! ```
+//!
+//! A definition of this model in Rust looks like this:
+//!
+//! ```rust
+//! // Types
+//! // -----------
+//!
+//! #[derive(Debug)]
+//! struct Person(String);
+//!
+//! // how a Person is identified in OpenFGA's space
+//! impl fga::model::Type for Person {
+//!     const NAMESPACE: &'static str = "person";
+//!
+//!     fn id(&self) -> &str {
+//!        self.0.as_str()
+//!     }
+//! }
+//!
+//! // marker trait indicating that a Person can appear at the USER part of an OpenFGA tuple
+//! impl fga::model::User for Person {}
+//!
+//! // needed to build back Persons from OpenFGA's responses (such as /list-users)
+//! impl From<String> for Person {
+//!     fn from(s: String) -> Self {
+//!         Self(s)
+//!     }
+//! }
+//!
+//! #[derive(Debug)]
+//! struct Document(String);
+//!
+//! // how a Document is identified in OpenFGA's space
+//! impl fga::model::Type for Document {
+//!     const NAMESPACE: &'static str = "document";
+//!
+//!     fn id(&self) -> &str {
+//!        self.0.as_str()
+//!     }
+//! }
+//!
+//! // marker trait indicating that a Document can appear at the OBJECT part of an OpenFGA tuple
+//! impl fga::model::Object for Document {}
+//!
+//! // needed to build back Documents from OpenFGA's responses (such as /list-objects)
+//! impl From<String> for Document {
+//!     fn from(s: String) -> Self {
+//!         Self(s)
+//!     }
+//! }
+//!
+//! // Relations
+//! // -----------
+//!
+//! #[derive(Debug)]
+//! struct DocumentReader;
+//!
+//! impl fga::model::Relation for DocumentReader {
+//!     const NAME: &'static str = "reader";
+//!     type User = Person;
+//!     type Object = Document;
+//! }
+//!
+//! #[derive(Debug)]
+//! struct DocumentCanRead;
+//!
+//! impl fga::model::Relation for DocumentCanRead {
+//!     const NAME: &'static str = "can_read";
+//!     type User = Person;
+//!     type Object = Document;
+//! }
+//! ```
+//!
+//! We can then leverage these definitions to use OpenFGA in a type-safe way.
+//!
+//! ```rust
+//! # use fga::model::{Relation, User, Object, Type};
+//! # #[derive(Debug)] struct Person(String);
+//! # impl From<String> for Person { fn from(s: String) -> Self { Self(s) } }
+//! # impl Type for Person { const NAMESPACE: &'static str = "person"; fn id(&self) -> &str { self.0.as_str() } }
+//! # impl User for Person {}
+//! # #[derive(Debug)] struct Document(String);
+//! # impl From<String> for Document { fn from(s: String) -> Self { Self(s) } }
+//! # impl Type for Document { const NAMESPACE: &'static str = "document"; fn id(&self) -> &str { self.0.as_str() } }
+//! # impl Object for Document {}
+//! # #[derive(Debug)] struct DocumentReader;
+//! # impl Relation for DocumentReader { const NAME: &'static str = "reader"; type User = Person; type Object = Document; }
+//! # #[derive(Debug)] struct DocumentCanRead;
+//! # impl Relation for DocumentCanRead { const NAME: &'static str = "can_read"; type User = Person; type Object = Document; }
+//! let bob = Person("bob".to_string());
+//! let doc = Document("2021-budget".to_string());
+//!
+//! // a tuple
+//! let tuple = DocumentReader.tuple(&bob, &doc);
+//!
+//! // the opposite fails to compile thanks to type safety
+//! // let wrong_tuple = DocumentReader.tuple(&doc, &bob);
+//!
+//! // type-bound public access support
+//! let public = DocumentReader.tuple(&User::wildcard(), &Document("public".to_string()));
+//!
+//! // a check for permission
+//! let bob_can_read = DocumentCanRead.check(&bob, &doc);
+//!
+//! // a query for related objects
+//! let bobs_docs = DocumentReader.query_objects(&bob);
+//! ```
+//!
+//! These objects obtained from using the relations can be used in the HTTP client to interact with an OpenFGA
+//! server. More about this below.
+//!
+//! ## A more concise syntax
+//!
+//! ### Authorization model definitions
+//!
+//! This library provides a bunch of macros to define types, relations and OpenFGA objects in a more concise way.
+//! We tried to stay as close as possible / necessary to OpenFGA syntaxes.
+//!
+//! For the derive macros [`fga::User`](User) and [`fga::Type`](Type), it is recommended to use the `derive_more::From` derive
+//! macro to generate the `From<String>` bound required by [`trait User`](model::User) and [`trait Object`](model::Object).
+//!
+//! ```
+//! #[derive(fga::Type, fga::User, derive_more::From, Debug)]
+//! struct Person(String);
+//!
+//! #[derive(fga::Type, fga::Object, derive_more::From, Debug)]
+//! struct Document(String);
+//!
+//! fga::relations! {
+//!     Document {
+//!         reader: Person,
+//!         can_read: Person
+//!     }
+//! }
+//! ```
+//!
+//! The only difference with the previous example is that relations are now accessible through the `Document` namespace
+//! as `const` associated functions. For example:
+//!
+//! ```
+//! # include!("doctest_setup.rs");
+//! # fn main() {
+//! # let bob = Person("bob".to_string());
+//! # let doc = Document("2021-budget".to_string());
+//! let tuple = Document::reader().tuple(&bob, &doc);
+//! # }
+//! ```
+//!
+//! ### OpenFGA literals
+//!
+//! In a test context, it's useful to be able to write OpenFGA literals in a concise way. This library provides
+//! the [`fga!()`] macro for this purpose. It tries to stick as much as possible to OpenFGA's syntax for users, objects
+//! and tuples.
+//!
+//! ```
+//! # use fga::fga;
+//! # use fga::model::{Relation, User, Object};
+//! # include!("doctest_setup.rs");
+//! # fn main() {
+//! let bob = fga!(Person:"bob");
+//! let doc = fga!(Document:"2021-budget");
+//!
+//! let tuple = fga!(Document:"2021-budget"#reader@Person:"bob");
+//! let public = fga!(Document:"public"#reader@Person:*);
+//! # }
+//! ```
+//!
+//! # The HTTP client
+//!
+//! The crate provides an HTTP client to interact with an OpenFGA server. It exposes an high-level API
+//! that interfaces with the high-level type-safe modelization types of the OpenFGA authorization model
+//! defined in [`mod model`].
+//!
+//! Note that the [`client::Client`] doesn't yet cover the whole OpenFGA API. That may come in the future
+//! according to OSRD's needs.
+//!
+//! Consult the [`struct Client`](client::Client) documentation for more information.
+
+pub mod client;
+pub mod model;
+
+pub use fga_derive::Object;
+pub use fga_derive::Type;
+pub use fga_derive::User;
+
+/// A little DSL to define the OpenFGA relations of an object in a somewhat similar way to the OpenFGA model syntax
+///
+/// # Example
+///
+/// ```
+/// # include!("doctest_setup.rs");
+/// # use fga::relations;
+/// # impl fga::model::Object for Person {}
+/// relations! {
+///     Person {
+///         friend: Person
+///     },
+///     Document {
+///         owner: Person,
+///         can_delete: Person
+///     }
+/// }
+/// # fn main() {}
+/// ```
+///
+/// This will generate the following methods:
+///
+/// ```ignore
+/// impl User {
+///     pub const fn friend() -> impl Relation<User = Person, Object = Person>;
+/// }
+///
+/// impl Document {
+///     pub const fn owner() -> impl Relation<User = Person, Object = Document>;
+///     pub const fn can_delete() -> impl Relation<User = Person, Object = Document>;
+/// }
+/// ```
+///
+/// Consult macro expansion and crate documentation for more information.
+#[macro_export]
+macro_rules! relations {
+    ($($object:ty { $($name:ident : $user:ty),* }),*) => {
+        $(
+            impl $object {
+                $(
+                    #[allow(unused)]
+                    pub const fn $name() -> impl $crate::model::Relation<User = $user, Object = $object> {
+                        #[derive(Debug)]
+                        struct R;
+                        impl $crate::model::Relation for R {
+                            const NAME: &'static str = stringify!($name);
+                            type User = $user;
+                            type Object = $object;
+                        }
+                        R
+                    }
+                )*
+            }
+        )*
+    };
+}
+
+/// Compiles an OpenFGA authorization model defined using OpenFGA's DSL into JSON
+///
+/// **The model is assumed to be valid! This function panics otherwise.**
+///
+/// The `fga` binary must be installed and available in the `$PATH`. It's
+/// available at <https://github.com/openfga/cli>.
+///
+/// This function is mostly meant to be used in unit tests.
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - A temporary file cannot be created or written to.
+/// - The `fga` command fails to execute (errored model or binary not in `$PATH`).
+pub fn compile_model(model: &str) -> serde_json::Value {
+    use std::process::Command;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("model.fga");
+    std::fs::write(&file, model).unwrap();
+    // requires https://github.com/openfga/cli
+    let json = Command::new("fga")
+        .arg("model")
+        .arg("transform")
+        .arg("--input-format")
+        .arg("fga")
+        .arg("--file")
+        .arg(file)
+        .output()
+        .expect("should work—is `fga` CLI installed and in $PATH? https://github.com/openfga/cli")
+        .stdout;
+    serde_json::from_slice(json.as_slice()).expect("invalid fga transform output")
+}
+
+#[cfg(test)]
+mod defs {
+    use derive_more::From;
+
+    // We can't use the derive macros `fga::Type`, `fga::User` and `fga::Object` in the tests
+    // as we're still in the `fga` crate.
+    macro_rules! fga_type {
+        (@ $vis:vis struct $name:ident $ns:literal) => {
+            #[derive(Debug, From, PartialEq, Eq, PartialOrd, Ord, Clone)]
+            pub struct $name(#[from] pub String);
+            #[automatically_derived]
+            impl crate::model::Type for $name {
+                const NAMESPACE: &'static str = $ns;
+                fn id(&self) -> &str {
+                    self.0.as_str()
+                }
+            }
+        };
+        (@ $name:ident : User) => {
+            #[automatically_derived]
+            impl crate::model::User for $name {}
+        };
+        (@ $name:ident : Object) => {
+            #[automatically_derived]
+            impl crate::model::Object for $name {}
+        };
+        ($vis:vis struct $name:ident($ns:literal) : $($derive:ident),+) => {
+            fga_type!(@ $vis struct $name $ns);
+            $(fga_type!(@ $name : $derive);)*
+
+            #[allow(unused)]
+            macro_rules! $name {
+                ($s:literal) => {
+                    $name($s.to_string())
+                };
+            }
+        };
+    }
+
+    fga_type!(pub struct Role("role"): User);
+    fga_type!(pub struct User("user"): User, Object);
+    fga_type!(pub struct Group("group"): User, Object);
+    fga_type!(pub struct Infra("infra"): Object);
+
+    relations! {
+        User {
+            role: Role,
+            group: Group,
+            manager: User
+        },
+        Group {
+            role: Role,
+            member: User,
+            manager: User
+        },
+        Infra {
+            reader: User,
+            writer: User,
+            can_read: User,
+            can_write: User
+        }
+    }
+}
+
+/// Type-safe OpenFGA literals
+///
+/// # Supported syntaxes
+///
+/// ```rust
+/// # include!("doctest_setup.rs");
+/// # fn main() {
+/// # use fga::fga;
+/// # use fga::model::{Relation, User, Object};
+/// // User and objects literals
+/// let alice = fga!(Person:"alice");
+/// let doc = fga!(Document:"2021-budget");
+/// assert_eq!(alice, Person("alice".to_string()));
+/// assert_eq!(doc, Document("2021-budget".to_string()));
+///
+/// // Type-bound public access
+/// let everyone = fga!(Person:*);
+/// assert_eq!(everyone, Person::wildcard());
+///
+/// // Usersets
+/// assert_eq!(
+///     fga!(Document:"topsecret"#reader),
+///     Document::reader().userset(&Document("topsecret".to_string()))
+/// );
+///
+/// // Simple tuples
+/// assert_eq!(
+///     fga!(Document:"2021-budget"#reader@Person:"alice"),
+///     Document::reader()
+///         .tuple(&Person("alice".to_string()), &Document("2021-budget".to_string()))
+/// );
+///
+/// // Tuples with type-bound public access
+/// assert_eq!(
+///     fga!(Document:"2021-budget"#reader@Person:*),
+///     Document::reader()
+///         .tuple(&Person::wildcard(), &Document("2021-budget".to_string()))
+/// );
+///
+/// // Tuples with usersets
+/// assert_eq!(
+///     fga!(Document:"2021-budget"#reader@Document:"topsecret"#can_write),
+///     Document::reader()
+///         .tuple(
+///             &Document::can_write().userset(&Document("topsecret".to_string())),
+///             &Document("2021-budget".to_string())
+///         )
+/// );
+/// # }
+/// ```
+///
+/// # About temporary references
+///
+/// ```compile_fail
+/// # include!("doctest_setup.rs");
+/// # fn main() {
+/// # use fga::fga;
+/// # use fga::model::{Relation, User, Object};
+/// let userset = fga!(Document:"topsecret"#reader); // creates a temporary value which is freed while still in use
+/// println!("{userset:?}");
+/// # }
+/// ```
+///
+/// This is expected since the [model::Relation] API doesn't take ownership of users and objects to
+/// build compound objects (such as tuples, queries, usersets, etc.). In the previous example, the "temporary value"
+/// refers to the `Document("topsecret")`. If we inlined the userset, there wouldn't be any issue (so nothing to worry
+/// about if the value is directly sent to the [client::Client]).
+///
+/// To circumvent this issue, the following syntaxes are supported:
+///
+/// ```rust
+/// # include!("doctest_setup.rs");
+/// # fn main() {
+/// # use fga::fga;
+/// # use fga::model::{Relation, User, Object};
+/// // Usersets
+/// let secret = fga!(Document:"topsecret");
+/// let userset = fga!(Document:secret # reader);
+/// println!("{userset:?}");
+///
+/// // Simple tuples
+/// let alice = fga!(Person:"alice");
+/// let tuple = fga!(Document:secret # reader @ alice);
+/// println!("{tuple:?}");
+///
+/// // Tuples with type-bound public access
+/// let wildcard = fga!(Person:*);
+/// let tuple = fga!(Document:secret # reader @ wildcard);
+/// println!("{tuple:?}");
+///
+/// // Tuples with usersets
+/// let budget = fga!(Document:"2021-budget");
+/// let writers = fga!(Document:secret # can_write);
+/// let tuple = fga!(Document:budget # reader @ writers);
+/// println!("{tuple:?}");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! fga {
+    // User notations
+    // --------------
+
+    // fga!(User:"bob") => "user:bob"
+    ($ty:ident : $id:literal) => {
+        $ty($id.to_string())
+    };
+
+    // fga!(User:*) => "user:*"
+    ($ty:ident : *) => {
+        <$ty as $crate::model::User>::wildcard()
+    };
+
+    // fga!(Group:"my_friends"#member) => userset syntax "group:my_friends#member"
+    ($ty:ident : $id:literal # $relation:ident) => {
+        {
+            use $crate::model::Relation as _;
+            $ty::$relation().userset(&fga!($ty:$id))
+        }
+    };
+
+    ($ty:ident : $var:ident # $relation:ident) => {
+        {
+            use $crate::model::Relation as _;
+            $ty::$relation().userset(&$var)
+        }
+    };
+
+    // Tuple notations
+    // ---------------
+
+    // fga!(doc:id#reader@user:id) => tuple syntax
+    //
+    // Read it backwards: "the user of type 'user' with this id is a reader of this doc with that id"
+    ($object:ident : $object_id:literal # $relation:ident @ $user:ident : $user_id:literal) => {
+        $object::$relation().tuple(&fga!($user:$user_id), &fga!($object:$object_id))
+    };
+
+    // fga!(group:id#member@user:*) => tuple syntax for public type access bounds
+    ($object:ident : $object_id:literal # $relation:ident @ $user:ident : *) => {
+        $object::$relation().tuple(&fga!($user:*), &fga!($object:$object_id))
+    };
+
+    // fga!(doc:id#reader@group#member) => tuple syntax for user set
+    ($object:ident : $object_id:literal # $relation:ident @ $user:ident : $user_id:literal # $user_relation:ident) => {
+        $object::$relation().tuple(&fga!($user:$user_id # $user_relation), &fga!($object:$object_id))
+    };
+
+    ($object:ident : $object_var:ident # $relation:ident @ $user_var:ident) => {
+        $object::$relation().tuple(&$user_var, &$object_var)
+    };
+}
+
+#[cfg(test)]
+/// The [client::ConnectionSettings] to use for unit and doc tests
+///
+/// Configurable through the `OPENFGA_HOST` and `OPENFGA_PORT` environment variables.
+/// Defaults to `localhost` and `8091` (as used by OSRD).
+fn connection_settings() -> client::ConnectionSettings {
+    let address = std::env::var("OPENFGA_HOST").unwrap_or_else(|_| "localhost".to_string());
+    let port = std::env::var("OPENFGA_PORT")
+        .unwrap_or_else(|_| "8091".to_string())
+        .parse()
+        .expect("invalid port");
+    client::ConnectionSettings::new(address, port).reset_store()
+}

--- a/editoast/fga/src/model.rs
+++ b/editoast/fga/src/model.rs
@@ -1,0 +1,540 @@
+//! # High-level modelization of OpenFGA authorization models definitions
+//!
+//! This module exposes a bunch of types and traits that represents everything
+//! defined in an OpenFGA authorization model and needed to interact with it.
+//!
+//! For a small tutorial on how to use this module to represent your authorization
+//! model, see the [crate-level documentation](crate).
+
+use core::fmt;
+
+/// Representation of an OpenFGA `type`
+///
+/// In order to be used with the [`trait Relation`], the implementor type
+/// must also implement either or both of the [`trait User`] and [`trait Object`].
+///
+/// # Example
+///
+/// OpenFGA model:
+///
+/// ```ignore
+/// model:
+///     schema: 1.1
+///
+/// type group
+/// ```
+///
+/// Rust representation:
+///
+/// ```
+/// #[derive(Debug)]
+/// struct Group(String);
+///
+/// impl fga::model::Type for Group {
+///     const NAMESPACE: &'static str = "group";
+///
+///     fn id(&self) -> &str {
+///         &self.0
+///     }
+/// }
+/// ```
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-type-definition>
+pub trait Type: Sized {
+    /// The name of the OpenFGA `type`
+    const NAMESPACE: &'static str;
+
+    /// The identifier of the instance of the `type` `Self`
+    fn id(&self) -> &str;
+}
+
+/// Representation of an OpenFGA type that can be used as an OpenFGA user (tuple position)
+///
+/// The implementor type must also implement `From<String>` in order to be constructed
+/// from values received in OpenFGA responses.
+///
+/// # Example
+///
+/// OpenFGA model:
+///
+/// ```ignore
+/// model:
+///    schema: 1.1
+///
+/// type person
+/// ```
+///
+/// Rust representation:
+///
+/// ```
+/// #[derive(Debug, derive_more::From)]
+/// struct Person(#[from] String);
+///
+/// impl fga::model::Type for Person {
+///     const NAMESPACE: &'static str = "person";
+///
+///     fn id(&self) -> &str {
+///         &self.0
+///     }
+/// }
+///
+/// // can be used as a marker trait, but has functions to override
+/// impl fga::model::User for Person {}
+/// ```
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-user>
+pub trait User: Type + From<String> + fmt::Debug + Sized {
+    /// Builds the OpenFGA USER string from a [`User`] instance
+    ///
+    /// This string is sent to OpenFGA to represent the USER in a tuple.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fga::fga;
+    /// # use fga::model::User;
+    /// # use fga::model::Type;
+    /// # #[derive(Debug, derive_more::From)]
+    /// # struct Person(#[from] String);
+    /// # impl Type for Person { const NAMESPACE: &'static str = "person"; fn id(&self) -> &str { &self.0 } }
+    /// impl User for Person {}
+    /// assert_eq!(Person::NAMESPACE, "person");
+    /// assert_eq!(fga!(Person:"bob").fga_user(), "person:bob");
+    /// ```
+    ///
+    /// # About security and panics
+    ///
+    /// This function will panic **by default** if the user identifier is `*`.
+    /// This is a security measure to avoid having user identifiers coerced to
+    /// public accesses maliciously. For example, without the panic, the following
+    /// injection would be possible:
+    ///
+    /// ```
+    /// # include!("doctest_setup.rs");
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let user_provided_data = "*".to_string();
+    /// assert_eq!(user_provided_data, "*");
+    /// let user = Person::from(user_provided_data);
+    /// let object = Document::from("confidential".to_string());
+    /// let tuple = Document::can_read().tuple(&user, &object);
+    /// // write the tuple
+    /// // now the topsecret document is public and the world burns
+    /// # }
+    /// ```
+    ///
+    /// To grant public accesses, the [`Wildcard`] should be used to ensure a different
+    /// code path.
+    ///
+    /// If this function is overridden, **unless you absolutely know what you're doing**,
+    /// a panic should be triggered when `self.id() == "*"`.
+    fn fga_user(&self) -> String {
+        let id = self.id();
+        if id == "*" {
+            panic!(
+                "Refusing to generate an identifier for a type-bound public access\n\
+                without using the `fga::model::Wildcard` type.\n\
+                This is a security measure to avoid having user identifiers coerced to\n\
+                public accesses maliciously."
+            );
+        }
+        format!("{}:{}", Self::NAMESPACE, id)
+    }
+
+    /// Returns the [`Wildcard`] type for this user type
+    ///
+    /// This function probably shouldn't be overridden.
+    fn wildcard() -> Wildcard<Self> {
+        Wildcard(std::marker::PhantomData)
+    }
+}
+
+/// Representation of an OpenFGA relation
+///
+/// While implementable manually, it is recommended to use the [`relations!()`](super::relations!)
+/// macro to generate the necessary boilerplate.
+///
+/// The functions defined in this trait are used to build OpenFGA objects and queries
+/// in a type-safe way. They are not made to be overridden. If you decide to do so,
+/// make sure their behavior still makes sense for OpenFGA.
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-relation>
+pub trait Relation: fmt::Debug + Sized {
+    /// The name of the relation as defined in the OpenFGA model
+    const NAME: &'static str;
+
+    /// The type of the USER side of the relation
+    ///
+    /// While OpenFGA supports multiple types of users, `fga` only supports
+    /// a single type by design. However, it may be possible to implement [`trait User`]
+    /// for an enum which variants would represent the different types of users.
+    /// This is outside the scope of `fga` though.
+    type User: User;
+
+    /// The type of the OBJECT side of the relation
+    type Object: Object;
+
+    // ----- Related objects
+
+    /// Builds a tuple object
+    ///
+    /// Can be written in OpenFGA using
+    /// [`Client::write_tuples`](crate::client::Client::write_tuples)
+    /// or
+    /// [`Client::prepare_writes`](crate::client::Client::prepare_writes).
+    fn tuple<'a: 'c, 'b: 'c, 'c, U: AsUser<User = Self::User>>(
+        &self,
+        user: &'a U,
+        object: &'b Self::Object,
+    ) -> Tuple<'c, Self, U> {
+        Tuple { user, object }
+    }
+
+    /// Builds a userset object
+    ///
+    /// Can be used in the USER part of a tuple in [`Relation::tuple`] or [`Relation::query_objects`].
+    fn userset<'a>(&self, object: &'a Self::Object) -> UserSet<'a, Self> {
+        UserSet(object)
+    }
+
+    // ----- Queries
+
+    /// Builds a check query
+    ///
+    /// Can be used in [`Client::check`](crate::client::Client::check) to check if `user`
+    /// is related via `Self` to `object`.
+    fn check<'a: 'c, 'b: 'c, 'c>(
+        &self,
+        user: &'a Self::User,
+        object: &'b Self::Object,
+    ) -> Check<'c, Self> {
+        Check { user, object }
+    }
+
+    /// Builds a user list query
+    ///
+    /// Can be used in [`Client::list_users`](crate::client::Client::list_users) to
+    /// compute which users are related to `object` via `Self`.
+    fn query_users<'a>(&'a self, object: &'a Self::Object) -> QueryUsers<'a, Self> {
+        QueryUsers(object)
+    }
+
+    /// Builds a userset list query
+    ///
+    /// Can be used in [`Client::list_usersets`](crate::client::Client::list_usersets) to
+    /// compute which usersets are related to `object` via `Self`.
+    fn query_usersets<'a, R: Relation>(
+        &'a self,
+        _userset_relation: R,
+        object: &'a Self::Object,
+    ) -> QueryUsersets<'a, Self, R> {
+        QueryUsersets(object, std::marker::PhantomData)
+    }
+
+    /// Builds an object list query
+    ///
+    /// Can be used in [`Client::list_objects`](crate::client::Client::list_objects) to
+    /// compute which objects are related to `user` via `Self`.
+    fn query_objects<'a, U: AsUser<User = Self::User>>(
+        &'a self,
+        user: &'a U,
+    ) -> QueryObjects<'a, Self, U> {
+        QueryObjects::<Self, U>(user, std::marker::PhantomData)
+    }
+
+    // tuple_key = { user: user:bob, relation: reader, object: document: }
+    /// NOT YET IMPLEMENTED
+    fn query_objects_stored<'a>(&'a self, user: &'a Self::User) -> QueryObjectsStored<'a, Self> {
+        let _ = user;
+        todo!()
+    }
+
+    // tuple_key = { object: document:budget-2021, relation: reader }
+    /// NOT YET IMPLEMENTED
+    fn query_users_stored<'a>(&'a self, object: &'a Self::Object) -> QueryUsersStored<'a, Self> {
+        let _ = object;
+        todo!()
+    }
+
+    // ----- Extra
+
+    /// Parses an OpenFGA userset expression and returns the id of the object used in it
+    ///
+    /// Returns an error if the relation used to define the userset is not [`Relation::NAME`].
+    ///
+    /// This function is used by the [`Client`](crate::client::Client) to parse the results of
+    /// some queries.
+    fn parse_userset_object(ident: &str) -> Result<Self::Object, ParsingError> {
+        // TODO: use strip_suffix
+        let (object_ident, relation) = ident.split_once('#').ok_or_else(|| ParsingError {
+            ident: ident.to_string(),
+            expected_type: "userset", // TODO: make a new error variant
+        })?;
+        let object = Self::Object::parse_fga_object(object_ident)?;
+        if relation != Self::NAME {
+            return Err(ParsingError {
+                ident: ident.to_string(),
+                expected_type: Self::NAME,
+            });
+        }
+        Ok(object)
+    }
+}
+
+/// Representation of an OpenFGA type that can be used as an OpenFGA object (tuple position)
+///
+/// The implementor type must also implement `From<String>` in order to be constructed
+/// from values received in OpenFGA responses.
+///
+/// # Example
+///
+/// OpenFGA model:
+///
+/// ```ignore
+/// model:
+///    schema: 1.1
+///
+/// type document
+/// ```
+///
+/// Rust representation:
+///
+/// ```
+/// #[derive(Debug, derive_more::From)]
+/// struct Document(#[from] String);
+///
+/// impl fga::model::Type for Document {
+///     const NAMESPACE: &'static str = "document";
+///
+///     fn id(&self) -> &str {
+///         &self.0
+///     }
+/// }
+///
+/// // can be used as a marker trait, but has functions to override
+/// impl fga::model::Object for Document {}
+/// ```
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-an-object>
+pub trait Object: Type + fmt::Debug + From<String> {
+    /// Builds the OpenFGA OBJECT string from an [`Object`] instance
+    ///
+    /// This string is sent to OpenFGA to represent the OBJECT in a tuple.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use fga::fga;
+    /// # use fga::model::Object;
+    /// # use fga::model::Type;
+    /// # #[derive(Debug, derive_more::From)]
+    /// # struct Document(#[from] String);
+    /// # impl Type for Document { const NAMESPACE: &'static str = "document"; fn id(&self) -> &str { &self.0 } }
+    /// impl Object for Document {}
+    /// assert_eq!(Document::NAMESPACE, "document");
+    /// assert_eq!(fga!(Document:"budget").fga_object(), "document:budget");
+    /// ```
+    fn fga_object(&self) -> String {
+        format!("{}:{}", Self::NAMESPACE, self.id())
+    }
+
+    /// Parses an OpenFGA OBJECT string as a Self instance
+    fn parse_fga_object(ident: &str) -> Result<Self, ParsingError> {
+        let prefix: String = format!("{}:", Self::NAMESPACE);
+        if let Some(id) = ident.strip_prefix(&prefix) {
+            Ok(Self::from(id.to_string()))
+        } else {
+            Err(ParsingError {
+                ident: ident.to_string(),
+                expected_type: Self::NAMESPACE,
+            })
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Cannot parse string as '{expected_type}': '{ident}'")]
+pub struct ParsingError {
+    ident: String,
+    expected_type: &'static str,
+}
+
+/// Indicates that the implementor can be used in the USER position of a tuple
+///
+/// According to <https://openfga.dev/docs/concepts#what-is-a-user>, a user can be one of:
+///
+/// 1. A regular user `user:identifier` — represented by the [`trait User`]
+/// 2. A userset `object:identifier#relation` — represented by the [`struct UserSet`]
+/// 3. A type-bound public access `user:*` — represented by the [`struct Wildcard`]
+///
+/// All these values can be used in the USER position of a tuple, and therefore must be accepted
+/// by queries builders, such as [`Relation::query_objects`].
+///
+/// Auto-implemented for types that implement [`trait User`].
+pub trait AsUser {
+    /// The USER type that the implementor can be used as
+    type User: User;
+
+    /// Builds the OpenFGA USER string from an [`AsUser`] instance
+    ///
+    /// This string is sent to OpenFGA to represent the USER in a tuple.
+    ///
+    /// Has the same semantics as [`User::fga_user`].
+    fn fga_user(&self) -> String;
+}
+
+impl<U: User> AsUser for U {
+    type User = U;
+
+    fn fga_user(&self) -> String {
+        Self::User::fga_user(&self)
+    }
+}
+
+/// A check query built by [`Relation::check`]
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-check-request>
+#[derive(Debug)]
+pub struct Check<'a, R: Relation> {
+    pub(crate) user: &'a R::User,
+    pub(crate) object: &'a R::Object,
+}
+
+/// A list object query built by [`Relation::query_objects`]
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-list-objects-request>
+#[derive(Debug)]
+pub struct QueryObjects<'a, R: Relation, U: AsUser<User = R::User>>(
+    pub(crate) &'a U,
+    pub(crate) std::marker::PhantomData<R>,
+);
+
+/// A list user query built by [`Relation::query_users`]
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-list-users-request>
+#[derive(Debug)]
+pub struct QueryUsers<'a, R: Relation>(pub(crate) &'a R::Object);
+
+/// A list user query specialized for usersets built by [`Relation::query_usersets`]
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-list-users-request>
+#[derive(Debug)]
+pub struct QueryUsersets<'a, R: Relation, S: Relation>(
+    pub(crate) &'a R::Object,
+    pub(crate) std::marker::PhantomData<S>,
+);
+
+#[expect(unused)]
+#[derive(Debug)]
+pub struct QueryObjectsStored<'a, R: Relation>(&'a R::User);
+#[expect(unused)]
+#[derive(Debug)]
+pub struct QueryUsersStored<'a, R: Relation>(&'a R::Object);
+
+/// A type-safe OpenFGA tuple representation built by [`Relation::tuple`]
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-relationship-tuple>
+#[derive(Debug)]
+pub struct Tuple<'a, R, U>
+where
+    R: Relation,
+    U: AsUser<User = R::User>,
+{
+    pub(crate) user: &'a U,
+    pub(crate) object: &'a R::Object,
+}
+
+impl<'a, R: Relation, U: AsUser<User = R::User>> PartialEq for Tuple<'a, R, U>
+where
+    U: PartialEq,
+    R::Object: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.user == other.user && self.object == other.object
+    }
+}
+
+/// User set: `group:my-team#member`, `infra:france#can_read`, etc.
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-a-user>
+#[derive(Debug)]
+pub struct UserSet<'a, R: Relation + 'static>(&'a R::Object);
+
+impl<'a, R: Relation> AsUser for UserSet<'a, R> {
+    type User = R::User;
+
+    fn fga_user(&self) -> String {
+        format!("{}:{}#{}", R::Object::NAMESPACE, self.0.id(), R::NAME)
+    }
+}
+
+impl<'a, R: Relation> PartialEq for UserSet<'a, R>
+where
+    R::Object: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<'a, R: Relation> Eq for UserSet<'a, R> where R::Object: Eq {}
+
+/// Type-bound public access: `user:*`, `document:*`, etc.
+///
+/// # OpenFGA concept
+///
+/// <https://openfga.dev/docs/concepts#what-is-type-bound-public-access>
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Wildcard<U: User>(pub(crate) std::marker::PhantomData<U>);
+
+impl<U: User> AsUser for Wildcard<U> {
+    type User = U;
+
+    fn fga_user(&self) -> String {
+        format!("{}:*", U::NAMESPACE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::defs;
+
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn public_access_injection_protection_user() {
+        let _ = User::fga_user(&defs::User("*".to_owned()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn public_access_injection_protection_user_asuser() {
+        let _ = AsUser::fga_user(&defs::User("*".to_owned()));
+    }
+
+    #[test]
+    fn no_injection_protection_for_wildcard() {
+        let _ = defs::Group::wildcard();
+    }
+}

--- a/editoast/fga/tests/doctest.fga
+++ b/editoast/fga/tests/doctest.fga
@@ -1,0 +1,15 @@
+model
+  schema 1.1
+
+type person
+
+type group
+  relations
+    define member: [person]
+
+type document
+    relations
+        define reader: [person, group#member]
+        define can_read: reader or can_write
+        define writer: [person, group#member]
+        define can_write: writer

--- a/editoast/fga/tests/model.fga
+++ b/editoast/fga/tests/model.fga
@@ -1,0 +1,28 @@
+model
+  schema 1.1
+
+type role
+
+type user
+  relations
+    define group: [group]
+    define manager: manager from group
+    define role: [role] or role from group
+
+type group
+  relations
+    define role: [role]
+    define manager: [user]
+    define member: [user]
+
+type infra
+  relations
+    define can_delete: owner
+    define can_read: reader or can_write
+    define can_share_ownership: owner
+    define can_share_read: can_read
+    define can_share_write: can_write
+    define can_write: writer or can_delete
+    define owner: [user, group#member, group#manager, user#manager]
+    define reader: [user, user:*, group#member, group#manager, user#manager]
+    define writer: [user, group#member, group#manager, user#manager]

--- a/editoast/fga_derive/Cargo.toml
+++ b/editoast/fga_derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fga_derive"
+edition = "2021"
+version.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[lints]
+workspace = true

--- a/editoast/fga_derive/src/lib.rs
+++ b/editoast/fga_derive/src/lib.rs
@@ -1,0 +1,114 @@
+//! Derive macros for the `fga` crate
+
+use darling::FromDeriveInput as _;
+use proc_macro::TokenStream;
+use syn::DeriveInput;
+
+#[derive(Debug, darling::FromDeriveInput)]
+#[darling(
+    attributes(fga),
+    forward_attrs(allow, doc, cfg),
+    supports(struct_newtype, struct_named, struct_tuple)
+)]
+struct TypeArgs {
+    #[darling(default)]
+    name: Option<String>,
+
+    ident: syn::Ident,
+    data: darling::ast::Data<darling::util::Ignored, TypeFieldArgs>,
+}
+
+#[derive(Debug, PartialEq, Eq, darling::FromField)]
+#[darling(attributes(fga), forward_attrs(allow, doc, cfg))]
+struct TypeFieldArgs {
+    #[darling(default)]
+    id: bool,
+    ident: Option<syn::Ident>,
+}
+
+fn expand_type(input: &DeriveInput) -> darling::Result<TokenStream> {
+    let TypeArgs { name, ident, data } = TypeArgs::from_derive_input(&input)?;
+
+    let name = name.unwrap_or_else(|| ident.to_string().to_lowercase());
+
+    let Some(fields) = data.take_struct() else {
+        return Err(darling::Error::unsupported_shape("enum"));
+    };
+
+    let id_field = fields
+        .fields
+        .iter()
+        .find(|field| field.id)
+        .or_else(|| fields.fields.first())
+        .ok_or_else(|| darling::Error::unsupported_shape("unit struct"))?;
+
+    let id_field_ident = match id_field.ident {
+        Some(ref ident) => quote::quote! { #ident },
+        None => {
+            let index = fields
+                .fields
+                .iter()
+                .position(|field| field == id_field)
+                .unwrap();
+            quote::quote! { #index }
+        }
+    };
+
+    Ok(quote::quote! {
+        impl fga::model::Type for #ident {
+            const NAMESPACE: &'static str = #name;
+            fn id(&self) -> &str {
+                self.#id_field_ident.as_ref()
+            }
+        }
+    }
+    .into())
+}
+
+/// Derive macro for the trait `fga::model::Type`
+///
+/// The `#[fga(id)]` must implement `AsRef<str>`.
+///
+/// Valid forms:
+///
+/// ```ignore
+/// #[derive(Type)]
+/// #[fga(name = "mytype")]
+/// struct MyType(u64, #[fga(id)] String);
+///
+/// #[derive(Type)] // name defaults to the struct name lowercased
+/// struct Document { doc_id: String } // id defaults to the first field if not specified
+///
+/// #[derive(Type)]
+/// struct Group(String);
+/// ```
+#[proc_macro_derive(Type, attributes(fga))]
+pub fn derive_type(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    match expand_type(&input) {
+        Ok(expanded) => expanded,
+        Err(e) => e.write_errors().into(),
+    }
+}
+
+/// Derive macro for the marker trait `fga::model::User`
+#[proc_macro_derive(User)]
+pub fn derive_user(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    quote::quote! {
+        impl fga::model::User for #ident {}
+    }
+    .into()
+}
+
+/// Derive macro for the marker trait `fga::model::Object`
+#[proc_macro_derive(Object)]
+pub fn derive_object(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    let ident = input.ident;
+    quote::quote! {
+        impl fga::model::Object for #ident {}
+    }
+    .into()
+}


### PR DESCRIPTION
> [!NOTE]
> This is a lengthy PR which also requires some amount of OpenFGA knowledge to be understood. It's probably better to peer review it.

* Meant to remain a new sub-crate which will be included in `editoast_authz` (in which we'll map the authorization model, define our objects, their conversion, relations, etc.)
* The `fga` binary is necessary to run unit tests for now: https://github.com/openfga/cli
* So is a running OpenFGA instance

TODO:

- [ ] Implement all the operations we'll need
	- [x] Operations needed for the roles reimplementation
	- [x] `POST /stores/{}/list-users`
	- [ ] `POST /stores/{}/stream-list-objects`
	- [ ] `POST /stores/{}/expand`
	- [ ] `POST /stores/{}/read`
	- [x] `POST /stores/{}/batch-check`
	- [ ] Other operations currently not needed, but since there's so few of them, we may want to implement them for completeness?
- [x] Keep an `authorization_model_id` in the client to forward it to requests—as advised by OpenFGA
- [x] Improve tests utils & debugging tools
	- [x] Client `check` assertions (make them public + async variant?)
	- [x] Parse OpenFGA errors instead of just forwarding them generically
	- [x] Expose `compile_model`?
- [x] Documentation (for real this time :eyes:)
	- [x] `mod client`
	- [x] `mod model`
	- [x] `crate` (ongoing)
- [x] **INSTRUMENT EVERYTHING**
- [x] Setup OpenFGA in `docker compose`
- [x] Add check for `User.id ≠ '*'`
- [ ] Add early verification of `User.id` and `Object.id`? Not really required for us.
- [x] Implement `list-users` as this will change the `trait User` API
- [x] Macros
	- [x] `fga!`
	- [x] `relations!`
	- [x] `derive(User)`
	- [x] `derive(Object)`

### About macros

This crates introduces a few macro_rules, which are only used for tests currently.

* `relations!` allows defining typed relations concisely to allow quick comparisons with the OpenFGA schema. I think we should keep this one, that'll help the review process and reduce straightforward boilerplate.
* `fga_type!` declares the newtype structs representing the `types` of OpenFGA and generates a few implementations. I think this one should remain a `#[cfg(test)]` definition. However I think derive macros `derive(fga::User, fga::Object)` would help us and cost nothing as they are trivial to implement.
* `fga!` allows manipulating and instantiating types and relations with *the same syntax* as OpenFGA, but in a type-safe way. This is particularly useful for the conciseness of unit tests. I think it should be exported.
