### PR TITLE
editoast: integrate `MqClientError` into `CoreError`

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4643,6 +4643,25 @@ components:
           type: string
           enum:
           - editoast:coreclient:GenericCoreError
+    EditoastCoreErrorMqClientError:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:coreclient:MqClientError
     EditoastCoreErrorUnparsableErrorOutput:
       type: object
       required:
@@ -4874,6 +4893,7 @@ components:
       - $ref: '#/components/schemas/EditoastCoreErrorConnectionResetByPeer'
       - $ref: '#/components/schemas/EditoastCoreErrorCoreResponseFormatError'
       - $ref: '#/components/schemas/EditoastCoreErrorGenericCoreError'
+      - $ref: '#/components/schemas/EditoastCoreErrorMqClientError'
       - $ref: '#/components/schemas/EditoastCoreErrorUnparsableErrorOutput'
       - $ref: '#/components/schemas/EditoastDatabaseAccessErrorDatabaseAccessError'
       - $ref: '#/components/schemas/EditoastDelimitedAreaErrorInvalidLocations'
@@ -4897,12 +4917,6 @@ components:
       - $ref: '#/components/schemas/EditoastListErrorsRailjsonWrongRailjsonVersionProvided'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
       - $ref: '#/components/schemas/EditoastModelError'
-      - $ref: '#/components/schemas/EditoastMqClientErrorConnectionDoesNotExist'
-      - $ref: '#/components/schemas/EditoastMqClientErrorLapin'
-      - $ref: '#/components/schemas/EditoastMqClientErrorPoolChannelFail'
-      - $ref: '#/components/schemas/EditoastMqClientErrorResponseTimeout'
-      - $ref: '#/components/schemas/EditoastMqClientErrorSerialization'
-      - $ref: '#/components/schemas/EditoastMqClientErrorStatusParsing'
       - $ref: '#/components/schemas/EditoastNoSuchUserErrorNoSuchUser'
       - $ref: '#/components/schemas/EditoastOperationErrorEmptyId'
       - $ref: '#/components/schemas/EditoastOperationErrorInvalidPatch'
@@ -5291,120 +5305,6 @@ components:
           type: string
           enum:
           - editoast:model:ModelError
-    EditoastMqClientErrorConnectionDoesNotExist:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:ConnectionDoesNotExist
-    EditoastMqClientErrorLapin:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:Lapin
-    EditoastMqClientErrorPoolChannelFail:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:PoolChannelFail
-    EditoastMqClientErrorResponseTimeout:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:ResponseTimeout
-    EditoastMqClientErrorSerialization:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:Serialization
-    EditoastMqClientErrorStatusParsing:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:StatusParsing
     EditoastNoSuchUserErrorNoSuchUser:
       type: object
       required:

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -17,6 +17,7 @@ use std::marker::PhantomData;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use editoast_derive::EditoastError;
+use mq_client::MqClientError;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
@@ -48,7 +49,9 @@ pub enum CoreClient {
 
 impl CoreClient {
     pub async fn new_mq(options: mq_client::Options) -> Result<Self> {
-        let client = RabbitMQClient::new(options).await?;
+        let client = RabbitMQClient::new(options)
+            .await
+            .map_err(CoreError::MqClientError)?;
 
         Ok(Self::MessageQueue(client))
     }
@@ -109,7 +112,8 @@ impl CoreClient {
 
                 let response = client
                     .call_with_response(infra_id.to_string(), path, &body, true, None)
-                    .await?;
+                    .await
+                    .map_err(CoreError::MqClientError)?;
 
                 if response.status == b"ok" {
                     return R::from_bytes(&response.payload);
@@ -285,6 +289,10 @@ pub enum CoreError {
     #[error("Core connection broken. Should retry.")]
     #[editoast_error(status = 500)]
     BrokenPipe,
+
+    #[error(transparent)]
+    #[editoast_error(status = "500")]
+    MqClientError(MqClientError),
 
     #[cfg(test)]
     #[error("The mocked response had no body configured - check out StubResponseBuilder::body if this is unexpected")]

--- a/editoast/src/core/mq_client.rs
+++ b/editoast/src/core/mq_client.rs
@@ -1,5 +1,4 @@
 use deadpool::managed::{Manager, Metrics, Pool, RecycleError, RecycleResult};
-use editoast_derive::EditoastError;
 use futures_util::StreamExt;
 use itertools::Itertools;
 use lapin::{
@@ -161,26 +160,19 @@ pub struct Options {
     pub num_channels: usize,
 }
 
-#[derive(Debug, Error, EditoastError)]
-#[editoast_error(base_id = "coreclient")]
+#[derive(Debug, Error)]
 pub enum MqClientError {
     #[error("AMQP error: {0}")]
-    #[editoast_error(status = "500")]
     Lapin(#[from] lapin::Error),
     #[error("Cannot serialize request: {0}")]
-    #[editoast_error(status = "500")]
     Serialization(serde_json::Error),
     #[error("Cannot parse response status")]
-    #[editoast_error(status = "500")]
     StatusParsing,
     #[error("Response timeout")]
-    #[editoast_error(status = "500")]
     ResponseTimeout,
     #[error("Connection does not exist")]
-    #[editoast_error(status = "500")]
     ConnectionDoesNotExist,
     #[error("Fail to pool a channel")]
-    #[editoast_error(status = "500")]
     PoolChannelFail,
 }
 

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -42,13 +42,8 @@
       "ConnectionResetByPeer": "Core connection reset by peer. Should retry.",
       "CoreResponseFormatError": "Cannot parse Core response: {{msg}}",
       "GenericCoreError": "Core error {{raw_error}}",
-      "Lapin": "Core: message queue: protocol error",
-      "ResponseTimeout": "Core: request timeout",
-      "Serialization": "Core: cannot serialize request",
-      "StatusParsing": "Core: cannot parse status",
       "UnparsableErrorOutput": "Core returned an error in an unknown format",
-      "ConnectionDoesNotExist": "Core: message queue: connection not established",
-      "PoolChannelFail": "Core: message queue: channel failure"
+      "MqClientError": "Core: MQ client error"
     },
     "DatabaseAccessError": "Database access fatal error",
     "delimited_area": {

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -42,13 +42,8 @@
       "ConnectionResetByPeer": "Core: réinitialisation de la connexion. Nouvelle tentative.",
       "CoreResponseFormatError": "Core: impossible d'analyser la réponse '{{msg}}'",
       "GenericCoreError": "Core: erreur {{raw_error}}",
-      "Lapin": "Core: file d'attente de messages: erreur de protocole",
-      "ResponseTimeout": "Core: temps d'attente écoulé",
-      "Serialization": "Core: impossible de sérialiser la requête",
-      "StatusParsing": "Core: impossible d'obtenir le status",
       "UnparsableErrorOutput": "Core: a renvoyé une erreur dans un format inconnu",
-      "ConnectionDoesNotExist": "Core: file d'attente de messages: connexion non établie",
-      "PoolChannelFail": "Core: file d'attente de messages: erreur de pool des channels rabbitmq"
+      "MqClientError": "Core: erreur du client MQ"
     },
     "delimited_area": {
       "InvalidLocations": "Certaines localisations sont invalides"


### PR DESCRIPTION
Refactor `MqClientError`: Remove `EditoastError` derive and integrate it into `CoreError`.