### PR TITLE
docker: use cache mount for npm install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           set -eo pipefail
 
           # disable cache mounts as github cache is slow
-          find -name Dockerfile -print0 | xargs -0 sed -Ei 's/--mount=type=cache,target=[^[:blank:]]+//g'
+          find -name Dockerfile -o -name "Dockerfile.*" -print0 | xargs -0 sed -Ei 's/--mount=type=cache,target=[^[:blank:]]+//g'
 
           TRANSIENT_FAILURES=(
             "failed to solve: failed to compute cache key"

--- a/front/docker/Dockerfile.playwright
+++ b/front/docker/Dockerfile.playwright
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/playwright:$PLAYWRIGHT_VERSION
 
 COPY front/package.json front/package-lock.json /app/front/
 WORKDIR /app/front
-RUN npm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.npm \
+    npm install --frozen-lockfile
 
 COPY front /app/front/
 COPY tests /app/tests

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -74,12 +74,13 @@ ENV VITE_OSRD_GIT_DESCRIBE=${OSRD_GIT_DESCRIBE}
 COPY --from=front_src package.json package-lock.json /app/
 
 # If SKIP_FRONT is set to 1, skip the front build
-RUN if [ "$SKIP_FRONT" = "1" ]; then exit 0; else npm ci; fi
+RUN --mount=type=cache,target=/root/.npm \
+    if [ "$SKIP_FRONT" = "1" ]; then exit 0; else npm ci; fi
 
 # Generate the licenses file and build
 COPY --from=front_src . /app
 ENV NODE_OPTIONS="--max_old_space_size=4096"
-RUN if [ "$SKIP_FRONT" = "1" ]; then \ 
+RUN if [ "$SKIP_FRONT" = "1" ]; then \
     mkdir -p build; \
     echo '<html><body><h1>No front, as this image was built for running it in dev mode</h1></body></html>' > build/index.html; \
     else \


### PR DESCRIPTION
This should avoid re-downloading dependencies when re-building the container.