### PR TITLE
front: drop formatToIsoDate()

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -11,7 +11,6 @@ import type {
   TrainScheduleResultWithTrainId,
 } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
-import { formatToIsoDate } from 'utils/date';
 import { Duration } from 'utils/duration';
 import {
   formatEditoastTrainIdToTrainScheduleId,
@@ -263,7 +262,7 @@ const createTrainSchedulePayload = async ({
     train_name: trainrun.name,
     labels: compact(trainrunLabels),
     path: path.flat(),
-    start_time: formatToIsoDate(startDate),
+    start_time: startDate.toISOString(),
     schedule,
   };
 };

--- a/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayloads.ts
+++ b/front/src/modules/trainschedule/components/ImportTrainSchedule/generateTrainSchedulesPayloads.ts
@@ -3,7 +3,6 @@ import nextId from 'react-id-generator';
 
 import type { ImportedTrainSchedule } from 'applications/operationalStudies/types';
 import type { TrainScheduleBase } from 'common/api/osrdEditoastApi';
-import { formatToIsoDate } from 'utils/date';
 import { Duration } from 'utils/duration';
 
 export function generateTrainSchedulesPayloads(
@@ -63,7 +62,7 @@ export function generateTrainSchedulesPayloads(
       rolling_stock_name: train.rollingStock || '',
       constraint_distribution: 'MARECO',
       schedule,
-      start_time: formatToIsoDate(train.departureTime, false),
+      start_time: departureTime.toISOString(),
     });
     return payloads;
   }, [] as TrainScheduleBase[]);

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -18,7 +18,6 @@ import type {
 } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { formatToIsoDate } from 'utils/date';
 import { castErrorToFailure } from 'utils/error';
 import {
   formatEditoastTrainIdToTrainScheduleId,
@@ -75,7 +74,7 @@ const useUpdateTrainSchedule = (
         dispatch(
           setSuccess({
             title: t('trainUpdated'),
-            text: `${confName}: ${formatToIsoDate(startTime, true)}`,
+            text: `${confName}: ${startTime.toLocaleString()}`,
           })
         );
         dispatch(updateSelectedTrainId(trainIdToEdit as TrainScheduleId));

--- a/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
@@ -20,7 +20,7 @@ import type {
 } from 'reducers/osrdconf/types';
 import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
-import { formatToIsoDate, isoDateToMs } from 'utils/date';
+import { Duration, addDurationToDate } from 'utils/duration';
 import { castErrorToFailure } from 'utils/error';
 import {
   formatEditoastTrainIdToTrainScheduleId,
@@ -121,11 +121,11 @@ const TrainScheduleItem = ({
       });
 
     if (trainDetail) {
-      const formattedStartTimeMs = isoDateToMs(trainDetail.start_time);
-      const newStartTimeString = formatToIsoDate(formattedStartTimeMs + 1000 * 60 * trainDelta);
+      const startTime = new Date(trainDetail.start_time);
+      const newStartTime = addDurationToDate(startTime, new Duration({ minutes: trainDelta }));
       const newTrain: TrainScheduleBase = {
         ...omit(trainDetail, ['id', 'timetable_id']),
-        start_time: newStartTimeString,
+        start_time: newStartTime.toISOString(),
         train_name: trainNameWithNum(trainName, actualTrainCount, trainCount),
       };
 

--- a/front/src/utils/__tests__/date.spec.ts
+++ b/front/src/utils/__tests__/date.spec.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest';
 import {
   parseLocalDateTime,
   isoDateToMs,
-  formatToIsoDate,
   serializeDateTimeWithoutYear,
   extractDateAndTime,
   isArrivalDateInSearchTimeWindow,
@@ -40,14 +39,6 @@ describe('isoDateToMs', () => {
     const isoDate = '2024-04-26T20:30:15+02:00';
     const msDate = isoDateToMs(isoDate);
     expect(msDate).toEqual(1714156215000);
-  });
-});
-
-describe('formatToIsoDate', () => {
-  it('should return the date in ISO 8601', () => {
-    const msDate = 1714156215000;
-    const isoDate = formatToIsoDate(msDate);
-    expect(isoDate).toEqual('2024-04-26T18:30:15Z'); // Ends by Z because CI seems to be in UTC timezone
   });
 });
 

--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -50,16 +50,6 @@ export const formatLocalDateTime = (date: Date) =>
   dayjs(date).local().format('YYYY-MM-DDTHH:mm:ss');
 
 /**
- * Transform a milliseconds date to an ISO 8601 date with the user timezone
- * @param msDate milliseconds date (elapsed from January 1st 1970)
- * @return an ISO 8601 date (e.g. 2024-04-25T08:30:00+02:00)
- */
-export const formatToIsoDate = (date: number | string | Date, formatDate: boolean = false) => {
-  const format = formatDate ? 'D/MM/YYYY HH:mm:ss' : '';
-  return dayjs(date).tz(userTimeZone).format(format);
-};
-
-/**
  * Transform a locale date to an ISO 8601 date
  * @param date Date we want to transform to ISO 8601
  * @return an ISO 8601 date (e.g. 2024-04-25T08:30:00+02:00)


### PR DESCRIPTION
_See individual commits._

This function was a bit weird, because it had two unrelated purposes: format a human-readable string with a fixed frenchy format, or format a machine-readable string for API purposes. The function also accepted strings and numbers as input (implicitly converting these to dates), making it so callers are less type-safe.