### PR TITLE
editoast: force 'otel::tracing=info' for some tests

### DIFF
--- a/editoast/editoast_common/src/tracing.rs
+++ b/editoast/editoast_common/src/tracing.rs
@@ -27,6 +27,7 @@ pub struct Telemetry {
 pub struct TracingConfig {
     pub stream: Stream,
     pub telemetry: Option<Telemetry>,
+    pub directives: Vec<tracing_subscriber::filter::Directive>,
 }
 
 pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
@@ -38,6 +39,13 @@ pub fn create_tracing_subscriber<T: SpanExporter + 'static>(
         // Set the default log level to 'info'
         .with_default_directive(log_level.into())
         .from_env_lossy();
+    let env_filter_layer = tracing_config
+        .directives
+        .clone()
+        .into_iter()
+        .fold(env_filter_layer, |env_filter_layer, directive| {
+            env_filter_layer.add_directive(directive)
+        });
     let fmt_layer = tracing_subscriber::fmt::layer()
         .pretty()
         .with_file(true)

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -114,6 +114,7 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
     let tracing_config = TracingConfig {
         stream: EditoastMode::from_client(&client).into(),
         telemetry,
+        directives: vec![],
     };
     create_tracing_subscriber(
         tracing_config,

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -350,6 +350,7 @@ mod tests {
             .enable_authorization(config.enable_authorization)
             .enable_stdcm_logging(config.enable_stdcm_logging)
             .enable_telemetry(config.enable_telemetry)
+            .with_rust_log_directive("otel::tracing=info".parse().unwrap())
             .user(user.clone())
             .roles(roles)
             .build();

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -177,6 +177,7 @@ impl TestAppBuilder {
         let tracing_config = TracingConfig {
             stream: Stream::Stdout,
             telemetry,
+            directives: vec!["otel::tracing=info".parse().unwrap()],
         };
         let sub = create_tracing_subscriber(
             tracing_config,

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -24,6 +24,7 @@ use opentelemetry_sdk::export::trace::SpanData;
 use opentelemetry_sdk::export::trace::SpanExporter;
 use serde::de::DeserializeOwned;
 use tower_http::trace::TraceLayer;
+use tracing_subscriber::filter::Directive;
 use url::Url;
 
 use crate::{
@@ -65,6 +66,7 @@ pub(crate) struct TestAppBuilder {
     enable_authorization: bool,
     enable_stdcm_logging: bool,
     enable_telemetry: bool,
+    telemetry_directives: Vec<Directive>,
     user: Option<UserInfo>,
     roles: HashSet<BuiltinRole>,
 }
@@ -78,6 +80,7 @@ impl TestAppBuilder {
             enable_authorization: false,
             enable_stdcm_logging: false,
             enable_telemetry: true,
+            telemetry_directives: vec![],
             user: None,
             roles: HashSet::new(),
         }
@@ -113,6 +116,11 @@ impl TestAppBuilder {
 
     pub fn enable_telemetry(mut self, enable_telemetry: bool) -> Self {
         self.enable_telemetry = enable_telemetry;
+        self
+    }
+
+    pub fn with_rust_log_directive(mut self, directive: Directive) -> Self {
+        self.telemetry_directives.push(directive);
         self
     }
 
@@ -177,7 +185,7 @@ impl TestAppBuilder {
         let tracing_config = TracingConfig {
             stream: Stream::Stdout,
             telemetry,
-            directives: vec!["otel::tracing=info".parse().unwrap()],
+            directives: self.telemetry_directives,
         };
         let sub = create_tracing_subscriber(
             tracing_config,


### PR DESCRIPTION
The STDCM log feature depends on Opentelemetry span being created in the Axum middleware. If `RUST_LOG=warn`, tests will fail because no span is created and therefore no trace ID is created and tests depends on this trace ID.

The added directives are applied after reading `RUST_LOG`.

This is an alternative solution to what was proposed in #10526.