### PR TITLE
front: use Map instead of Record for train summaries/projections

### DIFF
--- a/front/src/applications/operationalStudies/helpers/formatTrainScheduleSummaries.ts
+++ b/front/src/applications/operationalStudies/helpers/formatTrainScheduleSummaries.ts
@@ -19,7 +19,7 @@ import { isScheduledPointsNotHonored, isTooFast } from '../utils';
 
 const formatTrainScheduleSummaries = (
   trainIds: TrainId[],
-  rawSummaries: Record<TrainScheduleId, SimulationSummaryResult>,
+  rawSummaries: Map<TrainScheduleId, SimulationSummaryResult>,
   rawTrainSchedules: Map<TrainScheduleId, TrainScheduleResultWithTrainId>,
   rollingStocks: LightRollingStockWithLiveries[]
 ): Map<TrainId, TrainScheduleWithDetails> => {
@@ -31,7 +31,7 @@ const formatTrainScheduleSummaries = (
   const trainScheduleWithDetails = relevantTrainSchedules.map((trainSchedule) => {
     const rollingStock = rollingStocks.find((rs) => rs.name === trainSchedule.rolling_stock_name);
 
-    const trainSummary = rawSummaries[trainSchedule.id];
+    const trainSummary = rawSummaries.get(trainSchedule.id);
 
     if (!trainSummary) return null;
 

--- a/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertNewProjectedTrains.ts
@@ -8,30 +8,24 @@ import type {
 
 const upsertNewProjectedTrains = (
   projectedTrains: Map<TrainId, TrainSpaceTimeData>,
-  projectedTrainsToUpsert: Record<TrainScheduleId, ProjectPathTrainResult>,
+  projectedTrainsToUpsert: Map<TrainScheduleId, ProjectPathTrainResult>,
   trainSchedulesById: Map<TrainScheduleId, TrainScheduleResultWithTrainId>
 ) => {
   const newProjectedTrains = new Map(projectedTrains);
 
   // For each key (train id) in projectPathTrainResult, we either add it or update it in the state
-  Object.entries(projectedTrainsToUpsert).forEach(([trainIdKey, trainData]) => {
-    if (!trainData) {
-      console.error(`Train ${trainIdKey} not found in the projectedTrainsToUpsert`);
-      return;
-    }
-
-    // trainIdKey is in format TrainScheduleId but Object.entries tells typescript it's a string
-    const matchingTrain = trainSchedulesById.get(trainIdKey as TrainScheduleId);
+  for (const [trainIdKey, trainData] of projectedTrainsToUpsert) {
+    const matchingTrain = trainSchedulesById.get(trainIdKey);
     const projectedTrain = {
-      id: trainIdKey as TrainScheduleId,
+      id: trainIdKey,
       name: matchingTrain?.train_name || 'Train name not found',
       departureTime: new Date(trainData.departure_time),
       spaceTimeCurves: trainData.space_time_curves,
       signalUpdates: trainData.signal_updates,
     };
 
-    newProjectedTrains.set(trainIdKey as TrainScheduleId, projectedTrain);
-  });
+    newProjectedTrains.set(trainIdKey, projectedTrain);
+  }
 
   return newProjectedTrains;
 };

--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -81,10 +81,10 @@ const useLazyLoadTrains = ({
         }).unwrap();
 
         // TODO Paced train : Adapt this for the add paced train issue : https://github.com/OpenRailAssociation/osrd/issues/10615
-        const formattedRawSummaries: { [key: TrainScheduleId]: SimulationSummaryResult } = {};
+        const formattedRawSummaries: Map<TrainScheduleId, SimulationSummaryResult> = new Map();
         for (const [editoastTrainId, trainSummary] of Object.entries(rawSummaries)) {
           const trainId = formatEditoastTrainIdToTrainScheduleId(Number(editoastTrainId));
-          formattedRawSummaries[trainId] = trainSummary;
+          formattedRawSummaries.set(trainId, trainSummary);
         }
 
         // the two rtk-query calls postTrainSchedule & postTrainScheduleSimulationSummary

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -250,10 +250,10 @@ const useScenarioData = (
       }).unwrap();
 
       // TODO Paced train : Adapt this for the add paced train issue : https://github.com/OpenRailAssociation/osrd/issues/10615
-      const formattedRawSummaries: { [key: TrainScheduleId]: SimulationSummaryResult } = {};
+      const formattedRawSummaries: Map<TrainScheduleId, SimulationSummaryResult> = new Map();
       for (const [_editoastTrainId, trainSummary] of Object.entries(rawSummaries)) {
         const formattedTrainId = formatEditoastTrainIdToTrainScheduleId(Number(_editoastTrainId));
-        formattedRawSummaries[formattedTrainId] = trainSummary;
+        formattedRawSummaries.set(formattedTrainId, trainSummary);
       }
 
       const summaries = formatTrainScheduleSummaries(

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -94,10 +94,10 @@ const useLazyProjectTrains = ({
         },
       }).unwrap();
 
-      const formattedRawProjectedTrains: { [key: TrainScheduleId]: ProjectPathTrainResult } = {};
+      const formattedRawProjectedTrains: Map<TrainScheduleId, ProjectPathTrainResult> = new Map();
       for (const [editoastTrainId, projectedTrain] of Object.entries(rawProjectedTrains)) {
         const trainId = formatEditoastTrainIdToTrainScheduleId(Number(editoastTrainId));
-        formattedRawProjectedTrains[trainId] = projectedTrain;
+        formattedRawProjectedTrains.set(trainId, projectedTrain);
       }
 
       setProjectedTrainsById((prevTrains) => {


### PR DESCRIPTION
TypeScript implicitly converts Record keys to strings. Map is safer.