### PR TITLE
editoast: rename and invert authorization flag for consistency

### DIFF
--- a/editoast/editoast_authz/src/builtin_role.rs
+++ b/editoast/editoast_authz/src/builtin_role.rs
@@ -26,7 +26,7 @@ use crate::roles::BuiltinRoleSet;
 pub enum BuiltinRole {
     /// A user with this role short-circuits all role and permission checks
     ///
-    /// Alternatively, especially for development, the `EDITOAST_DISABLE_AUTHORIZATION` environment variable can be set
+    /// Alternatively, especially for development, the `EDITOAST_ENABLE_AUTHORIZATION` environment variable can be set to `false`
     /// when no user identity header is present. (This is the case when editoast is queried directly and
     /// not through the gateway.)
     Superuser,

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -36,13 +36,13 @@ pub struct RunserverArgs {
     address: String,
     #[command(flatten)]
     core: CoreArgs,
-    /// If this option is set, any role and permission check will be bypassed. Even if no user is
+    /// If this option is set to false, any role and permission check will be bypassed. Even if no user is
     /// provided by the request headers of if the provided user doesn't have the required privileges.
     // TODO: once the whole role system will be deployed, the default value of this option should
     // be set to false. It's currently set to true in order to pass integration tests, which otherwise
-    // only recieve 401 responses.
-    #[clap(long, env = "EDITOAST_DISABLE_AUTHORIZATION", default_value_t = true)]
-    disable_authorization: bool,
+    // only receive 401 responses.
+    #[clap(long, env = "EDITOAST_ENABLE_AUTHORIZATION", default_value_t = false)]
+    enable_authorization: bool,
     /// If this option is set, logging for the STDCM will be enabled.
     /// When enabled, relevant logs will be captured to aid in debugging and monitoring.
     #[clap(long, env = "ENABLE_STDCM_LOGGING", default_value_t = true)]
@@ -67,7 +67,7 @@ pub async fn runserver(
                 core_single_worker,
                 core_client_channels_size,
             },
-        disable_authorization,
+        enable_authorization,
         enable_stdcm_logging,
         osrdyne_api_url,
         health_check_timeout_ms,
@@ -80,7 +80,7 @@ pub async fn runserver(
         address,
         health_check_timeout: Duration::milliseconds(health_check_timeout_ms as i64),
         map_layers_max_zoom: map_layers_config.max_zoom as u8,
-        disable_authorization,
+        enable_authorization,
         enable_stdcm_logging,
         postgres_config: postgres.into(),
         osrdyne_config: views::OsrdyneConfig {

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -191,11 +191,11 @@ impl Authentication {
 pub type AuthenticationExt = axum::extract::Extension<Authentication>;
 
 async fn authenticate(
-    disable_authorization: bool,
+    enable_authorization: bool,
     headers: &axum::http::HeaderMap,
     db_pool: Arc<DbConnectionPoolV2>,
 ) -> Result<Authentication, AuthorizationError> {
-    if disable_authorization {
+    if !enable_authorization {
         return Ok(Authentication::Authenticated(Authorizer::new_superuser(
             PgAuthDriver::<BuiltinRole>::new(db_pool),
         )));
@@ -234,7 +234,7 @@ async fn authentication_middleware(
     next: Next,
 ) -> Result<Response> {
     let headers = req.headers();
-    let authorizer = authenticate(config.disable_authorization, headers, db_pool).await?;
+    let authorizer = authenticate(config.enable_authorization, headers, db_pool).await?;
     req.extensions_mut().insert(authorizer);
     Ok(next.run(req).await)
 }
@@ -365,7 +365,7 @@ pub struct ServerConfig {
     pub address: String,
     pub health_check_timeout: Duration,
     pub map_layers_max_zoom: u8,
-    pub disable_authorization: bool,
+    pub enable_authorization: bool,
     pub enable_stdcm_logging: bool,
     pub postgres_config: PostgresConfig,
     pub osrdyne_config: OsrdyneConfig,
@@ -516,11 +516,11 @@ impl Server {
         let ServerConfig {
             address,
             port,
-            disable_authorization,
+            enable_authorization,
             ..
         } = app_state.config.as_ref();
 
-        if *disable_authorization {
+        if !*enable_authorization {
             warn!("authorization disabled — all role and permission checks are bypassed");
         }
 

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -143,7 +143,7 @@ impl TestAppBuilder {
             port: 0,
             address: String::default(),
             health_check_timeout: chrono::Duration::milliseconds(500),
-            disable_authorization: !self.enable_authorization,
+            enable_authorization: self.enable_authorization,
             enable_stdcm_logging: self.enable_stdcm_logging,
             map_layers_max_zoom: 18,
             postgres_config: PostgresConfig {


### PR DESCRIPTION
Renames `disable_authorization` to `enable_authorization` and inverts its logic for better clarity. 