### PR TITLE
core: refactor type Path to BlockPath

### DIFF
--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -2,7 +2,6 @@ package fr.sncf.osrd.envelope_sim.etcs
 
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
-import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
 
@@ -28,7 +27,7 @@ interface ETCSBrakingSimulator {
 }
 
 data class LimitOfAuthority(
-    val offset: Offset<Path>,
+    val offset: Offset<TravelledPath>,
     val speed: Double,
 ) {
     init {

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/pipelines/MaxSpeedEnvelope.kt
@@ -18,7 +18,6 @@ import fr.sncf.osrd.envelope_sim.etcs.EndOfAuthority
 import fr.sncf.osrd.envelope_sim.etcs.LimitOfAuthority
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
@@ -111,7 +110,7 @@ object MaxSpeedEnvelope {
         val cursor = EnvelopeCursor.backward(envelope)
         val limitsOfAuthority = mutableListOf<LimitOfAuthority>()
         while (cursor.findPartTransition(MaxSpeedEnvelope::increase)) {
-            val offset = Offset<Path>(cursor.position.meters)
+            val offset = Offset<TravelledPath>(cursor.position.meters)
             if (etcsRanges.contains(offset.distance)) {
                 limitsOfAuthority.add(
                     LimitOfAuthority(

--- a/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
+++ b/core/kt-osrd-signaling/src/main/kotlin/fr/sncf/osrd/signaling/impl/SignalingSimulatorImpl.kt
@@ -94,7 +94,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
             )
         for (block in blockInfra.blocks) {
             val sigSystem = blockInfra.getBlockSignalingSystem(block)
-            val path = blockInfra.getBlockPath(block)
+            val path = blockInfra.getBlockZonePaths(block)
             val length =
                 Distance(
                     path
@@ -184,7 +184,7 @@ class SignalingSimulatorImpl(override val sigModuleManager: SigSystemManager) : 
         var blockZoneOffset = 0
         for (i in 0 until evaluatedPathEnd) {
             blockZoneMap[i] = blockZoneOffset
-            blockZoneOffset += blocks.getBlockPath(fullPath[i]).size
+            blockZoneOffset += blocks.getBlockZonePaths(fullPath[i]).size
         }
         blockZoneMap[evaluatedPathEnd] = blockZoneOffset
 

--- a/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
+++ b/core/kt-osrd-signaling/src/test/kotlin/fr/sncf/osrd/signaling/BlockBuilderTest.kt
@@ -153,7 +153,9 @@ class BlockBuilderTest {
     private fun blockInfraToSet(infra: BlockInfra): MutableSet<BlockDescriptor> {
         val res: MutableSet<BlockDescriptor> = mutableSetOf()
         for (blockId in infra.blocks) {
-            res.add(BlockDescriptor(infra.getBlockPath(blockId), infra.getBlockSignals(blockId)))
+            res.add(
+                BlockDescriptor(infra.getBlockZonePaths(blockId), infra.getBlockSignals(blockId))
+            )
         }
         return res
     }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/LoadedSignalingInfra.kt
@@ -86,7 +86,7 @@ interface LoadedSignalInfra {
 interface BlockInfra {
     val blocks: StaticIdxSpace<Block>
 
-    fun getBlockPath(block: BlockId): StaticIdxList<ZonePath>
+    fun getBlockZonePaths(block: BlockId): StaticIdxList<ZonePath>
 
     fun getBlocksInZone(zone: ZoneId): StaticIdxList<Block>
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/api/PathProperties.kt
@@ -16,7 +16,9 @@ data class IdxWithOffset<T, U>(
     val offset: Offset<U>,
 )
 
-typealias IdxWithPathOffset<T> = IdxWithOffset<T, Path>
+typealias IdxWithBlockPathOffset<T> = IdxWithOffset<T, BlockPath>
+
+typealias IdxWithTravelledPathOffset<T> = IdxWithOffset<T, TravelledPath>
 
 data class TrackLocation(
     @get:JvmName("getTrackId") val trackId: TrackSectionId,
@@ -24,11 +26,10 @@ data class TrackLocation(
 )
 
 /**
- * A marker type for Length and Offset. "Path" *mostly* refers to "BlockPath", where start is the
- * beginning of the first block (NOT the real start of the train).
+ * A marker type for Length and Offset. In BlockPath, start refers to the beginning of the first
+ * block (NOT the real start of the train).
  */
-// TODO: rename this to BlockPath and make sure it's used appropriately
-sealed interface Path
+sealed interface BlockPath
 
 /**
  * A marker type for Length and Offset. In TravelledPath, start refers to the real start of the head
@@ -40,7 +41,7 @@ sealed interface TravelledPath
 interface PathProperties {
     fun getSlopes(): DistanceRangeMap<Double>
 
-    fun getOperationalPointParts(): List<IdxWithPathOffset<OperationalPointPart>>
+    fun getOperationalPointParts(): List<IdxWithTravelledPathOffset<OperationalPointPart>>
 
     fun getGradients(): DistanceRangeMap<Double>
 
@@ -65,10 +66,10 @@ interface PathProperties {
     @JvmName("getLength") fun getLength(): Distance
 
     @JvmName("getTrackLocationAtOffset")
-    fun getTrackLocationAtOffset(pathOffset: Offset<Path>): TrackLocation
+    fun getTrackLocationAtOffset(pathOffset: Offset<TravelledPath>): TrackLocation
 
     @JvmName("getTrackLocationOffset")
-    fun getTrackLocationOffset(location: TrackLocation): Offset<Path>?
+    fun getTrackLocationOffset(location: TrackLocation): Offset<TravelledPath>?
 
     fun <T> getRangeMapFromUndirected(
         getData: (chunkId: TrackChunkId) -> DistanceRangeMap<T>
@@ -87,8 +88,8 @@ interface PathProperties {
 fun buildPathPropertiesFrom(
     infra: RawSignalingInfra,
     chunks: DirStaticIdxList<TrackChunk>,
-    pathBeginOffset: Offset<Path>,
-    pathEndOffset: Offset<Path>,
+    pathBeginOffset: Offset<BlockPath>,
+    pathEndOffset: Offset<BlockPath>,
     routes: List<RouteId>? = null,
 ): PathProperties {
     val chunkPath = buildChunkPath(infra, chunks, pathBeginOffset, pathEndOffset)
@@ -126,7 +127,10 @@ fun makeTrackLocation(track: TrackSectionId, offset: Offset<TrackSection>): Trac
  * it's generic.
  */
 @JvmName("getTrackLocationOffsetOrThrow")
-fun getTrackLocationOffsetOrThrow(path: PathProperties, location: TrackLocation): Offset<Path> {
+fun getTrackLocationOffsetOrThrow(
+    path: PathProperties,
+    location: TrackLocation
+): Offset<TravelledPath> {
     return path.getTrackLocationOffset(location)
         ?: throw RuntimeException("Can't find location on path")
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/BlockInfraImpl.kt
@@ -79,7 +79,7 @@ class BlockInfraImpl(
             }
 
             // Update trackChunkToBlockMap, blockToTrackChunkMap, and zoneToBlockMap
-            for (zonePath in getBlockPath(blockId)) {
+            for (zonePath in getBlockZonePaths(blockId)) {
                 val trackChunks = rawInfra.getZonePathChunks(zonePath)
                 val blockTrackChunks =
                     blockToTrackChunkMap.getOrPut(blockId) { mutableDirStaticIdxArrayListOf() }
@@ -105,7 +105,7 @@ class BlockInfraImpl(
     override val blocks: StaticIdxSpace<Block>
         get() = blockPool.space()
 
-    override fun getBlockPath(block: BlockId): StaticIdxList<ZonePath> {
+    override fun getBlockZonePaths(block: BlockId): StaticIdxList<ZonePath> {
         return blockPool[block].path
     }
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
@@ -79,10 +79,10 @@ fun makeZonePath(infra: RawInfra, id: StaticIdx<ZonePath>): ZonePathViewer {
 
 @JvmName("makeBlock")
 fun makeBlock(rawInfra: RawInfra, blockInfra: BlockInfra, id: StaticIdx<Block>): BlockViewer {
-    val entry = rawInfra.getZonePathEntry(blockInfra.getBlockPath(id)[0])
-    val exit = rawInfra.getZonePathExit(blockInfra.getBlockPath(id).last())
+    val entry = rawInfra.getZonePathEntry(blockInfra.getBlockZonePaths(id)[0])
+    val exit = rawInfra.getZonePathExit(blockInfra.getBlockZonePaths(id).last())
     return BlockViewer(
-        blockInfra.getBlockPath(id).map { path -> makeZonePath(rawInfra, path) },
+        blockInfra.getBlockZonePaths(id).map { path -> makeZonePath(rawInfra, path) },
         id,
         makeDirViewer(entry, rawInfra.getDetectorName(entry.value)),
         makeDirViewer(exit, rawInfra.getDetectorName(exit.value)),

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/PathPropertiesImpl.kt
@@ -28,13 +28,13 @@ data class ChunkPath(
      * Offset of the head of the train when it starts its path, compared to the start of the first
      * element in `chunks`.
      */
-    val beginOffset: Offset<Path>,
+    val beginOffset: Offset<BlockPath>,
 
     /**
      * Offset of the head of the train when it ends its path, compared to the start of the first
      * element in `chunks`.
      */
-    val endOffset: Offset<Path>
+    val endOffset: Offset<BlockPath>
 ) {
     val length: Distance = endOffset.distance - beginOffset.distance
 }
@@ -48,7 +48,8 @@ data class PathPropertiesImpl(
         return getRangeMap { dirChunkId -> infra.getTrackChunkSlope(dirChunkId) }
     }
 
-    override fun getOperationalPointParts(): List<IdxWithPathOffset<OperationalPointPart>> {
+    override fun getOperationalPointParts():
+        List<IdxWithTravelledPathOffset<OperationalPointPart>> {
         return getElementsOnPath { dirChunkId ->
             infra.getTrackChunkOperationalPointParts(dirChunkId.value).map { opId ->
                 IdxWithOffset(opId, infra.getOperationalPointPartChunkOffset(opId))
@@ -145,8 +146,8 @@ data class PathPropertiesImpl(
         return chunkPath.endOffset - chunkPath.beginOffset
     }
 
-    override fun getTrackLocationAtOffset(pathOffset: Offset<Path>): TrackLocation {
-        val offset: Offset<Path> = pathOffset + chunkPath.beginOffset.distance
+    override fun getTrackLocationAtOffset(pathOffset: Offset<TravelledPath>): TrackLocation {
+        val offset: Offset<TravelledPath> = pathOffset + chunkPath.beginOffset.distance
         var lengthPrevChunks = 0.meters
         for (chunk in chunkPath.chunks) {
             val chunkLength = infra.getTrackChunkLength(chunk.value)
@@ -167,7 +168,7 @@ data class PathPropertiesImpl(
         throw RuntimeException("The given path offset is larger than the path length")
     }
 
-    override fun getTrackLocationOffset(location: TrackLocation): Offset<Path>? {
+    override fun getTrackLocationOffset(location: TrackLocation): Offset<TravelledPath>? {
         val offset =
             getOffsetOfTrackLocationOnChunks(infra, location, chunkPath.chunks) ?: return null
         if (offset < chunkPath.beginOffset || offset > chunkPath.endOffset) return null
@@ -263,13 +264,13 @@ data class PathPropertiesImpl(
 
     /**
      * Use the given function to get punctual data from a chunk, and concatenates all the values on
-     * the path
+     * the path. // TODO change type: types should be DirStaticIdxList<TrackChunk>
      */
     private fun <T> getElementsOnPath(
         getData: (chunk: DirTrackChunkId) -> Iterable<IdxWithOffset<T, TrackChunk>>
-    ): List<IdxWithPathOffset<T>> {
-        val res = ArrayList<IdxWithPathOffset<T>>()
-        var chunkOffset = Offset<Path>(0.meters)
+    ): List<IdxWithTravelledPathOffset<T>> {
+        val res = ArrayList<IdxWithBlockPathOffset<T>>()
+        var chunkOffset = Offset<BlockPath>(0.meters)
         for (chunk in chunkPath.chunks) {
             for ((element, offset) in getData.invoke(chunk)) {
                 val projectedOffset = projectPosition(chunk, offset)
@@ -296,16 +297,18 @@ data class PathPropertiesImpl(
     }
 
     /**
-     * Keeps only the elements that are not outside the path, and shift the offsets to start at 0
+     * Keeps only the elements that are not outside the path, and shift the offsets to start at 0 //
+     * TODO change type: type DirStaticIdxList<TrackChunk> (= Offset<ChunkSequence> in and
+     * Offset<TravelledPath> out)
      */
     private fun <T> filterAndShiftElementsOnPath(
-        res: List<IdxWithPathOffset<T>>
-    ): List<IdxWithPathOffset<T>> {
+        res: List<IdxWithBlockPathOffset<T>>
+    ): List<IdxWithTravelledPathOffset<T>> {
         return res.filter { element ->
                 element.offset >= chunkPath.beginOffset && element.offset <= chunkPath.endOffset
             }
             .map { element ->
-                IdxWithOffset(element.value, element.offset - chunkPath.beginOffset.distance)
+                IdxWithOffset(element.value, Offset(element.offset - chunkPath.beginOffset))
             }
     }
 }
@@ -315,8 +318,8 @@ fun getOffsetOfTrackLocationOnChunks(
     infra: TrackProperties,
     location: TrackLocation,
     chunks: DirStaticIdxList<TrackChunk>,
-): Offset<Path>? {
-    var offsetAfterFirstChunk = Offset<Path>(0.meters)
+): Offset<BlockPath>? {
+    var offsetAfterFirstChunk = Offset<BlockPath>(0.meters)
     for (dirChunk in chunks) {
         val chunkLength = infra.getTrackChunkLength(dirChunk.value)
         if (location.trackId == infra.getTrackFromChunk(dirChunk.value)) {
@@ -343,11 +346,11 @@ fun getOffsetOfTrackLocationOnChunks(
 fun buildChunkPath(
     infra: TrackProperties,
     chunks: DirStaticIdxList<TrackChunk>,
-    pathBeginOffset: Offset<Path>,
-    pathEndOffset: Offset<Path>
+    pathBeginOffset: Offset<BlockPath>,
+    pathEndOffset: Offset<BlockPath>
 ): ChunkPath {
     val filteredChunks = mutableDirStaticIdxArrayListOf<TrackChunk>()
-    var totalChunksLength = Offset<Path>(0.meters)
+    var totalChunksLength = Offset<BlockPath>(0.meters)
     var mutBeginOffset = pathBeginOffset
     var mutEndOffset = pathEndOffset
     for (dirChunkId in chunks) {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
@@ -53,9 +53,9 @@ private fun filterBlocks(
                 !allowedSignalingSystems.contains(blockInfra.getBlockSignalingSystem(block))
         )
             continue
-        val blockPath = blockInfra.getBlockPath(block)
-        if (blockPath.size > remainingZonePaths) continue
-        for (i in 0 until blockPath.size) if (routePath[routeOffset + i] != blockPath[i])
+        val blockZonePaths = blockInfra.getBlockZonePaths(block)
+        if (blockZonePaths.size > remainingZonePaths) continue
+        for (i in 0 until blockZonePaths.size) if (routePath[routeOffset + i] != blockZonePaths[i])
             continue@blockLoop
         res.add(block)
     }
@@ -94,7 +94,7 @@ private fun findRouteBlocks(
         val blocksOnRoute =
             filterBlocks(allowedSignalingSystems, blockInfra, blocks, routePath, routeOffset)
         for (block in blocksOnRoute) {
-            val blockSize = blockInfra.getBlockPath(block).size
+            val blockSize = blockInfra.getBlockZonePaths(block).size
             addPath(
                 BlockPathElement(
                     prevPath,
@@ -114,7 +114,7 @@ private fun findRouteBlocks(
         val blocks = blockInfra.getBlocksStartingAtDetector(currentDet)
         val blocksOnRoute = filterBlocks(allowedSignalingSystems, blockInfra, blocks, routePath, 0)
         for (block in blocksOnRoute) {
-            val blockPath = blockInfra.getBlockPath(block)
+            val blockPath = blockInfra.getBlockZonePaths(block)
             addPath(BlockPathElement(null, block, routeIndex, 0, 0, blockPath.size))
         }
     } else {

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -68,15 +68,15 @@ fun BlockInfra.getNextBlocks(infra: RawSignalingInfra, blockId: BlockId): Set<Bl
 
 /** Returns the block's entry detector */
 fun BlockInfra.getBlockEntry(rawInfra: RawInfra, block: BlockId): DirDetectorId {
-    val blockPath: StaticIdxList<ZonePath> = getBlockPath(block)
-    val firstZone: ZonePathId = blockPath[0]
+    val blockZonePaths: StaticIdxList<ZonePath> = getBlockZonePaths(block)
+    val firstZone: ZonePathId = blockZonePaths[0]
     return rawInfra.getZonePathEntry(firstZone)
 }
 
 /** Returns the block's exit detector */
 fun BlockInfra.getBlockExit(rawInfra: RawInfra, block: BlockId): DirDetectorId {
-    val blockPath: StaticIdxList<ZonePath> = getBlockPath(block)
-    val lastZonePath: ZonePathId = blockPath[blockPath.size - 1]
+    val blockZonePaths: StaticIdxList<ZonePath> = getBlockZonePaths(block)
+    val lastZonePath: ZonePathId = blockZonePaths[blockZonePaths.size - 1]
     return rawInfra.getZonePathExit(lastZonePath)
 }
 

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/PathPropertiesView.kt
@@ -16,14 +16,15 @@ import fr.sncf.osrd.utils.units.meters
  */
 data class PathPropertiesView(
     val base: PathProperties,
-    val startOffset: Offset<Path>,
-    val endOffset: Offset<Path>
+    val startOffset: Offset<TravelledPath>,
+    val endOffset: Offset<TravelledPath>
 ) : PathProperties {
     override fun getSlopes(): DistanceRangeMap<Double> {
         return sliceRangeMap(base.getSlopes())
     }
 
-    override fun getOperationalPointParts(): List<IdxWithPathOffset<OperationalPointPart>> {
+    override fun getOperationalPointParts():
+        List<IdxWithTravelledPathOffset<OperationalPointPart>> {
         return base
             .getOperationalPointParts()
             .map { IdxWithOffset(it.value, it.offset - startOffset.distance) }
@@ -72,11 +73,11 @@ data class PathPropertiesView(
         return endOffset - startOffset
     }
 
-    override fun getTrackLocationAtOffset(pathOffset: Offset<Path>): TrackLocation {
+    override fun getTrackLocationAtOffset(pathOffset: Offset<TravelledPath>): TrackLocation {
         return base.getTrackLocationAtOffset(pathOffset - startOffset.distance)
     }
 
-    override fun getTrackLocationOffset(location: TrackLocation): Offset<Path>? {
+    override fun getTrackLocationOffset(location: TrackLocation): Offset<TravelledPath>? {
         val baseResult = base.getTrackLocationOffset(location) ?: return null
         if (baseResult < startOffset || baseResult > endOffset) return null
         return baseResult - startOffset.distance

--- a/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt
@@ -11,7 +11,7 @@ import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 
-data class PathStop(val pathOffset: Offset<Path>, val receptionSignal: RJSReceptionSignal)
+data class PathStop(val pathOffset: Offset<BlockPath>, val receptionSignal: RJSReceptionSignal)
 
 // Used to type offsets that use as reference the start of the first block on a given path fragment
 sealed interface FragmentBlocks
@@ -69,23 +69,23 @@ interface IncrementalPath {
 
     fun getZonePath(zonePathIndex: Int): ZonePathId
 
-    fun getZonePathStartOffset(zonePathIndex: Int): Offset<Path>
+    fun getZonePathStartOffset(zonePathIndex: Int): Offset<BlockPath>
 
-    fun getBlockStartOffset(blockIndex: Int): Offset<Path>
+    fun getBlockStartOffset(blockIndex: Int): Offset<BlockPath>
 
-    fun getRouteStartOffset(routeIndex: Int): Offset<Path>
+    fun getRouteStartOffset(routeIndex: Int): Offset<BlockPath>
 
-    fun getZonePathEndOffset(zonePathIndex: Int): Offset<Path>
+    fun getZonePathEndOffset(zonePathIndex: Int): Offset<BlockPath>
 
-    fun getBlockEndOffset(blockIndex: Int): Offset<Path>
+    fun getBlockEndOffset(blockIndex: Int): Offset<BlockPath>
 
-    fun getRouteEndOffset(routeIndex: Int): Offset<Path>
+    fun getRouteEndOffset(routeIndex: Int): Offset<BlockPath>
 
-    fun convertZonePathOffset(zonePathIndex: Int, offset: Offset<ZonePath>): Offset<Path>
+    fun convertZonePathOffset(zonePathIndex: Int, offset: Offset<ZonePath>): Offset<BlockPath>
 
-    fun convertBlockOffset(blockIndex: Int, offset: Offset<Block>): Offset<Path>
+    fun convertBlockOffset(blockIndex: Int, offset: Offset<Block>): Offset<BlockPath>
 
-    fun convertRouteOffset(routeIndex: Int, offset: Offset<Route>): Offset<Path>
+    fun convertRouteOffset(routeIndex: Int, offset: Offset<Route>): Offset<BlockPath>
 
     fun getRouteStartZone(routeIndex: Int): Int
 
@@ -95,30 +95,33 @@ interface IncrementalPath {
 
     fun getBlockEndZone(blockIndex: Int): Int
 
-    fun getStopOffset(stopIndex: Int): Offset<Path>
+    fun getStopOffset(stopIndex: Int): Offset<BlockPath>
 
     fun isStopOnClosedSignal(stopIndex: Int): Boolean
 
     val pathStarted: Boolean
     /** can only be called if pathStarted */
-    val travelledPathBegin: Offset<Path>
+    val travelledPathBegin: Offset<BlockPath>
 
     val pathComplete: Boolean
     /** can only be called if pathComplete */
-    val travelledPathEnd: Offset<Path>
+    val travelledPathEnd: Offset<BlockPath>
 
-    fun toTravelledPath(offset: Offset<Path>): Offset<TravelledPath>
+    fun toTravelledPath(offset: Offset<BlockPath>): Offset<TravelledPath>
 
-    fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<Path>
+    fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<BlockPath>
 
-    fun getBlockPathEnd(): Offset<Path>
+    fun getBlockPathEnd(): Offset<BlockPath>
 }
 
 fun incrementalPathOf(rawInfra: RawInfra, blockInfra: BlockInfra): IncrementalPath {
     return IncrementalPathImpl(rawInfra, blockInfra)
 }
 
-private class IncrementalStop(val offset: Offset<Path>, val receptionSignal: RJSReceptionSignal)
+private class IncrementalStop(
+    val offset: Offset<BlockPath>,
+    val receptionSignal: RJSReceptionSignal
+)
 
 private class IncrementalPathImpl(
     private val rawInfra: RawInfra,
@@ -135,17 +138,17 @@ private class IncrementalPathImpl(
     private val routeZoneBounds: AppendOnlyLinkedList<Int> = appendOnlyLinkedListOf(0),
 
     // a lookup table from zone index to zone start path offset
-    private var zonePathBounds: AppendOnlyLinkedList<Offset<Path>> =
+    private var zonePathBounds: AppendOnlyLinkedList<Offset<BlockPath>> =
         appendOnlyLinkedListOf(Offset(0.meters)),
-    override var travelledPathBegin: Offset<Path> = Offset((-1).meters),
-    override var travelledPathEnd: Offset<Path> = Offset((-1).meters),
+    override var travelledPathBegin: Offset<BlockPath> = Offset((-1).meters),
+    override var travelledPathEnd: Offset<BlockPath> = Offset((-1).meters),
 ) : IncrementalPath {
 
     override val pathStarted
-        get() = travelledPathBegin != Offset<Path>((-1).meters)
+        get() = travelledPathBegin != Offset<BlockPath>((-1).meters)
 
     override val pathComplete
-        get() = travelledPathEnd != Offset<Path>((-1).meters)
+        get() = travelledPathEnd != Offset<BlockPath>((-1).meters)
 
     override val zonePathCount
         get() = zonePaths.size
@@ -192,7 +195,7 @@ private class IncrementalPathImpl(
         // route
         if (blockZoneBounds.isEmpty()) {
             val firstBlock = fragment.blocks[0]
-            val firstBlockZonePath = blockInfra.getBlockPath(firstBlock)[0]
+            val firstBlockZonePath = blockInfra.getBlockZonePaths(firstBlock)[0]
             var firstBlockZonePathIndex = -1
             val zonePathList = zonePaths.toList()
             for (zonePathIndex in zonePathList.indices) {
@@ -231,8 +234,8 @@ private class IncrementalPathImpl(
                     blockInfra.getBlockEntry(rawInfra, block) ==
                         blockInfra.getBlockExit(rawInfra, blocks.last())
             )
-            val blockPath = blockInfra.getBlockPath(block)
-            fragBlocksZoneCount += blockPath.size
+            val blockZonePaths = blockInfra.getBlockZonePaths(block)
+            fragBlocksZoneCount += blockZonePaths.size
             val blockEndZonePathIndex = fragmentBlocksStartZoneIndex + fragBlocksZoneCount
             assert(blockEndZonePathIndex <= zonePaths.size)
             blocks.add(block)
@@ -273,39 +276,42 @@ private class IncrementalPathImpl(
         return zonePaths[zonePathIndex]
     }
 
-    override fun getZonePathStartOffset(zonePathIndex: Int): Offset<Path> {
+    override fun getZonePathStartOffset(zonePathIndex: Int): Offset<BlockPath> {
         return zonePathBounds[zonePathIndex]
     }
 
-    override fun getBlockStartOffset(blockIndex: Int): Offset<Path> {
+    override fun getBlockStartOffset(blockIndex: Int): Offset<BlockPath> {
         return getZonePathStartOffset(getBlockStartZone(blockIndex))
     }
 
-    override fun getRouteStartOffset(routeIndex: Int): Offset<Path> {
+    override fun getRouteStartOffset(routeIndex: Int): Offset<BlockPath> {
         return getZonePathStartOffset(getRouteStartZone(routeIndex))
     }
 
-    override fun getZonePathEndOffset(zonePathIndex: Int): Offset<Path> {
+    override fun getZonePathEndOffset(zonePathIndex: Int): Offset<BlockPath> {
         return zonePathBounds[zonePathIndex + 1]
     }
 
-    override fun getBlockEndOffset(blockIndex: Int): Offset<Path> {
+    override fun getBlockEndOffset(blockIndex: Int): Offset<BlockPath> {
         return getZonePathEndOffset(getBlockEndZone(blockIndex) - 1)
     }
 
-    override fun getRouteEndOffset(routeIndex: Int): Offset<Path> {
+    override fun getRouteEndOffset(routeIndex: Int): Offset<BlockPath> {
         return getZonePathEndOffset(getRouteEndZone(routeIndex) - 1)
     }
 
-    override fun convertZonePathOffset(zonePathIndex: Int, offset: Offset<ZonePath>): Offset<Path> {
+    override fun convertZonePathOffset(
+        zonePathIndex: Int,
+        offset: Offset<ZonePath>
+    ): Offset<BlockPath> {
         return getZonePathStartOffset(zonePathIndex) + offset.distance
     }
 
-    override fun convertBlockOffset(blockIndex: Int, offset: Offset<Block>): Offset<Path> {
+    override fun convertBlockOffset(blockIndex: Int, offset: Offset<Block>): Offset<BlockPath> {
         return getBlockStartOffset(blockIndex) + offset.distance
     }
 
-    override fun convertRouteOffset(routeIndex: Int, offset: Offset<Route>): Offset<Path> {
+    override fun convertRouteOffset(routeIndex: Int, offset: Offset<Route>): Offset<BlockPath> {
         return getRouteStartOffset(routeIndex) + offset.distance
     }
 
@@ -325,7 +331,7 @@ private class IncrementalPathImpl(
         return blockZoneBounds[blockIndex + 1]
     }
 
-    override fun getStopOffset(stopIndex: Int): Offset<Path> {
+    override fun getStopOffset(stopIndex: Int): Offset<BlockPath> {
         return stops[stopIndex].offset
     }
 
@@ -333,15 +339,15 @@ private class IncrementalPathImpl(
         return stops[stopIndex].receptionSignal.isStopOnClosedSignal
     }
 
-    override fun toTravelledPath(offset: Offset<Path>): Offset<TravelledPath> {
+    override fun toTravelledPath(offset: Offset<BlockPath>): Offset<TravelledPath> {
         return Offset(offset.distance - travelledPathBegin.distance)
     }
 
-    override fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<Path> {
+    override fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<BlockPath> {
         return Offset(offset.distance + travelledPathBegin.distance)
     }
 
-    override fun getBlockPathEnd(): Offset<Path> {
+    override fun getBlockPathEnd(): Offset<BlockPath> {
         return getBlockEndOffset(blocks.size - 1)
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/conflicts/Resources.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/Resources.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.conflicts
 
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.LogicalSignalId
-import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
 
@@ -39,7 +39,7 @@ interface IncrementalRequirementCallbacks {
 
 data class PathSignal(
     val signal: LogicalSignalId,
-    val pathOffset: Offset<Path>,
+    val pathOffset: Offset<BlockPath>,
     // when a signal is between blocks, prefer the index of the first block
     val minBlockPathIndex: Int,
 )

--- a/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
+++ b/core/src/main/java/fr/sncf/osrd/conflicts/SpacingResourceGenerator.kt
@@ -33,13 +33,13 @@ private val logger = KotlinLogging.logger {}
 
 data class PendingSpacingRequirement(
     val zoneIndex: Int,
-    val zoneEntryOffset: Offset<Path>,
-    val zoneExitOffset: Offset<Path>,
+    val zoneEntryOffset: Offset<BlockPath>,
+    val zoneExitOffset: Offset<BlockPath>,
     val beginTime: Double
 )
 
 data class ProcessedStop(
-    val offset: Offset<Path>,
+    val offset: Offset<BlockPath>,
     val nextBlockIdx: Int,
     val nextZoneIdx: Int,
 )
@@ -237,7 +237,7 @@ class SpacingRequirementAutomaton(
         val firstSimulatedZone = incrementalPath.getBlockStartZone(firstBlockIndex)
 
         // Number of zones included in the block path
-        var nSimulatedZones = blockInfra.getBlockPath(blocks[0]).size
+        var nSimulatedZones = blockInfra.getBlockZonePaths(blocks[0]).size
 
         // Add blocks in the block path until the probed zone is covered
         while (probedZoneIndex - firstSimulatedZone > nSimulatedZones) {
@@ -247,7 +247,7 @@ class SpacingRequirementAutomaton(
             }
             val newBlock = incrementalPath.getBlock(firstBlockIndex + blocks.size)
             blocks.add(newBlock)
-            nSimulatedZones += blockInfra.getBlockPath(newBlock).size
+            nSimulatedZones += blockInfra.getBlockZonePaths(newBlock).size
         }
 
         val zoneStates = MutableList(nSimulatedZones) { ZoneStatus.CLEAR }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SafetySpeed.kt
@@ -92,7 +92,7 @@ private fun makeEndOfPathStop(
 fun getSignalOffsets(
     infra: FullInfra,
     zonePaths: List<StaticIdx<ZonePath>>,
-    pathStartOffset: Offset<Path>,
+    pathStartOffset: Offset<BlockPath>,
 ): List<Offset<TravelledPath>> {
     val res = mutableListOf<Offset<TravelledPath>>()
     val rawInfra = infra.rawInfra

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -44,11 +44,11 @@ const val CLOSED_SIGNAL_RESERVATION_MARGIN = 20.0
 
 // the start offset is the distance from the start of the first block to the start location
 class PathOffsetBuilder(val startOffset: Distance) {
-    fun toTravelledPath(offset: Offset<Path>): Offset<TravelledPath> {
+    fun toTravelledPath(offset: Offset<BlockPath>): Offset<TravelledPath> {
         return Offset(offset.distance - startOffset)
     }
 
-    fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<Path> {
+    fun fromTravelledPath(offset: Offset<TravelledPath>): Offset<BlockPath> {
         return Offset(offset.distance + startOffset)
     }
 }
@@ -254,7 +254,7 @@ fun getBlockOffsets(
     blockInfra: BlockInfra
 ): OffsetArray<TravelledPath> {
     val blockOffsets = MutableOffsetArray(blockPath.size) { Offset.zero<TravelledPath>() }
-    var curOffset = Offset.zero<Path>()
+    var curOffset = Offset.zero<BlockPath>()
     for (i in 0 until blockPath.size) {
         blockOffsets[i] = pathOffsetBuilder.toTravelledPath(curOffset)
         val blockLength = blockInfra.getBlockLength(blockPath[i])
@@ -410,7 +410,7 @@ fun routingRequirements(
     }
 
     val res = mutableListOf<RoutingRequirement>()
-    var routePathOffset = Offset.zero<Path>()
+    var routePathOffset = Offset.zero<BlockPath>()
     // for all routes, generate requirements
     for (routeIndex in 0 until routePath.size) {
         // start out by figuring out when the route needs to be set
@@ -539,7 +539,7 @@ fun zoneOccupationChangeEvents(
     var currentOffset = pathOffsetBuilder.toTravelledPath(Offset.zero())
     val zoneOccupationChangeEvents = mutableListOf<ZoneOccupationChangeEvent>()
     for ((blockIdx, block) in blockPath.withIndex()) {
-        for (zonePath in blockInfra.getBlockPath(block)) {
+        for (zonePath in blockInfra.getBlockZonePaths(block)) {
             // Compute occupation change event
             if (currentOffset.distance > envelope.endPos.meters) break
             val entryOffset = Offset.max(Offset.zero(), currentOffset)

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/SignalProjection.kt
@@ -62,7 +62,7 @@ fun project(
     val zoneMap = mutableMapOf<String, Int>()
     var zoneCount = 0
     for (block in blockPath) {
-        for (zonePath in blockInfra.getBlockPath(block)) {
+        for (zonePath in blockInfra.getBlockZonePaths(block)) {
             val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
             val zoneName = rawInfra.getZoneName(zone)
             zoneMap[zoneName] = zoneCount
@@ -114,7 +114,7 @@ private fun computeSignalAspectChangeEvents(
     leastConstrainingStates: Map<SignalingSystemId, SigState>,
 ): Map<PathSignal, MutableList<SignalAspectChangeEvent>> {
     val routes = routePath.toList()
-    val zoneCount = blockPath.sumOf { blockInfra.getBlockPath(it).size }
+    val zoneCount = blockPath.sumOf { blockInfra.getBlockZonePaths(it).size }
     val zoneStates = ArrayList<ZoneStatus>(zoneCount)
     for (i in 0 until zoneCount) zoneStates.add(ZoneStatus.CLEAR)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/path_properties/PathPropResponse.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.RangeValues
 import fr.sncf.osrd.railjson.schema.geom.RJSLineString
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Offset
 
@@ -32,7 +32,7 @@ data class OperationalPointResponse(
     val id: String,
     val part: OperationalPointPartResponse,
     val extensions: OperationalPointExtensions?,
-    val position: Offset<Path>,
+    val position: Offset<TravelledPath>,
     val weight: Long?
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingBlockResponse.kt
@@ -9,7 +9,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import fr.sncf.osrd.api.api_v2.DirectionalTrackRange
 import fr.sncf.osrd.graph.Pathfinding.Range
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
 import fr.sncf.osrd.utils.units.Length
@@ -25,10 +24,10 @@ class PathfindingBlockSuccess(
     // Route ids
     val routes: List<String>,
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<Path>,
+    val length: Length<TravelledPath>,
 
     /** Offsets of the waypoints given as input */
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<Path>>
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TravelledPath>>
 ) : PathfindingBlockResponse {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -50,12 +49,12 @@ class PathfindingBlockSuccess(
 
 class NotFoundInBlocks(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<Path>,
+    val length: Length<TravelledPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInRoutes(
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    val length: Length<Path>,
+    val length: Length<TravelledPath>,
 ) : PathfindingBlockResponse
 
 class NotFoundInTracks : PathfindingBlockResponse

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/pathfinding/PathfindingPostProcessing.kt
@@ -11,7 +11,7 @@ import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
@@ -62,7 +62,7 @@ fun validatePathfindingResponse(
         val stopAtBufferStop = infra.blockInfra.blockStopAtBufferStop(block)
         val isLastBlock = i == res.blocks.size - 1
         if (stopAtBufferStop && !isLastBlock) {
-            val zonePath = infra.blockInfra.getBlockPath(block).last()
+            val zonePath = infra.blockInfra.getBlockZonePaths(block).last()
             val detector = infra.rawInfra.getZonePathExit(zonePath)
             val detectorName = infra.rawInfra.getDetectorName(detector.value)
             val err = OSRDError(ErrorType.MissingSignalOnRouteTransition)
@@ -86,14 +86,16 @@ fun validatePathfindingResponse(
         throw OSRDError(ErrorType.PathHasInvalidItemPositions)
 }
 
-fun makePathItemPositions(path: Pathfinding.Result<StaticIdx<Block>, Block>): List<Offset<Path>> {
+fun makePathItemPositions(
+    path: Pathfinding.Result<StaticIdx<Block>, Block>
+): List<Offset<TravelledPath>> {
     val pathItemLocations = mutableMapOf<BlockId, MutableList<PathfindingEdgeLocationId<Block>>>()
     for (waypoint in path.waypoints) {
         val edgeWaypoints = pathItemLocations.computeIfAbsent(waypoint.edge) { mutableListOf() }
         edgeWaypoints.add(waypoint)
     }
-    var offsetSinceStart = Offset<Path>(0.meters)
-    val res = mutableListOf<Offset<Path>>()
+    var offsetSinceStart = Offset<TravelledPath>(0.meters)
+    val res = mutableListOf<Offset<TravelledPath>>()
     for (range in path.ranges) {
         for (waypoint in pathItemLocations[range.edge] ?: listOf()) {
             res.add(offsetSinceStart + waypoint.offset.distance - range.start.distance)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/api_v2/standalone_sim/SimulationRequest.kt
@@ -10,7 +10,6 @@ import fr.sncf.osrd.railjson.schema.rollingstock.RJSEtcsBrakeParams
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
 import fr.sncf.osrd.railjson.schema.schedule.RJSAllowanceDistribution
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal
-import fr.sncf.osrd.sim_infra.api.Path
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.json.UnitAdapterFactory
@@ -85,7 +84,7 @@ class SimulationPath(
     val blocks: List<String>,
     val routes: List<String>,
     @Json(name = "track_section_ranges") val trackSectionRanges: List<DirectionalTrackRange>,
-    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<Path>>
+    @Json(name = "path_item_positions") val pathItemPositions: List<Offset<TravelledPath>>
 )
 
 class SimulationScheduleItem(
@@ -137,8 +136,8 @@ class MarginValueAdapter {
 }
 
 class SimulationPowerRestrictionItem(
-    val from: Offset<Path>,
-    val to: Offset<Path>,
+    val from: Offset<TravelledPath>,
+    val to: Offset<TravelledPath>,
     val value: String,
 )
 

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathPropUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathPropUtils.kt
@@ -50,13 +50,13 @@ fun makePathProps(
     rawInfra: RawSignalingInfra,
     blockInfra: BlockInfra,
     blockIds: List<BlockId>,
-    offsetFirstBlock: Length<Path>,
+    offsetFirstBlock: Length<BlockPath>,
     routes: List<RouteId>? = null
 ): PathProperties {
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
-    var totalLength: Length<Path> = Length(0.meters)
+    var totalLength: Length<BlockPath> = Length(0.meters)
     for (blockId in blockIds) {
-        for (zoneId in blockInfra.getBlockPath(blockId)) {
+        for (zoneId in blockInfra.getBlockZonePaths(blockId)) {
             chunks.addAll(rawInfra.getZonePathChunks(zoneId))
             totalLength += rawInfra.getZonePathLength(zoneId).distance
         }
@@ -97,17 +97,17 @@ fun makeChunkPath(
     blockRanges: List<PathfindingEdgeRangeId<Block>>
 ): ChunkPath {
     assert(blockRanges.isNotEmpty())
-    var totalBlockPathLength: Length<Path> = Length(0.meters)
+    var totalBlockPathLength: Length<BlockPath> = Length(0.meters)
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
     for (range in blockRanges) {
-        val zonePaths = blockInfra.getBlockPath(range.edge)
+        val zonePaths = blockInfra.getBlockZonePaths(range.edge)
         for (zonePath in zonePaths) {
             chunks.addAll(rawInfra.getZonePathChunks(zonePath))
             val zoneLength = rawInfra.getZonePathLength(zonePath)
             totalBlockPathLength += zoneLength.distance
         }
     }
-    val startOffset: Offset<Path> = blockRanges[0].start.cast()
+    val startOffset: Offset<BlockPath> = blockRanges[0].start.cast()
     val lastRange = blockRanges[blockRanges.size - 1]
     val lastBlockLength = blockInfra.getBlockLength(lastRange.edge)
     val endOffset = totalBlockPathLength - lastBlockLength.distance + lastRange.end.distance

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -108,7 +108,7 @@ fun validatePathfindingResult(
         val stopAtBufferStop = blockInfra.blockStopAtBufferStop(blockRange.edge)
         val isLastBlock = i == path.ranges.size - 1
         if (stopAtBufferStop && !isLastBlock) {
-            val zonePath = blockInfra.getBlockPath(blockRange.edge).last()
+            val zonePath = blockInfra.getBlockZonePaths(blockRange.edge).last()
             val detector = rawInfra.getZonePathExit(zonePath)
             val detectorName = rawInfra.getDetectorName(detector.value)
             val err = OSRDError(ErrorType.MissingSignalOnRouteTransition)

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingResultConverter.kt
@@ -78,16 +78,16 @@ private fun makeUserDefinedWaypoints(
         offsets.add(waypoint.offset)
     }
     val res = ArrayList<PathWaypointResult>()
-    var lengthPrevBlocks: Offset<Path> = Offset(0.meters)
     val startFirstRange = rawPath.ranges[0].start
+    var startBlockOffset = Offset<TravelledPath>(-startFirstRange.distance)
     for (blockRange in rawPath.ranges) {
         for (waypoint in userDefinedWaypointsPerBlock.getOrDefault(blockRange.edge, ArrayList())) {
             if (blockRange.start <= waypoint && waypoint <= blockRange.end) {
-                val pathOffset = lengthPrevBlocks + waypoint.distance - startFirstRange.distance
+                val pathOffset = startBlockOffset + waypoint.distance
                 res.add(makePendingUserDefinedWaypoint(infra, path, pathOffset))
             }
         }
-        lengthPrevBlocks += blockInfra.getBlockLength(blockRange.edge).distance
+        startBlockOffset += blockInfra.getBlockLength(blockRange.edge).distance
     }
     return res
 }
@@ -107,7 +107,7 @@ fun makeOperationalPoints(
 /** Creates a pending waypoint from an operational point part */
 private fun makePendingOPWaypoint(
     infra: RawSignalingInfra,
-    pathOffset: Offset<Path>,
+    pathOffset: Offset<TravelledPath>,
     opPartId: OperationalPointPartId
 ): PathWaypointResult {
     val partChunk = infra.getOperationalPointPartChunk(opPartId)
@@ -124,7 +124,7 @@ private fun makePendingOPWaypoint(
 private fun makePendingUserDefinedWaypoint(
     infra: RawSignalingInfra,
     path: PathProperties,
-    pathOffset: Offset<Path>
+    pathOffset: Offset<TravelledPath>
 ): PathWaypointResult {
     val (trackId, offset) = path.getTrackLocationAtOffset(pathOffset)
     val trackName = infra.getTrackSectionName(trackId)
@@ -248,7 +248,7 @@ private fun makeRJSTrackRanges(
     routeEndOffset: Offset<Route>
 ): List<RJSDirectionalTrackRange> {
     val res = ArrayList<RJSDirectionalTrackRange>()
-    var chunkStartPathOffset: Offset<Path> = Offset(0.meters)
+    var chunkStartPathOffset: Offset<BlockPath> = Offset(0.meters)
     for (dirChunkId in infra.getChunksOnRoute(route)) {
         val chunkLength = infra.getTrackChunkLength(dirChunkId.value)
         val trackId = infra.getTrackFromChunk(dirChunkId.value)

--- a/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/signal_projection/SignalProjectionV2.kt
@@ -64,7 +64,7 @@ fun projectSignals(
     val zoneMap = mutableMapOf<String, Int>()
     var zoneCount = 0
     for (block in blockPath) {
-        for (zonePath in blockInfra.getBlockPath(block)) {
+        for (zonePath in blockInfra.getBlockZonePaths(block)) {
             val zone = rawInfra.getNextZone(rawInfra.getZonePathEntry(zonePath))!!
             val zoneName = rawInfra.getZoneName(zone)
             zoneMap[zoneName] = zoneCount
@@ -128,7 +128,7 @@ private fun computeSignalAspectChangeEvents(
     leastConstrainingStates: Map<SignalingSystemId, SigState>,
 ): Map<PathSignal, MutableList<SignalAspectChangeEventV2>> {
     val routes = routePath.toList()
-    val zoneCount = blockPath.sumOf { blockInfra.getBlockPath(it).size }
+    val zoneCount = blockPath.sumOf { blockInfra.getBlockZonePaths(it).size }
     val zoneStates = ArrayList<ZoneStatus>(zoneCount)
     for (i in 0 until zoneCount) zoneStates.add(ZoneStatus.CLEAR)
 

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -32,7 +32,7 @@ fun runScheduleMetadataExtractor(
     routePath: StaticIdxList<Route>,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<Path>>,
+    pathItemPositions: List<Offset<TravelledPath>>,
 ): CompleteReportTrain {
     assert(envelope.continuous)
 
@@ -269,7 +269,7 @@ fun makeSimpleReportTrain(
     trainPath: PathProperties,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
-    pathItemPositions: List<Offset<Path>>,
+    pathItemPositions: List<Offset<TravelledPath>>,
 ): ReportTrain {
     // Compute energy consumed
     val envelopePath = EnvelopeTrainPath.from(fullInfra.rawInfra, trainPath)
@@ -286,7 +286,7 @@ fun makeSimpleReportTrain(
     val envelopeStopWrapper = EnvelopeStopWrapper(envelope, stops)
 
     val pathItemTimes =
-        pathItemPositions.map { position: Offset<Path> ->
+        pathItemPositions.map { position: Offset<TravelledPath> ->
             TimeDelta.fromSeconds(
                 envelopeStopWrapper.interpolateArrivalAt(position.distance.meters)
             )

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -68,7 +68,7 @@ fun runStandaloneSimulation(
     schedule: List<SimulationScheduleItem>,
     initialSpeed: Double,
     margins: RangeValues<MarginValue>,
-    pathItemPositions: List<Offset<Path>>,
+    pathItemPositions: List<Offset<TravelledPath>>,
     driverBehaviour: DriverBehaviour = DriverBehaviour()
 ): SimulationSuccess {
     if (chunkPath.length == 0.meters) throw OSRDError(ZeroLengthPath)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.stdcm.graph
 
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Distance
@@ -154,18 +154,18 @@ data class STDCMEdge(
     }
 
     /**
-     * Converts from Path Offset (references start of first route) to Travelled path offset
+     * Converts from BlockPath Offset (references start of first route) to Travelled path offset
      * (references train departure point)
      */
-    fun toTravelledOffset(pathOffset: Offset<Path>): Offset<TravelledPath> {
+    fun toTravelledOffset(pathOffset: Offset<BlockPath>): Offset<TravelledPath> {
         return infraExplorer.getIncrementalPath().toTravelledPath(pathOffset)
     }
 
     /**
-     * Converts from Travelled path offset (references train departure point) to Path Offset
+     * Converts from Travelled path offset (references train departure point) to BlockPath Offset
      * (references start of first route)
      */
-    fun fromTravelledOffset(travelledPathOffset: Offset<TravelledPath>): Offset<Path> {
+    fun fromTravelledOffset(travelledPathOffset: Offset<TravelledPath>): Offset<BlockPath> {
         return infraExplorer.getIncrementalPath().fromTravelledPath(travelledPathOffset)
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMUtils.kt
@@ -26,14 +26,14 @@ fun getNextStopOnCurrentBlock(
 fun makeChunkPathFromEdges(graph: STDCMGraph, edges: List<STDCMEdge>): ChunkPath {
     val blocks = edges.stream().map { edge -> edge.block }.distinct().toList()
     val totalPathLength =
-        Length<Path>(
+        Length<TravelledPath>(
             Distance(
                 millimeters =
                     edges.stream().mapToLong { edge -> (edge.length.distance).millimeters }.sum()
             )
         )
-    val firstOffset = Offset<Path>(edges[0].envelopeStartOffset.distance)
-    val lastOffset = totalPathLength + firstOffset.distance
+    val firstOffset = Offset<BlockPath>(edges[0].envelopeStartOffset.distance)
+    val lastOffset = firstOffset + totalPathLength.distance
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
     for (block in blocks) for (chunk in graph.blockInfra.getTrackChunksFromBlock(block)) chunks.add(
         chunk

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -86,7 +86,7 @@ interface InfraExplorer {
     fun getCurrentBlockLength(): Length<Block>
 
     /** Returns the length of all blocks before the current one */
-    fun getPredecessorLength(): Length<Path>
+    fun getPredecessorLength(): Length<BlockPath>
 
     /** Returns all the blocks before the current one */
     fun getPredecessorBlocks(): AppendOnlyLinkedList<BlockId>
@@ -167,7 +167,7 @@ private class InfraExplorerImpl(
     private var pathPropertiesCache: MutableMap<BlockId, PathProperties>,
     private var currentIndex: Int = 0,
     private var stepTracker: StepTracker,
-    private var predecessorLength: Length<Path> = Length(0.meters), // to avoid re-computing it
+    private var predecessorLength: Length<BlockPath> = Length(0.meters), // to avoid re-computing it
     private var constraints: List<PathfindingConstraint<Block>>,
 ) : InfraExplorer {
 
@@ -196,12 +196,13 @@ private class InfraExplorerImpl(
         val blockPathProperties = path.withRoutes(listOf(route))
         pathPropertiesCache[getCurrentBlock()] = blockPathProperties
 
-        val blockLength = Length<Path>(blockInfra.getBlockLength(getCurrentBlock()).distance)
-        val endOffset = if (length == null) blockLength else offset.plus(length).cast()
+        val blockLength = blockInfra.getBlockLength(getCurrentBlock())
+        val endOffset: Offset<Block> = if (length == null) blockLength else offset.plus(length)
         if (offset.distance == 0.meters && endOffset == blockLength) {
             return blockPathProperties
         }
-        return PathPropertiesView(blockPathProperties, offset.cast(), endOffset)
+        // In that case, start of the block is start of the travelled path
+        return PathPropertiesView(blockPathProperties, offset.cast(), endOffset.cast())
     }
 
     override fun getLastEdgeIdentifier(): EdgeIdentifier {
@@ -246,7 +247,7 @@ private class InfraExplorerImpl(
         return blockInfra.getBlockLength(getCurrentBlock())
     }
 
-    override fun getPredecessorLength(): Length<Path> {
+    override fun getPredecessorLength(): Length<BlockPath> {
         return predecessorLength
     }
 
@@ -375,7 +376,7 @@ private class InfraExplorerImpl(
     private fun hasRepeatedElements(block: StaticIdx<Block>): Boolean {
         val tracks =
             blockInfra
-                .getBlockPath(block)
+                .getBlockZonePaths(block)
                 .flatMap { rawInfra.getZonePathChunks(it) }
                 .map { rawInfra.getTrackFromChunk(it.value) }
         for (track in tracks) {

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.graph.PathfindingConstraint
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.standalone_sim.result.ResultTrain
 import fr.sncf.osrd.stdcm.STDCMStep
@@ -55,10 +55,10 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun updateTimeData(updatedTimeData: TimeData): InfraExplorerWithEnvelope
 
     /**
-     * Calls `InterpolateDepartureFromClamp` on the underlying envelope, taking the travelled path
-     * offset into account.
+     * Calls `InterpolateDepartureFromClamp` on the underlying envelope, taking the BlockPath offset
+     * into account and transforms it into TravelledPath.
      */
-    fun interpolateDepartureFromClamp(pathOffset: Offset<Path>): Double
+    fun interpolateDepartureFromClamp(pathOffset: Offset<BlockPath>): Double
 
     /** Returns the spacing requirements since the last update */
     fun getSpacingRequirements(): List<ResultTrain.SpacingRequirement>
@@ -70,7 +70,7 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     fun getSimulatedLength(): Length<TravelledPath>
 
     /** Returns the end of the simulation as an offset on the Path */
-    fun getSimulationEndPathOffset(): Offset<Path>
+    fun getSimulationEndPathOffset(): Offset<BlockPath>
 
     /**
      * Generate a list of reached train stops, mostly for debugging purposes. Lookahead isn't

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.envelope.EnvelopeConcat.LocatedEnvelope
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
@@ -121,7 +121,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return this
     }
 
-    override fun interpolateDepartureFromClamp(pathOffset: Offset<Path>): Double {
+    override fun interpolateDepartureFromClamp(pathOffset: Offset<BlockPath>): Double {
         return getFullEnvelope()
             .interpolateDepartureFromClamp(
                 getIncrementalPath().toTravelledPath(pathOffset).distance.meters
@@ -186,7 +186,7 @@ data class InfraExplorerWithEnvelopeImpl(
         return Length(Distance.fromMeters(lastEnvelope.startOffset + lastEnvelope.envelope.endPos))
     }
 
-    override fun getSimulationEndPathOffset(): Offset<Path> {
+    override fun getSimulationEndPathOffset(): Offset<BlockPath> {
         return getIncrementalPath().fromTravelledPath(getSimulatedLength())
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.stdcm.preprocessing.implementation
 
 import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
@@ -23,8 +23,8 @@ data class BlockAvailability(
 
     override fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
         startTime: Double
     ): BlockAvailabilityInterface.Availability {
         var timeShift = 0.0
@@ -89,8 +89,8 @@ data class BlockAvailability(
      */
     private fun getStepAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
         pathStartTime: Double,
     ): BlockAvailabilityInterface.Availability {
         var minimumDelayToBecomeAvailable = 0.0
@@ -151,8 +151,8 @@ data class BlockAvailability(
     private fun getStepAvailabilityProperties(
         step: LocatedStep,
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
         pathStartTime: Double
     ): AvailabilityProperties? {
         val incrementalPath = infraExplorer.getIncrementalPath()
@@ -203,7 +203,7 @@ data class BlockAvailability(
     /** Check the conflicts on the given path and return the corresponding availability. */
     private fun getConflictAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
         pathStartTime: Double,
         startTime: Double,
         endTime: Double

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/interfaces/BlockAvailabilityInterface.kt
@@ -1,6 +1,6 @@
 package fr.sncf.osrd.stdcm.preprocessing.interfaces
 
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.units.Offset
@@ -38,8 +38,8 @@ interface BlockAvailabilityInterface {
      */
     fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
         startTime: Double
     ): Availability
 

--- a/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/utils/OffsetConversions.kt
@@ -6,12 +6,14 @@ import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 
-/** Returns the offset where the train actually starts, compared to the start of the first route. */
+/**
+ * Computes the offset between the beginning of the first route and the beginning of the train path
+ */
 fun getRoutePathStartOffset(
     infra: RawInfra,
     chunkPath: ChunkPath,
     routes: StaticIdxList<Route>
-): Offset<Path> {
+): Offset<BlockPath> {
     val zonePaths = routes.flatMap { infra.getRoutePath(it) }
     return trainPathZonePathOffset(infra, zonePaths, chunkPath)
 }
@@ -24,8 +26,8 @@ fun trainPathBlockOffset(
     blockInfra: BlockInfra,
     blockPath: StaticIdxList<Block>,
     chunkPath: ChunkPath
-): Offset<Path> {
-    val zonePaths = blockPath.flatMap { blockInfra.getBlockPath(it) }
+): Offset<BlockPath> {
+    val zonePaths = blockPath.flatMap { blockInfra.getBlockZonePaths(it) }
     return trainPathZonePathOffset(infra, zonePaths, chunkPath)
 }
 
@@ -37,8 +39,8 @@ fun trainPathZonePathOffset(
     infra: RawInfra,
     zonePaths: List<ZonePathId>,
     chunkPath: ChunkPath
-): Offset<Path> {
-    var prevChunksLength = Offset<Path>(0.meters)
+): Offset<BlockPath> {
+    var prevChunksLength = Offset<BlockPath>(0.meters)
     val routeChunks = zonePaths.flatMap { infra.getZonePathChunks(it) }
 
     val firstChunk = Pair(chunkPath.chunks[0], chunkPath.beginOffset)

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingResultConverterTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingResultConverterTest.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.graph.Pathfinding.EdgeRange
 import fr.sncf.osrd.graph.PathfindingEdgeRangeId
 import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.Helpers
@@ -31,7 +31,7 @@ class PathfindingResultConverterTest {
         }
         val chunkPath = makeChunkPath(infra.rawInfra, infra.blockInfra, ranges)
         val expectedLength = 10000.meters + 1000.meters // length of route 1 + 2
-        Assertions.assertEquals(Offset<Path>(0.meters), chunkPath.beginOffset)
+        Assertions.assertEquals(Offset<BlockPath>(0.meters), chunkPath.beginOffset)
         Assertions.assertEquals(expectedLength, chunkPath.endOffset.distance)
         checkBlocks(
             infra,
@@ -61,7 +61,7 @@ class PathfindingResultConverterTest {
             )
         val chunkPath = makeChunkPath(infra.rawInfra, infra.blockInfra, ranges)
         val expectedBlockLength = 1050.meters + 10000.meters // length of route 1 + 2
-        Assertions.assertEquals(Offset<Path>(10.meters), chunkPath.beginOffset)
+        Assertions.assertEquals(Offset<BlockPath>(10.meters), chunkPath.beginOffset)
         Assertions.assertEquals((expectedBlockLength - 10.meters), chunkPath.endOffset.distance)
         checkBlocks(
             infra,

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/RemainingDistanceEstimatorTest.kt
@@ -9,7 +9,7 @@ import fr.sncf.osrd.graph.Pathfinding.EdgeLocation
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
 import fr.sncf.osrd.sim_infra.api.Block
 import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.PathProperties
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.units.Distance
@@ -75,7 +75,7 @@ class RemainingDistanceEstimatorTest {
                 0
             ), // Test with target at the end of the edge
             Arguments.of(
-                listOf(EdgeLocation(block, Offset<Path>(path!!.getLength()))),
+                listOf(EdgeLocation(block, Offset<BlockPath>(path!!.getLength()))),
                 0,
                 fromMeters(points[0].distanceAsMeters(Iterables.getLast(points))).millimeters,
                 0
@@ -83,14 +83,14 @@ class RemainingDistanceEstimatorTest {
             Arguments.of(
                 listOf(
                     EdgeLocation(block, Offset(0.meters)),
-                    EdgeLocation(block, Offset<Path>(path!!.getLength()))
+                    EdgeLocation(block, Offset<BlockPath>(path!!.getLength()))
                 ),
                 0,
                 0,
                 0
             ), // Test with an offset on the block
             Arguments.of(
-                listOf(EdgeLocation(block, Offset<Path>(path!!.getLength()))),
+                listOf(EdgeLocation(block, Offset<BlockPath>(path!!.getLength()))),
                 0,
                 0,
                 path!!.getLength().millimeters

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/DummyBlockAvailability.kt
@@ -3,7 +3,7 @@ package fr.sncf.osrd.stdcm.preprocessing
 import com.google.common.collect.Multimap
 import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.sim_infra.api.BlockInfra
-import fr.sncf.osrd.sim_infra.api.Path
+import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
@@ -30,8 +30,8 @@ class DummyBlockAvailability(
     private data class BlockWithOffset(val blockId: BlockId, val pathOffset: Distance)
 
     private data class ResourceUse(
-        val startOffset: Offset<Path>,
-        val endOffset: Offset<Path>,
+        val startOffset: Offset<BlockPath>,
+        val endOffset: Offset<BlockPath>,
         val startTime: Double,
         val endTime: Double,
         val blockId: BlockId,
@@ -40,8 +40,8 @@ class DummyBlockAvailability(
     /** Returns all resource usage for the given path, or null if more lookahead is needed */
     private fun generateResourcesForPath(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
     ): List<ResourceUse> {
         val blocks = makeBlocksWithOffsets(infraExplorer)
         val res = mutableListOf<ResourceUse>()
@@ -56,9 +56,9 @@ class DummyBlockAvailability(
                         endOffset
                     ) ?: continue
                 val segmentStartOffset =
-                    Offset<Path>(blockWithOffset.pathOffset + unavailableSegment.distanceStart)
+                    Offset<BlockPath>(blockWithOffset.pathOffset + unavailableSegment.distanceStart)
                 val segmentEndOffset =
-                    Offset<Path>(blockWithOffset.pathOffset + unavailableSegment.distanceEnd)
+                    Offset<BlockPath>(blockWithOffset.pathOffset + unavailableSegment.distanceEnd)
                 res.add(
                     ResourceUse(
                         segmentStartOffset,
@@ -86,7 +86,7 @@ class DummyBlockAvailability(
         for (segment in unavailableSpace[resource.blockId]) {
             // Can be optimized
             val blockOffset =
-                Offset<Path>(blocks.first { it.blockId == resource.blockId }.pathOffset)
+                Offset<BlockPath>(blocks.first { it.blockId == resource.blockId }.pathOffset)
             if (segment.enabledIfBlockInLookahead != null) {
                 val lookahead = infraExplorer.getLookahead()
                 if (lookahead.contains(segment.disabledIfBlockInLookahead)) continue
@@ -111,8 +111,8 @@ class DummyBlockAvailability(
 
     override fun getAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>,
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>,
         startTime: Double
     ): BlockAvailabilityInterface.Availability {
         val resourceUses = generateResourcesForPath(infraExplorer, startOffset, endOffset)
@@ -131,10 +131,10 @@ class DummyBlockAvailability(
         infraExplorer: InfraExplorerWithEnvelope,
         resourceUses: List<ResourceUse>,
         pathStartTime: Double,
-        startOffset: Offset<Path>
+        startOffset: Offset<BlockPath>
     ): BlockAvailabilityInterface.Unavailable? {
         var minimumDelay = 0.0
-        var conflictOffset = Offset<Path>(0.meters)
+        var conflictOffset = Offset<BlockPath>(0.meters)
         for (resourceUse in resourceUses) {
             val resourceStartTime = resourceUse.startTime + pathStartTime
             val resourceEndTime = resourceUse.endTime + pathStartTime
@@ -236,8 +236,8 @@ class DummyBlockAvailability(
         unavailableSegment: OccupancySegment,
         block: BlockWithOffset,
         explorer: InfraExplorerWithEnvelope,
-        startOffset: Offset<Path>,
-        endOffset: Offset<Path>
+        startOffset: Offset<BlockPath>,
+        endOffset: Offset<BlockPath>
     ): TimeInterval? {
         val blockEnterOffset = (block.pathOffset + unavailableSegment.distanceStart)
         val blockExitOffset = (block.pathOffset + unavailableSegment.distanceEnd)
@@ -252,8 +252,8 @@ class DummyBlockAvailability(
     /** Returns the list of blocks in the given interval on the path */
     private fun getBlocksInRange(
         blocks: List<BlockWithOffset>,
-        start: Offset<Path>,
-        end: Offset<Path>
+        start: Offset<BlockPath>,
+        end: Offset<BlockPath>
     ): List<BlockWithOffset> {
         return blocks
             .stream()

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/DummyInfra.kt
@@ -485,7 +485,7 @@ class DummyInfra : RawInfra, BlockInfra {
     override val blocks: StaticIdxSpace<Block>
         get() = TODO("Not yet implemented")
 
-    override fun getBlockPath(block: BlockId): StaticIdxList<ZonePath> {
+    override fun getBlockZonePaths(block: BlockId): StaticIdxList<ZonePath> {
         return makeIndexList(block)
     }
 

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/OffsetConversionTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/OffsetConversionTests.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class OffsetConversionTests {
     val infra = DummyInfra()
     val blocks = (0 ..< 10).map { infra.addBlock(it.toString(), (it + 1).toString(), 1_000.meters) }
-    val zones = blocks.flatMap { infra.getBlockPath(it) }
+    val zones = blocks.flatMap { infra.getBlockZonePaths(it) }
     val chunks = zones.flatMap { infra.getZonePathChunks(it) }
 
     @Test

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/PathUtils.kt
@@ -32,7 +32,7 @@ fun pathFromRoutes(
     routes: List<RouteId>,
 ): ChunkPath {
     val chunks = MutableDirStaticIdxArrayList<TrackChunk>()
-    var length = Length<Path>(0.meters)
+    var length = Length<BlockPath>(0.meters)
     for (route in routes) {
         for (chunk in infra.getChunksOnRoute(route)) {
             chunks.add(chunk)


### PR DESCRIPTION
Close https://github.com/OpenRailAssociation/osrd/issues/10595

I tried not to change the current behavior, even if sometimes it looks that the wrong type is used, to ease the review of this PR. The hunt of the wrong typing can be done in another PR. For instance, we could take a look on the calls to these types of functions:
- `toTravelledPath`
- `fromTravelledPath`

For the review:
- I mainly renamed `Path` into `BlockPath`
- I, only a few times (but it might be the most important part for review), fixed the typing from `Path` into `TravelledPath`. Theses changes are important, because the behaviour of the both types are different:
```patch
- Path
+ TravelledPath
```

I also suspect a wrong typing for [these variables](https://github.com/OpenRailAssociation/osrd/blob/f7a7db46bed212a61be6b641e2efd09f58c1fe2c/core/src/main/java/fr/sncf/osrd/conflicts/IncrementalPath.kt#L140-L141), but I did not changed them.

Finally, I also, in the second commit, renamed `getBlockPath` into `getBlockZonePaths` to avoid confusion.

