### PR TITLE
Front: fix stdcm config crash when changing scenario in stdcm debug

### DIFF
--- a/front/src/applications/stdcm/components/StdcmSimulationParams.tsx
+++ b/front/src/applications/stdcm/components/StdcmSimulationParams.tsx
@@ -1,9 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import ScenarioExplorer from 'modules/scenario/components/ScenarioExplorer';
 import StdcmAllowances from 'modules/stdcmAllowances/components/StdcmAllowances';
-import { getStdcmTimetableID } from 'reducers/osrdconf/stdcmConf/selectors';
 
 import StdcmCard from './StdcmForm/StdcmCard';
 
@@ -22,8 +20,6 @@ const StdcmSimulationParams = ({
 }: StdcmSimulationParamsProps) => {
   const { t } = useTranslation('stdcm');
 
-  const timetableId = useSelector(getStdcmTimetableID);
-
   return (
     <StdcmCard name={t('debug.simulationSettings')} disabled={disabled}>
       <div className="d-flex stdcm-simulation-params">
@@ -33,7 +29,6 @@ const StdcmSimulationParams = ({
             globalStudyId={studyID}
             globalScenarioId={scenarioID}
             displayImgProject={false}
-            timetableId={timetableId}
           />
         </div>
         <div className="stdcm-allowances ml-2">

--- a/front/src/applications/stdcm/views/StdcmView.tsx
+++ b/front/src/applications/stdcm/views/StdcmView.tsx
@@ -6,6 +6,7 @@ import {
   type Dispatch,
   type SetStateAction,
   useMemo,
+  useCallback,
 } from 'react';
 
 import { isEqual, isNil } from 'lodash';
@@ -35,17 +36,15 @@ import useStdcmForm from '../hooks/useStdcmForm';
 import type { StdcmSimulation } from '../types';
 
 const StdcmViewContent = ({
-  loading,
-  error,
   isDebugMode,
-  onIsDebugModeToggle,
   stdcmConf,
+  showStatusBanner,
+  setShowStatusBanner,
 }: {
   stdcmConf: OsrdStdcmConfState;
-  loading?: boolean;
-  error?: Error | null;
   isDebugMode: boolean;
-  onIsDebugModeToggle: Dispatch<SetStateAction<boolean>>;
+  showStatusBanner: boolean;
+  setShowStatusBanner: Dispatch<SetStateAction<boolean>>;
 }) => {
   // TODO : refacto. state useStdcm. Maybe we can merge some state together in order to reduce the number of refresh
   const currentSimulationInputs = useStdcmForm();
@@ -54,9 +53,7 @@ const StdcmViewContent = ({
   const selectedSimulationIndex = useSelector(getSelectedSimulationIndex);
   const retainedSimulationIndex = useSelector(getRetainedSimulationIndex);
 
-  const [showStatusBanner, setShowStatusBanner] = useState(false);
   const [showBtnToLaunchSimulation, setShowBtnToLaunchSimulation] = useState(false);
-  const [showHelpModule, setShowHelpModule] = useState(false);
   const [buttonsVisible, setButtonsVisible] = useState(true);
   const [skipPathfindingStatusMessage, setSkipPathfindingStatusMessage] = useState(false);
 
@@ -118,8 +115,6 @@ const StdcmViewContent = ({
     setButtonsVisible(false);
     openNewWindow(true);
   };
-
-  const toggleHelpModule = () => setShowHelpModule((show) => !show);
 
   useEffect(() => {
     setShowBtnToLaunchSimulation(
@@ -198,60 +193,53 @@ const StdcmViewContent = ({
   }, [selectedSimulationIndex]);
 
   return (
-    <div role="button" tabIndex={0} className="stdcm" onClick={() => setShowStatusBanner(false)}>
-      <StdcmHeader
+    <div>
+      <StdcmConfig
+        isPending={isPending}
         isDebugMode={isDebugMode}
-        onDebugModeToggle={onIsDebugModeToggle}
-        toggleHelpModule={toggleHelpModule}
-        showHelpModule={showHelpModule}
+        showBtnToLaunchSimulation={showBtnToLaunchSimulation}
+        retainedSimulationIndex={retainedSimulationIndex}
+        skipPathfindingStatusMessage={skipPathfindingStatusMessage}
+        setSkipPathfindingStatusMessage={setSkipPathfindingStatusMessage}
+        launchStdcmRequest={launchStdcmRequest}
+        cancelStdcmRequest={cancelStdcmRequest}
       />
 
-      {!isNil(error) ? (
-        <StdcmEmptyConfigError />
-      ) : (
-        <div>
-          <StdcmConfig
-            isPending={isPending}
+      {showStatusBanner && <StdcmStatusBanner isFailed={isCalculationFailed} />}
+
+      {completedSimulations.length > 0 && (
+        <div ref={resultSectionRef} className="stdcm-results">
+          <StdcmResults
+            isCalculationFailed={isCalculationFailed}
             isDebugMode={isDebugMode}
-            showBtnToLaunchSimulation={showBtnToLaunchSimulation}
-            retainedSimulationIndex={retainedSimulationIndex}
-            skipPathfindingStatusMessage={skipPathfindingStatusMessage}
-            setSkipPathfindingStatusMessage={setSkipPathfindingStatusMessage}
-            launchStdcmRequest={launchStdcmRequest}
-            cancelStdcmRequest={cancelStdcmRequest}
+            onSelectSimulation={handleSelectSimulation}
+            onStartNewQuery={handleStartNewQuery}
+            onStartNewQueryWithData={handleStartNewQueryWithData}
+            buttonsVisible={buttonsVisible}
+            showStatusBanner={showStatusBanner}
           />
-
-          {showStatusBanner && <StdcmStatusBanner isFailed={isCalculationFailed} />}
-
-          {completedSimulations.length > 0 && (
-            <div ref={resultSectionRef} className="stdcm-results">
-              <StdcmResults
-                isCalculationFailed={isCalculationFailed}
-                isDebugMode={isDebugMode}
-                onSelectSimulation={handleSelectSimulation}
-                onStartNewQuery={handleStartNewQuery}
-                onStartNewQueryWithData={handleStartNewQueryWithData}
-                buttonsVisible={buttonsVisible}
-                showStatusBanner={showStatusBanner}
-              />
-            </div>
-          )}
-          <StdcmHelpModule showHelpModule={showHelpModule} toggleHelpModule={toggleHelpModule} />
         </div>
       )}
-      {loading && <LoaderFill />}
     </div>
   );
 };
 
 const StdcmView = () => {
-  const [isDebugMode, setIsDebugMode] = useState(false);
   const { loading, error, loadStdcmEnvironment } = useStdcmEnvironment();
   const stdcmConf = useSelector(getStdcmConf);
+
+  const [isDebugMode, setIsDebugMode] = useState(false);
+  const [showStatusBanner, setShowStatusBanner] = useState(false);
+  const [showHelpModule, setShowHelpModule] = useState(false);
 
   const isStdcmConfValid = useMemo(
     () => !!stdcmConf.searchDatetimeWindow && !!stdcmConf.timetableID && !!stdcmConf.infraID,
     [stdcmConf]
+  );
+
+  const toggleHelpModule = useCallback(
+    () => setShowHelpModule((show) => !show),
+    [setShowHelpModule]
   );
 
   useEffect(() => {
@@ -266,20 +254,41 @@ const StdcmView = () => {
 
   // When the STDCM environment is being loaded and the conf is not valid, we do not mount the actual STDCM
   // view content yet:
-  if (loading && !isStdcmConfValid) return null;
-
-  if (!isStdcmConfValid) {
-    throw new Error('STDCM conf is not valid.');
-  }
+  if (loading)
+    return (
+      <div role="button" tabIndex={0} className="stdcm" onClick={() => setShowStatusBanner(false)}>
+        <StdcmHeader
+          isDebugMode={isDebugMode}
+          onDebugModeToggle={setIsDebugMode}
+          toggleHelpModule={toggleHelpModule}
+          showHelpModule={showHelpModule}
+        />
+        <LoaderFill />
+        <StdcmHelpModule showHelpModule={showHelpModule} toggleHelpModule={toggleHelpModule} />
+      </div>
+    );
 
   return (
-    <StdcmViewContent
-      loading={loading}
-      error={error}
-      isDebugMode={isDebugMode}
-      onIsDebugModeToggle={setIsDebugMode}
-      stdcmConf={stdcmConf}
-    />
+    <div role="button" tabIndex={0} className="stdcm" onClick={() => setShowStatusBanner(false)}>
+      <StdcmHeader
+        isDebugMode={isDebugMode}
+        onDebugModeToggle={setIsDebugMode}
+        toggleHelpModule={toggleHelpModule}
+        showHelpModule={showHelpModule}
+      />
+
+      {!isNil(error) || !isStdcmConfValid ? (
+        <StdcmEmptyConfigError />
+      ) : (
+        <StdcmViewContent
+          isDebugMode={isDebugMode}
+          stdcmConf={stdcmConf}
+          showStatusBanner={showStatusBanner}
+          setShowStatusBanner={setShowStatusBanner}
+        />
+      )}
+      <StdcmHelpModule showHelpModule={showHelpModule} toggleHelpModule={toggleHelpModule} />
+    </div>
   );
 };
 

--- a/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
@@ -2,33 +2,36 @@ import { useContext } from 'react';
 
 import cx from 'classnames';
 
-import type {
-  ProjectWithStudies,
-  ScenarioWithDetails,
-  StudyWithScenarios,
+import {
+  osrdEditoastApi,
+  type ProjectWithStudies,
+  type ScenarioWithDetails,
+  type StudyWithScenarios,
 } from 'common/api/osrdEditoastApi';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
-import { useOsrdConfActions } from 'common/osrdContext';
+import { getScenarioDatetimeWindow } from 'modules/scenario/helpers/utils';
+import { updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
 import { useAppDispatch } from 'store';
 
 import Project2Image from './ScenarioExplorerProject2Image';
 
 type MiniCardProps = {
   isSelected?: boolean;
-  setSelectedID: (arg0?: number) => void;
 };
 
-interface MiniCardProjectProps extends MiniCardProps {
+type MiniCardProjectProps = MiniCardProps & {
   project: ProjectWithStudies;
-}
-interface MiniCardStudyProps extends MiniCardProps {
+  setSelectedID: (id: number) => void;
+};
+type MiniCardStudyProps = MiniCardProps & {
   study: StudyWithScenarios;
-}
-interface MiniCardScenarioProps extends MiniCardProps {
+  setSelectedID: (id: number) => void;
+};
+type MiniCardScenarioProps = MiniCardProps & {
   scenario: ScenarioWithDetails;
   projectID: number;
   studyID: number;
-}
+};
 
 export const ProjectMiniCard = ({ project, setSelectedID, isSelected }: MiniCardProjectProps) => (
   <div
@@ -71,24 +74,38 @@ export const StudyMiniCard = ({ study, setSelectedID, isSelected }: MiniCardStud
 
 export const ScenarioMiniCard = ({
   scenario,
-  setSelectedID,
   isSelected,
   projectID,
   studyID,
 }: MiniCardScenarioProps) => {
   const dispatch = useAppDispatch();
   const { closeModal } = useContext(ModalContext);
-  const { updateInfraID, updateProjectID, updateScenarioID, updateStudyID, updateTimetableID } =
-    useOsrdConfActions();
-  const selectScenario = () => {
-    setSelectedID(scenario.id);
-    dispatch(updateProjectID(projectID));
-    dispatch(updateStudyID(studyID));
-    dispatch(updateScenarioID(scenario.id));
-    dispatch(updateInfraID(scenario.infra_id));
-    dispatch(updateTimetableID(scenario.timetable_id));
+
+  const [getTimetableTrainSchedules] =
+    osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useLazyQuery();
+
+  const selectScenario = async () => {
+    const trainSchedules = await getTimetableTrainSchedules({
+      timetableId: scenario.timetable_id,
+    }).unwrap();
+
+    const scenarioDateTimeWindow = getScenarioDatetimeWindow(trainSchedules);
+
+    dispatch(
+      updateStdcmEnvironment({
+        infraID: scenario.infra_id,
+        timetableID: scenario.timetable_id,
+        electricalProfileSetId: scenario.electrical_profile_set_id,
+        searchDatetimeWindow: scenarioDateTimeWindow,
+        projectID,
+        studyID,
+        scenarioID: scenario.id,
+      })
+    );
+
     closeModal();
   };
+
   return (
     <div
       className={cx('minicard', 'scenario', {

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -12,9 +12,6 @@ import { getDocument } from 'common/api/documentApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
 import { LoaderFill } from 'common/Loaders';
-import { getScenarioDatetimeWindow } from 'modules/scenario/helpers/utils';
-import { updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
-import { useAppDispatch } from 'store';
 
 import ScenarioExplorerModal, { type ScenarioExplorerProps } from './ScenarioExplorerModal';
 
@@ -23,13 +20,10 @@ const ScenarioExplorer = ({
   globalStudyId,
   globalScenarioId,
   displayImgProject = true,
-  timetableId,
 }: ScenarioExplorerProps & {
   displayImgProject?: boolean;
-  timetableId: number | undefined;
 }) => {
   const { t } = useTranslation('common/scenarioExplorer');
-  const dispatch = useAppDispatch();
   const { openModal } = useModal();
   const [imageUrl, setImageUrl] = useState<string>();
 
@@ -57,13 +51,6 @@ const ScenarioExplorer = ({
       }
     );
 
-  const { data: timetable } = osrdEditoastApi.endpoints.getAllTimetableByIdTrainSchedules.useQuery(
-    { timetableId: timetableId! },
-    {
-      skip: !timetableId,
-    }
-  );
-
   const getProjectImage = async (imageId: number) => {
     try {
       const blobImage = await getDocument(imageId);
@@ -72,22 +59,6 @@ const ScenarioExplorer = ({
       console.error(error);
     }
   };
-
-  useEffect(() => {
-    if (scenario && timetable) {
-      const scenarioDateTimeWindow = getScenarioDatetimeWindow(timetable);
-
-      // We also set the stdcm environment in case we select a scenario from the stdcm interface.
-      dispatch(
-        updateStdcmEnvironment({
-          infraID: scenario.infra_id,
-          timetableID: scenario.timetable_id,
-          electricalProfileSetId: scenario.electrical_profile_set_id,
-          searchDatetimeWindow: scenarioDateTimeWindow,
-        })
-      );
-    }
-  }, [timetable]);
 
   useEffect(() => {
     if (projectDetails?.image) {
@@ -161,7 +132,7 @@ const ScenarioExplorer = ({
                 </span>
 
                 <span className="scenario-explorator-card-head-scenario-traincount">
-                  {timetable && timetable.length}
+                  {scenario.trains_count}
                   <MdTrain />
                 </span>
               </div>

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorer.tsx
@@ -74,7 +74,7 @@ const ScenarioExplorer = ({
   };
 
   useEffect(() => {
-    if (scenario) {
+    if (scenario && timetable) {
       const scenarioDateTimeWindow = getScenarioDatetimeWindow(timetable);
 
       // We also set the stdcm environment in case we select a scenario from the stdcm interface.
@@ -87,7 +87,7 @@ const ScenarioExplorer = ({
         })
       );
     }
-  }, [scenario, timetable]);
+  }, [timetable]);
 
   useEffect(() => {
     if (projectDetails?.image) {

--- a/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/ScenarioExplorerModal.tsx
@@ -34,9 +34,8 @@ const ScenarioExplorerModal = ({
   const { t } = useTranslation('common/scenarioExplorer');
   const dispatch = useAppDispatch();
 
-  const [projectID, setProjectID] = useState<number | undefined>(globalProjectId);
-  const [studyID, setStudyID] = useState<number | undefined>(globalStudyId);
-  const [scenarioID, setScenarioID] = useState<number | undefined>(globalScenarioId);
+  const [projectID, setProjectID] = useState(globalProjectId);
+  const [studyID, setStudyID] = useState(globalStudyId);
   const [studiesList, setStudiesList] = useState<StudyWithScenarios[]>();
   const [scenariosList, setScenariosList] = useState<ScenarioWithDetails[]>();
 
@@ -173,8 +172,7 @@ const ScenarioExplorerModal = ({
                   scenariosList.map((scenario) => (
                     <ScenarioMiniCard
                       scenario={scenario}
-                      setSelectedID={setScenarioID}
-                      isSelected={scenario.id === scenarioID}
+                      isSelected={scenario.id === globalScenarioId}
                       projectID={projectID}
                       studyID={studyID}
                       key={`scenario-explorator-modal-${scenario.id}`}

--- a/front/src/modules/scenario/helpers/__tests__/scenario.spec.ts
+++ b/front/src/modules/scenario/helpers/__tests__/scenario.spec.ts
@@ -7,7 +7,11 @@ import { getScenarioDatetimeWindow } from '../utils';
 describe('getScenarioDatetimeWindow', () => {
   it('should return undefined if trainsDetails is empty', () => {
     const result = getScenarioDatetimeWindow([]);
-    expect(result).toBeUndefined();
+    const expected = {
+      begin: new Date(new Date().setHours(0, 0, 0, 0)),
+      end: new Date(new Date().setHours(23, 59, 59, 999)),
+    };
+    expect(result).toEqual(expected);
   });
 
   it('should return the correct begin and end dates', () => {

--- a/front/src/modules/scenario/helpers/utils.ts
+++ b/front/src/modules/scenario/helpers/utils.ts
@@ -9,8 +9,14 @@ import type { ScenarioForm } from '../components/AddOrEditScenarioModal';
  * @param trainsDetails - An array of TrainScheduleResult objects containing train details.
  * @returns An object representing the datetime window of the scenario, with `begin` and `end` properties.
  */
-export const getScenarioDatetimeWindow = (trainsDetails: TrainScheduleResult[] = []) => {
-  if (trainsDetails.length === 0) return undefined;
+export const getScenarioDatetimeWindow = (trainsDetails: TrainScheduleResult[]) => {
+  if (trainsDetails.length === 0) {
+    return {
+      begin: new Date(new Date().setHours(0, 0, 0, 0)),
+      end: new Date(new Date().setHours(23, 59, 59, 999)),
+    };
+  }
+
   const sortedDateList = trainsDetails
     .map((train) => new Date(train.start_time))
     .sort((a, b) => a.getTime() - b.getTime());

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -145,7 +145,10 @@ export const stdcmConfSlice = createSlice({
           | 'electricalProfileSetId'
           | 'workScheduleGroupId'
           | 'temporarySpeedLimitGroupId'
-          | 'searchDatetimeWindow',
+          | 'searchDatetimeWindow'
+          | 'projectID'
+          | 'studyID'
+          | 'scenarioID',
           'infraID' | 'timetableID'
         >
       >
@@ -157,6 +160,10 @@ export const stdcmConfSlice = createSlice({
       state.searchDatetimeWindow = searchDatetimeWindow;
       state.workScheduleGroupId = action.payload.workScheduleGroupId;
       state.temporarySpeedLimitGroupId = action.payload.temporarySpeedLimitGroupId;
+
+      state.projectID = action.payload.projectID;
+      state.studyID = action.payload.studyID;
+      state.scenarioID = action.payload.scenarioID;
 
       // check that the arrival dates are in the search time window
       const origin = state.stdcmPathSteps.at(0) as Extract<StdcmPathStep, { isVia: false }>;


### PR DESCRIPTION
closes #10973

Thanks to the first commit, from now on, if a user selects an empty timetable in STDCM, then he will be able to request a train with a departure within the current day.