### PR TITLE
editoast: ensure spans are created in tests regardless of log level

### DIFF
--- a/editoast/editoast_common/src/tracing.rs
+++ b/editoast/editoast_common/src/tracing.rs
@@ -32,12 +32,19 @@ pub struct TracingConfig {
 pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
     tracing_config: TracingConfig,
     log_level: tracing_subscriber::filter::LevelFilter,
+    ignore_rust_log: bool,
     exporter: T,
 ) -> impl tracing::Subscriber {
-    let env_filter_layer = tracing_subscriber::EnvFilter::builder()
+    let env_filter_builder = tracing_subscriber::EnvFilter::builder()
         // Set the default log level to 'info'
-        .with_default_directive(log_level.into())
-        .from_env_lossy();
+        .with_default_directive(log_level.into());
+
+    let env_filter_layer = if ignore_rust_log {
+        env_filter_builder.parse_lossy("")
+    } else {
+        env_filter_builder.from_env_lossy()
+    };
+
     let fmt_layer = tracing_subscriber::fmt::layer()
         .pretty()
         .with_file(true)

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -46,7 +46,7 @@ pub struct RunserverArgs {
     /// If this option is set, logging for the STDCM will be enabled.
     /// When enabled, relevant logs will be captured to aid in debugging and monitoring.
     #[clap(long, env = "ENABLE_STDCM_LOGGING", default_value_t = true)]
-    enable_stdcm_logging: bool,
+    pub(crate) enable_stdcm_logging: bool,
     #[clap(long, env = "OSRDYNE_API_URL", default_value_t = Url::parse("http://127.0.0.1:4242/").unwrap())]
     osrdyne_api_url: Url,
     /// The timeout to use when performing the healthcheck, in milliseconds

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -115,9 +115,11 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
         stream: EditoastMode::from_client(&client).into(),
         telemetry,
     };
+
     create_tracing_subscriber(
         tracing_config,
         tracing_subscriber::filter::LevelFilter::INFO,
+        false,
         exporter,
     )
     .init();

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -350,6 +350,7 @@ mod tests {
             .enable_authorization(config.enable_authorization)
             .enable_stdcm_logging(config.enable_stdcm_logging)
             .enable_telemetry(config.enable_telemetry)
+            .ignore_rust_log()
             .user(user.clone())
             .roles(roles)
             .build();

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -65,6 +65,7 @@ pub(crate) struct TestAppBuilder {
     enable_authorization: bool,
     enable_stdcm_logging: bool,
     enable_telemetry: bool,
+    ignore_rust_log: bool,
     user: Option<UserInfo>,
     roles: HashSet<BuiltinRole>,
 }
@@ -78,6 +79,7 @@ impl TestAppBuilder {
             enable_authorization: false,
             enable_stdcm_logging: false,
             enable_telemetry: true,
+            ignore_rust_log: false,
             user: None,
             roles: HashSet::new(),
         }
@@ -113,6 +115,11 @@ impl TestAppBuilder {
 
     pub fn enable_telemetry(mut self, enable_telemetry: bool) -> Self {
         self.enable_telemetry = enable_telemetry;
+        self
+    }
+
+    pub fn ignore_rust_log(mut self) -> Self {
+        self.ignore_rust_log = true;
         self
     }
 
@@ -179,9 +186,11 @@ impl TestAppBuilder {
             stream: Stream::Stdout,
             telemetry,
         };
+
         let sub = create_tracing_subscriber(
             tracing_config,
             tracing_subscriber::filter::LevelFilter::DEBUG,
+            self.ignore_rust_log,
             NoopSpanExporter,
         );
         let tracing_guard = tracing::subscriber::set_default(sub);


### PR DESCRIPTION
### Problem:
When running tests with `RUST_LOG=warn` or `RUST_LOG=error`, the `axum-tracing-opentelemetry` [crate doesn't create spans if the log level is below `info`](https://github.com/OpenRailAssociation/osrd/pull/10113). This causes tests of `views::stdcm_logs` to fail because there is no `trace_id` (span) generated.

### Solution:
To fix this, we modified the `create_tracing_subscriber` function to ignore the `RUST_LOG` environment variable during tests. This ensures that spans (`trace_id`) are always created, even when the log level is set to `warn` or `error`, allowing the tests to run correctly.

