### PR TITLE
front: remove grid margins

### DIFF
--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -37,8 +37,8 @@ export const stdcmConfInitialState: OsrdStdcmConfState = {
   ],
   margins: {
     standardAllowance: { type: 'time_per_distance', value: 4.5 },
-    gridMarginBefore: new Duration({ seconds: 15 }),
-    gridMarginAfter: new Duration({ seconds: 15 }),
+    gridMarginBefore: new Duration({ seconds: 0 }),
+    gridMarginAfter: new Duration({ seconds: 0 }),
   },
   totalMass: undefined,
   totalLength: undefined,
@@ -113,8 +113,8 @@ export const stdcmConfSlice = createSlice({
     resetMargins(state: Draft<OsrdStdcmConfState>) {
       state.margins = {
         standardAllowance: { type: 'time_per_distance', value: 4.5 },
-        gridMarginBefore: new Duration({ seconds: 15 }),
-        gridMarginAfter: new Duration({ seconds: 15 }),
+        gridMarginBefore: new Duration({ seconds: 0 }),
+        gridMarginAfter: new Duration({ seconds: 0 }),
       };
     },
     updateStandardAllowance(


### PR DESCRIPTION
They were redundant with the "green signal" requirements of our conflict detection module, we'd miss out on solutions for no good reason.

Fix https://github.com/OpenRailAssociation/osrd/issues/11020