### PR TITLE
Fix gateway mock provider

### DIFF
--- a/docker/gateway.dev.front.toml
+++ b/docker/gateway.dev.front.toml
@@ -36,4 +36,3 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false

--- a/docker/gateway.dev.host-front.toml
+++ b/docker/gateway.dev.host-front.toml
@@ -35,4 +35,3 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false

--- a/docker/gateway.dev.host.toml
+++ b/docker/gateway.dev.host.toml
@@ -34,4 +34,3 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false

--- a/docker/gateway.pr-tests.simple.toml
+++ b/docker/gateway.pr-tests.simple.toml
@@ -38,4 +38,3 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -83,11 +83,6 @@ type = "Mocked"
 provider_id = "mock"
 # The username reported to the front-end
 username = "Example User"
-# The unique user id sent to the back-end
-user_id = "example-user-id"
-# Whether users actually need to log in to call targets where require_auth = true.
-# It's used for testing.
-require_login = true
 ```
 
 # Enable open telemetry

--- a/gateway/actix_auth/src/auth_context.rs
+++ b/gateway/actix_auth/src/auth_context.rs
@@ -222,11 +222,11 @@ impl AuthContext {
             };
 
             match id_provider.get_identity(req) {
-                ProviderIdentityStatus::Known { user_id } => {
+                ProviderIdentityStatus::Known { user_id, username } => {
                     return AuthStatus::Known {
                         provider_handler: handler,
                         user_id,
-                        username: None,
+                        username,
                     }
                 }
                 ProviderIdentityStatus::Unknown => continue,

--- a/gateway/actix_auth/src/providers/bearer.rs
+++ b/gateway/actix_auth/src/providers/bearer.rs
@@ -32,6 +32,7 @@ impl IdentityProvider for BearerProvider {
         if let Some(token_id) = self.allowed_tokens.get(bearer.token()) {
             ProviderIdentityStatus::Known {
                 user_id: token_id.clone(),
+                username: None,
             }
         } else {
             ProviderIdentityStatus::Error("unknown HTTP Authorization Bearer token")

--- a/gateway/actix_auth/src/providers/mock.rs
+++ b/gateway/actix_auth/src/providers/mock.rs
@@ -1,28 +1,21 @@
 use actix_web::HttpRequest;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
-use super::{IdentityProvider, ProviderIdentityStatus, ProviderSessionStatus, SessionProvider};
+use super::IdentityProvider;
+use super::ProviderIdentityStatus;
+use super::ProviderSessionStatus;
+use super::SessionProvider;
 
 #[derive(Clone)]
 pub struct MockProvider {
-    require_login: bool,
     username: String,
-    user_id: Option<String>,
+    user_id: String,
 }
 
 impl MockProvider {
-    pub fn new(require_login: bool, username: String, user_id: Option<String>) -> Self {
-        Self {
-            require_login,
-            username,
-            user_id,
-        }
-    }
-
-    fn get_user_id(&self) -> &str {
-        self.user_id
-            .as_deref()
-            .unwrap_or_else(|| self.username.as_ref())
+    pub fn new(username: String, user_id: String) -> Self {
+        Self { username, user_id }
     }
 }
 
@@ -46,7 +39,7 @@ impl SessionProvider for MockProvider {
         match ctx.state() {
             None => ProviderSessionStatus::LoggedOut,
             Some(MockState::LoggedIn) => ProviderSessionStatus::LoggedIn {
-                user_id: self.get_user_id().to_owned(),
+                user_id: self.user_id.clone(),
                 username: self.username.clone(),
             },
         }
@@ -75,12 +68,9 @@ impl SessionProvider for MockProvider {
 
 impl IdentityProvider for MockProvider {
     fn get_identity(&self, _: &HttpRequest) -> ProviderIdentityStatus {
-        if self.require_login {
-            ProviderIdentityStatus::Unknown
-        } else {
-            ProviderIdentityStatus::Known {
-                user_id: self.get_user_id().to_owned(),
-            }
+        ProviderIdentityStatus::Known {
+            user_id: self.user_id.clone(),
+            username: Some(self.username.clone()),
         }
     }
 }

--- a/gateway/actix_auth/src/providers/mod.rs
+++ b/gateway/actix_auth/src/providers/mod.rs
@@ -16,7 +16,10 @@ pub mod oidc;
 mod provider_context;
 
 pub enum ProviderIdentityStatus {
-    Known { user_id: String },
+    Known {
+        user_id: String,
+        username: Option<String>,
+    },
     Unknown,
     Error(&'static str),
 }

--- a/gateway/gateway.bundled.toml
+++ b/gateway/gateway.bundled.toml
@@ -27,7 +27,6 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false
 
 # Example of OIDC auth
 # [auth]

--- a/gateway/gateway.toml
+++ b/gateway/gateway.toml
@@ -31,4 +31,3 @@ secure_cookies = false
 type = "Mocked"
 provider_id = "mock"
 username = "Example User"
-require_login = false

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -118,7 +118,6 @@ pub enum AuthProvider {
     Mocked {
         provider_id: String,
         username: String,
-        require_login: bool,
         user_id: Option<String>,
     },
 

--- a/gateway/src/config_parser.rs
+++ b/gateway/src/config_parser.rs
@@ -114,12 +114,10 @@ pub async fn parse_auth_config(config: AuthConfig) -> AuthContext {
             config::AuthProvider::Mocked {
                 provider_id,
                 username,
-                require_login,
                 user_id,
             } => {
-                let provider = MockProvider::new(require_login, username, user_id);
-                auth_context
-                    .add_identity_provider(format!("{provider_id}.identity"), provider.clone());
+                let provider = MockProvider::new(username, user_id.unwrap_or("mocked".into()));
+                auth_context.add_identity_provider(provider_id.clone(), provider.clone());
                 auth_context.add_session_provider(provider_id, provider);
             }
             config::AuthProvider::Bearer {


### PR DESCRIPTION
This PR cleans the `x-remote-user-identity` and `x-remote-user-name` when using the mock provider.

Before: `mock.identity/Example User`
After: `mock/mocked`

---------

I also fixed the username that was not being passed to editoast. As the mock provider was registered as both a session provider and an identity provider, it always matched the identity (which doesn't provide the username). 
To solve this problem, I removed the mock provider's identity implementation. By doing so, the `require_login` field became unused, so I deleted it.
