### PR TITLE
front: don't use front/tests/ to write PDF files

### DIFF
--- a/front/tests/013-stdcm-simulation-sheet.spec.ts
+++ b/front/tests/013-stdcm-simulation-sheet.spec.ts
@@ -48,8 +48,10 @@ test.describe('Verify stdcm simulation page', () => {
     await waitForInfraStateToBeCached(infra.id);
   });
 
+  let downloadDir: string | undefined;
+
   /** *************** Test 1 **************** */
-  test('Verify STDCM stops and simulation sheet', async ({ browserName, context }) => {
+  test('Verify STDCM stops and simulation sheet', async ({ browserName, context }, testInfo) => {
     // Populate STDCM page with origin, destination, and via details
     await stdcmPage.fillAndVerifyConsistDetails(
       consistDetails,
@@ -77,7 +79,8 @@ test.describe('Verify stdcm simulation page', () => {
     await stdcmPage.displayAllOperationalPoints();
     await stdcmPage.verifyTableData('./tests/assets/stdcm/stdcmWithAllVia.json');
     await stdcmPage.retainSimulation();
-    await stdcmPage.downloadSimulation(browserName);
+    downloadDir = testInfo.outputDir;
+    await stdcmPage.downloadSimulation(downloadDir);
     // Reset and verify empty fields
     const [newPage] = await Promise.all([context.waitForEvent('page'), stdcmPage.startNewQuery()]);
     await newPage.waitForLoadState();
@@ -86,9 +89,8 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 2 **************** */
-  test('Verify simulation sheet content', async ({ browserName }) => {
-    const downloadDir = `./tests/stdcm-results/${browserName}`;
-    const pdfFilePath = findFirstPdf(downloadDir);
+  test('Verify simulation sheet content', async () => {
+    const pdfFilePath = findFirstPdf(downloadDir!);
 
     if (!pdfFilePath) {
       throw new Error(`No PDF files found in directory: ${downloadDir}`);

--- a/front/tests/014-stdcm-linked-train.spec.ts
+++ b/front/tests/014-stdcm-linked-train.spec.ts
@@ -51,7 +51,7 @@ test.describe('Verify stdcm simulation page', () => {
   });
 
   /** *************** Test 1 **************** */
-  test('Verify STDCM anterior linked train', async ({ browserName }) => {
+  test('Verify STDCM anterior linked train', async ({}, testInfo) => {
     await stdcmPage.fillAndVerifyConsistDetails(
       towedConsistDetails,
       fastRollingStockPrefilledValues.tonnage,
@@ -72,11 +72,11 @@ test.describe('Verify stdcm simulation page', () => {
       './tests/assets/stdcm/linkedTrain/anteriorLinkedTrainTable.json'
     );
     await stdcmPage.retainSimulation();
-    await stdcmPage.downloadSimulation(browserName, true);
+    await stdcmPage.downloadSimulation(testInfo.outputDir);
   });
 
   /** *************** Test 2 **************** */
-  test('Verify STDCM posterior linked train', async ({ browserName }) => {
+  test('Verify STDCM posterior linked train', async ({}, testInfo) => {
     await stdcmPage.fillAndVerifyConsistDetails(
       towedConsistDetails,
       fastRollingStockPrefilledValues.tonnage,
@@ -97,6 +97,6 @@ test.describe('Verify stdcm simulation page', () => {
       './tests/assets/stdcm/linkedTrain/posteriorLinkedTrainTable.json'
     );
     await stdcmPage.retainSimulation();
-    await stdcmPage.downloadSimulation(browserName, true);
+    await stdcmPage.downloadSimulation(testInfo.outputDir);
   });
 });

--- a/front/tests/pages/stdcm-page-model.ts
+++ b/front/tests/pages/stdcm-page-model.ts
@@ -711,7 +711,7 @@ class STDCMPage extends HomePage {
     await expect(this.startNewQueryWithDataButton).toBeVisible();
   }
 
-  async downloadSimulation(browserName: string, isLinkedTrain: boolean = false): Promise<void> {
+  async downloadSimulation(downloadDir: string): Promise<void> {
     try {
       // Wait until there are no network requests for stability
       await this.page.waitForLoadState('networkidle');
@@ -720,9 +720,6 @@ class STDCMPage extends HomePage {
       const suggestedFilename = await this.downloadLink.getAttribute('download');
       expect(suggestedFilename).toMatch(/^Stdcm.*\.pdf$/);
 
-      const downloadDir = isLinkedTrain
-        ? path.join('./tests/stdcm-results/linkedTrain', browserName)
-        : path.join('./tests/stdcm-results', browserName);
       const downloadPath = path.join(downloadDir, suggestedFilename!);
 
       await fs.promises.mkdir(downloadDir, { recursive: true });


### PR DESCRIPTION
Closes #10492 
front/tests/ is not a directory meant to be used for test results. It should only contain source files.

Playwright sets up a specific directory for test outputs, so we can just use that instead. As a bonus, the PDF is now included in CI artifacts and can be inspected manually if needed.

Fixes permission errors when running tests in a container for me.