### PR TITLE
front: map: factorize sources

### DIFF
--- a/front/src/common/Map/Layers/Background.tsx
+++ b/front/src/common/Map/Layers/Background.tsx
@@ -1,4 +1,4 @@
-import { Source, type LayerProps } from 'react-map-gl/maplibre';
+import { type LayerProps } from 'react-map-gl/maplibre';
 
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import type { Theme } from 'types';
@@ -22,11 +22,7 @@ function Background(props: BackgroundProps) {
     },
   };
 
-  return (
-    <Source id="background" type="vector">
-      <OrderedLayer {...backgroundParams} layerOrder={layerOrder} />
-    </Source>
-  );
+  return <OrderedLayer {...backgroundParams} layerOrder={layerOrder} />;
 }
 
 export default Background;

--- a/front/src/common/Map/Layers/Hillshade.tsx
+++ b/front/src/common/Map/Layers/Hillshade.tsx
@@ -1,7 +1,6 @@
-import { Source, type LayerProps } from 'react-map-gl/maplibre';
+import { type LayerProps } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
-import { TERRAIN_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import { getTerrain3DExaggeration } from 'reducers/map/selectors';
 
@@ -13,7 +12,7 @@ type HillshadeProps = {
 
 const hillshadeParams: LayerProps = {
   id: 'osm/hillshade',
-  source: 'hillshade',
+  source: 'terrain',
   type: 'hillshade',
   paint: {},
 };
@@ -25,18 +24,7 @@ const Hillshade = ({ mapStyle, layerOrder }: HillshadeProps) => {
     return null;
   }
 
-  return (
-    <Source
-      id="hillshade"
-      type="raster-dem"
-      encoding="terrarium"
-      url={TERRAIN_URL}
-      tileSize={256}
-      maxzoom={12}
-    >
-      <OrderedLayer {...hillshadeParams} layerOrder={layerOrder} />
-    </Source>
-  );
+  return <OrderedLayer {...hillshadeParams} layerOrder={layerOrder} />;
 };
 
 export default Hillshade;

--- a/front/src/common/Map/Layers/OSM.tsx
+++ b/front/src/common/Map/Layers/OSM.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react';
 
 import { get } from 'lodash';
-import { type LayerProps, Source } from 'react-map-gl/maplibre';
+import { type LayerProps } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
 import mapStyleDarkJson from 'assets/mapstyles/OSMDarkStyle.json';
 import mapStyleMinimalJson from 'assets/mapstyles/OSMMinimalStyle.json';
 import mapStyleJson from 'assets/mapstyles/OSMStyle.json';
-import { OSM_URL } from 'common/Map/const';
 import OrderedLayer, { type OrderedLayerProps } from 'common/Map/Layers/OrderedLayer';
 import { getShowOSM3dBuildings } from 'reducers/map/selectors';
 
@@ -57,6 +56,7 @@ export function genOSMLayerProps(
         ...layer,
         id: `osm/${layer.id}`,
         layerOrder,
+        source: 'osm',
       },
     ];
   }, []);
@@ -82,16 +82,7 @@ function OSM({ mapStyle, layerOrder, mapIsLoaded }: OSMProps) {
   const toggledLayers = { showOSM3dBuildings };
 
   if (reload) return null;
-  return (
-    <Source
-      id="osm"
-      type="vector"
-      url={OSM_URL}
-      attribution='© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    >
-      {genOSMLayers(mapStyle, toggledLayers, layerOrder)}
-    </Source>
-  );
+  return <>{genOSMLayers(mapStyle, toggledLayers, layerOrder)}</>;
 }
 
 export default OSM;

--- a/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
@@ -1,5 +1,6 @@
 import colors from 'common/Map/Consts/colors';
 import OpenStreetMapSource from 'common/Map/Sources/OpenStreetMap';
+import TerrainSource from 'common/Map/Sources/Terrain';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import type { MapStyle } from 'reducers/map';
 
@@ -7,7 +8,6 @@ import Background from '../Background';
 import Hillshade from '../Hillshade';
 import OSM from '../OSM';
 import PlatformsLayer from '../Platforms';
-import Terrain from '../Terrain';
 import TracksOSM from '../TracksOSM';
 
 type OSMLayersProps = {
@@ -19,6 +19,8 @@ type OSMLayersProps = {
 const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
   <>
     <OpenStreetMapSource />
+    <TerrainSource />
+
     <Background
       colors={colors[mapStyle]}
       layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}
@@ -30,8 +32,6 @@ const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
         layerOrder={LAYER_GROUPS_ORDER[LAYERS.PLATFORMS.GROUP]}
       />
     )}
-
-    <Terrain />
 
     <TracksOSM colors={colors[mapStyle]} layerOrder={LAYER_GROUPS_ORDER[LAYERS.TRACKS_OSM.GROUP]} />
 

--- a/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
+++ b/front/src/common/Map/Layers/OSMLayers/OSMLayers.tsx
@@ -1,4 +1,5 @@
 import colors from 'common/Map/Consts/colors';
