### PR TITLE
editoast: fix gitignore sprites globbing

### DIFF
--- a/editoast/.gitignore
+++ b/editoast/.gitignore
@@ -1,4 +1,4 @@
 target
 *.snap.new
-assets/sprites/*/sprites.*
+assets/sprites/*/sprites*
 assets/fonts/glyphs/*


### PR DESCRIPTION
Otherwise doesn't ignores files such as:

```
assets/sprites/TVM430/sprites@3x.png
```

Signed-off-by: Leo Valais <leo.valais97@gmail.com>
