### PR TITLE
front: fix useEffet warning in useScenarioData

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -45,13 +45,18 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
 
   const projectionPath = usePathProjection(infra);
 
-  const { data: trainSchedulesResults = [] } =
+  const { data: fetchedTrainSchedulesResults } =
     osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery(
       { timetableId: scenario?.timetable_id },
       {
         skip: !scenario,
       }
     );
+
+  const trainSchedulesResults = useMemo(
+    () => fetchedTrainSchedulesResults || [],
+    [fetchedTrainSchedulesResults]
+  );
 
   const { trainScheduleSummariesById, setTrainScheduleSummariesById, allTrainsLoaded } =
     useLazyLoadTrains({


### PR DESCRIPTION
The call to get the train schedule results was recently moved into a useQuery. By defaulting the respone with an empty array and using it in some useEffect dependencies, the useEffects were called multiple times (since the ref of the array changes at each rerender) while the endpoint was loading.

fix #10917 