### PR TITLE
front: improves common conf selectors management

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
+++ b/front/src/applications/operationalStudies/hooks/useLazyLoadTrains.ts
@@ -1,10 +1,7 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 import { useEffect, useState, type Dispatch, type SetStateAction, useMemo } from 'react';
 
-import { useSelector } from 'react-redux';
-
 import { osrdEditoastApi, type SimulationSummaryResult } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import type {
   TrainId,
@@ -24,6 +21,7 @@ const BATCH_SIZE = 10;
 
 type UseLazyLoadTrainsProps = {
   infraId?: number;
+  electricalProfileSetId?: number;
   trainIdsToFetch?: TrainId[];
   trainSchedules?: TrainScheduleResultWithTrainId[];
   setTrainIdsToFetch?: Dispatch<SetStateAction<TrainId[] | undefined>>;
@@ -39,13 +37,11 @@ type UseLazyLoadTrainsProps = {
  */
 const useLazyLoadTrains = ({
   infraId,
+  electricalProfileSetId,
   trainIdsToFetch,
   trainSchedules,
   setTrainIdsToProject,
 }: UseLazyLoadTrainsProps) => {
-  const { getElectricalProfileSetId } = useOsrdConfSelectors();
-  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
-
   const [trainScheduleSummariesById, setTrainScheduleSummariesById] = useState<
     Map<TrainId, TrainScheduleWithDetails>
   >(new Map());

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -9,8 +9,8 @@ import {
   type ScenarioResponse,
   type SimulationSummaryResult,
 } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains';
+import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type {
   TimetableItemId,
   TrainId,
@@ -30,8 +30,7 @@ import usePathProjection from './usePathProjection';
 import formatTrainScheduleSummaries from '../helpers/formatTrainScheduleSummaries';
 
 const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
-  const { getElectricalProfileSetId } = useOsrdConfSelectors();
-  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
+  const electricalProfileSetId = useSelector(getOperationalStudiesElectricalProfileSetId);
   const trainIdUsedForProjection = useSelector(getTrainIdUsedForProjection);
 
   const [trainSchedules, setTrainSchedules] = useState<TrainScheduleResultWithTrainId[]>();
@@ -57,6 +56,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
   const { trainScheduleSummariesById, setTrainScheduleSummariesById, allTrainsLoaded } =
     useLazyLoadTrains({
       infraId: scenario.infra_id,
+      electricalProfileSetId,
       trainIdsToFetch,
       trainSchedules,
       setTrainIdsToProject,

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -1,8 +1,9 @@
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
+import { useInfraID } from 'common/osrdContext';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
+import { getOperationalStudiesElectricalProfileSetId } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TrainScheduleId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { formatTrainScheduleIdToEditoastTrainId } from 'utils/trainId';
@@ -14,8 +15,7 @@ import type { SimulationResultsData } from '../types';
  */
 const useSimulationResults = (): SimulationResultsData => {
   const infraId = useInfraID();
-  const { getElectricalProfileSetId } = useOsrdConfSelectors();
-  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
+  const electricalProfileSetId = useSelector(getOperationalStudiesElectricalProfileSetId);
   const selectedTrainId = useSelector(getSelectedTrainId);
 
   // TODO Paced train : Adapt this to handle paced trains in issue https://github.com/OpenRailAssociation/osrd/issues/10615

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import useStdcmForm from 'applications/stdcm/hooks/useStdcmForm';
 import { extractMarkersInfo } from 'applications/stdcm/utils';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
 import {
   resetMargins,
@@ -20,6 +19,9 @@ import {
   getStdcmDestination,
   getStdcmOrigin,
   getStdcmPathSteps,
+  getStdcmProjectID,
+  getStdcmScenarioID,
+  getStdcmStudyID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
@@ -74,13 +76,12 @@ const StdcmConfig = ({
   const { infra } = useInfraStatus();
   const dispatch = useAppDispatch();
 
-  const { getProjectID, getScenarioID, getStudyID } = useOsrdConfSelectors();
   const origin = useSelector(getStdcmOrigin);
   const pathSteps = useSelector(getStdcmPathSteps);
   const destination = useSelector(getStdcmDestination);
-  const projectID = useSelector(getProjectID);
-  const studyID = useSelector(getStudyID);
-  const scenarioID = useSelector(getScenarioID);
+  const projectID = useSelector(getStdcmProjectID);
+  const studyID = useSelector(getStdcmStudyID);
+  const scenarioID = useSelector(getStdcmScenarioID);
 
   const [showMessage, setShowMessage] = useState(false);
 

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
@@ -4,8 +4,8 @@ import { DatePicker, Select, TimePicker, TolerancePicker } from '@osrd-project/u
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { updateStdcmPathStep } from 'reducers/osrdconf/stdcmConf';
+import { getSearchDatetimeWindow } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { formatDateString } from 'utils/date';
@@ -24,7 +24,6 @@ const StdcmOpSchedule = ({ disabled, pathStep, opId, isOrigin = false }: StdcmOp
   const { t } = useTranslation('stdcm');
   const dispatch = useAppDispatch();
 
-  const { getSearchDatetimeWindow } = useOsrdConfSelectors();
   const searchDatetimeWindow = useSelector(getSearchDatetimeWindow);
 
   const { arrivalTimeHours, arrivalTimeMinutes } = useMemo(() => {
@@ -49,13 +48,10 @@ const StdcmOpSchedule = ({ disabled, pathStep, opId, isOrigin = false }: StdcmOp
   );
 
   const selectableSlot = useMemo(
-    () =>
-      searchDatetimeWindow
-        ? {
-            start: searchDatetimeWindow.begin,
-            end: searchDatetimeWindow.end,
-          }
-        : undefined,
+    () => ({
+      start: searchDatetimeWindow.begin,
+      end: searchDatetimeWindow.end,
+    }),
     [searchDatetimeWindow]
   );
 
@@ -63,8 +59,8 @@ const StdcmOpSchedule = ({ disabled, pathStep, opId, isOrigin = false }: StdcmOp
     () => ({
       invalidInput: t('form.datePickerErrors.invalidInput'),
       invalidDate: t('form.datePickerErrors.invalidDate', {
-        startDate: formatDateString(searchDatetimeWindow?.begin),
-        endDate: formatDateString(searchDatetimeWindow?.end),
+        startDate: formatDateString(searchDatetimeWindow.begin),
+        endDate: formatDateString(searchDatetimeWindow.end),
       }),
     }),
     [t, searchDatetimeWindow]
@@ -134,7 +130,7 @@ const StdcmOpSchedule = ({ disabled, pathStep, opId, isOrigin = false }: StdcmOp
             minutes={arrivalTimeMinutes}
             onTimeChange={({ hours, minutes }) => {
               onArrivalChange({
-                date: pathStep.arrival || searchDatetimeWindow!.begin,
+                date: pathStep.arrival || searchDatetimeWindow.begin,
                 hours,
                 minutes,
               });

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmDebugResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmDebugResults.tsx
@@ -7,13 +7,13 @@ import useProjectedTrainsForStdcm from 'applications/stdcm/hooks/useProjectedTra
 import type { StdcmSimulationOutputs } from 'applications/stdcm/types';
 import { hasResults } from 'applications/stdcm/utils/simulationOutputUtils';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import ResizableSection from 'common/ResizableSection';
 import i18n from 'i18n';
 import ManchetteWithSpaceTimeChartWrapper, {
   MANCHETTE_WITH_SPACE_TIME_CHART_DEFAULT_HEIGHT,
 } from 'modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart';
 import SpeedSpaceChartContainer from 'modules/simulationResult/components/SpeedSpaceChart/SpeedSpaceChartContainer';
+import { getWorkScheduleGroupId } from 'reducers/osrdconf/stdcmConf/selectors';
 
 const SPEED_SPACE_CHART_HEIGHT = 521.5;
 const HANDLE_TAB_RESIZE_HEIGHT = 20;
@@ -24,7 +24,6 @@ type StdcmDebugResultsProps = {
 };
 
 const StdcmDebugResults = ({ simulationOutputs }: StdcmDebugResultsProps) => {
-  const { getWorkScheduleGroupId } = useOsrdConfSelectors();
   const workScheduleGroupId = useSelector(getWorkScheduleGroupId);
   const successfulSimulation = hasResults(simulationOutputs) ? simulationOutputs : undefined;
 

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -13,10 +13,10 @@ import {
 } from 'applications/stdcm/utils/formatSimulationReportSheet';
 import { hasConflicts, hasResults } from 'applications/stdcm/utils/simulationOutputUtils';
 import DefaultBaseMap from 'common/Map/DefaultBaseMap';
-import { useInfraID } from 'common/osrdContext';
 import {
   getRetainedSimulationIndex,
   getSelectedSimulation,
+  getStdcmInfraID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
@@ -44,7 +44,7 @@ const StcdmResults = ({
   buttonsVisible,
   showStatusBanner,
 }: StcdmResultsProps) => {
-  const infraId = useInfraID()!;
+  const infraId = useSelector(getStdcmInfraID);
 
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -44,7 +44,8 @@ const StcdmResults = ({
   buttonsVisible,
   showStatusBanner,
 }: StcdmResultsProps) => {
-  const infraId = useInfraID();
+  const infraId = useInfraID()!;
+
   const { t } = useTranslation('stdcm', { keyPrefix: 'simulation.results' });
   const deploymentSettings = useDeploymentSettings();
 

--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -10,8 +10,11 @@ import type {
   SearchResultItemTrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
-import { getSearchDatetimeWindow } from 'reducers/osrdconf/stdcmConf/selectors';
+import {
+  getSearchDatetimeWindow,
+  getStdcmInfraID,
+  getStdcmTimetableID,
+} from 'reducers/osrdconf/stdcmConf/selectors';
 import { isArrivalDateInSearchTimeWindow, isEqualDate } from 'utils/date';
 import { Duration } from 'utils/duration';
 
@@ -23,11 +26,9 @@ const useLinkedTrainSearch = () => {
   const [postTrainScheduleSimulationSummary] =
     osrdEditoastApi.endpoints.postTrainScheduleSimulationSummary.useLazyQuery();
 
-  const { getTimetableID } = useOsrdConfSelectors();
-
-  const infraId = useInfraID()!;
-  const timetableId = useSelector(getTimetableID)!;
-  const searchDatetimeWindow = useSelector(getSearchDatetimeWindow)!;
+  const infraId = useSelector(getStdcmInfraID);
+  const timetableId = useSelector(getStdcmTimetableID);
+  const searchDatetimeWindow = useSelector(getSearchDatetimeWindow);
 
   const selectableSlot = useMemo(() => {
     const startDate = new Date(searchDatetimeWindow.begin);

--- a/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
+++ b/front/src/applications/stdcm/hooks/useLinkedTrainSearch.ts
@@ -11,6 +11,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
+import { getSearchDatetimeWindow } from 'reducers/osrdconf/stdcmConf/selectors';
 import { isArrivalDateInSearchTimeWindow, isEqualDate } from 'utils/date';
 import { Duration } from 'utils/duration';
 
@@ -22,17 +23,17 @@ const useLinkedTrainSearch = () => {
   const [postTrainScheduleSimulationSummary] =
     osrdEditoastApi.endpoints.postTrainScheduleSimulationSummary.useLazyQuery();
 
-  const { getTimetableID, getSearchDatetimeWindow } = useOsrdConfSelectors();
+  const { getTimetableID } = useOsrdConfSelectors();
 
-  const infraId = useInfraID();
-  const timetableId = useSelector(getTimetableID);
-  const searchDatetimeWindow = useSelector(getSearchDatetimeWindow);
+  const infraId = useInfraID()!;
+  const timetableId = useSelector(getTimetableID)!;
+  const searchDatetimeWindow = useSelector(getSearchDatetimeWindow)!;
 
   const selectableSlot = useMemo(() => {
-    const startDate = searchDatetimeWindow ? new Date(searchDatetimeWindow.begin) : new Date();
+    const startDate = new Date(searchDatetimeWindow.begin);
     return {
       start: startDate,
-      end: searchDatetimeWindow?.end || startDate,
+      end: searchDatetimeWindow.end,
     };
   }, [searchDatetimeWindow]);
 
@@ -74,7 +75,6 @@ const useLinkedTrainSearch = () => {
 
   const getTrainsSummaries = useCallback(
     async (trainsIds: number[]) => {
-      if (!infraId) return undefined;
       const trainsSummaries = await postTrainScheduleSimulationSummary({
         body: {
           infra_id: infraId,
@@ -98,7 +98,7 @@ const useLinkedTrainSearch = () => {
           query: [
             'and',
             ['search', ['train_name'], trainNameInput],
-            ['=', ['timetable_id'], timetableId!],
+            ['=', ['timetable_id'], timetableId],
           ],
         },
         pageSize: 25,

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -55,19 +55,16 @@ const keepTrainsRunningDuringStdcm = (
 };
 
 const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
-  const infraId = useInfraID();
   const { getTimetableID } = useOsrdConfSelectors();
-  const timetableId = useSelector(getTimetableID);
+  const infraId = useInfraID()!;
+  const timetableId = useSelector(getTimetableID)!;
 
   const [spaceTimeData, setSpaceTimeData] = useState<TrainSpaceTimeData[]>([]);
   const [trainIdsToProject, setTrainIdsToProject] = useState<Set<TrainId>>(new Set());
 
-  const { data: timetable } = osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery(
-    { timetableId: timetableId! },
-    {
-      skip: !timetableId,
-    }
-  );
+  const { data: timetable } = osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery({
+    timetableId,
+  });
 
   const trainIds = useMemo(() => timetable?.map((t) => t.id) || [], [timetable]);
 
@@ -132,7 +129,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
     setSpaceTimeData(newSpaceTimeData);
   }, [projectedTrainsById]);
 
-  if (!infraId || !stdcmResponse) return null;
+  if (!stdcmResponse) return null;
 
   return {
     spaceTimeData,

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -6,9 +6,13 @@ import useLazyLoadTrains from 'applications/operationalStudies/hooks/useLazyLoad
 import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import type { StdcmSuccessResponse } from 'applications/stdcm/types';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
 import useLazyProjectTrains from 'modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains';
 import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
+import {
+  getStdcmElectricalProfileSetId,
+  getStdcmInfraID,
+  getStdcmTimetableID,
+} from 'reducers/osrdconf/stdcmConf/selectors';
 import type { TrainId, TrainScheduleResultWithTrainId } from 'reducers/osrdconf/types';
 import { Duration, addDurationToDate } from 'utils/duration';
 import { formatEditoastTrainIdToTrainScheduleId } from 'utils/trainId';
@@ -55,9 +59,9 @@ const keepTrainsRunningDuringStdcm = (
 };
 
 const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
-  const { getTimetableID } = useOsrdConfSelectors();
-  const infraId = useInfraID()!;
-  const timetableId = useSelector(getTimetableID)!;
+  const infraId = useSelector(getStdcmInfraID);
+  const timetableId = useSelector(getStdcmTimetableID);
+  const electricalProfileSetId = useSelector(getStdcmElectricalProfileSetId);
 
   const [spaceTimeData, setSpaceTimeData] = useState<TrainSpaceTimeData[]>([]);
   const [trainIdsToProject, setTrainIdsToProject] = useState<Set<TrainId>>(new Set());
@@ -85,6 +89,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
   // Progressive loading of the trains
   const { trainScheduleSummariesById } = useLazyLoadTrains({
     infraId,
+    electricalProfileSetId,
     trainIdsToFetch: formattedTrainIds,
     trainSchedules: formattedTrainSchedules,
   });

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -21,10 +21,9 @@ import {
   type Conflict,
   type TrainScheduleResult,
 } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector';
 import { setFailure } from 'reducers/main';
-import { getStdcmConf } from 'reducers/osrdconf/stdcmConf/selectors';
+import { getStdcmConf, getStdcmTimetableID } from 'reducers/osrdconf/stdcmConf/selectors';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
@@ -53,9 +52,8 @@ const useStdcm = ({
 
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['translation', 'stdcm']);
-  const { getTimetableID } = useOsrdConfSelectors();
   const osrdconf = useSelector(getStdcmConf);
-  const timetableId = useSelector(getTimetableID)!;
+  const timetableId = useSelector(getStdcmTimetableID);
   const requestPromise = useRef<ReturnType<typeof postTimetableByIdStdcm>>();
 
   const stdcmResults = useStdcmResults(stdcmResponse, stdcmTrainResult, setPathProperties);

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -55,7 +55,7 @@ const useStdcm = ({
   const { t } = useTranslation(['translation', 'stdcm']);
   const { getTimetableID } = useOsrdConfSelectors();
   const osrdconf = useSelector(getStdcmConf);
-  const timetableId = useSelector(getTimetableID);
+  const timetableId = useSelector(getTimetableID)!;
   const requestPromise = useRef<ReturnType<typeof postTimetableByIdStdcm>>();
 
   const stdcmResults = useStdcmResults(stdcmResponse, stdcmTrainResult, setPathProperties);
@@ -116,7 +116,7 @@ const useStdcm = ({
 
           const stdcmTrain: TrainScheduleResult = {
             id: STDCM_TRAIN_ID,
-            timetable_id: timetableId!,
+            timetable_id: timetableId,
             comfort: payload.body.comfort,
             constraint_distribution: 'MARECO',
             path: payload.body.steps.map((step) => ({ ...step.location, id: nextId() })),

--- a/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
+++ b/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
@@ -12,7 +12,7 @@ export default function useStdcmEnvironment() {
   const [getStdcmSearchEnvironment] =
     osrdEditoastApi.endpoints.getStdcmSearchEnvironment.useLazyQuery();
 
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<null | Error>(null);
 
   const loadStdcmEnvironment = useCallback(async () => {

--- a/front/src/applications/stdcm/hooks/useStdcmForm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmForm.ts
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import useStdcmTowedRollingStock from 'applications/stdcm/hooks/useStdcmTowedRollingStock';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
 import {
   getLinkedTrains,
   getMaxSpeed,
   getStdcmOrigin,
   getStdcmPathSteps,
+  getStdcmSpeedLimitByTag,
   getTotalLength,
   getTotalMass,
 } from 'reducers/osrdconf/stdcmConf/selectors';
@@ -18,10 +18,8 @@ import type { StdcmSimulationInputs } from '../types';
 import { getTimesInfoFromDate } from '../utils';
 
 const useStdcmForm = (): StdcmSimulationInputs => {
-  const { getSpeedLimitByTag } = useOsrdConfSelectors();
-
   const pathSteps = useSelector(getStdcmPathSteps);
-  const speedLimitByTag = useSelector(getSpeedLimitByTag);
+  const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
   const totalMass = useSelector(getTotalMass);
   const totalLength = useSelector(getTotalLength);
   const maxSpeed = useSelector(getMaxSpeed);

--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -11,10 +11,10 @@ import {
   type PostInfraByInfraIdPathPropertiesApiArg,
   type TrainScheduleResult,
 } from 'common/api/osrdEditoastApi';
-import { useInfraID } from 'common/osrdContext';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
 import useSpeedSpaceChart from 'modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
+import { getStdcmInfraID } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { TrainScheduleId } from 'reducers/osrdconf/types';
 import { getSelectedTrainId } from 'reducers/simulationResults/selectors';
 import { useAppDispatch } from 'store';
@@ -27,7 +27,7 @@ const useStdcmResults = (
   stdcmTrainResult: TrainScheduleResult | undefined,
   setPathProperties: (pathProperties?: StdcmPathProperties) => void
 ) => {
-  const infraId = useInfraID()!;
+  const infraId = useSelector(getStdcmInfraID);
   const selectedTrainId = useSelector(getSelectedTrainId);
   const editoastSelectedTrainId = selectedTrainId
     ? formatTrainScheduleIdToEditoastTrainId(selectedTrainId as TrainScheduleId)

--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -27,7 +27,7 @@ const useStdcmResults = (
   stdcmTrainResult: TrainScheduleResult | undefined,
   setPathProperties: (pathProperties?: StdcmPathProperties) => void
 ) => {
-  const infraId = useInfraID();
+  const infraId = useInfraID()!;
   const selectedTrainId = useSelector(getSelectedTrainId);
   const editoastSelectedTrainId = selectedTrainId
     ? formatTrainScheduleIdToEditoastTrainId(selectedTrainId as TrainScheduleId)
@@ -64,9 +64,9 @@ const useStdcmResults = (
   );
 
   useEffect(() => {
-    const getPathProperties = async (_infraId: number, path: PathfindingResultSuccess) => {
+    const getPathProperties = async (path: PathfindingResultSuccess) => {
       const pathPropertiesParams: PostInfraByInfraIdPathPropertiesApiArg = {
-        infraId: _infraId,
+        infraId,
         props: ['geometry', 'operational_points', 'zones'],
         pathPropertiesInput: {
           track_section_ranges: path.track_section_ranges,
@@ -122,8 +122,8 @@ const useStdcmResults = (
       });
     };
 
-    if (infraId && stdcmResponse && stdcmResponse?.path) {
-      getPathProperties(infraId, stdcmResponse.path);
+    if (stdcmResponse?.path) {
+      getPathProperties(stdcmResponse.path);
     }
   }, [stdcmResponse]);
 

--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  useLayoutEffect,
+  type Dispatch,
+  type SetStateAction,
+  useMemo,
+} from 'react';
 
 import { isEqual, isNil } from 'lodash';
 import { useSelector } from 'react-redux';
@@ -13,6 +21,7 @@ import {
   getStdcmConf,
   getStdcmSimulations,
 } from 'reducers/osrdconf/stdcmConf/selectors';
+import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 
 import StdcmEmptyConfigError from '../components/StdcmEmptyConfigError';
@@ -25,10 +34,21 @@ import useStdcmEnvironment, { NO_CONFIG_FOUND_MSG } from '../hooks/useStdcmEnv';
 import useStdcmForm from '../hooks/useStdcmForm';
 import type { StdcmSimulation } from '../types';
 
-const StdcmView = () => {
+const StdcmViewContent = ({
+  loading,
+  error,
+  isDebugMode,
+  onIsDebugModeToggle,
+  stdcmConf,
+}: {
+  stdcmConf: OsrdStdcmConfState;
+  loading?: boolean;
+  error?: Error | null;
+  isDebugMode: boolean;
+  onIsDebugModeToggle: Dispatch<SetStateAction<boolean>>;
+}) => {
   // TODO : refacto. state useStdcm. Maybe we can merge some state together in order to reduce the number of refresh
   const currentSimulationInputs = useStdcmForm();
-  const stdcmConf = useSelector(getStdcmConf);
   const simulationsList = useSelector(getStdcmSimulations);
   const completedSimulations = useSelector(getStdcmCompletedSimulations);
   const selectedSimulationIndex = useSelector(getSelectedSimulationIndex);
@@ -36,7 +56,6 @@ const StdcmView = () => {
 
   const [showStatusBanner, setShowStatusBanner] = useState(false);
   const [showBtnToLaunchSimulation, setShowBtnToLaunchSimulation] = useState(false);
-  const [isDebugMode, setIsDebugMode] = useState(false);
   const [showHelpModule, setShowHelpModule] = useState(false);
   const [buttonsVisible, setButtonsVisible] = useState(true);
   const [skipPathfindingStatusMessage, setSkipPathfindingStatusMessage] = useState(false);
@@ -57,8 +76,6 @@ const StdcmView = () => {
     hasConflicts,
     isCalculationFailed,
   } = useStdcm({ showFailureNotification: false });
-
-  const { loading, error, loadStdcmEnvironment } = useStdcmEnvironment();
 
   const dispatch = useAppDispatch();
 
@@ -124,12 +141,6 @@ const StdcmView = () => {
   }, [isCanceled]);
 
   useEffect(() => {
-    if (!isDebugMode) {
-      loadStdcmEnvironment();
-    }
-  }, [isDebugMode]);
-
-  useEffect(() => {
     /*
      * Due to frequent re-renders and the fact that "speedSpaceChartData" is initially null before
      * "formattedPathProperties" is computed, we need to check if the current simulation is already
@@ -186,15 +197,11 @@ const StdcmView = () => {
     }
   }, [selectedSimulationIndex]);
 
-  // If we've got an error during the loading of the stdcm env which is not the "no config error" message,
-  // we let the error boundary manage it
-  if (error && error.message !== NO_CONFIG_FOUND_MSG) throw error;
-
   return (
     <div role="button" tabIndex={0} className="stdcm" onClick={() => setShowStatusBanner(false)}>
       <StdcmHeader
         isDebugMode={isDebugMode}
-        onDebugModeToggle={setIsDebugMode}
+        onDebugModeToggle={onIsDebugModeToggle}
         toggleHelpModule={toggleHelpModule}
         showHelpModule={showHelpModule}
       />
@@ -234,6 +241,45 @@ const StdcmView = () => {
       )}
       {loading && <LoaderFill />}
     </div>
+  );
+};
+
+const StdcmView = () => {
+  const [isDebugMode, setIsDebugMode] = useState(false);
+  const { loading, error, loadStdcmEnvironment } = useStdcmEnvironment();
+  const stdcmConf = useSelector(getStdcmConf);
+
+  const isStdcmConfValid = useMemo(
+    () => !!stdcmConf.searchDatetimeWindow && !!stdcmConf.timetableID && !!stdcmConf.infraID,
+    [stdcmConf]
+  );
+
+  useEffect(() => {
+    if (!isDebugMode) {
+      loadStdcmEnvironment();
+    }
+  }, [isDebugMode]);
+
+  // If we've got an error during the loading of the stdcm env which is not the "no config error" message,
+  // we let the error boundary manage it
+  if (error && error.message !== NO_CONFIG_FOUND_MSG) throw error;
+
+  // When the STDCM environment is being loaded and the conf is not valid, we do not mount the actual STDCM
+  // view content yet:
+  if (loading && !isStdcmConfValid) return null;
+
+  if (!isStdcmConfValid) {
+    throw new Error('STDCM conf is not valid.');
+  }
+
+  return (
+    <StdcmViewContent
+      loading={loading}
+      error={error}
+      isDebugMode={isDebugMode}
+      onIsDebugModeToggle={setIsDebugMode}
+      stdcmConf={stdcmConf}
+    />
   );
 };
 

--- a/front/src/reducers/infra/selectors.ts
+++ b/front/src/reducers/infra/selectors.ts
@@ -1,7 +1,29 @@
 import type { RootState, OsrdSlice } from 'reducers';
 
-const buildInfraStateSelectors = (slice: OsrdSlice) => ({
-  getInfraID: (state: RootState) => state[slice.name].infraID,
-});
+export type InfraStateSelectors<Name extends string> = {
+  [P in `get${Name}InfraID`]: (state: RootState) => number | undefined;
+};
+
+/**
+ * This function builds a predefined collection of selectors on a given slice. It is possible to add
+ * a name so that the selectors have custom names, to clarify how to use them later.
+ *
+ * For instance, you can use it as:
+ * - `buildInfraStateSelectors(someSlice).getStdcmID`
+ * - `buildInfraStateSelectors(someSlice, 'Stdcm').getStdcmStdcmID`
+ */
+function buildInfraStateSelectors(slice: OsrdSlice): InfraStateSelectors<''>;
+function buildInfraStateSelectors<Name extends string>(
+  slice: OsrdSlice,
+  name: Name
+): InfraStateSelectors<Name>;
+function buildInfraStateSelectors<Name extends string>(
+  slice: OsrdSlice,
+  name?: Name
+): InfraStateSelectors<Name> {
+  return {
+    [`get${name || ''}InfraID`]: (state: RootState) => state[slice.name].infraID,
+  } as InfraStateSelectors<Name>;
+}
 
 export default buildInfraStateSelectors;

--- a/front/src/reducers/osrdconf/operationalStudiesConf/selectors.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/selectors.ts
@@ -10,8 +10,6 @@ import buildCommonConfSelectors from 'reducers/osrdconf/osrdConfCommon/selectors
 import { makeSubSelector } from 'utils/selectors';
 
 const buildOperationalStudiesConfSelectors = () => {
-  const commonConfSelectors = buildCommonConfSelectors(operationalStudiesConfSlice);
-
   const getOperationalStudiesConf = (state: RootState) => state[operationalStudiesConfSlice.name];
   const makeOsrdConfSelector =
     makeSubSelector<OperationalStudiesConfState>(getOperationalStudiesConf);
@@ -27,7 +25,8 @@ const buildOperationalStudiesConfSelectors = () => {
   );
 
   return {
-    ...commonConfSelectors,
+    ...buildCommonConfSelectors(operationalStudiesConfSlice),
+
     getOperationalStudiesConf,
 
     getName: makeOsrdConfSelector('name'),
@@ -62,6 +61,15 @@ const buildOperationalStudiesConfSelectors = () => {
 const selectors = buildOperationalStudiesConfSelectors();
 
 export const {
+  getInfraID: getOperationalStudiesInfraID,
+  getProjectID: getOperationalStudiesProjectID,
+  getStudyID: getOperationalStudiesStudyID,
+  getScenarioID: getOperationalStudiesScenarioID,
+  getTimetableID: getOperationalStudiesTimetableID,
+  getElectricalProfileSetId: getOperationalStudiesElectricalProfileSetId,
+  getRollingStockID: getOperationalStudiesRollingStockID,
+  getSpeedLimitByTag: getOperationalStudiesSpeedLimitByTag,
+
   getOperationalStudiesConf,
   getName,
   getStartTime,

--- a/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
@@ -14,8 +14,6 @@ const buildCommonConfSelectors = (slice: OperationalStudiesConfSlice | StdcmConf
     getScenarioID: makeOsrdConfSelector('scenarioID'),
     getTimetableID: makeOsrdConfSelector('timetableID'),
     getElectricalProfileSetId: makeOsrdConfSelector('electricalProfileSetId'),
-    getWorkScheduleGroupId: makeOsrdConfSelector('workScheduleGroupId'),
-    getSearchDatetimeWindow: makeOsrdConfSelector('searchDatetimeWindow'),
     getRollingStockID: makeOsrdConfSelector('rollingStockID'),
     getSpeedLimitByTag: makeOsrdConfSelector('speedLimitByTag'),
   };

--- a/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
+++ b/front/src/reducers/osrdconf/osrdConfCommon/selectors.ts
@@ -1,22 +1,63 @@
 import type { RootState } from 'reducers';
-import buildInfraStateSelectors from 'reducers/infra/selectors';
+import buildInfraStateSelectors, { type InfraStateSelectors } from 'reducers/infra/selectors';
 import type { OperationalStudiesConfSlice } from 'reducers/osrdconf/operationalStudiesConf';
 import type { StdcmConfSlice } from 'reducers/osrdconf/stdcmConf';
 import { makeSubSelector } from 'utils/selectors';
 
-const buildCommonConfSelectors = (slice: OperationalStudiesConfSlice | StdcmConfSlice) => {
+import type { OsrdConfState } from '../types';
+
+type SelectorResults = {
+  ProjectID: OsrdConfState['projectID'];
+  StudyID: OsrdConfState['studyID'];
+  ScenarioID: OsrdConfState['scenarioID'];
+  TimetableID: OsrdConfState['timetableID'];
+  ElectricalProfileSetId: OsrdConfState['electricalProfileSetId'];
+  RollingStockID: OsrdConfState['rollingStockID'];
+  SpeedLimitByTag: OsrdConfState['speedLimitByTag'];
+};
+
+type Selectors<Name extends string> = {
+  [Result in keyof SelectorResults as `get${Name}${string & Result}`]: (
+    state: RootState
+  ) => SelectorResults[Result];
+};
+
+type CommonSelectors<Name extends string> = Selectors<Name> & InfraStateSelectors<Name>;
+
+/**
+ * This function builds a predefined collection of selectors on a given slice. It is possible to add
+ * a name so that the selectors have custom names, to clarify how to use them later.
+ *
+ * For instance, you can use it as:
+ * - `buildCommonConfSelectors(someSlice).getProjectID`
+ * - `buildCommonConfSelectors(someSlice, 'Stdcm').getStdcmProjectID`
+ */
+function buildCommonConfSelectors(
+  slice: OperationalStudiesConfSlice | StdcmConfSlice
+): CommonSelectors<''>;
+function buildCommonConfSelectors<Name extends string>(
+  slice: OperationalStudiesConfSlice | StdcmConfSlice,
+  name: Name
+): CommonSelectors<Name>;
+function buildCommonConfSelectors<Name extends string>(
+  slice: OperationalStudiesConfSlice | StdcmConfSlice,
+  name?: Name
+): CommonSelectors<Name> {
   const makeOsrdConfSelector = makeSubSelector((state: RootState) => state[slice.name]);
 
-  return {
-    ...buildInfraStateSelectors(slice),
-    getProjectID: makeOsrdConfSelector('projectID'),
-    getStudyID: makeOsrdConfSelector('studyID'),
-    getScenarioID: makeOsrdConfSelector('scenarioID'),
-    getTimetableID: makeOsrdConfSelector('timetableID'),
-    getElectricalProfileSetId: makeOsrdConfSelector('electricalProfileSetId'),
-    getRollingStockID: makeOsrdConfSelector('rollingStockID'),
-    getSpeedLimitByTag: makeOsrdConfSelector('speedLimitByTag'),
-  };
-};
+  const infraSelector = buildInfraStateSelectors(slice, name || '');
+
+  const additionalSelectors = {
+    [`get${name || ''}ProjectID`]: makeOsrdConfSelector('projectID'),
+    [`get${name || ''}StudyID`]: makeOsrdConfSelector('studyID'),
+    [`get${name || ''}ScenarioID`]: makeOsrdConfSelector('scenarioID'),
+    [`get${name || ''}TimetableID`]: makeOsrdConfSelector('timetableID'),
+    [`get${name || ''}ElectricalProfileSetId`]: makeOsrdConfSelector('electricalProfileSetId'),
+    [`get${name || ''}RollingStockID`]: makeOsrdConfSelector('rollingStockID'),
+    [`get${name || ''}SpeedLimitByTag`]: makeOsrdConfSelector('speedLimitByTag'),
+  } as Selectors<Name>;
+
+  return { ...infraSelector, ...additionalSelectors };
+}
 
 export default buildCommonConfSelectors;

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -70,6 +70,13 @@ const buildStdcmConfSelectors = () => {
     getSelectedSimulationIndex,
     getSelectedSimulation,
     getRetainedSimulationIndex: makeOsrdConfSelector('retainedSimulationIndex'),
+    getWorkScheduleGroupId: makeOsrdConfSelector('workScheduleGroupId'),
+
+    // For some selectors, if data were missing, errors would have been thrown earlier, at startup.
+    // The useStdcmEnv hook ensures that.
+    getSearchDatetimeWindow: makeOsrdConfSelector('searchDatetimeWindow', { nonNullable: true }),
+    getTimetableID: makeOsrdConfSelector('timetableID', { nonNullable: true }),
+    getInfraID: makeOsrdConfSelector('infraID', { nonNullable: true }),
   };
 };
 
@@ -92,6 +99,8 @@ export const {
   getSelectedSimulationIndex,
   getSelectedSimulation,
   getRetainedSimulationIndex,
+  getWorkScheduleGroupId,
+  getSearchDatetimeWindow,
 } = selectors;
 
 export type StdcmConfSelectors = typeof selectors;

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -8,8 +8,6 @@ import type { OsrdStdcmConfState } from 'reducers/osrdconf/types';
 import { makeSubSelector } from 'utils/selectors';
 
 const buildStdcmConfSelectors = () => {
-  const commonConfSelectors = buildCommonConfSelectors(stdcmConfSlice);
-
   const getStdcmConf = (state: RootState) => state[stdcmConfSlice.name];
   const makeOsrdConfSelector = makeSubSelector<OsrdStdcmConfState>(getStdcmConf);
 
@@ -37,7 +35,8 @@ const buildStdcmConfSelectors = () => {
   );
 
   return {
-    ...commonConfSelectors,
+    ...buildCommonConfSelectors(stdcmConfSlice),
+
     getStdcmConf,
 
     getMargins: makeOsrdConfSelector('margins'),
@@ -83,9 +82,18 @@ const buildStdcmConfSelectors = () => {
 const selectors = buildStdcmConfSelectors();
 
 export const {
-  getStdcmConf,
-  getMargins,
+  getInfraID: getStdcmInfraID,
+  getProjectID: getStdcmProjectID,
+  getStudyID: getStdcmStudyID,
+  getScenarioID: getStdcmScenarioID,
+  getTimetableID: getStdcmTimetableID,
+  getElectricalProfileSetId: getStdcmElectricalProfileSetId,
+  getRollingStockID: getStdcmRollingStockID,
+  getSpeedLimitByTag: getStdcmSpeedLimitByTag,
 
+  getStdcmConf,
+
+  getMargins,
   getTotalMass,
   getTotalLength,
   getMaxSpeed,

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -23,9 +23,6 @@ export type OsrdConfState = InfraState & {
   scenarioID?: number;
   timetableID?: number;
   electricalProfileSetId?: number;
-  workScheduleGroupId?: number;
-  temporarySpeedLimitGroupId?: number;
-  searchDatetimeWindow?: StdcmSearchDatetimeWindow;
   rollingStockID?: number;
   speedLimitByTag?: string;
 };
@@ -50,6 +47,9 @@ export type OsrdStdcmConfState = OsrdConfState & {
   simulations: StdcmSimulation[];
   selectedSimulationIndex?: number;
   retainedSimulationIndex?: number;
+  workScheduleGroupId?: number;
+  temporarySpeedLimitGroupId?: number;
+  searchDatetimeWindow?: StdcmSearchDatetimeWindow;
 };
 
 export type PathStep = PathItemLocation & {

--- a/front/src/utils/selectors.ts
+++ b/front/src/utils/selectors.ts
@@ -1,8 +1,35 @@
 /* eslint-disable import/prefer-default-export */
+import { isNil } from 'lodash';
+
 import type { RootState } from 'reducers';
 
-export const makeSubSelector =
-  <ReducerState>(rootSelector: (state: RootState) => ReducerState) =>
-  <Key extends keyof ReducerState>(key: Key) =>
-  (state: RootState) =>
-    rootSelector(state)[key];
+type SubSelectorOptions = {
+  nonNullable?: boolean;
+};
+
+export const makeSubSelector = <ReducerState>(rootSelector: (state: RootState) => ReducerState) => {
+  function subSelector<Key extends keyof ReducerState>(
+    key: Key,
+    options: SubSelectorOptions & { nonNullable: true }
+  ): (state: RootState) => NonNullable<ReducerState[Key]>;
+  function subSelector<Key extends keyof ReducerState>(
+    key: Key,
+    options?: SubSelectorOptions & { nonNullable?: false }
+  ): (state: RootState) => ReducerState[Key];
+  function subSelector<Key extends keyof ReducerState>(
+    key: Key,
+    options: SubSelectorOptions = {}
+  ): (state: RootState) => ReducerState[Key] {
+    return (state: RootState) => {
+      const val = rootSelector(state)[key];
+      if (options.nonNullable && isNil(val)) {
+        throw new Error(
+          `Value ${key as string} of RootState is ${val}, while the selector should remain non-nullable.`
+        );
+      }
+      return val;
+    };
+  }
+
+  return subSelector;
+};


### PR DESCRIPTION
Fixes osrd-project/osrd-confidential#882

This commit:
- Moves some properties from `OsrdConfState` to `OsrdStdcmConfState`
- In STDCM, ensures `OsrdStdcmConfState` is valid before mounting the app, and improves typings so that `infraID`, `timetableID` and `searchDatetimeWindow` are never null in the code
- Improves the way we must retrieve the proper conf selectors from the application codebases, and removes all remaining calls to `useOsrdConfSelectors` from the application codebases
- Improves common selectors generation, to make it easier later to completely remove all selectors from the context later