### PR TITLE
front: fix some /dist imports from ui-spacetimechart

### DIFF
--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -18,11 +18,7 @@ import {
   WorkScheduleLayer,
   OccupancyBlockLayer,
 } from '@osrd-project/ui-spacetimechart';
-import type { Conflict } from '@osrd-project/ui-spacetimechart';
-import type {
-  SpaceTimeChartProps,
-  HoveredItem,
-} from '@osrd-project/ui-spacetimechart/dist/lib/types';
+import type { Conflict, HoveredItem, SpaceTimeChartProps } from '@osrd-project/ui-spacetimechart';
 import cx from 'classnames';
 import { compact } from 'lodash';
 import { createPortal } from 'react-dom';


### PR DESCRIPTION
Since bump of osrd-ui 0.0.66, we can fix these

> [!NOTE]
> There are still remaining /dist imports from osrd-ui (mainly from ui-speedspacechart)