### PR TITLE
front: simplify translation types in e2e tests

### DIFF
--- a/front/tests/001-home-page.spec.ts
+++ b/front/tests/001-home-page.spec.ts
@@ -4,17 +4,10 @@ import test from './logging-fixture';
 import HomePage from './pages/home-page-model';
 import { getTranslations } from './utils';
 import readJsonFile from './utils/file-utils';
+import type { FlatTranslations } from './utils/types';
 
-type HomeTranslations = {
-  operationalStudies: string;
-  stdcm: string;
-  editor: string;
-  rollingStockEditor: string;
-  map: string;
-};
-
-const enTranslations: HomeTranslations = readJsonFile('public/locales/en/home/home.json');
-const frTranslations: HomeTranslations = readJsonFile('public/locales/fr/home/home.json');
+const enTranslations: FlatTranslations = readJsonFile('public/locales/en/home/home.json');
+const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/home/home.json');
 
 test.describe('Home page OSRD', () => {
   let homePage: HomePage;

--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -10,17 +10,11 @@ import { formatDateToDayMonthYear } from './utils/date';
 import readJsonFile from './utils/file-utils';
 import { createStudy } from './utils/setup-utils';
 import { deleteStudy } from './utils/teardown-utils';
-import type { StudyData } from './utils/types';
+import type { FlatTranslations, StudyData } from './utils/types';
 
 type StudyTranslations = {
-  studyCategories: {
-    flowRate: string;
-    operability: string;
-  };
-  studyStates: {
-    started: string;
-    inProgress: string;
-  };
+  studyCategories: FlatTranslations;
+  studyStates: FlatTranslations;
 };
 
 const studyData: StudyData = readJsonFile('tests/assets/operationStudies/study.json');

--- a/front/tests/011-op-times-and-stops-tab.spec.ts
+++ b/front/tests/011-op-times-and-stops-tab.spec.ts
@@ -16,22 +16,10 @@ import readJsonFile from './utils/file-utils';
 import createScenario from './utils/scenario';
 import scrollContainer from './utils/scrollHelper';
 import { deleteScenario } from './utils/teardown-utils';
-import type { StationData } from './utils/types';
+import type { FlatTranslations, StationData } from './utils/types';
 
-type TimeStopsTranslation = {
-  name: string;
-  ch: string;
-  trackName: string;
-  arrivalTime: string;
-  stopTime: string;
-  departureTime: string;
-  receptionOnClosedSignal: string;
-  shortSlipDistance: string;
-  theoreticalMargin: string;
-};
-
-const enTranslations: TimeStopsTranslation = readJsonFile('public/locales/en/timesStops.json');
-const frTranslations: TimeStopsTranslation = readJsonFile('public/locales/fr/timesStops.json');
+const enTranslations: FlatTranslations = readJsonFile('public/locales/en/timesStops.json');
+const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/timesStops.json');
 
 test.describe('Times and Stops Tab Verification', () => {
   test.slow();
@@ -46,7 +34,7 @@ test.describe('Times and Stops Tab Verification', () => {
   let study: Study;
   let scenario: Scenario;
   let infra: Infra;
-  let translations: TimeStopsTranslation;
+  let translations: FlatTranslations;
 
   // Load test data for table inputs and expected results
   const initialInputsData: CellData[] = readJsonFile(
@@ -74,12 +62,10 @@ test.describe('Times and Stops Tab Verification', () => {
   // Define interface for table cell data
   interface CellData {
     stationName: string;
-    header: TranslationKeys;
+    header: string;
     value: string;
     marginForm?: string;
   }
-
-  type TranslationKeys = keyof TimeStopsTranslation;
 
   test.beforeAll('Fetch infrastructure and get translation', async () => {
     infra = await getInfra();

--- a/front/tests/012-op-simulation-settings-tab.spec.ts
+++ b/front/tests/012-op-simulation-settings-tab.spec.ts
@@ -29,22 +29,10 @@ import readJsonFile from './utils/file-utils';
 import createScenario from './utils/scenario';
 import scrollContainer from './utils/scrollHelper';
 import { deleteScenario } from './utils/teardown-utils';
-import type { StationData } from './utils/types';
+import type { FlatTranslations, StationData } from './utils/types';
 
-type TimeStopsTranslations = {
-  name: string;
-  ch: string;
-  trackName: string;
-  arrivalTime: string;
-  stopTime: string;
-  departureTime: string;
-  receptionOnClosedSignal: string;
-  shortSlipDistance: string;
-  theoreticalMargin: string;
-};
-
-const enTranslations: TimeStopsTranslations = readJsonFile('public/locales/en/timesStops.json');
-const frTranslations: TimeStopsTranslations = readJsonFile('public/locales/fr/timesStops.json');
+const enTranslations: FlatTranslations = readJsonFile('public/locales/en/timesStops.json');
+const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/timesStops.json');
 
 test.describe('Simulation Settings Tab Verification', () => {
   test.slow();

--- a/front/tests/assets/simulation-sheet-const.ts
+++ b/front/tests/assets/simulation-sheet-const.ts
@@ -1,28 +1,12 @@
 import { getTranslations } from '../utils';
 import { getLocalizedDateString } from '../utils/date';
 import readJsonFile from '../utils/file-utils';
-import type { Simulation } from '../utils/types';
+import type { FlatTranslations, Simulation } from '../utils/types';
 
-type SimSheetTranslations = {
-  warningMessage: string;
-  stdcm: string;
-  applicationDate: string;
-  speedLimitByTag: string;
-  towedMaterial: string;
-  maxSpeed: string;
-  maxWeight: string;
-  referenceEngine: string;
-  maxLength: string;
-  serviceStop: string;
-  passageStop: string;
-  asap: string;
-  withoutWarranty: string;
-};
-
-const enTranslations: SimSheetTranslations = readJsonFile(
+const enTranslations: FlatTranslations = readJsonFile(
   'public/locales/en/stdcm-simulation-report-sheet.json'
 );
-const frTranslations: SimSheetTranslations = readJsonFile(
+const frTranslations: FlatTranslations = readJsonFile(
   'public/locales/fr/stdcm-simulation-report-sheet.json'
 );
 

--- a/front/tests/pages/op-input-table-page-model.ts
+++ b/front/tests/pages/op-input-table-page-model.ts
@@ -3,21 +3,10 @@ import { type Locator, type Page, expect } from '@playwright/test';
 import { getTranslations } from '../utils';
 import { cleanWhitespace } from '../utils/dataNormalizer';
 import readJsonFile from '../utils/file-utils';
+import type { FlatTranslations } from '../utils/types';
 
-type TimeStopsTranslations = {
-  name: string;
-  ch: string;
-  trackName: string;
-  arrivalTime: string;
-  stopTime: string;
-  departureTime: string;
-  receptionOnClosedSignal: string;
-  shortSlipDistance: string;
-  theoreticalMargin: string;
-};
-
-const enTranslations: TimeStopsTranslations = readJsonFile('public/locales/en/timesStops.json');
-const frTranslations: TimeStopsTranslations = readJsonFile('public/locales/fr/timesStops.json');
+const enTranslations: FlatTranslations = readJsonFile('public/locales/en/timesStops.json');
+const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/timesStops.json');
 
 class OperationalStudiesInputTablePage {
   readonly page: Page;

--- a/front/tests/pages/op-output-table-page-model.ts
+++ b/front/tests/pages/op-output-table-page-model.ts
@@ -5,27 +5,10 @@ import { LOAD_PAGE_TIMEOUT } from '../assets/timeout-const';
 import { getTranslations } from '../utils';
 import { normalizeStationData } from '../utils/dataNormalizer';
 import readJsonFile from '../utils/file-utils';
-import type { StationData } from '../utils/types';
+import type { FlatTranslations, StationData } from '../utils/types';
 
-type TimeStopsTranslations = {
-  name: string;
-  ch: string;
-  trackName: string;
-  arrivalTime: string;
-  stopTime: string;
-  departureTime: string;
-  receptionOnClosedSignal: string;
-  shortSlipDistance: string;
-  theoreticalMargin: string;
-  theoreticalMarginSeconds: string;
-  realMargin: string;
-  diffMargins: string;
-  calculatedArrivalTime: string;
-  calculatedDepartureTime: string;
-};
-
-const enTranslations: TimeStopsTranslations = readJsonFile('public/locales/en/timesStops.json');
-const frTranslations: TimeStopsTranslations = readJsonFile('public/locales/fr/timesStops.json');
+const enTranslations: FlatTranslations = readJsonFile('public/locales/en/timesStops.json');
+const frTranslations: FlatTranslations = readJsonFile('public/locales/fr/timesStops.json');
 
 class OperationalStudiesOutputTablePage extends OperationalStudiesTimetablePage {
   private readonly columnHeaders: Locator;

--- a/front/tests/pages/op-route-page-model.ts
+++ b/front/tests/pages/op-route-page-model.ts
@@ -2,17 +2,12 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import { getTranslations } from '../utils';
 import readJsonFile from '../utils/file-utils';
+import type { FlatTranslations } from '../utils/types';
 
-type ManageTrainScheduleTranslations = {
-  noOriginChosen: string;
-  noDestinationChosen: string;
-  pathfindingMissingParams: string;
-};
-
-const enTranslations: ManageTrainScheduleTranslations = readJsonFile(
+const enTranslations: FlatTranslations = readJsonFile(
   'public/locales/en/operationalStudies/manageTrainSchedule.json'
 );
-const frTranslations: ManageTrainScheduleTranslations = readJsonFile(
+const frTranslations: FlatTranslations = readJsonFile(
   'public/locales/fr/operationalStudies/manageTrainSchedule.json'
 );
 

--- a/front/tests/pages/op-timetable-page-model.ts
+++ b/front/tests/pages/op-timetable-page-model.ts
@@ -4,17 +4,10 @@ import CommonPage from './common-page-model';
 import { EXPLICIT_UI_STABILITY_TIMEOUT, SIMULATION_RESULT_TIMEOUT } from '../assets/timeout-const';
 import { getTranslations } from '../utils';
 import readJsonFile from '../utils/file-utils';
+import type { FlatTranslations } from '../utils/types';
 
 type ScenarioTranslations = {
-  timetable: {
-    invalidTrains: string;
-    noSpeedLimitTagsShort: string;
-    showValidTrains: string;
-    showInvalidTrains: string;
-    showAllTrains: string;
-    showHonoredTrains: string;
-    showNotHonoredTrains: string;
-  };
+  timetable: FlatTranslations;
 };
 
 const enTranslations: ScenarioTranslations = readJsonFile(

--- a/front/tests/utils/types.ts
+++ b/front/tests/utils/types.ts
@@ -191,3 +191,5 @@ export type ScenarioData = {
   description: string;
   tags: Tags;
 };
+
+export type FlatTranslations = Record<string, string>;


### PR DESCRIPTION
Simplify the translation types by using records instead of listing all keys (which wasn't really more type safe since we couldn't automatically check the manual types corresponded to the actual keys in the file anyway)