### PR TITLE
editoast: do not ensure latest model when authorization disabled

### DIFF
--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -592,7 +592,9 @@ impl AppState {
             }
         };
         tracing::info!(url = %config.openfga_config.url, "connected to OpenFGA");
-        editoast_authz::ensure_latest_authorization_model(&mut openfga).await?;
+        if config.enable_authorization {
+            editoast_authz::ensure_latest_authorization_model(&mut openfga).await?;
+        }
 
         Ok(Self {
             valkey,


### PR DESCRIPTION
I would argue that all of these steps are not necessary when authorization is disabled, what do you think?