### PR TITLE
front: bump nge version to 2.9.21

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,7 +12,7 @@
         "@nivo/core": "^0.80.0",
         "@nivo/line": "^0.80.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
         "@osrd-project/ui-core": "^0.0.62",
         "@osrd-project/ui-icons": "^0.0.62",
         "@osrd-project/ui-manchette": "^0.0.62",
@@ -1899,9 +1899,9 @@
       "license": "MIT"
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415.tgz",
-      "integrity": "sha512-lalH7CHnIQfaPLh+dYMLcpIYb7+MnCJWov7wnJ5DUTLTnt7WhrKR+Q+wXRpac4j1ehjEDdoeuy2KViAhVIMTKg=="
+      "version": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1.tgz",
+      "integrity": "sha512-hQNL+o9+FtbkhMvw29TwM7lcDaiZGt2U2+AW9sevTv1VUoq+02nUF9tcXaxEogY8AwK+dM2bomjqzh68EaKUqw=="
     },
     "node_modules/@osrd-project/ui-core": {
       "version": "0.0.62",

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.37949a66933e8e1552c9b8e54f702ec491afd415",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
     "@osrd-project/ui-core": "^0.0.62",
     "@osrd-project/ui-icons": "^0.0.62",
     "@osrd-project/ui-manchette": "^0.0.62",


### PR DESCRIPTION
To test this change, you can follow the video, demonstrating a new feature of NGE that aligns the selected nodes using the arrow keys (up/down/right/left). This feature has been modified to emit operations that can be handled by OSRD

https://github.com/user-attachments/assets/1da95463-affe-4803-b534-6fcad5f9c8d6

Close https://github.com/OpenRailAssociation/osrd/issues/10588

