### PR TITLE
core: stdcm: explicitely output route path

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
@@ -1,0 +1,11 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.utils.indexing.StaticIdx
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+
+fun <T> List<StaticIdx<T>>.toIdxList(): StaticIdxList<T> {
+    val res = mutableStaticIdxArrayListOf<T>()
+    res.addAll(this)
+    return res
+}

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -25,7 +25,6 @@ import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.DirTrackChunkId
 import fr.sncf.osrd.sim_infra.api.SpeedLimitProperty
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
-import fr.sncf.osrd.sim_infra.utils.chunksToRoutes
 import fr.sncf.osrd.standalone_sim.makeElectricalProfiles
 import fr.sncf.osrd.standalone_sim.makeMRSPResponse
 import fr.sncf.osrd.standalone_sim.result.ElectrificationRange
@@ -42,6 +41,7 @@ import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.toIdxList
 import fr.sncf.osrd.utils.units.*
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
@@ -177,7 +177,7 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
                 path.trainPath,
                 path.chunkPath,
                 infra,
-                infra.blockInfra.chunksToRoutes(infra.rawInfra, path.chunkPath.chunks),
+                path.routePath.toIdxList(),
                 rollingStock,
                 parseSimulationScheduleItems(path.stopResults),
                 listOf(),

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMResult.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope_sim.PhysicsPath
 import fr.sncf.osrd.graph.PathfindingResultId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.PathProperties
+import fr.sncf.osrd.sim_infra.api.RouteId
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.train.TrainStop
 
@@ -18,6 +19,7 @@ data class STDCMResult(
     val trainPath: PathProperties,
     val chunkPath: ChunkPath,
     val physicsPath: PhysicsPath,
+    val routePath: List<RouteId>,
     val departureTime: Double,
     val stopResults: List<TrainStop>
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -98,6 +98,7 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
                 trainPath,
                 chunkPath,
                 physicsPath,
+                routes,
                 updatedTimeData.departureTime,
 
                 // Allow us to display OP, a hack that will be fixed

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -26,7 +26,6 @@ import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.moshi.MoshiUtils
 import fr.sncf.osrd.utils.units.Offset
 import java.io.File
@@ -187,10 +186,4 @@ object Helpers {
         val endOffset = getOffsetOfTrackLocationOnChunks(infra, end, chunks)
         return buildChunkPath(infra, chunks, startOffset!!, endOffset!!)
     }
-}
-
-fun <T> List<StaticIdx<T>>.toIdxList(): StaticIdxList<T> {
-    val res = mutableStaticIdxArrayListOf<T>()
-    res.addAll(this)
-    return res
 }


### PR DESCRIPTION
Sometimes the route path we'd use in `ScheduleMetadataExtractor` would take a different path than the one use in the exploration (at the very end of the path). This very rarely caused conflicts. 