### PR TITLE
front: fix isEqualDate()

### DIFF
--- a/front/src/utils/date.ts
+++ b/front/src/utils/date.ts
@@ -209,10 +209,10 @@ export const formatDateString = (date?: Date | null) => {
   return dayjs(date).format('DD/MM/YY');
 };
 
-export const formatLocaleDate = (date: Date) => date.toLocaleString().substring(0, 10);
-
 export const isEqualDate = (searchDate: Date, startDate: Date) =>
-  formatLocaleDate(searchDate) === formatLocaleDate(startDate);
+  searchDate.getFullYear() === startDate.getFullYear() &&
+  searchDate.getMonth() === startDate.getMonth() &&
+  searchDate.getDate() === startDate.getDate();
 
 /**
  * @param start timestamp or Date object


### PR DESCRIPTION
toLocaleString() returns an arbitrary human-readable string. For instance, in France it returns "18/02/2025 13:32:08" and in Korea it returns "2025. 2. 18. 오후 1:32:08".

The string cannot be used for anything else than display. Trying to extract the date from it will not work: substring(0, 10) will give "2025. 2. 1" in Korea (dropping the "8"). As a result, any day with the same first digit will be interpreted as equal.

Fix this by comparing the year, month, and day of the month instead.