### PR TITLE
front: fix results display when entering a scenario

### DIFF
--- a/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
+++ b/front/src/modules/simulationResult/components/SpeedSpaceChart/useSpeedSpaceChart.ts
@@ -76,7 +76,14 @@ const useSpeedSpaceChart = (
     };
 
     getPathProperties();
-  }, [pathProperties, infraId, rollingStock]);
+  }, [
+    infraId,
+    trainScheduleResult,
+    rollingStock,
+    pathfindingResult,
+    simulation?.status,
+    pathProperties,
+  ]);
 
   useEffect(() => {
     if (trainScheduleResult && rollingStock && pathfindingResult && formattedPathProperties) {


### PR DESCRIPTION
closes #10946

Some `getPathProperties` conditions were not in the useEffect depths, so changing these values did not update `trainSimulation` (which is undefined by default when entering a scenario), preventing the simulation results to be displayed
