### PR TITLE
editoast: remove 'async_trait'

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1300,7 +1300,6 @@ dependencies = [
  "anyhow",
  "approx",
  "async-std",
- "async-trait",
  "axum 0.8.1",
  "axum-extra",
  "axum-test",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 ]
 
 [workspace.lints.rust]
+async_fn_in_trait = "allow" # all of our public traits are only used inside the project
 dependency_on_unit_never_type_fallback = "allow" # this is caused by tracing, we can't do anything about it
 
 [workspace.package]
@@ -104,7 +105,6 @@ uuid = { version = "1.15.1", features = ["serde", "v4"] }
 [dependencies]
 anyhow = "1.0"
 approx = "0.5.1"
-async-trait = "0.1.86"
 axum = { version = "0.8.1", default-features = false, features = [
   "multipart",
   "tracing",

--- a/editoast/editoast_derive/src/model/codegen/count_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/count_impl.rs
@@ -13,7 +13,6 @@ impl ToTokens for CountImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::prelude::Count for #model {
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(
                     nb_filters = settings.filters.len(),
@@ -22,7 +21,7 @@ impl ToTokens for CountImpl {
                     offset,
                 ))]
                 async fn count(
-                    conn: &'async_trait mut editoast_models::DbConnection,
+                    conn: &mut editoast_models::DbConnection,
                     settings: crate::models::prelude::SelectionSettings<Self>,
                 ) -> crate::error::Result<u64> {
                     use diesel::QueryDsl;

--- a/editoast/editoast_derive/src/model/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/exists_impl.rs
@@ -26,7 +26,6 @@ impl ToTokens for ExistsImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::Exists<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn exists(

--- a/editoast/editoast_derive/src/model/codegen/list_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/list_impl.rs
@@ -20,7 +20,6 @@ impl ToTokens for ListImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::prelude::List for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(
                     nb_filters = settings.filters.len(),
@@ -30,7 +29,7 @@ impl ToTokens for ListImpl {
                     offset,
                 ))]
                 async fn list(
-                    conn: &'async_trait mut editoast_models::DbConnection,
+                    conn: &mut editoast_models::DbConnection,
                     settings: crate::models::prelude::SelectionSettings<Self>,
                 ) -> crate::error::Result<Vec<Self>> {
                     use diesel::QueryDsl;

--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -79,11 +79,10 @@ impl ToTokens for RetrieveBatchImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::RetrieveBatchUnchecked<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve_batch_unchecked<
-                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<#model> + Send + std::fmt::Debug,
                 >(
                     conn: &mut editoast_models::DbConnection,
@@ -102,7 +101,7 @@ impl ToTokens for RetrieveBatchImpl {
 
                 #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_id))]
                 async fn retrieve_batch_with_key_unchecked<
-                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send + std::fmt::Debug,
                 >(
                     conn: &mut editoast_models::DbConnection,

--- a/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
@@ -30,7 +30,6 @@ impl ToTokens for RetrieveImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::Retrieve<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve(

--- a/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
@@ -88,11 +88,10 @@ impl ToTokens for UpdateBatchImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::UpdateBatchUnchecked<#model, #ty> for #changeset {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_ids))]
                 async fn update_batch_unchecked<
-                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<#model> + Send + std::fmt::Debug,
                 >(
                     self,
@@ -112,7 +111,7 @@ impl ToTokens for UpdateBatchImpl {
 
                 #[tracing::instrument(name = #span_name_with_key, skip_all, err, fields(query_ids))]
                 async fn update_batch_with_key_unchecked<
-                    I: std::iter::IntoIterator<Item = #ty> + Send + 'async_trait,
+                    I: std::iter::IntoIterator<Item = #ty> + Send,
                     C: Default + std::iter::Extend<(#ty, #model)> + Send,
                 >(
                     self,

--- a/editoast/editoast_derive/src/model/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_impl.rs
@@ -32,7 +32,6 @@ impl ToTokens for UpdateImpl {
 
         tokens.extend(quote! {
             #[automatically_derived]
-            #[async_trait::async_trait]
             impl crate::models::Update<#ty, #model> for #changeset {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn update(

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -235,7 +235,6 @@ impl<'a> crate::models::Patch<'a, Document> {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Exists<(String)> for Document {
     #[tracing::instrument(
         name = "model:exists<Document>",
@@ -265,7 +264,6 @@ impl crate::models::Exists<(String)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Exists<(i64)> for Document {
     #[tracing::instrument(
         name = "model:exists<Document>",
@@ -292,7 +290,6 @@ impl crate::models::Exists<(i64)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Retrieve<(String)> for Document {
     #[tracing::instrument(
         name = "model:retrieve<Document>",
@@ -321,7 +318,6 @@ impl crate::models::Retrieve<(String)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Retrieve<(i64)> for Document {
     #[tracing::instrument(
         name = "model:retrieve<Document>",
@@ -349,7 +345,6 @@ impl crate::models::Retrieve<(i64)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Update<(String), Document> for DocumentChangeset {
     #[tracing::instrument(
         name = "model:update<Document>",
@@ -381,7 +376,6 @@ impl crate::models::Update<(String), Document> for DocumentChangeset {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Update<(i64), Document> for DocumentChangeset {
     #[tracing::instrument(
         name = "model:update<Document>",
@@ -515,7 +509,6 @@ impl crate::models::Delete for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::prelude::List for Document {
     #[tracing::instrument(
         name = "model:list<Document>",
@@ -530,7 +523,7 @@ impl crate::models::prelude::List for Document {
         )
     )]
     async fn list(
-        conn: &'async_trait mut editoast_models::DbConnection,
+        conn: &mut editoast_models::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
     ) -> crate::error::Result<Vec<Self>> {
         use diesel::QueryDsl;
@@ -566,7 +559,6 @@ impl crate::models::prelude::List for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::prelude::Count for Document {
     #[tracing::instrument(
         name = "model:count<Document>",
@@ -581,7 +573,7 @@ impl crate::models::prelude::Count for Document {
         )
     )]
     async fn count(
-        conn: &'async_trait mut editoast_models::DbConnection,
+        conn: &mut editoast_models::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
     ) -> crate::error::Result<u64> {
         use diesel::QueryDsl;
@@ -755,7 +747,6 @@ impl crate::models::CreateBatchWithKey<(i64)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Document>",
@@ -764,7 +755,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
         fields(query_id)
     )]
     async fn retrieve_batch_unchecked<
-        I: std::iter::IntoIterator<Item = (String)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Model;
@@ -810,7 +801,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
         fields(query_id)
     )]
     async fn retrieve_batch_with_key_unchecked<
-        I: std::iter::IntoIterator<Item = (String)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<((String), Document)> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Identifiable;
@@ -854,7 +845,6 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Document>",
@@ -863,7 +853,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
         fields(query_id)
     )]
     async fn retrieve_batch_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Model;
@@ -909,7 +899,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
         fields(query_id)
     )]
     async fn retrieve_batch_with_key_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<((i64), Document)> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Identifiable;
@@ -953,7 +943,6 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChangeset {
     #[tracing::instrument(
         name = "model:update_batch_unchecked<Document>",
@@ -962,7 +951,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         fields(query_ids)
     )]
     async fn update_batch_unchecked<
-        I: std::iter::IntoIterator<Item = (String)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
     >(
         self,
@@ -1016,7 +1005,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         fields(query_ids)
     )]
     async fn update_batch_with_key_unchecked<
-        I: std::iter::IntoIterator<Item = (String)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<((String), Document)> + Send,
     >(
         self,
@@ -1068,7 +1057,6 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset {
     #[tracing::instrument(
         name = "model:update_batch_unchecked<Document>",
@@ -1077,7 +1065,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         fields(query_ids)
     )]
     async fn update_batch_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
     >(
         self,
@@ -1131,7 +1119,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         fields(query_ids)
     )]
     async fn update_batch_with_key_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<((i64), Document)> + Send,
     >(
         self,

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -89,7 +89,6 @@ impl From<Timetable> for TimetableChangeset {
 }
 impl TimetableChangeset {}
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Exists<(i64)> for Timetable {
     #[tracing::instrument(
         name = "model:exists<Timetable>",
@@ -114,7 +113,6 @@ impl crate::models::Exists<(i64)> for Timetable {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::Retrieve<(i64)> for Timetable {
     #[tracing::instrument(
         name = "model:retrieve<Timetable>",
@@ -217,7 +215,6 @@ impl crate::models::Delete for Timetable {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::prelude::List for Timetable {
     #[tracing::instrument(
         name = "model:list<Timetable>",
@@ -232,7 +229,7 @@ impl crate::models::prelude::List for Timetable {
         )
     )]
     async fn list(
-        conn: &'async_trait mut editoast_models::DbConnection,
+        conn: &mut editoast_models::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
     ) -> crate::error::Result<Vec<Self>> {
         use diesel::QueryDsl;
@@ -268,7 +265,6 @@ impl crate::models::prelude::List for Timetable {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::prelude::Count for Timetable {
     #[tracing::instrument(
         name = "model:count<Timetable>",
@@ -283,7 +279,7 @@ impl crate::models::prelude::Count for Timetable {
         )
     )]
     async fn count(
-        conn: &'async_trait mut editoast_models::DbConnection,
+        conn: &mut editoast_models::DbConnection,
         settings: crate::models::prelude::SelectionSettings<Self>,
     ) -> crate::error::Result<u64> {
         use diesel::QueryDsl;
@@ -311,7 +307,6 @@ impl crate::models::prelude::Count for Timetable {
     }
 }
 #[automatically_derived]
-#[async_trait::async_trait]
 impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Timetable>",
@@ -320,7 +315,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
         fields(query_id)
     )]
     async fn retrieve_batch_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<Timetable> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Model;
@@ -366,7 +361,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
         fields(query_id)
     )]
     async fn retrieve_batch_with_key_unchecked<
-        I: std::iter::IntoIterator<Item = (i64)> + Send + 'async_trait,
+        I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<((i64), Timetable)> + Send + std::fmt::Debug,
     >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
         use crate::models::Identifiable;

--- a/editoast/editoast_models/src/db_connection_pool.rs
+++ b/editoast/editoast_models/src/db_connection_pool.rs
@@ -107,7 +107,7 @@ impl DerefMut for WriteHandle {
 ///
 /// # Testing pool
 ///
-/// In test mode, the [Pool::<AsyncPgConnection>::get] function will always return the same connection that has
+/// In test mode, the [Pool::get](Pool::<AsyncPgConnection>::get) function will always return the same connection that has
 /// been setup to drop all modification once the test ends.
 /// Since this connection will not commit any changes to the database, we ensure the isolation of each test.
 ///

--- a/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
@@ -15,7 +15,7 @@ editoast_common::schemas! {
 #[serde(deny_unknown_fields)]
 /// Braking parameters for ERTMS ETCS Level 2
 /// Commented with their names in ETCS specification document `SUBSET-026-3 v400.pdf` from the
-/// file at https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip
+/// file at <https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip>
 pub struct EtcsBrakeParams {
     /// A_brake_emergency: the emergency deceleration curve (values > 0 m/s²)
     pub gamma_emergency: SpeedIntervalValueCurve,

--- a/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
+++ b/editoast/editoast_schemas/src/train_schedule/schedule_item.rs
@@ -11,7 +11,7 @@ editoast_common::schemas! {
 }
 
 /// State of the signal where the train is received for its stop.
-/// For (important) details, see https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields.
+/// For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>.
 #[derive(Default, Debug, Hash, Copy, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ReceptionSignal {

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7232,7 +7232,7 @@ components:
       description: |-
         Braking parameters for ERTMS ETCS Level 2
         Commented with their names in ETCS specification document `SUBSET-026-3 v400.pdf` from the
-        file at https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip
+        file at <https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip>
       required:
       - gamma_emergency
       - gamma_service
@@ -9653,7 +9653,7 @@ components:
       type: string
       description: |-
         State of the signal where the train is received for its stop.
-        For (important) details, see https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields.
+        For (important) details, see <https://osrd.fr/en/docs/reference/design-docs/timetable/#modifiable-fields>.
       enum:
       - OPEN
       - STOP

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -14,7 +14,6 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::marker::PhantomData;
 
-use async_trait::async_trait;
 use axum::http::StatusCode;
 use editoast_derive::EditoastError;
 use mq_client::MqClientError;
@@ -165,7 +164,6 @@ impl CoreClient {
 /// // Builds the payload, executes the request at POST /test01 and deserializes its response
 /// let response: Response = TestReq::default().fetch(&coreclient).await.unwrap();
 /// ```
-#[async_trait]
 pub trait AsCoreRequest<R>
 where
     Self: Serialize + Sized + Sync,

--- a/editoast/src/generated_data/buffer_stop.rs
+++ b/editoast/src/generated_data/buffer_stop.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct BufferStopLayer;
 
-#[async_trait]
 impl GeneratedData for BufferStopLayer {
     fn table_name() -> &'static str {
         "infra_layer_buffer_stop"

--- a/editoast/src/generated_data/detector.rs
+++ b/editoast/src/generated_data/detector.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct DetectorLayer;
 
-#[async_trait]
 impl GeneratedData for DetectorLayer {
     fn table_name() -> &'static str {
         "infra_layer_detector"

--- a/editoast/src/generated_data/electrification.rs
+++ b/editoast/src/generated_data/electrification.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct ElectrificationLayer;
 
-#[async_trait]
 impl GeneratedData for ElectrificationLayer {
     fn table_name() -> &'static str {
         "infra_layer_electrification"

--- a/editoast/src/generated_data/error/mod.rs
+++ b/editoast/src/generated_data/error/mod.rs
@@ -14,7 +14,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::pin::Pin;
 
-use async_trait::async_trait;
 use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::Array;
@@ -399,7 +398,6 @@ async fn update_errors(
 
 pub struct ErrorLayer;
 
-#[async_trait]
 impl GeneratedData for ErrorLayer {
     fn table_name() -> &'static str {
         "infra_layer_error"

--- a/editoast/src/generated_data/mod.rs
+++ b/editoast/src/generated_data/mod.rs
@@ -15,7 +15,6 @@ pub mod sprite_config;
 mod switch;
 mod track_section;
 
-use async_trait::async_trait;
 use buffer_stop::BufferStopLayer;
 use detector::DetectorLayer;
 use diesel::sql_query;
@@ -48,7 +47,6 @@ editoast_common::schemas! {
 }
 
 /// This trait define how a generated data table should be handled
-#[async_trait]
 pub trait GeneratedData {
     fn table_name() -> &'static str;
     async fn generate(conn: &mut DbConnection, infra: i64, infra_cache: &InfraCache) -> Result<()>;

--- a/editoast/src/generated_data/neutral_section.rs
+++ b/editoast/src/generated_data/neutral_section.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel_async::RunQueryDsl;
@@ -13,7 +12,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct NeutralSectionLayer;
 
-#[async_trait]
 impl GeneratedData for NeutralSectionLayer {
     fn table_name() -> &'static str {
         "infra_layer_neutral_section"

--- a/editoast/src/generated_data/neutral_sign.rs
+++ b/editoast/src/generated_data/neutral_sign.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct NeutralSignLayer;
 
-#[async_trait]
 impl GeneratedData for NeutralSignLayer {
     fn table_name() -> &'static str {
         "infra_layer_neutral_sign"

--- a/editoast/src/generated_data/operational_point.rs
+++ b/editoast/src/generated_data/operational_point.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct OperationalPointLayer;
 
-#[async_trait]
 impl GeneratedData for OperationalPointLayer {
     fn table_name() -> &'static str {
         "infra_layer_operational_point"

--- a/editoast/src/generated_data/psl_sign.rs
+++ b/editoast/src/generated_data/psl_sign.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct PSLSignLayer;
 
-#[async_trait]
 impl GeneratedData for PSLSignLayer {
     fn table_name() -> &'static str {
         "infra_layer_psl_sign"

--- a/editoast/src/generated_data/signal.rs
+++ b/editoast/src/generated_data/signal.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -84,7 +83,6 @@ async fn generate_signaling_system_and_sprite<'a, T: Iterator<Item = &'a String>
     Ok(())
 }
 
-#[async_trait]
 impl GeneratedData for SignalLayer {
     fn table_name() -> &'static str {
         "infra_layer_signal"

--- a/editoast/src/generated_data/speed_section.rs
+++ b/editoast/src/generated_data/speed_section.rs
@@ -1,6 +1,5 @@
 use std::ops::DerefMut;
 
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -21,7 +20,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct SpeedSectionLayer;
 
-#[async_trait]
 impl GeneratedData for SpeedSectionLayer {
     fn table_name() -> &'static str {
         "infra_layer_speed_section"

--- a/editoast/src/generated_data/switch.rs
+++ b/editoast/src/generated_data/switch.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use diesel::sql_query;
 use diesel::sql_types::Array;
 use diesel::sql_types::BigInt;
@@ -16,7 +15,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct SwitchLayer;
 
-#[async_trait]
 impl GeneratedData for SwitchLayer {
     fn table_name() -> &'static str {
         "infra_layer_switch"

--- a/editoast/src/generated_data/track_section.rs
+++ b/editoast/src/generated_data/track_section.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use diesel::delete;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::sql_query;
@@ -20,7 +19,6 @@ use crate::infra_cache::InfraCache;
 
 pub struct TrackSectionLayer;
 
-#[async_trait]
 impl GeneratedData for TrackSectionLayer {
     fn table_name() -> &'static str {
         "infra_layer_track_section"

--- a/editoast/src/models/prelude/list.rs
+++ b/editoast/src/models/prelude/list.rs
@@ -175,30 +175,28 @@ impl<M: Model + 'static> SelectionSettings<M> {
     }
 }
 
-/// Describes how a [Model](super::Model) can be listed (and counted) in a database
+/// Describes how a [Model] can be listed (and counted) in a database
 /// given some settings and constraints provided by [SelectionSettings]
 ///
 /// You can implement this type manually but it is recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait List: Model {
     /// Lists the objects that match the provided settings
     async fn list(
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
     ) -> crate::error::Result<Vec<Self>>;
 }
 
-/// Describe how we can count the number of occurrences of the [Model](super::Model)
+/// Describe how we can count the number of occurrences of the [Model]
 /// that match the provided settings and constraints
 ///
 /// You can implement this type manually but it is recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait Count: Model {
     /// Counts the number of objects that match the provided settings
     async fn count(
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
     ) -> crate::error::Result<u64>;
 }
@@ -206,7 +204,6 @@ pub trait Count: Model {
 /// A trait that combines [List] and [Count] into a single function [ListAndCount::list_and_count]
 ///
 /// This trait is automatically implemented for any type that implements both [List] and [Count].
-#[async_trait::async_trait]
 pub trait ListAndCount: Model {
     /// Lists and counts the objects that match the provided settings
     ///
@@ -221,15 +218,14 @@ pub trait ListAndCount: Model {
     /// 3. Fetch in OSRD's git log that function original implementation and restore it
     ///    (this is a _very last resort_ solution ofc).
     async fn list_and_count(
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
     ) -> crate::error::Result<(Vec<Self>, u64)>;
 }
 
-#[async_trait::async_trait]
 impl<M: Model + List + Count> ListAndCount for M {
     async fn list_and_count(
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         settings: SelectionSettings<Self>,
     ) -> crate::error::Result<(Vec<Self>, u64)> {
         let count = Self::count(conn, settings.clone()).await?;

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -9,23 +9,19 @@ use crate::error::Result;
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait Retrieve<K>: Sized
 where
-    for<'async_trait> K: Send + 'async_trait,
+    K: Send,
+    Self: Send,
 {
     /// Retrieves the row #`id` and deserializes it as a model instance
     async fn retrieve(conn: &mut DbConnection, id: K) -> Result<Option<Self>>;
 
     /// Just like [Retrieve::retrieve] but returns `Err(fail())` if the row was not found
-    async fn retrieve_or_fail<E, F>(
-        conn: &'async_trait mut DbConnection,
-        id: K,
-        fail: F,
-    ) -> Result<Self>
+    async fn retrieve_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<Self>
     where
         E: EditoastError,
-        F: FnOnce() -> E + Send + 'async_trait,
+        F: FnOnce() -> E + Send,
     {
         match Self::retrieve(conn, id).await {
             Ok(Some(obj)) => Ok(obj),
@@ -39,10 +35,10 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait Exists<K>: Sized
 where
-    for<'async_trait> K: Send + 'async_trait,
+    K: Send,
+    Self: Send,
 {
     /// Returns whether the row #`id` exists in the database
     async fn exists(conn: &mut DbConnection, id: K) -> Result<bool>;
@@ -55,10 +51,10 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait RetrieveBatchUnchecked<K>: Sized + Debug
 where
-    for<'async_trait> K: Send + Debug + 'async_trait,
+    K: Send + Debug,
+    Self: Send,
 {
     /// Retrieves a batch of rows from the database given an iterator of keys
     ///
@@ -68,7 +64,7 @@ where
     /// if you want to fail if some rows were not found.
     /// Unless you know what you're doing, you should use these functions instead.
     async fn retrieve_batch_unchecked<
-        I: IntoIterator<Item = K> + Send + 'async_trait,
+        I: IntoIterator<Item = K> + Send,
         C: Default + std::iter::Extend<Self> + Send + Debug,
     >(
         conn: &mut DbConnection,
@@ -83,7 +79,7 @@ where
     /// if you want to fail if some rows were not found.
     /// Unless you know what you're doing, you should use these functions instead.
     async fn retrieve_batch_with_key_unchecked<
-        I: IntoIterator<Item = K> + Send + 'async_trait,
+        I: IntoIterator<Item = K> + Send,
         C: Default + std::iter::Extend<(K, Self)> + Send + Debug,
     >(
         conn: &mut DbConnection,
@@ -99,10 +95,10 @@ where
 ///
 /// 99% of the time you should use this trait instead of [RetrieveBatchUnchecked].
 /// This won't be possible however if the model's key is not `Eq` or `Hash`.
-#[async_trait::async_trait]
 pub trait RetrieveBatch<K>: RetrieveBatchUnchecked<K>
 where
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + Debug + 'async_trait,
+    K: Eq + std::hash::Hash + Clone + Send + Debug,
+    Self: Send,
 {
     /// Retrieves a batch of rows from the database given an iterator of keys
     ///
@@ -121,7 +117,7 @@ where
         ids: I,
     ) -> Result<(C, std::collections::HashSet<K>)>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<Self>
@@ -157,7 +153,7 @@ where
         ids: I,
     ) -> Result<(C, std::collections::HashSet<K>)>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<(K, Self)>
@@ -198,14 +194,14 @@ where
         fail: F,
     ) -> Result<C>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<Self>
             + std::iter::FromIterator<Self>
             + std::iter::IntoIterator<Item = Self>,
         E: EditoastError,
-        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = Self::retrieve_batch::<_, C>(conn, ids).await?;
         if missing.is_empty() {
@@ -229,14 +225,14 @@ where
         fail: F,
     ) -> Result<C>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<(K, Self)>
             + std::iter::FromIterator<(K, Self)>
             + std::iter::IntoIterator<Item = (K, Self)>,
         E: EditoastError,
-        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = Self::retrieve_batch_with_key::<_, C>(conn, ids).await?;
         if missing.is_empty() {
@@ -248,10 +244,9 @@ where
 }
 
 // Auto-impl of RetrieveBatch for all models that implement RetrieveBatchUnchecked
-#[async_trait::async_trait]
 impl<M, K> RetrieveBatch<K> for M
 where
     M: RetrieveBatchUnchecked<K>,
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + Debug + 'async_trait,
+    K: Eq + std::hash::Hash + Clone + Send + Debug,
 {
 }

--- a/editoast/src/models/prelude/update.rs
+++ b/editoast/src/models/prelude/update.rs
@@ -65,10 +65,9 @@ impl<M: Model> Patch<'_, M> {
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait Update<K, Row>: Sized
 where
-    for<'async_trait> K: Send + 'async_trait,
+    K: Send,
     Row: Send,
 {
     /// Updates the row #`id` with the changeset values and returns the updated model
@@ -77,7 +76,7 @@ where
     /// Just like [Update::update] but returns `Err(fail())` if the row was not found
     async fn update_or_fail<E: EditoastError, F: FnOnce() -> E + Send>(
         self,
-        conn: &'async_trait mut DbConnection,
+        conn: &mut DbConnection,
         id: K,
         fail: F,
     ) -> Result<Row> {
@@ -93,7 +92,6 @@ where
 ///
 /// This trait is automatically implemented for all models that implement
 /// [Update].
-#[async_trait::async_trait]
 pub trait Save<K: Send>: Sized {
     /// Persists the model instance to the database
     ///
@@ -108,10 +106,9 @@ pub trait Save<K: Send>: Sized {
     async fn save(&mut self, conn: &mut DbConnection) -> Result<()>;
 }
 
-#[async_trait::async_trait]
 impl<K, M> Save<K> for M
 where
-    for<'async_trait> K: Send + Clone + 'async_trait,
+    K: Send + Clone,
     M: Model + PreferredId<K> + Clone + Send,
     <M as Model>::Changeset: Update<K, M> + Send,
 {
@@ -130,7 +127,6 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-#[async_trait::async_trait]
 pub trait UpdateBatchUnchecked<M, K>: Sized
 where
     M: Send,
@@ -144,7 +140,7 @@ where
     /// if you want to fail if some rows were not found.
     /// Unless you know what you're doing, you should use these functions instead.
     async fn update_batch_unchecked<
-        I: IntoIterator<Item = K> + Send + 'async_trait,
+        I: IntoIterator<Item = K> + Send,
         C: Default + std::iter::Extend<M> + Send + Debug,
     >(
         self,
@@ -160,7 +156,7 @@ where
     /// if you want to fail if some rows were not found.
     /// Unless you know what you're doing, you should use these functions instead.
     async fn update_batch_with_key_unchecked<
-        I: IntoIterator<Item = K> + Send + 'async_trait,
+        I: IntoIterator<Item = K> + Send,
         C: Default + std::iter::Extend<(K, M)> + Send,
     >(
         self,
@@ -177,11 +173,10 @@ where
 ///
 /// 99% of the time you should use this trait instead of [UpdateBatchUnchecked].
 /// This won't be possible however if the model's key is not `Eq` or `Hash`.
-#[async_trait::async_trait]
 pub trait UpdateBatch<M, K>: UpdateBatchUnchecked<M, K>
 where
     M: Send,
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+    K: Eq + std::hash::Hash + Clone + Send,
 {
     /// Applies the changeset to a batch of rows in the database given an iterator of keys
     ///
@@ -206,7 +201,7 @@ where
         ids: I,
     ) -> Result<(C, std::collections::HashSet<K>)>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<M>
@@ -243,7 +238,7 @@ where
         ids: I,
     ) -> Result<(C, std::collections::HashSet<K>)>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<(K, M)>
@@ -283,14 +278,14 @@ where
         fail: F,
     ) -> Result<C>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<M>
             + std::iter::FromIterator<M>
             + std::iter::IntoIterator<Item = M>,
         E: EditoastError,
-        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch::<_, C>(conn, ids).await?;
         if missing.is_empty() {
@@ -316,14 +311,14 @@ where
         fail: F,
     ) -> Result<C>
     where
-        I: Send + IntoIterator<Item = K> + 'async_trait,
+        I: Send + IntoIterator<Item = K>,
         C: Send
             + Default
             + std::iter::Extend<(K, M)>
             + std::iter::FromIterator<(K, M)>
             + std::iter::IntoIterator<Item = (K, M)>,
         E: EditoastError,
-        F: FnOnce(std::collections::HashSet<K>) -> E + Send + 'async_trait,
+        F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch_with_key::<_, C>(conn, ids).await?;
         if missing.is_empty() {
@@ -335,11 +330,10 @@ where
 }
 
 // Auto-impl of UpdateBatch for all models that implement UpdateBatchUnchecked
-#[async_trait::async_trait]
 impl<Cs, M, K> UpdateBatch<M, K> for Cs
 where
     Cs: UpdateBatchUnchecked<M, K>,
     M: Send,
-    for<'async_trait> K: Eq + std::hash::Hash + Clone + Send + 'async_trait,
+    K: Eq + std::hash::Hash + Clone + Send,
 {
 }

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -104,7 +104,6 @@ pub struct TimetableWithTrains {
     pub train_ids: Vec<i64>,
 }
 
-#[async_trait::async_trait]
 impl Retrieve<i64> for TimetableWithTrains {
     async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
         let result = sql_query(

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -93,7 +93,6 @@ impl PaginationStats {
     }
 }
 
-#[async_trait::async_trait]
 pub trait PaginatedList: ListAndCount + 'static {
     /// Lists the models and compute [PaginationStats]
     ///

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -19,7 +19,7 @@ use editoast_schemas::rolling_stock::RollingResistance;
 use editoast_schemas::rolling_stock::RollingStockLivery;
 use editoast_schemas::rolling_stock::RollingStockMetadata;
 use editoast_schemas::rolling_stock::RollingStockSupportedSignalingSystems;
-use itertools::Itertools;
+use itertools::Itertools as _;
 use serde::Serialize;
 use std::collections::HashMap;
 use utoipa::ToSchema;

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -10,7 +10,7 @@ use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::MarginValue;
 use editoast_schemas::train_schedule::PathItem;
 use editoast_schemas::train_schedule::PathItemLocation;
-use itertools::Itertools;
+use itertools::Itertools as _;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;


### PR DESCRIPTION
It's not entirely needed since 'rust:1.75'. There is some limitations, but the project is not impacted by them.

This is what the warning looks like (and the reason why I chose to deactivate it in the `[lint.rust]` section in `Cargo.toml`).

![warning for async_fn_in_trait](https://github.com/user-attachments/assets/225bb06c-927e-42a5-9713-18cac1413c38)
