### PR TITLE
front: fix operational points names display in itinerary

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/osrdToNge.ts
@@ -37,7 +37,8 @@ const executeSearch = async (
   state: MacroEditorState,
   dispatch: AppDispatch
 ): Promise<SearchResultItemOperationalPoint[]> => {
-  const searchPayload = buildOpSearchQuery(state.scenario.infra_id, state.trainSchedules);
+  const pathSteps = state.trainSchedules.flatMap((ts) => ts.path);
+  const searchPayload = buildOpSearchQuery(state.scenario.infra_id, pathSteps);
   if (!searchPayload) {
     return [];
   }

--- a/front/src/modules/operationalPoint/helpers/buildOpSearchQuery.ts
+++ b/front/src/modules/operationalPoint/helpers/buildOpSearchQuery.ts
@@ -1,18 +1,15 @@
-import type { SearchPayload, SearchQuery, TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { SearchPayload, SearchQuery } from 'common/api/osrdEditoastApi';
+import type { PathStep } from 'reducers/osrdconf/types';
 
 /**
  * Build a search query to fetch all operational points from their UICs,
  * trigrams and IDs.
  */
-const buildOpSearchQuery = (
-  infraId: number,
-  trainSchedules: TrainScheduleResult[]
-): SearchPayload | null => {
-  const pathItems = trainSchedules.map((schedule) => schedule.path).flat();
+const buildOpSearchQuery = (infraId: number, pathSteps: PathStep[]): SearchPayload | null => {
   const pathItemQueries = [];
   const pathItemSet = new Set<string>();
 
-  for (const item of pathItems) {
+  for (const item of pathSteps) {
     let query: SearchQuery;
     if ('uic' in item) {
       query = ['=', ['uic'], item.uic];

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -11,8 +11,10 @@ import type {
   PathfindingInputError,
   PathfindingResultSuccess,
   PostInfraByInfraIdPathPropertiesApiArg,
+  SearchResultItemOperationalPoint,
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import buildOpSearchQuery from 'modules/operationalPoint/helpers/buildOpSearchQuery';
 import {
   formatSuggestedOperationalPoints,
   getPathfindingQuery,
@@ -55,7 +57,6 @@ const usePathfinding = ({
   const powerRestrictions = useSelector(getPowerRestrictions);
   const { infraId, getTrackSectionsByIds } = useScenarioContext();
   const { infra, reloadCount, setIsInfraError } = useInfraStatus({ infraId });
-
   const [pathfindingState, setPathfindingState] =
     useState<PathfindingState>(initialPathfindingState);
 
@@ -65,6 +66,53 @@ const usePathfinding = ({
     osrdEditoastApi.endpoints.postInfraByInfraIdPathfindingBlocks.useLazyQuery();
   const [postPathProperties] =
     osrdEditoastApi.endpoints.postInfraByInfraIdPathProperties.useLazyQuery();
+
+  const [postSearch] = osrdEditoastApi.endpoints.postSearch.useMutation();
+
+  const fetchOperationalPoints = useCallback(
+    async (steps: PathStep[]) => {
+      if (!infraId || !steps.length) return;
+
+      const searchPayload = buildOpSearchQuery(infraId, steps);
+
+      if (!searchPayload) return;
+      let results: SearchResultItemOperationalPoint[];
+      try {
+        results = (await postSearch({
+          searchPayload,
+          pageSize: 101,
+        }).unwrap()) as SearchResultItemOperationalPoint[];
+      } catch (error) {
+        console.error('Error fetching operational points:', error);
+        return;
+      }
+
+      const updatedSteps = steps.map((step) => {
+        let matchedOp: SearchResultItemOperationalPoint | undefined;
+        // TODO we should handle the case where the step is missing a secondary_code, as a path step who doesn't specify a secondary_code matches any ch.
+        if ('uic' in step && step.uic) {
+          matchedOp = results.find(
+            (op) => op.uic === step.uic && (!step.secondary_code || op.ch === step.secondary_code)
+          );
+        } else if ('trigram' in step && step.trigram) {
+          matchedOp = results.find(
+            (op) =>
+              op.trigram === step.trigram && (!step.secondary_code || op.ch === step.secondary_code)
+          );
+        } else if ('operational_point' in step && step.operational_point) {
+          matchedOp = results.find((op) => op.obj_id === step.operational_point);
+        }
+
+        return {
+          ...step,
+          name: matchedOp?.name,
+        };
+      });
+
+      dispatch(updatePathSteps(updatedSteps));
+    },
+    [infraId]
+  );
 
   const setIsMissingParam = () =>
     setPathfindingState({ ...initialPathfindingState, isMissingParam: true });
@@ -205,6 +253,7 @@ const usePathfinding = ({
 
       if (!pathfindingInput) {
         setIsMissingParam();
+        await fetchOperationalPoints(pathSteps.filter((step) => step !== null));
         return;
       }
 


### PR DESCRIPTION
close #10117 

The title says the issue happened after a viriato import. 
In fact, it was happening with all types of files during import when the name wasn't given in the file.