### PR TITLE
front: remove nesting levels in user stdcm results

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcmResults.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmResults.ts
@@ -74,55 +74,52 @@ const useStdcmResults = (
       };
       const { geometry, operational_points, zones } =
         await postPathProperties(pathPropertiesParams).unwrap();
+      if (!geometry || !operational_points || !zones || !infraId) return;
 
-      if (geometry && operational_points && zones) {
-        if (infraId) {
-          const trackIds = operational_points.map((op) => op.part.track);
-          const trackSections = await getEntities<TrackSectionEntity>(
-            infraId,
-            trackIds,
-            'TrackSection',
-            dispatch
-          );
-          const operationalPointsWithMetadata = operational_points.map((op) => {
-            const associatedTrackSection = trackSections[op.part.track];
-            const sncf = associatedTrackSection?.properties?.extensions?.sncf;
+      const trackIds = operational_points.map((op) => op.part.track);
+      const trackSections = await getEntities<TrackSectionEntity>(
+        infraId,
+        trackIds,
+        'TrackSection',
+        dispatch
+      );
+      const operationalPointsWithMetadata = operational_points.map((op) => {
+        const associatedTrackSection = trackSections[op.part.track];
+        const sncf = associatedTrackSection?.properties?.extensions?.sncf;
 
-            const metadata =
-              sncf && Object.values(sncf).every((value) => value !== undefined)
-                ? {
-                    lineCode: sncf.line_code!,
-                    lineName: sncf.line_name!,
-                    trackName: sncf.track_name!,
-                    trackNumber: sncf.track_number!,
-                  }
-                : undefined;
+        const metadata =
+          sncf && Object.values(sncf).every((value) => value !== undefined)
+            ? {
+                lineCode: sncf.line_code!,
+                lineName: sncf.line_name!,
+                trackName: sncf.track_name!,
+                trackNumber: sncf.track_number!,
+              }
+            : undefined;
 
-            return {
-              ...op,
-              metadata,
-            };
-          });
+        return {
+          ...op,
+          metadata,
+        };
+      });
 
-          const operationalPointsWithUniqueIds = operational_points.map((op, index) => ({
-            ...op,
-            id: `${op.id}-${op.position}-${index}`,
-          }));
+      const operationalPointsWithUniqueIds = operational_points.map((op, index) => ({
+        ...op,
+        id: `${op.id}-${op.position}-${index}`,
+      }));
 
-          const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
-            operationalPointsWithMetadata, // Pass the operational points with metadata
-            geometry,
-            path.length
-          );
+      const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
+        operationalPointsWithMetadata, // Pass the operational points with metadata
+        geometry,
+        path.length
+      );
 
-          setPathProperties({
-            manchetteOperationalPoints: operationalPointsWithUniqueIds,
-            geometry,
-            suggestedOperationalPoints,
-            zones,
-          });
-        }
-      }
+      setPathProperties({
+        manchetteOperationalPoints: operationalPointsWithUniqueIds,
+        geometry,
+        suggestedOperationalPoints,
+        zones,
+      });
     };
 
     if (infraId && stdcmResponse && stdcmResponse?.path) {


### PR DESCRIPTION
Better to return early than add nesting levels.