### PR TITLE
doc: carry over script changes to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker compose up -d --build
 xdg-open http://localhost:4000/
 ```
 
-(Linux or WSL users can use `scripts/host-compose.sh` instead of `docker compose` to enable host networking - useful to launch services in a debugger)
+(Linux or WSL users can use `./osrd-compose host` instead of `docker compose` to enable host networking - useful to launch services in a debugger)
 
 ## Deployment
 

--- a/core/README.md
+++ b/core/README.md
@@ -111,6 +111,16 @@ For core:
 ./gradlew shadowJar && ALL_INFRA=true java -jar -ea -Xmx12g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof build/libs/osrd-all.jar worker --editoast-url http://localhost:8090/
 ```
 
+Removing cache on editoast is also usually helpful to repeat requests
+(please see the [dedicated section](../editoast/README.md#no-cache-mode)). \
+For editoast server, combining single-worker and no-cache modes requires a
+local instance (or a tweak of `docker-compose.single-worker.yml`):
+```sh
+cd ../editoast
+EDITOAST_CORE_SINGLE_WORKER=true NO_CACHE=true cargo run -- runserver
+```
+
+
 Clean or restart the whole stack can be necessary sometimes and is also available
 through docker compose CLI (the following wipes the database too):
 ```sh

--- a/core/README.md
+++ b/core/README.md
@@ -97,22 +97,22 @@ Using a specific script (just through `docker compose` CLI and a set of docker-c
 allows to run a single core worker for all infra on localhost network:
 
 ```sh
-./scripts/single-worker-compose.sh up -d
+./osrd-compose host sw up -d
 
 # or exclude 'core' service straight away:
-./scripts/single-worker-compose.sh up -d --scale core=0
+./osrd-compose host sw up -d --scale core=0
 ```
 
 Then, it is easy to replace the desired component for debug purpose. \
 For core:
 
 ```sh
-./scripts/single-worker-compose.sh down core # if 'core' is running
+./osrd-compose host sw down core # if 'core' is running
 ./gradlew shadowJar && ALL_INFRA=true java -jar -ea -Xmx12g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=dump.hprof build/libs/osrd-all.jar worker --editoast-url http://localhost:8090/
 ```
 
 Clean or restart the whole stack can be necessary sometimes and is also available
 through docker compose CLI (the following wipes the database too):
 ```sh
-./scripts/single-worker-compose.sh down -v
+./osrd-compose host sw down -v
 ```

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -77,6 +77,13 @@ cargo install --locked taplo-cli
 
 To setup `grcov`, please see [its documentation](https://github.com/mozilla/grcov#how-to-get-grcov)
 
+## No-cache mode
+
+Running editoast with deactivated cache can help repeating calls when debugging.
+```sh
+NO_CACHE=true cargo run -- runserver
+```
+
 ## For M1 MacOS users
 
 Our `docker-compose.yml` at the root of the project uses the `postgis` image by default.

--- a/front/README.md
+++ b/front/README.md
@@ -58,7 +58,7 @@ as `npm run e2e-tests` or `npx playwright test`.
 >
 > - Run all the components locally (you might keep Postgres and Valkey in containers)
 > - If on Linux, you can also launch all the containers on the host network: you can replace the
->   `docker compose <something>` above with `osrd/scripts/host-compose.sh <something>`
+>   `docker compose <something>` above with `osrd/osrd-compose host <something>`
 
 If the tests fail, a `front/test-results` folder will be created, containing videos and traces of
 the failed test executions. These files can help you understand what went wrong. Additionally, the

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -18,7 +18,7 @@ This component is built around 3 crates:
 ## Config
 
 The gateway reads `gateway.toml` in its current working directory.
-Please refer to `gateway.prod.sample.toml` for a relevant example.
+Please refer to `gateway.bundled.toml` for a relevant example.
 
 ```toml
 # Address on which the gateway will listen


### PR DESCRIPTION
Just update readmes after [current work on script](https://github.com/OpenRailAssociation/osrd/pull/10502) (targeting the 🚧-branch)
If it's easier to just pick the commit to avoid multiple reviews, please do (and close this).

TODO:
- [x] add a mention to no-cache option for editoast