### PR TITLE
core: bump carrotsearch to 0.10.0

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'lo
 # java stuff
 guava = { module = 'com.google.guava:guava', version = '33.4.0-jre' } # Apache 2.0
 jcommander = { module = 'com.beust:jcommander', version = '1.82' } # Apache 2.0
-hppc = { module = 'com.carrotsearch:hppc', version = '0.9.1' } # Apache 2.0
+hppc = { module = 'com.carrotsearch:hppc', version = '0.10.0' } # Apache 2.0
 moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' } # Apache 2.0
 moshi-adapters = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' } # Apache 2.0
 moshi-kotlin = { module = 'com.squareup.moshi:moshi-kotlin', version.ref = 'moshi' } # Apache 2.0

--- a/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/LineString.java
+++ b/core/osrd-geom/src/main/java/fr/sncf/osrd/geom/LineString.java
@@ -114,8 +114,8 @@ public final class LineString {
                         .distanceAsMeters(new Point(lineString.bufferLat[0], lineString.bufferLon[0]));
 
                 if (distance < 1e-5) {
-                    newBufferLon.remove(newBufferLon.size() - 1);
-                    newBufferLat.remove(newBufferLat.size() - 1);
+                    newBufferLon.removeAt(newBufferLon.size() - 1);
+                    newBufferLat.removeAt(newBufferLat.size() - 1);
                 } else {
                     newCumulativeLengths.add(distance + newCumulativeLengths.get(newCumulativeLengths.size() - 1));
                 }


### PR DESCRIPTION
Bumping carrotsearch to 0.10.0 gives us access to the `reverse()` method.