### PR TITLE
editoast: add rustfmt.toml to .gitignore

### DIFF
--- a/editoast/.gitignore
+++ b/editoast/.gitignore
@@ -2,3 +2,6 @@ target
 *.snap.new
 assets/sprites/*/sprites.*
 assets/fonts/glyphs/*
+
+# allows using nightly rustfmt options locally without imposing nightly to everyone publicly
+rustfmt.toml


### PR DESCRIPTION
# Proposition

We prefer using un-merged `use` statements for clarity and ease of
review. `rustfmt` has a `nightly` option to do so automatically, but
we don't want to ask everyone to use `nightly` rust.

Ignoring `rustfmt.toml` allows to define it locally and still benefit
from the auto-formatting of `use` statements, without the risk of
accidentally committing it.

```
$ cat rustfmt.toml
imports_granularity = "item"
```

If one day we want to commit a mandatory `rustfmt.toml`, we can always
revert this commit.

