### PR TITLE
front: fix trad no item in timetabletoolbar

### DIFF
--- a/front/public/locales/de/operational-studies.json
+++ b/front/public/locales/de/operational-studies.json
@@ -178,7 +178,6 @@
       "invalidTrains": "Einige Züge sind ungültig",
       "noItem": "Kein Item",
       "noSpeedLimitTagsShort": "Kein Gesch.-Schl.",
-      "noTrain": "Kein Zug",
       "punctuality": "Pünktlichkeit",
       "rollingStockFilterPlaceholder": "Baureihe, Serie, Detail",
       "selectAll": "Alles auswählen",

--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -238,7 +238,6 @@
       "modeTrainScheduleSet": "Sort by train schedule set",
       "noItem": "No item",
       "noSpeedLimitTagsShort": "None",
-      "noTrain": "No train",
       "occurrenceChangeGroup": {
         "constraint_distribution": "Recovery margin",
         "initial_speed": "Initial velocity",

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -238,7 +238,6 @@
       "modeTrainScheduleSet": "Trier par paquet",
       "noItem": "Aucun item",
       "noSpeedLimitTagsShort": "Aucun",
-      "noTrain": "Aucun train",
       "occurrenceChangeGroup": {
         "constraint_distribution": "Marge de régularité",
         "initial_speed": "Vitesse initiale",

--- a/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
+++ b/front/src/applications/operationalStudies/views/Scenario/components/Timetable/TimetableBoardWrapper.tsx
@@ -283,11 +283,7 @@ const TimetableBoardWrapper = ({
   }, [handleCut]);
 
   return (
-    <BoardWrapper
-      withFooter
-      name={timetableItems.length > 0 ? computedItemLabel() : t('main.timetable.noTrain')}
-      dataTestId="timetable-board-wrapper"
-    >
+    <BoardWrapper withFooter name={computedItemLabel()} dataTestId="timetable-board-wrapper">
       <Timetable
         selectedTimetableItemIds={selectedTimetableItemIds}
         setSelectedTimetableItemIds={setSelectedTimetableItemIds}

--- a/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
+++ b/front/tests/02-operational-studies/nge/001-osrd-nge.spec.ts
@@ -123,7 +123,7 @@ test.describe('@op @nge', () => {
     });
 
     await test.step('Verify timetable is empty (UI message)', async () => {
-      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
 
     await test.step('Enable macro view while keeping the default train list visible', async () => {
@@ -150,12 +150,12 @@ test.describe('@op @nge', () => {
     });
 
     await test.step('Verify timetable is empty (UI)', async () => {
-      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
 
     await test.step('Reload and re-assert timetable is empty', async () => {
       await page.reload();
-      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
 
     await test.step('Re-toggle macro layout and re-assert graph is empty (no lines, nodes are persisted)', async () => {

--- a/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
+++ b/front/tests/02-operational-studies/timetable/003-train-timetable-multiselection.spec.ts
@@ -100,7 +100,7 @@ test.describe('@op @timetable-items @timetable-multiselection', () => {
     });
 
     await test.step('Verify timetable is empty', async () => {
-      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+      await scenarioTimetableSection.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
   });
 });

--- a/front/tests/02-operational-studies/timetable/005-timetable-import.spec.ts
+++ b/front/tests/02-operational-studies/timetable/005-timetable-import.spec.ts
@@ -68,7 +68,7 @@ test.describe('@op @timetable-items @import', () => {
 
   test('Verify timetable items are imported correctly', async () => {
     await test.step('Verify timetable is empty', async () => {
-      await importPage.verifyTimetableIsEmpty(frTranslations.timetable.noTrain);
+      await importPage.verifyTimetableIsEmpty(frTranslations.timetable.noItem);
     });
     await test.step('Import timetable items JSON and return to scenario', async () => {
       await importPage.openImportTimetableItemForm();


### PR DESCRIPTION
When our timetable is empty, we must display No item and not No train. During development of PacedTrainItem, we forgot to delete part of the code