### PR TITLE
front: get correct coordinates of uic pathsteps

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -12,6 +12,8 @@ import {
   type SearchResultItemOperationalPoint,
 } from 'common/api/osrdEditoastApi';
 import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQuery';
+import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPathCoordinates';
+import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import { formatSuggestedOperationalPoints, matchPathStepAndOp } from 'modules/pathfinding/utils';
 import { getSupportedElectrification, isThermal } from 'modules/rollingStock/helpers/electric';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
@@ -167,9 +169,22 @@ const useSetupItineraryForTrainUpdate = (trainIdToEdit: number) => {
       if (!electrifications || !geometry || !operational_points) {
         return null;
       }
-      const stepsCoordinates = pathfindingResult.path_item_positions.map((position) =>
-        getPointOnTrackCoordinates(geometry, pathfindingResult.length, position)
+
+      const trackIds = pathfindingResult.track_section_ranges.map((range) => range.track_section);
+      const tracks = await getTrackSectionsByIds(trackIds);
+      const tracksLengthCumulativeSums = getTrackLengthCumulativeSums(
+        pathfindingResult.track_section_ranges
       );
+
+      const stepsCoordinates = pathfindingResult.path_item_positions.map((position) =>
+        getPointOnPathCoordinates(
+          tracks,
+          pathfindingResult.track_section_ranges,
+          tracksLengthCumulativeSums,
+          position
+        )
+      );
+
       const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
         operational_points,
         geometry,

--- a/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
+++ b/front/src/applications/operationalStudies/hooks/useSetupItineraryForTrainUpdate.ts
@@ -21,7 +21,7 @@ import { updatePathSteps } from 'reducers/osrdconf/operationalStudiesConf';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
-import { getPointCoordinates } from 'utils/geometry';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import type { ManageTrainSchedulePathProperties } from '../types';
 import { useManageTrainScheduleContext } from './useManageTrainScheduleContext';
@@ -100,7 +100,7 @@ const useSetupItineraryForTrainUpdate = (trainIdToEdit: number) => {
         if ('track' in step) {
           const track = tracks[step.track];
           if (track) {
-            coordinates = getPointCoordinates(track.geo, track.length, step.offset);
+            coordinates = getPointOnTrackCoordinates(track.geo, track.length, step.offset);
           }
         } else {
           let op: SearchResultItemOperationalPoint | undefined;
@@ -168,7 +168,7 @@ const useSetupItineraryForTrainUpdate = (trainIdToEdit: number) => {
         return null;
       }
       const stepsCoordinates = pathfindingResult.path_item_positions.map((position) =>
-        getPointCoordinates(geometry, pathfindingResult.length, position)
+        getPointOnTrackCoordinates(geometry, pathfindingResult.length, position)
       );
       const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
         operational_points,

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -24,7 +24,7 @@ import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/
 import { updateViewport, type Viewport } from 'reducers/map';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { getPointCoordinates } from 'utils/geometry';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import useSimulationResults from '../hooks/useSimulationResults';
 import type { TrainSpaceTimeData } from '../types';
@@ -94,7 +94,7 @@ const SimulationResults = ({
     path &&
     pathProperties &&
     path.path_item_positions.map((positionOnPath) =>
-      getPointCoordinates(pathProperties.geometry, path.length, positionOnPath)
+      getPointOnTrackCoordinates(pathProperties.geometry, path.length, positionOnPath)
     );
 
   const {

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -2,11 +2,14 @@ import { useEffect, useState, useMemo } from 'react';
 
 import { ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
+import type { Position } from 'geojson';
 import { useTranslation } from 'react-i18next';
 
-import { type Conflict } from 'common/api/osrdEditoastApi';
+import { type Conflict, type PathfindingResultSuccess } from 'common/api/osrdEditoastApi';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
 import ResizableSection from 'common/ResizableSection';
+import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPathCoordinates';
+import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import ManchetteWithSpaceTimeChartWrapper, {
   MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
 } from 'modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart';
@@ -24,8 +27,8 @@ import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/
 import { updateViewport, type Viewport } from 'reducers/map';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { getPointOnTrackCoordinates } from 'utils/geometry';
 
+import { useScenarioContext } from '../hooks/useScenarioContext';
 import useSimulationResults from '../hooks/useSimulationResults';
 import type { TrainSpaceTimeData } from '../types';
 
@@ -55,6 +58,8 @@ const SimulationResults = ({
   const { t } = useTranslation('simulation');
   const dispatch = useAppDispatch();
 
+  const { getTrackSectionsByIds } = useScenarioContext();
+
   const {
     selectedTrainSchedule,
     selectedTrainRollingStock,
@@ -66,6 +71,7 @@ const SimulationResults = ({
 
   const [extViewport, setExtViewport] = useState<Viewport>();
   const [showWarpedMap, setShowWarpedMap] = useState(false);
+  const [pathItemsCoordinates, setPathItemsCoordinates] = useState<Position[]>();
 
   const [manchetteWithSpaceTimeChartHeight, setManchetteWithSpaceTimeChartHeight] = useState(
     MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT
@@ -90,12 +96,30 @@ const SimulationResults = ({
   }, [projectionData]);
 
   // Compute path items coordinates in order to place them on the map
-  const pathItemsCoordinates =
-    path &&
-    pathProperties &&
-    path.path_item_positions.map((positionOnPath) =>
-      getPointOnTrackCoordinates(pathProperties.geometry, path.length, positionOnPath)
-    );
+  useEffect(() => {
+    const getPathItemsCoordinates = async (pathfindingResult: PathfindingResultSuccess) => {
+      const trackIds = pathfindingResult.track_section_ranges.map((range) => range.track_section);
+      const tracks = await getTrackSectionsByIds(trackIds);
+      const tracksLengthCumulativeSums = getTrackLengthCumulativeSums(
+        pathfindingResult.track_section_ranges
+      );
+
+      const waypointsCoordinates = pathfindingResult.path_item_positions.map((position) =>
+        getPointOnPathCoordinates(
+          tracks,
+          pathfindingResult.track_section_ranges,
+          tracksLengthCumulativeSums,
+          position
+        )
+      );
+
+      setPathItemsCoordinates(waypointsCoordinates);
+    };
+
+    if (path) {
+      getPathItemsCoordinates(path);
+    }
+  }, [path]);
 
   const {
     operationalPoints: projectedOperationalPoints,

--- a/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 
 import type { TrackRange } from 'common/api/osrdEditoastApi';
 
-import { findTrackSectionOffset } from '../createPathStep';
+import findTrackSectionOffset from '../findTrackSectionOffset';
 
-describe('findTrackOffset', () => {
+describe('findTrackSectionOffset', () => {
   it('should correctly find the track offset', () => {
     const trackRangesLengthCumulativeSums = [1000, 2000, 3000, 4000, 5000];
     const trackRanges = [
@@ -81,5 +81,25 @@ describe('findTrackOffset', () => {
     );
 
     expect(result).toEqual(null);
+  });
+
+  it('should correctly find the track offset if it is located on the first track range', () => {
+    const trackRangesLengthCumulativeSums = [1000, 2000, 3000, 4000, 5000];
+    const trackRanges = [
+      { track_section: 'track_0', begin: 500, end: 1500, direction: 'START_TO_STOP' },
+      { track_section: 'track_1' },
+      { track_section: 'track_2', begin: 60, end: 1060, direction: 'STOP_TO_START' },
+      { track_section: 'track_3' },
+      { track_section: 'track_4' },
+    ] as TrackRange[];
+
+    const offsetOnPath = 900;
+    const result = findTrackSectionOffset(
+      offsetOnPath,
+      trackRangesLengthCumulativeSums,
+      trackRanges
+    );
+
+    expect(result).toEqual({ track: 'track_0', offset: 1400 });
   });
 });

--- a/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/findTrackSectionOffset.spec.ts
@@ -65,7 +65,7 @@ describe('findTrackSectionOffset', () => {
     expect(result).toEqual({ track: 'track_2', offset: 1050 });
   });
 
-  it('should not find the track offset if past cumulative sums', () => {
+  it('should throw an error if the given position on path is beyond the last position of the path', () => {
     const trackRangesLengthCumulativeSums = [1000, 2000, 3000];
     const trackRanges = [
       { track_section: 'track_0' },
@@ -74,13 +74,10 @@ describe('findTrackSectionOffset', () => {
     ] as TrackRange[];
 
     const offsetOnPath = 3001;
-    const result = findTrackSectionOffset(
-      offsetOnPath,
-      trackRangesLengthCumulativeSums,
-      trackRanges
-    );
 
-    expect(result).toEqual(null);
+    expect(() =>
+      findTrackSectionOffset(offsetOnPath, trackRangesLengthCumulativeSums, trackRanges)
+    ).toThrow('No track range found for the given position on path');
   });
 
   it('should correctly find the track offset if it is located on the first track range', () => {

--- a/front/src/modules/pathfinding/helpers/__tests__/getTrackLengthCumulativeSums.spec.ts
+++ b/front/src/modules/pathfinding/helpers/__tests__/getTrackLengthCumulativeSums.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import type { TrackRange } from 'common/api/osrdEditoastApi';
+
+import getTrackLengthCumulativeSums from '../getTrackLengthCumulativeSums';
+
+describe('getTrackLengthCumulativeSums', () => {
+  it('should return empty array for an empty input', () => {
+    const trackRanges: TrackRange[] = [];
+
+    const result = getTrackLengthCumulativeSums(trackRanges);
+    expect(result).toEqual([]);
+  });
+
+  it('should return the correct cumulative sums', () => {
+    const trackRanges: TrackRange[] = [
+      { begin: 1000, end: 1500, direction: 'START_TO_STOP', track_section: 'a' },
+      { begin: 0, end: 5000, direction: 'START_TO_STOP', track_section: 'b' },
+    ];
+
+    const result = getTrackLengthCumulativeSums(trackRanges);
+    expect(result).toEqual([500, 5500]);
+  });
+});

--- a/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
+++ b/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
@@ -1,0 +1,29 @@
+import type { TrackRange } from 'common/api/osrdEditoastApi';
+
+/**
+ * Return the track offset corresponding to the given position on path, composed of the track section id
+ * and the offset on this track section in mm
+ */
+const findTrackSectionOffset = (
+  positionOnPath: number, // in mm
+  tracksLengthCumulativeSums: number[], // in mm
+  trackRangesOnPath: TrackRange[]
+) => {
+  const index = tracksLengthCumulativeSums.findIndex(
+    (cumulativeSum) => positionOnPath <= cumulativeSum
+  );
+  const trackRange = trackRangesOnPath[index];
+  if (!trackRange) return null;
+
+  // compute offset
+  const inferiorSum = index > 0 ? tracksLengthCumulativeSums[index - 1] : 0;
+  const offsetOnTrackRange = positionOnPath - inferiorSum;
+  const offsetOnTrackSection =
+    trackRange.direction === 'START_TO_STOP'
+      ? trackRange.begin + offsetOnTrackRange
+      : trackRange.end - offsetOnTrackRange;
+
+  return { track: trackRange.track_section, offset: offsetOnTrackSection };
+};
+
+export default findTrackSectionOffset;

--- a/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
+++ b/front/src/modules/pathfinding/helpers/findTrackSectionOffset.ts
@@ -13,7 +13,10 @@ const findTrackSectionOffset = (
     (cumulativeSum) => positionOnPath <= cumulativeSum
   );
   const trackRange = trackRangesOnPath[index];
-  if (!trackRange) return null;
+
+  if (!trackRange) {
+    throw new Error('No track range found for the given position on path');
+  }
 
   // compute offset
   const inferiorSum = index > 0 ? tracksLengthCumulativeSums[index - 1] : 0;

--- a/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
+++ b/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
@@ -22,9 +22,9 @@ const getPointOnPathCoordinates = (
     trackRanges
   );
 
-  const track = tracks[trackOffset!.track];
+  const track = tracks[trackOffset.track];
 
-  return getPointOnTrackCoordinates(track.geo, mToMm(track.length), trackOffset!.offset);
+  return getPointOnTrackCoordinates(track.geo, mToMm(track.length), trackOffset.offset);
 };
 
 export default getPointOnPathCoordinates;

--- a/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
+++ b/front/src/modules/pathfinding/helpers/getPointOnPathCoordinates.ts
@@ -1,0 +1,30 @@
+import type { Position } from 'geojson';
+
+import type { TrackRange, TrackSection } from 'common/api/osrdEditoastApi';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
+import { mToMm } from 'utils/physics';
+
+import findTrackSectionOffset from './findTrackSectionOffset';
+
+/**
+ * Compute the coordinates of a point on a path from its path offset
+ * and the list of tracks (track sections and ranges) composing the path.
+ */
+const getPointOnPathCoordinates = (
+  tracks: Record<string, TrackSection>,
+  trackRanges: TrackRange[],
+  tracksLengthCumulativeSums: number[],
+  positionOnPath: number
+): Position => {
+  const trackOffset = findTrackSectionOffset(
+    positionOnPath,
+    tracksLengthCumulativeSums,
+    trackRanges
+  );
+
+  const track = tracks[trackOffset!.track];
+
+  return getPointOnTrackCoordinates(track.geo, mToMm(track.length), trackOffset!.offset);
+};
+
+export default getPointOnPathCoordinates;

--- a/front/src/modules/pathfinding/helpers/getTrackLengthCumulativeSums.ts
+++ b/front/src/modules/pathfinding/helpers/getTrackLengthCumulativeSums.ts
@@ -1,0 +1,22 @@
+import type { TrackRange } from 'common/api/osrdEditoastApi';
+
+/**
+ * Given a list of track ranges, return the array of cumulative sums of the lengths of the track ranges.
+ */
+const getTrackLengthCumulativeSums = (trackRanges: TrackRange[]): number[] => {
+  const results: number[] = [];
+
+  trackRanges.forEach((range, index) => {
+    const rangeLength = Math.abs(range.end - range.begin);
+
+    if (index === 0) {
+      results.push(rangeLength);
+    } else {
+      results.push(results[results.length - 1] + rangeLength);
+    }
+  });
+
+  return results;
+};
+
+export default getTrackLengthCumulativeSums;

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -33,6 +33,8 @@ import { Duration } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 
 import useInfraStatus from './useInfraStatus';
+import getPointOnPathCoordinates from '../helpers/getPointOnPathCoordinates';
+import getTrackLengthCumulativeSums from '../helpers/getTrackLengthCumulativeSums';
 import type { PathfindingState } from '../types';
 
 const initialPathfindingState = {
@@ -63,7 +65,7 @@ const usePathfinding = (
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
 
-  const { infraId } = useScenarioContext();
+  const { infraId, getTrackSectionsByIds } = useScenarioContext();
 
   const setIsMissingParam = () =>
     setPathfindingState({ ...initialPathfindingState, isMissingParam: true });
@@ -119,6 +121,12 @@ const usePathfinding = (
       return;
     }
 
+    const trackIds = pathResult.track_section_ranges.map((range) => range.track_section);
+    const trackSectionsById = await getTrackSectionsByIds(trackIds);
+    const tracksLengthCumulativeSums = getTrackLengthCumulativeSums(
+      pathResult.track_section_ranges
+    );
+
     const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
       operational_points,
       geometry,
@@ -142,12 +150,17 @@ const usePathfinding = (
         positionOnPath: pathResult.path_item_positions[i],
         stopFor,
         theoreticalMargin,
+        coordinates: getPointOnPathCoordinates(
+          trackSectionsById,
+          pathResult.track_section_ranges,
+          tracksLengthCumulativeSums,
+          pathResult.path_item_positions[i]
+        ),
         ...(correspondingOp && {
           name: correspondingOp.name,
           uic: correspondingOp.uic,
           secondary_code: correspondingOp.ch,
           kp: correspondingOp.kp,
-          coordinates: correspondingOp.coordinates,
         }),
       };
     });

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -12,7 +12,7 @@ import { getSupportedElectrification, isThermal } from 'modules/rollingStock/hel
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { addElementAtIndex } from 'utils/array';
-import { getPointCoordinates } from 'utils/geometry';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import getStepLocation from './helpers/getStepLocation';
 
@@ -35,7 +35,7 @@ export const formatSuggestedOperationalPoints = (
     offsetOnTrack: op.part.position,
     track: op.part.track,
     positionOnPath: op.position,
-    coordinates: getPointCoordinates(geometry, pathLength, op.position),
+    coordinates: getPointOnTrackCoordinates(geometry, pathLength, op.position),
     metadata: op?.metadata,
   }));
 

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -29,7 +29,6 @@ const createPathStep = (
     tracksLengthCumulativeSums,
     pathProperties.trackSectionRanges
   );
-  if (!trackOffset) return undefined;
 
   const coordinates = getPointOnPathCoordinates(
     tracksById,
@@ -84,8 +83,6 @@ export const createCutAtPathStep = (
     tracksLengthCumulativeSums,
     pathProperties.trackSectionRanges
   );
-
-  if (!trackOffset) return null;
 
   const coordinatesAtCut = getPointOnPathCoordinates(
     tracksById,

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -1,10 +1,11 @@
 import nextId from 'react-id-generator';
 
 import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import type { TrackSection } from 'common/api/osrdEditoastApi';
 import type { IntervalItem } from 'common/IntervalsEditor/types';
 import findTrackSectionOffset from 'modules/pathfinding/helpers/findTrackSectionOffset';
+import getPointOnPathCoordinates from 'modules/pathfinding/helpers/getPointOnPathCoordinates';
 import type { PathStep } from 'reducers/osrdconf/types';
-import { getPointOnTrackCoordinates } from 'utils/geometry';
 import { mmToM, mToMm } from 'utils/physics';
 
 import { NO_POWER_RESTRICTION } from '../consts';
@@ -13,7 +14,8 @@ const createPathStep = (
   positionOnPathInM: number, // in meters
   tracksLengthCumulativeSums: number[],
   pathProperties: ManageTrainSchedulePathProperties,
-  pathSteps: PathStep[]
+  pathSteps: PathStep[],
+  tracksById: Record<string, TrackSection>
 ): PathStep | undefined => {
   const positionOnPath = mToMm(positionOnPathInM);
   if (
@@ -29,10 +31,11 @@ const createPathStep = (
   );
   if (!trackOffset) return undefined;
 
-  const coordinates = getPointOnTrackCoordinates(
-    pathProperties.geometry,
-    pathProperties.length,
-    positionOnPath
+  const coordinates = getPointOnPathCoordinates(
+    tracksById,
+    pathProperties.trackSectionRanges,
+    tracksLengthCumulativeSums,
+    trackOffset.offset
   );
 
   return {
@@ -52,6 +55,7 @@ export const createCutAtPathStep = (
   rangesData: IntervalItem[],
   cutPositions: number[],
   tracksLengthCumulativeSums: number[],
+  tracksById: Record<string, TrackSection>,
   setCutPositions: (newCutPosition: number[]) => void
 ): PathStep | null => {
   const intervalCut = rangesData.find(
@@ -83,9 +87,10 @@ export const createCutAtPathStep = (
 
   if (!trackOffset) return null;
 
-  const coordinatesAtCut = getPointOnTrackCoordinates(
-    pathProperties.geometry,
-    pathProperties.length,
+  const coordinatesAtCut = getPointOnPathCoordinates(
+    tracksById,
+    pathProperties.trackSectionRanges,
+    tracksLengthCumulativeSums,
     cutAtPosition
   );
   return {

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -1,46 +1,13 @@
 import nextId from 'react-id-generator';
 
 import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
-import type { TrackRange } from 'common/api/osrdEditoastApi';
 import type { IntervalItem } from 'common/IntervalsEditor/types';
+import findTrackSectionOffset from 'modules/pathfinding/helpers/findTrackSectionOffset';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { getPointCoordinates } from 'utils/geometry';
 import { mmToM, mToMm } from 'utils/physics';
 
 import { NO_POWER_RESTRICTION } from '../consts';
-
-const findTrackSectionIndex = (position: number, tracksLengthCumulativeSums: number[]) => {
-  for (let i = 0; i < tracksLengthCumulativeSums.length; i += 1) {
-    if (position <= tracksLengthCumulativeSums[i]) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- * Return the track offset corresponding to the given position on path, composed of the track section id
- * and the offet on this track section in mm
- */
-export const findTrackSectionOffset = (
-  positionOnPath: number, // in mm
-  tracksLengthCumulativeSums: number[], // in mm
-  trackRangesOnPath: TrackRange[]
-) => {
-  const index = findTrackSectionIndex(positionOnPath, tracksLengthCumulativeSums);
-  const trackRange = trackRangesOnPath[index];
-  if (!trackRange) return null;
-
-  // compute offset
-  const inferiorSum = index > 0 ? tracksLengthCumulativeSums[index - 1] : 0;
-  const offsetOnTrackRange = positionOnPath - inferiorSum;
-  const offsetOnTrackSection =
-    trackRange.direction === 'START_TO_STOP'
-      ? trackRange.begin + offsetOnTrackRange
-      : trackRange.end - offsetOnTrackRange;
-
-  return { track: trackRange.track_section, offset: offsetOnTrackSection };
-};
 
 const createPathStep = (
   positionOnPathInM: number, // in meters

--- a/front/src/modules/powerRestriction/helpers/createPathStep.ts
+++ b/front/src/modules/powerRestriction/helpers/createPathStep.ts
@@ -4,7 +4,7 @@ import type { ManageTrainSchedulePathProperties } from 'applications/operational
 import type { IntervalItem } from 'common/IntervalsEditor/types';
 import findTrackSectionOffset from 'modules/pathfinding/helpers/findTrackSectionOffset';
 import type { PathStep } from 'reducers/osrdconf/types';
-import { getPointCoordinates } from 'utils/geometry';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
 import { mmToM, mToMm } from 'utils/physics';
 
 import { NO_POWER_RESTRICTION } from '../consts';
@@ -29,7 +29,7 @@ const createPathStep = (
   );
   if (!trackOffset) return undefined;
 
-  const coordinates = getPointCoordinates(
+  const coordinates = getPointOnTrackCoordinates(
     pathProperties.geometry,
     pathProperties.length,
     positionOnPath
@@ -83,7 +83,7 @@ export const createCutAtPathStep = (
 
   if (!trackOffset) return null;
 
-  const coordinatesAtCut = getPointCoordinates(
+  const coordinatesAtCut = getPointOnTrackCoordinates(
     pathProperties.geometry,
     pathProperties.length,
     cutAtPosition

--- a/front/src/modules/powerRestriction/helpers/utils.ts
+++ b/front/src/modules/powerRestriction/helpers/utils.ts
@@ -1,4 +1,5 @@
 import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
+import type { TrackSection } from 'common/api/osrdEditoastApi';
 import type { IntervalItem } from 'common/IntervalsEditor/types';
 import type { PathStep } from 'reducers/osrdconf/types';
 import { mToMm } from 'utils/physics';
@@ -13,32 +14,42 @@ export const getOrCreatePathStepAtPosition = (
   positionOnPathInM: number,
   pathSteps: PathStep[],
   tracksLengthCumulativeSums: number[],
-  pathProperties: ManageTrainSchedulePathProperties
+  pathProperties: ManageTrainSchedulePathProperties,
+  tracksById: Record<string, TrackSection>
 ) => {
   const pathStep = getPathStep(pathSteps, positionOnPathInM);
   if (pathStep) {
     return pathStep;
   }
-  return createPathStep(positionOnPathInM, tracksLengthCumulativeSums, pathProperties, pathSteps);
+  return createPathStep(
+    positionOnPathInM,
+    tracksLengthCumulativeSums,
+    pathProperties,
+    pathSteps,
+    tracksById
+  );
 };
 
 export const extractPathStepsFromRange = (
   range: IntervalItem,
   pathSteps: PathStep[],
   tracksLengthCumulativeSums: number[],
-  pathProperties: ManageTrainSchedulePathProperties
+  pathProperties: ManageTrainSchedulePathProperties,
+  tracksById: Record<string, TrackSection>
 ) => {
   const from = getOrCreatePathStepAtPosition(
     range.begin,
     pathSteps,
     tracksLengthCumulativeSums,
-    pathProperties
+    pathProperties,
+    tracksById
   );
   const to = getOrCreatePathStepAtPosition(
     range.end,
     pathSteps,
     tracksLengthCumulativeSums,
-    pathProperties
+    pathProperties,
+    tracksById
   );
   return { from, to };
 };

--- a/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
+++ b/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
@@ -6,6 +6,7 @@ import type {
 } from 'applications/operationalStudies/types';
 import type { IntervalItem } from 'common/IntervalsEditor/types';
 import { useOsrdConfActions } from 'common/osrdContext';
+import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
 import { createCutAtPathStep } from 'modules/powerRestriction/helpers/createPathStep';
 import type { OperationalStudiesConfSliceActions } from 'reducers/osrdconf/operationalStudiesConf';
 import type { PathStep } from 'reducers/osrdconf/types';
@@ -48,16 +49,7 @@ const usePowerRestrictionSelectorBehaviours = ({
 
   /** Cumulative sums of the trackSections' length on path (in mm) */
   const tracksLengthCumulativeSums = useMemo(
-    () =>
-      pathProperties.trackSectionRanges.reduce((acc, range, index) => {
-        const rangeLength = Math.abs(range.end - range.begin);
-        if (index === 0) {
-          acc.push(rangeLength);
-        } else {
-          acc.push(acc[acc.length - 1] + rangeLength);
-        }
-        return acc;
-      }, [] as number[]),
+    () => getTrackLengthCumulativeSums(pathProperties.trackSectionRanges),
     [pathProperties.trackSectionRanges]
   );
 

--- a/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
+++ b/front/src/modules/powerRestriction/hooks/usePowerRestrictionSelectorBehaviours.ts
@@ -1,9 +1,11 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type {
   ManageTrainSchedulePathProperties,
   PowerRestriction,
 } from 'applications/operationalStudies/types';
+import type { TrackSection } from 'common/api/osrdEditoastApi';
 import type { IntervalItem } from 'common/IntervalsEditor/types';
 import { useOsrdConfActions } from 'common/osrdContext';
 import getTrackLengthCumulativeSums from 'modules/pathfinding/helpers/getTrackLengthCumulativeSums';
@@ -39,6 +41,8 @@ const usePowerRestrictionSelectorBehaviours = ({
 }: UsePowerRestrictionSelectorBehavioursArgs) => {
   const dispatch = useAppDispatch();
 
+  const { getTrackSectionsByIds } = useScenarioContext();
+
   const {
     upsertPowerRestrictionRanges,
     cutPowerRestrictionRanges,
@@ -46,6 +50,8 @@ const usePowerRestrictionSelectorBehaviours = ({
     resizeSegmentEndInput,
     resizeSegmentBeginInput,
   } = useOsrdConfActions() as OperationalStudiesConfSliceActions;
+
+  const [trackSectionsById, setTrackSectionsById] = useState<Record<string, TrackSection>>({});
 
   /** Cumulative sums of the trackSections' length on path (in mm) */
   const tracksLengthCumulativeSums = useMemo(
@@ -64,7 +70,8 @@ const usePowerRestrictionSelectorBehaviours = ({
       newRange,
       pathSteps,
       tracksLengthCumulativeSums,
-      pathProperties
+      pathProperties,
+      trackSectionsById
     );
 
     if (from && to) {
@@ -89,6 +96,7 @@ const usePowerRestrictionSelectorBehaviours = ({
       ranges,
       cutPositions,
       tracksLengthCumulativeSums,
+      trackSectionsById,
       setCutPositions
     );
     if (cutAt) {
@@ -125,7 +133,8 @@ const usePowerRestrictionSelectorBehaviours = ({
       newPosition,
       pathSteps,
       tracksLengthCumulativeSums,
-      pathProperties
+      pathProperties,
+      trackSectionsById
     );
     if (!newPathStep) return;
 
@@ -147,6 +156,16 @@ const usePowerRestrictionSelectorBehaviours = ({
         })
       );
   };
+
+  useEffect(() => {
+    const fetchTracks = async () => {
+      const trackIds = pathProperties.trackSectionRanges.map((range) => range.track_section);
+      const tracks = await getTrackSectionsByIds(trackIds);
+      setTrackSectionsById(tracks);
+    };
+
+    if (pathProperties.trackSectionRanges) fetchTracks();
+  }, [pathProperties.trackSectionRanges]);
 
   return {
     resizeSegments,

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
@@ -20,7 +20,7 @@ import { useOsrdConfSelectors } from 'common/osrdContext';
 import { setPointIti } from 'modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/setPointIti';
 import { getOrigin, getDestination } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { PathStep } from 'reducers/osrdconf/types';
-import { getPointCoordinates } from 'utils/geometry';
+import { getPointOnTrackCoordinates } from 'utils/geometry';
 
 import type { FeatureInfoClick } from '../types';
 import OperationalPointPopupDetails from './OperationalPointPopupDetails';
@@ -122,7 +122,7 @@ const AddPathStepPopup = ({
 
       const trackPartCoordinates = operationalPoint.parts.map((part) => ({
         trackName: tracks[part.track]?.extensions?.sncf?.track_name,
-        coordinates: getPointCoordinates(
+        coordinates: getPointOnTrackCoordinates(
           tracks[part.track]?.geo,
           tracks[part.track]?.length,
           part.position

--- a/front/src/utils/geometry.ts
+++ b/front/src/utils/geometry.ts
@@ -151,16 +151,21 @@ export function nearestPointOnLine(
   });
 }
 
-export function getPointCoordinates(
+/**
+ * Given a track's geometry and length and an offset from the start of the track (in mm),
+ * returns the coordinates of the point for the given offset.
+ */
+export function getPointOnTrackCoordinates(
   geometry: GeoJsonLineString,
-  pathLength: number,
-  infraPositionOnPath: number
+  trackLength: number, // in mm
+  infraPositionOnTrack: number // in mm
 ): Position {
   const pathLineString = lineString(geometry.coordinates);
   const geometryTrackLength = length(pathLineString, { units: 'millimeters' });
-  const infraTrackLength = pathLength;
+  const infraTrackLength = trackLength;
   // TODO TS2 : when adapting train update check that this computation works properly
-  const geometryDistanceAlongTrack = infraPositionOnPath * (geometryTrackLength / infraTrackLength);
+  const geometryDistanceAlongTrack =
+    infraPositionOnTrack * (geometryTrackLength / infraTrackLength);
   return along(pathLineString, geometryDistanceAlongTrack, { units: 'millimeters' }).geometry
     .coordinates;
 }


### PR DESCRIPTION
closes #8901 

See commits

The markers were not correctly placed because the calculations were wrong: we could not use a simple rule of three to find the correct point in the path geometry.
