### PR TITLE
editoast: remove duplicated clap declaration in Cargo.toml

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -26,7 +26,7 @@ license = "LGPL-3.0"
 
 [workspace.dependencies]
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
-clap = { version = "4.5.27", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 derivative = "2.2.0"
 diesel = { version = "2.2", default-features = false, features = [
   "32-column-tables",
@@ -109,7 +109,7 @@ axum-tracing-opentelemetry = { version = "0.25.0", default-features = false, fea
   "tracing_level_info",
 ] }
 chrono.workspace = true
-clap = { version = "4.5.27", features = ["derive", "env"] }
+clap.workspace = true
 colored = "3.0.0"
 dashmap = "6.1.0"
 deadpool = { version = "0.12.1", features = [


### PR DESCRIPTION
The version is specified in both `workspace.dependencies` and `dependencies` sections.