### PR TITLE
core: stdcm: handle engineering allowances at low speed

### DIFF
--- a/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
+++ b/core/envelope-sim/src/test/java/fr/sncf/osrd/envelope/EnvelopeOverlayTest.java
@@ -269,4 +269,39 @@ public class EnvelopeOverlayTest {
         assertEquals(2, envelope.size());
         assertTrue(envelope.continuous);
     }
+
+    /** Testing around edge cases with overlays that stop within the first step*/
+    @Test
+    void interruptedAtStart() {
+        //  +==============+
+        //  0              8
+        var baseEnvelope = Envelope.make(EnvelopeTestUtils.generateTimes(new double[] {0, 8}, new double[] {1, 1}));
+
+        // Constraint has been broken immediately after start, part with no step
+        {
+            var partBuilder = new EnvelopePartBuilder();
+            partBuilder.setAttr(EnvelopeProfile.ACCELERATING);
+            var overlayBuilder =
+                    new ConstrainedEnvelopePartBuilder(partBuilder, new EnvelopeConstraint(baseEnvelope, CEILING));
+            assertTrue(overlayBuilder.initEnvelopePart(0, 1, 1));
+            assertTrue(overlayBuilder.addStep(0, 1));
+            assertFalse(overlayBuilder.addStep(1, 2));
+            var res = partBuilder.build();
+            assertEquals(0, res.stepCount());
+        }
+
+        // Constraint has been broken within the first step, part with one (partial) step
+        {
+            var partBuilder = new EnvelopePartBuilder();
+            partBuilder.setAttr(EnvelopeProfile.ACCELERATING);
+            var overlayBuilder =
+                    new ConstrainedEnvelopePartBuilder(partBuilder, new EnvelopeConstraint(baseEnvelope, CEILING));
+            assertTrue(overlayBuilder.initEnvelopePart(0, 0.5, 1));
+            assertTrue(overlayBuilder.addStep(0, 0.5));
+            assertFalse(overlayBuilder.addStep(1, 5));
+            var res = partBuilder.build();
+            assertEquals(1, res.stepCount());
+            assertTrue(res.getPointPos(1) < 1);
+        }
+    }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/EngineeringAllowanceManager.kt
@@ -130,8 +130,8 @@ class EngineeringAllowanceManager(private val graph: STDCMGraph) {
                 -1.0
             )
             val builder = OverlayEnvelopeBuilder.backward(maxEffort)
-            if (speedupPartBuilder.stepCount() > 1) {
-                val speedupPart = speedupPartBuilder.build()
+            val speedupPart = speedupPartBuilder.build()
+            if (speedupPart.stepCount() > 0) {
                 builder.addPart(speedupPart)
                 val lastAccelerationPosition = speedupPart.beginPos
                 if (lastAccelerationPosition > 0.0) {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/EngineeringAllowanceTests.kt
@@ -494,4 +494,79 @@ class EngineeringAllowanceTests {
         occupancyTest(res, occupancyGraph)
         Assertions.assertEquals(3600.0, res.departureTime, 2 * timeStep)
     }
+
+    /**
+     * Reproduces a bug: the engineering allowance area has a very low speed limit, to the point
+     * where we reach speed=0 within one step.
+     */
+    @Test
+    fun testSlowdownWithLowLimitSpeed() {
+        /*
+        a --> b --> c --> d
+
+        space
+          ^
+        d |######### end
+          |######### /
+        c |#########/
+          |     __/
+        b |  __/
+          | /##################
+        a |/_##################_> time
+
+         */
+        val infra = DummyInfra()
+        val firstBlock = infra.addBlock("a", "b", 1000.meters, 0.5)
+        val secondBlock = infra.addBlock("b", "c", 10000.meters, 0.5)
+        val thirdBlock = infra.addBlock("c", "d", 100.meters, 0.5)
+        val firstBlockEnvelope =
+            simulateBlock(
+                infra,
+                infraExplorerFromBlock(infra, infra, firstBlock),
+                0.0,
+                Offset(0.meters),
+                TestTrains.REALISTIC_FAST_TRAIN,
+                Comfort.STANDARD,
+                2.0,
+                null,
+                null,
+                null
+            )!!
+        val secondBlockEnvelope =
+            simulateBlock(
+                infra,
+                infraExplorerFromBlock(infra, infra, secondBlock),
+                firstBlockEnvelope.endSpeed,
+                Offset(0.meters),
+                TestTrains.REALISTIC_FAST_TRAIN,
+                Comfort.STANDARD,
+                2.0,
+                null,
+                null,
+                null
+            )!!
+        val timeThirdBlockFree = firstBlockEnvelope.totalTime + secondBlockEnvelope.totalTime
+        val occupancyGraph =
+            ImmutableMultimap.of(
+                firstBlock,
+                OccupancySegment(
+                    firstBlockEnvelope.totalTime + 10,
+                    Double.POSITIVE_INFINITY,
+                    0.meters,
+                    1000.meters
+                ),
+                thirdBlock,
+                OccupancySegment(0.0, timeThirdBlockFree + 30, 0.meters, 100.meters)
+            )
+        val timeStep = 2.0
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra.fullInfra())
+                .setStartLocations(setOf(EdgeLocation(firstBlock, Offset(0.meters))))
+                .setEndLocations(setOf(EdgeLocation(thirdBlock, Offset(1.meters))))
+                .setUnavailableTimes(occupancyGraph)
+                .setTimeStep(timeStep)
+                .run()!!
+        occupancyTest(res, occupancyGraph, 2 * timeStep)
+    }
 }


### PR DESCRIPTION
Low speeds would mess with the envelope operations, we'd stop before the first step