### PR TITLE
editoast: be able to delete tuples on openfga client

### DIFF
--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -246,6 +246,9 @@ impl Client {
     /// If the tuple slice is more than 100 elements, an error will be returned.
     /// If you want them to be chunked into several requests, or if your tuples cannot
     /// be monomorphized into a single type, use [Client::prepare_writes] instead.
+    ///
+    /// Warning: just like OpenFGA's Write API, this function is **not** idempotent.
+    /// If a tuple is written twice, the second write will fail.
     pub async fn write_tuples<'a, R: Relation, U: AsUser<User = R::User>>(
         &self,
         tuples: &[Tuple<'a, R, U>],
@@ -278,9 +281,60 @@ impl Client {
     /// after a [PreparedWrites::push]. So any form of post-processing is impossible.
     /// Likewise, once a [Tuple] is injected into [PreparedWrites], all its typing information
     /// is lost.
+    ///
+    /// Like [Client::write_tuples], this function is not idempotent.
     pub fn prepare_writes(&self) -> PreparedWrites<'_> {
         PreparedWrites {
             writes: Vec::new(),
+            client: self,
+        }
+    }
+
+    /// Deletes up to 100 tuples in OpenFGA
+    ///
+    /// If the tuple slice is more than 100 elements, an error will be returned.
+    /// If you want them to be chunked into several requests, or if your tuples cannot
+    /// be monomorphized into a single type, use [Client::prepare_deletes] instead.
+    ///
+    /// Warning: just like OpenFGA's Write API, this function is **not** idempotent.
+    /// If a tuple is deleted twice, the second delete will fail.
+    pub async fn delete_tuples<'a, R: Relation, U: AsUser<User = R::User>>(
+        &self,
+        tuples: &[Tuple<'a, R, U>],
+    ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
+        if tuples.len() > OPENFGA_WRITES_MAX_TUPLES {
+            return Err(Either::Right(TooManyTuples {
+                max: OPENFGA_WRITES_MAX_TUPLES,
+                provided_count: tuples.len(),
+            }));
+        }
+        self.post_stores_write(
+            &self.store.id,
+            &[],
+            &tuples.into_iter().map_into().collect::<Vec<_>>(),
+            self.authorization_model_id.clone(),
+        )
+        .await
+        .map_err(Either::Left)
+    }
+
+    /// Prepares multiple delete requests to OpenFGA
+    ///
+    /// OpenFGA Writes API do not accept more than 100 tuples per request.
+    /// The [PreparedDeletes] type returned by this function accepts any number
+    /// of tuples through [PreparedDeletes::push] and will chunk them into
+    /// requests of 100 tuples each. The requests are sent concurrently when
+    /// [PreparedDeletes::execute] is called.
+    ///
+    /// Beware that the tuples injected into [PreparedDeletes] cannot be accessed
+    /// after a [PreparedDeletes::push]. So any form of post-processing is impossible.
+    /// Likewise, once a [Tuple] is injected into [PreparedDeletes], all its typing information
+    /// is lost.
+    ///
+    /// Like [Client::delete_tuples], this function is not idempotent.
+    pub fn prepare_deletes(&self) -> PreparedDeletes<'_> {
+        PreparedDeletes {
+            deletes: Vec::new(),
             client: self,
         }
     }
@@ -469,6 +523,46 @@ impl PreparedWrites<'_> {
                         &self.client.store.id,
                         chunk,
                         &[],
+                        self.client.authorization_model_id.clone(),
+                    )
+                    .in_current_span()
+            })
+            .collect_vec();
+        futures::future::try_join_all(futs).await?;
+        Ok(())
+    }
+}
+
+pub struct PreparedDeletes<'a> {
+    deletes: Vec<RawTuple>,
+    client: &'a Client,
+}
+
+impl PreparedDeletes<'_> {
+    pub fn push<'a, R: Relation, U: AsUser<User = R::User>>(
+        mut self,
+        tuple: &Tuple<'_, R, U>,
+    ) -> Self {
+        self.deletes.push(RawTuple::from(tuple));
+        self
+    }
+
+    /// Concurrently sends delete requests to OpenFGA in 100-tuple chunks
+    ///
+    /// /!\ WARNING /!\ No transactional state is set up, so should any request fail,
+    /// the tuples deleted by other successful requests will remain deleted in OpenFGA.
+    /// This function also returns at the first failing request, so OpenFGA may still
+    /// delete some tuples **after** this function exits.
+    pub async fn execute(self) -> Result<(), RequestFailure> {
+        let futs = self
+            .deletes
+            .chunks(100)
+            .map(|chunk| {
+                self.client
+                    .post_stores_write(
+                        &self.client.store.id,
+                        &[],
+                        chunk,
                         self.client.authorization_model_id.clone(),
                     )
                     .in_current_span()
@@ -1001,5 +1095,60 @@ mod tests {
             groups,
             vec![fga!(Group:"company"), fga!(Group:"competitor")]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_tuples() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .write_tuples(&[
+                fga!(Infra:"france"#reader@User:"alice"),
+                fga!(Infra:"espagne"#reader@User:"bob"),
+            ])
+            .await
+            .unwrap();
+
+        client
+            .delete_tuples(&[fga!(Infra:"france"#reader@User:"alice")])
+            .await
+            .unwrap();
+
+        client
+            .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
+            .assert_check(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"espagne")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn prepare_deletes() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+
+        client
+            .write_tuples(&[
+                fga!(Infra:"france"#reader@User:"alice"),
+                fga!(Infra:"espagne"#reader@User:"bob"),
+                fga!(Infra:"germany"#reader@User:"charlie"),
+            ])
+            .await
+            .unwrap();
+
+        client
+            .prepare_deletes()
+            .push(&fga!(Infra:"france"#reader@User:"alice"))
+            .push(&fga!(Infra:"espagne"#reader@User:"bob"))
+            .execute()
+            .await
+            .unwrap();
+
+        client
+            .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
+            .assert_check_not(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"espagne")))
+            .assert_check(Infra::can_read().check(&fga!(User:"charlie"), &fga!(Infra:"germany")));
     }
 }


### PR DESCRIPTION
Following the work on PR #10504

This PR add the ability to delete a tuple in openfga. 