### PR TITLE
editoast: rename paced train fields

### DIFF
--- a/editoast/editoast_models/src/tables.rs
+++ b/editoast/editoast_models/src/tables.rs
@@ -452,8 +452,8 @@ diesel::table! {
         speed_limit_tag -> Nullable<Varchar>,
         power_restrictions -> Jsonb,
         options -> Jsonb,
-        duration -> Interval,
-        step -> Interval,
+        time_window -> Interval,
+        interval -> Interval,
     }
 }
 

--- a/editoast/editoast_schemas/src/paced_train.rs
+++ b/editoast/editoast_schemas/src/paced_train.rs
@@ -12,10 +12,10 @@ editoast_common::schemas! {
 pub struct Paced {
     /// Duration of the paced train, an ISO 8601 format is expected
     #[schema(value_type = chrono::Duration, example = "PT2H")]
-    pub duration: PositiveDuration,
+    pub time_window: PositiveDuration,
     /// Time between two occurrences, an ISO 8601 format is expected
     #[schema(value_type = chrono::Duration, example = "PT15M")]
-    pub step: PositiveDuration,
+    pub interval: PositiveDuration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]

--- a/editoast/migrations/2025-03-26-090235_rename_paced_train_fields/down.sql
+++ b/editoast/migrations/2025-03-26-090235_rename_paced_train_fields/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE paced_train RENAME COLUMN interval TO step;
+ALTER TABLE paced_train RENAME COLUMN time_window TO duration;

--- a/editoast/migrations/2025-03-26-090235_rename_paced_train_fields/up.sql
+++ b/editoast/migrations/2025-03-26-090235_rename_paced_train_fields/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE paced_train RENAME COLUMN step TO interval;
+ALTER TABLE paced_train RENAME COLUMN duration TO time_window;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1706,17 +1706,17 @@ paths:
                   paced:
                     type: object
                     required:
-                    - duration
-                    - step
+                    - time_window
+                    - interval
                     properties:
-                      duration:
-                        type: string
-                        description: Duration of the paced train, an ISO 8601 format is expected
-                        example: PT2H
-                      step:
+                      interval:
                         type: string
                         description: Time between two occurrences, an ISO 8601 format is expected
                         example: PT15M
+                      time_window:
+                        type: string
+                        description: Duration of the paced train, an ISO 8601 format is expected
+                        example: PT2H
         required: true
       responses:
         '204':
@@ -8686,17 +8686,17 @@ components:
           paced:
             type: object
             required:
-            - duration
-            - step
+            - time_window
+            - interval
             properties:
-              duration:
-                type: string
-                description: Duration of the paced train, an ISO 8601 format is expected
-                example: PT2H
-              step:
+              interval:
                 type: string
                 description: Time between two occurrences, an ISO 8601 format is expected
                 example: PT15M
+              time_window:
+                type: string
+                description: Duration of the paced train, an ISO 8601 format is expected
+                example: PT2H
     PacedTrainForm:
       allOf:
       - $ref: '#/components/schemas/PacedTrain'

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -102,8 +102,8 @@ pub fn simple_paced_train_base() -> PacedTrain {
     PacedTrain {
         train_schedule_base,
         paced: Paced {
-            duration: ChronoDuration::hours(2).try_into().unwrap(),
-            step: ChronoDuration::minutes(15).try_into().unwrap(),
+            time_window: ChronoDuration::hours(2).try_into().unwrap(),
+            interval: ChronoDuration::minutes(15).try_into().unwrap(),
         },
     }
 }

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -45,10 +45,10 @@ pub struct PacedTrain {
     pub power_restrictions: Vec<PowerRestrictionItem>,
     #[model(json)]
     pub options: TrainScheduleOptions,
-    /// Total duration of the paced train
-    pub duration: ChronoDuration,
+    /// Time window of the paced train
+    pub time_window: ChronoDuration,
     /// Time between two occurrences
-    pub step: ChronoDuration,
+    pub interval: ChronoDuration,
 }
 
 impl PacedTrain {
@@ -94,8 +94,8 @@ impl From<paced_train::PacedTrain> for PacedTrainChangeset {
             .start_time(train_schedule_base.start_time)
             .train_name(train_schedule_base.train_name)
             .options(train_schedule_base.options)
-            .duration(ChronoDuration::from(paced.duration))
-            .step(ChronoDuration::from(paced.step))
+            .time_window(ChronoDuration::from(paced.time_window))
+            .interval(ChronoDuration::from(paced.interval))
     }
 }
 
@@ -118,8 +118,8 @@ impl From<PacedTrain> for paced_train::PacedTrain {
                 options: paced_train.options,
             },
             paced: Paced {
-                duration: paced_train.duration.try_into().unwrap(),
-                step: paced_train.step.try_into().unwrap(),
+                time_window: paced_train.time_window.try_into().unwrap(),
+                interval: paced_train.interval.try_into().unwrap(),
             },
         }
     }

