### PR TITLE
editoast: authz api with openfga

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,7 @@ services:
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
       OSRD_MQ_URL: "amqp://osrd:password@osrd-rabbitmq:5672/%2f"
       EDITOAST_OPENFGA_URL: "http://openfga:8091"
+      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-false}
     command:
       - /bin/sh
       - -c

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -57,6 +57,126 @@ impl<S: StorageDriver> Authorizer<S> {
     pub async fn check_roles(&self, roles: HashSet<Role>) -> Result<bool, Error<S::Error>> {
         self.regulator.check_roles(self.user_id, roles).await
     }
+
+    pub async fn check_infra_grant_reader(&self, infra_id: i64) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_grant_reader(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_grant_writer(&self, infra_id: i64) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_grant_writer(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_grant_owner(&self, infra_id: i64) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_grant_owner(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_privilege_can_read(
+        &self,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_privilege_can_read(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_privilege_can_share_read(
+        &self,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_privilege_can_share_read(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_privilege_can_write(
+        &self,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_privilege_can_share_write(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn check_infra_privilege_can_share_ownership(
+        &self,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        self.regulator
+            .check_infra_privilege_can_share_ownership(self.user_id, infra_id)
+            .await
+    }
+
+    pub async fn grant_infra_reader(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .grant_infra_reader(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn grant_infra_writer(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .grant_infra_writer(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn grant_infra_owner(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .grant_infra_owner(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_reader(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .revoke_infra_reader(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_writer(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .revoke_infra_writer(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_owner(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        self.regulator
+            .revoke_infra_owner(self.user_id, user_id, infra_id)
+            .await?;
+        Ok(())
+    }
 }
 
 impl<S: StorageDriver> std::fmt::Debug for Authorizer<S> {
@@ -89,6 +209,61 @@ mod tests {
         counter: Arc<RwLock<i64>>,
         users: Arc<Mutex<HashMap<UserIdentity, i64>>>,
         groups: Arc<Mutex<HashMap<GroupName, i64>>>,
+    }
+
+    #[tokio::test]
+    async fn check_user_grants() {
+        let user_identity = || "toto".to_owned();
+        let user = || UserInfo {
+            identity: user_identity(),
+            name: "Sir Toto, the One and Only".to_owned(),
+        };
+        let regulator = Regulator::new(crate::openfga!(), MockAuthDriver::default());
+        let regulator = move || regulator.clone();
+
+        let user_id = regulator()
+            .driver
+            .ensure_user(&user())
+            .await
+            .expect("toto should be created")
+            .id;
+
+        let authorizer = Authorizer::try_initialize(user_identity(), regulator())
+            .await
+            .unwrap();
+
+        authorizer
+            .regulator
+            .grant_infra_reader_unchecked(authorizer.user_id(), 1)
+            .await
+            .expect("Update grants should be successful");
+        let is_reader = authorizer
+            .check_infra_grant_reader(1)
+            .await
+            .expect("Check grants should be successful");
+        assert_eq!(is_reader, true,);
+
+        authorizer
+            .regulator
+            .grant_infra_writer_unchecked(user_id, 1)
+            .await
+            .expect("Update grants should be successful");
+        let is_writer = authorizer
+            .check_infra_grant_writer(1)
+            .await
+            .expect("Check grants should be successful");
+        assert_eq!(is_writer, true,);
+
+        authorizer
+            .regulator
+            .grant_infra_writer_unchecked(user_id, 1)
+            .await
+            .expect("Update grants should be successful");
+        let is_owner = authorizer
+            .check_infra_grant_writer(1)
+            .await
+            .expect("Check grants should be successful");
+        assert_eq!(is_owner, true,);
     }
 
     #[tokio::test]
@@ -429,6 +604,11 @@ mod tests {
                     .into_iter()
                     .map(|(name, id)| Ok((id, GroupInfo { name }))),
             ))
+        }
+
+        async fn infra_exists(&self, _infra_id: i64) -> Result<bool, Self::Error> {
+            // Mock implementation, always return true
+            Ok(true)
         }
     }
 }

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -49,12 +49,27 @@ pub async fn ensure_latest_authorization_model(
 pub enum Error<StorageError: std::error::Error> {
     #[error("unknown subject {0}")]
     UnknownSubject(i64),
+    #[error("unknown resource {0}")]
+    UnknownResource(i64),
     #[error("unknown user {identity}")]
     UnknownUser { identity: String },
     #[error(transparent)]
     OpenFga(#[from] fga::client::RequestFailure),
     #[error(transparent)]
+    OpenFgaParsing(#[from] fga::model::ParsingError),
+    #[error(transparent)]
     Storage(StorageError),
+    #[error("Unauthorized")]
+    Unauthorized,
+}
+
+impl<StorageError: std::error::Error> From<fga::client::QueryError> for Error<StorageError> {
+    fn from(err: fga::client::QueryError) -> Self {
+        match err {
+            fga::client::QueryError::Parsing(parsing_error) => Self::OpenFgaParsing(parsing_error),
+            fga::client::QueryError::Request(request_failure) => Self::OpenFga(request_failure),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/editoast/editoast_authz/src/model.rs
+++ b/editoast/editoast_authz/src/model.rs
@@ -4,6 +4,9 @@ pub(crate) struct User(pub(crate) String);
 #[derive(fga::Type, fga::User, fga::Object, derive_more::From, Debug)]
 pub(crate) struct Group(pub(crate) String);
 
+#[derive(fga::Type, fga::User, fga::Object, derive_more::From, Debug)]
+pub(crate) struct Infra(pub(crate) String);
+
 #[derive(fga::Type, fga::User, derive_more::From, Debug)]
 pub(crate) struct Role(pub(crate) String);
 
@@ -15,5 +18,17 @@ fga::relations! {
     Group {
         role: Role,
         member: User
+    },
+    Infra {
+        reader: User,
+        writer:User,
+        owner: User,
+        // Computed
+        can_read: User,
+        can_write: User,
+        can_delete: User,
+        can_share_read: User,
+        can_share_write: User,
+        can_share_ownership: User
     }
 }

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::future::Future;
 
+use fga::client::UserList;
 use fga::fga;
 use fga::model::Relation;
 use futures::stream;
@@ -91,6 +92,9 @@ pub trait StorageDriver: Clone {
             Self::Error,
         >,
     > + Send;
+
+    fn infra_exists(&self, infra_id: i64)
+    -> impl Future<Output = Result<bool, Self::Error>> + Send;
 }
 
 impl<S: StorageDriver> Regulator<S> {
@@ -161,6 +165,7 @@ impl<S: StorageDriver> Regulator<S> {
             .openfga
             .list_users(Group::member().query_users(&group))
             .await?;
+
         debug_assert!(
             members.public_access.is_none(),
             "we don't write public accesses for groups"
@@ -224,7 +229,8 @@ impl<S: StorageDriver> Regulator<S> {
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn user_roles(&self, user_id: i64) -> Result<HashSet<Role>, Error<S::Error>> {
         // no need to check for user inexistence, an empty set will be returned in this case
-        let roles = Role::list_roles(&self.openfga, User::role(), &fga!(User:user_id)).await?;
+        let roles =
+            Role::list_roles(&self.openfga, model::User::role(), &fga!(User:user_id)).await?;
         Ok(roles.into_iter().collect())
     }
 
@@ -330,5 +336,721 @@ impl<S: StorageDriver> Regulator<S> {
             return Ok(true);
         }
         Ok(false)
+    }
+
+    pub async fn check_infra_grant_reader(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::reader().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_grant_writer(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::writer().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_grant_owner(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::owner().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_privilege_can_read(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::can_read().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_privilege_can_share_read(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::can_share_read().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_privilege_can_write(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::can_write().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_privilege_can_share_write(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::can_share_write().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn check_infra_privilege_can_share_ownership(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<bool, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Bypass if user is an admin
+        if self.check_roles(user_id, [Role::Admin].into()).await? {
+            return Ok(true);
+        }
+
+        // Calling openfga
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .check(model::Infra::can_share_ownership().check(&user, &infra))
+            .await?;
+        Ok(result)
+    }
+
+    pub async fn get_infra_readers(
+        &self,
+        infra_id: i64,
+    ) -> Result<Vec<UserSubject>, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .list_users(Infra::reader().query_users(&infra))
+            .await?;
+
+        let users = self.parse_userlist(result).await?;
+        Ok(users)
+    }
+
+    pub async fn get_infra_writers(
+        &self,
+        infra_id: i64,
+    ) -> Result<Vec<UserSubject>, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .list_users(Infra::writer().query_users(&infra))
+            .await?;
+
+        let users = self.parse_userlist(result).await?;
+        Ok(users)
+    }
+
+    pub async fn get_infra_owners(
+        &self,
+        infra_id: i64,
+    ) -> Result<Vec<UserSubject>, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        let infra = fga!(Infra:infra_id);
+        let result = self
+            .openfga
+            .list_users(Infra::owner().query_users(&infra))
+            .await?;
+
+        let users = self.parse_userlist(result).await?;
+        Ok(users)
+    }
+
+    async fn parse_userlist(
+        &self,
+        userlist: UserList<User>,
+    ) -> Result<Vec<UserSubject>, Error<S::Error>> {
+        let user_ids =
+            userlist
+                .users
+                .into_iter()
+                .filter_map(|User(user)| match user.parse::<i64>() {
+                    Ok(id) => Some(id),
+                    Err(_) => {
+                        tracing::error!(user, "unparsable user member — skipping it");
+                        None
+                    }
+                });
+
+        let mut users = Vec::new();
+        for user_id in user_ids {
+            let user_info = self
+                .driver
+                .get_user_info(user_id)
+                .await
+                .map_err(Error::Storage)?;
+
+            if let Some(user_info) = user_info {
+                users.push(UserSubject {
+                    id: user_id,
+                    info: user_info,
+                });
+            }
+        }
+        Ok(users)
+    }
+
+    pub async fn grant_infra_reader_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        let has_grant = self.check_infra_grant_reader(user_id, infra_id).await?;
+        if !has_grant {
+            // Remove other grants before to add the new one
+            self.revoke_infra_writer_unchecked(user_id, infra_id)
+                .await?;
+            self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+            // Grant the new one
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_writes()
+                .write(&Infra::reader().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn grant_infra_reader(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that issuer has the right to add the grants
+        let can_share = self
+            .check_infra_privilege_can_share_read(issuer_id, infra_id)
+            .await?;
+        if !can_share {
+            return Err(Error::Unauthorized);
+        }
+
+        // Grant
+        self.grant_infra_reader_unchecked(user_id, infra_id).await?;
+        Ok(())
+    }
+
+    pub async fn grant_infra_writer_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        let has_grant = self.check_infra_grant_writer(user_id, infra_id).await?;
+        if !has_grant {
+            // Remove other grants before to add the new one
+            self.revoke_infra_reader_unchecked(user_id, infra_id)
+                .await?;
+            self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+            // Grant the new one
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_writes()
+                .write(&Infra::writer().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+    pub async fn grant_infra_writer(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that issuer has the right to add the grants
+        let can_share = self
+            .check_infra_privilege_can_share_write(issuer_id, infra_id)
+            .await?;
+        if !can_share {
+            return Err(Error::Unauthorized);
+        }
+
+        // Grant
+        self.grant_infra_writer_unchecked(user_id, infra_id).await?;
+        Ok(())
+    }
+
+    pub async fn grant_infra_owner_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        let has_grant = self.check_infra_grant_owner(user_id, infra_id).await?;
+        if !has_grant {
+            // Remove other grants before to add the new one
+            self.revoke_infra_reader_unchecked(user_id, infra_id)
+                .await?;
+            self.revoke_infra_writer_unchecked(user_id, infra_id)
+                .await?;
+            // Grant the new one
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_writes()
+                .write(&Infra::owner().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn grant_infra_owner(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that issuer has the right to add the grants
+        let can_share = self
+            .check_infra_privilege_can_share_ownership(issuer_id, infra_id)
+            .await?;
+        if !can_share {
+            return Err(Error::Unauthorized);
+        }
+
+        // Grant
+        self.grant_infra_owner_unchecked(user_id, infra_id).await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_reader_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        // Check if the user has already the grant, if not, grant it
+        let has_grant = self.check_infra_grant_reader(user_id, infra_id).await?;
+        if has_grant {
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_deletes()
+                .delete(&Infra::reader().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn revoke_infra_reader(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that the connected user has the right to remove the grants
+        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
+        if !is_owner {
+            return Err(Error::Unauthorized);
+        }
+
+        // Revoke
+        self.revoke_infra_reader_unchecked(user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_writer_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        let has_grant = self.check_infra_grant_writer(user_id, infra_id).await?;
+        if has_grant {
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_deletes()
+                .delete(&Infra::writer().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn revoke_infra_writer(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that the connected user has the right to remove the grants
+        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
+        if !is_owner {
+            return Err(Error::Unauthorized);
+        }
+
+        // Revoke
+        self.revoke_infra_writer_unchecked(user_id, infra_id)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn revoke_infra_owner_unchecked(
+        &self,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra_id)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra_id));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+
+        let has_grant = self.check_infra_grant_owner(user_id, infra_id).await?;
+        if has_grant {
+            let user = fga!(User:user_id);
+            let infra = fga!(Infra:infra_id);
+            self.openfga
+                .prepare_deletes()
+                .delete(&Infra::owner().tuple(&user, &infra))
+                .execute()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn revoke_infra_owner(
+        &self,
+        issuer_id: i64,
+        user_id: i64,
+        infra_id: i64,
+    ) -> Result<(), Error<S::Error>> {
+        // Check that the connected user has the right to remove the grants
+        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
+        if !is_owner {
+            return Err(Error::Unauthorized);
+        }
+
+        // Revoke
+        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+        Ok(())
     }
 }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -7,6 +7,94 @@ info:
     url: https://www.gnu.org/licenses/lgpl-3.0.html
   version: 0.1.0
 paths:
+  /authz/grants:
+    post:
+      tags:
+      - authz
+      requestBody:
+        description: List of new authorization to add or to remove (ie grants a resource to a person). Expect grant XOR revoke, not both
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                grant:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - resource_type
+                    - resource_id
+                    - subject_id
+                    - grant
+                    properties:
+                      grant:
+                        type: string
+                        enum:
+                        - READER
+                        - WRITER
+                        - OWNER
+                      resource_id:
+                        type: integer
+                        format: int64
+                      resource_type:
+                        type: string
+                        enum:
+                        - infra
+                      subject_id:
+                        type: integer
+                        format: int64
+                  nullable: true
+                revoke:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - resource_type
+                    - resource_id
+                    - subject_id
+                    properties:
+                      resource_id:
+                        type: integer
+                        format: int64
+                      resource_type:
+                        $ref: '#/components/schemas/Resource'
+                      subject_id:
+                        type: integer
+                        format: int64
+                  nullable: true
+        required: true
+      responses:
+        '201':
+          description: Grants updated
+  /authz/grants/{resource_type}:
+    get:
+      tags:
+      - authz
+      parameters:
+      - name: resource_type
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Resource'
+      responses:
+        '200':
+          description: Get privileges for each grant associated to the resource type
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - can_read
+                    - can_share_read
+                    - can_write
+                    - can_share_write
+                    - can_delete
+                    - can_share_ownership
   /authz/me:
     get:
       tags:
@@ -32,106 +120,120 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Role'
-  /authz/roles/me:
-    get:
-      tags:
-      - authz
-      responses:
-        '200':
-          description: List the roles of the issuer of the request
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                - builtin
-                properties:
-                  builtin:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Role'
-                    uniqueItems: true
-  /authz/roles/{user_id}:
-    get:
-      tags:
-      - authz
-      parameters:
-      - name: user_id
-        in: path
-        description: A user ID (not to be mistaken for its identity, cf. editoast user model documentation)
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: List the roles of a user
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                - builtin
-                properties:
-                  builtin:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Role'
-                    uniqueItems: true
+  /authz/me/grants:
     post:
       tags:
       - authz
-      parameters:
-      - name: user_id
-        in: path
-        description: A user ID (not to be mistaken for its identity, cf. editoast user model documentation)
-        required: true
-        schema:
-          type: integer
-          format: int64
       requestBody:
+        description: HashMap of resource type with a list of resource id to get the grants for. If a resource doesn't exist, it will be omitted.
         content:
           application/json:
             schema:
               type: object
-              required:
-              - roles
-              properties:
-                roles:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Role'
+              additionalProperties:
+                type: array
+                items:
+                  type: integer
+                  format: int64
         required: true
       responses:
-        '204':
-          description: The roles have been granted successfully
-    delete:
+        '200':
+          description: Get grants info of the current user for the given resources in body
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - resource_type
+                    - resource_id
+                    - grant
+                    properties:
+                      grant:
+                        type: string
+                        enum:
+                        - READER
+                        - WRITER
+                        - OWNER
+                      resource_id:
+                        type: integer
+                        format: int64
+                      resource_type:
+                        type: string
+                        enum:
+                        - infra
+  /authz/{resource_type}/{resource_id}:
+    get:
       tags:
       - authz
       parameters:
-      - name: user_id
+      - name: resource_type
         in: path
-        description: A user ID (not to be mistaken for its identity, cf. editoast user model documentation)
+        required: true
+        schema:
+          $ref: '#/components/schemas/Resource'
+      - name: resource_id
+        in: path
         required: true
         schema:
           type: integer
           format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - roles
-              properties:
-                roles:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Role'
-        required: true
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 1
+          minimum: 1
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 25
+          nullable: true
+          minimum: 1
       responses:
-        '204':
-          description: The roles have been removed successfully
+        '200':
+          description: Get list of user that have access to the resource
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - subject
+                  - grant
+                  properties:
+                    grant:
+                      type: string
+                      enum:
+                      - READER
+                      - WRITER
+                      - OWNER
+                    subject:
+                      type: object
+                      required:
+                      - id
+                      - name
+                      - type
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum:
+                          - User
+                          - Group
   /documents:
     post:
       tags:
@@ -4679,6 +4781,92 @@ components:
           type: string
           enum:
           - editoast:authz:Authz
+    EditoastAuthzErrorSimultaneousGrantsAndRevokes:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 400
+        type:
+          type: string
+          enum:
+          - editoast:authz:SimultaneousGrantsAndRevokes
+    EditoastAuthzErrorUnauthorized:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 403
+        type:
+          type: string
+          enum:
+          - editoast:authz:Unauthorized
+    EditoastAuthzErrorUnknownResource:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - resource_id
+          properties:
+            resource_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:authz:UnknownResource
+    EditoastAuthzErrorUnknownSubject:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - subject_id
+          properties:
+            subject_id:
+              type: integer
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:authz:UnknownSubject
     EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject:
       type: object
       required:
@@ -5112,6 +5300,10 @@ components:
       - $ref: '#/components/schemas/EditoastAuthorizationErrorUnauthorized'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthorizer'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthz'
+      - $ref: '#/components/schemas/EditoastAuthzErrorSimultaneousGrantsAndRevokes'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnauthorized'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
+      - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorFixTrialFailure'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorMaximumIterationReached'
@@ -5145,7 +5337,6 @@ components:
       - $ref: '#/components/schemas/EditoastMacroNodeErrorDatabase'
       - $ref: '#/components/schemas/EditoastMacroNodeErrorNotFound'
       - $ref: '#/components/schemas/EditoastModelError'
-      - $ref: '#/components/schemas/EditoastNoSuchUserErrorNoSuchUser'
       - $ref: '#/components/schemas/EditoastOperationErrorEmptyId'
       - $ref: '#/components/schemas/EditoastOperationErrorInvalidPatch'
       - $ref: '#/components/schemas/EditoastOperationErrorModifyId'
@@ -5165,6 +5356,7 @@ components:
       - $ref: '#/components/schemas/EditoastProjectErrorImageNotFound'
       - $ref: '#/components/schemas/EditoastProjectErrorNotFound'
       - $ref: '#/components/schemas/EditoastRailJsonErrorUnsupportedVersion'
+      - $ref: '#/components/schemas/EditoastResourceErrorUnknownResourceType'
       - $ref: '#/components/schemas/EditoastRollingStockErrorBasePowerClassEmpty'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotCreateCompoundImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotReadImage'
@@ -5557,30 +5749,6 @@ components:
           type: string
           enum:
           - editoast:model:ModelError
-    EditoastNoSuchUserErrorNoSuchUser:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - user_id
-          properties:
-            user_id:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 404
-        type:
-          type: string
-          enum:
-          - editoast:authz:NoSuchUser
     EditoastOperationErrorEmptyId:
       type: object
       required:
@@ -6019,6 +6187,30 @@ components:
           type: string
           enum:
           - editoast:railjson:UnsupportedVersion
+    EditoastResourceErrorUnknownResourceType:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - resource_type
+          properties:
+            resource_type:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:authz:UnknownResourceType
     EditoastRollingStockErrorBasePowerClassEmpty:
       type: object
       required:
@@ -9853,6 +10045,10 @@ components:
             type: integer
             format: int64
             minimum: 0
+    Resource:
+      type: string
+      enum:
+      - infra
     RjsPowerRestrictionRange:
       type: object
       description: A range along the train path where a power restriction is applied.

--- a/editoast/src/models/auth_driver.rs
+++ b/editoast/src/models/auth_driver.rs
@@ -1,6 +1,9 @@
 use std::ops::DerefMut;
 use std::sync::Arc;
 
+use crate::error::InternalError;
+use crate::models::Infra;
+use crate::models::prelude::Exists;
 use diesel::dsl;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -19,6 +22,8 @@ use tracing::Level;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AuthDriverError {
+    #[error(transparent)]
+    Internal(#[from] InternalError),
     #[error(transparent)]
     Database(#[from] editoast_models::DatabaseError),
     #[error(transparent)]
@@ -237,6 +242,14 @@ impl StorageDriver for PgAuthDriver {
                 Err(e) => Err(e.into()),
             });
         Ok(groups)
+    }
+
+    async fn infra_exists(&self, infra_id: i64) -> Result<bool, Self::Error> {
+        let conn = &mut self.pool.get().await?;
+        let exists = Infra::exists(conn, infra_id)
+            .await
+            .map_err(InternalError::from)?;
+        Ok(exists)
     }
 }
 

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -1,41 +1,66 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use crate::error::Result;
+use crate::models::Infra;
+use crate::models::prelude::*;
 use axum::Extension;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::response::Json;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
+use serde::{Deserialize, Serialize};
+use strum::Display;
+use utoipa::IntoParams;
+use utoipa::ToSchema;
 
 use super::AppState;
 use super::AuthenticationExt;
 use super::AuthorizationError;
 use super::AuthorizerError;
-use super::Regulator;
+use super::pagination::PaginationQueryParams;
 
 crate::routes! {
     "/authz" => {
         "/me" => whoami,
-        "/roles" => {
-            "/me" => list_current_roles,
-            "/{user_id}" => {
-                list_user_roles,
-                grant_roles,
-                strip_roles,
-            },
-        },
+        "/me/grants" => user_authorizations,
+        "/grants" => update_grants,
+        "/{resource_type}/{resource_id}" =>  users_grants_for_resource_id,
+        "/grants/{resource_type}"=> privileges_by_resource_type,
     },
 }
 
 editoast_common::schemas! {
+    Resource,
     Role,
 }
 
-#[derive(serde::Deserialize, utoipa::IntoParams)]
-struct UserIdPathParam {
-    /// A user ID (not to be mistaken for its identity, cf. editoast user model documentation)
-    user_id: i64,
+#[derive(Serialize, Deserialize, ToSchema)]
+#[cfg_attr(test, derive(Debug))]
+enum Subject {
+    User,
+    Group,
+}
+
+#[derive(Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[cfg_attr(test, derive(Debug))]
+enum Resource {
+    Infra,
+}
+
+#[derive(Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(test, derive(Debug))]
+pub(in crate::views) enum InfraGrant {
+    Reader,
+    Writer,
+    Owner,
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]
@@ -43,21 +68,47 @@ struct UserIdPathParam {
 enum AuthzError {
     #[error("Internal error")]
     #[editoast_error(status = 500, no_context)]
-    Authorizer(#[from] AuthorizerError),
+    Authorizer(AuthorizerError),
+    #[error("Unknown resource {resource_id}")]
+    #[editoast_error(status = 404)]
+    UnknownResource { resource_id: i64 },
+    #[error("Unknown resource {subject_id}")]
+    #[editoast_error(status = 404)]
+    UnknownSubject { subject_id: i64 },
     #[error("Authorization error")]
     Authz(#[from] AuthorizationError),
+    #[error("Grant and Revoke cannot be defined at the same time")]
+    SimultaneousGrantsAndRevokes,
+    #[error("Unauthorized")]
+    #[editoast_error(status = 403)]
+    Unauthorized,
+}
+
+impl From<AuthorizerError> for AuthzError {
+    fn from(err: AuthorizerError) -> Self {
+        match err {
+            AuthorizerError::UnknownResource(resource_id) => {
+                AuthzError::UnknownResource { resource_id }
+            }
+            AuthorizerError::UnknownSubject(subject_id) => {
+                AuthzError::UnknownSubject { subject_id }
+            }
+            AuthorizerError::Unauthorized => AuthzError::Unauthorized,
+            err => AuthzError::Authorizer(err),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error, EditoastError)]
 #[editoast_error(base_id = "authz")]
-enum NoSuchUserError {
-    #[error("No user with ID {user_id} found")]
+enum ResourceError {
+    #[error("unknown resource type {resource_type}")]
     #[editoast_error(status = 404)]
-    NoSuchUser { user_id: i64 },
+    UnknownResourceType { resource_type: String },
 }
 
-#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
-#[cfg_attr(test, derive(serde::Deserialize, PartialEq))]
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
 struct WhoamiResponse {
     id: i64,
     name: String,
@@ -83,163 +134,604 @@ async fn whoami(Extension(auth): AuthenticationExt) -> Result<Json<WhoamiRespons
     }))
 }
 
-#[derive(serde::Serialize, utoipa::ToSchema)]
-struct Roles {
-    builtin: HashSet<Role>,
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
+struct ResourceGrant {
+    #[schema(inline)]
+    resource_type: Resource,
+    resource_id: i64,
+    #[schema(inline)]
+    grant: InfraGrant,
 }
 
 #[utoipa::path(
-    get, path = "",
+    post,
+    path = "",
     tag = "authz",
-    responses(
-        (status = 200, description = "List the roles of the issuer of the request", body = inline(Roles)),
+    request_body(
+        content = inline(HashMap<Resource, Vec<i64>>),
+        description = "HashMap of resource type with a list of resource id to get the grants for. If a resource doesn't exist, it will be omitted.",
     ),
+    responses((
+        status = 200,
+        description = "Get grants info of the current user for the given resources in body",
+        body = inline(HashMap<Resource, Vec<ResourceGrant>>)
+    )),
 )]
-async fn list_current_roles(
-    State(AppState { config, .. }): State<AppState>,
+async fn user_authorizations(
+    State(AppState { db_pool, .. }): State<AppState>,
     Extension(auth): AuthenticationExt,
-) -> Result<Json<Roles>> {
-    // This is especially necessary as this endpoint is always queried by the frontend
-    // when loading. Making it return 401 results in a blank page.
-    // We return `Admin` as when no authorization is enabled, we want everyone to have
-    // access to full feature set of OSRD.
-    if !config.enable_authorization {
-        return Ok(Json(Roles {
-            builtin: HashSet::from([Role::Admin]),
-        }));
-    }
+    Json(body): Json<HashMap<Resource, Vec<i64>>>,
+) -> Result<Json<HashMap<Resource, Vec<ResourceGrant>>>> {
     let authorizer = auth.authorizer()?;
-    Ok(Json(Roles {
-        builtin: authorizer
-            .user_roles()
-            .await
-            .map_err(AuthzError::Authorizer)?
-            .clone(),
-    }))
-}
+    let mut result = HashMap::new();
+    let conn = &mut db_pool.get().await?;
 
-async fn check_user_exists(user_id: i64, regulator: &Regulator) -> Result<()> {
-    if !regulator
-        .user_exists(user_id)
-        .await
-        .map_err(AuthzError::from)?
-    {
-        return Err(NoSuchUserError::NoSuchUser { user_id }.into());
+    if let Some(infra_ids) = body.get(&Resource::Infra) {
+        for infra_id in infra_ids {
+            // check that the infra exists before to check the grants
+            if Infra::exists(conn, *infra_id).await? {
+                let is_reader = authorizer
+                    .check_infra_grant_reader(*infra_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                if is_reader {
+                    result.insert(
+                        Resource::Infra,
+                        vec![ResourceGrant {
+                            resource_type: Resource::Infra,
+                            resource_id: *infra_id,
+                            grant: InfraGrant::Reader,
+                        }],
+                    );
+                }
+
+                let is_writer = authorizer
+                    .check_infra_grant_writer(*infra_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                if is_writer {
+                    result.insert(
+                        Resource::Infra,
+                        vec![ResourceGrant {
+                            resource_type: Resource::Infra,
+                            resource_id: *infra_id,
+                            grant: InfraGrant::Writer,
+                        }],
+                    );
+                }
+
+                let is_owner = authorizer
+                    .check_infra_grant_owner(*infra_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                if is_owner {
+                    result.insert(
+                        Resource::Infra,
+                        vec![ResourceGrant {
+                            resource_type: Resource::Infra,
+                            resource_id: *infra_id,
+                            grant: InfraGrant::Owner,
+                        }],
+                    );
+                }
+            }
+        }
     }
 
-    Ok(())
+    Ok(Json(result))
+}
+
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Debug, Deserialize))]
+struct SubjectItem {
+    pub id: i64,
+    pub name: String,
+    #[schema(inline)]
+    pub r#type: Subject,
+}
+
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(test, derive(Debug, Deserialize))]
+struct SubjectGrant {
+    #[schema(inline)]
+    subject: SubjectItem,
+    #[schema(inline)]
+    grant: InfraGrant,
+}
+
+#[derive(Deserialize, IntoParams)]
+struct ResourceTypeParam {
+    resource_type: Resource,
+}
+
+#[derive(Deserialize, IntoParams)]
+struct ResourceIdParam {
+    resource_id: i64,
 }
 
 #[utoipa::path(
-    get, path = "",
+    get,
+    path = "",
     tag = "authz",
-    params(UserIdPathParam),
+    params(ResourceTypeParam, ResourceIdParam, PaginationQueryParams),
     responses(
-        (status = 200, description = "List the roles of a user", body = inline(Roles)),
+        (status = 200, description = "Get list of user that have access to the resource", body = inline(Vec<SubjectGrant>)),
     ),
 )]
-async fn list_user_roles(
-    Path(UserIdPathParam { user_id }): Path<UserIdPathParam>,
-    Extension(auth): AuthenticationExt,
+async fn users_grants_for_resource_id(
     State(AppState { regulator, .. }): State<AppState>,
-) -> Result<Json<Roles>> {
-    if !auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::from)?
-    {
-        return Err(AuthorizationError::Forbidden.into());
+    Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
+    Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
+    Query(pagination_params): Query<PaginationQueryParams>,
+) -> Result<Json<Vec<SubjectGrant>>> {
+    // Validate pagination params
+    let (page, page_size) = pagination_params.validate(100)?.unpack();
+    let mut skip = (page - 1) * page_size;
+
+    let mut result: Vec<SubjectGrant> = Vec::new();
+
+    match resource_type {
+        Resource::Infra => {
+            // Work on infra owners
+            if result.len() < page_size as usize {
+                let owners = regulator
+                    .get_infra_owners(resource_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                for owner in owners {
+                    if skip > 0 {
+                        skip -= 1;
+                        continue;
+                    }
+                    result.push(SubjectGrant {
+                        subject: SubjectItem {
+                            id: owner.id,
+                            name: owner.info.name,
+                            r#type: Subject::User,
+                        },
+                        grant: InfraGrant::Owner,
+                    });
+                }
+            }
+
+            // Work on infra Writers
+            if result.len() < page_size as usize {
+                let writers = regulator
+                    .get_infra_writers(resource_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                for writer in writers {
+                    if skip > 0 {
+                        skip -= 1;
+                        continue;
+                    }
+                    result.push(SubjectGrant {
+                        subject: SubjectItem {
+                            id: writer.id,
+                            name: writer.info.name,
+                            r#type: Subject::User,
+                        },
+                        grant: InfraGrant::Writer,
+                    });
+                }
+            }
+
+            // Work on infra readers
+            if result.len() < page_size as usize {
+                let readers = regulator
+                    .get_infra_readers(resource_id)
+                    .await
+                    .map_err(AuthzError::from)?;
+                for reader in readers {
+                    if skip > 0 {
+                        skip -= 1;
+                        continue;
+                    }
+                    result.push(SubjectGrant {
+                        subject: SubjectItem {
+                            id: reader.id,
+                            name: reader.info.name,
+                            r#type: Subject::User,
+                        },
+                        grant: InfraGrant::Reader,
+                    });
+                }
+            }
+        }
     }
 
-    check_user_exists(user_id, &regulator).await?;
-
-    Ok(Json(Roles {
-        builtin: regulator
-            .user_roles(user_id)
-            .await
-            .map_err(AuthzError::from)?,
-    }))
+    Ok(Json(result))
 }
 
-#[derive(serde::Deserialize, utoipa::ToSchema)]
-struct RoleListBody {
-    roles: Vec<Role>,
+#[derive(Display, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
+#[cfg_attr(test, derive(Debug, Deserialize))]
+enum InfraPrivilege {
+    CanRead,
+    CanShareRead,
+    CanWrite,
+    CanShareWrite,
+    CanDelete,
+    CanShareOwnership,
 }
 
 #[utoipa::path(
-    post, path = "",
+    get,
+    path = "",
     tag = "authz",
-    params(UserIdPathParam),
-    request_body = inline(RoleListBody),
+    params(ResourceTypeParam),
     responses(
-        (status = 204, description = "The roles have been granted successfully"),
+        (status = 200, description = "Get privileges for each grant associated to the resource type", body = inline(HashMap<Grant, Vec<InfraPrivilege>>)),
     ),
 )]
-async fn grant_roles(
-    Path(UserIdPathParam { user_id }): Path<UserIdPathParam>,
-    Extension(auth): AuthenticationExt,
-    State(AppState { regulator, .. }): State<AppState>,
-    Json(RoleListBody { roles }): Json<RoleListBody>,
-) -> Result<impl axum::response::IntoResponse> {
-    if !auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::from)?
-    {
-        return Err(AuthorizationError::Forbidden.into());
+async fn privileges_by_resource_type(
+    Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
+) -> Result<Json<HashMap<InfraGrant, Vec<InfraPrivilege>>>> {
+    if resource_type != Resource::Infra {
+        return Err(ResourceError::UnknownResourceType {
+            resource_type: resource_type.to_string(),
+        })?;
     }
 
-    check_user_exists(user_id, &regulator).await?;
+    let mut infra_privileges: HashMap<InfraGrant, Vec<InfraPrivilege>> = HashMap::new();
+    infra_privileges.insert(
+        InfraGrant::Owner,
+        vec![
+            InfraPrivilege::CanRead,
+            InfraPrivilege::CanShareRead,
+            InfraPrivilege::CanWrite,
+            InfraPrivilege::CanShareWrite,
+            InfraPrivilege::CanDelete,
+            InfraPrivilege::CanShareOwnership,
+        ],
+    );
+    infra_privileges.insert(
+        InfraGrant::Writer,
+        vec![
+            InfraPrivilege::CanRead,
+            InfraPrivilege::CanShareRead,
+            InfraPrivilege::CanWrite,
+            InfraPrivilege::CanShareWrite,
+        ],
+    );
+    infra_privileges.insert(
+        InfraGrant::Reader,
+        vec![InfraPrivilege::CanRead, InfraPrivilege::CanShareRead],
+    );
 
-    regulator
-        .grant_user_roles(user_id, HashSet::from_iter(roles))
-        .await
-        .map_err(AuthzError::from)?;
-    Ok(axum::http::StatusCode::NO_CONTENT)
+    Ok(Json(infra_privileges))
 }
 
+#[derive(Deserialize, ToSchema)]
+struct SubjectResourceGrant {
+    #[schema(inline)]
+    resource_type: Resource,
+    resource_id: i64,
+    subject_id: i64,
+    #[schema(inline)]
+    grant: InfraGrant,
+}
+
+#[derive(Deserialize, ToSchema)]
+struct SubjectResource {
+    resource_type: Resource,
+    resource_id: i64,
+    subject_id: i64,
+}
+
+#[derive(Deserialize, ToSchema)]
+struct BodyUpdateGrants {
+    #[schema(inline)]
+    grant: Option<Vec<SubjectResourceGrant>>,
+    #[schema(inline)]
+    revoke: Option<Vec<SubjectResource>>,
+}
 #[utoipa::path(
-    delete, path = "",
+    post,
+    path = "",
     tag = "authz",
-    params(UserIdPathParam),
-    request_body = inline(RoleListBody),
-    responses(
-        (status = 204, description = "The roles have been removed successfully"),
+    request_body(
+        content = inline(BodyUpdateGrants),
+        description = "List of new authorization to add or to remove (ie grants a resource to a person). Expect grant XOR revoke, not both",
     ),
+    responses((
+        status = 201,
+        description = "Grants updated"
+    )),
 )]
-async fn strip_roles(
-    Path(UserIdPathParam { user_id }): Path<UserIdPathParam>,
+async fn update_grants(
     Extension(auth): AuthenticationExt,
-    State(AppState { regulator, .. }): State<AppState>,
-    Json(RoleListBody { roles }): Json<RoleListBody>,
-) -> Result<impl axum::response::IntoResponse> {
-    if !auth
-        .check_roles([Role::Admin].into())
-        .await
-        .map_err(AuthorizationError::from)?
-    {
-        return Err(AuthorizationError::Forbidden.into());
+    Json(BodyUpdateGrants { grant, revoke }): Json<BodyUpdateGrants>,
+) -> Result<impl IntoResponse> {
+    let authorizer = auth.authorizer()?;
+    if grant.is_none() && revoke.is_none() {
+        return Err(AuthzError::SimultaneousGrantsAndRevokes.into());
+    }
+    if grant.is_some() && revoke.is_some() {
+        return Err(AuthzError::SimultaneousGrantsAndRevokes.into());
     }
 
-    check_user_exists(user_id, &regulator).await?;
+    if let Some(grants) = grant {
+        for grant in grants {
+            match grant.resource_type {
+                Resource::Infra => match grant.grant {
+                    InfraGrant::Reader => {
+                        authorizer
+                            .grant_infra_reader(grant.subject_id, grant.resource_id)
+                            .await
+                            .map_err(AuthzError::from)?;
+                    }
+                    InfraGrant::Writer => {
+                        authorizer
+                            .grant_infra_writer(grant.subject_id, grant.resource_id)
+                            .await
+                            .map_err(AuthzError::from)?;
+                    }
+                    InfraGrant::Owner => {
+                        authorizer
+                            .grant_infra_owner(grant.subject_id, grant.resource_id)
+                            .await
+                            .map_err(AuthzError::from)?;
+                    }
+                },
+            }
+        }
+    }
+    if let Some(revoke) = revoke {
+        for grant in revoke {
+            match grant.resource_type {
+                Resource::Infra => {
+                    authorizer
+                        .revoke_infra_reader(grant.subject_id, grant.resource_id)
+                        .await
+                        .map_err(AuthzError::from)?;
 
-    regulator
-        .revoke_user_roles(user_id, HashSet::from_iter(roles))
-        .await
-        .map_err(AuthzError::from)?;
-    Ok(axum::http::StatusCode::NO_CONTENT)
+                    authorizer
+                        .revoke_infra_writer(grant.subject_id, grant.resource_id)
+                        .await
+                        .map_err(AuthzError::from)?;
+
+                    authorizer
+                        .revoke_infra_owner(grant.subject_id, grant.resource_id)
+                        .await
+                        .map_err(AuthzError::from)?;
+                }
+            }
+        }
+    }
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
 
-    use crate::views::test_app::TestRequestExt as _;
     use crate::views::test_app::test_app;
 
     use super::*;
+    use crate::models::fixtures::create_small_infra;
+    use crate::views::test_app::TestApp;
+    use crate::views::test_app::TestRequestExt;
+    use editoast_authz::subject::UserInfo;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+    use serde_json::json;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn user_authorizations_test() {
+        let app = test_app!().enable_authorization(true).build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("test", "Test")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .create();
+
+        // Ask the authorizations of the user for the infra
+        let request = app.post("/authz/me/grants").by_user(&user).json(&json!({
+            "infra": [infra.id],
+        }));
+        let response: HashMap<String, Vec<ResourceGrant>> =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        // Checks
+        assert_eq!(response.contains_key("infra"), true);
+        let infra_grants = response.get("infra").unwrap();
+        assert_eq!(infra_grants.len(), 1);
+        assert_eq!(
+            infra_grants[0],
+            ResourceGrant {
+                resource_type: Resource::Infra,
+                resource_id: infra.id,
+                grant: InfraGrant::Owner
+            }
+        );
+    }
+
+    #[rstest]
+    async fn users_grants_for_resource_id_test() {
+        // This test start with an infra with one owner, one writer, and 5 readers
+        let app = test_app!().enable_authorization(true).build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("authz", "Authz")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .create();
+
+        Vec::from(["ben", "hal", "joe", "luc", "mar"])
+            .into_iter()
+            .for_each(|name| {
+                app.user(name, name)
+                    .with_roles([Role::OperationalStudies])
+                    .with_infra_grant(infra.id, InfraGrant::Reader)
+                    .create();
+            });
+
+        // Get the full user list for the infra
+        let request_all = app
+            .get(&format!(
+                "/authz/{}/{}?page=1&page_size=10",
+                Resource::Infra,
+                infra.id
+            ))
+            .by_user(&user);
+        let readers: Vec<SubjectGrant> = app
+            .fetch(request_all)
+            .assert_status(StatusCode::OK)
+            .json_into();
+        assert_eq!(readers.len(), 6);
+
+        // Get the partial user list for the infra to test pagination
+        let request_all = app
+            .get(&format!(
+                "/authz/{}/{}?page=2&page_size=5",
+                Resource::Infra,
+                infra.id
+            ))
+            .by_user(&user);
+        let users: Vec<SubjectGrant> = app
+            .fetch(request_all)
+            .assert_status(StatusCode::OK)
+            .json_into();
+        assert_eq!(users.len(), 1);
+    }
+
+    #[rstest]
+    async fn grants_test() {
+        // This test starts with a user that is the owner of an infra.
+        // Then it creates a new user and adds it as a writer to the infra.
+        // Finally, it removes the new user from the infra.
+        let app = test_app!().enable_authorization(true).build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("authz", "Authz")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .create();
+        let user_data = whoami(&app, &user);
+
+        // Check that user is the owner of the infra via /authz/Infra/{infra_id}
+        check_grant_on_resource(&app, &user, infra.id, user_data.id, Some(InfraGrant::Owner));
+
+        // Create a new user and add it as a writer to the infra with the grant API
+        let user_new = app.user("new", "New Authz").create();
+        let user_new_data = whoami(&app, &user_new);
+        let request_grant = app.post("/authz/grants").by_user(&user).json(&json!({
+            "grant": [
+                {
+                    "subject_id": user_new_data.id,
+                    "resource_type": Resource::Infra,
+                    "resource_id": infra.id,
+                    "grant": InfraGrant::Writer
+                }
+            ]
+        }));
+        app.fetch(request_grant)
+            .assert_status(StatusCode::NO_CONTENT);
+        // Check that the new user has the good grant
+        check_grant_on_resource(
+            &app,
+            &user,
+            infra.id,
+            user_new_data.id,
+            Some(InfraGrant::Writer),
+        );
+
+        // Remove the user from the API
+        let request_revoke = app.post("/authz/grants").by_user(&user).json(&json!({
+            "revoke": [
+                {
+                    "subject_id": user_new_data.id,
+                    "resource_type": Resource::Infra,
+                    "resource_id": infra.id
+                }
+            ]
+        }));
+        app.fetch(request_revoke)
+            .assert_status(StatusCode::NO_CONTENT);
+        // Check that the new user has the good grant
+        check_grant_on_resource(&app, &user, infra.id, user_new_data.id, None);
+    }
+
+    #[rstest]
+    async fn privileges_by_resource_type_test() {
+        let app = test_app!().enable_authorization(true).build();
+
+        let request = app.get(&format!("/authz/grants/{}", Resource::Infra));
+        let response: HashMap<InfraGrant, Vec<InfraPrivilege>> =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        // Checks
+        assert_eq!(response.get(&InfraGrant::Reader).unwrap().len(), 2);
+        assert_eq!(response.get(&InfraGrant::Writer).unwrap().len(), 4);
+        assert_eq!(response.get(&InfraGrant::Owner).unwrap().len(), 6);
+    }
+
+    #[rstest]
+    async fn adding_a_grant_that_already_exists() {
+        let app = test_app!().enable_authorization(true).build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("authz", "Authz")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .create();
+
+        let user_data = whoami(&app, &user);
+
+        // Adding OWNER on the same user/infra
+        let request_revoke = app.post("/authz/grants").by_user(&user).json(&json!({
+            "grant": [
+                {
+                    "subject_id": user_data.id,
+                    "resource_type": Resource::Infra,
+                    "resource_id": infra.id,
+                    "grant": InfraGrant::Owner
+                }
+            ]
+        }));
+        app.fetch(request_revoke)
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    #[rstest]
+    async fn remove_a_grant_that_doesnt_exists() {
+        let app = test_app!().enable_authorization(true).build();
+        let db_pool = app.db_pool();
+        let infra = create_small_infra(&mut db_pool.get_ok()).await;
+        let user = app
+            .user("authz", "Authz")
+            .with_roles([Role::OperationalStudies])
+            .with_infra_grant(infra.id, InfraGrant::Owner)
+            .create();
+
+        let user_new = app.user("new", "New Authz").create();
+        let user_new_data = whoami(&app, &user_new);
+
+        // Remove the READER grant should not fail
+        let request_grant = app.post("/authz/grants").by_user(&user).json(&json!({
+            "revoke": [
+                {
+                    "subject_id": user_new_data.id,
+                    "resource_type": Resource::Infra,
+                    "resource_id": infra.id,
+                }
+            ]
+        }));
+        app.fetch(request_grant)
+            .assert_status(StatusCode::NO_CONTENT);
+    }
+
+    #[rstest]
     async fn whoami_test() {
         let app = test_app!().enable_authorization(true).build();
         let user = app
@@ -263,7 +755,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
     async fn whoami_authorization_disabled() {
         let app = test_app!().enable_authorization(false).build();
         let user = app.user("test", "test").create();
@@ -275,5 +767,38 @@ mod tests {
             .json_into::<WhoamiResponse>();
 
         assert_eq!(roles, vec![Role::Admin]);
+    }
+
+    fn whoami(app: &TestApp, user: &impl AsRef<UserInfo>) -> WhoamiResponse {
+        let request = app.get("/authz/me").by_user(user);
+        app.fetch(request).assert_status(StatusCode::OK).json_into()
+    }
+
+    fn check_grant_on_resource(
+        app: &TestApp,
+        by_user: &impl AsRef<UserInfo>,
+        infra_id: i64,
+        user_id: i64,
+        grant: Option<InfraGrant>,
+    ) {
+        let request = app
+            .get(&format!("/authz/{}/{}", Resource::Infra, infra_id))
+            .by_user(by_user);
+        let response: Vec<SubjectGrant> =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        match grant {
+            Some(grant) => {
+                assert_eq!(
+                    true,
+                    response
+                        .into_iter()
+                        .any(|s| s.subject.id == user_id && s.grant == grant)
+                );
+            }
+            None => {
+                assert_eq!(false, response.into_iter().any(|s| s.subject.id == user_id));
+            }
+        }
     }
 }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -2,6 +2,7 @@
 //! test actix server, database connection pool, and different mocking
 //! components.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -46,6 +47,7 @@ use super::PostgresConfig;
 use super::Regulator;
 use super::ServerConfig;
 use super::authentication_middleware;
+use super::authz::InfraGrant;
 
 // NoopSpanExporter exists in 'opentelemetry-sdk' but is hidden behind
 // 'testing' feature which brings with it tons of unneeded dependencies
@@ -379,6 +381,7 @@ pub struct UserBuilder<'a> {
     app: &'a TestApp,
     info: UserInfo,
     roles: HashSet<Role>,
+    infras_grant: HashMap<i64, InfraGrant>,
 }
 
 impl<'a> UserBuilder<'a> {
@@ -387,6 +390,7 @@ impl<'a> UserBuilder<'a> {
             app,
             info,
             roles: Default::default(),
+            infras_grant: HashMap::default(),
         }
     }
 
@@ -395,8 +399,18 @@ impl<'a> UserBuilder<'a> {
         self
     }
 
+    pub fn with_infra_grant(mut self, infra_id: i64, grant: InfraGrant) -> Self {
+        self.infras_grant.insert(infra_id, grant);
+        self
+    }
+
     pub fn create(self) -> subject::User {
-        let Self { app, info, roles } = self;
+        let Self {
+            app,
+            info,
+            roles,
+            infras_grant,
+        } = self;
         let authz_disabled =
             app.authorization_model.is_none() || !app.app_state.config.enable_authorization;
         if !roles.is_empty() && authz_disabled {
@@ -405,6 +419,7 @@ impl<'a> UserBuilder<'a> {
             );
         }
         let regulator = &app.app_state.regulator;
+
         block_on(async move {
             let user = regulator
                 .driver()
@@ -416,6 +431,29 @@ impl<'a> UserBuilder<'a> {
                     .grant_user_roles(user.id, roles)
                     .await
                     .expect("roles should be granted successfully");
+
+                for (infra_id, grant) in infras_grant.into_iter() {
+                    match grant {
+                        InfraGrant::Owner => {
+                            regulator
+                                .grant_infra_owner_unchecked(user.id, infra_id)
+                                .await
+                                .expect("Infra owner should be granted successfully");
+                        }
+                        InfraGrant::Writer => {
+                            regulator
+                                .grant_infra_writer_unchecked(user.id, infra_id)
+                                .await
+                                .expect("Infra writer should be granted successfully");
+                        }
+                        InfraGrant::Reader => {
+                            regulator
+                                .grant_infra_reader_unchecked(user.id, infra_id)
+                                .await
+                                .expect("Infra reader should be granted successfully");
+                        }
+                    }
+                }
             }
             user
         })

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -33,7 +33,11 @@
       "ForbiddenImpersonation": "Impersonation denied",
       "ImpersonatedUserNotFound": "Unknown impersonated user",
       "NoSuchUser": "Unknown user",
-      "Unauthorized": "Unauthenticated user"
+      "SimultaneousGrantsAndRevokes": "Simultaneous grants and revokes are not allowed",
+      "Unauthorized": "Unauthenticated user",
+      "UnknownResource": "Unkown resource",
+      "UnknownResourceType": "Unkown resource type",
+      "UnknownSubject": "Unkown subject"
     },
     "auto_fixes": {
       "ConflictingFixesOnSameObject": "Conflicting fixes for the same object on the same fix-iteration",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -33,7 +33,11 @@
       "ForbiddenImpersonation": "Usurpation refusée",
       "ImpersonatedUserNotFound": "Utilisateur usurpé inconnu",
       "NoSuchUser": "Utilisateur inconnu",
-      "Unauthorized": "Utilisateur non authentifié"
+      "SimultaneousGrantsAndRevokes": "Une unique entrée d'operation (grant ou revoke) est attendue",
+      "Unauthorized": "Utilisateur non authentifié",
+      "UnknownResource": "Resource inconnue",
+      "UnknownResourceType": "Type de ressource inconnu",
+      "UnknownSubject": "Sujet inconnu"
     },
     "auto_fixes": {
       "ConflictingFixesOnSameObject": "Correctifs conflictuels pour le même objet sur la même itération de correctif",

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -32,42 +32,37 @@ const injectedRtkApi = api
   })
   .injectEndpoints({
     endpoints: (build) => ({
+      postAuthzGrants: build.mutation<PostAuthzGrantsApiResponse, PostAuthzGrantsApiArg>({
+        query: (queryArg) => ({ url: `/authz/grants`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['authz'],
+      }),
+      getAuthzGrantsByResourceType: build.query<
+        GetAuthzGrantsByResourceTypeApiResponse,
+        GetAuthzGrantsByResourceTypeApiArg
+      >({
+        query: (queryArg) => ({ url: `/authz/grants/${queryArg.resourceType}` }),
+        providesTags: ['authz'],
+      }),
       getAuthzMe: build.query<GetAuthzMeApiResponse, GetAuthzMeApiArg>({
         query: () => ({ url: `/authz/me` }),
         providesTags: ['authz'],
       }),
-      getAuthzRolesMe: build.query<GetAuthzRolesMeApiResponse, GetAuthzRolesMeApiArg>({
-        query: () => ({ url: `/authz/roles/me` }),
-        providesTags: ['authz'],
-      }),
-      getAuthzRolesByUserId: build.query<
-        GetAuthzRolesByUserIdApiResponse,
-        GetAuthzRolesByUserIdApiArg
-      >({
-        query: (queryArg) => ({ url: `/authz/roles/${queryArg.userId}` }),
-        providesTags: ['authz'],
-      }),
-      postAuthzRolesByUserId: build.mutation<
-        PostAuthzRolesByUserIdApiResponse,
-        PostAuthzRolesByUserIdApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/authz/roles/${queryArg.userId}`,
-          method: 'POST',
-          body: queryArg.body,
-        }),
+      postAuthzMeGrants: build.mutation<PostAuthzMeGrantsApiResponse, PostAuthzMeGrantsApiArg>({
+        query: (queryArg) => ({ url: `/authz/me/grants`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['authz'],
       }),
-      deleteAuthzRolesByUserId: build.mutation<
-        DeleteAuthzRolesByUserIdApiResponse,
-        DeleteAuthzRolesByUserIdApiArg
+      getAuthzByResourceTypeAndResourceId: build.query<
+        GetAuthzByResourceTypeAndResourceIdApiResponse,
+        GetAuthzByResourceTypeAndResourceIdApiArg
       >({
         query: (queryArg) => ({
-          url: `/authz/roles/${queryArg.userId}`,
-          method: 'DELETE',
-          body: queryArg.body,
+          url: `/authz/${queryArg.resourceType}/${queryArg.resourceId}`,
+          params: {
+            page: queryArg.page,
+            page_size: queryArg.pageSize,
+          },
         }),
-        invalidatesTags: ['authz'],
+        providesTags: ['authz'],
       }),
       postDocuments: build.mutation<PostDocumentsApiResponse, PostDocumentsApiArg>({
         query: (queryArg) => ({
@@ -1207,39 +1202,75 @@ const injectedRtkApi = api
     overrideExisting: false,
   });
 export { injectedRtkApi as generatedEditoastApi };
+export type PostAuthzGrantsApiResponse = unknown;
+export type PostAuthzGrantsApiArg = {
+  /** List of new authorization to add or to remove (ie grants a resource to a person). Expect grant XOR revoke, not both */
+  body: {
+    grant?:
+      | {
+          grant: 'READER' | 'WRITER' | 'OWNER';
+          resource_id: number;
+          resource_type: 'infra';
+          subject_id: number;
+        }[]
+      | null;
+    revoke?:
+      | {
+          resource_id: number;
+          resource_type: Resource;
+          subject_id: number;
+        }[]
+      | null;
+  };
+};
+export type GetAuthzGrantsByResourceTypeApiResponse =
+  /** status 200 Get privileges for each grant associated to the resource type */ {
+    [key: string]: (
+      | 'can_read'
+      | 'can_share_read'
+      | 'can_write'
+      | 'can_share_write'
+      | 'can_delete'
+      | 'can_share_ownership'
+    )[];
+  };
+export type GetAuthzGrantsByResourceTypeApiArg = {
+  resourceType: Resource;
+};
 export type GetAuthzMeApiResponse = /** status 200 Get the info of the current user */ {
   id: number;
   name: string;
   roles: Role[];
 };
 export type GetAuthzMeApiArg = void;
-export type GetAuthzRolesMeApiResponse =
-  /** status 200 List the roles of the issuer of the request */ {
-    builtin: Role[];
+export type PostAuthzMeGrantsApiResponse =
+  /** status 200 Get grants info of the current user for the given resources in body */ {
+    [key: string]: {
+      grant: 'READER' | 'WRITER' | 'OWNER';
+      resource_id: number;
+      resource_type: 'infra';
+    }[];
   };
-export type GetAuthzRolesMeApiArg = void;
-export type GetAuthzRolesByUserIdApiResponse = /** status 200 List the roles of a user */ {
-  builtin: Role[];
-};
-export type GetAuthzRolesByUserIdApiArg = {
-  /** A user ID (not to be mistaken for its identity, cf. editoast user model documentation) */
-  userId: number;
-};
-export type PostAuthzRolesByUserIdApiResponse = unknown;
-export type PostAuthzRolesByUserIdApiArg = {
-  /** A user ID (not to be mistaken for its identity, cf. editoast user model documentation) */
-  userId: number;
+export type PostAuthzMeGrantsApiArg = {
+  /** HashMap of resource type with a list of resource id to get the grants for. If a resource doesn't exist, it will be omitted. */
   body: {
-    roles: Role[];
+    [key: string]: number[];
   };
 };
-export type DeleteAuthzRolesByUserIdApiResponse = unknown;
-export type DeleteAuthzRolesByUserIdApiArg = {
-  /** A user ID (not to be mistaken for its identity, cf. editoast user model documentation) */
-  userId: number;
-  body: {
-    roles: Role[];
-  };
+export type GetAuthzByResourceTypeAndResourceIdApiResponse =
+  /** status 200 Get list of user that have access to the resource */ {
+    grant: 'READER' | 'WRITER' | 'OWNER';
+    subject: {
+      id: number;
+      name: string;
+      type: 'User' | 'Group';
+    };
+  }[];
+export type GetAuthzByResourceTypeAndResourceIdApiArg = {
+  resourceType: Resource;
+  resourceId: number;
+  page?: number;
+  pageSize?: number | null;
 };
 export type PostDocumentsApiResponse =
   /** status 201 The document was created */ NewDocumentResponse;
@@ -2162,6 +2193,7 @@ export type PostWorkSchedulesProjectPathApiArg = {
     work_schedule_group_id: number;
   };
 };
+export type Resource = 'infra';
 export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
 export type NewDocumentResponse = {
   document_key: number;

--- a/front/src/utils/hooks/useAuth.ts
+++ b/front/src/utils/hooks/useAuth.ts
@@ -26,7 +26,7 @@ function useAuth(): AuthHookData {
 
   const [logout] = osrdGatewayApi.endpoints.logout.useMutation();
 
-  const { data } = osrdEditoastApi.endpoints.getAuthzRolesMe.useQuery(undefined, {
+  const { data } = osrdEditoastApi.endpoints.getAuthzMe.useQuery(undefined, {
     skip: !isUserLogged,
   });
   const user = osrdEditoastApi.endpoints.getAuthzMe.useQuery(undefined, {
@@ -41,7 +41,7 @@ function useAuth(): AuthHookData {
 
   useEffect(() => {
     if (data) {
-      dispatch(setUserRoles(data?.builtin));
+      dispatch(setUserRoles(data?.roles));
     }
   }, [isUserLogged, data]);
 


### PR DESCRIPTION
This PR implements the API of ticket #10579 

To unmock the front, this task is needed: 

- [x] API `subjects`

Tasks for the futur : 

- [ ] While revoking an owner, check at least one owner will remains 
   - [ ]  for now at least, can't self-remove which prevents orphan resources
- [ ] Check the size of the FGA queries
- [x] Check that adding a grant that already exists doesn't fail
- [x] Check that revoking a grant that doesn't exists doesn't fail
- [ ] Check transactional feature (for batch or when doing deletes & writes)
- [ ] Handle subject (ie. User & Group) instead of just User
- [ ] Adding multi-check request on FGA client