### PR TITLE
front: spacetimechart: fix drag behaviour when draging train to the left

### DIFF
--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { ChevronLeft, ChevronRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import { type Conflict } from 'common/api/osrdEditoastApi';
 import SimulationWarpedMap from 'common/Map/WarpedMap/SimulationWarpedMap';
@@ -23,6 +24,7 @@ import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import { updateViewport, type Viewport } from 'reducers/map';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
+import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
 import { getPointCoordinates } from 'utils/geometry';
 
@@ -63,6 +65,8 @@ const SimulationResults = ({
     pathProperties,
     path,
   } = useSimulationResults();
+
+  const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const [extViewport, setExtViewport] = useState<Viewport>();
   const [showWarpedMap, setShowWarpedMap] = useState(false);
@@ -203,21 +207,24 @@ const SimulationResults = ({
 
               <div className="osrd-simulation-container d-flex flex-grow-1 flex-shrink-1">
                 <div className="chart-container">
-                  <ManchetteWithSpaceTimeChartWrapper
-                    operationalPoints={projectedOperationalPoints}
-                    projectPathTrainResult={projectPathTrainResult}
-                    selectedTrainScheduleId={selectedTrainSchedule?.id}
-                    waypointsPanelData={{
-                      filteredWaypoints: filteredOperationalPoints,
-                      setFilteredWaypoints: setFilteredOperationalPoints,
-                      projectionPath: projectionData.trainSchedule.path,
-                    }}
-                    conflicts={conflictZones}
-                    projectionLoaderData={projectionData.projectionLoaderData}
-                    height={manchetteWithSpaceTimeChartHeight - MANCHETTE_HEIGHT_DIFF}
-                    handleTrainDrag={handleTrainDrag}
-                    onTrainClick={(trainId) => dispatch(updateSelectedTrainId(trainId))}
-                  />
+                  {trainIdUsedForProjection && (
+                    <ManchetteWithSpaceTimeChartWrapper
+                      operationalPoints={projectedOperationalPoints}
+                      projectPathTrainResult={projectPathTrainResult}
+                      selectedTrainScheduleId={selectedTrainSchedule?.id}
+                      waypointsPanelData={{
+                        filteredWaypoints: filteredOperationalPoints,
+                        setFilteredWaypoints: setFilteredOperationalPoints,
+                        projectionPath: projectionData.trainSchedule.path,
+                      }}
+                      conflicts={conflictZones}
+                      projectionLoaderData={projectionData.projectionLoaderData}
+                      height={manchetteWithSpaceTimeChartHeight - MANCHETTE_HEIGHT_DIFF}
+                      handleTrainDrag={handleTrainDrag}
+                      onTrainClick={(trainId) => dispatch(updateSelectedTrainId(trainId))}
+                      selectedProjection={trainIdUsedForProjection}
+                    />
+                  )}
                 </div>
               </div>
             </>

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -63,6 +63,7 @@ type ManchetteWithSpaceTimeChartProps = {
   ) => Promise<void>;
   height?: number;
   onTrainClick?: (trainId: number) => void;
+  selectedProjection?: number;
 };
 
 export const MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT = 561;
@@ -80,6 +81,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   height = MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
   handleTrainDrag,
   onTrainClick,
+  selectedProjection,
 }: ManchetteWithSpaceTimeChartProps) => {
   const dispatch = useAppDispatch();
 
@@ -94,6 +96,15 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   const spaceTimeChartRef = useRef<HTMLDivElement>(null);
 
   const [waypointsPanelIsOpen, setWaypointsPanelIsOpen] = useState(false);
+
+  const [minDepartureTime, setMinDepartureTime] = useState<number | null>(null);
+  useEffect(() => {
+    const projectedTrains = projectPathTrainResult.filter(
+      (train) => train.spaceTimeCurves.length > 0
+    );
+    const minTime = Math.min(...projectedTrains.map((p) => +p.departureTime));
+    setMinDepartureTime(minTime);
+  }, [selectedProjection, projectPathTrainResult.length]);
 
   const [tmpSelectedTrain, setTmpSelectedTrain] = useState(selectedTrainScheduleId);
   useEffect(() => {
@@ -381,41 +392,43 @@ const ManchetteWithSpaceTimeChartWrapper = ({
               onClose={() => setShowSettingsPanel(false)}
             />
           )}
-          <SpaceTimeChart
-            className="inset-0 absolute h-full"
-            height={height}
-            spaceOrigin={
-              (waypointsPanelData?.filteredWaypoints ?? operationalPoints).at(0)?.position || 0
-            }
-            timeOrigin={Math.min(...projectPathTrainResult.map((p) => +p.departureTime))}
-            {...spaceTimeChartProps}
-            onPan={onPanOverloaded}
-            onClick={handleClick}
-            onHoveredChildUpdate={handleHoveredChildUpdate}
-          >
-            {spaceTimeChartProps.paths.map((path) => (
-              <PathLayer
-                key={path.id}
-                path={path}
-                {...getPathStyle(hoveredItem, path, !!draggingState)}
-              />
-            ))}
-            {workSchedules && (
-              <WorkScheduleLayer
-                workSchedules={workSchedules.map((ws) => ({
-                  type: ws.type,
-                  timeStart: new Date(ws.start_date_time),
-                  timeEnd: new Date(ws.end_date_time),
-                  spaceRanges: ws.path_position_ranges.map(({ start, end }) => [start, end]),
-                }))}
-                imageUrl={upward}
-              />
-            )}
-            {settings.showConflicts && <ConflictLayer conflicts={cutConflicts} />}
-            {settings.showSignalsStates && (
-              <OccupancyBlockLayer occupancyBlocks={occupancyBlocks} />
-            )}
-          </SpaceTimeChart>
+          {minDepartureTime !== null && (
+            <SpaceTimeChart
+              className="inset-0 absolute h-full"
+              height={height}
+              spaceOrigin={
+                (waypointsPanelData?.filteredWaypoints ?? operationalPoints).at(0)?.position || 0
+              }
+              timeOrigin={minDepartureTime}
+              {...spaceTimeChartProps}
+              onPan={onPanOverloaded}
+              onClick={handleClick}
+              onHoveredChildUpdate={handleHoveredChildUpdate}
+            >
+              {spaceTimeChartProps.paths.map((path) => (
+                <PathLayer
+                  key={path.id}
+                  path={path}
+                  {...getPathStyle(hoveredItem, path, !!draggingState)}
+                />
+              ))}
+              {workSchedules && (
+                <WorkScheduleLayer
+                  workSchedules={workSchedules.map((ws) => ({
+                    type: ws.type,
+                    timeStart: new Date(ws.start_date_time),
+                    timeEnd: new Date(ws.end_date_time),
+                    spaceRanges: ws.path_position_ranges.map(({ start, end }) => [start, end]),
+                  }))}
+                  imageUrl={upward}
+                />
+              )}
+              {settings.showConflicts && <ConflictLayer conflicts={cutConflicts} />}
+              {settings.showSignalsStates && (
+                <OccupancyBlockLayer occupancyBlocks={occupancyBlocks} />
+              )}
+            </SpaceTimeChart>
+          )}
         </div>
       </div>
       <Slider


### PR DESCRIPTION
close #10511

Previously when you were dragging the earliest train to the left, the spaceTimeChart window was sliding to the left.
Now the SpaceTimeChart window won't move anymore unless you stop the train drag and pan the window 