### PR TITLE
core: replace homemade bloom filter with guava's

### DIFF
--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyMap.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlyMap.kt
@@ -7,7 +7,6 @@ package fr.sncf.osrd.utils
  */
 class AppendOnlyMap<K, V>(
     private val list: AppendOnlyLinkedList<Pair<K, V>>,
-    private val keyFilter: BloomFilter<K>,
 ) {
     /**
      * Returns the value associated with the key. O(n) in worst case, O(1) if the value is near the
@@ -19,22 +18,12 @@ class AppendOnlyMap<K, V>(
 
     /** Add the given pair of values to the map. O(1). */
     operator fun set(k: K, v: V) {
-        keyFilter.add(k)
         list.add(Pair(k, v))
     }
 
     /** Returns a copy of the map. The underlying structure is *not* copied. O(1). */
     fun shallowCopy(): AppendOnlyMap<K, V> {
-        return AppendOnlyMap(list.shallowCopy(), keyFilter.copy())
-    }
-
-    /**
-     * Returns true if the key is in the key set. O(n) in worst case, O(1) if the value is near the
-     * end. Pre-filtered using a bloom filter.
-     */
-    fun containsKey(key: K): Boolean {
-        if (!keyFilter.mayContain(key)) return false
-        return list.findLast { it.first == key } != null
+        return AppendOnlyMap(list.shallowCopy())
     }
 
     /**
@@ -51,6 +40,6 @@ class AppendOnlyMap<K, V>(
 }
 
 /** Returns a new empty list */
-fun <K, V> appendOnlyMapOf(): AppendOnlyMap<K, V> {
-    return AppendOnlyMap(appendOnlyLinkedListOf(), emptyBloomFilter())
+inline fun <reified K, V> appendOnlyMapOf(): AppendOnlyMap<K, V> {
+    return AppendOnlyMap(appendOnlyLinkedListOf())
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlySet.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/AppendOnlySet.kt
@@ -1,5 +1,7 @@
 package fr.sncf.osrd.utils
 
+import com.google.common.hash.BloomFilter
+
 /**
  * Append-only set implementation. The internal structure is a linked list. Used to store data on
  * diverging paths while minimizing copies. See also `AppendOnlyLinkedList`.
@@ -11,7 +13,7 @@ class AppendOnlySet<T>(
 
     /** Add the given value to the set. O(1). */
     fun add(k: T) {
-        keyFilter.add(k)
+        keyFilter.put(k)
         list.add(k)
     }
 
@@ -25,12 +27,18 @@ class AppendOnlySet<T>(
      * end. Pre-filtered using a bloom filter.
      */
     fun contains(key: T): Boolean {
-        if (!keyFilter.mayContain(key)) return false
+        if (!keyFilter.mightContain(key)) return false
         return list.findLast { it == key } != null
     }
 }
 
 /** Returns a new empty set */
-fun <T> appendOnlySetOf(): AppendOnlySet<T> {
-    return AppendOnlySet(appendOnlyLinkedListOf(), emptyBloomFilter())
+inline fun <reified T> createAppendOnlySet(
+    expectedInsertions: Int,
+    falsePositiveRate: Double,
+): AppendOnlySet<T> {
+    return AppendOnlySet(
+        appendOnlyLinkedListOf(),
+        emptyBloomFilter(expectedInsertions, falsePositiveRate)
+    )
 }

--- a/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/BloomFilter.kt
+++ b/core/kt-osrd-utils/src/main/kotlin/fr/sncf/osrd/utils/BloomFilter.kt
@@ -1,37 +1,30 @@
 package fr.sncf.osrd.utils
 
-import java.util.BitSet
+import com.google.common.hash.BloomFilter
+import com.google.common.hash.Funnel
+import com.google.common.hash.Funnels
+import fr.sncf.osrd.utils.indexing.StaticIdx
 
-/** Simple bloom filter implementation. */
-class BloomFilter<T>(private val bitField: BitSet, private val nHash: Int) {
-
-    /** Add a value to the set. */
-    fun add(value: T) {
-        var hash = value.hashCode()
-        for (i in 0..nHash) {
-            bitField.set(hash % bitField.size())
-            hash = hash.hashCode()
-        }
-    }
-
-    /**
-     * Check whether a value can be present in the set. False positive are possible, false negative
-     * are not.
-     */
-    fun mayContain(value: T): Boolean {
-        var hash = value.hashCode()
-        for (i in 0..nHash) {
-            if (!bitField.get(hash % bitField.size())) return false
-            hash = hash.hashCode()
-        }
-        return true
-    }
-
-    fun copy(): BloomFilter<T> {
-        return BloomFilter(bitField.clone() as BitSet, nHash)
-    }
+/** Create a bloom filter with the given expected insertions and false positive rate. */
+inline fun <reified T> emptyBloomFilter(
+    expectedInsertions: Int,
+    falsePositiveRate: Double,
+    funnel: Funnel<T> = defaultFunnelProvider(),
+): BloomFilter<T> {
+    return BloomFilter.create(funnel, expectedInsertions, falsePositiveRate)
 }
 
-fun <T> emptyBloomFilter(bitsetSize: Int = 2048, nHash: Int = 2): BloomFilter<T> {
-    return BloomFilter(BitSet(bitsetSize), nHash)
+/**
+ * Create a funnel for the right underlying type. Avoids propagating that added complexity to the
+ * rest of the code.
+ */
+@Suppress("UNCHECKED_CAST") // We know the return type match the `when` type
+inline fun <reified T> defaultFunnelProvider(): Funnel<T> {
+    return when (T::class) {
+        String::class -> Funnels.stringFunnel(Charsets.UTF_8) as Funnel<T>
+        Int::class -> Funnels.integerFunnel() as Funnel<T>
+        Long::class -> Funnels.longFunnel() as Funnel<T>
+        StaticIdx::class -> Funnel { obj, into -> into.putInt((obj as StaticIdx<*>).index.toInt()) }
+        else -> throw IllegalArgumentException("No default funnel for type ${T::class}.")
+    }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -15,6 +15,7 @@ import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage
 import java.io.IOException
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
+import kotlin.time.measureTime
 import okhttp3.OkHttpClient
 import okio.buffer
 import okio.source
@@ -65,24 +66,27 @@ class ReproduceRequest : CliCommand {
                 val bufferedSource = fileSource.buffer()
                 return checkNotNull(adapter.fromJson(bufferedSource))
             }
-            if (stdcmPayloadPath != null) {
-                logger.info("running stdcm request at $stdcmPayloadPath")
-                STDCMEndpointV2(infraManager)
-                    .run(loadRequest(stdcmPayloadPath!!, stdcmRequestAdapter))
+
+            val time = measureTime {
+                if (stdcmPayloadPath != null) {
+                    logger.info("running stdcm request at $stdcmPayloadPath")
+                    STDCMEndpointV2(infraManager)
+                        .run(loadRequest(stdcmPayloadPath!!, stdcmRequestAdapter))
+                }
+                if (pathfindingPayloadPath != null) {
+                    logger.info("running pathfinding request at $pathfindingPayloadPath")
+                    PathfindingBlocksEndpointV2(infraManager)
+                        .run(loadRequest(pathfindingPayloadPath!!, pathfindingRequestAdapter))
+                }
+                if (simulationPayloadPath != null) {
+                    logger.info("running simulation request at $simulationPayloadPath")
+                    val electricalProfileSetManager =
+                        ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient)
+                    SimulationEndpoint(infraManager, electricalProfileSetManager)
+                        .run(loadRequest(simulationPayloadPath!!, SimulationRequest.adapter))
+                }
             }
-            if (pathfindingPayloadPath != null) {
-                logger.info("running pathfinding request at $pathfindingPayloadPath")
-                PathfindingBlocksEndpointV2(infraManager)
-                    .run(loadRequest(pathfindingPayloadPath!!, pathfindingRequestAdapter))
-            }
-            if (simulationPayloadPath != null) {
-                logger.info("running simulation request at $simulationPayloadPath")
-                val electricalProfileSetManager =
-                    ElectricalProfileSetManager(editoastUrl, editoastAuthorization, httpClient)
-                SimulationEndpoint(infraManager, electricalProfileSetManager)
-                    .run(loadRequest(simulationPayloadPath!!, SimulationRequest.adapter))
-            }
-            logger.info("done")
+            logger.info("done in ${time.inWholeMilliseconds / 1_000.0} seconds")
         } catch (e: IOException) {
             throw RuntimeException(e)
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -18,7 +18,7 @@ import fr.sncf.osrd.utils.AppendOnlyMap
 import fr.sncf.osrd.utils.AppendOnlySet
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.appendOnlyMapOf
-import fr.sncf.osrd.utils.appendOnlySetOf
+import fr.sncf.osrd.utils.createAppendOnlySet
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
@@ -119,6 +119,10 @@ fun initInfraExplorer(
     stops: List<Collection<PathfindingEdgeLocationId<Block>>> = listOf(setOf()),
     constraints: List<PathfindingConstraint<Block>> = listOf(),
 ): Collection<InfraExplorer> {
+    // Determined empirically on a timetable import
+    val maxExpectedTracks = 1600
+    val falsePositiveRate = 0.03
+
     val infraExplorers = mutableListOf<InfraExplorer>()
     val block = location.edge
     val pathProps = makePathProps(blockInfra, rawInfra, block)
@@ -134,7 +138,7 @@ fun initInfraExplorer(
                 appendOnlyLinkedListOf(),
                 appendOnlyLinkedListOf(),
                 appendOnlyMapOf(),
-                appendOnlySetOf(),
+                createAppendOnlySet(maxExpectedTracks, falsePositiveRate),
                 null,
                 incrementalPath,
                 blockToPathProperties,
@@ -359,7 +363,6 @@ private class InfraExplorerImpl(
      * visited.
      */
     private fun hasRepeatedElements(block: StaticIdx<Block>): Boolean {
-        if (blockRoutes.containsKey(block)) return true
         val tracks =
             blockInfra
                 .getBlockPath(block)


### PR DESCRIPTION
And a few related adjustments / cleanups.

Some pathfinding requests took way too long because we sometimes saturated the bloom filter. As a result, we'd iterate through the whole path at every single step to look for duplicates, which is painfully slow. We'd end up taking more than a minute, with even timeouts in more extreme cases.

1. Remove homemade bloom filter: it was simple enough, but guava's has more convenient init values
2. Said values have been tweaked to account for what I've empirically observed on a timetable import
3. Remove redundant duplicate checks for blocks, and related code (they'd have duplicated tracks anyway)
4. Add time measurement when reproducing requests, just because why not


I didn't run *extensive* benchmarks, but the requests that took more than a minutes are now <30s. Still way too slow in my opinion, but not as extreme as before. 

It also speeds up stdcm in the same way, the difference is just less noticeable there. 