### PR TITLE
editoast: fix comments and reformat 'Cargo.toml'

### DIFF
--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -55,6 +55,9 @@ hostname = "0.4.0"
 itertools = "0.13.0"
 mvt = "0.9.5"
 openssl = "0.10.70"
+opentelemetry = { version = "0.27.1", default-features = false, features = [
+  "trace",
+] }
 opentelemetry-semantic-conventions = { version = "0.26", features = [
   "semconv_experimental",
 ] }
@@ -65,12 +68,9 @@ postgres-openssl = "0.5.1"
 pretty_assertions = "1.4.1"
 rand = "0.9.0"
 rangemap = "1.5.1"
+regex = "1.11"
 # 0.12.0 to 0.12.4 have weird timeout issues https://github.com/seanmonstar/reqwest/issues/2283
 # This bug was introduced between 0.12.0 and 0.12.3.
-opentelemetry = { version = "0.27.1", default-features = false, features = [
-  "trace",
-] }
-regex = "1.11"
 reqwest = { version = "0.11.27", features = ["json"] }
 rstest = { version = "0.19.0", default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
The comment is not targetting the correct dependency, and the order of dependency is kind of weird
(`opentelemetry` is far away from its friends).