### PR TITLE
editoast: add 'NoopSpanExporter' to avoid dependencies

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -352,25 +352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
- "rustix 0.38.42",
- "tracing",
-]
-
-[[package]]
 name = "async-reactor-trait"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,24 +361,6 @@ dependencies = [
  "async-trait",
  "futures-core",
  "reactor-trait",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io 2.4.0",
- "async-lock 3.4.0",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 0.38.42",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -411,7 +374,6 @@ dependencies = [
  "async-global-executor",
  "async-io 2.4.0",
  "async-lock 3.4.0",
- "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -2250,7 +2212,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3148,7 +3110,6 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
- "async-std",
  "async-trait",
  "futures-channel",
  "futures-executor",
@@ -4431,15 +4392,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "simd-adler32"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -224,7 +224,6 @@ axum = { version = "0.8.1", default-features = false, features = [
 editoast_authz = { workspace = true, features = ["fixtures"] }
 editoast_models = { workspace = true, features = ["testing"] }
 editoast_osrdyne_client = { workspace = true, features = ["mock_client"] }
-opentelemetry_sdk = { workspace = true, features = ["testing"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
 serial_test = "3.2.0"

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -18,7 +18,10 @@ use editoast_common::tracing::TracingConfig;
 use editoast_models::DbConnectionPoolV2;
 use editoast_osrdyne_client::OsrdyneClient;
 use futures::executor::block_on;
-use opentelemetry_sdk::testing::trace::NoopSpanExporter;
+use futures::future::BoxFuture;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::SpanData;
+use opentelemetry_sdk::trace::SpanExporter;
 use serde::de::DeserializeOwned;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::filter::Directive;
@@ -42,6 +45,24 @@ use super::OpenfgaConfig;
 use super::OsrdyneConfig;
 use super::PostgresConfig;
 use super::ServerConfig;
+
+// NoopSpanExporter exists in 'opentelemetry-sdk' but is hidden behind
+// 'testing' feature which brings with it tons of unneeded dependencies
+// like 'async-std'.
+#[derive(Debug)]
+struct NoopSpanExporter;
+
+impl NoopSpanExporter {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl SpanExporter for NoopSpanExporter {
+    fn export(&mut self, _: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
 
 /// A builder interface for [TestApp]
 ///


### PR DESCRIPTION
The recent [update of opentelemetry dependencies](https://github.com/OpenRailAssociation/osrd/pull/11007) led me to remove `NoopSpanExporter`, not understand why we would manually implement ourselves something that [already exists in `opentelemetry_sdk`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/testing/trace/struct.NoopSpanExporter.html). But then I did some digging and found [that](https://github.com/OpenRailAssociation/osrd/pull/10122#discussion_r1895733870) explaining why we did it. So bringing back the old code, with a comment this time explaining why we do it.