### PR TITLE
editoast: update `modified` field of `infra` upon modification

### DIFF
--- a/editoast/src/infra_cache/operation/mod.rs
+++ b/editoast/src/infra_cache/operation/mod.rs
@@ -4,6 +4,7 @@ mod update;
 
 use std::ops::Deref as _;
 
+use chrono::Utc;
 use editoast_derive::EditoastError;
 use editoast_schemas::primitives::OSRDObject as _;
 use json_patch::Patch;
@@ -16,6 +17,8 @@ use utoipa::ToSchema;
 pub use self::delete::DeleteOperation;
 use crate::error::Result;
 use crate::infra_cache::ObjectCache;
+use crate::models::prelude::*;
+use crate::models::Infra;
 use editoast_models::DbConnection;
 use editoast_schemas::infra::InfraObject;
 use editoast_schemas::primitives::ObjectRef;
@@ -142,10 +145,10 @@ impl Operation {
         infra_id: i64,
         conn: &mut DbConnection,
     ) -> Result<Option<InfraObject>> {
-        match self {
+        let res = match self {
             Operation::Delete(deletion) => {
                 deletion.apply(infra_id, conn).await?;
-                Ok(None)
+                Ok::<_, crate::error::InternalError>(None)
             }
             Operation::Create(railjson_object) => {
                 create::apply_create_operation(railjson_object, infra_id, conn).await?;
@@ -155,7 +158,12 @@ impl Operation {
                 let railjson_object = update.apply(infra_id, conn).await?;
                 Ok(Some(railjson_object))
             }
-        }
+        }?;
+        Infra::changeset()
+            .modified(Utc::now())
+            .update(conn, infra_id)
+            .await?;
+        Ok(res)
     }
 }
 
@@ -165,7 +173,7 @@ pub fn patch_infra_object(infra_object: &InfraObject, json_patch: &Patch) -> Res
     // (1) transform `RailjsonObject` into `serde_json::Value`,
     // (2) patch the object,
     // (3) transform `serde_json::Value` back into a `RailjsonObject`.
