### PR TITLE
front: show occurrence name in conflict list

### DIFF
--- a/front/src/modules/conflict/components/ConflictsList.tsx
+++ b/front/src/modules/conflict/components/ConflictsList.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import type { Conflict } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
+import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
 
 import ConflictCard from './ConflictCard';
 import type { ConflictWithTrainNames } from '../types';
@@ -14,7 +14,7 @@ import addTrainNamesToConflicts from '../utils';
 type ConflictsListProps = {
   conflicts: Conflict[];
   expanded: boolean;
-  trainSchedulesDetails: TrainScheduleWithDetails[];
+  timetableItems: TimetableItemWithDetails[];
   toggleConflictsList: () => void;
   onConflictClick: (conflict: ConflictWithTrainNames) => void;
 };
@@ -22,14 +22,14 @@ type ConflictsListProps = {
 const ConflictsList = ({
   conflicts,
   expanded,
-  trainSchedulesDetails,
+  timetableItems,
   toggleConflictsList,
   onConflictClick,
 }: ConflictsListProps) => {
   const { t } = useTranslation(['operationalStudies/scenario']);
   const enrichedConflicts = useMemo(
-    () => addTrainNamesToConflicts(conflicts, trainSchedulesDetails),
-    [conflicts, trainSchedulesDetails]
+    () => addTrainNamesToConflicts(conflicts, timetableItems),
+    [conflicts, timetableItems]
   );
   if (conflicts.length === 0) {
     return null;
@@ -52,11 +52,7 @@ const ConflictsList = ({
 
       <div className={cx('conflicts-container', expanded && 'expanded')}>
         {enrichedConflicts.map((conflict, index) => (
-          <ConflictCard
-            key={`${conflict.train_schedule_ids.join(', ')}-${conflict.conflict_type}-${index}`}
-            conflict={conflict}
-            onConflictClick={onConflictClick}
-          />
+          <ConflictCard key={index} conflict={conflict} onConflictClick={onConflictClick} />
         ))}
       </div>
     </div>

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -1,23 +1,40 @@
 import type { Conflict } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleWithDetails } from 'modules/trainschedule/components/Timetable/types';
-import { formatTrainScheduleIdToEditoastTrainId } from 'utils/trainId';
+import type { TimetableItemWithDetails } from 'modules/trainschedule/components/Timetable/types';
+import computeOccurrenceName from 'modules/trainschedule/helpers/computeOccurrenceName';
+import type { TimetableItemId } from 'reducers/osrdconf/types';
+import {
+  formatEditoastTrainIdToTrainScheduleId,
+  formatEditoastTrainIdToPacedTrainId,
+} from 'utils/trainId';
 
 import type { ConflictWithTrainNames } from './types';
 
+function getConflictTrainNames(
+  conflict: Conflict,
+  trainNameMap: Map<TimetableItemId, string>
+): string[] {
+  const trainScheduleNames = conflict.train_schedule_ids.map((id) =>
+    trainNameMap.get(formatEditoastTrainIdToTrainScheduleId(id))
+  );
+  const occurenceNames = conflict.paced_train_occurrence_ids.map(({ paced_train_id, index }) => {
+    const pacedTrainName = trainNameMap.get(formatEditoastTrainIdToPacedTrainId(paced_train_id));
+    if (!pacedTrainName) return undefined;
+    return computeOccurrenceName(pacedTrainName, index);
+  });
+  return [...trainScheduleNames, ...occurenceNames].filter((name) => name !== undefined);
+}
+
 export default function addTrainNamesToConflicts(
   conflicts: Conflict[],
-  trainSchedulesDetails: TrainScheduleWithDetails[]
+  timetableItems: TimetableItemWithDetails[]
 ): ConflictWithTrainNames[] {
-  const trainNameMap: { [id: number]: string } = {};
-
-  trainSchedulesDetails.forEach(({ id, name }) => {
-    // TODO Paced train : Adapt this to handle paced trains in conflict issue
-    const editoastTrainId = formatTrainScheduleIdToEditoastTrainId(id);
-    trainNameMap[editoastTrainId] = name;
-  });
+  const trainNameMap: Map<TimetableItemId, string> = new Map();
+  for (const timetableItem of timetableItems) {
+    trainNameMap.set(timetableItem.id, timetableItem.name);
+  }
 
   return conflicts.map((conflict) => ({
     ...conflict,
-    trainNames: conflict.train_schedule_ids.map((id) => trainNameMap[id] || ''),
+    trainNames: getConflictTrainNames(conflict, trainNameMap),
   }));
 }

--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrences.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/hooks/useOccurrences.tsx
@@ -2,22 +2,10 @@ import { useMemo } from 'react';
 
 import dayjs from 'dayjs';
 
+import computeOccurrenceName from 'modules/trainschedule/helpers/computeOccurrenceName';
 import type { OccurrenceId } from 'reducers/osrdconf/types';
 
 import type { Occurrence, PacedTrainWithDetails } from '../../types';
-
-export const computeOccurrenceName = (pacedTrainName: string, index: number): string => {
-  const endByNumber = /\b\w+\s\d+$/;
-
-  if (endByNumber.test(pacedTrainName)) {
-    const endOfPacedTrainName = Number(pacedTrainName.split(' ').pop());
-    return `${pacedTrainName.replace(/\s\d+$/, '')} ${endOfPacedTrainName + 2 * index}`;
-  }
-  if (!Number.isNaN(+pacedTrainName)) {
-    return `${+pacedTrainName + 2 * index}`;
-  }
-  return `${pacedTrainName} ${2 * index + 1}`;
-};
 
 type OccurrencesState = {
   occurrences: Occurrence[];

--- a/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/Timetable.tsx
@@ -222,12 +222,7 @@ const Timetable = ({
           conflicts={conflicts}
           expanded={conflictsListExpanded}
           toggleConflictsList={toggleConflictsListExpanded}
-          // TODO PACED TRAIN : Adapt this props to handle paced trains in issue
-          trainSchedulesDetails={
-            filteredTimetableItems.filter((timetableItem) =>
-              isTrainSchedule(timetableItem.id)
-            ) as TrainScheduleWithDetails[]
-          }
+          timetableItems={filteredTimetableItems}
           onConflictClick={handleConflictClick}
         />
       )}

--- a/front/src/modules/trainschedule/helpers/computeOccurrenceName.spec.ts
+++ b/front/src/modules/trainschedule/helpers/computeOccurrenceName.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { computeOccurrenceName } from './useOccurrences';
+import computeOccurrenceName from './computeOccurrenceName';
 
 describe('computeOccurrenceName', () => {
   it('should properly compute occurrence name', () => {

--- a/front/src/modules/trainschedule/helpers/computeOccurrenceName.ts
+++ b/front/src/modules/trainschedule/helpers/computeOccurrenceName.ts
@@ -1,0 +1,14 @@
+const computeOccurrenceName = (pacedTrainName: string, index: number): string => {
+  const endByNumber = /\b\w+\s\d+$/;
+
+  if (endByNumber.test(pacedTrainName)) {
+    const endOfPacedTrainName = Number(pacedTrainName.split(' ').pop());
+    return `${pacedTrainName.replace(/\s\d+$/, '')} ${endOfPacedTrainName + 2 * index}`;
+  }
+  if (!Number.isNaN(+pacedTrainName)) {
+    return `${+pacedTrainName + 2 * index}`;
+  }
+  return `${pacedTrainName} ${2 * index + 1}`;
+};
+
+export default computeOccurrenceName;


### PR DESCRIPTION
_See individual commits._

Part of https://github.com/OpenRailAssociation/osrd/issues/10602

To test:

- Create a regular train schedule at 11:00
- Create a paced train at 10:00, every 60min, with the same path
- Conflict card should show both