### PR TITLE
Add initial German language set

### DIFF
--- a/front/public/locales/de/common/common.json
+++ b/front/public/locales/de/common/common.json
@@ -1,0 +1,24 @@
+{
+  "actions": {
+    "add": "Hinzufügen",
+    "collapse": "Einklappen",
+    "delete": "Löschen",
+    "expand": "Ausklappen",
+    "merge": "Mit nächstem Abschnitt vereinigen",
+    "reset": "Zurücksetzen",
+    "split": "Trennen",
+    "translate": "Übersetzen",
+    "zoom-in": "Reinzoomen",
+    "zoom-out": "Rauszoomen",
+    "deleteSelectionCount": "Wollen Sie wirklich {{items}} Elemente löschen?"
+  },
+  "navigation": {
+    "next": "Weiter",
+    "previous": "Zurück",
+    "goBack": "Zur letzten Seite",
+    "goHome": "Zur Startseite"
+  },
+  "begin": "Start",
+  "end": "Ende",
+  "value": "Wert"
+}

--- a/front/public/locales/de/common/itemTypes.json
+++ b/front/public/locales/de/common/itemTypes.json
@@ -1,0 +1,8 @@
+{
+  "trains_one": "Ein Zug",
+  "trains_other": "{{count}} Züge",
+  "scenarios_one": "Ein Szenario",
+  "scenarios_other": "{{count}} Szenarien",
+  "studies_one": "Eine Studie",
+  "studies_other": "{{count}} Studien"
+}

--- a/front/public/locales/de/common/scenarioExplorer.json
+++ b/front/public/locales/de/common/scenarioExplorer.json
@@ -1,0 +1,15 @@
+{
+  "errorMessages": {
+    "error": "Ein Fehler ist aufgetreten",
+    "unableToRetrieveProjectsMessage": "Projekte konnten nicht abgerufen werden"
+  },
+  "infraLegend": "Betriebsnetz",
+  "noScenarioSelected": "Hier klicken, um ein Szenario mit einem Betriebsnetz und eigenem Kursbuch auszuwählen.",
+  "projectLegend": "Projekt",
+  "projects": "Projekte",
+  "scenarioExplorator": "Szenariensuche",
+  "scenarioLegend": "Szenario",
+  "scenarios": "Szenarien",
+  "studies": "Studien",
+  "studyLegend": "Studie"
+}

--- a/front/public/locales/de/common/typeAndPath.json
+++ b/front/public/locales/de/common/typeAndPath.json
@@ -1,0 +1,3 @@
+{
+  "refineSearchForMoreResults": "Konkretisieren Sie Ihre Suche für mehr Ergebnisse."
+}

--- a/front/public/locales/de/home/home.json
+++ b/front/public/locales/de/home/home.json
@@ -1,7 +1,7 @@
 {
-  "editor": "Infrastrukturverlag",
-  "map": "Kartografie",
-  "operationalStudies": "Eisenbahnbetriebsstudien",
-  "rollingStockEditor": "Schienenfahrzeugbearbeiter",
-  "stdcm": "Click'n ride"
+  "editor": "Betriebsnetz-Editor",
+  "map": "Karte",
+  "operationalStudies": "Betriebsstudien",
+  "rollingStockEditor": "Schienenfahrzeug-Editor",
+  "stdcm": "Schnellauftrag"
 }

--- a/front/public/locales/de/home/navbar.json
+++ b/front/public/locales/de/home/navbar.json
@@ -17,12 +17,12 @@
     "fr": "Français",
     "it": "Italiano",
     "jp": "やまと",
-    "languageChoice": "Sprache der Schnittstelle",
+    "languageChoice": "Sprache",
     "ru": "Русский",
     "uk": "Українська"
   },
-  "safeWord": "Mot clé de sécurité",
-  "safeWordHelp": "Le « mot-clé de sécurité » permet de filtrer de manière transparente la liste des projets avec le mot renseigné, utilisé comme une étiquette. Préférez un mot compliqué dans l'idée que personne ne l'utilise par inadvertance. Ajoutez-le comme une étiquette à un projet ; il sera automatiquement ajouté à la création de projet si le mot est renseigné ici.",
-  "userSettings": "Paramètres utilisateur",
-  "yourSafeWord": "Tapez votre mot"
+  "safeWord": "Stichwort",
+  "safeWordHelp": "Durch das „Stichwort“ können Projekte in der Liste gefiltert werden, wenn es eingegeben wird. Es sollte einzigartig sein und kein Risiko für eine Doppelung bergen, um eine versehentliche Nutzung zu meiden. Fügen Sie es einem Projekt als Label hinzu – es wird bei Erstellung automatisch hinzugefügt, sofern das Stichwort hier eingetragen wird.",
+  "userSettings": "Benutzereinstellungen",
+  "yourSafeWord": "Stichwort eingeben"
 }

--- a/front/public/locales/de/infraManagement.json
+++ b/front/public/locales/de/infraManagement.json
@@ -1,0 +1,40 @@
+{
+  "actions": {
+    "cancel": "Abbrechen",
+    "check": "Prüfen",
+    "copy": "Kopieren",
+    "delete": "Löschen",
+    "export": "Als RailJSON exportieren",
+    "lock": "Sperren",
+    "rename": "Umbenennen",
+    "unlock": "Entsperren",
+    "waiting": "Bitte warten"
+  },
+  "addInfra": "Betriebsnetz erstellen",
+  "addInfraJSON": "Ein Betriebsnetz aus einer RailJSON-Datei erstellen",
+  "addInfraJSONFile": "RailJSON-Datei hinzufügen",
+  "addInfraJSONFileRemove": "RailJSON-Import abbrechen",
+  "chooseInfrastructure": "Betriebsnetz auswählen",
+  "createInfra": "Erstellen",
+  "deleteConfirm": "Wollen Sie das Betriebsnetz löschen?",
+  "errorMessages": {
+    "noExistingInfra": "Kein Betriebsnetz verfügbar",
+    "unableToRetrieveInfra": "Betriebsnetz kann nicht geladen werden",
+    "unableToRetrieveInfraList": "Betriebsnetzliste kann nicht geladen werden",
+    "noEmptyName": "Bitte geben Sie einen Namen ein"
+  },
+  "goToEditionMode": "Bearbeiten",
+  "goToStandardMode": "Zurück zur Auswahl",
+  "infraChoice": "Betriebsnetze",
+  "infraDeleted": "Das Betriebsnetz „{{name}}“ wurde gelöscht.",
+  "infraManagement": "Betriebsnetzverwalter",
+  "infraName": "Betriebsnetzname",
+  "infrasFound_zero": "Kein Betriebsnetz gefunden",
+  "infrasFound_one": "Ein Betriebsnetz gefunden",
+  "infrasFound_other": "{{count}} Betriebsnetze gefunden",
+  "infrastructure": "Betriebsnetz",
+  "locked": "Gesperrt",
+  "no": "Nein",
+  "noInfra": "Bitte wählen Sie ein Betriebsnetz aus",
+  "yes": "Ja"
+}

--- a/front/src/i18n.ts
+++ b/front/src/i18n.ts
@@ -13,9 +13,9 @@ i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
-    fallbackLng: ['fr', 'en'],
+    fallbackLng: ['en', 'fr', 'de'],
     debug: false,
-    supportedLngs: ['en', 'fr'],
+    supportedLngs: ['de', 'en', 'fr'],
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
This commit introduces the basic functionality to select German as a language and some keys (though still vastly incomplete) for this language. This is supposed to be a base for subsequent additions in German.