### PR TITLE
front: removes useOsrdConfSelectors hook

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
+++ b/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
@@ -10,7 +10,10 @@ import usePathfinding from 'modules/pathfinding/hooks/usePathfinding';
 import type { PathfindingState } from 'modules/pathfinding/types';
 import { upsertPathStepsInOPs } from 'modules/pathfinding/utils';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
-import { getPathSteps } from 'reducers/osrdconf/operationalStudiesConf/selectors';
+import {
+  getOperationalStudiesRollingStockID,
+  getPathSteps,
+} from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { PathStep } from 'reducers/osrdconf/types';
 
 import type { ManageTrainSchedulePathProperties } from '../types';
@@ -41,7 +44,11 @@ export const ManageTrainScheduleContextProvider = ({
 
   const [pathProperties, setPathProperties] = useState<ManageTrainSchedulePathProperties>();
 
-  const { launchPathfinding, pathfindingState, infraInfo } = usePathfinding(setPathProperties);
+  const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
+  const { launchPathfinding, pathfindingState, infraInfo } = usePathfinding({
+    setPathProperties,
+    rollingStockId,
+  });
 
   const voltageRanges = useMemo(
     () => getPathVoltages(pathProperties?.electrifications, pathProperties?.length),

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -75,6 +75,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
 
   const { projectedTrainsById, allTrainsProjected, setProjectedTrainsById } = useLazyProjectTrains({
     infraId: scenario.infra_id,
+    electricalProfileSetId,
     trainIdsToProject,
     path: projectionPath?.path,
     trainSchedules,

--- a/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
+++ b/front/src/applications/operationalStudies/views/ManageTrainSchedule.tsx
@@ -34,6 +34,8 @@ import {
 import {
   getConstraintDistribution,
   getDestination,
+  getOperationalStudiesRollingStockID,
+  getOperationalStudiesSpeedLimitByTag,
   getOrigin,
   getPathSteps,
   getStartTime,
@@ -53,6 +55,8 @@ const ManageTrainSchedule = () => {
   const origin = useSelector(getOrigin);
   const destination = useSelector(getDestination);
   const pathSteps = useSelector(getPathSteps);
+  const speedLimitByTag = useSelector(getOperationalStudiesSpeedLimitByTag);
+  const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
 
   const markersInformation = useMemo(
     () =>
@@ -79,10 +83,11 @@ const ManageTrainSchedule = () => {
   const constraintDistribution = useSelector(getConstraintDistribution);
   const startTime = useSelector(getStartTime);
 
-  const { speedLimitByTag, speedLimitsByTags, dispatchUpdateSpeedLimitByTag } =
-    useStoreDataForSpeedLimitByTagSelector();
-  const { rollingStockId, rollingStockComfort, rollingStock } =
-    useStoreDataForRollingStockSelector();
+  const { speedLimitsByTags, dispatchUpdateSpeedLimitByTag } =
+    useStoreDataForSpeedLimitByTagSelector({ speedLimitByTag });
+  const { rollingStockComfort, rollingStock } = useStoreDataForRollingStockSelector({
+    rollingStockId,
+  });
 
   const onSelectRollingStock = useCallback(
     (_rollingStockId: number, comfort: Comfort) => {
@@ -112,6 +117,7 @@ const ManageTrainSchedule = () => {
     label: t('tabs.rollingStock'),
     content: (
       <RollingStockSelector
+        rollingStockId={rollingStockId}
         rollingStockSelected={rollingStock}
         rollingStockComfort={rollingStockComfort}
         onSelectRollingStock={onSelectRollingStock}
@@ -139,7 +145,7 @@ const ManageTrainSchedule = () => {
     content: (
       <div className="osrd-config-item-container-map" data-testid="map">
         <div className="floating-itinerary">
-          <Itinerary />
+          <Itinerary rollingStockId={rollingStockId} />
         </div>
 
         <Map

--- a/front/src/applications/operationalStudies/views/Scenario.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario.tsx
@@ -1,3 +1,5 @@
+import { useSelector } from 'react-redux';
+
 import BreadCrumbs from 'applications/operationalStudies/components/BreadCrumbs';
 import ScenarioContent from 'applications/operationalStudies/components/Scenario/ScenarioContent';
 import useScenario from 'applications/operationalStudies/hooks/useScenario';
@@ -5,14 +7,17 @@ import { ScenarioContextProvider } from 'applications/operationalStudies/hooks/u
 import useScenarioQueryParams from 'applications/operationalStudies/hooks/useScenarioQueryParams';
 import NavBarSNCF from 'common/BootstrapSNCF/NavBarSNCF';
 import useInfraStatus from 'modules/pathfinding/hooks/useInfraStatus';
+import { getOperationalStudiesInfraID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 
 const Scenario = () => {
   const { scenario } = useScenario();
 
+  const infraId = useSelector(getOperationalStudiesInfraID);
+
   // Initialize and sync the URL and local storage with Redux
   useScenarioQueryParams();
 
-  const infraData = useInfraStatus();
+  const infraData = useInfraStatus({ infraId });
   const { infra } = infraData;
 
   if (!scenario || !infra) return null;

--- a/front/src/applications/operationalStudies/views/SimulationResults.tsx
+++ b/front/src/applications/operationalStudies/views/SimulationResults.tsx
@@ -22,6 +22,7 @@ import SimulationResultExport from 'modules/simulationResult/SimulationResultExp
 import type { ProjectionData } from 'modules/simulationResult/types';
 import TimesStopsOutput from 'modules/timesStops/TimesStopsOutput';
 import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
+import { getOperationalStudiesTimetableID } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { TrainId } from 'reducers/osrdconf/types';
 import { updateSelectedTrainId } from 'reducers/simulationResults';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
@@ -59,6 +60,8 @@ const SimulationResults = ({
 }: SimulationResultsProps) => {
   const { t } = useTranslation('simulation');
   const dispatch = useAppDispatch();
+
+  const timetableId = useSelector(getOperationalStudiesTimetableID);
 
   const {
     selectedTrainSchedule,
@@ -99,11 +102,12 @@ const SimulationResults = ({
     operationalPoints: projectedOperationalPoints,
     filteredOperationalPoints,
     setFilteredOperationalPoints,
-  } = useGetProjectedTrainOperationalPoints(
-    projectionData?.trainSchedule,
-    projectionData?.trainSchedule.id,
-    infraId
-  );
+  } = useGetProjectedTrainOperationalPoints({
+    trainScheduleUsedForProjection: projectionData?.trainSchedule,
+    trainIdUsedForProjection: projectionData?.trainSchedule.id,
+    infraId,
+    timetableId,
+  });
 
   const trainUsedForProjectionSpaceTimeData = useMemo(
     () =>
@@ -207,6 +211,7 @@ const SimulationResults = ({
                         filteredWaypoints: filteredOperationalPoints,
                         setFilteredWaypoints: setFilteredOperationalPoints,
                         projectionPath: projectionData.trainSchedule.path,
+                        timetableId,
                       }}
                       conflicts={conflictZones}
                       projectionLoaderData={projectionData.projectionLoaderData}

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConfig.tsx
@@ -17,6 +17,7 @@ import {
 } from 'reducers/osrdconf/stdcmConf';
 import {
   getStdcmDestination,
+  getStdcmInfraID,
   getStdcmOrigin,
   getStdcmPathSteps,
   getStdcmProjectID,
@@ -73,7 +74,9 @@ const StdcmConfig = ({
   const { t } = useTranslation('stdcm');
   const launchButtonRef = useRef<HTMLDivElement>(null);
 
-  const { infra } = useInfraStatus();
+  const infraId = useSelector(getStdcmInfraID);
+  const { infra } = useInfraStatus({ infraId });
+
   const dispatch = useAppDispatch();
 
   const origin = useSelector(getStdcmOrigin);

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Input, ComboBox, useDefaultComboBox } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import useConsistFieldStatus from 'applications/stdcm/hooks/useConsistFieldStatus';
 import useStdcmTowedRollingStock from 'applications/stdcm/hooks/useStdcmTowedRollingStock';
@@ -21,6 +22,10 @@ import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/compon
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 import useFilterTowedRollingStock from 'modules/towedRollingStock/hooks/useFilterTowedRollingStock';
 import { updateMaxSpeed, updateTowedRollingStockID } from 'reducers/osrdconf/stdcmConf';
+import {
+  getStdcmRollingStockID,
+  getStdcmSpeedLimitByTag,
+} from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
 
 import StdcmCard from './StdcmCard';
@@ -48,13 +53,15 @@ export type StdcmConsistProps = {
 const StdcmConsist = ({ isDebugMode, disabled = false }: StdcmConsistProps) => {
   const { t } = useTranslation('stdcm');
 
-  const { speedLimitByTag, speedLimitsByTags, dispatchUpdateSpeedLimitByTag } =
-    useStoreDataForSpeedLimitByTagSelector({ isStdcm: true });
+  const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
+  const { speedLimitsByTags, dispatchUpdateSpeedLimitByTag } =
+    useStoreDataForSpeedLimitByTagSelector({ isStdcm: true, speedLimitByTag });
 
   const { updateRollingStockID } = useOsrdConfActions();
   const dispatch = useAppDispatch();
 
-  const { rollingStock } = useStoreDataForRollingStockSelector();
+  const rollingStockId = useSelector(getStdcmRollingStockID);
+  const { rollingStock } = useStoreDataForRollingStockSelector({ rollingStockId });
   const towedRollingStock = useStdcmTowedRollingStock();
 
   const [statusMessagesVisible, setStatusMessagesVisible] = useState({

--- a/front/src/applications/stdcm/components/StdcmSimulationParams.tsx
+++ b/front/src/applications/stdcm/components/StdcmSimulationParams.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import ScenarioExplorer from 'modules/scenario/components/ScenarioExplorer';
 import StdcmAllowances from 'modules/stdcmAllowances/components/StdcmAllowances';
+import { getStdcmTimetableID } from 'reducers/osrdconf/stdcmConf/selectors';
 
 import StdcmCard from './StdcmForm/StdcmCard';
 
@@ -19,6 +21,9 @@ const StdcmSimulationParams = ({
   scenarioID,
 }: StdcmSimulationParamsProps) => {
   const { t } = useTranslation('stdcm');
+
+  const timetableId = useSelector(getStdcmTimetableID);
+
   return (
     <StdcmCard name={t('debug.simulationSettings')} disabled={disabled}>
       <div className="d-flex stdcm-simulation-params">
@@ -28,6 +33,7 @@ const StdcmSimulationParams = ({
             globalStudyId={studyID}
             globalScenarioId={scenarioID}
             displayImgProject={false}
+            timetableId={timetableId}
           />
         </div>
         <div className="stdcm-allowances ml-2">

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -97,6 +97,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
   // Progressive projection of the trains
   const { projectedTrainsById, allTrainsProjected } = useLazyProjectTrains({
     infraId,
+    electricalProfileSetId,
     trainIdsToProject,
     path: stdcmResponse?.path,
     trainSchedules: formattedTrainSchedules,

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -11,7 +11,7 @@ import {
 import usePathProperties from 'modules/pathfinding/hooks/usePathProperties';
 import { getPathfindingQuery } from 'modules/pathfinding/utils';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import { getStdcmPathSteps } from 'reducers/osrdconf/stdcmConf/selectors';
+import { getStdcmPathSteps, getStdcmRollingStockID } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
 /**
@@ -26,7 +26,9 @@ function pathStepsToLocations(
 const useStaticPathfinding = (infra?: InfraWithState) => {
   const pathSteps = useSelector(getStdcmPathSteps);
   const [pathStepsLocations, setPathStepsLocations] = useState(pathStepsToLocations(pathSteps));
-  const { rollingStock } = useStoreDataForRollingStockSelector();
+
+  const rollingStockId = useSelector(getStdcmRollingStockID);
+  const { rollingStock } = useStoreDataForRollingStockSelector({ rollingStockId });
 
   const [pathfinding, setPathfinding] = useState<PathfindingResult>();
 

--- a/front/src/applications/stdcm/hooks/useStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcm.ts
@@ -68,7 +68,10 @@ const useStdcm = ({
       { skip: !osrdconf.rollingStockID }
     );
 
-  const { speedLimitByTag } = useStoreDataForSpeedLimitByTagSelector({ isStdcm: true });
+  useStoreDataForSpeedLimitByTagSelector({
+    isStdcm: true,
+    speedLimitByTag: osrdconf.speedLimitByTag,
+  });
 
   const resetStdcmState = () => {
     setStdcmTrainResult(undefined);
@@ -108,7 +111,7 @@ const useStdcm = ({
             ...response,
             rollingStock: stdcmRollingStock,
             creationDate: new Date(),
-            speedLimitByTag,
+            speedLimitByTag: osrdconf.speedLimitByTag,
             simulationPathSteps: osrdconf.stdcmPathSteps,
           } as StdcmSuccessResponse);
 
@@ -129,7 +132,7 @@ const useStdcm = ({
             ...response,
             rollingStock: stdcmRollingStock,
             creationDate: new Date(),
-            speedLimitByTag,
+            speedLimitByTag: osrdconf.speedLimitByTag,
             simulationPathSteps: osrdconf.stdcmPathSteps,
             path: response.pathfinding_result,
           } as StdcmConflictsResponse);

--- a/front/src/applications/stdcm/hooks/useStdcmForm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmForm.ts
@@ -9,6 +9,7 @@ import {
   getMaxSpeed,
   getStdcmOrigin,
   getStdcmPathSteps,
+  getStdcmRollingStockID,
   getStdcmSpeedLimitByTag,
   getTotalLength,
   getTotalMass,
@@ -25,7 +26,8 @@ const useStdcmForm = (): StdcmSimulationInputs => {
   const maxSpeed = useSelector(getMaxSpeed);
   const linkedTrains = useSelector(getLinkedTrains);
   const origin = useSelector(getStdcmOrigin);
-  const { rollingStock } = useStoreDataForRollingStockSelector();
+  const rollingStockId = useSelector(getStdcmRollingStockID);
+  const { rollingStock } = useStoreDataForRollingStockSelector({ rollingStockId });
   const towedRollingStock = useStdcmTowedRollingStock();
 
   const currentSimulationInputs = useMemo(() => {

--- a/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
+++ b/front/src/common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector.ts
@@ -2,21 +2,24 @@ import { useEffect, useMemo } from 'react';
 
 import { compact, concat, uniq } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import { COMPOSITION_CODES, DEFAULT_COMPOSITION_CODE } from 'applications/stdcm/consts';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors, useOsrdConfActions, useInfraID } from 'common/osrdContext';
+import { useOsrdConfActions, useInfraID } from 'common/osrdContext';
 import { setFailure } from 'reducers/main';
 import { useAppDispatch } from 'store';
 import { castErrorToFailure } from 'utils/error';
 
-export const useStoreDataForSpeedLimitByTagSelector = ({ isStdcm } = { isStdcm: false }) => {
+export const useStoreDataForSpeedLimitByTagSelector = ({
+  isStdcm,
+  speedLimitByTag,
+}: {
+  isStdcm?: boolean;
+  speedLimitByTag: string | undefined;
+}) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
 
-  const { getSpeedLimitByTag } = useOsrdConfSelectors();
-  const speedLimitByTag = useSelector(getSpeedLimitByTag);
   const infraID = useInfraID();
 
   const { updateSpeedLimitByTag } = useOsrdConfActions();
@@ -57,7 +60,6 @@ export const useStoreDataForSpeedLimitByTagSelector = ({ isStdcm } = { isStdcm: 
   const speedLimitsByTagsOrdered = useMemo(() => speedLimitsByTags.sort(), [speedLimitsByTags]);
 
   return {
-    speedLimitByTag,
     speedLimitsByTags: speedLimitsByTagsOrdered,
     dispatchUpdateSpeedLimitByTag,
   };

--- a/front/src/common/osrdContext.tsx
+++ b/front/src/common/osrdContext.tsx
@@ -55,15 +55,6 @@ export const useOsrdConfActions = () => {
   return slice.actions as ConfSliceActions;
 };
 
-export const useOsrdConfSelectors = () => {
-  const { selectors } = useOsrdContext();
-  if (!selectors) {
-    throw new Error('OsrdContext selectors are not available');
-  }
-
-  return selectors as ConfSelectors;
-};
-
 export const useInfraID = () => {
   const { selectors } = useOsrdContext();
   if (!selectors) {

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -30,7 +30,7 @@ import Origin from './DisplayItinerary/Origin';
 import Vias from './DisplayItinerary/Vias';
 import ModalSuggestedVias from './ModalSuggestedVias';
 
-const Itinerary = () => {
+const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) => {
   const origin = useSelector(getOrigin);
   const destination = useSelector(getDestination);
   const pathSteps = useSelector(getPathSteps);
@@ -95,7 +95,7 @@ const Itinerary = () => {
   return (
     <div className="osrd-config-item">
       <div className="mb-2 d-flex">
-        <Pathfinding />
+        <Pathfinding rollingStockId={rollingStockId} />
         <button
           type="button"
           className="btn btn-sm btn-only-icon btn-white px-3 ml-2"
@@ -109,7 +109,10 @@ const Itinerary = () => {
       </div>
       {displayTypeAndPath && (
         <div className="mb-2">
-          <TypeAndPath setDisplayTypeAndPath={setDisplayTypeAndPath} />
+          <TypeAndPath
+            setDisplayTypeAndPath={setDisplayTypeAndPath}
+            rollingStockId={rollingStockId}
+          />
         </div>
       )}
       {origin && destination && (

--- a/front/src/modules/pathfinding/components/Pathfinding/Pathfinding.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/Pathfinding.tsx
@@ -8,7 +8,6 @@ import InfraLoadingState from 'applications/operationalStudies/components/Scenar
 import { useManageTrainScheduleContext } from 'applications/operationalStudies/hooks/useManageTrainScheduleContext';
 import infraLogo from 'assets/pictures/components/tracks.svg';
 import { Spinner } from 'common/Loaders';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { isPathStepInvalid } from 'modules/pathfinding/utils';
 import {
   getPathSteps,
@@ -19,16 +18,13 @@ import { conditionalStringConcat, formatKmValue } from 'utils/strings';
 
 import { InfraHardError, InfraSoftError } from './InfraError';
 
-const Pathfinding = () => {
+const Pathfinding = ({ rollingStockId }: { rollingStockId: number | undefined }) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
 
   const pathSteps = useSelector(getPathSteps);
   const hasInvalidPathStep = pathSteps.some((pathStep) => isPathStepInvalid(pathStep));
   const origin = useSelector(getOrigin, isEqual);
   const destination = useSelector(getDestination, isEqual);
-
-  const { getRollingStockID } = useOsrdConfSelectors();
-  const rollingStockId = useSelector(getRollingStockID);
 
   const {
     pathProperties,

--- a/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
+++ b/front/src/modules/pathfinding/components/Pathfinding/TypeAndPath.tsx
@@ -5,7 +5,6 @@ import { Alert, TriangleRight } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import nextId from 'react-id-generator';
-import { useSelector } from 'react-redux';
 
 import { useManageTrainScheduleContext } from 'applications/operationalStudies/hooks/useManageTrainScheduleContext';
 import type {
@@ -14,7 +13,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { MAIN_OP_CH_CODES } from 'common/Map/Search/useSearchOperationalPoint';
-import { useInfraID, useOsrdConfSelectors } from 'common/osrdContext';
+import { useInfraID } from 'common/osrdContext';
 import { useDebounce } from 'utils/helpers';
 import {
   isCursorSurroundedBySpace,
@@ -56,9 +55,10 @@ function OpTooltips({ opList }: { opList: SearchResultItemOperationalPoint[] }) 
 }
 type TypeAndPathProps = {
   setDisplayTypeAndPath: React.Dispatch<React.SetStateAction<boolean>>;
+  rollingStockId: number | undefined;
 };
 
-const TypeAndPath = ({ setDisplayTypeAndPath }: TypeAndPathProps) => {
+const TypeAndPath = ({ setDisplayTypeAndPath, rollingStockId }: TypeAndPathProps) => {
   const { launchPathfinding } = useManageTrainScheduleContext();
 
   const [inputText, setInputText] = useState('');
@@ -68,9 +68,6 @@ const TypeAndPath = ({ setDisplayTypeAndPath }: TypeAndPathProps) => {
 
   const { t: tManageTrainSchedule } = useTranslation('operationalStudies/manageTrainSchedule');
   const { t: tTypeAndPath } = useTranslation('common/typeAndPath');
-
-  const { getRollingStockID } = useOsrdConfSelectors();
-  const rollingStockId = useSelector(getRollingStockID);
 
   const [searchResults, setSearchResults] = useState<SearchResultItemOperationalPoint[]>([]);
   const [searchState, setSearch] = useState('');

--- a/front/src/modules/pathfinding/hooks/useInfraStatus.ts
+++ b/front/src/modules/pathfinding/hooks/useInfraStatus.ts
@@ -1,15 +1,8 @@
 import { useState, useEffect } from 'react';
 
-import { isEqual } from 'lodash';
-import { useSelector } from 'react-redux';
-
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 
-export default function useInfraStatus() {
-  const { getInfraID } = useOsrdConfSelectors();
-  const infraId = useSelector(getInfraID, isEqual);
-
+export default function useInfraStatus({ infraId }: { infraId: number | undefined }) {
   const [reloadInfra] = osrdEditoastApi.endpoints.postInfraByInfraIdLoad.useMutation();
 
   const [isInfraLoaded, setIsInfraLoaded] = useState(false);

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -13,7 +13,6 @@ import type {
   PostInfraByInfraIdPathPropertiesApiArg,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import {
   formatSuggestedOperationalPoints,
   getPathfindingQuery,
@@ -43,16 +42,19 @@ const initialPathfindingState = {
   isMissingParam: false,
 };
 
-const usePathfinding = (
-  setPathProperties: (pathProperties?: ManageTrainSchedulePathProperties) => void
-) => {
+const usePathfinding = ({
+  rollingStockId: currentRollingStockId,
+  setPathProperties,
+}: {
+  rollingStockId: number | undefined;
+  setPathProperties: (pathProperties?: ManageTrainSchedulePathProperties) => void;
+}) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
   const dispatch = useAppDispatch();
   const pathSteps = useSelector(getPathSteps);
   const powerRestrictions = useSelector(getPowerRestrictions);
-  const { infra, reloadCount, setIsInfraError } = useInfraStatus();
-  const { getRollingStockID } = useOsrdConfSelectors();
-  const currentRollingStockId = useSelector(getRollingStockID);
+  const { infraId, getTrackSectionsByIds } = useScenarioContext();
+  const { infra, reloadCount, setIsInfraError } = useInfraStatus({ infraId });
 
   const [pathfindingState, setPathfindingState] =
     useState<PathfindingState>(initialPathfindingState);
@@ -63,8 +65,6 @@ const usePathfinding = (
     osrdEditoastApi.endpoints.postInfraByInfraIdPathfindingBlocks.useLazyQuery();
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
-
-  const { infraId, getTrackSectionsByIds } = useScenarioContext();
 
   const setIsMissingParam = () =>
     setPathfindingState({ ...initialPathfindingState, isMissingParam: true });

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockModal.tsx
@@ -1,27 +1,28 @@
 import React, { useState, useEffect, useContext, useMemo, type MutableRefObject } from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import type { Comfort } from 'common/api/osrdEditoastApi';
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { Loader } from 'common/Loaders';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import RollingStockCard from 'modules/rollingStock/components/RollingStockCard/RollingStockCard';
 import SearchRollingStock from 'modules/rollingStock/components/RollingStockSelector/SearchRollingStock';
 import useFilterRollingStock from 'modules/rollingStock/hooks/useFilterRollingStock';
 
 type RollingStockModal = {
+  rollingStockId: number | undefined;
   ref2scroll: MutableRefObject<HTMLDivElement | null>;
   onSelectRollingStock: (rollingStockId: number, comfort: Comfort) => void;
 };
 
-function RollingStockModal({ ref2scroll, onSelectRollingStock }: RollingStockModal) {
-  const { getRollingStockID } = useOsrdConfSelectors();
-  const rollingStockID = useSelector(getRollingStockID);
+function RollingStockModal({
+  rollingStockId,
+  ref2scroll,
+  onSelectRollingStock,
+}: RollingStockModal) {
   const { t } = useTranslation(['translation', 'rollingstock']);
-  const [openRollingStockCardId, setOpenRollingStockCardId] = useState(rollingStockID);
+  const [openRollingStockCardId, setOpenRollingStockCardId] = useState(rollingStockId);
   const { closeModal } = useContext(ModalContext);
 
   const { filteredRollingStockList, filters, searchRollingStock, toggleFilter, searchIsLoading } =

--- a/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/RollingStockSelector.tsx
@@ -14,6 +14,7 @@ import {
 import RollingStockModal from 'modules/rollingStock/components/RollingStockSelector/RollingStockModal';
 
 type RollingStockProps = {
+  rollingStockId: number | undefined;
   condensed?: boolean;
   rollingStockSelected?: RollingStockWithLiveries;
   rollingStockComfort: Comfort;
@@ -22,6 +23,7 @@ type RollingStockProps = {
 };
 
 const RollingStockSelector = ({
+  rollingStockId,
   condensed,
   rollingStockSelected,
   rollingStockComfort,
@@ -33,8 +35,8 @@ const RollingStockSelector = ({
   const ref2scroll = useRef<HTMLDivElement>(null);
 
   const selectRollingStock = useCallback(
-    (rollingStockId: number, comfort: Comfort) => {
-      onSelectRollingStock(rollingStockId, comfort);
+    (newRollingStockId: number, comfort: Comfort) => {
+      onSelectRollingStock(newRollingStockId, comfort);
       closeModal();
     },
     [onSelectRollingStock]
@@ -49,7 +51,11 @@ const RollingStockSelector = ({
         data-testid="rollingstock-selector"
         onClick={() => {
           openModal(
-            <RollingStockModal ref2scroll={ref2scroll} onSelectRollingStock={selectRollingStock} />,
+            <RollingStockModal
+              rollingStockId={rollingStockId}
+              ref2scroll={ref2scroll}
+              onSelectRollingStock={selectRollingStock}
+            />,
             'lg'
           );
         }}

--- a/front/src/modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector.ts
+++ b/front/src/modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector.ts
@@ -1,12 +1,13 @@
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { getRollingStockComfort } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 
-export const useStoreDataForRollingStockSelector = () => {
-  const { getRollingStockID } = useOsrdConfSelectors();
-  const rollingStockId = useSelector(getRollingStockID);
+export const useStoreDataForRollingStockSelector = ({
+  rollingStockId,
+}: {
+  rollingStockId: number | undefined;
+}) => {
   const rollingStockComfort = useSelector(getRollingStockComfort);
 
   const { currentData: rollingStock } =

--- a/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
+++ b/front/src/modules/scenario/components/AddOrEditScenarioModal.tsx
@@ -7,10 +7,13 @@ import { useTranslation } from 'react-i18next';
 import { FaPlus } from 'react-icons/fa';
 import { GiElectric } from 'react-icons/gi';
 import { MdDescription, MdTitle } from 'react-icons/md';
-import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { osrdEditoastApi, type ScenarioPatchForm } from 'common/api/osrdEditoastApi';
+import {
+  osrdEditoastApi,
+  type ScenarioPatchForm,
+  type ScenarioResponse,
+} from 'common/api/osrdEditoastApi';
 import ChipsSNCF from 'common/BootstrapSNCF/ChipsSNCF';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
 import { ConfirmModal } from 'common/BootstrapSNCF/ModalSNCF';
@@ -20,7 +23,7 @@ import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import SelectImprovedSNCF from 'common/BootstrapSNCF/SelectImprovedSNCF';
 import TextareaSNCF from 'common/BootstrapSNCF/TextareaSNCF';
-import { useInfraID, useOsrdConfActions, useOsrdConfSelectors } from 'common/osrdContext';
+import { useInfraID, useOsrdConfActions } from 'common/osrdContext';
 import { InfraSelectorModal } from 'modules/infra/components/InfraSelector';
 import { setFailure, setSuccess } from 'reducers/main';
 import { useAppDispatch } from 'store';
@@ -41,7 +44,7 @@ export type ScenarioForm = ScenarioPatchForm & {
 
 type AddOrEditScenarioModalProps = {
   editionMode?: boolean;
-  scenario?: ScenarioForm;
+  scenario?: ScenarioResponse;
 };
 
 type createScenarioParams = {
@@ -64,8 +67,6 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const infraID = useInfraID();
-  const { getTimetableID } = useOsrdConfSelectors();
-  const timetableId = useSelector(getTimetableID);
   const { updateScenarioID } = useOsrdConfActions();
 
   const [currentScenario, setCurrentScenario] = useState<ScenarioForm>(scenario || emptyScenario);
@@ -222,7 +223,7 @@ const AddOrEditScenarioModal = ({ editionMode = false, scenario }: AddOrEditScen
         .unwrap()
         .then(() => {
           dispatch(updateScenarioID(undefined));
-          cleanScenarioLocalStorage(timetableId!);
+          cleanScenarioLocalStorage(scenario.timetable_id);
           navigate(`projects/${projectId}/studies/${studyId}`);
           closeModal();
           dispatch(

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { MdTrain } from 'react-icons/md';
-import { useSelector } from 'react-redux';
 
 import infraIcon from 'assets/pictures/components/tracks.svg';
 import scenarioIcon from 'assets/pictures/home/operationalStudies.svg';
@@ -13,7 +12,6 @@ import { getDocument } from 'common/api/documentApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { LoaderFill } from 'common/Loaders';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { getScenarioDatetimeWindow } from 'modules/scenario/helpers/utils';
 import { updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
 import { useAppDispatch } from 'store';
@@ -25,14 +23,14 @@ const ScenarioExplorer = ({
   globalStudyId,
   globalScenarioId,
   displayImgProject = true,
+  timetableId,
 }: ScenarioExplorerProps & {
   displayImgProject?: boolean;
+  timetableId: number | undefined;
 }) => {
   const { t } = useTranslation('common/scenarioExplorer');
   const dispatch = useAppDispatch();
   const { openModal } = useModal();
-  const { getTimetableID } = useOsrdConfSelectors();
-  const timetableID = useSelector(getTimetableID);
   const [imageUrl, setImageUrl] = useState<string>();
 
   const { data: projectDetails } = osrdEditoastApi.endpoints.getProjectsByProjectId.useQuery(
@@ -60,9 +58,9 @@ const ScenarioExplorer = ({
     );
 
   const { data: timetable } = osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery(
-    { timetableId: timetableID! },
+    { timetableId: timetableId! },
     {
-      skip: !timetableID,
+      skip: !timetableId,
     }
   );
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
@@ -5,10 +5,8 @@ import { Alert } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import type { OperationalPoint } from 'applications/operationalStudies/types';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import type { WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mmToKm } from 'utils/physics';
@@ -24,11 +22,9 @@ const WaypointsPanel = ({
   waypointsPanelIsOpen,
   setWaypointsPanelIsOpen,
   waypoints,
-  waypointsPanelData: { filteredWaypoints, setFilteredWaypoints, projectionPath },
+  waypointsPanelData: { filteredWaypoints, setFilteredWaypoints, projectionPath, timetableId },
 }: WaypointsPanelProps) => {
   const { t } = useTranslation();
-  const { getTimetableID } = useOsrdConfSelectors();
-  const timetableId = useSelector(getTimetableID);
 
   const modalRef = useRef<HTMLDialogElement>(null);
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -2,25 +2,27 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
 import type { OperationalPoint } from 'applications/operationalStudies/types';
 import { STDCM_TRAIN_ID } from 'applications/stdcm/consts';
 import { osrdEditoastApi, type PathProperties } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { isStation } from 'modules/pathfinding/utils';
 import type { TrainScheduleId, TrainScheduleResultWithTrainId } from 'reducers/osrdconf/types';
 import { formatTrainScheduleIdToEditoastTrainId } from 'utils/trainId';
 
-const useGetProjectedTrainOperationalPoints = (
-  trainScheduleUsedForProjection?: TrainScheduleResultWithTrainId,
-  trainIdUsedForProjection?: TrainScheduleId,
-  infraId?: number
-) => {
+const useGetProjectedTrainOperationalPoints = ({
+  infraId,
+  timetableId,
+  trainScheduleUsedForProjection,
+  trainIdUsedForProjection,
+}: {
+  infraId: number | undefined;
+  timetableId: number | undefined;
+  trainScheduleUsedForProjection?: TrainScheduleResultWithTrainId;
+  trainIdUsedForProjection?: TrainScheduleId;
+}) => {
   const { t } = useTranslation('simulation');
-  const { getTimetableID } = useOsrdConfSelectors();
-  const timetableId = useSelector(getTimetableID);
 
   const [operationalPoints, setOperationalPoints] = useState<OperationalPoint[]>([]);
   const [filteredOperationalPoints, setFilteredOperationalPoints] =

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useLazyProjectTrains.ts
@@ -1,8 +1,6 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 import { useEffect, useState, type Dispatch, type SetStateAction, useMemo, useRef } from 'react';
 
-import { useSelector } from 'react-redux';
-
 import upsertNewProjectedTrains from 'applications/operationalStudies/helpers/upsertNewProjectedTrains';
 import type { TrainSpaceTimeData } from 'applications/operationalStudies/types';
 import {
@@ -10,7 +8,6 @@ import {
   type PathfindingResultSuccess,
   type ProjectPathTrainResult,
 } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { setFailure } from 'reducers/main';
 import type {
   TrainId,
@@ -30,6 +27,7 @@ const BATCH_SIZE = 5;
 
 type useLazyLoadTrainsProp = {
   infraId?: number;
+  electricalProfileSetId: number | undefined;
   trainIdsToProject: Set<TrainId>;
   path?: PathfindingResultSuccess;
   trainSchedules?: TrainScheduleResultWithTrainId[];
@@ -46,6 +44,7 @@ type useLazyLoadTrainsProp = {
  */
 const useLazyProjectTrains = ({
   infraId,
+  electricalProfileSetId,
   trainIdsToProject,
   path,
   trainSchedules,
@@ -53,8 +52,6 @@ const useLazyProjectTrains = ({
   setTrainIdsToProject,
 }: useLazyLoadTrainsProp) => {
   const dispatch = useAppDispatch();
-  const { getElectricalProfileSetId } = useOsrdConfSelectors();
-  const electricalProfileSetId = useSelector(getElectricalProfileSetId);
 
   const [projectedTrainsById, setProjectedTrainsById] = useState<Map<TrainId, TrainSpaceTimeData>>(
     new Map()

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
@@ -3,19 +3,15 @@ import { useEffect, useRef, useState } from 'react';
 import { EyeClosed } from '@osrd-project/ui-icons';
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import type { OSRDMenuItem } from 'common/OSRDMenu';
 import type { WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
 const useWaypointMenu = (waypointsPanelData?: WaypointsPanelData) => {
-  const { filteredWaypoints, setFilteredWaypoints, projectionPath } = waypointsPanelData || {};
+  const { filteredWaypoints, setFilteredWaypoints, projectionPath, timetableId } =
+    waypointsPanelData || {};
   const { t } = useTranslation('simulation');
-
-  const { getTimetableID } = useOsrdConfSelectors();
-  const timetableId = useSelector(getTimetableID);
 
   const [activeWaypointId, setActiveWaypointId] = useState<string>();
 
@@ -59,7 +55,7 @@ const useWaypointMenu = (waypointsPanelData?: WaypointsPanelData) => {
             (waypoint) => waypoint.id !== activeWaypointId
           );
 
-          // We need to removed the id because it can change for waypoints added by map click
+          // We need to remove the id because it can change for waypoints added by map click
           const simplifiedPath = projectionPath?.map((waypoint) =>
             omit(waypoint, ['id', 'deleted'])
           );

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -42,6 +42,7 @@ export type ProjectionData = {
 };
 
 export type WaypointsPanelData = {
+  timetableId: number | undefined;
   filteredWaypoints: OperationalPoint[];
   setFilteredWaypoints: Dispatch<SetStateAction<OperationalPoint[]>>;
   projectionPath: TrainScheduleBase['path'];

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
@@ -47,7 +47,9 @@ const AddTrainScheduleButton = ({
   const { showPacedTrains } = useSelector(getUserPreferences);
 
   // TODO TS2 : remove this when rollingStockName will replace rollingStockId in the store
-  const { rollingStock } = useStoreDataForRollingStockSelector();
+  const { rollingStock } = useStoreDataForRollingStockSelector({
+    rollingStockId: simulationConf.rollingStockID,
+  });
 
   const createTrainSchedules = async () => {
     const validTrainConfig = checkCurrentConfig(simulationConf, t, dispatch, rollingStock?.name);

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/AddPathStepPopup.tsx
@@ -15,7 +15,6 @@ import { useManageTrainScheduleContext } from 'applications/operationalStudies/h
 import { useScenarioContext } from 'applications/operationalStudies/hooks/useScenarioContext';
 import type { ManageTrainSchedulePathProperties } from 'applications/operationalStudies/types';
 import { osrdEditoastApi, type OperationalPoint } from 'common/api/osrdEditoastApi';
-import { useOsrdConfSelectors } from 'common/osrdContext';
 import { setPointIti } from 'modules/trainschedule/components/ManageTrainSchedule/ManageTrainScheduleMap/setPointIti';
 import { getOrigin, getDestination } from 'reducers/osrdconf/operationalStudiesConf/selectors';
 import type { PathStep } from 'reducers/osrdconf/types';
@@ -25,20 +24,20 @@ import type { FeatureInfoClick } from '../types';
 import OperationalPointPopupDetails from './OperationalPointPopupDetails';
 
 type AddPathStepPopupProps = {
+  infraId: number | undefined;
   pathProperties?: ManageTrainSchedulePathProperties;
   featureInfoClick: FeatureInfoClick;
   resetFeatureInfoClick: () => void;
 };
 
 const AddPathStepPopup = ({
+  infraId,
   pathProperties,
   featureInfoClick,
   resetFeatureInfoClick,
 }: AddPathStepPopupProps) => {
-  const { getInfraID } = useOsrdConfSelectors();
   const { launchPathfinding } = useManageTrainScheduleContext();
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
-  const infraId = useSelector(getInfraID);
   const origin = useSelector(getOrigin);
   const destination = useSelector(getDestination);
 

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/Map.tsx
@@ -213,6 +213,7 @@ const Map = ({
       >
         {!showStdcmAssets && featureInfoClick && (
           <AddPathStepPopup
+            infraId={infraID}
             pathProperties={pathProperties}
             featureInfoClick={featureInfoClick}
             resetFeatureInfoClick={resetFeatureInfoClick}

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/hooks/useUpdateTrainSchedule.ts
@@ -41,7 +41,9 @@ const useUpdateTrainSchedule = (
   const confName = useSelector(getName);
   const simulationConf = useSelector(getOperationalStudiesConf);
   const startTime = useSelector(getStartTime);
-  const { rollingStock } = useStoreDataForRollingStockSelector();
+  const { rollingStock } = useStoreDataForRollingStockSelector({
+    rollingStockId: simulationConf.rollingStockID,
+  });
 
   return async function submitConfUpdateTrainSchedules() {
     const formattedSimulationConf = checkCurrentConfig(


### PR DESCRIPTION
This PR keeps removing selectors from the context, and is a continuation of #10853.

Details:
- In each hook or component that used `useOsrdConfSelectors` for some parts of the conf, moves these parts as props
- Updates accordingly all uses of these hooks and components
- Finally safely deletes `useOsrdConfSelectors`