### PR TITLE
Remove InternalError dependency for Model's Update traits

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "deadpool",
  "deadpool-redis",
  "derivative",
+ "derive_more",
  "diesel",
  "diesel-async",
  "diesel_json",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { version = "0.4.40", default-features = false, features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 darling = "0.20"
 derivative = "2.2.0"
+derive_more = { version = "2.0.1", features = ["from"] }
 diesel = { version = "2.2", default-features = false, features = [
   "32-column-tables",
   "chrono",
@@ -131,6 +132,7 @@ deadpool-redis = { version = "0.20.0", features = [
   "tokio-native-tls-comp",
 ] }
 derivative.workspace = true
+derive_more.workspace = true
 diesel.workspace = true
 diesel-async = { workspace = true }
 diesel_json = "0.2.1"

--- a/editoast/editoast_authz/Cargo.toml
+++ b/editoast/editoast_authz/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more.workspace = true
 fga.workspace = true
 futures.workspace = true
 itertools.workspace = true

--- a/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
@@ -60,8 +60,11 @@ impl ToTokens for UpdateBatchImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
-                    .await?
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_ok(<#model as Model>::from_row)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
@@ -76,14 +79,14 @@ impl ToTokens for UpdateBatchImpl {
                 .returning((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map(|s| {
-                    s.map_ok(|row| {
-                        let model = <#model as Model>::from_row(row);
-                        (model.get_id(), model)
-                    })
-                    .try_collect::<Vec<_>>()
-                })?
-                .await?
+                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_ok(|row| {
+                    let model = <#model as Model>::from_row(row);
+                    (model.get_id(), model)
+                })
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
         });
 
         tokens.extend(quote! {
@@ -97,12 +100,13 @@ impl ToTokens for UpdateBatchImpl {
                     self,
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C> {
+                ) -> crate::error::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::stream::TryStreamExt as _;
+                    use futures_util::TryFutureExt as _;
                     use std::ops::DerefMut;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -117,14 +121,15 @@ impl ToTokens for UpdateBatchImpl {
                     self,
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C> {
+                ) -> crate::error::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
-                    use futures_util::stream::TryStreamExt;
+                    use futures_util::stream::TryStreamExt as _;
+                    use futures_util::TryFutureExt as _;
                     let ids = ids.into_iter().collect::<Vec<_>>();
                     tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
                     Ok({ #update_with_key_loop })

--- a/editoast/editoast_derive/src/model/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_impl.rs
@@ -38,7 +38,7 @@ impl ToTokens for UpdateImpl {
                     self,
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> crate::error::Result<Option<#model>> {
+                ) -> std::result::Result<Option<#model>, <#model as crate::models::Model>::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -51,7 +51,7 @@ impl ToTokens for UpdateImpl {
                         .await
                         .map(Into::into)
                         .optional()
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -356,7 +356,10 @@ impl crate::models::Update<(String), Document> for DocumentChangeset {
         self,
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> crate::error::Result<Option<Document>> {
+    ) -> std::result::Result<
+        Option<Document>,
+        <Document as crate::models::Model>::Error,
+    > {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -372,7 +375,9 @@ impl crate::models::Update<(String), Document> for DocumentChangeset {
             .await
             .map(Into::into)
             .optional()
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]
@@ -387,7 +392,10 @@ impl crate::models::Update<(i64), Document> for DocumentChangeset {
         self,
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> crate::error::Result<Option<Document>> {
+    ) -> std::result::Result<
+        Option<Document>,
+        <Document as crate::models::Model>::Error,
+    > {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -400,7 +408,9 @@ impl crate::models::Update<(i64), Document> for DocumentChangeset {
             .await
             .map(Into::into)
             .optional()
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -967,12 +967,13 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C> {
+    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryFutureExt as _;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -996,12 +997,15 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Document as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Document as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -1021,14 +1025,15 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C> {
+    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryFutureExt as _;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
         Ok({
@@ -1051,14 +1056,18 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -1081,12 +1090,13 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C> {
+    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryFutureExt as _;
         use std::ops::DerefMut;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
@@ -1110,12 +1120,15 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Document as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Document as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -1135,14 +1148,15 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C> {
+    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
-        use futures_util::stream::TryStreamExt;
+        use futures_util::stream::TryStreamExt as _;
+        use futures_util::TryFutureExt as _;
         let ids = ids.into_iter().collect::<Vec<_>>();
         tracing::Span::current().record("query_ids", tracing::field::debug(&ids));
         Ok({
@@ -1165,14 +1179,18 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_models/src/db_connection_pool.rs
+++ b/editoast/editoast_models/src/db_connection_pool.rs
@@ -27,6 +27,8 @@ use url::Url;
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
 
+use crate::DatabaseError;
+
 pub type DbConnectionConfig = AsyncDieselConnectionManager<AsyncPgConnection>;
 
 #[derive(Clone)]
@@ -58,7 +60,7 @@ impl DbConnection {
     pub async fn transaction<'a, R, E, F>(&self, callback: F) -> std::result::Result<R, E>
     where
         F: FnOnce(Self) -> ScopedBoxFuture<'a, 'a, std::result::Result<R, E>> + Send + 'a,
-        E: From<diesel::result::Error> + Send + 'a,
+        E: From<DatabaseError> + Send + 'a,
         R: Send + 'a,
     {
         use diesel_async::TransactionManager as _;
@@ -67,13 +69,17 @@ impl DbConnection {
 
         {
             let mut handle = self.write().await;
-            TxManager::begin_transaction(handle.deref_mut()).await?;
+            TxManager::begin_transaction(handle.deref_mut())
+                .await
+                .map_err(DatabaseError)?;
         }
 
         match callback(self.clone()).await {
             Ok(result) => {
                 let mut handle = self.write().await;
-                TxManager::commit_transaction(handle.deref_mut()).await?;
+                TxManager::commit_transaction(handle.deref_mut())
+                    .await
+                    .map_err(DatabaseError)?;
                 Ok(result)
             }
             Err(callback_error) => {
@@ -82,10 +88,21 @@ impl DbConnection {
                     Ok(()) | Err(diesel::result::Error::BrokenTransactionManager) => {
                         Err(callback_error)
                     }
-                    Err(rollback_error) => Err(rollback_error.into()),
+                    Err(rollback_error) => Err(E::from(DatabaseError(rollback_error))),
                 }
             }
         }
+    }
+
+    pub async fn rollback_transaction(&self) -> Result<(), DatabaseError> {
+        use diesel_async::TransactionManager as _;
+
+        let mut handle = self.write().await;
+        <AsyncPgConnection as AsyncConnection>::TransactionManager::rollback_transaction(
+            handle.deref_mut(),
+        )
+        .await
+        .map_err(DatabaseError)
     }
 }
 

--- a/editoast/editoast_models/src/lib.rs
+++ b/editoast/editoast_models/src/lib.rs
@@ -9,6 +9,6 @@ pub use db_connection_pool::DbConnectionPoolV2;
 /// Generic error type to forward errors from the database
 ///
 /// Useful for functions which only points of failure are the DB calls.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq)]
 #[error("an error occurred while querying the database: {0}")]
 pub struct DatabaseError(#[from] diesel::result::Error);

--- a/editoast/editoast_models/src/model.rs
+++ b/editoast/editoast_models/src/model.rs
@@ -1,9 +1,12 @@
 use std::sync::LazyLock;
 
-use diesel::result::{DatabaseErrorInformation, DatabaseErrorKind};
+use diesel::result::DatabaseErrorInformation;
+use diesel::result::DatabaseErrorKind;
 use regex::Regex;
 
-#[derive(Debug, thiserror::Error)]
+use crate::DatabaseError;
+
+#[derive(Debug, thiserror::Error, PartialEq)]
 pub enum Error {
     #[error("unique constraint violation \"{constraint}\" on column \"{column}\" with value \"{value}\"")]
     UniqueViolation {
@@ -13,8 +16,10 @@ pub enum Error {
     },
     #[error("check constraint violation of \"{constraint}\"")]
     CheckViolation { constraint: String },
+    #[error("foreign key constraint violation of \"{constraint}\"")]
+    ForeignKeyViolation { constraint: String },
     #[error(transparent)]
-    DatabaseError(diesel::result::Error),
+    DatabaseError(#[from] DatabaseError),
 }
 
 fn try_parse_unique_violation(e: &(dyn DatabaseErrorInformation + Send + Sync)) -> Option<Error> {
@@ -54,6 +59,24 @@ fn try_parse_check_violation(e: &(dyn DatabaseErrorInformation + Send + Sync)) -
     }
 }
 
+fn try_parse_foreign_key_violation(
+    e: &(dyn DatabaseErrorInformation + Send + Sync),
+) -> Option<Error> {
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"update or delete on table .* violates foreign key constraint"#).unwrap()
+    });
+    if RE.is_match(e.message()) {
+        Some(Error::ForeignKeyViolation {
+            constraint: e
+                .constraint_name()
+                .expect("PostgreSQL should provide the constraint name")
+                .to_owned(),
+        })
+    } else {
+        None
+    }
+}
+
 impl From<diesel::result::Error> for Error {
     fn from(e: diesel::result::Error) -> Self {
         match &e {
@@ -64,7 +87,7 @@ impl From<diesel::result::Error> for Error {
                         error = %e,
                         "failed to parse PostgreSQL details message"
                     );
-                    Self::DatabaseError(e)
+                    Self::DatabaseError(DatabaseError(e))
                 })
             }
             diesel::result::Error::DatabaseError(DatabaseErrorKind::CheckViolation, inner) => {
@@ -74,10 +97,20 @@ impl From<diesel::result::Error> for Error {
                         error = %e,
                         "failed to parse PostgreSQL details message"
                     );
-                    Self::DatabaseError(e)
+                    Self::DatabaseError(DatabaseError(e))
                 })
             }
-            _ => Self::DatabaseError(e),
+            diesel::result::Error::DatabaseError(DatabaseErrorKind::ForeignKeyViolation, inner) => {
+                try_parse_foreign_key_violation(inner.as_ref()).unwrap_or_else(|| {
+                    // falling back to the generic error — since it's still semantically correct, logging the error is enough
+                    tracing::error!(
+                        error = %e,
+                        "failed to parse PostgreSQL details message"
+                    );
+                    Self::DatabaseError(DatabaseError(e))
+                })
+            }
+            _ => Self::DatabaseError(DatabaseError(e)),
         }
     }
 }

--- a/editoast/fga/Cargo.toml
+++ b/editoast/fga/Cargo.toml
@@ -19,6 +19,6 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more.workspace = true
 stdext.workspace = true
 tracing-subscriber.workspace = true

--- a/editoast/migrations/2025-03-16-172133_model_update_errors/down.sql
+++ b/editoast/migrations/2025-03-16-172133_model_update_errors/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE project ADD CONSTRAINT project_image_id_key UNIQUE (image_id);
+
+ALTER TABLE project
+DROP CONSTRAINT IF EXISTS project_image_id_fkey;
+
+ALTER TABLE project ADD CONSTRAINT project_image_id_fkey FOREIGN KEY (image_id) REFERENCES document (id) DEFERRABLE INITIALLY DEFERRED;

--- a/editoast/migrations/2025-03-16-172133_model_update_errors/up.sql
+++ b/editoast/migrations/2025-03-16-172133_model_update_errors/up.sql
@@ -1,0 +1,9 @@
+-- Allows two different projects to use the same image
+ALTER TABLE project
+DROP CONSTRAINT project_image_id_key;
+
+-- Prevents an image from being deleted if it is used by a project
+ALTER TABLE project
+DROP CONSTRAINT IF EXISTS project_image_id_fkey;
+
+ALTER TABLE project ADD CONSTRAINT project_image_id_fkey FOREIGN KEY (image_id) REFERENCES document (id) ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -2301,7 +2301,7 @@ paths:
     get:
       tags:
       - scenarios
-      summary: Get macro node list by scneario id
+      summary: Get macro node list by scenario id
       parameters:
       - name: project_id
         in: path
@@ -5150,6 +5150,7 @@ components:
       - $ref: '#/components/schemas/EditoastGeometryErrorUnexpectedGeometry'
       - $ref: '#/components/schemas/EditoastGetObjectsErrorsDuplicateIdsProvided'
       - $ref: '#/components/schemas/EditoastGetObjectsErrorsObjectIdNotFound'
+      - $ref: '#/components/schemas/EditoastInfraApiErrorDatabase'
       - $ref: '#/components/schemas/EditoastInfraApiErrorNotFound'
       - $ref: '#/components/schemas/EditoastInfraCacheEditoastErrorObjectNotFound'
       - $ref: '#/components/schemas/EditoastInfraStateErrorFetchError'
@@ -5157,6 +5158,7 @@ components:
       - $ref: '#/components/schemas/EditoastLayersErrorViewNotFound'
       - $ref: '#/components/schemas/EditoastLinesErrorsLineNotFound'
       - $ref: '#/components/schemas/EditoastListErrorsErrorsWrongErrorTypeProvided'
+      - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
       - $ref: '#/components/schemas/EditoastModelError'
       - $ref: '#/components/schemas/EditoastNoSuchUserErrorNoSuchUser'
@@ -5174,6 +5176,7 @@ components:
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsInvalidNumberOfPaths'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsStartingTrackLocationNotFound'
+      - $ref: '#/components/schemas/EditoastProjectErrorDatabase'
       - $ref: '#/components/schemas/EditoastProjectErrorImageError'
       - $ref: '#/components/schemas/EditoastProjectErrorImageNotFound'
       - $ref: '#/components/schemas/EditoastProjectErrorNotFound'
@@ -5215,6 +5218,7 @@ components:
       - $ref: '#/components/schemas/EditoastTimetableErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorNotFound'
       - $ref: '#/components/schemas/EditoastTimetableErrorParseError'
+      - $ref: '#/components/schemas/EditoastTowedRollingStockErrorDatabase'
       - $ref: '#/components/schemas/EditoastTowedRollingStockErrorIdNotFound'
       - $ref: '#/components/schemas/EditoastTowedRollingStockErrorIsLocked'
       - $ref: '#/components/schemas/EditoastTrainScheduleErrorBatchTrainScheduleNotFound'
@@ -5321,6 +5325,25 @@ components:
           type: string
           enum:
           - editoast:infra:objects:ObjectIdNotFound
+    EditoastInfraApiErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:infra:Database
     EditoastInfraApiErrorNotFound:
       type: object
       required:
@@ -5488,6 +5511,25 @@ components:
           type: string
           enum:
           - editoast:infra:errors:WrongErrorTypeProvided
+    EditoastMacroNodeErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:macro_node:Database
     EditoastMacroNodeErrorNotFound:
       type: object
       required:
@@ -5875,6 +5917,25 @@ components:
           type: string
           enum:
           - editoast:infra:pathfinding:StartingTrackLocationNotFound
+    EditoastProjectErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:project:Database
     EditoastProjectErrorImageError:
       type: object
       required:
@@ -6806,6 +6867,25 @@ components:
           type: string
           enum:
           - editoast:timetable:ParseError
+    EditoastTowedRollingStockErrorDatabase:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 500
+        type:
+          type: string
+          enum:
+          - editoast:towedrollingstocks:Database
     EditoastTowedRollingStockErrorIdNotFound:
       type: object
       required:

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -20,13 +20,19 @@ use tracing::Level;
 #[derive(Debug, thiserror::Error)]
 pub enum AuthDriverError {
     #[error(transparent)]
-    DieselError(#[from] diesel::result::Error),
+    Database(#[from] editoast_models::DatabaseError),
     #[error(transparent)]
     DbPoolError(#[from] editoast_models::db_connection_pool::DatabasePoolError),
     #[error("Subject with id {subject_id} not found")]
     SubjectNotFound { subject_id: i64 },
     #[error(transparent)]
     OpenFgaRequestFailure(#[from] fga::client::RequestFailure),
+}
+
+impl From<diesel::result::Error> for AuthDriverError {
+    fn from(e: diesel::result::Error) -> Self {
+        Self::Database(e.into())
+    }
 }
 
 #[derive(Clone)]

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -105,7 +105,7 @@ impl Infra {
             .collect()
     }
 
-    pub async fn bump_version(&mut self, conn: &mut DbConnection) -> Result<()> {
+    pub async fn bump_version(&mut self, conn: &mut DbConnection) -> Result<(), ModelError<Self>> {
         let new_version = self
             .version
             .parse::<u32>()
@@ -116,7 +116,10 @@ impl Infra {
         self.save(conn).await
     }
 
-    pub async fn bump_generated_version(&mut self, conn: &mut DbConnection) -> Result<()> {
+    pub async fn bump_generated_version(
+        &mut self,
+        conn: &mut DbConnection,
+    ) -> Result<(), ModelError<Self>> {
         self.generated_version = Some(self.version.clone());
         self.save(conn).await
     }

--- a/editoast/src/models/prelude/create.rs
+++ b/editoast/src/models/prelude/create.rs
@@ -15,7 +15,7 @@ use super::Model;
 pub trait Create<M: Model>: Sized {
     /// Creates a new row in the database with the values of the changeset and
     /// returns the created model instance
-    async fn create(self, conn: &mut DbConnection) -> std::result::Result<M, M::Error>;
+    async fn create(self, conn: &mut DbConnection) -> Result<M, M::Error>;
 
     /// Just like [Create::create] but discards the error if any and returns `Err(fail())` instead
     async fn create_or_fail<E: From<M::Error>, F: FnOnce() -> E + Send>(

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -1,6 +1,7 @@
 use std::result::Result;
 
-use editoast_models::{model, DbConnection};
+use editoast_models::model;
+use editoast_models::DbConnection;
 
 use crate::error::EditoastError;
 
@@ -14,7 +15,7 @@ pub trait Delete: Model {
     /// Deletes the row corresponding to this model instance
     ///
     /// Returns `true` if the row was deleted, `false` if it didn't exist
-    async fn delete(&self, conn: &mut DbConnection) -> std::result::Result<bool, Self::Error>;
+    async fn delete(&self, conn: &mut DbConnection) -> Result<bool, Self::Error>;
 
     /// Just like [Delete::delete] but returns `Err(fail())` if the row didn't exist
     async fn delete_or_fail<E, F>(&self, conn: &mut DbConnection, fail: F) -> Result<(), E>

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -42,6 +42,19 @@ where
 {
     /// Returns whether the row #`id` exists in the database
     async fn exists(conn: &mut DbConnection, id: K) -> Result<bool>;
+
+    /// Just like [Exists::exists] but returns `Err(fail())` if the row doesn't exist
+    async fn exists_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<()>
+    where
+        E: EditoastError,
+        F: FnOnce() -> E + Send,
+    {
+        match Self::exists(conn, id).await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(fail().into()),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 /// Unchecked batch retrieval of a [Model](super::Model) from the database

--- a/editoast/src/models/prelude/update.rs
+++ b/editoast/src/models/prelude/update.rs
@@ -3,8 +3,6 @@ use std::fmt::Debug;
 use diesel::result::Error::NotFound;
 use editoast_models::DbConnection;
 
-use crate::error::EditoastError;
-use crate::error::Result;
 use crate::models::PreferredId;
 
 use super::Model;
@@ -138,7 +136,7 @@ where
 /// derive macro instead.
 pub trait UpdateBatchUnchecked<M, K>: Sized
 where
-    M: Send,
+    M: Model,
     K: Send + Clone,
 {
     /// Updates a batch of rows in the database given an iterator of keys
@@ -155,7 +153,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C>;
+    ) -> Result<C, M::Error>;
 
     /// Just like [UpdateBatchUnchecked::update_batch_unchecked] but the returned models are paired with their key
     ///
@@ -171,7 +169,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C>;
+    ) -> Result<C, M::Error>;
 }
 
 /// Describes how a [Model] can be updated in the database given a batch of its changesets
@@ -184,7 +182,7 @@ where
 /// This won't be possible however if the model's key is not `Eq` or `Hash`.
 pub trait UpdateBatch<M, K>: UpdateBatchUnchecked<M, K>
 where
-    M: Send,
+    M: Model,
     K: Eq + std::hash::Hash + Clone + Send,
 {
     /// Applies the changeset to a batch of rows in the database given an iterator of keys
@@ -208,7 +206,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>)>
+    ) -> Result<(C, std::collections::HashSet<K>), M::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -245,7 +243,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>)>
+    ) -> Result<(C, std::collections::HashSet<K>), M::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -285,7 +283,7 @@ where
         conn: &mut DbConnection,
         ids: I,
         fail: F,
-    ) -> Result<C>
+    ) -> Result<C, E>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -293,14 +291,14 @@ where
             + std::iter::Extend<M>
             + std::iter::FromIterator<M>
             + std::iter::IntoIterator<Item = M>,
-        E: EditoastError,
+        E: From<M::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch::<_, C>(conn, ids).await?;
         if missing.is_empty() {
             Ok(result)
         } else {
-            Err(fail(missing).into())
+            Err(fail(missing))
         }
     }
 
@@ -318,7 +316,7 @@ where
         conn: &mut DbConnection,
         ids: I,
         fail: F,
-    ) -> Result<C>
+    ) -> Result<C, E>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -326,14 +324,14 @@ where
             + std::iter::Extend<(K, M)>
             + std::iter::FromIterator<(K, M)>
             + std::iter::IntoIterator<Item = (K, M)>,
-        E: EditoastError,
+        E: From<M::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch_with_key::<_, C>(conn, ids).await?;
         if missing.is_empty() {
             Ok(result)
         } else {
-            Err(fail(missing).into())
+            Err(fail(missing))
         }
     }
 }
@@ -342,7 +340,7 @@ where
 impl<Cs, M, K> UpdateBatch<M, K> for Cs
 where
     Cs: UpdateBatchUnchecked<M, K>,
-    M: Send,
+    M: Model,
     K: Eq + std::hash::Hash + Clone + Send,
 {
 }

--- a/editoast/src/models/prelude/update.rs
+++ b/editoast/src/models/prelude/update.rs
@@ -8,6 +8,7 @@ use crate::error::Result;
 use crate::models::PreferredId;
 
 use super::Model;
+use super::ModelError;
 
 /// A couple ([Model] mutable reference, a [Model] changeset instance)
 ///
@@ -45,14 +46,19 @@ impl<M: Model> Patch<'_, M> {
     ///
     /// If this method is not implemented for your model for whatever reason, just
     /// use [Save::save].
-    pub async fn apply<K>(self, conn: &mut DbConnection) -> Result<()>
+    pub async fn apply<K>(self, conn: &mut DbConnection) -> Result<(), M::Error>
     where
         for<'b> K: Send + Clone + 'b,
         M: Model + PreferredId<K> + Send,
         <M as Model>::Changeset: Update<K, M> + Send,
     {
         let id: K = self.model.get_id();
-        let updated: M = self.changeset.update_or_fail(conn, id, || NotFound).await?;
+        let updated: M = self
+            .changeset
+            .update_or_fail(conn, id, || {
+                M::Error::from(editoast_models::model::Error::from(NotFound))
+            })
+            .await?;
         *self.model = updated;
         Ok(())
     }
@@ -65,25 +71,24 @@ impl<M: Model> Patch<'_, M> {
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-pub trait Update<K, Row>: Sized
+pub trait Update<K, M>: Sized
 where
     K: Send,
-    Row: Send,
+    M: Model,
 {
     /// Updates the row #`id` with the changeset values and returns the updated model
-    async fn update(self, conn: &mut DbConnection, id: K) -> Result<Option<Row>>;
+    async fn update(self, conn: &mut DbConnection, id: K) -> Result<Option<M>, M::Error>;
 
     /// Just like [Update::update] but returns `Err(fail())` if the row was not found
-    async fn update_or_fail<E: EditoastError, F: FnOnce() -> E + Send>(
-        self,
-        conn: &mut DbConnection,
-        id: K,
-        fail: F,
-    ) -> Result<Row> {
+    async fn update_or_fail<E, F>(self, conn: &mut DbConnection, id: K, fail: F) -> Result<M, E>
+    where
+        E: From<M::Error>,
+        F: FnOnce() -> E + Send,
+    {
         match self.update(conn, id).await {
             Ok(Some(obj)) => Ok(obj),
-            Ok(None) => Err(fail().into()),
-            Err(e) => Err(e),
+            Ok(None) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }
@@ -92,7 +97,7 @@ where
 ///
 /// This trait is automatically implemented for all models that implement
 /// [Update].
-pub trait Save<K: Send>: Sized {
+pub trait Save<K: Send>: Model {
     /// Persists the model instance to the database
     ///
     /// # Example
@@ -103,7 +108,7 @@ pub trait Save<K: Send>: Sized {
     /// doc.save(&mut conn).await?;
     /// assert_eq!(doc.title, "new title");
     /// ```
-    async fn save(&mut self, conn: &mut DbConnection) -> Result<()>;
+    async fn save(&mut self, conn: &mut DbConnection) -> Result<(), Self::Error>;
 }
 
 impl<K, M> Save<K> for M
@@ -112,10 +117,14 @@ where
     M: Model + PreferredId<K> + Clone + Send,
     <M as Model>::Changeset: Update<K, M> + Send,
 {
-    async fn save(&mut self, conn: &mut DbConnection) -> Result<()> {
+    async fn save(&mut self, conn: &mut DbConnection) -> Result<(), M::Error> {
         let id = self.get_id();
         let changeset = <M as Model>::Changeset::from(self.clone()); // FIXME: I don't like that clone, maybe a ChangesetOwned/Changeset pair would work?
-        *self = changeset.update_or_fail(conn, id, || NotFound).await?;
+        *self = changeset
+            .update_or_fail(conn, id, || {
+                M::Error::from(editoast_models::model::Error::from(NotFound))
+            })
+            .await?;
         Ok(())
     }
 }

--- a/editoast/src/models/projects.rs
+++ b/editoast/src/models/projects.rs
@@ -1,17 +1,20 @@
 use chrono::NaiveDateTime;
 use chrono::Utc;
+use diesel_async::scoped_futures::ScopedBoxFuture;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::Model;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::error::Result;
+use crate::error::InternalError;
 use crate::models::prelude::*;
 use crate::models::Document;
 use crate::models::Study;
 use crate::models::Tags;
 use crate::views::projects::ProjectError;
 use crate::SelectionSettings;
+use editoast_models::model;
 use editoast_models::DbConnection;
 
 editoast_common::schemas! {
@@ -21,6 +24,7 @@ editoast_common::schemas! {
 #[derive(Clone, Debug, Serialize, Deserialize, Model, ToSchema, PartialEq)]
 #[model(table = editoast_models::tables::project)]
 #[model(gen(ops = crud, list))]
+#[model(error = Error)]
 pub struct Project {
     pub id: i64,
     pub name: String,
@@ -36,15 +40,58 @@ pub struct Project {
     pub image: Option<i64>,
 }
 
+#[derive(Debug, thiserror::Error, derive_more::From)]
+pub enum Error {
+    #[error(transparent)]
+    #[from(forward)]
+    Database(model::Error),
+    #[error(transparent)]
+    Legacy(#[from] InternalError),
+}
+
+#[tracing::instrument(skip(conn), ret, err)]
+async fn try_delete_document(conn: &DbConnection, doc_id: i64) -> Result<(), Error> {
+    let res = conn
+        .transaction(|mut conn| {
+            async move {
+                match Document::delete_static(&mut conn, doc_id).await {
+                    Ok(false) => unreachable!(
+                        "cannot happen as the Document has to be there because of the FK on `image`"
+                    ),
+                    Ok(true) => Ok(()),
+                    // We want the delete to occur in a transaction in order to rollback it if the deletion fails.
+                    // The deletion can fail if the document is still used by another project (FK violation). This
+                    // is acceptable, it's what this function does.
+                    // However, if a FK violation occurs, the transaction must rolloback otherwise each subsequent
+                    // query will fail. If the violation occurs, `e` is an `Err`, therefore we return it in order
+                    // to let `transaction` rollback. We then match on the error below in order to accept the
+                    // FK violation, which is not an error in our workflow.
+                    Err(e) => Err(e),
+                }
+            }
+            .scope_boxed()
+        })
+        .await;
+    match res {
+        Ok(_) => Ok(()),
+        Err(model::Error::ForeignKeyViolation { constraint })
+            if constraint == "project_image_id_fkey" =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(self::Error::from(e)),
+    }
+}
+
 impl Project {
     /// This function takes a filled project and update to now the last_modification field
-    pub async fn update_last_modified(&mut self, conn: &mut DbConnection) -> Result<()> {
+    pub async fn update_last_modified(&mut self, conn: &mut DbConnection) -> Result<(), Error> {
         self.last_modification = Utc::now().naive_utc();
         self.save(conn).await?;
         Ok(())
     }
 
-    pub async fn studies_count(&self, conn: &mut DbConnection) -> Result<u64> {
+    pub async fn studies_count(&self, conn: &mut DbConnection) -> Result<u64, InternalError> {
         let project_id = self.id;
         let studies_count = Study::count(
             conn,
@@ -54,44 +101,91 @@ impl Project {
         Ok(studies_count)
     }
 
+    /// Updates a project's image and deletes the old one if it is not used by another project
+    #[tracing::instrument(skip(conn), ret, err)]
     pub async fn update_and_prune_document(
+        &mut self,
         conn: &mut DbConnection,
-        project_changeset: Changeset<Self>,
-        project_id: i64,
-    ) -> Result<Project> {
-        let old_project =
-            Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-                .await?;
-        let image_to_delete = if Some(old_project.image) != project_changeset.image {
-            old_project.image
-        } else {
-            None
-        };
-        let project = project_changeset
-            .update_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
-        if let Some(image) = image_to_delete {
-            // We don't check the result. We don't want to throw an error if the image is used in another project.
-            let _ = Document::delete_static(conn, image).await;
-        }
-        Ok(project)
+        new_doc_id: Option<i64>,
+    ) -> Result<(), Error> {
+        conn.transaction(|mut conn| {
+            async move {
+                let old_doc_id = self.image;
+                self.image = new_doc_id;
+                self.save(&mut conn).await?;
+                if new_doc_id != old_doc_id {
+                    if let Some(old_doc_id) = old_doc_id {
+                        try_delete_document(&conn, old_doc_id).await?;
+                    }
+                }
+                Ok::<_, Error>(())
+            }
+            .scope_boxed()
+        })
+        .await?;
+        Ok(())
     }
 
-    pub async fn delete_and_prune_document(
-        conn: &mut DbConnection,
+    /// Deletes a project and prunes the image if it is not used by another project
+    #[tracing::instrument(skip(conn), ret, err)]
+    pub async fn delete_and_prune_document(self, conn: &mut DbConnection) -> Result<(), Error> {
+        conn.transaction(|mut conn| {
+            async move {
+                if !self.delete(&mut conn).await? {
+                    tracing::warn!(
+                        project_id = self.id,
+                        "project to delete not found, probable race condition"
+                    );
+                }
+                if let Some(doc_id) = self.image {
+                    try_delete_document(&conn, doc_id).await?;
+                }
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await
+    }
+
+    /// Opens a transaction querying a [Project] and calls the provided function with it
+    ///
+    /// The [Project::last_modification] field is updated to the current time after the function is called.
+    #[tracing::instrument(skip(conn, f), err)]
+    pub async fn transactional_content_update<T, E, F>(
+        conn: DbConnection,
         project_id: i64,
-    ) -> Result<bool> {
-        let project_obj =
-            Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
+        f: F,
+    ) -> Result<(T, Self), InternalError>
+    where
+        T: Send,
+        E: Into<InternalError> + Send, // EditoastError bound will be removed when retrieve will return the model's error
+        F: for<'a> FnOnce(DbConnection, &'a mut Self) -> ScopedBoxFuture<'a, 'a, Result<T, E>>
+            + Send,
+    {
+        conn.transaction(|mut conn| {
+            async move {
+                let mut project = Self::retrieve_or_fail(&mut conn, project_id, || {
+                    ProjectError::NotFound { project_id }
+                })
                 .await?;
-        let _ = Project::delete_static(conn, project_id).await?;
 
-        if let Some(image) = project_obj.image {
-            // We don't check the result. We don't want to throw an error if the image is used in another project.
-            let _ = Document::delete_static(conn, image).await;
-        }
+                let res = f(conn.clone(), &mut project).await;
 
-        Ok(true)
+                project
+                    .patch()
+                    .last_modification(Utc::now().naive_utc())
+                    .apply(&mut conn)
+                    .await
+                    .map_err(|err| match err {
+                        Error::Database(e) => e.into(),
+                        Error::Legacy(e) => e,
+                    })?;
+
+                res.map(|t| (t, project)).map_err(Into::into)
+            }
+            .scope_boxed()
+        })
+        .await
     }
 }
 
@@ -172,5 +266,129 @@ pub mod tests {
             let name_2 = p2.name.to_lowercase();
             assert!(name_1.ge(&name_2));
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn update_project_prune_document() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let mut project1 = create_project(&mut db_pool.get_ok(), "Project 1").await;
+        let mut project2 = create_project(&mut db_pool.get_ok(), "Project 2").await;
+        let image = Document::changeset()
+            .content_type("data/text".to_owned())
+            .data("wassup?".bytes().collect())
+            .create(&mut db_pool.get_ok())
+            .await
+            .unwrap();
+        let image2 = Document::changeset()
+            .content_type("data/text".to_owned())
+            .data("ohno".bytes().collect())
+            .create(&mut db_pool.get_ok())
+            .await
+            .unwrap();
+
+        project1
+            .update_and_prune_document(&mut db_pool.get_ok(), Some(image.id))
+            .await
+            .expect("should work");
+        project2
+            .update_and_prune_document(&mut db_pool.get_ok(), Some(image.id))
+            .await
+            .expect("should work");
+
+        project2
+            .update_and_prune_document(&mut db_pool.get_ok(), None)
+            .await
+            .expect("should work - image is still used by project1");
+        assert!(Document::exists(&mut db_pool.get_ok(), image.id)
+            .await
+            .unwrap());
+
+        project1
+            .update_and_prune_document(&mut db_pool.get_ok(), Some(image2.id))
+            .await
+            .expect("should work");
+        assert!(
+            !Document::exists(&mut db_pool.get_ok(), image.id)
+                .await
+                .unwrap(),
+            "image should be deleted"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn delete_project_prune_document() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+
+        let mut project1 = create_project(&mut db_pool.get_ok(), "Project 1").await;
+        let mut project2 = create_project(&mut db_pool.get_ok(), "Project 2").await;
+        let mut project3 = create_project(&mut db_pool.get_ok(), "Project 3").await;
+        let project4 = create_project(&mut db_pool.get_ok(), "Project 4").await;
+        let image1 = Document::changeset()
+            .content_type("data/text".to_owned())
+            .data("image 1".bytes().collect())
+            .create(&mut db_pool.get_ok())
+            .await
+            .unwrap();
+        project1.image = Some(image1.id);
+        project1.save(&mut db_pool.get_ok()).await.unwrap();
+        project2.image = Some(image1.id);
+        project2.save(&mut db_pool.get_ok()).await.unwrap();
+        let image2 = Document::changeset()
+            .content_type("data/text".to_owned())
+            .data("image 2".bytes().collect())
+            .create(&mut db_pool.get_ok())
+            .await
+            .unwrap();
+        project3.image = Some(image2.id);
+        project3.save(&mut db_pool.get_ok()).await.unwrap();
+
+        // project1 -> image1, project2 -> image1, project3 -> image2, project4 -> nothing
+
+        let p1_id = project1.id;
+        project1
+            .delete_and_prune_document(&mut db_pool.get_ok())
+            .await
+            .expect("should work");
+        assert!(
+            Document::exists(&mut db_pool.get_ok(), image1.id)
+                .await
+                .unwrap(),
+            "image should not be deleted - still used by project2"
+        );
+
+        // project2 -> image1, project3 -> image2, project4 -> nothing
+
+        let p3_id = project3.id;
+        project3
+            .delete_and_prune_document(&mut db_pool.get_ok())
+            .await
+            .expect("should work");
+        assert!(
+            !Document::exists(&mut db_pool.get_ok(), image2.id)
+                .await
+                .unwrap(),
+            "image2 should be deleted"
+        );
+
+        // project2 -> image1, project4 -> nothing
+
+        let p4_id = project4.id;
+        project4
+            .delete_and_prune_document(&mut db_pool.get_ok())
+            .await
+            .expect("should work");
+
+        // project2 -> image1
+
+        assert!(Project::exists(&mut db_pool.get_ok(), project2.id)
+            .await
+            .unwrap());
+        assert!(Document::exists(&mut db_pool.get_ok(), image1.id)
+            .await
+            .unwrap());
+
+        assert!(!Project::exists(&mut db_pool.get_ok(), p1_id).await.unwrap());
+        assert!(!Project::exists(&mut db_pool.get_ok(), p3_id).await.unwrap());
+        assert!(!Project::exists(&mut db_pool.get_ok(), p4_id).await.unwrap());
     }
 }

--- a/editoast/src/models/rolling_stock_model.rs
+++ b/editoast/src/models/rolling_stock_model.rs
@@ -4,9 +4,13 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use editoast_common::units;
-use editoast_common::units::quantities::{
-    Acceleration, Deceleration, Length, Mass, Ratio, Time, Velocity,
-};
+use editoast_common::units::quantities::Acceleration;
+use editoast_common::units::quantities::Deceleration;
+use editoast_common::units::quantities::Length;
+use editoast_common::units::quantities::Mass;
+use editoast_common::units::quantities::Ratio;
+use editoast_common::units::quantities::Time;
+use editoast_common::units::quantities::Velocity;
 use editoast_derive::Model;
 use editoast_models::model;
 use editoast_models::rolling_stock::RollingStockCategories;
@@ -109,6 +113,7 @@ pub struct RollingStockModel {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Error {
     #[error("Rolling stock name already used: {name}")]
     NameAlreadyUsed { name: String },
@@ -291,17 +296,13 @@ pub mod tests {
     use editoast_models::rolling_stock::RollingStockCategories;
     use editoast_models::rolling_stock::RollingStockCategory;
     use rstest::rstest;
-    use serde_json::to_value;
 
     use super::RollingStockModel;
-    use crate::error::InternalError;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_rolling_stock_with_energy_sources;
     use crate::models::fixtures::fast_rolling_stock_changeset;
     use crate::models::fixtures::rolling_stock_with_energy_sources_changeset;
     use crate::models::prelude::*;
-    use crate::views::rolling_stock::map_diesel_error;
-    use crate::views::rolling_stock::RollingStockError;
     use editoast_models::DbConnectionPoolV2;
 
     #[rstest]
@@ -336,35 +337,27 @@ pub mod tests {
 
         // GIVEN
         // Creating the first rolling stock
-        let rs_name = "fast_rolling_stock_name";
-        let created_fast_rolling_stock =
-            create_fast_rolling_stock(&mut db_pool.get_ok(), rs_name).await;
+        let original_name = "micheline";
+        let _ = create_fast_rolling_stock(&mut db_pool.get_ok(), original_name).await;
 
         // Creating the second rolling stock
-        let rs_name_with_energy_sources_name = "fast_rolling_stock_with_energy_sources_name";
-        let created_fast_rolling_stock_with_energy_sources =
-            create_rolling_stock_with_energy_sources(
-                &mut db_pool.get_ok(),
-                rs_name_with_energy_sources_name,
-            )
-            .await;
+        let new_name = "wrong name";
+        let mut other_rs =
+            create_rolling_stock_with_energy_sources(&mut db_pool.get_ok(), new_name).await;
 
         // WHEN
-        let result = created_fast_rolling_stock_with_energy_sources
-            .into_changeset()
-            .update(&mut db_pool.get_ok(), created_fast_rolling_stock.id)
+        let error = other_rs
+            .patch()
+            .name(original_name.to_owned())
+            .apply(&mut db_pool.get_ok())
             .await
-            .map_err(|e| map_diesel_error(e, rs_name));
+            .expect_err("update should fail - name already used");
 
-        let error: InternalError = RollingStockError::NameAlreadyUsed {
-            name: String::from(rs_name),
-        }
-        .into();
-
-        // THEN
         assert_eq!(
-            to_value(result.unwrap_err()).unwrap(),
-            to_value(error).unwrap()
+            error,
+            super::Error::NameAlreadyUsed {
+                name: String::from(original_name)
+            }
         );
     }
 

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -4,17 +4,24 @@ use chrono::NaiveDateTime;
 use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
+use diesel_async::scoped_futures::ScopedBoxFuture;
+use diesel_async::scoped_futures::ScopedFutureExt as _;
 use diesel_async::RunQueryDsl;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::prelude::*;
 use crate::models::timetable::Timetable;
 use crate::models::Tags;
+use crate::views::scenario::ScenarioError;
 use editoast_derive::Model;
 use editoast_models::DbConnection;
+
+use super::Project;
+use super::Study;
 
 #[derive(Debug, Clone, Model, Deserialize, Serialize, ToSchema)]
 #[model(table = editoast_models::tables::scenario)]
@@ -59,5 +66,60 @@ impl Scenario {
         self.last_modification = Utc::now().naive_utc();
         self.save(conn).await?;
         Ok(())
+    }
+
+    /// Opens a transaction, retrieves the [Scenario], its [Study] and [Project] and
+    /// calls the provided closure with these objects
+    ///
+    /// The last modification field of these three objects are updated before the transaction is committed.
+    #[tracing::instrument(skip(conn, f), err)]
+    pub async fn transactional_content_update<T, E, F>(
+        conn: DbConnection,
+        scenario_id: i64,
+        f: F,
+    ) -> Result<(T, Self, Study, Project), InternalError>
+    where
+        T: Send,
+        E: Into<InternalError> + Send, // EditoastError bound will be removed when retrieve will return the model's error
+        F: for<'a> FnOnce(
+                DbConnection,
+                &'a mut Self,
+                &'a mut Study,
+                &'a mut Project,
+            ) -> ScopedBoxFuture<'a, 'a, Result<T, E>>
+            + Send
+            + 'static,
+    {
+        conn.transaction(|mut conn| {
+            async move {
+                let mut scenario = Self::retrieve_or_fail(&mut conn, scenario_id, || {
+                    ScenarioError::NotFound { scenario_id }
+                })
+                .await?;
+
+                let ((t, mut scenario), study, project) = Study::transactional_content_update(
+                    conn.clone(),
+                    scenario.study_id,
+                    |conn, study, project| {
+                        async move {
+                            let res = f(conn.clone(), &mut scenario, study, project).await;
+                            res.map(|t| (t, scenario))
+                        }
+                        .scope_boxed()
+                    },
+                )
+                .await?;
+
+                scenario
+                    .patch()
+                    .last_modification(Utc::now().naive_utc())
+                    .apply(&mut conn)
+                    .await?;
+
+                Ok((t, scenario, study, project))
+            }
+            .scope_boxed()
+        })
+        .await
     }
 }

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -2,16 +2,22 @@ use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 use chrono::Utc;
 
+use diesel_async::scoped_futures::ScopedBoxFuture;
+use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_derive::Model;
 use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::prelude::*;
 use crate::models::Scenario;
 use crate::models::Tags;
+use crate::views::study::StudyError;
+
+use super::Project;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Model, ToSchema)]
 #[model(table = editoast_models::tables::study)]
@@ -62,6 +68,59 @@ impl Study {
         }
 
         Ok(())
+    }
+
+    /// Opens a transaction, retrieves the [Study] and its [Project] and calls the provided closure with these
+    ///
+    /// The last modification field of these objects are updated before the transaction is committed.
+    #[tracing::instrument(skip(conn, f), err)]
+    pub async fn transactional_content_update<T, E, F>(
+        conn: DbConnection,
+        study_id: i64,
+        f: F,
+    ) -> Result<(T, Self, Project), InternalError>
+    where
+        T: Send,
+        E: Into<InternalError> + Send, // EditoastError bound will be removed when retrieve will return the model's error
+        F: for<'a> FnOnce(
+                DbConnection,
+                &'a mut Self,
+                &'a mut Project,
+            ) -> ScopedBoxFuture<'a, 'a, Result<T, E>>
+            + Send
+            + 'static,
+    {
+        conn.transaction(|mut conn| {
+            async move {
+                let mut study = Self::retrieve_or_fail(&mut conn, study_id, || {
+                    StudyError::NotFound { study_id }
+                })
+                .await?;
+
+                let ((t, mut study), project) = Project::transactional_content_update(
+                    conn.clone(),
+                    study.project_id,
+                    |conn, project| {
+                        async move {
+                            let res = f(conn.clone(), &mut study, project).await;
+                            res.map(|t| (t, study))
+                        }
+                        .scope_boxed()
+                    },
+                )
+                .await?;
+
+                study
+                    .patch()
+                    .last_modification(Utc::now().naive_utc())
+                    .apply(&mut conn)
+                    .await?;
+
+                Ok((t, study, project))
+            }
+            .scope_boxed()
+        })
+        .await
     }
 }
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -18,6 +18,7 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
+use editoast_models::model;
 use editoast_osrdyne_client::OsrdyneClient;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -91,6 +92,10 @@ pub enum InfraApiError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     NotFound { infra_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] model::Error),
 }
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -650,7 +655,8 @@ async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) ->
     })
     .await?;
     infra.locked = locked;
-    infra.save(&mut db_pool.get().await?).await
+    infra.save(&mut db_pool.get().await?).await?;
+    Ok(())
 }
 
 /// Lock an infra

--- a/editoast/src/views/projects.rs
+++ b/editoast/src/views/projects.rs
@@ -6,6 +6,7 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use chrono::Utc;
 use derivative::Derivative;
+use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
@@ -23,6 +24,7 @@ use super::pagination::PaginationStats;
 use super::study;
 use super::AuthenticationExt;
 use crate::error::Result;
+use crate::models::projects;
 use crate::models::Changeset;
 use crate::models::Create;
 use crate::models::Document;
@@ -30,6 +32,7 @@ use crate::models::Model;
 use crate::models::Project;
 use crate::models::Retrieve;
 use crate::models::Tags;
+use crate::models::Update;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::AuthorizationError;
 
@@ -53,7 +56,7 @@ editoast_common::schemas! {
     ProjectWithStudyCount,
 }
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "project")]
 pub enum ProjectError {
     /// Couldn't found the project with the given id
@@ -64,8 +67,12 @@ pub enum ProjectError {
     #[error("Image document '{document_key}' not found")]
     ImageNotFound { document_key: i64 },
     // Couldn't found the project with the given id
-    #[error("The provided image is not valid : {error}")]
+    #[error("The provided image is not valid: {error}")]
     ImageError { error: String },
+    #[error(transparent)]
+    #[from(forward)]
+    #[editoast_error(status = 500)]
+    Database(projects::Error),
 }
 
 /// Creation form for a project
@@ -163,7 +170,7 @@ async fn create(
         check_image_content(conn, image).await?;
     }
     let project: Changeset<Project> = project_create_form.into();
-    let project = project.create(conn).await?;
+    let project = project.create(conn).await.map_err(ProjectError::from)?;
     let project_with_studies = ProjectWithStudyCount::try_fetch(conn, project).await?;
 
     Ok(Json(project_with_studies))
@@ -281,12 +288,27 @@ async fn delete(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let conn = &mut db_pool.get().await?;
-    if Project::delete_and_prune_document(conn, project_id).await? {
-        Ok(axum::http::StatusCode::NO_CONTENT)
-    } else {
-        Err(ProjectError::NotFound { project_id }.into())
-    }
+
+    db_pool
+        .get()
+        .await?
+        .transaction(|mut conn| {
+            async move {
+                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                    ProjectError::NotFound { project_id }
+                })
+                .await?;
+                project
+                    .delete_and_prune_document(&mut conn)
+                    .await
+                    .map_err(ProjectError::from)?;
+                Ok::<_, ProjectError>(())
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Patch form for a project
@@ -344,7 +366,7 @@ async fn patch(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
-    Json(form): Json<ProjectPatchForm>,
+    Json(mut form): Json<ProjectPatchForm>,
 ) -> Result<Json<ProjectWithStudyCount>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -353,13 +375,47 @@ async fn patch(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let conn = &mut db_pool.get().await?;
-    if let Some(Some(image)) = form.image {
-        check_image_content(conn, image).await?;
-    }
+
+    let mut conn = db_pool.get().await?;
+    let update_image = match form.image {
+        // image replacement
+        Some(Some(new_image)) => {
+            check_image_content(&mut conn, new_image).await?;
+            form.image = None;
+            Some(Some(new_image))
+        }
+        // image removal
+        Some(None) => {
+            form.image = None;
+            Some(None)
+        }
+        // no image change requested, there may or may not be an image
+        None => None,
+    };
     let project_changeset: Changeset<Project> = form.into();
-    let project = Project::update_and_prune_document(conn, project_changeset, project_id).await?;
-    Ok(Json(ProjectWithStudyCount::try_fetch(conn, project).await?))
+
+    let (project, _) =
+        Project::transactional_content_update(conn.clone(), project_id, |mut conn, project| {
+            async move {
+                let mut project = project_changeset
+                    .update_or_fail(&mut conn, project.id, || ProjectError::NotFound {
+                        project_id: project.id,
+                    })
+                    .await?;
+                if let Some(new_doc_id) = update_image {
+                    project
+                        .update_and_prune_document(&mut conn, new_doc_id)
+                        .await?;
+                }
+                Ok::<_, ProjectError>(project)
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    Ok(Json(
+        ProjectWithStudyCount::try_fetch(&mut conn, project).await?,
+    ))
 }
 
 #[cfg(test)]
@@ -492,8 +548,6 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
-        assert_eq!(response.project, response.project);
-
         let project = Project::retrieve(&mut db_pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
@@ -502,5 +556,99 @@ pub mod tests {
         assert_eq!(project.name, updated_name);
         assert_eq!(project.budget, Some(updated_budget));
         assert!(project.last_modification > created_project.last_modification);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_image() {
+        let app = test_app!().build();
+        let db_pool = app.db_pool();
+
+        // no image by default
+        let project = create_project(&mut db_pool.get_ok(), &app.name("project")).await;
+
+        let check_image = |mut conn: DbConnection, image_id: Option<i64>| async move {
+            let p = Project::retrieve(&mut conn, project.id)
+                .await
+                .expect("Failed to retrieve project")
+                .expect("Project not found");
+            assert_eq!(p.image, image_id);
+        };
+
+        let data = [
+            // PNG Signature (8 bytes)
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // IHDR Chunk (Image Header)
+            0x00, 0x00, 0x00, 0x0D, // Chunk Length
+            0x49, 0x48, 0x44, 0x52, // "IHDR"
+            0x00, 0x00, 0x00, 0x02, // Width: 2 pixels
+            0x00, 0x00, 0x00, 0x02, // Height: 2 pixels
+            0x08, // Bit depth: 8
+            0x02, // Color type: Truecolor (RGB)
+            0x00, // Compression method: 0 (deflate)
+            0x00, // Filter method: 0
+            0x00, // Interlace method: 0 (no interlace)
+            0xFD, 0xD4, 0x9A, 0x73, // CRC
+            // IDAT Chunk (Image Data)
+            0x00, 0x00, 0x00, 0x13, // Chunk Length
+            0x49, 0x44, 0x41, 0x54, // "IDAT"
+            0x78, 0x01, // zlib compression header
+            0x63, 0x64, 0x60, 0xF8, 0xCF, 0xC0, 0xC0, 0xC0, 0x04, 0xC4, 0x40, 0x00, 0x00, 0x0B,
+            0x1F, 0x01, // Compressed image data
+            0x03, 0xD5, 0xA9, 0x3F, 0xA9, // CRC
+            // IEND Chunk (Image End)
+            0x00, 0x00, 0x00, 0x00, // Chunk Length
+            0x49, 0x45, 0x4E, 0x44, // "IEND"
+            0xAE, 0x42, 0x60, 0x82, // CRC
+        ];
+
+        let image = Document::changeset()
+            .content_type("image/png".to_owned())
+            .data(data.to_vec())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create image");
+
+        // let's add one
+        let request = app
+            .patch(format!("/projects/{}", project.id).as_str())
+            .json(&json!({
+                "image": image.id
+            }));
+        app.fetch(request).assert_status(StatusCode::OK);
+
+        check_image(db_pool.get_ok(), Some(image.id)).await;
+
+        // now we update it
+        let old_image = image;
+        let new_image = Document::changeset()
+            .content_type("image/png".to_owned())
+            .data(data.to_vec())
+            .create(&mut db_pool.get_ok())
+            .await
+            .expect("Failed to create new image");
+
+        let request = app
+            .patch(format!("/projects/{}", project.id).as_str())
+            .json(&json!({
+                "image": new_image.id
+            }));
+        app.fetch(request).assert_status(StatusCode::OK);
+
+        check_image(db_pool.get_ok(), Some(new_image.id)).await;
+        assert!(!Document::exists(&mut db_pool.get_ok(), old_image.id)
+            .await
+            .unwrap());
+
+        // now we remove the image
+        let request = app
+            .patch(format!("/projects/{}", project.id).as_str())
+            .json(&json!({
+                "image": null
+            }));
+        app.fetch(request).assert_status(StatusCode::OK);
+
+        check_image(db_pool.get_ok(), None).await;
+        assert!(!Document::exists(&mut db_pool.get_ok(), new_image.id)
+            .await
+            .unwrap());
     }
 }

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -179,19 +179,6 @@ pub(crate) enum LiveryMultipartError {
     },
 }
 
-// Still used to parse the error of `Update` and `Save`. Will be removed soon.
-pub fn map_diesel_error(e: InternalError, name: impl AsRef<str>) -> InternalError {
-    if e.message
-        .contains(r#"duplicate key value violates unique constraint "rolling_stock_name_key""#)
-    {
-        RollingStockError::NameAlreadyUsed { name: name.as_ref().to_string() }.into()
-    } else if e.message.contains(r#"new row for relation "rolling_stock" violates check constraint "base_power_class_null_or_non_empty""#) {
-        RollingStockError::BasePowerClassEmpty.into()
-    } else {
-        e
-    }
-}
-
 // This implementation could be generated rather trivially...
 impl From<rolling_stock_model::Error> for RollingStockError {
     fn from(e: rolling_stock_model::Error) -> Self {
@@ -376,7 +363,6 @@ async fn update(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let name = rolling_stock_form.name.clone();
     let rolling_stock_changeset: Changeset<RollingStockModel> = rolling_stock_form.into();
     rolling_stock_changeset.validate()?;
 
@@ -398,7 +384,7 @@ async fn update(
                 let mut new_rolling_stock = rolling_stock_changeset
                     .update(&mut conn.clone(), rolling_stock_id)
                     .await
-                    .map_err(|e| map_diesel_error(e, name.clone()))?
+                    .map_err(RollingStockError::from)?
                     .ok_or(RollingStockError::KeyNotFound {
                         rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
                     })?;
@@ -408,7 +394,7 @@ async fn update(
                     new_rolling_stock
                         .save(&mut conn.clone())
                         .await
-                        .map_err(|err| map_diesel_error(err, name))?;
+                        .map_err(RollingStockError::from)?
                 }
                 Ok(new_rolling_stock)
             }

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -23,6 +23,7 @@ use editoast_common::units::quantities::Mass;
 use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Velocity;
 use editoast_derive::EditoastError;
+use editoast_models::model;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
 use editoast_schemas::rolling_stock::ROLLING_STOCK_RAILJSON_VERSION;
@@ -108,6 +109,10 @@ pub enum TowedRollingStockError {
     #[error("Towed rolling stock '{towed_rolling_stock_id}' is locked")]
     #[editoast_error(status = 409)]
     IsLocked { towed_rolling_stock_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] model::Error),
 }
 
 #[editoast_derive::annotate_units]
@@ -426,7 +431,10 @@ mod tests {
         let towed_rolling_stock = create_towed_rolling_stock(&app, &name, LOCKED);
 
         let towed_rolling_stocks: TowedRollingStockCountList = app
-            .fetch(app.get("/towed_rolling_stock"))
+            .fetch(
+                app.get("/towed_rolling_stock")
+                    .add_query_param("page_size", 50),
+            )
             .assert_status(StatusCode::OK)
             .json_into();
 

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -102,23 +102,6 @@ impl From<ScenarioCreateForm> for Changeset<Scenario> {
     }
 }
 
-pub async fn check_project_study(
-    conn: &mut DbConnection,
-    project_id: i64,
-    study_id: i64,
-) -> Result<(Project, Study)> {
-    let project =
-        Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
-    let study =
-        Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
-
-    if study.project_id != project_id {
-        return Err(StudyError::NotFound { study_id }.into());
-    }
-    Ok((project, study))
-}
-
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "scenario")]
 #[allow(clippy::enum_variant_names)]
@@ -214,56 +197,37 @@ async fn create(
 
     let timetable_id = data.timetable_id;
     let infra_id = data.infra_id;
-    let scenario: Changeset<Scenario> = data.into();
+    let scenario_cs: Changeset<Scenario> = data.into();
 
-    let scenarios_response = db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    let (details, study, project) = Study::transactional_content_update(
+        db_pool.get().await?,
+        study_id,
+        move |mut conn, study, project| {
             async move {
-                // Check if the project and the study exist
-                let (mut project, study) =
-                    check_project_study(&mut conn.clone(), project_id, study_id).await?;
+                if project.id != project_id {
+                    return Err(ProjectError::NotFound { project_id }.into());
+                }
 
-                // Check if the timetable exists
-                let _ = Timetable::retrieve_or_fail(&mut conn.clone(), timetable_id, || {
+                Timetable::exists_or_fail(&mut conn, timetable_id, || {
                     ScenarioError::TimetableNotFound { timetable_id }
                 })
                 .await?;
 
-                // Check if the infra exists
-                if !Infra::exists(&mut conn.clone(), infra_id).await? {
-                    return Err(ScenarioError::InfraNotFound { infra_id }.into());
-                }
+                Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
+                    infra_id,
+                })
+                .await?;
 
-                // Create Scenario
-                let scenario = scenario
-                    .study_id(study_id)
-                    .create(&mut conn.clone())
-                    .await?;
+                let scenario = scenario_cs.study_id(study.id).create(&mut conn).await?;
 
-                // Update study last_modification field
-                study
-                    .clone()
-                    .update_last_modified(&mut conn.clone())
-                    .await?;
-
-                // Update project last_modification field
-                project.update_last_modified(&mut conn.clone()).await?;
-
-                let scenarios_with_details =
-                    ScenarioWithDetails::from_scenario(scenario, &mut conn.clone()).await?;
-
-                let scenarios_response =
-                    ScenarioResponse::new(scenarios_with_details, project, study);
-
-                Ok(scenarios_response)
+                ScenarioWithDetails::from_scenario(scenario, &mut conn).await
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
-    Ok(Json(scenarios_response))
+    Ok(Json(ScenarioResponse::new(details, project, study)))
 }
 
 /// Delete a scenario
@@ -293,37 +257,31 @@ async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    let ((), _, _) = Study::transactional_content_update(
+        db_pool.get().await?,
+        study_id,
+        move |mut conn, study, project| {
             async move {
-                // Check if the project and the study exist
-                let (mut project, study) =
-                    check_project_study(&mut conn.clone(), project_id, study_id)
-                        .await
-                        .unwrap();
+                if project.id != project_id {
+                    return Err(ProjectError::NotFound { project_id }.into());
+                }
 
-                // Delete scenario
-                Scenario::delete_static_or_fail(&mut conn.clone(), scenario_id, || {
+                let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
                 .await?;
 
-                // Update project last_modification field
-                project.update_last_modified(&mut conn.clone()).await?;
+                if scenario.study_id != study.id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
 
-                // Update study last_modification field
-                study
-                    .clone()
-                    .update_last_modified(&mut conn.clone())
-                    .await?;
-
-                Ok(())
+                scenario.delete(&mut conn).await?;
+                Ok::<_, InternalError>(())
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -381,52 +339,39 @@ async fn patch(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let scenarios_response = db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    let (details, _, study, project) = Scenario::transactional_content_update(
+        db_pool.get().await?,
+        scenario_id,
+        move |mut conn, _, study, project| {
             async move {
-                // Check if project and study exist
-                let (mut project, study) =
-                    check_project_study(&mut conn.clone(), project_id, study_id).await?;
-
-                // Check if the infra exists
+                if project.id != project_id {
+                    return Err(ProjectError::NotFound { project_id }.into());
+                }
+                if study.id != study_id {
+                    return Err(StudyError::NotFound { study_id }.into());
+                }
                 if let Some(infra_id) = form.infra_id {
-                    if !Infra::exists(&mut conn.clone(), infra_id).await? {
-                        return Err(ScenarioError::InfraNotFound { infra_id }.into());
-                    }
+                    Infra::exists_or_fail(&mut conn, infra_id, || ScenarioError::InfraNotFound {
+                        infra_id,
+                    })
+                    .await?;
                 }
 
-                // Update the scenario
-                let scenario: Changeset<Scenario> = form.into();
-                let scenario = scenario
-                    .update_or_fail(&mut conn.clone(), scenario_id, || ScenarioError::NotFound {
+                let scenario_cs: Changeset<Scenario> = form.into();
+                let scenario = scenario_cs
+                    .update_or_fail(&mut conn, scenario_id, || ScenarioError::NotFound {
                         scenario_id,
                     })
                     .await?;
 
-                // Update study last_modification field
-                study
-                    .clone()
-                    .update_last_modified(&mut conn.clone())
-                    .await?;
-
-                // Update project last_modification field
-                project.update_last_modified(&mut conn.clone()).await?;
-
-                let scenario_with_details =
-                    ScenarioWithDetails::from_scenario(scenario, &mut conn.clone()).await?;
-
-                let scenarios_response =
-                    ScenarioResponse::new(scenario_with_details, project, study);
-
-                Ok(scenarios_response)
+                ScenarioWithDetails::from_scenario(scenario, &mut conn).await
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
-    Ok(Json(scenarios_response))
+    Ok(Json(ScenarioResponse::new(details, project, study)))
 }
 
 /// Return a specific scenario
@@ -456,23 +401,42 @@ async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let conn = &mut db_pool.get().await?;
+    let (details, study, project) = db_pool
+        .get()
+        .await?
+        .transaction(|mut conn| {
+            async move {
+                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                    ProjectError::NotFound { project_id }
+                })
+                .await?;
+                let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
+                    study_id,
+                })
+                .await?;
+                if study.project_id != project.id {
+                    return Err(ProjectError::NotFound { project_id }.into());
+                }
 
-    let (project, study) = check_project_study(conn, project_id, study_id).await?;
-    // Return the scenarios
-    let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
-        scenario_id,
-    })
-    .await?;
+                let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
+                    ScenarioError::NotFound { scenario_id }
+                })
+                .await?;
+                if scenario.study_id != study_id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
 
-    // Check if the scenario belongs to the study
-    if scenario.study_id != study_id {
-        return Err(ScenarioError::NotFound { scenario_id }.into());
-    }
+                Ok::<_, InternalError>((
+                    ScenarioWithDetails::from_scenario(scenario, &mut conn).await?,
+                    study,
+                    project,
+                ))
+            }
+            .scope_boxed()
+        })
+        .await?;
 
-    let scenarios_with_details = ScenarioWithDetails::from_scenario(scenario, conn).await?;
-    let scenarios_response = ScenarioResponse::new(scenarios_with_details, project, study);
-    Ok(Json(scenarios_response))
+    Ok(Json(ScenarioResponse::new(details, project, study)))
 }
 
 #[derive(Serialize, ToSchema)]
@@ -510,7 +474,11 @@ async fn list(
 
     let conn = &mut db_pool.get().await?;
 
-    let _ = check_project_study(conn, project_id, study_id).await?;
+    let study =
+        Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
+    if study.project_id != project_id {
+        return Err(ProjectError::NotFound { project_id }.into());
+    }
 
     let settings = pagination_params
         .validate(1000)?

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -54,6 +54,10 @@ enum MacroNodeError {
     #[error("Node '{node_id}', could not be found")]
     #[editoast_error(status = 404)]
     NotFound { node_id: i64 },
+
+    #[error(transparent)]
+    #[editoast_error(status = 500)]
+    Database(#[from] editoast_models::model::Error),
 }
 
 #[derive(IntoParams, Deserialize)]
@@ -126,7 +130,7 @@ struct MacroNodeListResponse {
     results: Vec<MacroNodeResponse>,
 }
 
-/// Get macro node list by scneario id
+/// Get macro node list by scenario id
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
@@ -197,33 +201,32 @@ async fn create(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let created = db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    let (created, _, _, _) = Scenario::transactional_content_update(
+        db_pool.get().await?,
+        scenario_id,
+        move |mut conn, scenario, study, project| {
             async move {
-                let db_conn = &mut conn.clone();
-                // check if scneario exists
-                let (mut project, mut study, mut scenario) =
-                    check_project_study_scenario(db_conn, project_id, study_id, scenario_id)
-                        .await?;
+                if project.id != project_id {
+                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
+                }
+                if study.id != study_id {
+                    return Err(StudyError::NotFound { study_id }.into());
+                }
+                if scenario.id != scenario_id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
 
-                // save the node
                 let macro_node = data
                     .into_macro_node_changeset(scenario_id)?
-                    .create(db_conn)
+                    .create(&mut conn)
                     .await?;
-
-                // Update last_modification fields
-                scenario.update_last_modified(db_conn).await?;
-                study.update_last_modified(db_conn).await?;
-                project.update_last_modified(db_conn).await?;
 
                 Ok(macro_node)
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     Ok(Json(MacroNodeResponse::from(created)))
 }
@@ -285,34 +288,40 @@ async fn update(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let updated = db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    let (updated, _, _, _) = Scenario::transactional_content_update(
+        db_pool.get().await?,
+        scenario_id,
+        move |mut conn, scenario, study, project| {
             async move {
-                let db_conn = &mut conn.clone();
+                let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
+                    MacroNodeError::NotFound { node_id }
+                })
+                .await?;
 
-                // Get / check the node
-                let (mut project, mut study, mut scenario) =
-                    check_project_study_scenario(db_conn, project_id, study_id, scenario_id)
-                        .await?;
-                retrieve_macro_node_and_check_scenario(db_conn, scenario_id, node_id).await?;
+                if project.id != project_id {
+                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
+                }
+                if study.id != study_id {
+                    return Err(StudyError::NotFound { study_id }.into());
+                }
+                if scenario.id != scenario_id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
+                if node.scenario_id != scenario_id {
+                    return Err(MacroNodeError::NotFound { node_id }.into());
+                }
 
-                let macro_node = data
+                let node = data
                     .into_macro_node_changeset(scenario_id)?
-                    .update_or_fail(db_conn, node_id, || ScenarioError::NotFound { scenario_id })
+                    .update_or_fail(&mut conn, node_id, || MacroNodeError::NotFound { node_id })
                     .await?;
 
-                // Update last_modification fields
-                scenario.update_last_modified(db_conn).await?;
-                study.update_last_modified(db_conn).await?;
-                project.update_last_modified(db_conn).await?;
-
-                Ok(macro_node)
+                Ok(node)
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     Ok(Json(MacroNodeResponse::from(updated)))
 }
@@ -339,34 +348,36 @@ async fn delete(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    db_pool
-        .get()
-        .await?
-        .transaction::<_, InternalError, _>(|conn| {
+    Scenario::transactional_content_update(
+        db_pool.get().await?,
+        scenario_id,
+        move |mut conn, scenario, study, project| {
             async move {
-                let db_conn = &mut conn.clone();
+                let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
+                    MacroNodeError::NotFound { node_id }
+                })
+                .await?;
 
-                // Get / check the node
-                let (mut project, mut study, mut scenario) =
-                    check_project_study_scenario(db_conn, project_id, study_id, scenario_id)
-                        .await?;
+                if project.id != project_id {
+                    return Err::<_, InternalError>(ProjectError::NotFound { project_id }.into());
+                }
+                if study.id != study_id {
+                    return Err(StudyError::NotFound { study_id }.into());
+                }
+                if scenario.id != scenario_id {
+                    return Err(ScenarioError::NotFound { scenario_id }.into());
+                }
+                if node.scenario_id != scenario_id {
+                    return Err(MacroNodeError::NotFound { node_id }.into());
+                }
 
-                let macro_node =
-                    retrieve_macro_node_and_check_scenario(db_conn, scenario_id, node_id).await?;
-
-                // Delete
-                macro_node.delete(db_conn).await?;
-
-                // Update last_modification fields
-                scenario.update_last_modified(db_conn).await?;
-                study.update_last_modified(db_conn).await?;
-                project.update_last_modified(db_conn).await?;
-
+                node.delete(&mut conn).await?;
                 Ok(())
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -151,31 +151,21 @@ async fn create(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let connection = db_pool.get().await?;
-
-    let (study, project) = connection
-        .transaction::<_, InternalError, _>(|conn| {
+    let (study, project) = Project::transactional_content_update(
+        db_pool.get().await?,
+        project_id,
+        |mut conn, project| {
             async move {
-                // Check if project exists
-                let mut project = Project::retrieve_or_fail(&mut conn.clone(), project_id, || {
-                    ProjectError::NotFound { project_id }
-                })
-                .await?;
-
-                // Create study
-                let study: Study = data
-                    .into_study_changeset(project_id)?
-                    .create(&mut conn.clone())
+                let study = data
+                    .into_study_changeset(project.id)?
+                    .create(&mut conn)
                     .await?;
-
-                // Update project last_modification field
-                project.update_last_modified(&mut conn.clone()).await?;
-
-                Ok((study, project))
+                Ok::<_, InternalError>(study)
             }
             .scope_boxed()
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     // Return study with list of scenarios
     let study_response = StudyResponse {
@@ -215,17 +205,16 @@ async fn delete(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    // Check if project exists
-    let conn = &mut db_pool.get().await?;
-    let mut project =
-        Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
 
-    // Delete study
-    Study::delete_static_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
-
-    // Update project last_modification field
-    project.update_last_modified(conn).await?;
+    Project::transactional_content_update(db_pool.get().await?, project_id, |mut conn, _| {
+        async move {
+            Study::delete_static_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
+                .await?;
+            Ok::<_, StudyError>(())
+        }
+        .scope_boxed()
+    })
+    .await?;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -252,23 +241,33 @@ async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    // Check if project exists
-    let conn = &mut db_pool.get().await?;
-    use crate::models::Retrieve;
-    let project =
-        Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
 
-    // Return the study
-    let study =
-        Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
+    let (project, study_scenarios) = db_pool
+        .get()
+        .await?
+        .transaction(|mut conn| {
+            async move {
+                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                    ProjectError::NotFound { project_id }
+                })
+                .await?;
+                let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
+                    study_id,
+                })
+                .await?;
 
-    //Check if the study belongs to the project
-    if study.project_id != project_id {
-        return Err(StudyError::NotFound { study_id }.into());
-    }
+                // Check if the study belongs to the project
+                if study.project_id != project_id {
+                    return Err::<_, InternalError>(StudyError::NotFound { study_id }.into());
+                }
 
-    let study_scenarios = StudyWithScenarioCount::try_fetch(conn, study).await?;
+                let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
+                Ok((project, study_scenarios))
+            }
+            .scope_boxed()
+        })
+        .await?;
+
     let study_response = StudyResponse::new(study_scenarios, project);
     Ok(Json(study_response))
 }
@@ -344,37 +343,28 @@ async fn patch(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let connection = db_pool.get().await?;
-    let (study_scenarios, project) = connection
-        .transaction::<_, InternalError, _>(|conn| {
-            async move {
-                // Check if project exists
-                let mut project = Project::retrieve_or_fail(&mut conn.clone(), project_id, || {
-                    ProjectError::NotFound { project_id }
-                })
-                .await?;
 
-                // Update study
+    let (response, _, project) = Study::transactional_content_update(
+        db_pool.get().await?,
+        study_id,
+        move |mut conn, _, project| {
+            async move {
+                if project.id != project_id {
+                    return Err::<_, InternalError>(StudyError::NotFound { study_id }.into());
+                }
                 let study = data
                     .into_study_changeset()?
-                    .last_modification(Utc::now().naive_utc())
-                    .update_or_fail(&mut conn.clone(), study_id, || StudyError::NotFound {
-                        study_id,
-                    })
+                    .update_or_fail(&mut conn, study_id, || StudyError::NotFound { study_id })
                     .await?;
-                let study_scenarios =
-                    StudyWithScenarioCount::try_fetch(&mut conn.clone(), study).await?;
-
-                // Update project last_modification field
-                project.update_last_modified(&mut conn.clone()).await?;
-
-                Ok((study_scenarios, project))
+                let study_scenarios = StudyWithScenarioCount::try_fetch(&mut conn, study).await?;
+                Ok::<_, InternalError>(study_scenarios)
             }
             .scope_boxed()
-        })
-        .await?;
-    let study_response = StudyResponse::new(study_scenarios, project);
-    Ok(Json(study_response))
+        },
+    )
+    .await?;
+
+    Ok(Json(StudyResponse::new(response, project)))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -282,6 +282,7 @@ impl TestAppBuilder {
         let server = TestServer::new(router).expect("test server should build properly");
 
         TestApp {
+            test_name: self.test_name,
             server,
             app_state,
             authorization_model: self.authorization_model,
@@ -314,6 +315,7 @@ pub(crate) use test_app;
 /// It also holds a reference to the database connection pool and the core client,
 /// which can be accessed through the [TestApp] methods.
 pub(crate) struct TestApp {
+    test_name: String,
     server: TestServer,
     app_state: AppState,
     authorization_model: Option<&'static str>,
@@ -322,6 +324,10 @@ pub(crate) struct TestApp {
 }
 
 impl TestApp {
+    pub fn name(&self, resource_name: impl std::fmt::Display) -> String {
+        format!("{}_{}", self.test_name, resource_name)
+    }
+
     pub fn db_pool(&self) -> Arc<DbConnectionPoolV2> {
         self.app_state.db_pool.clone()
     }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -66,7 +66,8 @@
       "ObjectNotFound": "{{obj_type}} '{{obj_id}}', could not be found everywhere in the infrastructure cache"
     },
     "infra": {
-      "NotFound": "",
+      "Database": "Internal error",
+      "NotFound": "Infrastructure '{{infra_id}}' could not be found",
       "edition": {
         "InfraIsLocked": "Infrastructure is locked",
         "SplitTrackSectionBadOffset": "Distance to split track section '{{tracksection_id}}' in infrastructure '{{infra_id}}' is invalid. It must be between 0 and {{tracksection_length}} meters."
@@ -100,6 +101,7 @@
       "ViewNotFound": "View {{view_name}} not found."
     },
     "macro_node": {
+      "Database": "Internal error",
       "NotFound": "Node {{node_id}} not found."
     },
     "model": {
@@ -131,6 +133,7 @@
       "Username": "Invalid username"
     },
     "project": {
+      "Database": "Internal error",
       "ImageError": "The provided image is not valid",
       "ImageNotFound": "Image document '{{document_key}}' not found",
       "NotFound": "Project '{{project_id}}', could not be found"
@@ -153,6 +156,7 @@
       "IsUsed": "Rolling stock '{{rolling_stock_id}}' is used"
     },
     "towedrollingstocks": {
+      "Database": "Internal error",
       "IdNotFound": "Towed rolling stock '{{towed_rolling_stock_id}}' could not be found",
       "IsLocked": "Towed rolling stock '{{towed_rolling_stock_id}}' is locked"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -66,7 +66,8 @@
       "ObjectNotFound": "{{obj_type}} '{{obj_id}}' introuvable dans le cache de l'infrastructure"
     },
     "infra": {
-      "NotFound": "",
+      "Database": "Erreur interne",
+      "NotFound": "Infrastructure '{{infra_id}}' n'existe pas",
       "edition": {
         "InfraIsLocked": "Infrastructure verrouillée",
         "SplitTrackSectionBadOffset": "La distance pour scinder la section de voie '{{tracksection_id}}' de l'infrastructure '{{infra_id}}' est invalide. La valeur doit être comprise entre 0 et {{tracksection_length}} mètres."
@@ -100,6 +101,7 @@
       "ViewNotFound": "View {{view_name}} non trouvé."
     },
     "macro_node": {
+      "Database": "Erreur interne",
       "NotFound": "Noeud {{node_id}} non trouvé."
     },
     "model": {
@@ -131,6 +133,7 @@
       "Username": "Identifiant invalide"
     },
     "project": {
+      "Database": "Erreur interne",
       "ImageError": "L'image fournie est invalide",
       "ImageNotFound": "Image '{{document_key}}' non trouvée",
       "NotFound": "Projet '{{project_id}}' non trouvé"
@@ -153,6 +156,7 @@
       "IsUsed": "Matériel roulant '{{rolling_stock_id}}' est occupé"
     },
     "towedrollingstocks": {
+      "Database": "Erreur interne",
       "IdNotFound": "Matériel remorqué '{{towed_rolling_stock_id}}' non trouvé",
       "IsLocked": "Matériel remorqué '{{towed_rolling_stock_id}}' est verrouillé"
     },


### PR DESCRIPTION
* Updates `Update`, `Save`, `Patch` and `UpdateBatch`
* Propagates the change where needed, either by coercing to InternalError
  or by adding new error variants
* Rework `last_modification` for projects, studies and scenario to:
    1. actualize the date in a transaction
    2. update the project if a study is modified, and the study if a
       scenario is modified
* Fixes API limits of `Connection::transaction` by not exposing
  `diesel::result::Error`
* Adds the `exists_or_fail` function
* Add the parsing of foreign key violations in model's error
* Rework project image suppression to be:
    1. atomic by nesting everything into a transaction
    2. simplifying the behavior of `update_and_prune` and
       `delete_and_prune`
    3. fixing the database allowing a document to be deleted even if it
       was referenced by a project
    4. removing the unicity constraint on the image FK
    5. adding some missing tests for these functions
* Simplifies the workflow of a rolling stock test
* Makes a towed rolling stock test **less** (but *still*) flaky
* Removes the `check_study_project`, `check_study_project_scenario` kind
  of functions:
    1. they fit ill in the new workflow
    2. the check will be removed once we fix our URL scheme
    3. replaced by plain `if`s