### PR TITLE
editoast: remove unused code

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4792,44 +4792,6 @@ components:
           type: string
           enum:
           - editoast:coreclient:BrokenPipe
-    EditoastCoreErrorConnectionClosedBeforeMessageCompleted:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:ConnectionClosedBeforeMessageCompleted
-    EditoastCoreErrorConnectionResetByPeer:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 500
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:ConnectionResetByPeer
     EditoastCoreErrorCoreResponseFormatError:
       type: object
       required:
@@ -4854,36 +4816,6 @@ components:
           type: string
           enum:
           - editoast:coreclient:CoreResponseFormatError
-    EditoastCoreErrorGenericCoreError:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - raw_error
-          - status
-          - url
-          properties:
-            raw_error:
-              type: string
-            status:
-              type: object
-            url:
-              type: string
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 400
-        type:
-          type: string
-          enum:
-          - editoast:coreclient:GenericCoreError
     EditoastCoreErrorMqClientError:
       type: object
       required:
@@ -5131,10 +5063,7 @@ components:
       - $ref: '#/components/schemas/EditoastCacheOperationErrorDuplicateIdsProvided'
       - $ref: '#/components/schemas/EditoastCacheOperationErrorObjectNotFound'
       - $ref: '#/components/schemas/EditoastCoreErrorBrokenPipe'
-      - $ref: '#/components/schemas/EditoastCoreErrorConnectionClosedBeforeMessageCompleted'
-      - $ref: '#/components/schemas/EditoastCoreErrorConnectionResetByPeer'
       - $ref: '#/components/schemas/EditoastCoreErrorCoreResponseFormatError'
-      - $ref: '#/components/schemas/EditoastCoreErrorGenericCoreError'
       - $ref: '#/components/schemas/EditoastCoreErrorMqClientError'
       - $ref: '#/components/schemas/EditoastCoreErrorUnparsableErrorOutput'
       - $ref: '#/components/schemas/EditoastDatabaseAccessErrorDatabaseAccessError'

--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -266,24 +266,10 @@ pub enum CoreError {
     #[error("Cannot parse Core response: {msg}")]
     #[editoast_error(status = 500)]
     CoreResponseFormatError { msg: String },
-    /// A fallback error variant for when no meaningful error could be parsed
-    /// from core's output.
-    #[error("Core error {}: {raw_error}", status.unwrap_or(500))]
-    #[editoast_error(status = status.unwrap_or(500))]
-    GenericCoreError {
-        status: Option<u16>,
-        url: String,
-        raw_error: String,
-    },
+
     #[error("Core returned an error in an unknown format")]
     UnparsableErrorOutput,
 
-    #[error("Core connection closed before message completed. Should retry.")]
-    #[editoast_error(status = 500)]
-    ConnectionClosedBeforeMessageCompleted,
-    #[error("Core connection reset by peer. Should retry.")]
-    #[editoast_error(status = 500)]
-    ConnectionResetByPeer,
     #[error("Core connection broken. Should retry.")]
     #[editoast_error(status = 500)]
     BrokenPipe,
@@ -335,37 +321,6 @@ impl std::error::Error for StandardCoreError {}
 impl Display for StandardCoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)
-    }
-}
-
-impl From<reqwest::Error> for CoreError {
-    fn from(value: reqwest::Error) -> Self {
-        // Since we should retry the request it's useful to have its own kind of error.
-        if value
-            .to_string()
-            .contains("connection closed before message completed")
-        {
-            return Self::ConnectionClosedBeforeMessageCompleted;
-        }
-        if value.to_string().contains("Connection reset by peer") {
-            return Self::ConnectionResetByPeer;
-        }
-        if value
-            .to_string()
-            .contains("error writing a body to connection: Broken pipe")
-        {
-            return Self::BrokenPipe;
-        }
-
-        // Convert the reqwest error
-        Self::GenericCoreError {
-            status: value.status().map(|st| st.as_u16()),
-            url: value
-                .url()
-                .map_or("<NO URL>", |url| url.as_str())
-                .to_owned(),
-            raw_error: value.to_string(),
-        }
     }
 }
 

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -39,10 +39,7 @@
     "coreclient": {
       "BrokenPipe": "Core connection broken pipe. Should retry.",
       "CannotExtractResponseBody": "Cannot extract Core response body: {{msg}}",
-      "ConnectionClosedBeforeMessageCompleted": "Core connection closed before message completed. Should retry.",
-      "ConnectionResetByPeer": "Core connection reset by peer. Should retry.",
       "CoreResponseFormatError": "Cannot parse Core response: {{msg}}",
-      "GenericCoreError": "Core error {{raw_error}}",
       "UnparsableErrorOutput": "Core returned an error in an unknown format",
       "MqClientError": "Core: MQ client error"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -39,10 +39,7 @@
     "coreclient": {
       "BrokenPipe": "Core: connexion interrompue. Nouvelle tentative.",
       "CannotExtractResponseBody": "Core: Impossible d'extraire le corps de la réponse : {{msg}}",
-      "ConnectionClosedBeforeMessageCompleted": "Core: connexion fermée avant la fin du message. Nouvelle tentative.",
-      "ConnectionResetByPeer": "Core: réinitialisation de la connexion. Nouvelle tentative.",
       "CoreResponseFormatError": "Core: impossible d'analyser la réponse '{{msg}}'",
-      "GenericCoreError": "Core: erreur {{raw_error}}",
       "UnparsableErrorOutput": "Core: a renvoyé une erreur dans un format inconnu",
       "MqClientError": "Core: erreur du client MQ"
     },


### PR DESCRIPTION
Previously, we made direct calls to `core` from `editoast` using `reqwest`, but now we use `mq_client` to communicate with `core`. Therefore, we no longer need the `From<reqwest::Error> for CoreError`, and we can remove these variants of `CoreError`:
```rust
GenericCoreError { status: Option<u16>, url: String, raw_error: String }
ConnectionClosedBeforeMessageCompleted
ConnectionResetByPeer
```