### PR TITLE
ci: update 'redis' and 'deadpool-redis' in the same dependabot's group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       opentelemetry:
         patterns:
           - "*opentelemetry*"
+      redis:
+        patterns:
+          - "redis"
+          - "deadpool-redis"
     commit-message:
       prefix: "editoast:"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Should help avoiding [this kind of automatic update](https://github.com/OpenRailAssociation/osrd/pull/10748) and [this fix](https://github.com/OpenRailAssociation/osrd/pull/10765). It will not block them, but at least, the PR will be shown as a group so let's hope it's a good remainder to the maintainer who will take a look 🤷 

Maybe [a better solution can come up at some point](https://github.com/deadpool-rs/deadpool/issues/379#issuecomment-2657741607), we'll see 🤷 
