### PR TITLE
editoast: openfga port is none if value is 80 or 443

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -641,7 +641,7 @@ impl OpenfgaConfig {
             .ok_or_else(|| anyhow::anyhow!("Configured OpenFGA URL doesn't have a host part"))?;
         let port = self
             .url
-            .port()
+            .port_or_known_default()
             .ok_or_else(|| anyhow::anyhow!("Configured OpenFGA URL doesn't have a port part"))?;
         Ok(fga::client::ConnectionSettings::new(
             address.to_owned(),


### PR DESCRIPTION
critical bug making the app not running on production environments.