### PR TITLE
core: safety speeds: fix route path start offset

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/Extensions.kt
@@ -1,11 +1,15 @@
 package fr.sncf.osrd.utils
 
-import fr.sncf.osrd.utils.indexing.StaticIdx
-import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.*
 
 fun <T> List<StaticIdx<T>>.toIdxList(): StaticIdxList<T> {
     val res = mutableStaticIdxArrayListOf<T>()
+    res.addAll(this)
+    return res
+}
+
+fun <T> List<DirStaticIdx<T>>.toIdxList(): DirStaticIdxList<T> {
+    val res = mutableDirStaticIdxArrayListOf<T>()
     res.addAll(this)
     return res
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -7,6 +7,7 @@ import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
+import fr.sncf.osrd.utils.getRoutePathStartOffset
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.units.Offset
@@ -36,7 +37,7 @@ fun makeSafetySpeedRanges(
 ): DistanceRangeMap<Speed> {
     val rawInfra = infra.rawInfra
     val zonePaths = routes.flatMap { rawInfra.getRoutePath(it) }
-    val zonePathStartOffset = getRoutePathStartOffset(rawInfra, chunkPath, zonePaths)
+    val zonePathStartOffset = getRoutePathStartOffset(rawInfra, chunkPath, routes)
     val signalOffsets = getSignalOffsets(infra, zonePaths, zonePathStartOffset)
 
     val stopsWithSafetySpeed =
@@ -115,31 +116,4 @@ fun getSignalOffsets(
     // There must be either a signal or a buffer stop, on which we may end safety speed ranges.
     res.add(Offset(prevZonePathsLength - pathStartOffset.distance))
     return res.filter { it.distance >= 0.meters }
-}
-
-/** Returns the offset where the train actually starts, compared to the start of the first route. */
-fun getRoutePathStartOffset(
-    infra: RawInfra,
-    chunkPath: ChunkPath,
-    zonePaths: List<ZonePathId>
-): Offset<Path> {
-    var prevChunksLength = Offset<Path>(0.meters)
-    val routeChunks = zonePaths.flatMap { infra.getZonePathChunks(it) }
-
-    var firstChunk = chunkPath.chunks[0]
-    var firstChunkLength = infra.getTrackChunkLength(firstChunk.value)
-    if (firstChunkLength == chunkPath.beginOffset && chunkPath.chunks.size > 1) {
-        // If the path starts precisely at the end of the first chunk, it may not be present in the
-        // route path. We can look for the next chunk instead.
-        firstChunk = chunkPath.chunks[1]
-        prevChunksLength += firstChunkLength.distance
-    }
-
-    for (chunk in routeChunks) {
-        if (chunk == firstChunk) {
-            return prevChunksLength + chunkPath.beginOffset.distance
-        }
-        prevChunksLength += infra.getTrackChunkLength(chunk.value).distance
-    }
-    throw RuntimeException("Unreachable (couldn't find first chunk in route list)")
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -9,8 +9,6 @@ import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
-import fr.sncf.osrd.reporting.exceptions.ErrorType
-import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.signaling.SigSystemManager
 import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
@@ -33,6 +31,7 @@ import fr.sncf.osrd.train.StandaloneTrainSchedule
 import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.*
 import kotlin.collections.set
 import kotlin.math.abs
@@ -126,7 +125,7 @@ fun run(
     }
 
     // Compute signal updates
-    val startOffset = trainPathBlockOffset(rawInfra, blockInfra, blockPath, chunkPath)
+    val startOffset = trainPathBlockOffset(rawInfra, blockInfra, blockPath, chunkPath).distance
     val pathOffsetBuilder = PathOffsetBuilder(startOffset)
     var blockPathLength = 0.meters
     for (block in blockPath) blockPathLength += blockInfra.getBlockLength(block).distance
@@ -633,35 +632,6 @@ fun pathSignalsInRange(
     return pathSignals(pathOffsetBuilder, blockPath, blockInfra).filter { signal ->
         signal.pathOffset.distance in rangeStart..rangeEnd
     }
-}
-
-/**
- * Computes the offset between the beginning of the first block and the beginning of the train
- * path - and thus of the envelope
- */
-fun trainPathBlockOffset(
-    infra: RawInfra,
-    blockInfra: BlockInfra,
-    blockPath: StaticIdxList<Block>,
-    chunkPath: ChunkPath
-): Distance {
-    var firstChunk = chunkPath.chunks[0]
-    var prevChunksLength = 0.meters
-    if (infra.getTrackChunkLength(firstChunk.value) == chunkPath.beginOffset) {
-        firstChunk = chunkPath.chunks[1]
-        prevChunksLength = -chunkPath.beginOffset.distance
-    }
-    for (block in blockPath) {
-        for (zonePath in blockInfra.getBlockPath(block)) {
-            for (dirChunk in infra.getZonePathChunks(zonePath)) {
-                if (dirChunk == firstChunk) return prevChunksLength + chunkPath.beginOffset.distance
-                prevChunksLength += infra.getTrackChunkLength(dirChunk.value).distance
-            }
-        }
-    }
-    val error = OSRDError(ErrorType.ScheduleMetadataExtractionFailed)
-    error.context["reason"] = "Couldn't find first chunk on the block path"
-    throw error
 }
 
 fun simplifyPositions(positions: ArrayList<ResultPosition>): ArrayList<ResultPosition> {

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
@@ -12,6 +12,7 @@ import fr.sncf.osrd.standalone_sim.result.ResultTrain.ZoneUpdate
 import fr.sncf.osrd.standalone_sim.result.SignalUpdate
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.trainPathBlockOffset
 import java.awt.Color
 import kotlin.math.abs
 
@@ -72,6 +73,7 @@ fun project(
     // Compute signal updates
     val startOffset =
         trainPathBlockOffset(fullInfra.rawInfra, fullInfra.blockInfra, blockPath, chunkPath)
+            .distance
     val pathSignals = pathSignals(PathOffsetBuilder(startOffset), blockPath, blockInfra)
     if (pathSignals.isEmpty()) return SignalProjectionResult(listOf())
 

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
@@ -13,8 +13,8 @@ import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.standalone_sim.PathOffsetBuilder
 import fr.sncf.osrd.standalone_sim.PathSignal
 import fr.sncf.osrd.standalone_sim.pathSignalsInRange
-import fr.sncf.osrd.standalone_sim.trainPathBlockOffset
 import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.Duration
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.TimeDelta
@@ -75,6 +75,7 @@ fun projectSignals(
     // Compute signal updates
     val startOffset =
         trainPathBlockOffset(fullInfra.rawInfra, fullInfra.blockInfra, blockPath, chunkPath)
+            .distance
     // Compute path signals on path
     val pathOffsetBuilder = PathOffsetBuilder(startOffset)
     val pathSignals =

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -19,6 +19,7 @@ import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
+import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.*
 import kotlin.math.abs
 
@@ -72,7 +73,7 @@ fun runScheduleMetadataExtractor(
     }
 
     // Compute signal updates
-    val startOffset = trainPathBlockOffset(rawInfra, blockInfra, blockPath, chunkPath)
+    val startOffset = trainPathBlockOffset(rawInfra, blockInfra, blockPath, chunkPath).distance
     val pathOffsetBuilder = PathOffsetBuilder(startOffset)
     var blockPathLength = 0.meters
     for (block in blockPath) blockPathLength += blockInfra.getBlockLength(block).distance

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -39,6 +39,7 @@ import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.DistanceRangeMap
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -201,7 +202,8 @@ fun buildSignalingRanges(
     val blockInfra = infra.blockInfra
     var blockStartOffset =
         Offset<TravelledPath>(
-            trainPathBlockOffset(infra.rawInfra, infra.blockInfra, blockPath, chunkPath) * -1.0
+            trainPathBlockOffset(infra.rawInfra, infra.blockInfra, blockPath, chunkPath).distance *
+                -1.0
         )
     val res = distanceRangeMapOf<String>()
     for (blockId in blockPath) {

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/etcsContextBuilder.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.sim_infra.utils.getNextTrackSections
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.DistanceRangeMap
+import fr.sncf.osrd.utils.getRoutePathStartOffset
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.mapToRangeSet
@@ -49,7 +50,7 @@ fun buildETCSDangerPoints(
     routePath: StaticIdxList<Route>
 ): List<Offset<TravelledPath>> {
     val zonePaths = routePath.flatMap { infra.getRoutePath(it) }
-    var currentZonePathStartOffset = -getRoutePathStartOffset(infra, chunkPath, zonePaths).distance
+    var currentZonePathStartOffset = -getRoutePathStartOffset(infra, chunkPath, routePath).distance
 
     val res = mutableSetOf<Offset<TravelledPath>>()
     for (zonePath in zonePaths) {

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
@@ -1,0 +1,62 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.impl.ChunkPath
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+
+/** Returns the offset where the train actually starts, compared to the start of the first route. */
+fun getRoutePathStartOffset(
+    infra: RawInfra,
+    chunkPath: ChunkPath,
+    routes: StaticIdxList<Route>
+): Offset<Path> {
+    val zonePaths = routes.flatMap { infra.getRoutePath(it) }
+    return trainPathZonePathOffset(infra, zonePaths, chunkPath)
+}
+
+/**
+ * Computes the offset between the beginning of the first block and the beginning of the train path
+ */
+fun trainPathBlockOffset(
+    infra: RawInfra,
+    blockInfra: BlockInfra,
+    blockPath: StaticIdxList<Block>,
+    chunkPath: ChunkPath
+): Offset<Path> {
+    val zonePaths = blockPath.flatMap { blockInfra.getBlockPath(it) }
+    return trainPathZonePathOffset(infra, zonePaths, chunkPath)
+}
+
+/**
+ * Computes the offset between the beginning of the first zone path and the beginning of the train
+ * path
+ */
+fun trainPathZonePathOffset(
+    infra: RawInfra,
+    zonePaths: List<ZonePathId>,
+    chunkPath: ChunkPath
+): Offset<Path> {
+    var prevChunksLength = Offset<Path>(0.meters)
+    val routeChunks = zonePaths.flatMap { infra.getZonePathChunks(it) }
+
+    val firstChunk = Pair(chunkPath.chunks[0], chunkPath.beginOffset)
+    val startChunkCandidates = mutableListOf(firstChunk)
+    val firstChunkLength = infra.getTrackChunkLength(firstChunk.first.value)
+    if (firstChunkLength == firstChunk.second && chunkPath.chunks.size > 1) {
+        // If the path starts precisely at the end of the first chunk, it may not be present in the
+        // route path. We can look for the next chunk instead.
+        startChunkCandidates.add(Pair(chunkPath.chunks[1], Offset.zero()))
+    }
+
+    for (chunk in routeChunks) {
+        val matchingStart = startChunkCandidates.firstOrNull { chunk == it.first }
+        if (matchingStart != null) {
+            return prevChunksLength + matchingStart.second.distance
+        }
+        val len = infra.getTrackChunkLength(chunk.value).distance
+        prevChunksLength += len
+    }
+    throw RuntimeException("Unreachable (couldn't find first chunk in zone path list)")
+}

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/OffsetConversionTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/OffsetConversionTests.kt
@@ -1,0 +1,56 @@
+package fr.sncf.osrd.utils
+
+import fr.sncf.osrd.sim_infra.impl.ChunkPath
+import fr.sncf.osrd.utils.units.Offset
+import fr.sncf.osrd.utils.units.meters
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class OffsetConversionTests {
+    val infra = DummyInfra()
+    val blocks = (0 ..< 10).map { infra.addBlock(it.toString(), (it + 1).toString(), 1_000.meters) }
+    val zones = blocks.flatMap { infra.getBlockPath(it) }
+    val chunks = zones.flatMap { infra.getZonePathChunks(it) }
+
+    @Test
+    fun testStartOnFirstZone() {
+        val chunkPath = ChunkPath(chunks.toIdxList(), Offset(500.meters), Offset(950.meters))
+        val res = trainPathZonePathOffset(infra, zones, chunkPath)
+        assertEquals(Offset(500.meters), res)
+    }
+
+    @Test
+    fun testStartOnSecondZone() {
+        val partialChunks = chunks.subList(1, chunks.size)
+        val chunkPath = ChunkPath(partialChunks.toIdxList(), Offset(500.meters), Offset(850.meters))
+        val res = trainPathZonePathOffset(infra, zones, chunkPath)
+        assertEquals(Offset(1_500.meters), res)
+    }
+
+    @Test
+    fun testStartEndOfZone() {
+        val chunkPath = ChunkPath(chunks.toIdxList(), Offset(1_000.meters), Offset(10_000.meters))
+        val res = trainPathZonePathOffset(infra, zones, chunkPath)
+        assertEquals(Offset(1_000.meters), res)
+    }
+
+    @Test
+    fun testStartNotIncludedInZonePath() {
+        val partialZones = zones.subList(1, zones.size)
+        val chunkPath = ChunkPath(chunks.toIdxList(), Offset(1_000.meters), Offset(850.meters))
+        val res = trainPathZonePathOffset(infra, partialZones, chunkPath)
+        assertEquals(Offset(0.meters), res)
+    }
+
+    @Test
+    fun testSingleZone() {
+        // Not necessarily a use case we want to support (0 length path),
+        // but it's nice to know that it works
+        val partialZones = zones.subList(0, 1)
+        val partialChunks = chunks.subList(0, 1)
+        val chunkPath =
+            ChunkPath(partialChunks.toIdxList(), Offset(1_000.meters), Offset(1_000.meters))
+        val res = trainPathZonePathOffset(infra, partialZones, chunkPath)
+        assertEquals(Offset(1_000.meters), res)
+    }
+}


### PR DESCRIPTION
We'd end up adding a value instead of removing it, sometimes resulting in values outside the route range.

It caused an out of bounds at some point in the benchmark.