### PR TITLE
docker-compose: make editoast ROOT_URL point to localhost instead of the docker host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
     ports: [ "8090:80" ]
     environment:
       EDITOAST_PORT: 80
-      ROOT_URL: "http://osrd-gateway:4000/api"
+      ROOT_URL: "http://localhost:4000/api"
       VALKEY_URL: "redis://valkey"
       DATABASE_URL: "postgres://osrd:password@postgres/osrd"
       OSRDYNE_API_URL: "http://osrd-osrdyne:4242/"

--- a/docker/docker-compose.pr-tests.yml
+++ b/docker/docker-compose.pr-tests.yml
@@ -122,7 +122,7 @@ services:
     ports: [ "8089:8089" ]
     environment:
       EDITOAST_PORT: 8089
-      ROOT_URL: "http://osrd-gateway-pr-tests:4001/api"
+      ROOT_URL: "http://localhost:4001/api"
       VALKEY_URL: "redis://valkey:6380"
       DATABASE_URL: "postgres://osrd:password@postgres:5433/osrd"
       TELEMETRY_KIND: "opentelemetry"


### PR DESCRIPTION
Indeed, this url is sent to the frontend, which then tries to call this url from the web browser