+import OpenStreetMapSource from 'common/Map/Sources/OpenStreetMap';
 import { LAYER_GROUPS_ORDER, LAYERS } from 'config/layerOrder';
 import type { MapStyle } from 'reducers/map';
 
@@ -17,6 +18,7 @@ type OSMLayersProps = {
 
 const OSMLayers = ({ mapStyle, showOSM, hidePlatforms }: OSMLayersProps) => (
   <>
+    <OpenStreetMapSource />
     <Background
       colors={colors[mapStyle]}
       layerOrder={LAYER_GROUPS_ORDER[LAYERS.BACKGROUND.GROUP]}

--- a/front/src/common/Map/Layers/Platforms.tsx
+++ b/front/src/common/Map/Layers/Platforms.tsx
@@ -1,7 +1,6 @@
-import { Source, type LayerProps } from 'react-map-gl/maplibre';
+import { type LayerProps } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
-import { OSM_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import type { RootState } from 'reducers';
 import type { Theme } from 'types';
@@ -16,6 +15,7 @@ export function Platforms(props: PlatformsProps) {
 
   const platformsParams: LayerProps = {
     type: 'fill',
+    source: 'osm',
     'source-layer': 'transportation',
     filter: ['all', ['==', ['get', 'class'], 'path'], ['==', ['get', 'subclass'], 'platform']],
     paint: {
@@ -23,11 +23,7 @@ export function Platforms(props: PlatformsProps) {
     },
   };
 
-  return (
-    <Source id="platforms" type="vector" url={OSM_URL} source-layer="transportation">
-      <OrderedLayer {...platformsParams} layerOrder={layerOrder} />
-    </Source>
-  );
+  return <OrderedLayer {...platformsParams} layerOrder={layerOrder} />;
 }
 
 function PlatformsState(props: PlatformsProps) {

--- a/front/src/common/Map/Layers/TracksOSM.tsx
+++ b/front/src/common/Map/Layers/TracksOSM.tsx
@@ -1,7 +1,6 @@
-import { Source, type LayerProps } from 'react-map-gl/maplibre';
+import { type LayerProps } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
-import { OSM_URL } from 'common/Map/const';
 import OrderedLayer from 'common/Map/Layers/OrderedLayer';
 import type { RootState } from 'reducers';
 import type { Theme } from 'types';
@@ -18,7 +17,7 @@ function TracksOSM(props: TracksOSMProps) {
   const railwayMinor: LayerProps = {
     id: 'railwayMinor',
     type: 'line',
-    source: 'openmaptiles',
+    source: 'osm',
     'source-layer': 'transportation',
     filter: ['all', ['==', ['get', 'class'], 'rail'], ['==', ['get', 'service'], 'yard']],
     layout: {
@@ -32,7 +31,7 @@ function TracksOSM(props: TracksOSMProps) {
   const railwayMajor: LayerProps = {
     id: 'railwayMajor',
     type: 'line',
-    source: 'openmaptiles',
+    source: 'osm',
     'source-layer': 'transportation',
     filter: ['all', ['==', ['get', 'class'], 'rail'], ['!=', ['get', 'service'], 'yard']],
     layout: {
@@ -46,10 +45,10 @@ function TracksOSM(props: TracksOSMProps) {
 
   if (!showOSMtracksections) return null;
   return (
-    <Source id="tracksOSM" type="vector" url={OSM_URL} source-layer="transportation">
+    <>
       <OrderedLayer {...railwayMinor} layerOrder={layerOrder} />
       <OrderedLayer {...railwayMajor} layerOrder={layerOrder} />
-    </Source>
+    </>
   );
 }
 

--- a/front/src/common/Map/Sources/OpenStreetMap.tsx
+++ b/front/src/common/Map/Sources/OpenStreetMap.tsx
@@ -1,0 +1,16 @@
+import { Source } from 'react-map-gl/maplibre';
+
+import { OSM_URL } from 'common/Map/const';
+
+function OpenStreetMapSource() {
+  return (
+    <Source
+      id="osm"
+      type="vector"
+      url={OSM_URL}
+      attribution='© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    />
+  );
+}
+
+export default OpenStreetMapSource;

--- a/front/src/common/Map/Sources/Terrain.tsx
+++ b/front/src/common/Map/Sources/Terrain.tsx
@@ -2,7 +2,7 @@ import { Source } from 'react-map-gl/maplibre';
 
 import { TERRAIN_URL } from 'common/Map/const';
 
-export default function Terrain() {
+function TerrainSource() {
   return (
     <Source
       id="terrain"
@@ -14,3 +14,5 @@ export default function Terrain() {
     />
   );
 }
+
+export default TerrainSource;


### PR DESCRIPTION
This pull requests separates the map Sources from the Layers. This allows having only one data source if it is used in multiple layers.

There should be no visible change on the map (try adding layers such as OSM Tracks, plateforms, activate terrain…).

In the network console we should notice that there no longer are call multiple times to the same data source

Fixes #11106 