### PR TITLE
front: fix prettier formatting of jsonc

### DIFF
--- a/front/.eslintrc
+++ b/front/.eslintrc
@@ -2,10 +2,7 @@
   "env": {
     "browser": true
   },
-  "ignorePatterns": [
-    "src/common/api/generatedEditoastApi.ts",
-    "src/common/api/osrdGatewayApi.ts"
-  ],
+  "ignorePatterns": ["src/common/api/generatedEditoastApi.ts", "src/common/api/osrdGatewayApi.ts"],
   "extends": [
     "plugin:vitest/recommended",
     "airbnb",
@@ -145,7 +142,10 @@
     {
       "files": ["**/*.ts", "**/*.tsx"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+        ]
       }
     },
     {

--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -3,5 +3,13 @@
   "singleQuote": true,
   "arrowParens": "always",
   "proseWrap": "always",
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": ["*.jsonc", ".eslintrc", "tsconfig*.json"],
+      "options": {
+        "trailingComma": "none"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
- Fix prettier adding trailing commas to jsonc, which is incorrect for jsonc specs
- Thus formats .eslintrc with prettier, without any commas addition

See the [related prettier issue](https://github.com/prettier/prettier/issues/15956)