### PR TITLE
ci: enable external contributions for the labeler in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: pr
 on:
-  pull_request:
+  - pull_request_target
 jobs:
   label_pr:
     permissions:


### PR DESCRIPTION
This should help with PR #10731. The change is documented in the action of the labeler itself.

https://github.com/actions/labeler?tab=readme-ov-file#recommended-permissions