### PR TITLE
front: fix cached power restrictions on GEV

### DIFF
--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
@@ -72,20 +72,23 @@ const useSpeedSpaceChart = (
         );
 
         setFormattedPathProperties(formattedPathProps);
-
-        // Format power restrictions
-        const powerRestrictions = formatPowerRestrictionRangesWithHandled({
-          selectedTrainSchedule: trainScheduleResult,
-          selectedTrainRollingStock: rollingStock,
-          pathfindingResult,
-          pathProperties: formattedPathProps,
-        });
-        setFormattedPowerRestrictions(powerRestrictions);
       }
     };
 
     getPathProperties();
   }, [pathProperties, infraId, rollingStock]);
+
+  useEffect(() => {
+    if (trainScheduleResult && rollingStock && pathfindingResult && formattedPathProperties) {
+      const powerRestrictions = formatPowerRestrictionRangesWithHandled({
+        selectedTrainSchedule: trainScheduleResult,
+        selectedTrainRollingStock: rollingStock,
+        pathfindingResult,
+        pathProperties: formattedPathProperties,
+      });
+      setFormattedPowerRestrictions(powerRestrictions);
+    }
+  }, [formattedPathProperties, trainScheduleResult]);
 
   // setup chart synchronizer
   useEffect(() => {


### PR DESCRIPTION
closes #10493 

The power restrictions were computed only when the path of the selected train changed, and not when the selected train himself changed. Thus, if 2 trains had exactly the same path, then the power restrictions were not re-computed when switching from one to another.

Now, the power restrictions are computed each time the selected train or the pathfinding changes.