### PR TITLE
scripts: fix sync-openapi.sh

### DIFF
--- a/scripts/sync-openapi.sh
+++ b/scripts/sync-openapi.sh
@@ -8,4 +8,4 @@ echo "Generating editoast's openapi"
 ( cd "${root_path}/editoast" && cargo run openapi > "${root_path}"/editoast/openapi.yaml )
 
 echo "Generating the typescript client"
-npm run --cwd "${root_path}"/front generate-types
+( cd "${root_path}"/front && npm run generate-types )


### PR DESCRIPTION
Running the script from the project root causes npm to look for node_modules in the wrong location. This fixes it (and is more consistent with the above cargo usage)