### PR TITLE
core: stdcm: fix conflict introduced by planned steps

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMPostProcessing.kt
@@ -236,7 +236,11 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
 
     /**
      * Identify the max possible time we can add to the previous stop, assuming we can remove some
-     * time from next stops
+     * time from next stops.
+     *
+     * For example, with a train stopping at A, having a requested timing at B and then stopping
+     * again at C: We're trying to find by how much we can "move" stop duration from C to A, to
+     * delay B passage time without affecting what's outside the [A, C] range.
      */
     private fun findMaxPossibleTimeToAdd(
         lastStopIndexBeforeNode: Int,
@@ -246,7 +250,13 @@ class STDCMPostProcessing(private val graph: STDCMGraph) {
         lastTimeData: TimeData,
     ): Double {
         if (lastStopIndexBeforeNode == 0) return lastTimeData.maxFirstDepartureDelaying
-        var maxTimeDiff = Double.POSITIVE_INFINITY
+
+        // Init the result with the delay we can add without conflict between the last stop and the
+        // planned node
+        var maxTimeDiff =
+            if (node.stopDuration == null) node.timeData.maxDepartureDelayingWithoutConflict
+            else node.timeData.stopTimeData.last().maxDepartureDelayBeforeStop
+
         var nextStopIndex = lastStopIndexBeforeNode
         if (node.stopDuration != null) nextStopIndex++
         var timeRemovedFromStops = 0.0

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -292,6 +292,51 @@ class FullSTDCMTests {
         }
     }
 
+    /**
+     * Very long stop with an occupancy that starts after the stop end. The requested arrival time
+     * may make us stay longer at the stop location, to the point of causing a conflict. Not finding
+     * a solution is valid, we're looking for crashes (specifically postprocessing assertions).
+     * Reproduces a bug.
+     */
+    @Test
+    fun testConflictAtStop() {
+        val infra =
+            Helpers.fullInfraFromRJS(Helpers.getExampleInfra("overlapping_routes/infra.json"))
+        val start =
+            setOf(Helpers.convertRouteLocation(infra, "rt.det.a1.nf->det.b1.nf", Offset(0.meters)))
+        val stop =
+            setOf(
+                Helpers.convertRouteLocation(
+                    infra,
+                    "rt.det.a1.nf->det.b1.nf",
+                    Offset(6_000.meters) // Within sight distance of a signal
+                )
+            )
+        val end =
+            setOf(
+                Helpers.convertRouteLocation(
+                    infra,
+                    "rt.det.a1.nf->det.b1.nf",
+                    Offset(10_000.meters)
+                )
+            )
+        val zoneAtStop = "zone.[det.center.1:INCREASING, det.center.2:DECREASING]"
+        val requirements =
+            listOf(SpacingRequirement(zoneAtStop, 7_000.0, Double.POSITIVE_INFINITY, true))
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartTime(0.0)
+                .setStartLocations(start)
+                .addStep(STDCMStep(stop, 5_000.0, true))
+                .setEndLocations(end, PlannedTimingData(10_000.seconds, 0.seconds, 0.seconds))
+                .setBlockAvailability(makeBlockAvailability(requirements))
+                .setMaxRunTime(Double.POSITIVE_INFINITY)
+                .setMaxDepartureDelay(0.0)
+                .run() ?: return
+        checkNoConflict(infra, requirements, res)
+    }
+
     private fun plannedTimingDataArg(): Stream<Arguments> {
         val start =
             setOf(


### PR DESCRIPTION
The associated unit test used to fail and has been fixed. 

I thought I managed to reproduce a bug in a unit test. Turns out it's a different cause and doesn't actually fix any of the real requests I'm trying to fix. Still, it's a fix. 