### PR TITLE
docker-compose: use an env var to select image release channel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
   core:
     # This is a dummy container to build the core image
     # and document/provide parameters to other compose files
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-core:${TAG-dev}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-core:${TAG-dev}
     container_name: osrd-core-dummy
     depends_on:
       rabbitmq: { condition: service_healthy }
@@ -112,7 +112,7 @@ services:
     command: "true"
 
   editoast:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-editoast:${TAG-dev}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-editoast:${TAG-dev}
     container_name: osrd-editoast
     depends_on:
       postgres: { condition: service_healthy }
@@ -151,7 +151,7 @@ services:
       retries: 6
 
   gateway:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-front}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-front}
     container_name: osrd-gateway
     build:
       context: gateway
@@ -173,7 +173,7 @@ services:
     ports: [ "8080:8080" ]
 
   osrdyne:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-osrdyne:${TAG-dev}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-osrdyne:${TAG-dev}
     container_name: osrd-osrdyne
     depends_on:
       rabbitmq: { condition: service_healthy }
@@ -191,6 +191,7 @@ services:
     environment:
       RUST_LOG: "info"
       OSRDYNE__OPENTELEMETRY__ENDPOINT: "http://osrd-jaeger:4317"
+      OSRDYNE__WORKER_DRIVER__WORKER_IMAGE: "ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-core:${TAG-dev}"
 
   jaeger:
     image: jaegertracing/jaeger:latest

--- a/docker/docker-compose.front.yml
+++ b/docker/docker-compose.front.yml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-standalone}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-standalone}
     volumes:
       - "./docker/gateway.dev.front.toml:/srv/gateway.toml"
     build:
@@ -8,7 +8,7 @@ services:
         SKIP_FRONT: "1"
 
   front:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-front:${TAG-dev}-dev
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-dev
     container_name: osrd-front
     build:
       context: front

--- a/docker/docker-compose.host-front.yml
+++ b/docker/docker-compose.host-front.yml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-standalone}
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-gateway:${TAG-dev}-${GATEWAY_FLAVOR-standalone}
     volumes:
       - "./docker/gateway.dev.host-front.toml:/srv/gateway.toml"
     build:
@@ -8,7 +8,7 @@ services:
         SKIP_FRONT: "1"
 
   front:
-    image: ghcr.io/openrailassociation/osrd-edge/osrd-front:${TAG-dev}-dev
+    image: ghcr.io/openrailassociation/osrd-${RELEASE_CHANNEL-edge}/osrd-front:${TAG-dev}-dev
     container_name: osrd-front
     build:
       context: front


### PR DESCRIPTION
This allows to pull the images corresponding to specific published versions of OSRD. 
Usage: `RELEASE_CHANNEL=stable TAG=vX.X.X docker compose pull`.

I chose the name "release channel" because it's what rust uses to qualitfy nightly, beta and stable [in their docs](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html).

Also, add an env var for osrdyne, in order to use the same uri for core workers as the ones for the other services.

I did not update `docker/docker-compose.pr-tests.yml` because PR versions are only published on edge. 