### PR TITLE
core: fix unrecoverable freezes of rabbit's consumer

### DIFF
--- a/core/gradle/libs.versions.toml
+++ b/core/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ opentelemetry-instrumentation-annotations = { module = 'io.opentelemetry.instrum
 
 kaml = { module = 'com.charleskorn.kaml:kaml', version = '0.66.0' } # Apache 2.0
 
-amqp-client = { module = 'com.rabbitmq:amqp-client', version = '5.23.0' }
+amqp-client = { module = 'com.rabbitmq:amqp-client', version = '5.24.0' }
 
 [plugins]
 # kotlin

--- a/core/src/main/java/fr/sncf/osrd/App.java
+++ b/core/src/main/java/fr/sncf/osrd/App.java
@@ -41,7 +41,12 @@ public class App {
         }
 
         // run the user command
-        var statusCode = commands.get(commandName).run();
+        var statusCode = 1;
+        try {
+            statusCode = commands.get(commandName).run();
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+        }
         System.exit(statusCode);
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -293,6 +293,17 @@ class WorkerCommand : CliCommand {
                         executionTimeMS / 1_000.0
                     )
                 }
+
+            val terminatorCallback =
+                fun(message: Delivery) {
+                    try {
+                        callback(message)
+                    } catch (t: Throwable) {
+                        t.printStackTrace(System.err)
+                        exitProcess(1)
+                    }
+                }
+
             channel.basicConsume(
                 WORKER_REQUESTS_QUEUE,
                 false,
@@ -302,9 +313,9 @@ class WorkerCommand : CliCommand {
                         // We directly process the message with no dispatch if there's too many
                         // locally queued tasks. Prevents the worker from consuming all the rabbitmq
                         // at once, which would mess with the stats and automatic scaling.
-                        callback(message)
+                        terminatorCallback(message)
                     } else {
-                        executor.execute { callback(message) }
+                        executor.execute { terminatorCallback(message) }
                     }
                 },
                 { _ ->

--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -3,7 +3,10 @@ package fr.sncf.osrd.cli
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.rabbitmq.client.*
-import fr.sncf.osrd.api.*
+import fr.sncf.osrd.api.ElectricalProfileSetManager
+import fr.sncf.osrd.api.InfraLoadEndpoint
+import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.VersionEndpoint
 import fr.sncf.osrd.api.api_v2.conflicts.ConflictDetectionEndpointV2
 import fr.sncf.osrd.api.api_v2.path_properties.PathPropEndpoint
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlocksEndpointV2
@@ -20,6 +23,7 @@ import java.io.InputStream
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
 import okhttp3.OkHttpClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -303,7 +307,10 @@ class WorkerCommand : CliCommand {
                         executor.execute { callback(message) }
                     }
                 },
-                { _ -> logger.error("consumer cancelled") },
+                { _ ->
+                    logger.error("consumer cancelled")
+                    exitProcess(0)
+                },
                 { consumerTag, e ->
                     logger.info("consume shutdown: {}, {}", consumerTag, e.toString())
                 }


### PR DESCRIPTION
Hard fix (kind of) to kill the process if a thread's exception goes up to `main()`, or if rabbit's cancel/shutdown notification is received (even if other threads may run) and let orchestrator restart it.

Bump amqp-client on the way as it doesn't hurt.

Fixes #8621
Also reproduced and fixed the case that leads to the following (different) core logs:
```
[11:16:04,880] [INFO]          [WorkerCommand] consume shutdown: amq.ctag-LsXBfmFdL6n758icthlCYA, com.rabbitmq.client.ShutdownSignalException: connection error; protocol method: #method<connection.close>(reply-code=320, reply-text=CONNECTION_FORCED - broker forced connection closure with reason 'shutdown', class-id=0, method-id=0)
[11:16:04,883] [WARN]  [ForgivingExceptionHandler] An unexpected connection driver error occurred (Exception message: Connection reset by peer)
Exception in thread "main" com.rabbitmq.client.AlreadyClosedException: connection is already closed due to connection error; protocol method: #method<connection.close>(reply-code=320, reply-text=CONNECTION_FORCED - broker forced connection closure with reason 'shutdown', class-id=0, method-id=0)
        at com.rabbitmq.client.impl.AMQConnection.startShutdown(AMQConnection.java:1012)
        at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:1127)
        at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:1056)
        at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:1040)
        at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:1032)
        at com.rabbitmq.client.impl.recovery.AutorecoveringConnection.close(AutorecoveringConnection.java:289)
        at kotlin.io.CloseableKt.closeFinally(Closeable.kt:56)
        at fr.sncf.osrd.cli.WorkerCommand.run(WorkerCommand.kt:319)
        at fr.sncf.osrd.App.main(App.java:44)
```

### Hand-tested
- [x] Run classic (one per infra) core with rabbitmq up, without editoast to load infra from: ✅core crashes.
- [x] Run single-worker core with the whole stack running: ✅core works and OSRD does its job.
- [x] Run single-worker core with the whole stack, then stop rabbitmq: ✅core exits (on shutdown notification).
- [x] Run full stack single-worker mode, then remove the `core-req-all` queue to initiate cancel notification: ✅core logs "consumer cancelled" then stops (should cover #8621).
- [x] Run full stack + single-worker editoast (no core), initiate some core requests (using front).
  - Then stop editoast and start single-worker core (so impossible to load infra inside DeliverCallback): ✅core crashes and releases unacked messages.
  - Then start editoast, then start core: ✅core works and OSRD does its job.
>  - ~Then stop editoast and start single-worker core (so impossible to load infra inside DeliverCallback): ✔️❓Exceptions in threads when trying to load infra for pending requests, core stays alive (leaving pending requests unacked until core is stopped - after step below). \
>  ➡️We can try/catch in `callback` function and `exitProcess` to force shutdown.~ DONE in last commit.
>  - ~Then start editoast (keep core as-is) and initiate some new core request (using front): ✅core "correctly" processing only new requests.~
>  - ~Stop core: ✅Unacked requests are back to ready.~
>  - ~Start core: ✅Ready requests are processed.~

### Understanding of previous and current work

Previous:
- #9591 messed-up with core crashing as expected when exception is raised up to main (still not understanding exactly what prevents the app from stopping).
- Especially #9439 was worked on (and in my memory correctly hand-tested) at the same time, but when merged (after #9591) it "silently" didn't work 😞.

Current:
- ShutdownCallback looks like it's executed in the main thread (triggering the newly added `catch` in the `main()`, then the final `return`) and it may be an idea to use shutdown notification to exit cleanly
- The thread executors are messing with the handling of exceptions
- Looks like the CancelCallback doesn't trigger a "join" or a shutodwn process (because of threads? maybe more because it's on the implementation to decide what's graceful?)

### Looks like some improvements may be done (to be explored later, sorted by ROI)
- Improve/explicit some work applied in #9439 (use `isRecoverable`, cleanup consumer logs, properly close channels and connections)
- Avoid sharing channels between threads as stated [in dedicated documentation](https://www.rabbitmq.com/client-libraries/java-api-guide#concurrency)
- Handle more standardly shutdown (on exceptions or on notification) by issuing a shutdown notification, or sharing a signal (or common variable?)