### PR TITLE
core: stdcm: avoid infinite loop in logger edge case

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/ProgressLogger.kt
@@ -29,6 +29,11 @@ data class ProgressLogger(
         seenSteps++
         val progress =
             (graph.bestPossibleTime - node.remainingTimeEstimation) / graph.bestPossibleTime
+        if (progress.isInfinite()) {
+            // Sometimes happens when departure and destination have some overlapping points.
+            // Would cause infinite loops if we process normally.
+            return
+        }
         if (progress >= thresholdDistance * nSamplesReached) {
             val block = node.infraExplorer.getCurrentBlock()
             val geo = makePathProps(graph.blockInfra, graph.rawInfra, block).getGeo().points[0]


### PR DESCRIPTION
See comment for explanation. It triggered with the fuzzer, but I don't think it could have happened in real life conditions.

What made it annoying is that it's an infinite loop that isn't caught by the usual timeout, it would just lock a thread forever. 