### PR TITLE
core, python: rename use infra speed limits tag

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationEndpoint.kt
@@ -90,7 +90,7 @@ class SimulationEndpoint(
                     request.speedLimitTag,
                     parsePowerRestrictions(request.powerRestrictions),
                     request.options.useElectricalProfiles,
-                    request.options.useInfraSpeedLimits ?: true,
+                    request.options.useSpeedLimits ?: true,
                     2.0,
                     parseRawSimulationScheduleItems(request.schedule),
                     request.initialSpeed,

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
@@ -144,5 +144,5 @@ class SimulationPowerRestrictionItem(
 
 class TrainScheduleOptions(
     @Json(name = "use_electrical_profiles") val useElectricalProfiles: Boolean,
-    @Json(name = "use_infra_speed_limits_for_simulation") val useInfraSpeedLimits: Boolean?
+    @Json(name = "use_speed_limits_for_simulation") val useSpeedLimits: Boolean?
 )

--- a/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/envelope_sim_infra/MRSP.kt
@@ -30,8 +30,8 @@ import kotlin.math.min
  * @param addRollingStockLength whether the rolling stock length should be taken into account in the
  *   computation.
  * @param trainTag corresponding train.
- * @param useInfraSpeedLimits whether the speed limits coming from the infrastructure should be
- *   taken into account in the computation
+ * @param useSpeedLimits whether the speed limits coming from the infrastructure should be taken
+ *   into account in the computation
  * @return the corresponding MRSP as an Envelope.
  */
 fun computeMRSP(
@@ -41,7 +41,7 @@ fun computeMRSP(
     trainTag: String?,
     temporarySpeedLimitManager: TemporarySpeedLimitManager?,
     safetySpeedRanges: DistanceRangeMap<Speed>? = null,
-    useInfraSpeedLimits: Boolean = true,
+    useSpeedLimits: Boolean = true,
 ): Envelope {
     return computeMRSP(
         path,
@@ -51,7 +51,7 @@ fun computeMRSP(
         trainTag,
         temporarySpeedLimitManager,
         safetySpeedRanges,
-        useInfraSpeedLimits,
+        useSpeedLimits,
     )
 }
 
@@ -66,8 +66,8 @@ fun computeMRSP(
  * @param trainTag corresponding train.
  * @param safetySpeedRanges Extra speed ranges, used for safety speeds. Note: rolling stock length
  *   is *not* added at the end of these ranges.
- * @param useInfraSpeedLimits whether the speed limits coming from the infrastructure should be
- *   taken into account in the computation
+ * @param useSpeedLimits whether the speed limits coming from the infrastructure should be taken
+ *   into account in the computation
  * @return the corresponding MRSP as an Envelope.
  */
 fun computeMRSP(
@@ -78,14 +78,14 @@ fun computeMRSP(
     trainTag: String?,
     temporarySpeedLimitManager: TemporarySpeedLimitManager?,
     safetySpeedRanges: DistanceRangeMap<Speed>? = null,
-    useInfraSpeedLimits: Boolean = true,
+    useSpeedLimits: Boolean = true,
 ): Envelope {
     val builder = MRSPEnvelopeBuilder()
     val pathLength = toMeters(path.getLength())
 
     val offset = if (addRollingStockLength) rsLength else 0.0
     val speedLimitProperties =
-        if (useInfraSpeedLimits) path.getSpeedLimitProperties(trainTag, temporarySpeedLimitManager)
+        if (useSpeedLimits) path.getSpeedLimitProperties(trainTag, temporarySpeedLimitManager)
         else distanceRangeMapOf<SpeedLimitProperty>()
     for (speedLimitPropertyRange in speedLimitProperties) {
         // Compute where this limit is active from and to
@@ -126,7 +126,7 @@ fun computeMRSP(
     )
 
     // Add safety speeds
-    if (useInfraSpeedLimits && safetySpeedRanges != null) {
+    if (useSpeedLimits && safetySpeedRanges != null) {
         for (range in safetySpeedRanges) {
             val speed = range.value
             val newAttrs =

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -62,7 +62,7 @@ fun runStandaloneSimulation(
     speedLimitTag: String?,
     powerRestrictions: DistanceRangeMap<String>,
     useElectricalProfiles: Boolean,
-    useInfraSpeedLimits: Boolean,
+    useSpeedLimits: Boolean,
     timeStep: Double,
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
@@ -82,7 +82,7 @@ fun runStandaloneSimulation(
             speedLimitTag,
             null,
             safetySpeedRanges,
-            useInfraSpeedLimits
+            useSpeedLimits
         )
     mrsp = driverBehaviour.applyToMRSP(mrsp, signalingRanges)
     // We don't use speed safety ranges in the MRSP displayed in the front
@@ -95,7 +95,7 @@ fun runStandaloneSimulation(
             speedLimitTag,
             null,
             null,
-            useInfraSpeedLimits,
+            useSpeedLimits,
         )
 
     // Build paths and contexts

--- a/python/osrd_schemas/osrd_schemas/train_schedule.py
+++ b/python/osrd_schemas/osrd_schemas/train_schedule.py
@@ -199,7 +199,7 @@ class PowerRestrictionRanges(RootModel):
 class TrainScheduleOptions(BaseModel):
     """Optional arguments :
     - `use_electrical_profiles` : use the electrical profiles for the standalone simulation
-    - `use_infra_speed_limits_for_simulation` : use the speed limits coming from the infrastructure for
+    - `use_speed_limits_for_simulation` : use the speed limits coming from the infrastructure for
        the standalone simulation
     """
 
@@ -207,7 +207,7 @@ class TrainScheduleOptions(BaseModel):
         default=False,
         description="If true, the electrical profiles are used in the standalone simulation",
     )
-    use_infra_speed_limits_for_simulation: bool = Field(
+    use_speed_limits_for_simulation: bool = Field(
         default=True,
         description="If false, the speed limits of the infrastructure are ignored in the standalone simulation",
     )


### PR DESCRIPTION
Following this PR : https://github.com/OpenRailAssociation/osrd/pull/10681

We want to use the same name everywhere (sometimes we used `UseInfraSpeedLimits` and sometimes `UseSpeedLimits`)