### PR TITLE
editoast: manage authorization on infras

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -814,6 +814,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
+          EDITOAST_ENABLE_AUTHORIZATION: false
 
       - name: Run pytest
         run: |
@@ -915,6 +916,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
+          EDITOAST_ENABLE_AUTHORIZATION: false
 
       - name: Run Playwright tests
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,11 +140,13 @@ services:
       TELEMETRY_ENDPOINT: "http://jaeger:4317"
       OSRD_MQ_URL: "amqp://osrd:password@osrd-rabbitmq:5672/%2f"
       EDITOAST_OPENFGA_URL: "http://openfga:8091"
-      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-false}
-    command:
-      - /bin/sh
-      - -c
-      - "diesel migration run --locked-schema && exec editoast runserver"
+      EDITOAST_ENABLE_AUTHORIZATION: ${EDITOAST_ENABLE_AUTHORIZATION:-true}
+    command: >
+      /bin/sh -c "
+        diesel migration run --locked-schema &&
+        editoast user add 'mock/mocked' 'Example User' &&
+        editoast roles add 'mock/mocked' Admin &&
+        exec editoast runserver"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost/health" ]
       start_period: 4s

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -88,6 +88,32 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
+    pub async fn authorize_infra_write(
+        &self,
+        infra: &Infra,
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        self.regulator
+            .authorize_infra_write(&User(self.user_id), infra)
+            .await
+    }
+
+    pub async fn authorize_infra_delete(
+        &self,
+        infra: &Infra,
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        self.regulator
+            .authorize_infra_delete(&User(self.user_id), infra)
+            .await
+    }
+
+    pub async fn list_authorized_infra(
+        &self,
+    ) -> Result<Authorization<Vec<Infra>>, Error<S::Error>> {
+        self.regulator
+            .list_authorized_infra(&User(self.user_id))
+            .await
+    }
+
     pub async fn grant_infra_reader(
         &self,
         user: &User,

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -68,7 +68,7 @@ pub enum Authorization<T> {
     /// The initiator of the authorization is allowed to access the resource
     Granted(T),
     /// The initiator of the authorization is an admin and bypassed the authorization checks
-    Bypassed(T),
+    Bypassed,
     /// The initiator of the authorization is denied access to the resource
     Denied { reason: &'static str },
 }
@@ -78,27 +78,29 @@ pub enum Authorization<T> {
 pub struct Unauthorized {
     pub reason: &'static str,
 }
-
-impl<T> Authorization<T> {
-    pub fn allowed(self) -> Result<T, Unauthorized> {
+impl Authorization<()> {
+    pub fn allowed(self) -> Result<(), Unauthorized> {
         match self {
-            Authorization::Granted(value) | Authorization::Bypassed(value) => Ok(value),
+            Authorization::Granted(()) | Authorization::Bypassed => Ok(()),
             Authorization::Denied { reason } => Err(Unauthorized { reason }),
         }
     }
 
-    pub fn denied(&self) -> bool {
-        matches!(self, Self::Denied { .. })
-    }
-
     pub async fn allowed_then_try<U, E>(
         self,
-        f: impl AsyncFnOnce(T) -> Result<Authorization<U>, E>,
+        f: impl AsyncFnOnce() -> Result<Authorization<U>, E>,
     ) -> Result<Authorization<U>, E> {
         match self {
-            Authorization::Granted(t) | Authorization::Bypassed(t) => f(t).await,
+            Authorization::Granted(()) => f().await,
+            Authorization::Bypassed => f().await,
             Authorization::Denied { reason } => Ok(Authorization::Denied { reason }),
         }
+    }
+}
+
+impl<T> Authorization<T> {
+    pub fn denied(&self) -> bool {
+        matches!(self, Self::Denied { .. })
     }
 }
 

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -425,13 +425,81 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.is_admin(user).await? {
-            return Ok(Authorization::Bypassed(()));
+            return Ok(Authorization::Bypassed);
         }
 
         // Calling openfga
         let check = self
             .openfga
             .check(model::Infra::can_read().check(user, infra))
+            .await?;
+        Ok(Authorization::from_privilege_check(check))
+    }
+
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
+    pub async fn authorize_infra_write(
+        &self,
+        user: &User,
+        infra: &Infra,
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra.0)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra.0));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user.0).await? {
+            return Err(Error::UnknownSubject(user.0));
+        }
+
+        // Bypass if user is an admin
+        if self.is_admin(user).await? {
+            return Ok(Authorization::Bypassed);
+        }
+
+        // Calling openfga
+        let check = self
+            .openfga
+            .check(model::Infra::can_write().check(user, infra))
+            .await?;
+        Ok(Authorization::from_privilege_check(check))
+    }
+
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
+    pub async fn authorize_infra_delete(
+        &self,
+        user: &User,
+        infra: &Infra,
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        // Check if the infra exists
+        if !self
+            .driver
+            .infra_exists(infra.0)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::UnknownResource(infra.0));
+        }
+
+        // Check if user exists
+        if !self.user_exists(user.0).await? {
+            return Err(Error::UnknownSubject(user.0));
+        }
+
+        // Bypass if user is an admin
+        if self.is_admin(user).await? {
+            return Ok(Authorization::Bypassed);
+        }
+
+        // Calling openfga
+        let check = self
+            .openfga
+            .check(model::Infra::can_delete().check(user, infra))
             .await?;
         Ok(Authorization::from_privilege_check(check))
     }
