### PR TITLE
front: bump playwright from 1.43.1 to 1.50.1

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -100,7 +100,7 @@
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.50.1",
         "@rtk-query/codegen-openapi": "^2.0.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
@@ -2288,19 +2288,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
-      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.43.1"
+        "playwright": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@react-pdf/fns": {
@@ -15611,35 +15611,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/front/package.json
+++ b/front/package.json
@@ -96,7 +96,7 @@
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",
-    "@playwright/test": "^1.41.2",
+    "@playwright/test": "^1.50.1",
     "@rtk-query/codegen-openapi": "^2.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.2.0",

--- a/front/tests/assets/constants/project-const.ts
+++ b/front/tests/assets/constants/project-const.ts
@@ -1,3 +1,4 @@
+export const BASE_URL = 'http://localhost:4000';
 export const electricRollingStockName = 'ELECTRIC_RS_E2E';
 export const dualModeRollingStockName = 'DUAL-MODE_RS_E2E';
 export const slowRollingStockName = 'SLOW_RS_E2E';

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -25,6 +25,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 
 import {
+  BASE_URL,
   globalProjectName,
   globalStudyName,
   infrastructureName,
@@ -39,7 +40,7 @@ import readJsonFile from './file-utils';
  */
 export const getApiContext = async (): Promise<APIRequestContext> =>
   request.newContext({
-    baseURL: 'http://localhost:4000',
+    baseURL: BASE_URL,
   });
 
 /**
@@ -98,16 +99,19 @@ export const postApiRequest = async <T, U>(
  * Send a DELETE request to the specified API endpoint.
  *
  * @param url - The API endpoint URL.
- * @returns {Promise<APIResponse>} - The response from the API.
+ * @returns {Promise<Response>} - The API response.
  */
-export const deleteApiRequest = async (
-  url: string,
-  errorMessage?: string
-): Promise<APIResponse> => {
-  const apiContext = await getApiContext();
-  const response = await apiContext.delete(url);
-  handleErrorResponse(response, errorMessage);
-  return response;
+export const deleteApiRequest = async (urlExtend: string): Promise<Response> => {
+  // TODO: Reuse playwright apiContext when issue #11184 is resolved
+  const fullUrl = `${BASE_URL}${urlExtend}`;
+
+  return fetch(fullUrl, {
+    method: 'DELETE',
+    headers: {
+      Accept: '*/*',
+      'Content-Type': 'application/json',
+    },
+  });
 };
 
 /**


### PR DESCRIPTION
Playwright's APIRequestContext is encountering an unexpected response format, leading to this error:
```
Error: apiRequestContext.delete: Parse Error: Expected HTTP/
    Call log:
      - → DELETE http://localhost:4000/api/projects/3
        - user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.6943.16 Safari/537.36
        - accept: */*
        - accept-encoding: gzip,deflate,br
      - ← 204 No Content
        - access-control-allow-origin: *
        - vary: origin, access-control-request-method, access-control-request-headers, Origin, Access-Control-Request-Method, Access-Control-Request-Headers
        - date: Mon, 03 Feb 2025 18:50:23 GMT


       at utils/api-setup.ts:103
```
Using `curl` I get this response :
```
 curl -i -X DELETE 'http://localhost:4000/api/projects/1'
HTTP/1.1 204 No Content
vary: origin, access-control-request-method, access-control-request-headers, Origin, Access-Control-Request-Method, Access-Control-Request-Headers
access-control-allow-origin: *
date: Mon, 03 Mar 2025 16:24:48 GMT
```
with `Postman` the `DELETE` is done but I receive an error :

![image](https://github.com/user-attachments/assets/e587edfd-f40b-4968-b3fe-56736e8ddc4d)
```DELETE http://localhost:4000/api/projects/2
Error: Parse Error: Expected HTTP/
Request Headers
User-Agent: PostmanRuntime/7.43.0
Accept: */*
Cache-Control: no-cache
Postman-Token: 489cd4a8-1016-400e-a81e-feeb1ea0d95f
Host: localhost:4000
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
```

it's mostly related to server response anomalies and Playwright's HTTP parsing strictness

Closes #10093