### PR TITLE
editoast: fix some nightly clippy warnings

### DIFF
--- a/editoast/editoast_osrdyne_client/src/lib.rs
+++ b/editoast/editoast_osrdyne_client/src/lib.rs
@@ -161,7 +161,6 @@ impl HTTPClient {
                 let status = statuses
                     .get(key.as_ref())
                     .copied()
-                    .map(WorkerStatus::from)
                     .unwrap_or(WorkerStatus::Unscheduled);
                 (key.as_ref().to_owned(), status)
             })

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -31,7 +31,6 @@ impl Timetable {
             .default_values()
             .get_result::<Timetable>(conn.write().await.deref_mut())
             .await
-            .map(Into::into)
             .map_err(Into::into)
     }
 
@@ -119,10 +118,7 @@ impl Exists<i64> for Timetable {
     #[allow(clippy::blocks_in_conditions)] // TODO: Remove this once using clippy 0.1.80
     #[tracing::instrument(name = "model:exists<Timetable>", skip_all, ret, err)]
     async fn exists(conn: &mut DbConnection, id: i64) -> Result<bool> {
-        Self::retrieve(conn, id)
-            .await
-            .map(|r| r.is_some())
-            .map_err(Into::into)
+        Self::retrieve(conn, id).await.map(|r| r.is_some())
     }
 }
 


### PR DESCRIPTION
```
warning: useless conversion to the same type: `WorkerStatus`
   --> editoast_osrdyne_client/src/lib.rs:163:30
    |
163 |                        .copied()
    |   ______________________________^
    |  |______________________________|
164 | ||                     .map(WorkerStatus::from)
    | ||____________________________________________^
165 | |                      .unwrap_or(WorkerStatus::Unscheduled);
    | |_____________________- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default

warning: useless conversion to the same type: `models::timetable::Timetable`
  --> src/models/timetable.rs:46:19
   |
46 |                .await
   |   ___________________^
   |  |___________________|
47 | ||             .map(Into::into)
   | ||____________________________^
48 | |              .map_err(Into::into)
   | |_____________- help: consider removing
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
   = note: `#[warn(clippy::useless_conversion)]` on by default

warning: useless conversion to the same type: `error::InternalError`
   --> src/models/timetable.rs:135:34
    |
135 |                .map(|r| r.is_some())
    |   __________________________________^
    |  |__________________________________|
136 | ||             .map_err(Into::into)
    | ||________________________________^
137 | |      }
    | |_____- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
```