### PR TITLE
front: stop heating the room when selecting a train

### DIFF
--- a/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
+++ b/front/src/modules/simulationResult/SimulationResultExport/SimulationResultsExport.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Button } from '@osrd-project/ui-core';
 import { Download, File } from '@osrd-project/ui-icons';
-import { BlobProvider } from '@react-pdf/renderer';
+import { pdf } from '@react-pdf/renderer';
 import { useTranslation } from 'react-i18next';
 
 import type {
@@ -55,30 +55,32 @@ const SimulationResultExport = ({
     [simulatedTrain]
   );
 
+  const exportTrainPDF = useCallback(async () => {
+    const doc = (
+      <SimulationReportSheetScenario
+        path={path}
+        scenarioData={scenarioData}
+        trainData={simulationSheetData}
+        operationalPointsList={operationalPoints}
+        mapCanvas={mapCanvas}
+      />
+    );
+    const blob = await pdf(doc).toBlob();
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
+    URL.revokeObjectURL(url);
+  }, [path, scenarioData, simulationSheetData, operationalPoints, mapCanvas]);
+
   return (
     <div className="simulation-sheet-container">
       {/* Export simulation PDF */}
-      <BlobProvider
-        document={
-          <SimulationReportSheetScenario
-            path={path}
-            scenarioData={scenarioData}
-            trainData={simulationSheetData}
-            operationalPointsList={operationalPoints}
-            mapCanvas={mapCanvas}
-          />
-        }
-      >
-        {({ url }) => (
-          <Button
-            onClick={() => window.open(url!, '_blank')}
-            variant="Quiet"
-            label={t('simulationSheet')}
-            size="medium"
-            leadingIcon={<File />}
-          />
-        )}
-      </BlobProvider>
+      <Button
+        onClick={exportTrainPDF}
+        variant="Quiet"
+        label={t('simulationSheet')}
+        size="medium"
+        leadingIcon={<File />}
+      />
 
       {/* Export simulation CSV */}
       <Button


### PR DESCRIPTION
Spring is coming.

We were generating the PDF report (rendering and all) each time a train was selected. Instead, only generate the PDF when the user clicks the download button.

![image](https://github.com/user-attachments/assets/ec7f9e3c-d444-4767-a7fe-ac7ea9c21626)
