### PR TITLE
front: fix language list

### DIFF
--- a/front/src/common/ChangeLanguageModal.tsx
+++ b/front/src/common/ChangeLanguageModal.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import ModalBodySNCF from 'common/BootstrapSNCF/ModalSNCF/ModalBodySNCF';
 import ModalHeaderSNCF from 'common/BootstrapSNCF/ModalSNCF/ModalHeaderSNCF';
-import i18n from 'i18n';
+import i18n, { supportedLngs } from 'i18n';
 
 import { useModal } from './BootstrapSNCF/ModalSNCF';
 
@@ -43,7 +43,7 @@ const SortedLanguages = () => {
     }
   };
 
-  const availablesLanguages = i18n.languages.map((lng) => ({
+  const availablesLanguages = supportedLngs.map((lng) => ({
     key: lng,
     value: t(`language.${lng}`),
   }));

--- a/front/src/i18n.ts
+++ b/front/src/i18n.ts
@@ -8,14 +8,16 @@ import { initReactI18next } from 'react-i18next';
 
 const version = encodeURIComponent(import.meta.env.VITE_OSRD_GIT_DESCRIBE);
 
+export const supportedLngs = ['de', 'en', 'fr'];
+
 i18n
   .use(Backend)
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
-    fallbackLng: ['en', 'fr', 'de'],
+    fallbackLng: ['en', 'fr'],
     debug: false,
-    supportedLngs: ['de', 'en', 'fr'],
+    supportedLngs,
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
i18n.languages contains only the list of fallback langagues, ie. the list of languages used in case a translation doesn't exist in the currently selected language. This isn't what we want here: we want the full list of supported languages.

See this issue for more details:
https://github.com/i18next/i18next/issues/1068

Export our list of supported languages and use that instead.