### PR TITLE
front: disable vite-plugin-checker when running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -818,6 +818,20 @@ jobs:
 
           exit $(docker wait front-format)
 
+      - name: Check TypeScript
+        run: |
+          docker run --name=front-typescript --net=host \
+            ${{ fromJSON(needs.build.outputs.stable_tags).front-tests }} \
+            npx tsc --noEmit
+          exit $(docker wait front-typescript)
+
+      - name: Check ESLint
+        run: |
+          docker run --name=front-eslint --net=host \
+            ${{ fromJSON(needs.build.outputs.stable_tags).front-tests }} \
+            npm run lint
+          exit $(docker wait front-eslint)
+
       - name: Check for i18n missing keys
         run: |
           docker run --name=front-i18n-checker --net=host \

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       viteTsconfigPaths(),
-      checker({
+      mode !== 'test' && checker({
         typescript: {
           buildMode: true,
         },


### PR DESCRIPTION
Running tests should just run the tests, not lints or type checking.

- [ ] Consider keeping vite-plugin-checker when running tests in watch mode