### PR TITLE
front: map: switch to pmtiles for OSM and terrain

### DIFF
--- a/front/src/common/Map/const.ts
+++ b/front/src/common/Map/const.ts
@@ -4,8 +4,9 @@ import config from 'config/config';
 export const MAP_URL = `${config.proxy_editoast}/layers`;
 export const SPRITES_URL = `${config.proxy_editoast}/sprites`;
 export const FONTS_URL = `${config.proxy_editoast}/fonts`;
-export const OSM_URL = 'https://osm.osrd.fr/data/v3.json';
-export const TERRAIN_URL = 'https://osm.osrd.fr/data/terrain.json';
+export const OSM_URL = 'pmtiles://https://osm.nbg1.your-objectstorage.com/planet.pmtiles';
+export const TERRAIN_URL =
+  'pmtiles://https://osm.nbg1.your-objectstorage.com/terrain-europe.pmtiles';
 
 export const MAP_MODES = {
   display: 'display',


### PR DESCRIPTION
The vpn now let us access to Hetzner’s object storage.

The map (including terrain) fetches on https://osm.nbg1.your-objectstorage.com/.

There should no longer any request to osm.osrd.fr

Please test if the map loads when the VPN is on