### PR TITLE
core: stdcm: reduce visited margin

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -49,8 +49,8 @@ class STDCMGraph(
     val allowanceManager: EngineeringAllowanceManager = EngineeringAllowanceManager(this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)
 
-    // min 4 minutes between two edges, determined empirically
-    private val visitedNodes = VisitedNodes(4 * 60.0)
+    // min 2 minutes between two edges, determined empirically
+    private val visitedNodes = VisitedNodes(2 * 60.0)
 
     // A* heuristic
     val remainingTimeEstimator: STDCMAStarHeuristic


### PR DESCRIPTION
The value was too large for takeovers with fast trains, we'd "miss" an opening and let two trains pass instead of one.

This will have a performance cost, but there isn't any way around it. We were likely missing a few solutions in edge cases before.