### PR TITLE
editoast: adapt ScenarioResponse to add paced trains

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -10417,11 +10417,15 @@ components:
         required:
         - infra_name
         - trains_count
+        - paced_trains_count
         - project
         - study
         properties:
           infra_name:
             type: string
+          paced_trains_count:
+            type: integer
+            format: int64
           project:
             $ref: '#/components/schemas/Project'
           study:
@@ -10436,9 +10440,13 @@ components:
         required:
         - infra_name
         - trains_count
+        - paced_trains_count
         properties:
           infra_name:
             type: string
+          paced_trains_count:
+            type: integer
+            format: int64
           trains_count:
             type: integer
             format: int64
@@ -12070,21 +12078,6 @@ components:
             within the target document where the operation is performed.
         value:
           description: Value to test against.
-    TimetableDetailedResult:
-      type: object
-      description: Creation result for a Timetable
-      required:
-      - timetable_id
-      - train_ids
-      properties:
-        timetable_id:
-          type: integer
-          format: int64
-        train_ids:
-          type: array
-          items:
-            type: integer
-            format: int64
     TimetableResult:
       type: object
       description: Creation result for a Timetable

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -51,6 +51,10 @@ impl Scenario {
         Timetable::trains_count(self.timetable_id, conn).await
     }
 
+    pub async fn paced_trains_count(&self, conn: &mut DbConnection) -> Result<i64> {
+        Timetable::paced_trains_count(self.timetable_id, conn).await
+    }
+
     pub async fn update_last_modified(&mut self, conn: &mut DbConnection) -> Result<()> {
         self.last_modification = Utc::now().naive_utc();
         self.save(conn).await?;

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -42,6 +42,17 @@ impl Timetable {
             .map_err(Into::into)
     }
 
+    pub async fn paced_trains_count(timetable_id: i64, conn: &mut DbConnection) -> Result<i64> {
+        use editoast_models::tables::paced_train::dsl;
+
+        dsl::paced_train
+            .filter(dsl::timetable_id.eq(timetable_id))
+            .count()
+            .get_result(conn.write().await.deref_mut())
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn gather_start_times(
         timetable_id: i64,
         conn: &mut DbConnection,
@@ -102,15 +113,19 @@ pub struct TimetableWithTrains {
     pub id: i64,
     #[diesel(sql_type = Array<BigInt>)]
     pub train_ids: Vec<i64>,
+    #[diesel(sql_type = Array<BigInt>)]
+    pub paced_train_ids: Vec<i64>,
 }
 
 impl Retrieve<i64> for TimetableWithTrains {
     async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
         let result = sql_query(
             "SELECT timetable.*,
-        array_remove(array_agg(train_schedule.id), NULL) as train_ids
+        array_remove(array_agg(train_schedule.id), NULL) as train_ids,
+        array_remove(array_agg(paced_train.id), NULL) as paced_train_ids
         FROM timetable
         LEFT JOIN train_schedule ON timetable.id = train_schedule.timetable_id
+        LEFT JOIN paced_train ON timetable.id = paced_train.timetable_id
         WHERE timetable.id = $1
         GROUP BY timetable.id",
         )

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -146,6 +146,7 @@ pub struct ScenarioWithDetails {
     pub scenario: Scenario,
     pub infra_name: String,
     pub trains_count: i64,
+    pub paced_trains_count: i64,
 }
 
 impl ScenarioWithDetails {
@@ -153,6 +154,7 @@ impl ScenarioWithDetails {
         Ok(Self {
             infra_name: scenario.infra_name(conn).await?,
             trains_count: scenario.trains_count(conn).await?,
+            paced_trains_count: scenario.paced_trains_count(conn).await?,
             scenario,
         })
     }
@@ -164,6 +166,7 @@ pub struct ScenarioResponse {
     pub scenario: Scenario,
     pub infra_name: String,
     pub trains_count: i64,
+    pub paced_trains_count: i64,
     pub project: Project,
     pub study: Study,
 }
@@ -178,6 +181,7 @@ impl ScenarioResponse {
             scenario: scenarios_with_details.scenario,
             infra_name: scenarios_with_details.infra_name,
             trains_count: scenarios_with_details.trains_count,
+            paced_trains_count: scenarios_with_details.paced_trains_count,
             project,
             study,
         }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -69,7 +69,6 @@ crate::routes! {
 
 editoast_common::schemas! {
     TimetableResult,
-    TimetableDetailedResult,
     stdcm::schemas(),
 }
 
@@ -98,23 +97,6 @@ impl From<Timetable> for TimetableResult {
     fn from(timetable: Timetable) -> Self {
         Self {
             timetable_id: timetable.id,
-        }
-    }
-}
-
-/// Creation result for a Timetable
-#[derive(Debug, Default, Serialize, Deserialize, Derivative, ToSchema)]
-#[cfg_attr(test, derive(PartialEq))]
-struct TimetableDetailedResult {
-    pub timetable_id: i64,
-    pub train_ids: Vec<i64>,
-}
-
-impl From<TimetableWithTrains> for TimetableDetailedResult {
-    fn from(val: TimetableWithTrains) -> Self {
-        Self {
-            timetable_id: val.id,
-            train_ids: val.train_ids,
         }
     }
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3488,10 +3488,12 @@ export type Scenario = {
 };
 export type ScenarioWithDetails = Scenario & {
   infra_name: string;
+  paced_trains_count: number;
   trains_count: number;
 };
 export type ScenarioResponse = Scenario & {
   infra_name: string;
+  paced_trains_count: number;
   project: Project;
   study: Study;
   trains_count: number;

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -50,6 +50,7 @@ class _ScenarioResponse:
     infra_id: int
     electrical_profile_set_id: Optional[int]
     trains_count: int
+    paced_trains_count: int
     creation_date: str
     last_modification: str
     tags: list[str]


### PR DESCRIPTION
Adapt a struct that allows the front to display paced train's count in the scenario card.