### PR TITLE
front: remove internal names and assumptions about the names of imported files

### DIFF
--- a/front/src/applications/stdcm/components/StdcmHeader.tsx
+++ b/front/src/applications/stdcm/components/StdcmHeader.tsx
@@ -11,12 +11,7 @@ const LogoSTDCM = () => {
 
   if (deploymentSettings) {
     return deploymentSettings.stdcmLogo ? (
-      <img
-        src={deploymentSettings.stdcmLogo}
-        data-testid="lmr-logo"
-        alt="LMR Logo"
-        className="stdcm-header__logo"
-      />
+      <img src={deploymentSettings.stdcmLogo} alt="STDCM Logo" className="stdcm-header__logo" />
     ) : (
       <span className="stdcm-header__title pl-5">STDCM</span>
     );

--- a/front/src/applications/stdcm/components/StdcmResults/SimulationReportSheet.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SimulationReportSheet.tsx
@@ -38,7 +38,7 @@ const getArrivalTimes = (step: StdcmPathStep, t: TFunction, shouldDisplay: boole
 const LogoSTDCM = ({ logoUrl }: { logoUrl?: string }) => {
   const { t } = useTranslation(['stdcm-simulation-report-sheet']);
   if (logoUrl) {
-    return <Image src={logoUrl} style={styles.header.lmrLogo} />;
+    return <Image src={logoUrl} style={styles.header.stdcmLogo} />;
   }
   return (
     <>

--- a/front/src/applications/stdcm/components/StdcmResults/SimulationReportStyleSheet.ts
+++ b/front/src/applications/stdcm/components/StdcmResults/SimulationReportStyleSheet.ts
@@ -42,7 +42,7 @@ const styles = {
       height: '24',
       marginLeft: '20',
     },
-    lmrLogo: {
+    stdcmLogo: {
       width: 'auto',
       marginRight: 'auto',
     },

--- a/front/src/common/BootstrapSNCF/NavBarSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/NavBarSNCF.tsx
@@ -40,9 +40,9 @@ const LegacyNavBarSNCF = ({ appName, showLogoWithName }: Props) => {
       };
     return {
       logoUrl: showLogoWithName
-        ? deploymentSettings.digitalTwinLogoWithName
-        : deploymentSettings.digitalTwinLogo,
-      name: deploymentSettings.digitalTwinName,
+        ? deploymentSettings.operationalStudiesLogoWithName
+        : deploymentSettings.operationalStudiesLogo,
+      name: deploymentSettings.operationalStudiesName,
     };
   }, [deploymentSettings, showLogoWithName]);
 

--- a/front/src/common/ReleaseInformations/ReleaseInformations.tsx
+++ b/front/src/common/ReleaseInformations/ReleaseInformations.tsx
@@ -46,7 +46,11 @@ function ReleaseInformations() {
                   rel="noopener noreferrer"
                   onMouseEnter={motriceParty}
                 >
-                  <img src={deploymentSettings?.digitalTwinLogo} alt="OSRD logo" width={192} />
+                  <img
+                    src={deploymentSettings?.operationalStudiesLogo}
+                    alt="OSRD logo"
+                    width={192}
+                  />
                 </a>
                 <h2>OSRD</h2>
                 <h3>Open Source Railway Designer</h3>

--- a/front/src/utils/hooks/useDeploymentSettings.tsx
+++ b/front/src/utils/hooks/useDeploymentSettings.tsx
@@ -13,9 +13,9 @@ const MONTH_VALUES = {
 };
 
 const defaultSettings = {
-  digitalTwinName: 'Osrd',
-  digitalTwinLogo: defaultLogo,
-  digitalTwinLogoWithName: defaultOsrdLogo,
+  operationalStudiesName: 'Osrd',
+  operationalStudiesLogo: defaultLogo,
+  operationalStudiesLogoWithName: defaultOsrdLogo,
   stdcmName: 'Stdcm',
   stdcmLogo: undefined,
   stdcmSimulationSheetLogo: undefined,
@@ -25,9 +25,9 @@ const defaultSettings = {
 };
 
 export type DeploymentSettings = {
-  digitalTwinName: string;
-  digitalTwinLogo: string;
-  digitalTwinLogoWithName: string;
+  operationalStudiesName: string;
+  operationalStudiesLogo: string;
+  operationalStudiesLogoWithName: string;
   stdcmName: string;
   stdcmLogo?: string;
   stdcmSimulationSheetLogo?: string;
@@ -56,24 +56,24 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
       try {
         const response = await fetch('/overrides/overrides.json');
         if (!response.ok || response.headers.get('Content-Type') !== 'application/json') {
-          let digitalTwinLogo = defaultLogo;
-          let digitalTwinLogoWithName = defaultOsrdLogo;
+          let operationalStudiesLogo = defaultLogo;
+          let operationalStudiesLogoWithName = defaultOsrdLogo;
           const currentMonth = new Date().getMonth();
 
           if (currentMonth === MONTH_VALUES.JUNE) {
-            digitalTwinLogo = proudLogo;
-            digitalTwinLogoWithName = proudOsrdLogo;
+            operationalStudiesLogo = proudLogo;
+            operationalStudiesLogoWithName = proudOsrdLogo;
           } else if (currentMonth === MONTH_VALUES.DECEMBER) {
-            digitalTwinLogo = xmasLogo;
-            digitalTwinLogoWithName = xmasOsrdLogo;
+            operationalStudiesLogo = xmasLogo;
+            operationalStudiesLogoWithName = xmasOsrdLogo;
           }
 
           setCustomizedDeploymentSetting({
             isLoading: false,
             deploymentSettings: {
               ...defaultSettings,
-              digitalTwinLogo,
-              digitalTwinLogoWithName,
+              operationalStudiesLogo,
+              operationalStudiesLogoWithName,
             },
           });
         } else {
@@ -85,8 +85,8 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
           };
 
           if (names) {
-            if (names.digital_twin) {
-              deploySettings.digitalTwinName = names.digital_twin;
+            if (names.operational_studies) {
+              deploySettings.operationalStudiesName = names.operational_studies;
             }
             if (names.stdcm) {
               deploySettings.stdcmName = names.stdcm;
@@ -96,14 +96,14 @@ export const DeploymentContextProvider = ({ children }: DeploymentContextProvide
           if (icons) {
             deploySettings.hasCustomizedLogo = true;
 
-            if (icons.digital_twin) {
-              deploySettings.digitalTwinLogo = `/overrides/${icons.digital_twin.dark}_Logo_Grey40.svg`;
-              deploySettings.digitalTwinLogoWithName = `/overrides/${icons.digital_twin.dark}_Grey10.svg`;
+            if (icons.operational_studies) {
+              deploySettings.operationalStudiesLogo = `/overrides/${icons.operational_studies.logo}`;
+              deploySettings.operationalStudiesLogoWithName = `/overrides/${icons.operational_studies.logo_with_name}`;
             }
 
             if (icons.stdcm) {
-              deploySettings.stdcmLogo = `/overrides/${icons.stdcm.light}.svg`;
-              deploySettings.stdcmSimulationSheetLogo = `/overrides/${icons.stdcm.light}@2x.png`;
+              deploySettings.stdcmLogo = `/overrides/${icons.stdcm.logo}`;
+              deploySettings.stdcmSimulationSheetLogo = `/overrides/${icons.stdcm.simulation_sheet_logo}`;
             }
           }
 


### PR DESCRIPTION
closes #11204 

The override file should be modified like this:
  
```json
// overrides.json
{
 "names": {
    "stdcm": "Last Minute Request",
    "operational_studies": "Horizon"
  },
  "icons": {
    "stdcm": {
      "logo": "Logotype_LastMinuteRequest_light.svg",
      "simulation_sheet_logo": "Logotype_LastMinuteRequest_light@2x.png"
    },
    "operational_studies": {
      "logo": "Logotype_Horizon_dark_Logo_Grey40.svg",
      "logo_with_name": "Logotype_Horizon_dark_Grey10.svg"
    }
  }
} 
```