### PR TITLE
core: stdcm: add a stop at the end to avoid signal propagation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/stdcm/STDCMEndpointV2.kt
@@ -18,6 +18,7 @@ import fr.sncf.osrd.graph.Pathfinding
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
@@ -171,6 +172,16 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
         temporarySpeedLimitManager: TemporarySpeedLimitManager?,
         comfort: Comfort,
     ): SimulationSuccess {
+        val scheduleItems = parseSimulationScheduleItems(path.stopResults).toMutableList()
+        // Add a short stop at the end to avoid signal propagation
+        scheduleItems.add(
+            SimulationScheduleItem(
+                Offset(path.trainPath.getLength()),
+                null,
+                0.1.seconds,
+                RJSTrainStop.RJSReceptionSignal.STOP
+            )
+        )
         val reportTrain =
             runScheduleMetadataExtractor(
                 path.envelope,
@@ -179,7 +190,7 @@ class STDCMEndpointV2(private val infraManager: InfraManager) : Take {
                 infra,
                 path.routePath.toIdxList(),
                 rollingStock,
-                parseSimulationScheduleItems(path.stopResults),
+                scheduleItems,
                 listOf(),
             )
 


### PR DESCRIPTION
During the last post-processing simulation, the path includes the last route in full and didn't have a STOP at the end. So we'd propagate the requirements too far down.

Fix https://github.com/OpenRailAssociation/osrd/issues/10427 (or at least one possible cause)