### PR TITLE
editoast: fix Cargo.lock following dependency update

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-redis"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011ead1ec511457e06577f438fbb3a8c3de6c65c669bca9c95ed4dca6c396f6f"
+checksum = "c136f185b3ca9d1f4e4e19c11570e1002f4bfdd592d589053e225716d613851f"
 dependencies = [
  "deadpool",
  "redis",
@@ -1348,7 +1348,6 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.0",
  "rangemap",
- "redis",
  "regex",
  "reqwest",
  "rstest",
@@ -1903,7 +1902,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3795,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
+checksum = "8034fb926579ff49d3fe58d288d5dcb580bf11e9bccd33224b45adebf0fd0c23"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -3809,6 +3808,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "socket2 0.5.8",
  "tokio",
  "tokio-native-tls",
  "tokio-util",


### PR DESCRIPTION
missing from #11025 