### PR TITLE
editoast: doc: advertize migration with locked schema

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - "diesel migration run && exec editoast runserver"
+      - "diesel migration run --locked-schema && exec editoast runserver"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost/health" ]
       start_period: 4s

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -107,7 +107,7 @@ services:
     command:
       - /bin/sh
       - -c
-      - "diesel migration run && exec editoast runserver"
+      - "diesel migration run --locked-schema && exec editoast runserver"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8091/health" ]
       start_period: 4s

--- a/editoast/README.md
+++ b/editoast/README.md
@@ -20,7 +20,7 @@ For both tests or run:
 ```sh
 # apply database migration
 $ cargo install diesel_cli --no-default-features --features postgres
-$ diesel migration run
+$ diesel migration run --locked-schema  # avoids bumping modification date (then rebuild)
 # build the assets
 $ cargo install spreet
 $ ./assets/sprites/generate-atlas.sh
@@ -97,6 +97,13 @@ in a significant slowdown. Define this variable in your environment or in a `.en
 
 ```sh
 export OSRD_POSTGIS_IMAGE='nickblah/postgis:16-postgis-3'
+```
+
+## Editoast diesel tables model update
+
+After creating a new migration, one should update `editoast_models/src/tables.rs` with
+```sh
+$ diesel migration run  # without locking schema
 ```
 
 ## OpenApi generation

--- a/editoast/src/client/search_commands.rs
+++ b/editoast/src/client/search_commands.rs
@@ -105,8 +105,8 @@ pub fn make_search_migration(args: MakeMigrationArgs) -> Result<(), Box<dyn Erro
     println!(
         "✅ Migration {} generated!\n🚨 Don't forget to run {} or {} to apply it",
         migration.to_str().unwrap_or("<unprintable path>"),
-        "diesel migration run".bold(),
-        "diesel migration redo".bold(),
+        "diesel migration run --locked-schema".bold(),
+        "diesel migration redo --locked-schema".bold(),
     );
     Ok(())
 }

--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -79,4 +79,4 @@ docker exec "$OSRD_VALKEY" valkey-cli -p "$OSRD_VALKEY_PORT" FLUSHALL > /dev/nul
 
 echo 'Cleanup done!'
 echo "You may want to apply migrations if you don't load a backup:"
-echo "'diesel migration run --migration-dir \"$root_path/editoast/migrations\"'  # 'docker compose up editoast' does it automatically"
+echo "'diesel migration run --locked-schema --migration-dir \"$root_path/editoast/migrations\"'  # 'docker compose up editoast' does it automatically"


### PR DESCRIPTION
To be used as much as possible to avoid triggering rebuild (triggered by file's modification-date).
Should improve dev-ex.