@@ -459,7 +527,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user, [Role::Admin].into()).await? {
-            return Ok(Authorization::Bypassed(()));
+            return Ok(Authorization::Bypassed);
         }
 
         // Calling openfga
@@ -493,7 +561,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user, [Role::Admin].into()).await? {
-            return Ok(Authorization::Bypassed(()));
+            return Ok(Authorization::Bypassed);
         }
 
         // Calling openfga
@@ -527,7 +595,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user, [Role::Admin].into()).await? {
-            return Ok(Authorization::Bypassed(()));
+            return Ok(Authorization::Bypassed);
         }
 
         // Calling openfga
@@ -635,6 +703,25 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(users)
     }
 
+    /// Get IDS of infras a subject can read
+    pub async fn list_authorized_infra(
+        &self,
+        user: &User,
+    ) -> Result<Authorization<Vec<Infra>>, Error<S::Error>> {
+        // Bypass if user is an admin
+        if self.is_admin(user).await? {
+            return Ok(Authorization::Bypassed);
+        }
+
+        let infra_list = self
+            .openfga
+            .list_objects(Infra::can_read().query_objects(user))
+            .await
+            .map_err(QueryError::parsing_ok)?;
+
+        Ok(Authorization::Granted(infra_list))
+    }
+
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_reader_unchecked(
         &self,
@@ -687,7 +774,7 @@ impl<S: StorageDriver> Regulator<S> {
     ) -> Result<Authorization<()>, Error<S::Error>> {
         self.authorize_infra_sharing_read(issuer, infra)
             .await?
-            .allowed_then_try(async |()| {
+            .allowed_then_try(async || {
                 self.grant_infra_reader_unchecked(user, infra).await?;
                 Ok(Authorization::Granted(()))
             })
@@ -746,7 +833,7 @@ impl<S: StorageDriver> Regulator<S> {
     ) -> Result<Authorization<()>, Error<S::Error>> {
         self.authorize_infra_sharing_write(issuer, infra)
             .await?
-            .allowed_then_try(async |()| {
+            .allowed_then_try(async || {
                 self.grant_infra_writer_unchecked(user, infra).await?;
                 Ok(Authorization::Granted(()))
             })
@@ -805,7 +892,7 @@ impl<S: StorageDriver> Regulator<S> {
     ) -> Result<Authorization<()>, Error<S::Error>> {
         self.authorize_infra_sharing_ownership(issuer, infra)
             .await?
-            .allowed_then_try(async |()| {
+            .allowed_then_try(async || {
                 self.grant_infra_owner_unchecked(user, infra).await?;
                 Ok(Authorization::Granted(()))
             })
@@ -819,10 +906,11 @@ impl<S: StorageDriver> Regulator<S> {
         user: &User,
         infra: &Infra,
     ) -> Result<Authorization<()>, Error<S::Error>> {
-        if !self
-            .openfga
-            .check(Infra::owner().check(issuer, infra))
-            .await?
+        if !self.is_admin(issuer).await?
+            && !self
+                .openfga
+                .check(Infra::owner().check(issuer, infra))
+                .await?
         {
             return Ok(Authorization::Denied {
                 reason: "only owners can revoke grants",

--- a/editoast/src/client/runserver.rs
+++ b/editoast/src/client/runserver.rs
@@ -39,10 +39,7 @@ pub struct RunserverArgs {
     core: CoreArgs,
     /// If this option is set to false, any role and permission check will be bypassed. Even if no user is
     /// provided by the request headers of if the provided user doesn't have the required privileges.
-    // TODO: once the whole role system will be deployed, the default value of this option should
-    // be set to false. It's currently set to true in order to pass integration tests, which otherwise
-    // only receive 401 responses.
-    #[clap(long, env = "EDITOAST_ENABLE_AUTHORIZATION", default_value_t = false)]
+    #[clap(long, env = "EDITOAST_ENABLE_AUTHORIZATION", default_value_t = true)]
     enable_authorization: bool,
     /// If this option is set, logging for the STDCM will be enabled.
     /// When enabled, relevant logs will be captured to aid in debugging and monitoring.

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -166,6 +166,7 @@ async fn user_authorizations(
     let conn = &mut db_pool.get().await?;
 
     if let Some(infra_ids) = body.get(&Resource::Infra) {
+        let mut infra_authz: Vec<ResourceGrant> = Vec::new();
         for infra_id in infra_ids {
             // check that the infra exists before to check the grants
             if Infra::exists(conn, *infra_id).await? {
@@ -174,14 +175,11 @@ async fn user_authorizations(
                     .await
                     .map_err(AuthzError::from)?;
                 if is_reader {
-                    result.insert(
-                        Resource::Infra,
-                        vec![ResourceGrant {
-                            resource_type: Resource::Infra,
-                            resource_id: *infra_id,
-                            grant: InfraGrant::Reader,
-                        }],
-                    );
+                    infra_authz.push(ResourceGrant {
+                        resource_type: Resource::Infra,
+                        resource_id: *infra_id,
+                        grant: InfraGrant::Reader,
+                    });
                 }
 
                 let is_writer = authorizer
@@ -189,14 +187,11 @@ async fn user_authorizations(
                     .await
                     .map_err(AuthzError::from)?;
                 if is_writer {
-                    result.insert(
-                        Resource::Infra,
-                        vec![ResourceGrant {
-                            resource_type: Resource::Infra,
-                            resource_id: *infra_id,
-                            grant: InfraGrant::Writer,
-                        }],
-                    );
+                    infra_authz.push(ResourceGrant {
+                        resource_type: Resource::Infra,
+                        resource_id: *infra_id,
+                        grant: InfraGrant::Writer,
+                    });
                 }
 
                 let is_owner = authorizer
@@ -204,17 +199,15 @@ async fn user_authorizations(
                     .await
                     .map_err(AuthzError::from)?;
                 if is_owner {
-                    result.insert(
-                        Resource::Infra,
-                        vec![ResourceGrant {
-                            resource_type: Resource::Infra,
-                            resource_id: *infra_id,
-                            grant: InfraGrant::Owner,
-                        }],
-                    );
+                    infra_authz.push(ResourceGrant {
+                        resource_type: Resource::Infra,
+                        resource_id: *infra_id,
+                        grant: InfraGrant::Owner,
+                    });
                 }
             }
         }
+        result.insert(Resource::Infra, infra_authz);
     }
 
     Ok(Json(result))
@@ -258,7 +251,7 @@ struct ResourceIdParam {
     ),
 )]
 async fn users_grants_for_resource_id(
-    Extension(authn): AuthenticationExt,
+    Extension(auth): AuthenticationExt,
     State(AppState { regulator, .. }): State<AppState>,
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
@@ -266,19 +259,19 @@ async fn users_grants_for_resource_id(
 ) -> Result<Json<Vec<SubjectGrant>>> {
     // Validate pagination params
     let mut skip = (page - 1) * page_size;
-
-    // One must be able to interact with the resource in order to
-    // consult who has access to it.
-    authn
-        .authorizer()?
-        .authorize_infra_read(&authz::Infra(resource_id))
-        .await?
-        .allowed()?;
-
     let mut result: Vec<SubjectGrant> = Vec::new();
 
     match resource_type {
         Resource::Infra => {
+            // One must be able to interact with the resource in order to
+            // consult who has access to it.
+            auth.check_authorization(async |authorizer| {
+                authorizer
+                    .authorize_infra_read(&authz::Infra(resource_id))
+                    .await
+            })
+            .await?;
+
             // Work on infra owners
             if result.len() < page_size as usize {
                 let owners = regulator
@@ -355,7 +348,7 @@ async fn users_grants_for_resource_id(
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
 #[cfg_attr(test, derive(Debug, Deserialize))]
-enum InfraPrivilege {
+pub enum InfraPrivilege {
     CanRead,
     CanShareRead,
     CanWrite,

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -4,7 +4,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use serde::Deserialize;
 use thiserror::Error;
@@ -72,22 +72,32 @@ async fn attached(
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<HashMap<ObjectType, Vec<String>>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    // Check that infra exists
     let mut conn = db_pool.get().await?;
     // TODO: lock for share
     #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(&mut conn, infra_id, || InfraApiError::NotFound { infra_id })
             .await?;
-    let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     // Check track existence
+    let infra_cache = InfraCache::get_or_load(&mut conn, &infra_caches, &infra).await?;
     if !infra_cache.track_sections().contains_key(&track_id) {
         return Err(AttachedError::TrackNotFound {
             track_id: track_id.clone(),

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -5,7 +5,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use itertools::Itertools as _;
 use thiserror::Error;
@@ -93,7 +93,7 @@ async fn list_auto_fixes(
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<Operation>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -105,6 +105,14 @@ async fn list_auto_fixes(
     #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
 
     // accepting the early release of ReadGuard as it's anyway released when sending the suggestions (so before edit)
     let mut infra_cache_clone = InfraCache::get_or_load(conn, &infra_caches, &infra)

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -12,7 +12,7 @@ use axum::Extension;
 use axum::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
@@ -143,25 +143,32 @@ async fn delimited_area(
 ) -> Result<Json<DelimitedAreaResponse>> {
     // TODO in case of a missing exit, return an empty list of track ranges instead of returning all
     // the track ranges explored until the stopping condition ?
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     // Retrieve the infra
-
     let conn = &mut db_pool.get().await?;
     #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let infra_cache = InfraCache::get_or_load(conn, &infra_caches, &infra).await?;
     let graph = Graph::load(&infra_cache);
 
     // Validate user input
-
     let (valid_entries, invalid_entries): (Vec<_>, Vec<_>) =
         entries
             .into_iter()

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -2,7 +2,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_schemas::infra::ApplicableDirectionsTrackRange;
 use editoast_schemas::infra::DirectionalTrackRange;
@@ -84,11 +84,10 @@ async fn edit(
     Extension(auth): AuthenticationExt,
     Json(operations): Json<Vec<Operation>>,
 ) -> Result<Json<Vec<InfraObject>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -98,6 +97,15 @@ async fn edit(
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_write(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let mut infra_cache =
         InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
     let operation_results = apply_edit(
@@ -140,11 +148,11 @@ pub async fn split_track_section(
     Extension(auth): AuthenticationExt,
     Json(payload): Json<TrackOffset>,
 ) -> Result<Json<Vec<String>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -160,6 +168,15 @@ pub async fn split_track_section(
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_write(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let mut infra_cache =
         InfraCache::get_or_load_mut(&mut db_pool.get().await?, &infra_caches, &infra).await?;
 

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -5,7 +5,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_schemas::primitives::Identifier;
 use serde::Deserialize;
@@ -81,11 +81,11 @@ async fn list_errors(
         object_id,
     }): Query<ErrorListQueryParams>,
 ) -> Result<Json<ErrorListResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -99,6 +99,14 @@ async fn list_errors(
     #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
 
     let (results, total_count) = infra
         .get_paginated_errors(conn, level, error_type, object_id, page, page_size)

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -2,7 +2,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::TrackSection;
@@ -46,11 +46,11 @@ async fn get_line_bbox(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<BoundingBox>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -60,6 +60,14 @@ async fn get_line_bbox(
     #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
 
     let mut bbox = BoundingBox::default();
     let selection_settings =

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -16,7 +16,7 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::model;
 use editoast_osrdyne_client::OsrdyneClient;
@@ -29,6 +29,7 @@ use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use super::Authentication;
 use super::AuthenticationExt;
 use super::pagination::PaginationStats;
 use super::params::List;
@@ -151,9 +152,8 @@ async fn refresh(
     Query(query_params): Query<RefreshQueryParams>,
 ) -> Result<Json<RefreshResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
@@ -224,22 +224,28 @@ async fn list(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    Query(pagination_params): Query<PaginationQueryParams<1000>>,
+    Query(pagination): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<InfraListResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let settings = pagination_params.into_selection_settings();
+    let conn = &mut db_pool.get().await?;
 
-    let (infras, stats) = {
-        let conn = &mut db_pool.get().await?;
-        Infra::list_paginated(conn, settings).await?
+    let default_settings = pagination.into_selection_settings();
+    let settings = match auth.list_authorized_infra().await? {
+        authz::Authorization::Granted(infras) => default_settings
+            .filter(move || Infra::ID.eq_any(infras.iter().map(|infra| infra.0).collect())),
+        authz::Authorization::Bypassed => default_settings,
+        authz::Authorization::Denied { reason } => {
+            unreachable!("user is authenticated at this point: {reason}")
+        }
     };
+
+    let (infras, stats) = Infra::list_paginated(conn, settings).await?;
 
     let infra_states = fetch_all_infra_states(&infras, osrdyne_client.as_ref()).await?;
 
@@ -319,11 +325,11 @@ async fn get(
     Extension(auth): AuthenticationExt,
     Path(infra): Path<InfraIdParam>,
 ) -> Result<Json<InfraWithState>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -333,6 +339,15 @@ async fn get(
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let state = fetch_infra_state(infra.id, osrdyne_client.as_ref()).await?;
     Ok(Json(InfraWithState { infra, state }))
 }
@@ -362,12 +377,14 @@ impl From<InfraCreateForm> for Changeset<Infra> {
     ),
 )]
 async fn create(
-    State(db_pool): State<DbConnectionPoolV2>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
     Extension(auth): AuthenticationExt,
     Json(infra_form): Json<InfraCreateForm>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -376,6 +393,18 @@ async fn create(
 
     let infra: Changeset<Infra> = infra_form.into();
     let infra = infra.create(&mut db_pool.get().await?).await?;
+
+    // Assing OWNER to the user on the infra if authz is enabled
+    // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on grant_infra_owner
+    if let Authentication::Authenticated(authorizer) = auth {
+        regulator
+            .grant_infra_owner_unchecked(
+                &authz::User(authorizer.user_id()),
+                &authz::Infra(infra.id),
+            )
+            .await?;
+    }
+
     Ok((StatusCode::CREATED, Json(infra)))
 }
 
@@ -398,26 +427,49 @@ struct CloneQuery {
 )]
 async fn clone(
     Extension(auth): AuthenticationExt,
-    Path(params): Path<InfraIdParam>,
-    State(db_pool): State<DbConnectionPoolV2>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
+    State(AppState {
+        db_pool, regulator, ..
+    }): State<AppState>,
     Query(CloneQuery { name }): Query<CloneQuery>,
 ) -> Result<Json<i64>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+    // check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
 
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, params.infra_id, || InfraApiError::NotFound {
-        infra_id: params.infra_id,
-    })
-    .await?;
+    let infra =
+        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.clone()
+        .check_authorization(async |authorizer| {
+            authorizer
+                .authorize_infra_read(&authz::Infra(infra_id))
+                .await
+        })
+        .await?;
+
     let cloned_infra = infra.clone(conn, name).await?;
+
+    // Assing OWNER to the user on the infra if authz is enabled
+    // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on grant_infra_owner
+    if let Authentication::Authenticated(authorizer) = auth {
+        regulator
+            .grant_infra_owner_unchecked(
+                &authz::User(authorizer.user_id()),
+                &authz::Infra(cloned_infra.id),
+            )
+            .await?;
+    }
+
     Ok(Json(cloned_infra.id))
 }
 
@@ -444,13 +496,22 @@ async fn delete(
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_delete(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
 
     if Infra::fast_delete_static(db_pool.get().await?, infra_id).await? {
         Ok(StatusCode::NO_CONTENT)
@@ -489,7 +550,7 @@ async fn put(
     Json(patch): Json<InfraPatchForm>,
 ) -> Result<Json<Infra>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -518,21 +579,27 @@ async fn put(
 async fn get_switch_types(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<Json<Vec<SwitchType>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
 
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
-        infra_id: infra.infra_id,
+    let infra =
+        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -567,25 +634,32 @@ async fn get_switch_types(
 )]
 async fn get_speed_limit_tags(
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
     State(builtin_tags): State<Arc<SpeedLimitTagIds>>,
 ) -> Result<Json<HashSet<String>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     let conn = &mut db_pool.get().await?;
 
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
-        infra_id: infra.infra_id,
+    let infra =
+        Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
+
     let infra_tags = infra.get_speed_limit_tags(conn).await?;
     let union_tags: HashSet<String> = infra_tags
         .into_iter()
@@ -615,26 +689,32 @@ struct GetVoltagesQueryParams {
 )]
 async fn get_voltages(
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(param): Query<GetVoltagesQueryParams>,
     State(db_pool): State<DbConnectionPoolV2>,
 ) -> Result<Json<Vec<String>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra.infra_id, || {
-        InfraApiError::NotFound {
-            infra_id: infra.infra_id,
-        }
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+        InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let voltages = infra
         .get_voltages(&mut db_pool.get().await?, include_rolling_stock_modes)
         .await?;
@@ -655,7 +735,7 @@ async fn get_all_voltages(
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<Vec<String>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -672,6 +752,7 @@ async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) ->
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
     infra.locked = locked;
     infra.save(&mut db_pool.get().await?).await?;
     Ok(())
@@ -689,18 +770,26 @@ async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) ->
 )]
 async fn lock(
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    set_locked(infra.infra_id, true, db_pool).await?;
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_write(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
+    set_locked(infra_id, true, db_pool).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -716,18 +805,26 @@ async fn lock(
 )]
 async fn unlock(
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     State(db_pool): State<DbConnectionPoolV2>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    set_locked(infra.infra_id, false, db_pool).await?;
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_write(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
+    set_locked(infra_id, false, db_pool).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -748,22 +845,30 @@ async fn load(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    Path(path): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra_id = path.infra_id;
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let infra_request = InfraLoadRequest {
         infra: infra.id,
         expected_version: infra.version,

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -5,7 +5,7 @@ use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::primitives::ObjectType;
@@ -57,21 +57,20 @@ struct ObjectTypeParam {
     )
 )]
 async fn get_objects(
-    Path(infra_id_param): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Path(object_type_param): Path<ObjectTypeParam>,
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Json(obj_ids): Json<Vec<String>>,
 ) -> Result<Json<Vec<ObjectQueryable>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let infra_id = infra_id_param.infra_id;
     if !has_unique_ids(&obj_ids) {
         return Err(GetObjectsErrors::DuplicateIdsProvided.into());
     }
@@ -81,6 +80,15 @@ async fn get_objects(
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let objects = infra
         .get_objects(
             &mut db_pool.get().await?,
@@ -135,17 +143,26 @@ async fn list_objects_ids(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<ListObjectsResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -6,7 +6,7 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use derivative::Derivative;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use pathfinding::prelude::yen;
 use serde::Deserialize;
@@ -102,20 +102,19 @@ async fn pathfinding_view(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    Path(infra): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Query(params): Query<QueryParam>,
     Json(input): Json<InfraPathfindingInput>,
 ) -> Result<Json<Vec<PathfindingOutput>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
     // Parse and check input
-    let infra_id = infra.infra_id;
     let number = params.number.unwrap_or(DEFAULT_NUMBER_OF_PATHS);
     if !(1..=MAX_NUMBER_OF_PATHS).contains(&number) {
         return Err(PathfindingViewErrors::InvalidNumberOfPaths {
@@ -131,6 +130,15 @@ async fn pathfinding_view(
         InfraApiError::NotFound { infra_id }
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let infra_cache =
         InfraCache::get_or_load(&mut db_pool.get().await?, &infra_caches, &infra).await?;
 

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -6,7 +6,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::http::header;
 use axum::response::IntoResponse;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_schemas::infra::RailJson;
 use enum_map::EnumMap;
 use futures::future::try_join_all;
@@ -21,6 +21,7 @@ use crate::error::Result;
 use crate::infra_cache::InfraCache;
 use crate::models::Infra;
 use crate::models::prelude::*;
+use crate::views::Authentication;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::infra::InfraApiError;
@@ -48,11 +49,11 @@ async fn get_railjson(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<impl IntoResponse> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -60,6 +61,14 @@ async fn get_railjson(
     #[expect(deprecated)]
     let infra_meta = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -162,6 +171,7 @@ async fn post_railjson(
     State(AppState {
         db_pool,
         infra_caches,
+        regulator,
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
@@ -169,9 +179,8 @@ async fn post_railjson(
     Json(railjson): Json<RailJson>,
 ) -> Result<Json<PostRailjsonResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
+        .check_roles([authz::Role::OperationalStudies].into())
+        .await?;
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
@@ -182,6 +191,17 @@ async fn post_railjson(
         .persist(railjson, &mut db_pool.get().await?)
         .await?;
     let infra_id = infra.id;
+
+    // Assing OWNER to the user on the infra if authz is enabled
+    // NOTE: we use the regulator here instead of the one in the authorizer to bypass the checks on can_share_ownership
+    if let Authentication::Authenticated(authorizer) = auth {
+        regulator
+            .grant_infra_owner_unchecked(
+                &authz::User(authorizer.user_id()),
+                &authz::Infra(infra.id),
+            )
+            .await?;
+    }
 
     infra
         .bump_version(&mut db_pool.get().await?)

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -3,7 +3,7 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::RoutePath;
 use serde::Deserialize;
@@ -70,11 +70,11 @@ async fn get_routes_from_waypoint(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<RoutesResponse>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
-        .await
-        .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
+        .await?;
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -83,6 +83,14 @@ async fn get_routes_from_waypoint(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, path.infra_id, || InfraApiError::NotFound {
         infra_id: path.infra_id,
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(path.infra_id))
+            .await
     })
     .await?;
 
@@ -155,11 +163,12 @@ async fn get_routes_track_ranges(
     Path(infra): Path<i64>,
     Query(params): Query<RouteTrackRangesParams>,
 ) -> Result<Json<Vec<RouteTrackRangesResult>>> {
-    let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+    // Check user roles
+    let has_role = auth
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
-    if !authorized {
+    if !has_role {
         return Err(AuthorizationError::Forbidden.into());
     }
 
@@ -169,6 +178,14 @@ async fn get_routes_track_ranges(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -218,11 +235,11 @@ async fn get_routes_nodes(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    Path(params): Path<InfraIdParam>,
+    Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
     Json(node_states): Json<HashMap<String, Option<String>>>,
 ) -> Result<Json<RoutesFromNodesPositions>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -230,10 +247,16 @@ async fn get_routes_nodes(
     }
 
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, params.infra_id, || {
-        InfraApiError::NotFound {
-            infra_id: params.infra_id,
-        }
+    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
+        InfraApiError::NotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -24,6 +24,8 @@ pub mod work_schedules;
 
 #[cfg(test)]
 mod test_app;
+use editoast_authz::Authorization;
+use editoast_authz::Infra;
 use editoast_authz::StorageDriver;
 use editoast_common::Version;
 #[cfg(test)]
@@ -197,6 +199,38 @@ impl Authentication {
             Authentication::Authenticated(authorizer) => {
                 authorizer.check_roles(required_roles).await
             }
+        }
+    }
+
+    /// Function wrapper that allows you to check if the issuer of the request has the good privilege, grant, role....
+    /// If the request is unauthenticated, it will return an Unauthorized error, and for the SkipAuthorization.
+    /// The provided function will be called with the authorizer and its result will be checked by the allowed() method.
+    /// In case of error, a Forbidden error will be returned.
+    /// How to use it: `auth.check_authorization(async |authorizer| authorizer.authorize_infra_delete(infra_id).await).await?;`
+    async fn check_authorization<E: Into<AuthorizationError>>(
+        self,
+        f: impl AsyncFnOnce(Authorizer<PgAuthDriver>) -> Result<Authorization<()>, E>,
+    ) -> Result<(), AuthorizationError> {
+        match self {
+            Authentication::SkipAuthorization { .. } => Ok(()),
+            Authentication::Unauthenticated => Err(AuthorizationError::Unauthorized),
+            Authentication::Authenticated(authorizer) => f(authorizer)
+                .await
+                .map_err(Into::into)?
+                .allowed()
+                .map_err(|_| AuthorizationError::Forbidden),
+        }
+    }
+
+    /// Retuns the list of infra IDs that the issuer of the request is authorized to read.
+    /// If user has full access (in case of admin or skip authorization), it return a Bypassed with an empty list
+    async fn list_authorized_infra(&self) -> Result<Authorization<Vec<Infra>>, AuthorizerError> {
+        match self {
+            Authentication::SkipAuthorization { .. } => Ok(Authorization::Bypassed),
+            Authentication::Unauthenticated => Ok(Authorization::Denied {
+                reason: "user is not authenticated",
+            }),
+            Authentication::Authenticated(authorizer) => authorizer.list_authorized_infra().await,
         }
     }
 

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -41,6 +41,7 @@ use crate::views::AuthorizationError;
 use crate::views::get_app_version;
 use crate::views::path::PathfindingError;
 use crate::views::path::path_item_cache::PathItemCache;
+use editoast_authz as authz;
 use editoast_models::DbConnection;
 
 crate::routes! {
@@ -210,6 +211,14 @@ async fn post(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
         infra_id,
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 

--- a/editoast/src/views/path/properties.rs
+++ b/editoast/src/views/path/properties.rs
@@ -5,6 +5,7 @@
 //! - If a user requests only the slopes, the core will only compute the slopes and editoast will cache the result.
 //! - Then if the user requests the curves and slopes, editoast will retrieve the slopes from the cache and ask the core to compute the curves.
 
+use axum::Extension;
 use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::State;
@@ -31,7 +32,9 @@ use crate::core::path_properties::PropertyValuesF64;
 use crate::core::path_properties::PropertyZoneValues;
 use crate::core::pathfinding::TrackRange;
 use crate::error::Result;
+use crate::views::AuthenticationExt;
 use crate::views::path::retrieve_infra_version;
+use editoast_authz as authz;
 use editoast_common::geometry::GeoJsonLineString;
 use editoast_schemas::infra::OperationalPointExtensions;
 use editoast_schemas::infra::OperationalPointPart;
@@ -169,6 +172,7 @@ async fn post(
         core_client,
         ..
     }): State<AppState>,
+    Extension(auth): AuthenticationExt,
     Path(infra_id): Path<i64>,
     QsQuery(props): QsQuery<Props>,
     Json(path_properties_input): Json<PathPropertiesInput>,
@@ -176,6 +180,15 @@ async fn post(
     // Extract information from parameters
     let conn = &mut db_pool.get().await?;
     let infra_version = retrieve_infra_version(conn, infra_id).await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let query_props: Properties = props.into();
     let mut valkey_conn = valkey.get_connection().await?;
 

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -2,7 +2,7 @@ use axum::Extension;
 use axum::Json;
 use axum::extract::Query;
 use axum::extract::State;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use serde::Deserialize;
@@ -75,7 +75,7 @@ async fn list_stdcm_logs(
     Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<StdcmLogListResponse>> {
     let authorized = auth
-        .check_roles([Role::Admin].into())
+        .check_roles([authz::Role::Admin].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -120,7 +120,7 @@ async fn stdcm_log_by_id_or_trace_id(
     Query(StdcmLogParams { id, trace_id }): Query<StdcmLogParams>,
 ) -> Result<Json<StdcmLog>> {
     let authorized = auth
-        .check_roles([Role::Admin].into())
+        .check_roles([authz::Role::Admin].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -156,8 +156,7 @@ mod tests {
 
     use axum::http::StatusCode;
     use chrono::DateTime;
-    use editoast_authz::Role;
-    use editoast_authz::subject;
+    use editoast_authz as authz;
     use editoast_schemas::train_schedule::Comfort;
     use editoast_schemas::train_schedule::MarginValue;
     use editoast_schemas::train_schedule::OperationalPointIdentifier;
@@ -319,9 +318,17 @@ mod tests {
         }
     }
 
-    async fn execute_stdcm_request(app: &TestApp, user: Option<&subject::User>) -> String {
-        let small_infra = create_small_infra(&mut app.db_pool().get_ok()).await;
+    async fn execute_stdcm_request(app: &TestApp, user: Option<&authz::subject::User>) -> String {
         let timetable = create_timetable(&mut app.db_pool().get_ok()).await;
+        // create an infra and add the provided user as infra owner
+        let small_infra = create_small_infra(&mut app.db_pool().get_ok()).await;
+        if let Some(user) = user {
+            app.regulator()
+                .grant_infra_owner_unchecked(&authz::User(user.id), &authz::Infra(small_infra.id))
+                .await
+                .expect("Failed to grant infra owner");
+        }
+
         let rolling_stock =
             create_fast_rolling_stock(&mut app.db_pool().get_ok(), &Uuid::new_v4().to_string())
                 .await;
@@ -352,7 +359,10 @@ mod tests {
             .enable_telemetry(true)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let trace_id = execute_stdcm_request(&app, Some(&user)).await;
         let request = app.get("/stdcm_logs").by_user(&user);
         let stdcm_logs_response: StdcmLogListResponse =
@@ -371,7 +381,10 @@ mod tests {
             .enable_telemetry(true)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let trace_id = execute_stdcm_request(&app, Some(&user)).await;
         let request = app
             .get(format!("/stdcm_log?trace_id={trace_id}").as_str())
@@ -389,7 +402,10 @@ mod tests {
             .enable_telemetry(true)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let _ = execute_stdcm_request(&app, Some(&user)).await;
         let request = app
             .get("/stdcm_log?trace_id=not_existing_trace_id")
@@ -406,7 +422,10 @@ mod tests {
             .enable_telemetry(true)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let _ = execute_stdcm_request(&app, Some(&user)).await;
         let request = app.get("/stdcm_log?id=0").by_user(&user);
         app.fetch(request).assert_status(StatusCode::NOT_FOUND);
@@ -421,7 +440,10 @@ mod tests {
             .enable_telemetry(true)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let _ = execute_stdcm_request(&app, Some(&user)).await;
         let request = app.get("/stdcm_log").by_user(&user);
         app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
@@ -438,9 +460,10 @@ mod tests {
             .build();
         let user = app
             .user("bob", "Bob")
-            .with_roles([Role::Stdcm]) // only available to admins
+            .with_roles([authz::Role::Stdcm]) // only available to admins
             .create();
         let trace_id = execute_stdcm_request(&app, Some(&user)).await;
+
         let request = app
             .get(format!("/stdcm_log?trace_id={trace_id}").as_str())
             .by_user(&user);
@@ -471,7 +494,10 @@ mod tests {
             .enable_telemetry(false)
             .with_rust_log_directive(rust_log())
             .build();
-        let user = app.user("bob", "Bob").with_roles([Role::Admin]).create();
+        let user = app
+            .user("bob", "Bob")
+            .with_roles([authz::Role::Admin])
+            .create();
         let _ = execute_stdcm_request(&app, Some(&user)).await;
         let request = app.get("/stdcm_logs").by_user(&user);
         let stdcm_logs_response: StdcmLogListResponse =

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -334,6 +334,10 @@ impl TestApp {
         self.app_state.db_pool.clone()
     }
 
+    pub fn regulator(&self) -> Regulator {
+        self.app_state.regulator.clone()
+    }
+
     pub fn speed_limit_tag_ids(&self) -> Arc<SpeedLimitTagIds> {
         self.app_state.speed_limit_tag_ids.clone()
     }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -20,7 +20,7 @@ use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Utc;
 use derivative::Derivative;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
@@ -161,7 +161,7 @@ async fn get_train_schedules(
     Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<ListTrainSchedulesResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -198,7 +198,7 @@ async fn post(
     Extension(auth): AuthenticationExt,
 ) -> Result<Json<TimetableResult>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -228,7 +228,7 @@ async fn delete(
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -260,7 +260,7 @@ async fn post_train_schedule(
     Json(train_schedules): Json<Vec<TrainSchedule>>,
 ) -> Result<Json<Vec<TrainScheduleResponse>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -305,7 +305,7 @@ async fn post_paced_train(
     Json(paced_trains): Json<Vec<PacedTrain>>,
 ) -> Result<Json<Vec<PacedTrainResponse>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -356,7 +356,7 @@ async fn get_paced_trains(
     Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<ListPacedTrainsResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -521,7 +521,7 @@ async fn conflicts(
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<Vec<Conflict>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -533,6 +533,14 @@ async fn conflicts(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut conn, infra_id, || TimetableError::InfraNotFound {
         infra_id,
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -8,7 +8,7 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::paced_train::PacedTrain;
@@ -126,7 +126,7 @@ async fn get_by_id(
     Path(PacedTrainIdParam { id: paced_train_id }): Path<PacedTrainIdParam>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -163,7 +163,7 @@ async fn update_paced_train(
     Json(paced_train_base): Json<PacedTrain>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -203,7 +203,7 @@ async fn delete(
     }): Json<PacedTrainIds>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -251,7 +251,7 @@ async fn simulation_summary(
     }): Json<SimulationBatchForm>,
 ) -> Result<Json<HashMap<i64, SummaryResponse>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -263,6 +263,14 @@ async fn simulation_summary(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PacedTrainError::InfraNotFound {
         infra_id,
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -321,7 +329,7 @@ async fn get_path(
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -335,6 +343,15 @@ async fn get_path(
         infra_id,
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     #[expect(deprecated)]
     let paced_train = models::PacedTrain::retrieve_or_fail(conn, paced_train_id, || {
         PacedTrainError::NotFound { paced_train_id }
@@ -382,7 +399,7 @@ async fn simulation(
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -393,6 +410,14 @@ async fn simulation(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -453,7 +478,7 @@ async fn project_path(
     }): Json<ProjectPathForm>,
 ) -> Result<Json<HashMap<i64, ProjectPathTrainResult>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -518,7 +543,7 @@ async fn occupancy_blocks(
     .await?;
 
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -9,7 +9,7 @@ use axum::extract::State;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::primitives::PositiveDuration;
@@ -162,7 +162,7 @@ async fn stdcm(
     Json(stdcm_request): Json<Request>,
 ) -> Result<Json<StdcmResponse>> {
     let authorized = auth
-        .check_roles([Role::Stdcm].into())
+        .check_roles([authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -189,6 +189,15 @@ async fn stdcm(
         infra_id,
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.clone()
+        .check_authorization(async |authorizer| {
+            authorizer
+                .authorize_infra_read(&authz::Infra(infra_id))
+                .await
+        })
+        .await?;
 
     #[expect(deprecated)]
     let rolling_stock =

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -7,7 +7,7 @@ use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use editoast_authz::Role;
+use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::train_schedule::TrainSchedule;
@@ -158,7 +158,7 @@ async fn get(
     }): Path<TrainScheduleIdParam>,
 ) -> Result<Json<TrainScheduleResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -194,7 +194,7 @@ async fn delete(
     Json(TrainScheduleIds { ids: train_ids }): Json<TrainScheduleIds>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -229,7 +229,7 @@ async fn put(
     Json(train_schedule_form): Json<TrainScheduleForm>,
 ) -> Result<Json<TrainScheduleResponse>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -280,7 +280,7 @@ async fn simulation(
     }): Query<ElectricalProfileSetIdQueryParam>,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -291,6 +291,14 @@ async fn simulation(
     #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
+    })
+    .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
     })
     .await?;
 
@@ -351,7 +359,7 @@ async fn simulation_summary(
     }): Json<SimulationBatchForm>,
 ) -> Result<Json<HashMap<i64, SummaryResponse>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -365,6 +373,15 @@ async fn simulation_summary(
         infra_id,
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     let train_schedules: Vec<models::TrainSchedule> =
         models::TrainSchedule::retrieve_batch_or_fail(conn, train_schedule_ids, |missing| {
             TrainScheduleError::BatchTrainScheduleNotFound {
@@ -418,7 +435,7 @@ async fn get_path(
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -433,6 +450,15 @@ async fn get_path(
         infra_id,
     })
     .await?;
+
+    // Check user privilege on infra
+    auth.check_authorization(async |authorizer| {
+        authorizer
+            .authorize_infra_read(&authz::Infra(infra_id))
+            .await
+    })
+    .await?;
+
     #[expect(deprecated)]
     let train_schedule = models::TrainSchedule::retrieve_or_fail(conn, train_schedule_id, || {
         TrainScheduleError::NotFound { train_schedule_id }
@@ -473,7 +499,7 @@ async fn project_path(
     }): Json<ProjectPathForm>,
 ) -> Result<Json<HashMap<i64, ProjectPathTrainResult>>> {
     let authorized = auth
-        .check_roles([Role::OperationalStudies, Role::Stdcm].into())
+        .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {
@@ -533,7 +559,7 @@ async fn occupancy_blocks(
     .await?;
 
     let authorized = auth
-        .check_roles([Role::OperationalStudies].into())
+        .check_roles([authz::Role::OperationalStudies].into())
         .await
         .map_err(AuthorizationError::AuthError)?;
     if !authorized {

--- a/gateway/gateway.bundled.toml
+++ b/gateway/gateway.bundled.toml
@@ -1,4 +1,6 @@
 # This is an example production file. It's meant to be mounted inside the container at /gateway.toml
+# If you change the provider_id of the "Example User", don't forget to change it also on the docker-compose 
+# in the editoast section
 
 secret_key = "NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET++NOT+A+SECRET"
 listen_addr = "0.0.0.0"


### PR DESCRIPTION
Must be merge after #11197

This PR adds the authorization management on the infrastructure. 
It also enable per default the authorization system on editoast. So you have to add the role "Admin"  (or `OperationalStudies`) on your user : 

* In your browser go to http://localhost:4000/api/authz/me and remember your user ID
* In the editoast folder, type the command : ` cargo run roles add 373 Admin` where `373` is your user's ID