-    // The code below is explicitely typed (even if not needed) to help understand this dance.
+    // The code below is explicitly typed (even if not needed) to help understand this dance.
     let object_type = infra_object.get_type();
     let mut value: serde_json::Value = match &infra_object {
         InfraObject::TrackSection { railjson } => serde_json::to_value(railjson)?,

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -8,7 +8,7 @@ mod voltage;
 
 use std::ops::DerefMut;
 
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use chrono::Utc;
 use derivative::Derivative;
 use diesel::delete;
@@ -69,9 +69,9 @@ pub struct Infra {
     #[schema(required)]
     pub generated_version: Option<String>,
     pub locked: bool,
-    pub created: NaiveDateTime,
-    #[derivative(Default(value = "Utc::now().naive_utc()"))]
-    pub modified: NaiveDateTime,
+    pub created: DateTime<Utc>,
+    #[derivative(Default(value = "Utc::now()"))]
+    pub modified: DateTime<Utc>,
 }
 
 impl InfraChangeset {
@@ -112,6 +112,7 @@ impl Infra {
             .expect("Cannot convert version into an Integer")
             + 1;
         self.version = new_version.to_string();
+        self.modified = Utc::now();
         self.save(conn).await
     }
 
@@ -123,11 +124,12 @@ impl Infra {
     pub async fn clone(&self, conn: &mut DbConnection, new_name: String) -> Result<Infra> {
         conn.clone().transaction(|conn| Box::pin(async move {
             // Duplicate infra shell
+            let now = Utc::now();
             let cloned_infra = <Self as Clone>::clone(self)
                 .into_changeset()
                 .name(new_name)
-                .created(Utc::now().naive_utc())
-                .modified(Utc::now().naive_utc())
+                .created(now)
+                .modified(now)
                 .create(&mut conn.clone())
                 .await?;
 
@@ -353,6 +355,7 @@ pub mod tests {
         // GIVEN
         let db_pool = DbConnectionPoolV2::for_tests();
         let empty_infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let old_modification_date = empty_infra.modified;
         let infra_new_name = "clone_infra_with_new_name_returns_new_cloned_infra".to_string();
 
         // WHEN
@@ -363,6 +366,7 @@ pub mod tests {
 
         // THEN
         assert_eq!(result.name, infra_new_name);
+        assert!(old_modification_date < result.modified);
     }
 
     #[rstest]
@@ -384,6 +388,20 @@ pub mod tests {
             expected: RAILJSON_VERSION.to_string(),
         };
         assert_eq!(res.unwrap_err().get_type(), expected_error.get_type());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_change_updates_modification_date() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let mut infra = create_empty_infra(&mut db_pool.get_ok()).await;
+        let old = infra.modified;
+
+        infra
+            .bump_version(&mut db_pool.get_ok())
+            .await
+            .expect("could not bump version");
+
+        assert!(infra.modified > old);
     }
 
     #[rstest]

--- a/editoast/src/models/railjson.rs
+++ b/editoast/src/models/railjson.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::RailJson;
 use editoast_schemas::infra::RAILJSON_VERSION;
@@ -6,6 +7,8 @@ use crate::error::Result;
 use crate::models::infra_objects::*;
 use crate::models::prelude::*;
 use editoast_models::DbConnection;
+
+use super::Infra;
 
 #[derive(Debug, thiserror::Error, EditoastError)]
 #[editoast_error(base_id = "railjson")]
@@ -116,6 +119,10 @@ pub async fn persist_railjson(
                 )
                 .await?;
 
+                Infra::changeset()
+                    .modified(Utc::now())
+                    .update(&mut conn.clone(), infra_id)
+                    .await?;
                 Ok(())
             })
         })

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -717,7 +717,7 @@ fn get_split_patch_operations_for_applicable_ranges(
                 }));
             } else {
                 // Case where the range is fully on right side
-                // so we need to change the track and to substract the distance on begin & end
+                // so we need to change the track and to subtract the distance on begin & end
                 if range.begin >= distance {
                     patch_operations.push(PatchOperation::Replace(ReplaceOperation {
                         path: format!("{}/{}/track", path, index).parse().unwrap(),
@@ -792,7 +792,7 @@ fn get_split_patch_operations_for_ranges(
                 }));
             } else {
                 // Case where the range is fully on right side
-                // so we need to change the track and to substract the distance on begin & end
+                // so we need to change the track and to subtract the distance on begin & end
                 if range.begin >= distance {
                     patch_operations.push(PatchOperation::Replace(ReplaceOperation {
                         path: format!("{}/{}/track", path, index).parse().unwrap(),
@@ -1025,6 +1025,45 @@ pub mod tests {
             })
             .collect();
         assert_eq!(errors_without_routes.len() - init_errors.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn infra_edition_updates_modification_date() {
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+        let mut small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let mut infra_cache = InfraCache::load(&mut db_pool.get_ok(), &small_infra)
+            .await
+            .unwrap();
+
+        let old_modified = small_infra.modified;
+
+        let operations: Vec<Operation> = [
+            // Success operation
+            Operation::Update(UpdateOperation {
+                obj_type: ObjectType::TrackSection,
+                obj_id: "TA0".to_string(),
+                railjson_patch: Patch(
+                    [PatchOperation::Replace(ReplaceOperation {
+                        path: "/length".to_string().parse().unwrap(),
+                        value: json!(1234),
+                    })]
+                    .to_vec(),
+                ),
+            }),
+        ]
+        .to_vec();
+        apply_edit(
+            &mut db_pool.get_ok(),
+            &mut small_infra,
+            &operations,
+            &mut infra_cache,
+        )
+        .await
+        .ok()
+        .unwrap();
+
+        assert!(small_infra.modified > old_modified);
     }
 
     #[rstest]


### PR DESCRIPTION
Part of `editoast-statful` scalability work.

The field used to default to `NOW()` on `INSERT`, but was never updated.

Naive datetimes are also replaced by `DateTime<Utc>`.

