### PR TITLE
core: prioritize signaling system during pathfinding

### DIFF
--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/MockSigSystemManager.kt
@@ -66,6 +66,10 @@ class MockSigSystemManager(
         return this.sigSystem
     }
 
+    override fun getCost(sigSystem: SignalingSystemId): Double {
+        TODO("Implement this")
+    }
+
     override val drivers: StaticIdxSpace<SignalDriver>
         get() = StaticIdxSpace(1u)
 

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SigSystemManagerImpl.kt
@@ -9,13 +9,17 @@ import fr.sncf.osrd.utils.indexing.StaticPool
 class SigSystemManagerImpl : SigSystemManager {
     private val sigSystemMap = mutableMapOf<String, SignalingSystemId>()
     private val sigSystemPool = StaticPool<SignalingSystem, SignalingSystemDriver>()
+    private val sigSystemCost = mutableMapOf<SignalingSystemId, Double>()
     private val driverMap =
         mutableMapOf<Pair<SignalingSystemId, SignalingSystemId>, SignalDriverId>()
     private val driverPool = StaticPool<SignalDriver, fr.sncf.osrd.signaling.SignalDriver>()
 
-    fun addSignalingSystem(sigSystem: SignalingSystemDriver): SignalingSystemId {
+    // cost must be in [0; 1] (used to choose block when everything else is equal)
+    fun addSignalingSystem(sigSystem: SignalingSystemDriver, cost: Double): SignalingSystemId {
         val res = sigSystemPool.add(sigSystem)
         sigSystemMap[sigSystem.id] = res
+        assert(cost in 0.0..1.0) { "Signaling system costs must be normalized in [0; 1]" }
+        sigSystemCost[res] = cost
         return res
     }
 
@@ -71,6 +75,11 @@ class SigSystemManagerImpl : SigSystemManager {
 
     override fun getName(sigSystem: SignalingSystemId): String {
         return sigSystemPool[sigSystem].id
+    }
+
+    override fun getCost(sigSystem: SignalingSystemId): Double {
+        return sigSystemCost[sigSystem]
+            ?: throw RuntimeException("signaling system does not have an assigned cost")
     }
 
     override val drivers

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -48,6 +48,8 @@ interface InfraSigSystemManager {
 
     fun getName(sigSystem: SignalingSystemId): String
 
+    fun getCost(sigSystem: SignalingSystemId): Double
+
     val drivers: StaticIdxSpace<SignalDriver>
 
     fun findDriver(outputSig: SignalingSystemId, inputSig: SignalingSystemId): SignalDriverId

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBALtoBAL.kt
@@ -7,7 +7,8 @@ import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.decreasing
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -71,7 +72,7 @@ class TestBALtoBAL {
         val signalV = signals["V"]!!
 
         val sigSystemManager = SigSystemManagerImpl()
-        sigSystemManager.addSignalingSystem(BAL)
+        sigSystemManager.addSignalingSystem(BAL, 0.40)
         sigSystemManager.addSignalDriver(BALtoBAL)
         val simulator = SignalingSimulatorImpl(sigSystemManager)
         val loadedSignalInfra = simulator.loadSignals(infra)

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestBAPRtoBAL.kt
@@ -10,7 +10,10 @@ import fr.sncf.osrd.signaling.bapr.BAPRtoBAL
 import fr.sncf.osrd.signaling.bapr.BAPRtoBAPR
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.LogicalSignalId
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.increasing
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -77,8 +80,8 @@ class TestBAPRtoBAL {
         val signalN = signals["N"]!!
 
         val sigSystemManager = SigSystemManagerImpl()
-        sigSystemManager.addSignalingSystem(BAL)
-        sigSystemManager.addSignalingSystem(BAPR)
+        sigSystemManager.addSignalingSystem(BAPR, 0.50)
+        sigSystemManager.addSignalingSystem(BAL, 0.40)
         sigSystemManager.addSignalDriver(BALtoBAL)
         sigSystemManager.addSignalDriver(BAPRtoBAPR)
         sigSystemManager.addSignalDriver(BAPRtoBAL)

--- a/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
+++ b/core/kt-osrd-sncf-signaling/src/test/kotlin/fr/sncf/osrd/signaling/bal/TestTVM300toBAL.kt
@@ -8,7 +8,10 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.signaling.impl.SigSystemManagerImpl
 import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.signaling.tvm300.TVM300
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.LogicalSignalId
+import fr.sncf.osrd.sim_infra.api.SigState
+import fr.sncf.osrd.sim_infra.api.increasing
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,8 +62,8 @@ class TestTVM300toBAL {
         val signalN = signals["N"]!!
 
         val sigSystemManager = SigSystemManagerImpl()
-        sigSystemManager.addSignalingSystem(BAL)
-        sigSystemManager.addSignalingSystem(TVM300)
+        sigSystemManager.addSignalingSystem(BAL, 0.40)
+        sigSystemManager.addSignalingSystem(TVM300, 0.30)
         sigSystemManager.addSignalDriver(BALtoTVM300)
         sigSystemManager.addSignalDriver(BALtoBAL)
         val simulator = SignalingSimulatorImpl(sigSystemManager)

--- a/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSEtcsBrakeParams.java
+++ b/core/osrd-railjson/src/main/java/fr/sncf/osrd/railjson/schema/rollingstock/RJSEtcsBrakeParams.java
@@ -63,6 +63,31 @@ public class RJSEtcsBrakeParams {
     @Json(name = "t_be")
     public double tBe;
 
+    public RJSEtcsBrakeParams(
+            RJSSpeedIntervalValueCurve gammaEmergency,
+            RJSSpeedIntervalValueCurve gammaService,
+            RJSSpeedIntervalValueCurve gammaNormalService,
+            RJSSpeedIntervalValueCurve kDry,
+            RJSSpeedIntervalValueCurve kWet,
+            RJSSpeedIntervalValueCurve kNPos,
+            RJSSpeedIntervalValueCurve kNNeg,
+            double tTractionCutOff,
+            double tBs1,
+            double tBs2,
+            double tBe) {
+        this.gammaEmergency = gammaEmergency;
+        this.gammaService = gammaService;
+        this.gammaNormalService = gammaNormalService;
+        this.kDry = kDry;
+        this.kWet = kWet;
+        this.kNPos = kNPos;
+        this.kNNeg = kNNeg;
+        this.tTractionCutOff = tTractionCutOff;
+        this.tBs1 = tBs1;
+        this.tBs2 = tBs2;
+        this.tBe = tBe;
+    }
+
     /** See Subset §3.13.6.2.1.4. */
     public double getSafeBrakingAcceleration(double speed) {
         var aBrakeEmergency = getEmergencyBrakingDeceleration(speed);
@@ -113,6 +138,11 @@ public class RJSEtcsBrakeParams {
         // Interval values (unit to be made explicit at use)
         // There must be one more value than boundaries
         public double[] values;
+
+        public RJSSpeedIntervalValueCurve(double[] boundaries, double[] values) {
+            this.boundaries = boundaries;
+            this.values = values;
+        }
 
         public double getValue(double speed) {
             assert (boundaries != null);

--- a/core/src/main/java/fr/sncf/osrd/api/SignalingSimulator.kt
+++ b/core/src/main/java/fr/sncf/osrd/api/SignalingSimulator.kt
@@ -1,6 +1,7 @@
 package fr.sncf.osrd.api
 
 import fr.sncf.osrd.signaling.SignalingSimulator
+import fr.sncf.osrd.signaling.SignalingSystemDriver
 import fr.sncf.osrd.signaling.bal.*
 import fr.sncf.osrd.signaling.bapr.*
 import fr.sncf.osrd.signaling.etcs_level2.*
@@ -9,17 +10,27 @@ import fr.sncf.osrd.signaling.impl.SignalingSimulatorImpl
 import fr.sncf.osrd.signaling.tvm300.*
 import fr.sncf.osrd.signaling.tvm430.*
 
+val signalingSystemCost =
+    mapOf(BAPR to 0.50, BAL to 0.40, TVM300 to 0.30, TVM430 to 0.20, ETCS_LEVEL2 to 0.10)
+
+fun addSignalingSystem(sigSystemManager: SigSystemManagerImpl, sigSystem: SignalingSystemDriver) {
+    assert(signalingSystemCost.containsKey(sigSystem)) {
+        "Trying to add a signaling system without cost"
+    }
+    sigSystemManager.addSignalingSystem(sigSystem, signalingSystemCost[sigSystem]!!)
+}
+
 /**
  * Configure the signaling simulator for all the supported signaling systems Mainly useful because
  * we can't do it directly from java due to compiler issues
  */
 fun makeSignalingSimulator(): SignalingSimulator {
     val sigSystemManager = SigSystemManagerImpl()
-    sigSystemManager.addSignalingSystem(BAL)
-    sigSystemManager.addSignalingSystem(BAPR)
-    sigSystemManager.addSignalingSystem(TVM300)
-    sigSystemManager.addSignalingSystem(TVM430)
-    sigSystemManager.addSignalingSystem(ETCS_LEVEL2)
+    addSignalingSystem(sigSystemManager, BAL)
+    addSignalingSystem(sigSystemManager, BAPR)
+    addSignalingSystem(sigSystemManager, TVM300)
+    addSignalingSystem(sigSystemManager, TVM430)
+    addSignalingSystem(sigSystemManager, ETCS_LEVEL2)
 
     sigSystemManager.addSignalDriver(BALtoBAL)
     sigSystemManager.addSignalDriver(BALtoBAPR)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlocksEndpointV2.kt
@@ -165,14 +165,12 @@ private fun computePaths(
             initialRequest.rollingStockLength
         )
     val constraintCombiner = ConstraintCombiner(constraints.toMutableList())
+
     val pathFound =
         Pathfinding(PathfindingGraph())
             .setTimeout(timeout)
-            .setEdgeToLength { edge -> Offset(edge.length.distance) }
-            .setRangeCost { range ->
-                mrspBuilder.getBlockTime(range.edge.block, Offset(range.end.distance)) -
-                    mrspBuilder.getBlockTime(range.edge.block, Offset(range.start.distance))
-            }
+            .setEdgeToLength { Offset(it.length.distance) }
+            .setRangeCost { getRangeCost(it, mrspBuilder, infra) }
             .setRemainingDistanceEstimator(remainingDistanceEstimators)
             .runPathfinding(
                 getStartLocations(
@@ -202,6 +200,24 @@ private fun computePaths(
         initialRequest,
         timeout?.minus(elapsedSeconds)
     )
+}
+
+const val SIGNALING_SYSTEM_COST_WEIGHTING = 1e-2
+
+private fun getRangeCost(
+    range: EdgeRange<PathfindingEdge, Block>,
+    mrspBuilder: CachedBlockMRSPBuilder,
+    infra: FullInfra
+): Double {
+    val edgeDuration =
+        mrspBuilder.getBlockTime(range.edge.block, Offset(range.end.distance)) -
+            mrspBuilder.getBlockTime(range.edge.block, Offset(range.start.distance))
+    val signalingSystemPenaltyFactor =
+        SIGNALING_SYSTEM_COST_WEIGHTING *
+            infra.signalingSimulator.sigModuleManager.getCost(
+                infra.blockInfra.getBlockSignalingSystem(range.edge.block)
+            )
+    return (edgeDuration) * (1 + signalingSystemPenaltyFactor)
 }
 
 private fun getStartLocations(

--- a/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
+++ b/core/src/test/java/fr/sncf/osrd/train/TestTrains.java
@@ -5,6 +5,8 @@ import static fr.sncf.osrd.envelope_sim.SimpleRollingStock.createEffortSpeedCurv
 import com.google.common.collect.Lists;
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock.CurveShape;
 import fr.sncf.osrd.railjson.schema.rollingstock.Comfort;
+import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams;
+import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams.RJSSpeedIntervalValueCurve;
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSLoadingGaugeType;
 import fr.sncf.osrd.utils.Helpers;
 import java.util.*;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestTrains {
     public static final RollingStock REALISTIC_FAST_TRAIN;
+    public static final RollingStock REALISTIC_ETCS_FAST_TRAIN;
     public static final RollingStock REALISTIC_FAST_TRAIN_MAX_DEC_TYPE;
     public static final RollingStock VERY_SHORT_FAST_TRAIN;
     public static final RollingStock VERY_LONG_FAST_TRAIN;
@@ -164,6 +167,45 @@ public class TestTrains {
                 0.,
                 0.,
                 new String[] {"BAL", "BAPR", "TVM300", "TVM430"});
+
+        REALISTIC_ETCS_FAST_TRAIN = new RollingStock(
+                "realistic ETCS fast train",
+                400,
+                trainMass,
+                1.05,
+                (0.65 * trainMass) / 100,
+                ((0.008 * trainMass) / 100) * 3.6,
+                (((0.00012 * trainMass) / 100) * 3.6) * 3.6,
+                MAX_SPEED,
+                30,
+                0.05,
+                0.25,
+                0.5,
+                new RJSEtcsBrakeParams(
+                        new RJSSpeedIntervalValueCurve(
+                                new double[] {8.333333, 16.666667, 55.555556, 61.111111},
+                                new double[] {1.11, 1.25, 1.34, 1.17, 0.94}),
+                        new RJSSpeedIntervalValueCurve(
+                                new double[] {8.333333, 16.666667, 55.555556, 61.111111},
+                                new double[] {0.74, 0.833333, 0.983333, 0.78, 0.626667}),
+                        new RJSSpeedIntervalValueCurve(new double[] {61.111111}, new double[] {0.6, 0.35}),
+                        new RJSSpeedIntervalValueCurve(
+                                new double[] {8.333333, 61.111111}, new double[] {0.72, 0.69, 0.7}),
+                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {0.89}),
+                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {6.74e-3}),
+                        new RJSSpeedIntervalValueCurve(new double[] {}, new double[] {1.74e-3}),
+                        1,
+                        2,
+                        2,
+                        2.5),
+                RJSLoadingGaugeType.G1,
+                complexModeEffortCurves,
+                "thermal",
+                "5",
+                Map.of("Restrict1", "4", "Restrict2", "3"),
+                0.,
+                0.,
+                new String[] {"BAL", "BAPR", "TVM300", "TVM430", "ETCS_LEVEL2"});
 
         REALISTIC_FAST_TRAIN_MAX_DEC_TYPE = new RollingStock(
                 "fast train",

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.api.api_v2.pathfinding.NoPathFoundException
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockRequest
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockSuccess
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection.START_TO_STOP
+import fr.sncf.osrd.signaling.bapr.BAPR
 import fr.sncf.osrd.signaling.tvm300.TVM300
 import fr.sncf.osrd.signaling.tvm430.TVM430
 import fr.sncf.osrd.train.RollingStock
@@ -143,6 +144,35 @@ class PathfindingSignalingTest {
                     DirectionalTrackRange("a->b", Offset.zero(), Offset(100.meters), START_TO_STOP),
                     DirectionalTrackRange("b->S", Offset.zero(), Offset(100.meters), START_TO_STOP),
                     DirectionalTrackRange("S->d", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("d->e", Offset.zero(), Offset(100.meters), START_TO_STOP)
+                )
+            )
+    }
+
+    @Test
+    fun shouldPriorUseBalPathForBaprBalTrain() {
+        setSigSystemIds(listOf("b->N", "N->d"), BAPR.id) // Other blocks are BAL
+        val waypointsStart = listOf(TrackLocation("a->b", Offset.zero()))
+        val waypointsInter =
+            listOf(TrackLocation("S->d", Offset.zero()), TrackLocation("N->d", Offset.zero()))
+        val waypointsEnd = listOf(TrackLocation("d->e", Offset(100.meters)))
+
+        val pathfindingResp =
+            fr.sncf.osrd.api.api_v2.pathfinding.runPathfinding(
+                infra.fullInfra(),
+                getPathfindingBlockRequest(
+                    TestTrains.REALISTIC_FAST_TRAIN,
+                    listOf(waypointsStart, waypointsInter, waypointsEnd)
+                )
+            )
+        assertThat(pathfindingResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
+        assertThat((pathfindingResp as PathfindingBlockSuccess).trackSectionRanges)
+            .isEqualTo(
+                arrayListOf(
+                    DirectionalTrackRange("a->b", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    // xfail: Should go South here to prioritize BAL over BAPR
+                    DirectionalTrackRange("b->N", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("N->d", Offset.zero(), Offset(100.meters), START_TO_STOP),
                     DirectionalTrackRange("d->e", Offset.zero(), Offset(100.meters), START_TO_STOP)
                 )
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
@@ -1,20 +1,21 @@
 package fr.sncf.osrd.pathfinding
 
-import fr.sncf.osrd.api.pathfinding.request.PathfindingWaypoint
-import fr.sncf.osrd.api.pathfinding.runPathfinding
-import fr.sncf.osrd.graph.Pathfinding
-import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.sim_infra.api.findSignalingSystemOrThrow
+import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
+import fr.sncf.osrd.api.api_v2.TrackLocation
+import fr.sncf.osrd.api.api_v2.pathfinding.IncompatibleConstraintsPathResponse
+import fr.sncf.osrd.api.api_v2.pathfinding.NoPathFoundException
+import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockRequest
+import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockSuccess
+import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection.START_TO_STOP
+import fr.sncf.osrd.signaling.tvm300.TVM300
+import fr.sncf.osrd.signaling.tvm430.TVM430
+import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TestTrains
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
-import org.assertj.core.api.Assertions as assertjAssertions
-import org.assertj.core.api.AssertionsForClassTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,100 +24,126 @@ import org.junit.jupiter.api.TestInstance
 class PathfindingSignalingTest {
     private var infra: DummyInfra = DummyInfra()
 
-    private fun setSigSystemIds(list: List<BlockId>, signalingSystemName: String) {
+    private fun setSigSystemIds(blocks: List<String>, signaling: String) {
         val id =
-            infra
-                .fullInfra()
-                .signalingSimulator
-                .sigModuleManager
-                .findSignalingSystemOrThrow(signalingSystemName)
-        list.forEach { infra.blockPool[it.index.toInt()].signalingSystemId = id }
+            infra.fullInfra().signalingSimulator.sigModuleManager.findSignalingSystem(signaling)
+        infra.blockPool.forEach { if (blocks.contains(it.name)) it.signalingSystemId = id!! }
+    }
+
+    private fun getPathfindingBlockRequest(
+        rs: RollingStock,
+        pathItems: List<Collection<TrackLocation>>
+    ): PathfindingBlockRequest {
+        return PathfindingBlockRequest(
+            rs.loadingGaugeType,
+            rs.isThermal,
+            rs.modeNames.filterNot { it == "thermal" }.toList(),
+            rs.supportedSignalingSystems.toList(),
+            rs.maxSpeed,
+            rs.length,
+            null,
+            "unused_name",
+            "unused_version",
+            pathItems
+        )
     }
 
     @BeforeEach
     fun setUp() {
-        /*       c1
+        /*        N
                 ^  \
                /    v
         a --> b     d --> e
                \    ^
                 v  /
-                 c2
+                 S
          */
         infra = DummyInfra()
         infra.addBlock("a", "b")
-        infra.addBlock("b", "c1")
-        infra.addBlock("b", "c2")
-        infra.addBlock("c1", "d")
-        infra.addBlock("c2", "d")
+        infra.addBlock("b", "N")
+        infra.addBlock("b", "S")
+        infra.addBlock("N", "d")
+        infra.addBlock("S", "d")
         infra.addBlock("d", "e")
     }
 
     @Test
     fun balTrainOnTVMBlockShouldThrow() {
-        setSigSystemIds(listOf(1U, 2U, 3U, 4U).map { BlockId(it) }, "TVM300")
-        val waypointStart = PathfindingWaypoint("a->b", 0.0, EdgeDirection.START_TO_STOP)
-        val waypointEnd = PathfindingWaypoint("d->e", 100.0, EdgeDirection.START_TO_STOP)
-        val waypoints = Array(2) { Array(1) { waypointStart } }
-        waypoints[1][0] = waypointEnd
+        setSigSystemIds(listOf("b->N", "b->S", "N->d", "S->d"), TVM300.id)
+        val waypointsStart = listOf(TrackLocation("a->b", Offset.zero()))
+        val waypointsEnd = listOf(TrackLocation("d->e", Offset(100.meters)))
 
         // Run a pathfinding with a non TVM train, expecting not to find any path
-        AssertionsForClassTypes.assertThatThrownBy {
-                runPathfinding(
+        assertThatThrownBy {
+                fr.sncf.osrd.api.api_v2.pathfinding.runPathfinding(
                     infra.fullInfra(),
-                    waypoints,
-                    listOf(TestTrains.TRAIN_WITHOUT_TVM),
-                    null
+                    getPathfindingBlockRequest(
+                        TestTrains.TRAIN_WITHOUT_TVM,
+                        listOf(waypointsStart, waypointsEnd)
+                    )
                 )
             }
-            .isExactlyInstanceOf(OSRDError::class.java)
-            .satisfies({ exception: Throwable? ->
-                assertjAssertions
-                    .assertThat((exception as OSRDError?)!!.osrdErrorType)
-                    .isEqualTo(ErrorType.PathfindingSignalisationSystemError)
+            .isExactlyInstanceOf(NoPathFoundException::class.java)
+            .satisfies({ exception: Throwable ->
+                val resp =
+                    (exception as NoPathFoundException).response
+                        as IncompatibleConstraintsPathResponse
+                assert(resp.relaxedConstraintsPath.length.distance == 400.meters)
+                assert(
+                    resp.incompatibleConstraints.incompatibleSignalingSystemRanges.first().value ==
+                        TVM300.id
+                )
             })
     }
 
     @Test
-    fun shouldFindTopPathOnBalBlocksForBalTrain() {
-        setSigSystemIds(listOf(2U, 4U).map { BlockId(it) }, "TVM300")
-        val waypointStart = PathfindingWaypoint("a->b", 0.0, EdgeDirection.START_TO_STOP)
-        val waypointEnd = PathfindingWaypoint("d->e", 100.0, EdgeDirection.START_TO_STOP)
-        val waypoints = Array(2) { Array(1) { waypointStart } }
-        waypoints[1][0] = waypointEnd
+    fun shouldFindNorthPathOnBalBlocksForBalTrain() {
+        setSigSystemIds(listOf("b->S", "S->d"), TVM300.id)
+        val waypointsStart = listOf(TrackLocation("a->b", Offset(0.meters)))
+        val waypointsEnd = listOf(TrackLocation("d->e", Offset(100.meters)))
 
-        val pathfindingResult =
-            runPathfinding(infra.fullInfra(), waypoints, listOf(TestTrains.TRAIN_WITHOUT_TVM), null)
-
-        AssertionsForClassTypes.assertThat(pathfindingResult.ranges)
+        val pathfindingResp =
+            fr.sncf.osrd.api.api_v2.pathfinding.runPathfinding(
+                infra.fullInfra(),
+                getPathfindingBlockRequest(
+                    TestTrains.TRAIN_WITHOUT_TVM,
+                    listOf(waypointsStart, waypointsEnd)
+                )
+            )
+        assertThat(pathfindingResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
+        assertThat((pathfindingResp as PathfindingBlockSuccess).trackSectionRanges)
             .isEqualTo(
                 arrayListOf(
-                    Pathfinding.EdgeRange(BlockId(0U), Offset<Block>(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(1U), Offset(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(3U), Offset(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(5U), Offset(0.meters), Offset(100.meters))
+                    DirectionalTrackRange("a->b", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("b->N", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("N->d", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("d->e", Offset.zero(), Offset(100.meters), START_TO_STOP)
                 )
             )
     }
 
     @Test
-    fun shouldFindBottomPathOnBalBlocksForBalTrain() {
-        setSigSystemIds(listOf(1U, 3U).map { BlockId(it) }, "TVM430")
-        val waypointStart = PathfindingWaypoint("a->b", 0.0, EdgeDirection.START_TO_STOP)
-        val waypointEnd = PathfindingWaypoint("d->e", 100.0, EdgeDirection.START_TO_STOP)
-        val waypoints = Array(2) { Array(1) { waypointStart } }
-        waypoints[1][0] = waypointEnd
+    fun shouldFindSouthPathOnBalBlocksForBalTrain() {
+        setSigSystemIds(listOf("b->N", "N->d"), TVM430.id)
+        val waypointsStart = listOf(TrackLocation("a->b", Offset.zero()))
+        val waypointsEnd = listOf(TrackLocation("d->e", Offset(100.meters)))
 
-        val pathfindingResult =
-            runPathfinding(infra.fullInfra(), waypoints, listOf(TestTrains.TRAIN_WITHOUT_TVM), null)
-
-        AssertionsForClassTypes.assertThat(pathfindingResult.ranges)
+        val pathfindingResp =
+            fr.sncf.osrd.api.api_v2.pathfinding.runPathfinding(
+                infra.fullInfra(),
+                getPathfindingBlockRequest(
+                    TestTrains.TRAIN_WITHOUT_TVM,
+                    listOf(waypointsStart, waypointsEnd)
+                )
+            )
+        assertThat(pathfindingResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
+        assertThat((pathfindingResp as PathfindingBlockSuccess).trackSectionRanges)
             .isEqualTo(
                 arrayListOf(
-                    Pathfinding.EdgeRange(BlockId(0U), Offset<Block>(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(2U), Offset(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(4U), Offset(0.meters), Offset(100.meters)),
-                    Pathfinding.EdgeRange(BlockId(5U), Offset(0.meters), Offset(100.meters))
+                    DirectionalTrackRange("a->b", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("b->S", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("S->d", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange("d->e", Offset.zero(), Offset(100.meters), START_TO_STOP)
                 )
             )
     }

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingSignalingTest.kt
@@ -7,7 +7,6 @@ import fr.sncf.osrd.api.api_v2.pathfinding.NoPathFoundException
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockRequest
 import fr.sncf.osrd.api.api_v2.pathfinding.PathfindingBlockSuccess
 import fr.sncf.osrd.railjson.schema.common.graph.EdgeDirection.START_TO_STOP
-import fr.sncf.osrd.signaling.bapr.BAPR
 import fr.sncf.osrd.signaling.tvm300.TVM300
 import fr.sncf.osrd.signaling.tvm430.TVM430
 import fr.sncf.osrd.train.RollingStock
@@ -20,6 +19,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PathfindingSignalingTest {
@@ -149,30 +150,56 @@ class PathfindingSignalingTest {
             )
     }
 
-    @Test
-    fun shouldPriorUseBalPathForBaprBalTrain() {
-        setSigSystemIds(listOf("b->N", "N->d"), BAPR.id) // Other blocks are BAL
+    @ParameterizedTest
+    @CsvSource(
+        "ETCS_LEVEL2, TVM430, N",
+        "TVM430, TVM300, N",
+        "TVM300, BAL, N",
+        "BAL, BAPR, N",
+        "TVM430, ETCS_LEVEL2, S",
+        "TVM300, TVM430, S",
+        "BAL, TVM300, S",
+        "BAPR, BAL, S"
+    )
+    fun shouldPriorEtcsThenTvm430ThenTvm300ThenBalThenBaprForPathfinding(
+        northSigSystem: String,
+        southSigSystem: String,
+        intermediateWaypoint: String
+    ) {
+        // Other blocks are BAL
+        setSigSystemIds(listOf("b->N", "N->d"), northSigSystem)
+        setSigSystemIds(listOf("b->S", "S->d"), southSigSystem)
+
         val waypointsStart = listOf(TrackLocation("a->b", Offset.zero()))
         val waypointsInter =
             listOf(TrackLocation("S->d", Offset.zero()), TrackLocation("N->d", Offset.zero()))
         val waypointsEnd = listOf(TrackLocation("d->e", Offset(100.meters)))
 
-        val pathfindingResp =
+        val pathfindingSouthResp =
             fr.sncf.osrd.api.api_v2.pathfinding.runPathfinding(
                 infra.fullInfra(),
                 getPathfindingBlockRequest(
-                    TestTrains.REALISTIC_FAST_TRAIN,
+                    TestTrains.REALISTIC_ETCS_FAST_TRAIN,
                     listOf(waypointsStart, waypointsInter, waypointsEnd)
                 )
             )
-        assertThat(pathfindingResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
-        assertThat((pathfindingResp as PathfindingBlockSuccess).trackSectionRanges)
+        assertThat(pathfindingSouthResp).isExactlyInstanceOf(PathfindingBlockSuccess::class.java)
+        assertThat((pathfindingSouthResp as PathfindingBlockSuccess).trackSectionRanges)
             .isEqualTo(
                 arrayListOf(
                     DirectionalTrackRange("a->b", Offset.zero(), Offset(100.meters), START_TO_STOP),
-                    // xfail: Should go South here to prioritize BAL over BAPR
-                    DirectionalTrackRange("b->N", Offset.zero(), Offset(100.meters), START_TO_STOP),
-                    DirectionalTrackRange("N->d", Offset.zero(), Offset(100.meters), START_TO_STOP),
+                    DirectionalTrackRange(
+                        "b->$intermediateWaypoint",
+                        Offset.zero(),
+                        Offset(100.meters),
+                        START_TO_STOP
+                    ),
+                    DirectionalTrackRange(
+                        "$intermediateWaypoint->d",
+                        Offset.zero(),
+                        Offset(100.meters),
+                        START_TO_STOP
+                    ),
                     DirectionalTrackRange("d->e", Offset.zero(), Offset(100.meters), START_TO_STOP)
                 )
             )

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -6,6 +6,7 @@ import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.geom.LineString
 import fr.sncf.osrd.geom.Point
+import fr.sncf.osrd.signaling.bal.BAL
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.*
@@ -43,7 +44,7 @@ class DummyInfra : RawInfra, BlockInfra {
         exit: String,
         length: Distance = 100.meters,
         allowedSpeed: Double = Double.POSITIVE_INFINITY,
-        signalingSystemName: String = "BAL"
+        signalingSystemName: String = BAL.id
     ): BlockId {
         val name = String.format("%s->%s", entry, exit)
         val entryId = getOrCreateDetectorId(entry)
@@ -367,7 +368,7 @@ class DummyInfra : RawInfra, BlockInfra {
         get() = TODO("Not yet implemented")
 
     override fun getTrackSectionName(trackSection: TrackSectionId): String {
-        TODO("Not yet implemented")
+        return getRouteName(RouteId(trackSection.index))
     }
 
     override fun getTrackSectionFromName(name: String): TrackSectionId {
@@ -497,11 +498,11 @@ class DummyInfra : RawInfra, BlockInfra {
     }
 
     override fun blockStartAtBufferStop(block: BlockId): Boolean {
-        TODO("Not yet implemented")
+        return !exitMap.containsKey(blockPool[block.index].entry)
     }
 
     override fun blockStopAtBufferStop(block: BlockId): Boolean {
-        TODO("Not yet implemented")
+        return !entryMap.containsKey(blockPool[block.index].exit)
     }
 
     override fun getBlockSignalingSystem(block: BlockId): SignalingSystemId {
@@ -532,6 +533,8 @@ class DummyInfra : RawInfra, BlockInfra {
         trackChunk: TrackChunkId,
         direction: Direction
     ): MutableStaticIdxArraySet<Block> {
+        if (direction == Direction.DECREASING)
+            return mutableStaticIdxArraySetOf() // TODO: to implement eventually
         return mutableStaticIdxArraySetOf(StaticIdx(trackChunk.index))
     }
 


### PR DESCRIPTION
When everything else is equal, use the preferred signaling system.
Also migrate pathfinding signaling tests to API v2 (and add new tests).

🔍 please review by commit.

Fix #10296 