### PR TITLE
editoast: add categories to rolling stock edit endpoint

### DIFF
--- a/editoast/editoast_models/src/rolling_stock/rolling_stock_category.rs
+++ b/editoast/editoast_models/src/rolling_stock/rolling_stock_category.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::ops::Deref;
 use std::str::FromStr;
 
 use diesel::deserialize::FromSql;
@@ -32,6 +33,14 @@ impl ToSql<crate::tables::sql_types::RollingStockCategory, Pg> for RollingStockC
     }
 }
 
+impl Deref for RollingStockCategory {
+    type Target = editoast_schemas::rolling_stock::RollingStockCategory;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct RollingStockCategories(pub Vec<RollingStockCategory>);
 
@@ -44,5 +53,13 @@ impl From<Vec<Option<RollingStockCategory>>> for RollingStockCategories {
 impl From<RollingStockCategories> for Vec<Option<RollingStockCategory>> {
     fn from(categories: RollingStockCategories) -> Self {
         categories.0.into_iter().map(Some).collect()
+    }
+}
+
+impl Deref for RollingStockCategories {
+    type Target = Vec<RollingStockCategory>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -107,6 +107,8 @@ pub struct RollingStock {
     pub railjson_version: String,
     #[serde(default)]
     pub metadata: Option<RollingStockMetadata>,
+    pub primary_category: RollingStockCategory,
+    pub other_categories: RollingStockCategories,
 }
 
 impl<'de> Deserialize<'de> for RollingStock {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -9619,6 +9619,8 @@ components:
       - loading_gauge
       - power_restrictions
       - supported_signaling_systems
+      - primary_category
+      - other_categories
       properties:
         base_power_class:
           type: string
@@ -9677,11 +9679,15 @@ components:
           nullable: true
         name:
           type: string
+        other_categories:
+          $ref: '#/components/schemas/RollingStockCategories'
         power_restrictions:
           type: object
           description: Mapping of power restriction code to power class
           additionalProperties:
             type: string
+        primary_category:
+          $ref: '#/components/schemas/RollingStockCategory'
         raise_pantograph_time:
           type: number
           format: double

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -32,7 +32,7 @@ pub async fn import_rolling_stock(
         let rolling_stock: RollingStock =
             serde_json::from_reader(BufReader::new(rolling_stock_file))?;
         let rolling_stock: Changeset<RollingStockModel> = rolling_stock.into();
-        match rolling_stock.validate_imported_rolling_stock() {
+        match rolling_stock.validate() {
             Ok(()) => {
                 println!(
                     "🍞 Importing rolling stock {}",

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -17,6 +17,8 @@ use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::rolling_stock::RollingResistance;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::RollingStock;
+use editoast_schemas::rolling_stock::RollingStockCategories;
+use editoast_schemas::rolling_stock::RollingStockCategory;
 use editoast_schemas::rolling_stock::RollingStockSupportedSignalingSystems;
 use editoast_schemas::rolling_stock::TowedRollingStock;
 use editoast_schemas::train_schedule::TrainScheduleBase;
@@ -279,6 +281,8 @@ pub fn create_simple_rolling_stock() -> RollingStock {
         length: units::meter::new(140.0),
         mass: units::kilogram::new(15000.0),
         max_speed: units::meter_per_second::new(20.0),
+        primary_category: RollingStockCategory::HighSpeedTrain,
+        other_categories: RollingStockCategories(vec![]),
     }
 }
 

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -212,6 +212,15 @@ impl From<RollingStockModel> for RollingStock {
             electrical_power_startup_time: rolling_stock_model.electrical_power_startup_time,
             raise_pantograph_time: rolling_stock_model.raise_pantograph_time,
             supported_signaling_systems: rolling_stock_model.supported_signaling_systems,
+            primary_category: rolling_stock_model.primary_category.0,
+            other_categories: editoast_schemas::rolling_stock::RollingStockCategories(
+                rolling_stock_model
+                    .other_categories
+                    .0
+                    .into_iter()
+                    .map(|x| x.0)
+                    .collect::<Vec<_>>(),
+            ),
         }
     }
 }
@@ -241,6 +250,15 @@ impl From<RollingStock> for RollingStockModelChangeset {
             .electrical_power_startup_time(rolling_stock.electrical_power_startup_time)
             .raise_pantograph_time(rolling_stock.raise_pantograph_time)
             .supported_signaling_systems(rolling_stock.supported_signaling_systems)
+            .primary_category(RollingStockCategory(rolling_stock.primary_category))
+            .other_categories(RollingStockCategories(
+                rolling_stock
+                    .other_categories
+                    .0
+                    .into_iter()
+                    .map(RollingStockCategory)
+                    .collect::<Vec<_>>(),
+            ))
     }
 }
 
@@ -327,7 +345,7 @@ pub mod tests {
     }
 
     #[rstest]
-    async fn test_primary_category_is_unknown_with_other_categories_are_empty() {
+    async fn test_primary_category_with_empty_other_categories() {
         let db_pool = DbConnectionPoolV2::for_tests();
 
         let created_fast_rolling_stock =
@@ -336,7 +354,7 @@ pub mod tests {
         assert_eq!(
             created_fast_rolling_stock.primary_category,
             RollingStockCategory(
-                editoast_schemas::rolling_stock::RollingStockCategory::FreightTrain
+                editoast_schemas::rolling_stock::RollingStockCategory::CommuterTrain
             )
         );
         assert_eq!(

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -138,53 +138,78 @@ impl From<model::Error> for Error {
 }
 
 impl RollingStockModelChangeset {
-    pub fn validate_imported_rolling_stock(&self) -> std::result::Result<(), ValidationErrors> {
-        match &self.effort_curves {
-            Some(effort_curves) => validate_rolling_stock(
-                effort_curves,
-                self.electrical_power_startup_time
+    pub fn validate(&self) -> std::result::Result<(), ValidationErrors> {
+        let mut validation_errors = ValidationErrors::new();
+
+        self.validate_primary_category(&mut validation_errors);
+
+        self.validate_effort_curves(&mut validation_errors);
+
+        if !validation_errors.is_empty() {
+            return Err(validation_errors);
+        }
+
+        Ok(())
+    }
+
+    fn validate_effort_curves(&self, validation_errors: &mut ValidationErrors) {
+        if let Some(effort_curves) = &self.effort_curves {
+            if effort_curves.is_electric() {
+                if self
+                    .electrical_power_startup_time
                     .flatten()
-                    .map(units::second::new),
-                self.raise_pantograph_time.flatten().map(units::second::new),
-            )
-            .map_err(|e| {
-                let mut err = ValidationErrors::new();
-                err.add("effort_curves", e);
-                err
-            }),
-            None => {
-                let mut err = ValidationErrors::new();
-                err.add(
-                    "effort_curves",
-                    ValidationError::new("effort_curves is required"),
-                );
-                Err(err)
+                    .map(units::second::new)
+                    .is_none()
+                {
+                    let mut error = ValidationError::new("electrical_power_startup_time");
+                    error.message = Some(
+                        "electrical_power_startup_time is required for electric rolling stocks"
+                            .into(),
+                    );
+                    validation_errors.add("effort_curves", error);
+                }
+                if self
+                    .raise_pantograph_time
+                    .flatten()
+                    .map(units::second::new)
+                    .is_none()
+                {
+                    let mut error = ValidationError::new("raise_pantograph_time");
+                    error.message = Some(
+                        "raise_pantograph_time is required for electric rolling stocks".into(),
+                    );
+                    validation_errors.add("effort_curves", error);
+                }
             }
+        } else {
+            validation_errors.add(
+                "effort_curves",
+                ValidationError::new("effort_curves is required"),
+            );
         }
     }
-}
 
-pub fn validate_rolling_stock(
-    effort_curves: &EffortCurves,
-    electrical_power_startup_time: Option<Time>,
-    raise_pantograph_time: Option<Time>,
-) -> std::result::Result<(), ValidationError> {
-    if !effort_curves.is_electric() {
-        return Ok(());
+    fn validate_primary_category(&self, validation_errors: &mut ValidationErrors) {
+        if let Some(primary_category) = &self.primary_category {
+            if let Some(other_categories) = &self.other_categories {
+                if other_categories
+                    .iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .contains(&primary_category)
+                {
+                    let mut error = ValidationError::new("primary_category");
+                    error.message = Some("The primary_category cannot be listed in other_categories for rolling stocks.".into(),);
+                    validation_errors.add("primary_category", error);
+                }
+            }
+        } else {
+            validation_errors.add(
+                "primary_category",
+                ValidationError::new("primary_category is required"),
+            );
+        }
     }
-    if electrical_power_startup_time.is_none() {
-        let mut error = ValidationError::new("electrical_power_startup_time");
-        error.message =
-            Some("electrical_power_startup_time is required for electric rolling stocks".into());
-        return Err(error);
-    }
-    if raise_pantograph_time.is_none() {
-        let mut error = ValidationError::new("raise_pantograph_time");
-        error.message =
-            Some("raise_pantograph_time is required for electric rolling stocks".into());
-        return Err(error);
-    }
-    Ok(())
 }
 
 impl From<RollingStockModel> for RollingStock {

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -1,6 +1,7 @@
 mod power_restrictions;
 
 use std::collections::HashMap;
+use std::ops::Deref;
 
 use editoast_common::units;
 use editoast_common::units::quantities::{
@@ -195,11 +196,10 @@ impl RollingStockModelChangeset {
                 if other_categories
                     .iter()
                     .flatten()
-                    .collect::<Vec<_>>()
-                    .contains(&primary_category)
+                    .any(|category| category == primary_category)
                 {
                     let mut error = ValidationError::new("primary_category");
-                    error.message = Some("The primary_category cannot be listed in other_categories for rolling stocks.".into(),);
+                    error.message = Some("The primary_category cannot be listed in other_categories for rolling stocks.".into());
                     validation_errors.add("primary_category", error);
                 }
             }
@@ -237,13 +237,12 @@ impl From<RollingStockModel> for RollingStock {
             electrical_power_startup_time: rolling_stock_model.electrical_power_startup_time,
             raise_pantograph_time: rolling_stock_model.raise_pantograph_time,
             supported_signaling_systems: rolling_stock_model.supported_signaling_systems,
-            primary_category: rolling_stock_model.primary_category.0,
+            primary_category: rolling_stock_model.primary_category.deref().clone(),
             other_categories: editoast_schemas::rolling_stock::RollingStockCategories(
                 rolling_stock_model
                     .other_categories
-                    .0
-                    .into_iter()
-                    .map(|x| x.0)
+                    .iter()
+                    .map(|c| c.deref().clone())
                     .collect::<Vec<_>>(),
             ),
         }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -32,7 +32,6 @@ use strum::Display;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
-use validator::Validate;
 
 use crate::error::InternalError;
 use crate::error::Result;
@@ -338,9 +337,10 @@ async fn create(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    rolling_stock_form.validate()?;
+
     let conn = &mut db_pool.get().await?;
     let rolling_stock_changeset: Changeset<RollingStockModel> = rolling_stock_form.into();
+    rolling_stock_changeset.validate()?;
 
     let rolling_stock = rolling_stock_changeset
         .locked(query_params.locked)
@@ -375,8 +375,10 @@ async fn update(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    rolling_stock_form.validate()?;
+
     let name = rolling_stock_form.name.clone();
+    let rolling_stock_changeset: Changeset<RollingStockModel> = rolling_stock_form.into();
+    rolling_stock_changeset.validate()?;
 
     let new_rolling_stock = db_pool
         .get()
@@ -393,14 +395,13 @@ async fn update(
                 .await?;
                 assert_rolling_stock_unlocked(&previous_rolling_stock)?;
 
-                let mut new_rolling_stock =
-                    Into::<Changeset<RollingStockModel>>::into(rolling_stock_form)
-                        .update(&mut conn.clone(), rolling_stock_id)
-                        .await
-                        .map_err(|e| map_diesel_error(e, name.clone()))?
-                        .ok_or(RollingStockError::KeyNotFound {
-                            rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
-                        })?;
+                let mut new_rolling_stock = rolling_stock_changeset
+                    .update(&mut conn.clone(), rolling_stock_id)
+                    .await
+                    .map_err(|e| map_diesel_error(e, name.clone()))?
+                    .ok_or(RollingStockError::KeyNotFound {
+                        rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
+                    })?;
 
                 if new_rolling_stock != previous_rolling_stock {
                     new_rolling_stock.version += 1;
@@ -786,6 +787,8 @@ async fn create_compound_image(
 #[cfg(test)]
 pub mod tests {
     use axum::http::StatusCode;
+    use editoast_models::rolling_stock::RollingStockCategories;
+    use editoast_models::rolling_stock::RollingStockCategory;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -1168,6 +1171,105 @@ pub mod tests {
             updated_rolling_stock.version,
             fast_rolling_stock.version + 1
         );
+    }
+
+    #[rstest]
+    async fn update_rolling_stock_with_new_categories() {
+        // GIVEN
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_with_categories")
+                .await;
+
+        assert_eq!(
+            fast_rolling_stock.primary_category,
+            RollingStockCategory(
+                editoast_schemas::rolling_stock::RollingStockCategory::CommuterTrain,
+            )
+        );
+        assert_eq!(
+            fast_rolling_stock.other_categories,
+            RollingStockCategories(vec![])
+        );
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let primary_category = RollingStockCategory(
+            editoast_schemas::rolling_stock::RollingStockCategory::HighSpeedTrain,
+        );
+        rolling_stock_form.primary_category = primary_category.clone();
+        let other_categories = RollingStockCategories(vec![RollingStockCategory(
+            editoast_schemas::rolling_stock::RollingStockCategory::RegionalTrain,
+        )]);
+        rolling_stock_form.other_categories = other_categories.clone();
+
+        let request = app
+            .patch(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form);
+
+        // WHEN
+        let raw_response = app.fetch(request);
+
+        // THEN
+        raw_response.assert_status(StatusCode::OK);
+
+        let updated_rolling_stock: RollingStockModel =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+
+        assert_eq!(
+            updated_rolling_stock.version,
+            fast_rolling_stock.version + 1
+        );
+        assert_eq!(updated_rolling_stock.primary_category, primary_category);
+        assert_eq!(updated_rolling_stock.other_categories, other_categories);
+    }
+
+    #[rstest]
+    async fn update_rolling_stock_categories_should_fail_when_invalid() {
+        // GIVEN
+        let app = TestAppBuilder::default_app();
+        let db_pool = app.db_pool();
+
+        let fast_rolling_stock =
+            create_fast_rolling_stock(&mut db_pool.get_ok(), "fast_rolling_stock_with_categories")
+                .await;
+
+        let mut rolling_stock_form: RollingStockForm = fast_rolling_stock.clone().into();
+        let primary_category = RollingStockCategory(
+            editoast_schemas::rolling_stock::RollingStockCategory::HighSpeedTrain,
+        );
+        rolling_stock_form.primary_category = primary_category.clone();
+        let other_categories = RollingStockCategories(vec![primary_category.clone()]);
+        rolling_stock_form.other_categories = other_categories.clone();
+
+        let request = app
+            .patch(format!("/rolling_stock/{}", fast_rolling_stock.id).as_str())
+            .json(&&rolling_stock_form);
+
+        // WHEN
+        let raw_response = app.fetch(request);
+
+        // THEN
+        let response: InternalError = raw_response
+            .assert_status(StatusCode::BAD_REQUEST)
+            .json_into();
+        assert_eq!(response.error_type, "editoast:ValidationError");
+        assert_eq!(
+            &response.context.get("primary_category").unwrap()[0],
+            "The primary_category cannot be listed in other_categories for rolling stocks."
+        );
+
+        let updated_rolling_stock: RollingStockModel =
+            RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
+                .await
+                .expect("Failed to retrieve rolling stock")
+                .expect("Rolling stock not found");
+
+        assert_eq!(updated_rolling_stock.version, fast_rolling_stock.version);
     }
 
     #[rstest]

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use editoast_common::units::{quantities::*, *};
+use editoast_models::rolling_stock::RollingStockCategories;
+use editoast_models::rolling_stock::RollingStockCategory;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
 use editoast_schemas::rolling_stock::EtcsBrakeParams;
@@ -12,17 +14,13 @@ use editoast_schemas::rolling_stock::ROLLING_STOCK_RAILJSON_VERSION;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
-use validator::Validate;
-use validator::ValidationError;
 
-use crate::models::rolling_stock_model::validate_rolling_stock;
 use crate::models::Changeset;
 use crate::models::Model;
 use crate::models::RollingStockModel;
 
 #[editoast_derive::annotate_units]
-#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, Validate)]
-#[validate(schema(function = "validate_rolling_stock_form"))]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct RollingStockForm {
     pub name: String,
     pub effort_curves: EffortCurves,
@@ -64,6 +62,8 @@ pub struct RollingStockForm {
     pub supported_signaling_systems: RollingStockSupportedSignalingSystems,
     pub locked: Option<bool>,
     pub metadata: Option<RollingStockMetadata>,
+    pub primary_category: RollingStockCategory,
+    pub other_categories: RollingStockCategories,
 }
 
 impl From<RollingStockForm> for Changeset<RollingStockModel> {
@@ -91,17 +91,9 @@ impl From<RollingStockForm> for Changeset<RollingStockModel> {
             .electrical_power_startup_time(rolling_stock.electrical_power_startup_time)
             .raise_pantograph_time(rolling_stock.raise_pantograph_time)
             .supported_signaling_systems(rolling_stock.supported_signaling_systems)
+            .primary_category(rolling_stock.primary_category)
+            .other_categories(rolling_stock.other_categories)
     }
-}
-
-fn validate_rolling_stock_form(
-    rolling_stock_form: &RollingStockForm,
-) -> std::result::Result<(), ValidationError> {
-    validate_rolling_stock(
-        &rolling_stock_form.effort_curves,
-        rolling_stock_form.electrical_power_startup_time,
-        rolling_stock_form.raise_pantograph_time,
-    )
 }
 
 // Used in some tests where we import a rolling stock as a fixture
@@ -130,6 +122,8 @@ impl From<RollingStockModel> for RollingStockForm {
             supported_signaling_systems: value.supported_signaling_systems,
             locked: Some(value.locked),
             metadata: value.metadata,
+            primary_category: value.primary_category,
+            other_categories: value.other_categories,
         }
     }
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3214,10 +3214,12 @@ export type RollingStockForm = {
   max_speed: number;
   metadata?: RollingStockMetadata | null;
   name: string;
+  other_categories: RollingStockCategories;
   /** Mapping of power restriction code to power class */
   power_restrictions: {
     [key: string]: string;
   };
+  primary_category: RollingStockCategory;
   /** The time it takes to raise this train's pantograph in seconds. Is null if the train is not electric.
     Duration in s */
   raise_pantograph_time?: number | null;

--- a/front/src/modules/rollingStock/consts.ts
+++ b/front/src/modules/rollingStock/consts.ts
@@ -60,6 +60,8 @@ export const newRollingStockValues: RollingStockParametersValues = {
   basePowerClass: null,
   powerRestrictions: {},
   supportedSignalingSystems: DEFAULT_SIGNALING_SYSTEMS,
+  primary_category: 'FREIGHT_TRAIN',
+  other_categories: [],
 };
 
 export const RS_REQUIRED_FIELDS = Object.freeze({

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -110,6 +110,8 @@ export const getRollingStockEditorDefaultValues = (
         basePowerClass: rollingStockData.base_power_class || null,
         powerRestrictions: rollingStockData.power_restrictions,
         supportedSignalingSystems: rollingStockData.supported_signaling_systems,
+        primary_category: rollingStockData.primary_category,
+        other_categories: rollingStockData.other_categories,
       }
     : {
         ...newRollingStockValues,
@@ -196,6 +198,8 @@ export const rollingStockEditorQueryArg = (
     },
     base_power_class: data.basePowerClass,
     supported_signaling_systems: data.supportedSignalingSystems,
+    primary_category: data.primary_category,
+    other_categories: data.other_categories,
   };
 };
 

--- a/front/src/modules/rollingStock/types.ts
+++ b/front/src/modules/rollingStock/types.ts
@@ -3,6 +3,7 @@ import type {
   LoadingGaugeType,
   Comfort,
   RollingStock,
+  RollingStockCategory,
 } from 'common/api/osrdEditoastApi';
 
 export type RollingStockParametersValidValues = {
@@ -42,6 +43,8 @@ export type RollingStockParametersValidValues = {
   basePowerClass: string | null;
   powerRestrictions: RollingStock['power_restrictions'];
   supportedSignalingSystems: string[];
+  primary_category: RollingStockCategory;
+  other_categories: RollingStockCategory[];
 };
 
 export type RollingStockParametersValues = {
@@ -73,6 +76,8 @@ export type RollingStockParametersValues = {
   basePowerClass: string | null;
   powerRestrictions: RollingStock['power_restrictions'];
   supportedSignalingSystems: string[];
+  primary_category: RollingStockCategory;
+  other_categories: RollingStockCategory[];
 };
 
 export type MultiUnit =

--- a/front/tests/assets/rollingStock/dual-mode_rolling_stock.json
+++ b/front/tests/assets/rollingStock/dual-mode_rolling_stock.json
@@ -1,5 +1,5 @@
 {
-  "railjson_version": "3.2",
+  "railjson_version": "3.3",
   "name": "DUAL-MODE_RS_E2Ee",
   "effort_curves": {
     "modes": {
@@ -440,5 +440,7 @@
   "raise_pantograph_time": 16.0,
   "version": 1,
   "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
-  "liveries": []
+  "liveries": [],
+  "primary_category": "FREIGHT_TRAIN",
+  "other_categories": []
 }

--- a/front/tests/assets/rollingStock/fast_rolling_stock.json
+++ b/front/tests/assets/rollingStock/fast_rolling_stock.json
@@ -1,6 +1,6 @@
 {
   "id": 480,
-  "railjson_version": "3.2",
+  "railjson_version": "3.3",
   "name": "fast_rolling_stock",
   "effort_curves": {
     "modes": {
@@ -116,5 +116,7 @@
   "raise_pantograph_time": null,
   "version": 1,
   "supported_signaling_systems": ["BAL", "BAPR"],
-  "liveries": []
+  "liveries": [],
+  "primary_category": "FREIGHT_TRAIN",
+  "other_categories": []
 }

--- a/front/tests/assets/rollingStock/improbable_rolling_stock.json
+++ b/front/tests/assets/rollingStock/improbable_rolling_stock.json
@@ -1,6 +1,6 @@
 {
   "id": 789,
-  "railjson_version": "3.2",
+  "railjson_version": "3.3",
   "name": "IMPROBABLE_RS_E2E",
   "effort_curves": {
     "modes": {
@@ -938,5 +938,7 @@
   "raise_pantograph_time": 15.0,
   "version": 0,
   "supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430"],
-  "liveries": []
+  "liveries": [],
+  "primary_category": "FREIGHT_TRAIN",
+  "other_categories": []
 }

--- a/front/tests/assets/rollingStock/slow_rolling_stock.json
+++ b/front/tests/assets/rollingStock/slow_rolling_stock.json
@@ -1,6 +1,6 @@
 {
   "id": 479,
-  "railjson_version": "3.2",
+  "railjson_version": "3.3",
   "name": "slow_rolling_stock",
   "effort_curves": {
     "modes": {
@@ -75,5 +75,7 @@
   "raise_pantograph_time": null,
   "version": 1,
   "supported_signaling_systems": ["BAL", "BAPR"],
-  "liveries": []
+  "liveries": [],
+  "primary_category": "FREIGHT_TRAIN",
+  "other_categories": []
 }

--- a/python/osrd_schemas/osrd_schemas/rolling_stock.py
+++ b/python/osrd_schemas/osrd_schemas/rolling_stock.py
@@ -21,16 +21,16 @@ class RollingStockCategory(str, Enum):
     The list of categories that can be assigned to a rolling stock.
     """
 
-    HIGH_SPEED_TRAIN = "High Speed Train"
-    INTERCITY_TRAIN = "Intercity Train"
-    REGIONAL_TRAIN = "Regional Train"
-    NIGHT_TRAIN = "Night Train"
-    COMMUTER_TRAIN = "Commuter Train"
-    FREIGHT_TRAIN = "Freight Train"
-    FAST_FREIGHT_TRAIN = "Fast Freight Train"
-    TRAM_TRAIN = "Tram Train"
-    TOURISTIC_TRAIN = "Touristic Train"
-    WORK_TRAIN = "Work Train"
+    HIGH_SPEED_TRAIN = "HIGH_SPEED_TRAIN"
+    INTERCITY_TRAIN = "INTERCITY_TRAIN"
+    REGIONAL_TRAIN = "REGIONAL_TRAIN"
+    NIGHT_TRAIN = "NIGHT_TRAIN"
+    COMMUTER_TRAIN = "COMMUTER_TRAIN"
+    FREIGHT_TRAIN = "FREIGHT_TRAIN"
+    FAST_FREIGHT_TRAIN = "FAST_FREIGHT_TRAIN"
+    TRAM_TRAIN = "TRAM_TRAIN"
+    TOURISTIC_TRAIN = "TOURISTIC_TRAIN"
+    WORK_TRAIN = "WORK_TRAIN"
 
 
 class ComfortType(str, Enum):


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/10574

- [x] Add the columns to edit endpoints
- [x] Check that `primary_category` is not included in `other_categories`.