### PR TITLE
scripts: kill openfga when restoring a db backup

### DIFF
--- a/scripts/cleanup-db.sh
+++ b/scripts/cleanup-db.sh
@@ -19,6 +19,7 @@ root_path=$(realpath "$(dirname "$0")/..")
 # These variables are necessary to load the infra on the correct instance (the pr-infra or the dev one)
 OSRD_POSTGRES="osrd-postgres"
 OSRD_EDITOAST="osrd-editoast"
+OSRD_OPENFGA="osrd-openfga"
 OSRD_VALKEY="osrd-valkey"
 OSRD_VALKEY_VOLUME="osrd_valkey_data"
 OSRD_POSTGRES_PORT=5432
@@ -51,6 +52,11 @@ if [ "$DB_EXISTS" = 't' ]; then
   if [ "$(docker ps -q -f name=$OSRD_EDITOAST)" ]; then
     echo "Stopping $OSRD_EDITOAST..."
     docker stop "$OSRD_EDITOAST"
+  fi
+  # same for openfga
+  if [ "$(docker ps -q -f name=$OSRD_OPENFGA)" ]; then
+    echo "Stopping $OSRD_OPENFGA..."
+    docker stop "$OSRD_OPENFGA"
   fi
 
   DB_CONN="$(docker exec "$OSRD_POSTGRES" psql -p "$OSRD_POSTGRES_PORT" -c "SELECT numbackends FROM pg_stat_database WHERE datname = 'osrd';")"


### PR DESCRIPTION
Otherwise we get an error like "DB is in use, can't load backup".