--- a/editoast/src/views/paced_train.rs
+++ b/editoast/src/views/paced_train.rs
@@ -538,8 +538,8 @@ mod tests {
         let paced_train = create_simple_paced_train(&mut pool.get_ok(), timetable.id).await;
 
         let mut paced_train_base = simple_paced_train_base();
-        paced_train_base.paced.duration = Duration::minutes(90).try_into().unwrap();
-        paced_train_base.paced.step = Duration::minutes(15).try_into().unwrap();
+        paced_train_base.paced.time_window = Duration::minutes(90).try_into().unwrap();
+        paced_train_base.paced.interval = Duration::minutes(15).try_into().unwrap();
 
         let request = app
             .put(format!("/paced_train/{}", paced_train.id).as_str())
@@ -620,8 +620,8 @@ mod tests {
                     .expect("Unable to parse")
             },
             paced: Paced {
-                duration: Duration::hours(1).try_into().unwrap(),
-                step: Duration::minutes(15).try_into().unwrap(),
+                time_window: Duration::hours(1).try_into().unwrap(),
+                interval: Duration::minutes(15).try_into().unwrap(),
             },
         };
         let paced_train: PacedTrainChangeset = paced_train_base.into();

--- a/editoast/src/views/path/projection.rs
+++ b/editoast/src/views/path/projection.rs
@@ -86,7 +86,7 @@ impl<'a> PathProjection<'a> {
             let mut left = 0;
             let mut right = self.path.len() - 1;
             while left != right {
-                let mid = (left + right + 1) / 2;
+                let mid = (left + right).div_ceil(2);
                 let mid_track_range = &self.path[mid];
                 let mid_position = self.map_position[&mid_track_range.track_section];
                 if mid_position > position {

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -519,8 +519,8 @@ async fn conflicts(
     let mut paced_trains_ts = vec![];
     for paced_train in paced_trains.clone() {
         let occurrences =
-            (paced_train.duration.num_seconds() / paced_train.step.num_seconds()) as usize;
-        let step = paced_train.step;
+            (paced_train.time_window.num_seconds() / paced_train.interval.num_seconds()) as usize;
+        let interval = paced_train.interval;
         let mut start_time = paced_train.start_time;
 
         let mut all_occurrences = Vec::with_capacity(occurrences);
@@ -529,7 +529,7 @@ async fn conflicts(
             let mut first_occurrence = paced_train.clone().into_first_occurrence();
             first_occurrence.start_time = start_time;
             all_occurrences.push(first_occurrence);
-            start_time += step;
+            start_time += interval;
         }
 
         paced_trains_ts.extend(all_occurrences);
@@ -716,8 +716,8 @@ mod tests {
         let timetable = create_timetable(&mut pool.get_ok()).await;
         let paced_train_1 = simple_paced_train_base();
         let mut paced_train_2 = simple_paced_train_base();
-        paced_train_2.paced.duration = Duration::minutes(120).try_into().unwrap();
-        paced_train_2.paced.step = Duration::seconds(30).try_into().unwrap();
+        paced_train_2.paced.time_window = Duration::minutes(120).try_into().unwrap();
+        paced_train_2.paced.interval = Duration::seconds(30).try_into().unwrap();
 
         let paced_trains = vec![paced_train_1, paced_train_2];
 
@@ -755,8 +755,8 @@ mod tests {
         let paced_train_1 = simple_paced_train_base();
         let mut paced_train_2 = simple_paced_train_base();
         paced_train_2.train_schedule_base.start_time += Duration::minutes(200);
-        paced_train_2.paced.duration = Duration::minutes(120).try_into().unwrap();
-        paced_train_2.paced.step = Duration::seconds(30).try_into().unwrap();
+        paced_train_2.paced.time_window = Duration::minutes(120).try_into().unwrap();
+        paced_train_2.paced.interval = Duration::seconds(30).try_into().unwrap();
 
         let paced_trains = vec![paced_train_1, paced_train_2];
 

--- a/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
+++ b/front/src/applications/operationalStudies/hooks/useSimulationResults.ts
@@ -125,10 +125,10 @@ const useSimulationResults = (): SimulationResultsData => {
     if (!selectedPacedTrain) return undefined;
 
     const selectedOccurrenceIndex = getOccurrenceIndexFromOccurrenceId(selectedTrainId);
-    const pacedTrainStepInMs = Duration.parse(selectedPacedTrain.paced.step).ms;
+    const pacedTrainIntervalInMs = Duration.parse(selectedPacedTrain.paced.interval).ms;
 
     const selectedOccurrenceStartTime: string = dayjs(selectedPacedTrain.start_time)
-      .add(selectedOccurrenceIndex * pacedTrainStepInMs, 'ms')
+      .add(selectedOccurrenceIndex * pacedTrainIntervalInMs, 'ms')
       .toISOString();
 
     const updatedSelectedPacedTrain: PacedTrainResponseWithPacedTrainId = {

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1633,10 +1633,10 @@ export type PutPacedTrainByIdApiArg = {
   id: number;
   body: TrainSchedule & {
     paced: {
-      /** Duration of the paced train, an ISO 8601 format is expected */
-      duration: string;
       /** Time between two occurrences, an ISO 8601 format is expected */
-      step: string;
+      interval: string;
+      /** Duration of the paced train, an ISO 8601 format is expected */
+      time_window: string;
     };
   };
 };
@@ -3273,10 +3273,10 @@ export type TrainSchedule = {
 };
 export type PacedTrain = TrainSchedule & {
   paced: {
-    /** Duration of the paced train, an ISO 8601 format is expected */
-    duration: string;
     /** Time between two occurrences, an ISO 8601 format is expected */
-    step: string;
+    interval: string;
+    /** Duration of the paced train, an ISO 8601 format is expected */
+    time_window: string;
   };
 };
 export type PacedTrainResponse = PacedTrain & {

--- a/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
+++ b/front/src/modules/simulationResult/helpers/formatTimetableItemSummaries.ts
@@ -91,8 +91,8 @@ const formatTimetableItemSummaries = (
       return {
         ...formattedItem,
         paced: {
-          duration: Duration.parse(formattedItem.paced.duration),
-          step: Duration.parse(formattedItem.paced.step),
+          timeWindow: Duration.parse(formattedItem.paced.time_window),
+          interval: Duration.parse(formattedItem.paced.interval),
         },
       };
     }

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatTimetableItemPayload.ts
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/helpers/formatTimetableItemPayload.ts
@@ -28,8 +28,8 @@ export function formatPacedTrainPayload(validConfig: ValidConfig): PacedTrain {
   return {
     ...baseTrain,
     paced: {
-      duration: validConfig.timeRangeDuration,
-      step: validConfig.cadence,
+      time_window: validConfig.timeRangeDuration,
+      interval: validConfig.cadence,
     },
   };
 }

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/PacedTrainItem.tsx
@@ -224,7 +224,7 @@ const PacedTrainItem = ({
           <div className="paced-train-right-zone">
             {pacedTrain.isValid && (
               <div data-testid="paced-train-cadence">
-                &mdash;&nbsp;{`${ms2min(pacedTrain.paced.step.ms)}min`}
+                &mdash;&nbsp;{`${ms2min(pacedTrain.paced.interval.ms)}min`}
               </div>
             )}
             <div

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrences.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrences.tsx
@@ -27,10 +27,10 @@ const useOccurrences = ({
 
     for (let i = 0; i < occurrencesCount; i += 1) {
       const occurrenceStartTime = dayjs(startTime)
-        .add(i * paced.step.ms, 'ms')
+        .add(i * paced.interval.ms, 'ms')
         .toDate();
       const occurrenceArrivalTime = dayjs(arrivalTime)
-        .add(i * paced.step.ms, 'ms')
+        .add(i * paced.interval.ms, 'ms')
         .toDate();
       computedOccurrences.push({
         id: formatPacedTrainIdToOccurrenceId(id, i),
@@ -41,7 +41,7 @@ const useOccurrences = ({
       });
     }
     return { occurrencesCount, occurrences: computedOccurrences };
-  }, [paced.duration, paced.step, startTime, arrivalTime, name, id, rollingStock]);
+  }, [paced.timeWindow, paced.interval, startTime, arrivalTime, name, id, rollingStock]);
 
   return occurrencesState;
 };

--- a/front/src/modules/trainschedule/components/Timetable/types.ts
+++ b/front/src/modules/trainschedule/components/Timetable/types.ts
@@ -53,8 +53,8 @@ export type TrainScheduleWithDetails = TimetableItemWithSummaries & {
 export type PacedTrainWithDetails = TimetableItemWithSummaries & {
   id: PacedTrainId;
   paced: {
-    duration: Duration;
-    step: Duration;
+    timeWindow: Duration;
+    interval: Duration;
   };
 };
 

--- a/front/src/modules/trainschedule/helpers/__tests__/pacedTrain.spec.ts
+++ b/front/src/modules/trainschedule/helpers/__tests__/pacedTrain.spec.ts
@@ -5,33 +5,33 @@ import { Duration } from 'utils/duration';
 import { getOccurrencesNb } from '../pacedTrain';
 
 describe('getOccurrencesNb', () => {
-  it('should properly compute occurrence nb for duration of 2h and step of 30min', () => {
+  it('should properly compute occurrence nb for time window of 2h and interval of 30min', () => {
     expect(
-      getOccurrencesNb({ duration: Duration.parse('PT2H'), step: Duration.parse('PT30M') })
+      getOccurrencesNb({ timeWindow: Duration.parse('PT2H'), interval: Duration.parse('PT30M') })
     ).toEqual(4);
   });
 
-  it('should properly compute occurrence nb for duration of 30min and step of 20min', () => {
+  it('should properly compute occurrence nb for time window of 30min and interval of 20min', () => {
     expect(
-      getOccurrencesNb({ duration: Duration.parse('PT30M'), step: Duration.parse('PT20M') })
+      getOccurrencesNb({ timeWindow: Duration.parse('PT30M'), interval: Duration.parse('PT20M') })
     ).toEqual(2);
   });
 
-  it('should properly compute occurrence nb for duration of 20min and step of 30min', () => {
+  it('should properly compute occurrence nb for time window of 20min and interval of 30min', () => {
     expect(
-      getOccurrencesNb({ duration: Duration.parse('PT20M'), step: Duration.parse('PT30M') })
+      getOccurrencesNb({ timeWindow: Duration.parse('PT20M'), interval: Duration.parse('PT30M') })
     ).toEqual(1);
   });
 
-  it('should properly compute occurrence nb for duration of 0h and step of 30min', () => {
+  it('should properly compute occurrence nb for time window of 0h and interval of 30min', () => {
     expect(
-      getOccurrencesNb({ duration: Duration.parse('PT0S'), step: Duration.parse('PT30M') })
+      getOccurrencesNb({ timeWindow: Duration.parse('PT0S'), interval: Duration.parse('PT30M') })
     ).toEqual(0);
   });
 
-  it('should properly compute occurrence nb for duration of 2h and step of 0min', () => {
+  it('should properly compute occurrence nb for time window of 2h and interval of 0min', () => {
     expect(() =>
-      getOccurrencesNb({ duration: Duration.parse('PT2H'), step: Duration.parse('PT0S') })
-    ).toThrow('Step cannot be 0');
+      getOccurrencesNb({ timeWindow: Duration.parse('PT2H'), interval: Duration.parse('PT0S') })
+    ).toThrow('Interval cannot be 0');
   });
 });

--- a/front/src/modules/trainschedule/helpers/pacedTrain.ts
+++ b/front/src/modules/trainschedule/helpers/pacedTrain.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 import type { PacedTrainWithDetails } from '../components/Timetable/types';
 
-export const getOccurrencesNb = ({ duration, step }: PacedTrainWithDetails['paced']) => {
-  if (step.ms === 0) {
-    throw new Error('Step cannot be 0');
+export const getOccurrencesNb = ({ timeWindow, interval }: PacedTrainWithDetails['paced']) => {
+  if (interval.ms === 0) {
+    throw new Error('Interval cannot be 0');
   }
-  return Math.ceil(duration.ms / step.ms);
+  return Math.ceil(timeWindow.ms / interval.ms);
 };

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -121,8 +121,8 @@ describe('simulationConfReducer', () => {
         isValid: true,
         options: { use_electrical_profiles: false },
         paced: {
-          duration: new Duration({ minutes: 60 }),
-          step: new Duration({ minutes: 30 }),
+          timeWindow: new Duration({ minutes: 60 }),
+          interval: new Duration({ minutes: 30 }),
         },
       };
 

--- a/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/index.ts
@@ -79,8 +79,8 @@ export const operationalStudiesConfSlice = createSlice({
 
       if (isPacedTrainWithDetails(action.payload)) {
         state.editingTrainIsPacedTrain = true;
-        state.timeRangeDuration = action.payload.paced.duration;
-        state.cadence = action.payload.paced.step;
+        state.timeRangeDuration = action.payload.paced.timeWindow;
+        state.cadence = action.payload.paced.interval;
       } else {
         state.editingTrainIsPacedTrain = false;
         state.timeRangeDuration = new Duration({ minutes: 120 });

--- a/front/tests/assets/paced-train/paced_trains.json
+++ b/front/tests/assets/paced-train/paced_trains.json
@@ -24,7 +24,7 @@
     "speed_limit_tag": null,
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true },
-    "paced": { "duration": "PT2H", "step": "PT1H" }
+    "paced": { "time_window": "PT2H", "interval": "PT1H" }
   },
   {
     "train_name": "Paced Train 2",
@@ -51,7 +51,7 @@
     "speed_limit_tag": null,
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true },
-    "paced": { "duration": "PT2H", "step": "PT30M" }
+    "paced": { "time_window": "PT2H", "interval": "PT30M" }
   },
   {
     "train_name": "PacedTrain3",
@@ -86,7 +86,7 @@
     "speed_limit_tag": "HLP",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": false },
-    "paced": { "duration": "PT2H", "step": "PT50M" }
+    "paced": { "time_window": "PT2H", "interval": "PT50M" }
   },
   {
     "train_name": "PacedTrain4",
@@ -114,6 +114,6 @@
     "speed_limit_tag": "MA100",
     "power_restrictions": [],
     "options": { "use_electrical_profiles": true },
-    "paced": { "duration": "PT2H", "step": "PT1H" }
+    "paced": { "time_window": "PT2H", "interval": "PT1H" }
   }
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,8 +298,8 @@ def west_to_south_east_paced_train(
                 "speed_limit_tag": "foo",
                 "start_time": "2024-01-01T07:19:54+00:00",
                 "paced": {
-                    "duration": "PT2H",
-                    "step": "PT15M",
+                    "time_window": "PT2H",
+                    "interval": "PT15M",
                 },
             }
         ],
@@ -333,24 +333,24 @@ def west_to_south_east_paced_trains(
                 **base,
                 "start_time": "2024-01-01T07:19:54+00:00",
                 "paced": {
-                    "duration": "PT2H",
-                    "step": "PT15M",
+                    "time_window": "PT2H",
+                    "interval": "PT15M",
                 },
             },
             {
                 **base,
                 "start_time": "2024-01-01T10:29:54+00:00",
                 "paced": {
-                    "duration": "PT2H",
-                    "step": "PT15M",
+                    "time_window": "PT2H",
+                    "interval": "PT15M",
                 },
             },
             {
                 **base,
                 "start_time": "2024-01-01T13:39:59+00:00",
                 "paced": {
-                    "duration": "PT2H",
-                    "step": "PT15M",
+                    "time_window": "PT2H",
+                    "interval": "PT15M",
                 },
             },
         ],

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -72,7 +72,7 @@ def test_conflicts(
 
     stopping_paced_train_payload = stopping_train_schedule_payload[0]
     stopping_paced_train_payload["start_time"] = "2024-05-22T08:05:00.000Z"
-    stopping_paced_train_payload["paced"] = {"duration": "PT2H", "step": "PT15M"}
+    stopping_paced_train_payload["paced"] = {"time_window": "PT2H", "interval": "PT15M"}
 
     stopping_paced_train_response = requests.post(
         f"{EDITOAST_URL}/timetable/{timetable_id}/paced_trains",


### PR DESCRIPTION
This PR helps to unify front and back naming for the paced train model. 
We've chosen `time_window` instead of `duration` and `interval` instead of `step`. 