### PR TITLE
front: fix undefined markerInfo.op in ItineraryMarkers

### DIFF
--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/ItineraryMarkers.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/ItineraryMarkers.tsx
@@ -129,8 +129,10 @@ const ItineraryMarkers = ({
 
   useEffect(() => {
     const fetchTrackSections = async () => {
-      const trackId = markersInformation.map((markerInfo) => markerInfo.op!.track);
-      setTrackSections(await getTrackSectionsByIds(trackId));
+      const trackIds = markersInformation
+        .map((markerInfo) => markerInfo.op?.track)
+        .filter((trackId) => trackId !== undefined);
+      setTrackSections(await getTrackSectionsByIds(trackIds));
     };
 
     if (pathStepsAndSuggestedOPs) fetchTrackSections();


### PR DESCRIPTION
When launching a pathfinding this error pops up in the console:

    Uncaught (in promise) TypeError: markerInfo.op is undefined
        trackId ItineraryMarkers.tsx:132
        fetchTrackSections ItineraryMarkers.tsx:132
        ItineraryMarkers ItineraryMarkers.tsx:136

Before SuggestedOP are fetched, markerInfo.op is undefined.

Guard against undefined values to avoid the error.