### PR TITLE
Compress editoast cached data

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1318,6 +1318,7 @@ dependencies = [
  "itertools",
  "json-patch",
  "lapin",
+ "lz4_flex",
  "mime",
  "mvt",
  "opentelemetry",
@@ -2662,6 +2663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -4932,6 +4942,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -149,6 +149,9 @@ json-patch = { version = "3.0.1", default-features = false, features = [
   "utoipa",
 ] }
 lapin = "2.5.0"
+lz4_flex = { version = "0.11.3", default-features = false, features = [
+  "frame",
+] }
 mime = "0.3.17"
 mvt.workspace = true
 opentelemetry.workspace = true

--- a/editoast/src/valkey_utils.rs
+++ b/editoast/src/valkey_utils.rs
@@ -16,7 +16,7 @@ use redis::RedisResult;
 use redis::ToRedisArgs;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tracing::trace;
+use tracing::{debug, span, trace, Level};
 use url::Url;
 
 use crate::error::Result;
@@ -119,7 +119,7 @@ impl ValkeyConnection {
     }
 
     /// Get a list of deserializable value from valkey
-    #[tracing::instrument(name = "cache:get_bulk", skip(self), err)]
+    #[tracing::instrument(name = "cache:json_get_bulk", skip(self), err)]
     pub async fn json_get_bulk<T: DeserializeOwned, K: Debug + ToRedisArgs + Send + Sync>(
         &mut self,
         keys: &[K],
@@ -165,7 +165,7 @@ impl ValkeyConnection {
     }
 
     /// Set a list of serializable values to valkey
-    #[tracing::instrument(name = "cache:set_bulk", skip(self, items), err)]
+    #[tracing::instrument(name = "cache:json_set_bulk", skip(self, items), err)]
     pub async fn json_set_bulk<K: Debug + ToRedisArgs + Send + Sync, T: Serialize>(
         &mut self,
         items: &[(K, T)],
@@ -191,6 +191,77 @@ impl ValkeyConnection {
 
         self.mset(&serialized_items).await?;
         Ok(())
+    }
+
+    /// Set a list of compressed serializable values to valkey
+    #[tracing::instrument(name = "cache:compressed_set_bulk", skip(self, items), err)]
+    pub async fn compressed_set_bulk<K: Debug + ToRedisArgs + Send + Sync, T: Serialize>(
+        &mut self,
+        items: &[(K, T)],
+    ) -> Result<()> {
+        // Avoid mset to fail if keys is empty
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let compressed_items = span!(Level::INFO, "Compressing data").in_scope(|| {
+            items
+                .iter()
+                .map(|(key, value)| {
+                    // Create a LZ4 encoder.
+                    let mut encoder = lz4_flex::frame::FrameEncoder::new(Vec::new());
+                    // Serialize the `value` into JSON format and write it to the encoder (which compresses it).
+                    serde_json::to_writer(&mut encoder, value)?;
+                    // Finalize the compression process and retrieve the compressed data.
+                    let compressed_value = encoder.finish().map_err(|_| {
+                        RedisError::from((
+                            ErrorKind::IoError,
+                            "An error occured compressing the value",
+                        ))
+                    })?;
+                    Ok((key, compressed_value))
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
+
+        // Store the compressed values using mset
+        span!(Level::INFO, "Sending items to Redis")
+            .in_scope(|| async move { self.mset(&compressed_items).await })
+            .await?;
+        Ok(())
+    }
+
+    /// Retrieves a list of compressed serialized values from Valkey, decompresses them, and deserializes the result.
+    #[tracing::instrument(name = "cache:compressed_get_bulk", skip(self), err)]
+    pub async fn compressed_get_bulk<K: Debug + ToRedisArgs + Send + Sync, T: DeserializeOwned>(
+        &mut self,
+        keys: &[K],
+    ) -> Result<Vec<Option<T>>> {
+        // Avoid mget to fail if keys is empty
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+        debug!(nb_keys = keys.len());
+
+        // Fetch the values from Redis
+        let values = span!(Level::INFO, "Fetching values from Redis")
+            .in_scope(|| async move { self.mget::<_, Vec<Option<Vec<u8>>>>(keys).await })
+            .await?;
+
+        // Decompress each value if it exists
+        span!(Level::INFO, "Decompressing data").in_scope(|| {
+            values
+                .into_iter()
+                .map(|value| match value {
+                    Some(compressed_data) => {
+                        let mut decoder = lz4_flex::frame::FrameDecoder::new(&compressed_data[..]);
+                        let deserialized: T = serde_json::from_reader(&mut decoder)?;
+                        Ok(Some(deserialized))
+                    }
+                    None => Ok(None),
+                })
+                .collect()
+        })
     }
 }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -245,7 +245,7 @@ async fn pathfinding_blocks_batch(
 
     // Try to retrieve the result from Valkey
     let pathfinding_cached_results: Vec<Option<PathfindingResult>> =
-        valkey_conn.json_get_bulk(&hashes).await?;
+        valkey_conn.compressed_get_bulk(&hashes).await?;
     let pathfinding_cached_results: HashMap<_, _> =
         hashes.into_iter().zip(pathfinding_cached_results).collect();
 
@@ -325,7 +325,7 @@ async fn pathfinding_blocks_batch(
     }
 
     debug!(nb_cached = to_cache.len(), "Caching pathfinding response");
-    valkey_conn.json_set_bulk(&to_cache).await?;
+    valkey_conn.compressed_set_bulk(&to_cache).await?;
 
     Ok(pathfinding_results)
 }

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -87,7 +87,7 @@ editoast_common::schemas! {
     projection::schemas(),
 }
 
-pub const TRAIN_SIZE_BATCH: usize = 500;
+pub const TRAIN_SIZE_BATCH: usize = 250;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "train_schedule")]
@@ -427,6 +427,7 @@ pub async fn train_simulation_batch(
     Ok(results)
 }
 
+#[tracing::instrument(skip_all, fields(nb_trains = train_schedules.len()))]
 pub async fn consist_train_simulation_batch(
     conn: &mut DbConnection,
     valkey_client: Arc<ValkeyClient>,
@@ -514,8 +515,9 @@ pub async fn consist_train_simulation_batch(
         nb_unique_sim = to_sim.len()
     );
     let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();
-    let cached_results: Vec<Option<SimulationResponse>> =
-        valkey_conn.json_get_bulk(&cached_simulation_hash).await?;
+    let cached_results: Vec<Option<SimulationResponse>> = valkey_conn
+        .compressed_get_bulk(&cached_simulation_hash)
+        .await?;
 
     let nb_hit = cached_results.iter().flatten().count();
     let nb_miss = to_sim.len() - nb_hit;
@@ -561,7 +563,7 @@ pub async fn consist_train_simulation_batch(
     }
 
     // Cache the simulation response
-    valkey_conn.json_set_bulk(&to_cache).await?;
+    valkey_conn.compressed_set_bulk(&to_cache).await?;
 
     // Return the response
     Ok(simulation_results


### PR DESCRIPTION
The json request and response from the pathfinding and the simulation take too much time to be get from valkey or push in valkey. The solution is to use gzip to compress the payloads.

## Benchmarks

All benchmark were run on dev.

### No compression (`BATCH_SIZE=500`)

- LMR: ~20s
- Get from cache (total): 9.4s
- Get from cache (sum): 14.0s

![image](https://github.com/user-attachments/assets/f063b6f9-b265-4ef0-85a5-348402e70f04)

### Zstd -1 (`BATCH_SIZE=500`)

- LMR: ~20s
- Get from cache (total): 13.7s
- Get from cache (sum): 22.6s

![image](https://github.com/user-attachments/assets/61c2e7a4-257d-43cf-a7a3-4e724cbcb79a)

### LZ4 -1 (`BATCH_SIZE=500`)

- LMR: ~14.4s
- Get from cache (total): 8.8s
- Get from cache (sum): 11.9s

![image](https://github.com/user-attachments/assets/79ba2566-fb47-4bba-9f82-48c69b15ebc8)
