### PR TITLE
editoast: migrations: add missing indexes on foreign keys

### DIFF
--- a/editoast/migrations/2025-02-13-090913_add_missing_fkey_index/down.sql
+++ b/editoast/migrations/2025-02-13-090913_add_missing_fkey_index/down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS public.pga_idx_fk_infra_layer_psl_sign_infra_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_study_project_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_infra_layer_neutral_sign_infra_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_train_schedule_timetable_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_scenario_electrical_profile_set_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_scenario_infra_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_scenario_study_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_work_schedule_work_schedule_group_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_search_environment_electrical_profile_set_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_search_environment_infra_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_search_environment_temporary_speed_limit_group_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_search_environment_timetable_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_search_environment_work_schedule_group_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_temporary_speed_limit_temporary_speed_limit_group_id;
+DROP INDEX IF EXISTS public.pga_idx_fk_stdcm_logs_user_id;

--- a/editoast/migrations/2025-02-13-090913_add_missing_fkey_index/up.sql
+++ b/editoast/migrations/2025-02-13-090913_add_missing_fkey_index/up.sql
@@ -1,0 +1,32 @@
+CREATE INDEX pga_idx_fk_infra_layer_psl_sign_infra_id ON public.infra_layer_psl_sign (infra_id);
+ANALYZE public.infra_layer_psl_sign;
+
+CREATE INDEX pga_idx_fk_study_project_id ON public.study (project_id);
+ANALYZE public.study;
+
+CREATE INDEX pga_idx_fk_infra_layer_neutral_sign_infra_id ON public.infra_layer_neutral_sign (infra_id);
+ANALYZE public.infra_layer_neutral_sign;
+
+CREATE INDEX pga_idx_fk_train_schedule_timetable_id ON public.train_schedule (timetable_id);
+ANALYZE public.train_schedule;
+
+CREATE INDEX pga_idx_fk_scenario_electrical_profile_set_id ON public.scenario (electrical_profile_set_id);
+CREATE INDEX pga_idx_fk_scenario_infra_id ON public.scenario (infra_id);
+CREATE INDEX pga_idx_fk_scenario_study_id ON public.scenario (study_id);
+ANALYZE public.scenario;
+
+CREATE INDEX pga_idx_fk_work_schedule_work_schedule_group_id ON public.work_schedule (work_schedule_group_id);
+ANALYZE public.work_schedule;
+
+CREATE INDEX pga_idx_fk_stdcm_search_environment_electrical_profile_set_id ON public.stdcm_search_environment (electrical_profile_set_id);
+CREATE INDEX pga_idx_fk_stdcm_search_environment_infra_id ON public.stdcm_search_environment (infra_id);
+CREATE INDEX pga_idx_fk_stdcm_search_environment_temporary_speed_limit_group_id ON public.stdcm_search_environment (temporary_speed_limit_group_id);
+CREATE INDEX pga_idx_fk_stdcm_search_environment_timetable_id ON public.stdcm_search_environment (timetable_id);
+CREATE INDEX pga_idx_fk_stdcm_search_environment_work_schedule_group_id ON public.stdcm_search_environment (work_schedule_group_id);
+ANALYZE public.stdcm_search_environment;
+
+CREATE INDEX pga_idx_fk_temporary_speed_limit_temporary_speed_limit_group_id ON public.temporary_speed_limit (temporary_speed_limit_group_id);
+ANALYZE public.temporary_speed_limit;
+
+CREATE INDEX pga_idx_fk_stdcm_logs_user_id ON public.stdcm_logs (user_id);
+ANALYZE public.stdcm_logs;


### PR DESCRIPTION
Mostly generated with pgassistant, but can also be done with

```sql
WITH fkeys_without_indexes AS
  (SELECT conname AS fk_name,
          conrelid::regclass AS TABLE_NAME,
          a.attname AS COLUMN_NAME,
          n.nspname AS SCHEMA_NAME,
          condeferrable AS is_deferrable,
          confupdtype AS update_action,
          confdeltype AS delete_action,
          conkey
   FROM pg_constraint c
   JOIN pg_namespace n ON n.oid = c.connamespace
   JOIN pg_class r ON r.oid = c.conrelid
   JOIN unnest(c.conkey) AS col_num ON TRUE
   JOIN pg_attribute a ON a.attnum = col_num
   AND a.attrelid = r.oid
   LEFT JOIN pg_index i ON i.indrelid = r.oid
   AND col_num = ANY (i.indkey)
   WHERE c.contype = 'f'
     AND i.indexrelid IS NULL),
     suggested_indexes AS
  (SELECT SCHEMA_NAME,
          TABLE_NAME,
          COLUMN_NAME,
          'CREATE INDEX pga_idx_fk_' || TABLE_NAME || '_' || COLUMN_NAME || ' ON ' || SCHEMA_NAME || '.' || TABLE_NAME || '(' || COLUMN_NAME || ');' || 'ANALYZE ' || SCHEMA_NAME || '.' || TABLE_NAME || ';' AS pga_suggestion
   FROM fkeys_without_indexes)
SELECT SCHEMA_NAME,
       TABLE_NAME,
       COLUMN_NAME,
       pga_suggestion
FROM suggested_indexes
ORDER BY SCHEMA_NAME,
         TABLE_NAME,
         COLUMN_NAME;
```