### PR TITLE
editoast: do not explicitely depend on 'redis'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
       opentelemetry:
         patterns:
           - "*opentelemetry*"
-      redis:
-        patterns:
-          - "redis"
-          - "deadpool-redis"
     commit-message:
       prefix: "editoast:"
     open-pull-requests-limit: 100

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -124,7 +124,10 @@ deadpool = { version = "0.12.2", features = [
   "rt_tokio_1",
   "unmanaged",
 ] }
-deadpool-redis = "0.19.0"
+deadpool-redis = { version = "0.20.0", features = [
+  "tokio-comp",
+  "tokio-native-tls-comp",
+] }
 derivative.workspace = true
 diesel.workspace = true
 diesel-async = { workspace = true }
@@ -175,11 +178,6 @@ pathfinding = "4.14.0"
 postgis_diesel.workspace = true
 rand.workspace = true
 rangemap.workspace = true
-# Make sure to use the same version as deadpool-redis
-redis = { version = "0.28.2", default-features = false, features = [
-  "tokio-comp",
-  "tokio-native-tls-comp",
-] }
 regex.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
With the use of `deadpool-redis`, we needed specific `redis` features, that `deadpool-redis` did not expose.

The problem is that the version of `redis` we use must be the same one as `deadpool-redis` (annoying to maintain).

The recent version of `deadpool-redis` solves this by re-exposing all the `redis` features.