### PR TITLE
front: rethrow fatal errors in E2E tests

### DIFF
--- a/front/tests/global-teardown.ts
+++ b/front/tests/global-teardown.ts
@@ -51,6 +51,6 @@ teardown('teardown', async ({ browser }) => {
 
     logger.info('Test data teardown completed successfully.');
   } catch (error) {
-    logger.error('Error during test data teardown:', error);
+    throw new Error('Error during test data teardown', { cause: error });
   }
 });

--- a/front/tests/utils/api-utils.ts
+++ b/front/tests/utils/api-utils.ts
@@ -133,7 +133,7 @@ export const getInfraById = async (infraId: number): Promise<InfraWithState> => 
     const response = await getApiRequest(`/api/infra/${infraId}`);
     return response as InfraWithState;
   } catch (error) {
-    throw new Error(`Failed to retrieve infrastructure with ID ${infraId}: ${error}`);
+    throw new Error(`Failed to retrieve infrastructure with ID ${infraId}`, { cause: error });
   }
 };
 

--- a/front/tests/utils/setup-utils.ts
+++ b/front/tests/utils/setup-utils.ts
@@ -250,6 +250,6 @@ export async function createDataForTests(): Promise<void> {
 
     await setStdcmEnvironment(stdcmEnvironment);
   } catch (error) {
-    logger.error('Error during test data setup:', error);
+    throw new Error('Error during test data setup', { cause: error });
   }
 }


### PR DESCRIPTION
The global setup function logs a message and carries on when it fails. This makes it difficult to read logs: all tests fail with non-sensical errors. Instead, rethrow the error by setting the cause option to add more context to the logs.

Example cumbersome logs: https://github.com/OpenRailAssociation/osrd/actions/runs/13634562326/job/38111336186?pr=10325

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#differentiate_between_similar_errors