### PR TITLE
front: bump nge fork version

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,7 +12,7 @@
         "@nivo/core": "^0.88.0",
         "@nivo/line": "^0.88.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
         "@osrd-project/ui-core": "^0.0.62",
         "@osrd-project/ui-icons": "^0.0.62",
         "@osrd-project/ui-manchette": "^0.0.62",
@@ -1915,9 +1915,9 @@
       "license": "MIT"
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1.tgz",
-      "integrity": "sha512-hQNL+o9+FtbkhMvw29TwM7lcDaiZGt2U2+AW9sevTv1VUoq+02nUF9tcXaxEogY8AwK+dM2bomjqzh68EaKUqw=="
+      "version": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729.tgz",
+      "integrity": "sha512-A2LpjlIvj67Jrkv1pRg9rynWwi7Zj6/QtqrQdf72WQokMj2a215sbU3orxHDA4XlTOEYRGdkpi28bizvcfoSQQ=="
     },
     "node_modules/@osrd-project/ui-core": {
       "version": "0.0.62",

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "@nivo/core": "^0.88.0",
     "@nivo/line": "^0.88.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.182720c222aae0cded6b86c8b2be32a3fe1d01d1",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
     "@osrd-project/ui-core": "^0.0.62",
     "@osrd-project/ui-icons": "^0.0.62",
     "@osrd-project/ui-manchette": "^0.0.62",


### PR DESCRIPTION
Check that this : https://github.com/osrd-project/netzgrafik-editor-frontend/pull/11

is effective