### PR TITLE
core: add error on zero length simulations

### DIFF
--- a/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
+++ b/core/osrd-reporting/src/main/java/fr/sncf/osrd/reporting/exceptions/ErrorType.java
@@ -171,6 +171,7 @@ public enum ErrorType {
             "missing_route_from_chunk_path",
             "couldn't find a route matching the given chunk list",
             ErrorCause.INTERNAL),
+    ZeroLengthPath("zero_length_path", "can't simulate a zero length path", ErrorCause.USER),
     ;
 
     public final String type;

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -28,6 +28,8 @@ import fr.sncf.osrd.envelope_sim_infra.computeMRSP
 import fr.sncf.osrd.external_generated_inputs.ElectricalProfileMapping
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
+import fr.sncf.osrd.reporting.exceptions.ErrorType.ZeroLengthPath
+import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.standalone_sim.result.ElectrificationRange
@@ -67,6 +69,7 @@ fun runStandaloneSimulation(
     pathItemPositions: List<Offset<Path>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour()
 ): SimulationSuccess {
+    if (chunkPath.length == 0.meters) throw OSRDError(ZeroLengthPath)
     // MRSP & SpeedLimits
     val safetySpeedRanges = makeSafetySpeedRanges(infra, chunkPath, routes, schedule)
     var mrsp =


### PR DESCRIPTION
We sometimes have 500 errors in prod because of this