### PR TITLE
core: fix typing issues around path fragment stop offsets

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
@@ -13,10 +13,18 @@ import fr.sncf.osrd.utils.units.meters
 
 data class PathStop(val pathOffset: Offset<Path>, val receptionSignal: RJSReceptionSignal)
 
+// Used to type offsets that use as reference the start of the first block on a given path fragment
+sealed interface FragmentBlocks
+
+data class FragmentStop(
+    val fragmentOffset: Offset<FragmentBlocks>,
+    val receptionSignal: RJSReceptionSignal
+)
+
 class PathFragment(
     val routes: StaticIdxList<Route>,
     val blocks: StaticIdxList<Block>,
-    val stops: List<PathStop>,
+    val stops: List<FragmentStop>,
     val containsStart: Boolean,
     val containsEnd: Boolean,
 
@@ -212,7 +220,7 @@ private class IncrementalPathImpl(
         }
 
         for (stop in fragment.stops) {
-            val offset = fragmentStartOffset + stop.pathOffset.distance
+            val offset = fragmentStartOffset + stop.fragmentOffset.distance
             stops.add(IncrementalStop(offset, stop.receptionSignal))
         }
 

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -201,11 +201,17 @@ fun run(
                 it.receptionSignal
             )
         }
+    val fragmentStops =
+        pathStops.map {
+            // All blocks are in the fragment, Offset<Path> == Offset<FragmentBlocks> here
+            val fragmentOffset = it.pathOffset.cast<FragmentBlocks>()
+            FragmentStop(fragmentOffset, it.receptionSignal)
+        }
     incrementalPath.extend(
         PathFragment(
             routePath,
             blockPath,
-            pathStops,
+            fragmentStops,
             containsStart = true,
             containsEnd = true,
             startOffset,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -100,6 +100,12 @@ fun runScheduleMetadataExtractor(
         schedule.map {
             PathStop(pathOffsetBuilder.fromTravelledPath(it.pathOffset), it.receptionSignal)
         }
+    val fragmentStops =
+        pathStops.map {
+            // All blocks are in the fragment, Offset<Path> == Offset<FragmentBlocks> here
+            val fragmentOffset = it.pathOffset.cast<FragmentBlocks>()
+            FragmentStop(fragmentOffset, it.receptionSignal)
+        }
     val closedSignalStops = pathStops.filter { it.receptionSignal.isStopOnClosedSignal }
 
     val signalCriticalPositions = mutableListOf<SignalCriticalPosition>()
@@ -186,7 +192,7 @@ fun runScheduleMetadataExtractor(
         PathFragment(
             routePath,
             blockPath,
-            pathStops,
+            fragmentStops,
             containsStart = true,
             containsEnd = true,
             startOffset,

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -1,9 +1,10 @@
 package fr.sncf.osrd.stdcm.infra_exploration
 
 import fr.sncf.osrd.api.pathfinding.makePathProps
+import fr.sncf.osrd.conflicts.FragmentBlocks
+import fr.sncf.osrd.conflicts.FragmentStop
 import fr.sncf.osrd.conflicts.IncrementalPath
 import fr.sncf.osrd.conflicts.PathFragment
-import fr.sncf.osrd.conflicts.PathStop
 import fr.sncf.osrd.conflicts.incrementalPathOf
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
@@ -377,8 +378,8 @@ private class InfraExplorerImpl(
         block: StaticIdx<Block>,
         travelledPathBeginBlockOffset: Offset<Block>,
         travelledPathEndBlockOffset: Offset<Block>
-    ): List<PathStop> {
-        val pathStops = mutableListOf<PathStop>()
+    ): List<FragmentStop> {
+        val blockStops = mutableListOf<FragmentStop>()
         for (stop in stops) {
             for (location in stop) {
                 val isIncluded =
@@ -386,11 +387,14 @@ private class InfraExplorerImpl(
                         location.offset in
                             travelledPathBeginBlockOffset..travelledPathEndBlockOffset
                 if (isIncluded) {
-                    pathStops.add(PathStop(location.offset.cast(), SHORT_SLIP_STOP))
+                    // There's only one block in the fragment, Offset<FragmentBlocks> ==
+                    // Offset<Block> here
+                    val fragmentOffset = location.offset.cast<FragmentBlocks>()
+                    blockStops.add(FragmentStop(fragmentOffset, SHORT_SLIP_STOP))
                 }
             }
         }
-        return pathStops
+        return blockStops
     }
 
     override fun toString(): String {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerTests.kt
@@ -368,6 +368,76 @@ class InfraExplorerTests {
         assertEquals(2, extended.size) // Two routes start there (a1->b1 and a1->b2)
     }
 
+    @Test
+    fun testStops() {
+        /*
+        a --> b --> c --> d --> e
+          [                  ]         path
+          ^     ^   ^        ^         stops
+         */
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b"),
+                infra.addBlock("b", "c"),
+                infra.addBlock("c", "d"),
+                infra.addBlock("d", "e"),
+            )
+
+        var explorer =
+            initInfraExplorer(
+                    infra,
+                    infra,
+                    PathfindingEdgeLocationId(blocks[0], Offset(50.meters)),
+                    listOf(
+                        setOf(PathfindingEdgeLocationId(blocks[0], Offset(50.meters))),
+                        setOf(PathfindingEdgeLocationId(blocks[1], Offset(50.meters))),
+                        setOf(PathfindingEdgeLocationId(blocks[2], Offset(0.meters))),
+                        setOf(PathfindingEdgeLocationId(blocks[3], Offset(50.meters))),
+                    )
+                )
+                .single()
+        while (true) explorer = explorer.cloneAndExtendLookahead().firstOrNull() ?: break
+
+        val incrementalPath = explorer.getIncrementalPath()
+        assertEquals(4, incrementalPath.stopCount)
+        assertEquals(Offset(50.meters), incrementalPath.getStopOffset(0))
+        assertEquals(Offset(150.meters), incrementalPath.getStopOffset(1))
+        assertEquals(Offset(200.meters), incrementalPath.getStopOffset(2))
+        assertEquals(Offset(350.meters), incrementalPath.getStopOffset(3))
+    }
+
+    /** Similar test to the one above, but not starting on the first block on the route */
+    @Test
+    fun testStopsLongerRoute() {
+        val infra =
+            Helpers.fullInfraFromRJS(Helpers.getExampleInfra("overlapping_routes/infra.json"))
+        val detector =
+            infra.rawInfra.detectors.first { det ->
+                infra.rawInfra.getDetectorName(det) == "det.center.2"
+            }
+        val block =
+            infra.blockInfra
+                .getBlocksStartingAtDetector(DirDetectorId(detector, Direction.INCREASING))
+                .single()
+
+        // block 1->2, lookahead 2->3->bx
+        var explorers =
+            initInfraExplorer(
+                    infra.rawInfra,
+                    infra.blockInfra,
+                    PathfindingEdgeLocationId(block, Offset(32.meters)),
+                    listOf(setOf(PathfindingEdgeLocationId(block, Offset(42.meters))))
+                )
+                .first()
+        val incrementalPath = explorers.getIncrementalPath()
+        assertEquals(1, incrementalPath.stopCount)
+        assertEquals(
+            Offset(10.meters),
+            incrementalPath.toTravelledPath(incrementalPath.getStopOffset(0))
+        )
+    }
+
     private fun <T> allEqual(list: List<T>): Boolean {
         for (i in 1 ..< list.size) {
             if (list[0] != list[i]) return false


### PR DESCRIPTION
It was typed as an `Offset<Path>`, but it's only true in some contexts. It has its own offset type.

That was a fun one, chasing bugs that actually aren't there.