### PR TITLE
front: consolidate consecutive fake tracks overtake steps to single stops in stdcm report

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -142,6 +142,7 @@
     "stopType": {
       "driverSwitch": "driver switch",
       "passageTime": "passage time",
+      "overtake": "overtake",
       "serviceStop": "service stop"
     },
     "time": "Time",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -142,6 +142,7 @@
     "stopType": {
       "driverSwitch": "relève conducteur",
       "passageTime": "passage",
+      "overtake": "dépassement",
       "serviceStop": "arrêt de service"
     },
     "time": "Heure",

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResultsTable.tsx
@@ -62,7 +62,8 @@ const StcdmResultsTable = ({
               ({ location }) =>
                 location && location.name === step.name && location.secondary_code === step.ch
             );
-            const shouldRenderRow = isFirstStep || isRequestedPathStep || isLastStep;
+            const shouldRenderRow =
+              isFirstStep || isRequestedPathStep || isLastStep || step.duration;
             const isPathStep =
               isFirstStep || isLastStep || (isRequestedPathStep && step.duration === 0);
             const isNotExtremity = !isFirstStep && !isLastStep;

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -202,6 +202,7 @@ export enum StdcmStopTypes {
   PASSAGE_TIME = 'passageTime',
   DRIVER_SWITCH = 'driverSwitch',
   SERVICE_STOP = 'serviceStop',
+  OVERTAKE = 'overtake',
 }
 
 export type StdcmLinkedTrainExtremity = {

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -105,6 +105,40 @@ export function getStopDurationBetweenTwoPositions(
   return null;
 }
 
+// TODO : Remove this function as soon as fake takeover tracks cease to be used
+// It serves to consolidate steps of the form OVERTAKE_n_A;X, OVERTAKE_n_B;X in a single step X
+export function consolidateOvertakesToSingleSteps(
+  steps: StdcmResultsOperationalPoint[]
+): StdcmResultsOperationalPoint[] {
+  function convertHHMMTimeToSeconds(time: string): number {
+    const [hours, minutes] = time.split(':').map(Number);
+    return hours * 3600 + minutes * 60;
+  }
+  const consolidatedSteps: StdcmResultsOperationalPoint[] = [];
+  for (let i = 0; i < steps.length - 1; i += 1) {
+    const [step, nextStep] = [steps[i], steps[i + 1]];
+    const overtakenStepMatch = step.name?.match(/^OVERTAKE.*;(.*)$/);
+    if (overtakenStepMatch) {
+      const stopDuration =
+        convertHHMMTimeToSeconds(nextStep.time!) - convertHHMMTimeToSeconds(step.time!);
+      const consolidatedStep = {
+        ...step,
+        name: overtakenStepMatch[1],
+        duration: stopDuration,
+        stopEndTime: nextStep.time!,
+        stopType: 'overtake',
+        stopFor: stopDuration / 60,
+      };
+      consolidatedSteps.push(consolidatedStep);
+      i += 1; // to skip the next step, as we consolidated two overtake steps in one
+    } else {
+      consolidatedSteps.push(step);
+    }
+  }
+  consolidatedSteps.push(steps[steps.length - 1]);
+  return consolidatedSteps;
+}
+
 export function getOperationalPointsWithTimes(
   operationalPoints: SuggestedOP[],
   simulation: Extract<SimulationResponse, { status: 'success' }>,
@@ -160,5 +194,5 @@ export function getOperationalPointsWithTimes(
     };
   });
 
-  return opResults;
+  return consolidateOvertakesToSingleSteps(opResults);
 }


### PR DESCRIPTION
Close #10566

(If you want to test this PR, you will need an infra with such overtake tracks, feel free to ask me for a private infra.json ^^)

Before :
![fake_stops_overtaking_before](https://github.com/user-attachments/assets/f5578ac1-74ed-45f1-be79-10c94c4bda7b)
After :
![fake_stops_overtaking_after](https://github.com/user-attachments/assets/9a025829-e92b-4ab9-8e6e-ff208a23e55b)

Some notes : 

- we may not want to add a stopFor value, as it only seems to be used for user requested path steps
- the existing duration computation would not work as steps to be consolidated do not share a position, and our computatio0n for duration is only precise to the minute. However, it's only required at that precision level by all components that use it, so it should be fine
- this change does not affect the GET/GEV. If we want to modify them, other changes would be required
- depending on how temporary this change is supposed to be, we may want to add a specific stop type for overtaking and/or a translation, to avoid this ugly mention in the report sheet : 

![image](https://github.com/user-attachments/assets/b541c09b-a715-4a34-acf1-5f1f8eb5febe)

