### PR TITLE
core: stdcm: fix offset type inconsistency

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMSimulations.kt
@@ -93,15 +93,15 @@ class STDCMSimulations {
         trainTag: String?,
         temporarySpeedLimitManager: TemporarySpeedLimitManager?,
     ): Envelope? {
-        if (stopPosition != null && stopPosition == Offset<Block>(0.meters))
-            return makeSinglePointEnvelope(0.0)
+        assert(stopPosition == null || stopPosition >= start)
+        if (stopPosition != null && stopPosition == start) return makeSinglePointEnvelope(0.0)
         val blockLength = infraExplorer.getCurrentBlockLength()
         if (start >= blockLength) return makeSinglePointEnvelope(initialSpeed)
         var stops = doubleArrayOf()
         var simLength = blockLength.distance - start.distance
         if (stopPosition != null) {
-            stops = doubleArrayOf(stopPosition.distance.meters)
-            simLength = Distance.min(simLength, stopPosition.distance)
+            stops = doubleArrayOf((stopPosition - start).meters)
+            simLength = Distance.min(simLength, stops.single().meters)
         }
         val path = infraExplorer.getCurrentEdgePathProperties(start, simLength)
         val envelopePath = EnvelopeTrainPath.from(rawInfra, path)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -8,7 +8,6 @@ import fr.sncf.osrd.utils.indexing.MutableDirStaticIdxArrayList
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.meters
 import java.util.*
 
 /** Returns the offset of the stops on the given block, starting at startOffset */
@@ -28,8 +27,8 @@ fun getStopOnBlock(
     if (!nextStep.stop) return null
     for (endLocation in nextStep.locations) {
         if (endLocation.edge == block) {
-            val offset = endLocation.offset - startOffset.distance
-            if (offset >= Offset(0.meters)) res.add(offset)
+            val offset = endLocation.offset
+            if (offset >= startOffset) res.add(offset)
         }
     }
     return if (res.isEmpty()) null else Collections.min(res)


### PR DESCRIPTION
We'd use an `Offset<Block>` to mean an offset from the start of the simulation on this block, it's now a real `Offset<Block>`.

The function itself is quite weird (probably artifacts from the old java->kt conversion), but I'll rewrite it in a different refactoring.