### PR TITLE
core: fix adjusted permitted speed position calculation

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -629,8 +629,7 @@ private fun getAdjustedPermittedSpeedPosition(
     guiCurve: EnvelopePart
 ): Double {
     val guiPosition =
-        if (speed > guiCurve.maxSpeed || speed < guiCurve.minSpeed) Double.POSITIVE_INFINITY
-        else guiCurve.interpolatePosition(speed)
+        if (speed > guiCurve.maxSpeed) guiCurve.beginPos else guiCurve.interpolatePosition(speed)
     // Interpolating adds a position inaccuracy. If both positions are equal, keep more accurate
     // permitted speed position.
     return if (TrainPhysicsIntegrator.arePositionsEqual(permittedSpeedPosition, guiPosition))


### PR DESCRIPTION
Speed can be above gui curve max speed, however that doesn't mean the guidance shouldn't be followed. Rectify it so that when the speed is above gui max speed, gui position is the gui begin position.
Fixes #11117 