### PR TITLE
front: use Duration for OsrdStdcmConfState grid margins

### DIFF
--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -7,7 +7,7 @@ import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
 import { dateTimeFormatting } from 'utils/date';
-import { Duration } from 'utils/duration';
+import type { Duration } from 'utils/duration';
 import { kmhToMs, tToKg } from 'utils/physics';
 import { minToMs } from 'utils/timeManipulation';
 
@@ -190,8 +190,8 @@ export const checkStdcmConf = (
     maxSpeed,
     towedRollingStockID,
     margin: standardAllowance,
-    gridMarginBefore: new Duration({ seconds: gridMarginBefore }),
-    gridMarginAfter: new Duration({ seconds: gridMarginAfter }),
+    gridMarginBefore,
+    gridMarginAfter,
     workScheduleGroupId,
     temporarySpeedLimitGroupId,
     electricalProfileSetId,

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -7,8 +7,9 @@ import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
 import { dateTimeFormatting } from 'utils/date';
+import { Duration } from 'utils/duration';
 import { kmhToMs, tToKg } from 'utils/physics';
-import { minToMs, sec2ms } from 'utils/timeManipulation';
+import { minToMs } from 'utils/timeManipulation';
 
 import createMargin from './createMargin';
 import { StdcmStopTypes } from '../types';
@@ -24,8 +25,8 @@ type ValidStdcmConfig = {
   totalLength?: number;
   maxSpeed?: number;
   margin?: StandardAllowance;
-  gridMarginBefore?: number;
-  gridMarginAfter?: number;
+  gridMarginBefore?: Duration;
+  gridMarginAfter?: Duration;
   workScheduleGroupId?: number;
   temporarySpeedLimitGroupId?: number;
   electricalProfileSetId?: number;
@@ -189,16 +190,13 @@ export const checkStdcmConf = (
     maxSpeed,
     towedRollingStockID,
     margin: standardAllowance,
-    gridMarginBefore,
-    gridMarginAfter,
+    gridMarginBefore: new Duration({ seconds: gridMarginBefore }),
+    gridMarginAfter: new Duration({ seconds: gridMarginAfter }),
     workScheduleGroupId,
     temporarySpeedLimitGroupId,
     electricalProfileSetId,
   };
 };
-
-const toMsOrUndefined = (value: number | undefined): number | undefined =>
-  value ? sec2ms(value) : undefined;
 
 export const formatStdcmPayload = (
   validConfig: ValidStdcmConfig
@@ -215,8 +213,8 @@ export const formatStdcmPayload = (
     max_speed: validConfig.maxSpeed ? kmhToMs(validConfig.maxSpeed) : undefined,
     total_length: validConfig.totalLength,
     steps: validConfig.path,
-    time_gap_after: toMsOrUndefined(validConfig.gridMarginBefore),
-    time_gap_before: toMsOrUndefined(validConfig.gridMarginAfter),
+    time_gap_after: validConfig.gridMarginBefore?.ms,
+    time_gap_before: validConfig.gridMarginAfter?.ms,
     work_schedule_group_id: validConfig.workScheduleGroupId,
     temporary_speed_limit_group_id: validConfig.temporarySpeedLimitGroupId,
     electrical_profile_set_id: validConfig.electricalProfileSetId,

--- a/front/src/modules/stdcmAllowances/components/StdcmAllowances.tsx
+++ b/front/src/modules/stdcmAllowances/components/StdcmAllowances.tsx
@@ -14,6 +14,7 @@ import {
 import { getMargins } from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StandardAllowance } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
+import { Duration } from 'utils/duration';
 import { convertInputStringToNumber } from 'utils/strings';
 
 const StdcmAllowances = ({ disabled = false }: { disabled?: boolean }) => {
@@ -49,11 +50,13 @@ const StdcmAllowances = ({ disabled = false }: { disabled?: boolean }) => {
             <InputSNCF
               id="standardAllowanceTypeGridMarginBefore"
               type="number"
-              value={gridMarginBefore || ''}
+              value={gridMarginBefore?.total('second') || ''}
               unit={ALLOWANCE_UNITS_KEYS.time}
               onChange={(e) =>
                 dispatch(
-                  updateGridMarginBefore(Math.abs(convertInputStringToNumber(e.target.value)))
+                  updateGridMarginBefore(
+                    new Duration({ seconds: Math.abs(convertInputStringToNumber(e.target.value)) })
+                  )
                 )
               }
               disabled={disabled}
@@ -67,11 +70,13 @@ const StdcmAllowances = ({ disabled = false }: { disabled?: boolean }) => {
             <InputSNCF
               id="standardAllowanceTypeGridMarginAfter"
               type="number"
-              value={gridMarginAfter || ''}
+              value={gridMarginAfter?.total('second') || ''}
               unit={ALLOWANCE_UNITS_KEYS.time}
               onChange={(e) =>
                 dispatch(
-                  updateGridMarginAfter(Math.abs(convertInputStringToNumber(e.target.value)))
+                  updateGridMarginAfter(
+                    new Duration({ seconds: Math.abs(convertInputStringToNumber(e.target.value)) })
+                  )
                 )
               }
               disabled={disabled}

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -37,8 +37,8 @@ export const stdcmConfInitialState: OsrdStdcmConfState = {
   ],
   margins: {
     standardAllowance: { type: 'time_per_distance', value: 4.5 },
-    gridMarginBefore: 15,
-    gridMarginAfter: 15,
+    gridMarginBefore: new Duration({ seconds: 15 }),
+    gridMarginAfter: new Duration({ seconds: 15 }),
   },
   totalMass: undefined,
   totalLength: undefined,
@@ -113,8 +113,8 @@ export const stdcmConfSlice = createSlice({
     resetMargins(state: Draft<OsrdStdcmConfState>) {
       state.margins = {
         standardAllowance: { type: 'time_per_distance', value: 4.5 },
-        gridMarginBefore: 15,
-        gridMarginAfter: 15,
+        gridMarginBefore: new Duration({ seconds: 15 }),
+        gridMarginAfter: new Duration({ seconds: 15 }),
       };
     },
     updateStandardAllowance(

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -120,7 +120,7 @@ describe('stdcmConfReducers', () => {
     });
 
     it('should handle updateGridMarginBefore', () => {
-      const newGridMarginBefore = 5;
+      const newGridMarginBefore = new Duration({ seconds: 5 });
       const store = createStore(initialStateSTDCMConfig);
       store.dispatch(updateGridMarginBefore(newGridMarginBefore));
       const state = store.getState()[stdcmConfSlice.name];
@@ -128,7 +128,7 @@ describe('stdcmConfReducers', () => {
     });
 
     it('should handle updateGridMarginAfter', () => {
-      const newGridMarginAfter = 5;
+      const newGridMarginAfter = new Duration({ seconds: 5 });
       const store = createStore(initialStateSTDCMConfig);
       store.dispatch(updateGridMarginAfter(newGridMarginAfter));
       const state = store.getState()[stdcmConfSlice.name];

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -57,8 +57,8 @@ export type OsrdStdcmConfState = OsrdConfState & {
   stdcmPathSteps: StdcmPathStep[];
   margins: {
     standardAllowance?: StandardAllowance;
-    gridMarginBefore?: number;
-    gridMarginAfter?: number;
+    gridMarginBefore?: Duration;
+    gridMarginAfter?: Duration;
   };
   totalMass?: number;
   totalLength?: number;


### PR DESCRIPTION
Improves type safety.

Part of #10915

_See individual commits._