### PR TITLE
editoast: railjson: loosen the railjson version check for persisting

### DIFF
--- a/editoast/editoast_schemas/src/infra.rs
+++ b/editoast/editoast_schemas/src/infra.rs
@@ -51,6 +51,7 @@ pub use operational_point::OperationalPoint;
 pub use operational_point::OperationalPointExtensions;
 pub use operational_point::OperationalPointIdentifierExtension;
 pub use operational_point::OperationalPointPart;
+pub use railjson::major_version;
 pub use railjson::RailJson;
 pub use railjson::RAILJSON_VERSION;
 pub use route::Route;

--- a/editoast/editoast_schemas/src/infra/railjson.rs
+++ b/editoast/editoast_schemas/src/infra/railjson.rs
@@ -52,3 +52,10 @@ pub struct RailJson {
     /// `Detector` is a device that identifies the presence of a train in a TVD section (Track Vacancy Detection section), indicating when a track area is occupied.
     pub detectors: Vec<Detector>,
 }
+
+pub fn major_version(version: &str) -> &str {
+    match version.split_once('.') {
+        Some((major, _)) => major,
+        None => version,
+    }
+}

--- a/editoast/src/models/railjson.rs
+++ b/editoast/src/models/railjson.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::RailJson;
-use editoast_schemas::infra::RAILJSON_VERSION;
+use editoast_schemas::infra::{major_version, RAILJSON_VERSION};
 
 use crate::error::Result;
 use crate::models::infra_objects::*;
@@ -41,7 +41,7 @@ pub async fn persist_railjson(
         neutral_sections,
     } = railjson;
 
-    if version != RAILJSON_VERSION {
+    if major_version(&version) != major_version(RAILJSON_VERSION) {
         return Err(RailJsonError::UnsupportedVersion {
             actual: version,
             expected: RAILJSON_VERSION.to_string(),


### PR DESCRIPTION
This allows for railjsons with compatible versions to easily be loaded.

It's either this, or we have to write migrations for all railjson versions update, even if we don't need to update the content of the railjsons. (Currently, you can't download and reupload some railjsons on deployed envs)

I made two choices which are very much debatable:
* Checking only the major version
* Using a very naive way to check the semver. I thought about using a regex, but then we should rather use a crate (like [semver](https://docs.rs/semver/latest/semver/index.html)), but I thought another dependency could be too much.