### PR TITLE
core: stdcm: fix 20s margin bug

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -12,6 +12,12 @@ class IncrementalRequirementEnvelopeAdapter(
     private val rollingStock: PhysicsRollingStock,
     private val envelopeWithStops: EnvelopeInterpolate?,
     override var simulationComplete: Boolean,
+
+    // If set to true, we consider that the train doesn't leave its current stop (yet).
+    // Used to evaluate conflicts up to a stop, including the stop itself,
+    // but without considering the reservation on blocks/routes after the stop
+    // (especially to avoid being bothered by the reservation margin before restarting after a stop
+    // on closed signal).
     private val infiniteLastStop: Boolean = false,
 ) : IncrementalRequirementCallbacks {
     override fun maxSpeedInRange(
@@ -46,6 +52,9 @@ class IncrementalRequirementEnvelopeAdapter(
             pastStop = endPos
         }
         if (pastStop == endPos && infiniteLastStop) {
+            // The requested stop is at the end of the simulated path,
+            // and the requested behavior is to make that stop "infinite"
+            // (pushing next reservation's start-time to "never").
             return Double.POSITIVE_INFINITY
         }
         return envelopeWithStops.interpolateDepartureFrom(pastStop)
@@ -96,6 +105,7 @@ class IncrementalRequirementEnvelopeAdapter(
             rollingStock,
             envelopeWithStops, // This is effectively read-only, we don't need a deep copy here
             simulationComplete,
+            infiniteLastStop,
         )
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/conflicts/IncrementalRequirementEnvelopeAdapter.kt
@@ -12,6 +12,7 @@ class IncrementalRequirementEnvelopeAdapter(
     private val rollingStock: PhysicsRollingStock,
     private val envelopeWithStops: EnvelopeInterpolate?,
     override var simulationComplete: Boolean,
+    private val infiniteLastStop: Boolean = false,
 ) : IncrementalRequirementCallbacks {
     override fun maxSpeedInRange(
         pathBeginOff: Offset<TravelledPath>,
@@ -43,6 +44,9 @@ class IncrementalRequirementEnvelopeAdapter(
         var pastStop = (stopOffset.distance).meters
         if (pastStop > endPos) {
             pastStop = endPos
+        }
+        if (pastStop == endPos && infiniteLastStop) {
+            return Double.POSITIVE_INFINITY
         }
         return envelopeWithStops.interpolateDepartureFrom(pastStop)
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelope.kt
@@ -39,7 +39,6 @@ import fr.sncf.osrd.utils.units.Offset
  * `Offset<TravelledPath>` using the underlying incremental path.
  */
 interface InfraExplorerWithEnvelope : InfraExplorer {
-
     /** Access the full envelope from the train start. */
     fun getFullEnvelope(): EnvelopeTimeInterpolate
 
@@ -86,6 +85,8 @@ interface InfraExplorerWithEnvelope : InfraExplorer {
     override fun cloneAndExtendLookahead(): Collection<InfraExplorerWithEnvelope>
 
     override fun moveForward(): InfraExplorerWithEnvelope
+
+    fun endAtStop(): Boolean
 }
 
 /** Init all InfraExplorersWithEnvelope starting at the given location. */

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorerWithEnvelopeImpl.kt
@@ -105,7 +105,8 @@ data class InfraExplorerWithEnvelopeImpl(
                     IncrementalRequirementEnvelopeAdapter(
                         rollingStock,
                         EnvelopeConcat.from(listOf(envelope)),
-                        true
+                        true,
+                        endAtStop(),
                     ),
                     getIncrementalPath(),
                 ),
@@ -142,7 +143,8 @@ data class InfraExplorerWithEnvelopeImpl(
             IncrementalRequirementEnvelopeAdapter(
                 rollingStock,
                 getFullEnvelope(),
-                simulationComplete
+                simulationComplete,
+                endAtStop(),
             )
         val updatedRequirements =
             spacingRequirementAutomaton.processPathUpdate() as? SpacingRequirements
@@ -164,7 +166,8 @@ data class InfraExplorerWithEnvelopeImpl(
                 IncrementalRequirementEnvelopeAdapter(
                     rollingStock,
                     getFullEnvelope(),
-                    simulationComplete
+                    simulationComplete,
+                    endAtStop(),
                 ),
                 getIncrementalPath(),
             )
@@ -197,7 +200,14 @@ data class InfraExplorerWithEnvelopeImpl(
             spacingRequirementAutomaton.clone(),
             rollingStock,
             stopTimeData,
-            spacingRequirementsCache
+            spacingRequirementsCache,
         )
+    }
+
+    override fun endAtStop(): Boolean {
+        val steps = getStepTracker().getSeenSteps()
+        return steps
+            .filter { it.originalStep.stop }
+            .any { it.travelledPathOffset == getSimulatedLength() }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/preprocessing/implementation/BlockAvailability.kt
@@ -4,6 +4,7 @@ import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope_utils.DoubleBinarySearch
 import fr.sncf.osrd.sim_infra.api.BlockPath
 import fr.sncf.osrd.sim_infra.api.TravelledPath
+import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.infra_exploration.LocatedStep
@@ -213,6 +214,24 @@ data class BlockAvailability(
             if (needFullRequirements) infraExplorer.getFullSpacingRequirements()
             else infraExplorer.getSpacingRequirements()
 
+        // Ensures that we account for the 20s margin where a train must see a green signal before
+        // its departure: when the current segment starts at a stop, we want to consider conflicts
+        // up to 20s before the "start time".
+        val startsAtStop =
+            infraExplorer
+                .getStepTracker()
+                .getSeenSteps()
+                .drop(1) // Skip departure step
+                .filter { it.originalStep.stop }
+                .map {
+                    infraExplorer.getIncrementalPath().fromTravelledPath(it.travelledPathOffset)
+                }
+                .contains(startOffset)
+        var minRelevantTime = startTime
+        if (startsAtStop) {
+            minRelevantTime -= CLOSED_SIGNAL_RESERVATION_MARGIN
+        }
+
         // Modify the spacing requirements to adjust for the start time,
         // and filter out the ones that are outside the relevant time range
         val shiftedSpacingRequirements =
@@ -220,7 +239,7 @@ data class BlockAvailability(
                 .map {
                     SpacingRequirement(
                         it.zone,
-                        max(pathStartTime + it.beginTime, startTime),
+                        max(pathStartTime + it.beginTime, minRelevantTime),
                         min(pathStartTime + it.endTime, endTime),
                         it.isComplete
                     )

--- a/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
+++ b/core/src/test/java/fr/sncf/osrd/conflicts/SpacingResourceGeneratorTest.kt
@@ -5,12 +5,13 @@ import fr.sncf.osrd.envelope.part.EnvelopePart
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
 import fr.sncf.osrd.envelope_sim.PhysicsRollingStock
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock
-import fr.sncf.osrd.sim_infra.api.Block
-import fr.sncf.osrd.sim_infra.api.BlockId
-import fr.sncf.osrd.sim_infra.api.DirDetectorId
-import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.railjson.schema.schedule.RJSTrainStop.RJSReceptionSignal.SHORT_SLIP_STOP
+import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.standalone_sim.CLOSED_SIGNAL_RESERVATION_MARGIN
+import fr.sncf.osrd.standalone_sim.EnvelopeStopWrapper
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.SpacingRequirement
 import fr.sncf.osrd.train.TestTrains
+import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.Direction.INCREASING
 import fr.sncf.osrd.utils.Helpers
 import fr.sncf.osrd.utils.indexing.StaticIdx
@@ -19,6 +20,7 @@ import fr.sncf.osrd.utils.toIdxList
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import fr.sncf.osrd.utils.units.sumDistances
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -317,13 +319,103 @@ class SpacingResourceGeneratorTest {
         // We should have just enough data to generate resource use
         assertTrue { iterationResult != NotEnoughPath }
     }
+
+    /**
+     * The train stops and restarts within sight distance of a signal, with a stop on closed signal.
+     */
+    @Test
+    fun testIncrementalStop() {
+        val path = incrementalPathOf(infra.rawInfra, infra.blockInfra)
+        val train = TestTrains.VERY_SHORT_FAST_TRAIN
+        val stopDuration = 5_000.0
+        val zoneNameAfterStop =
+            "zone.[det.b1.nf:DECREASING, det.b2.nf:DECREASING, det.center.3:INCREASING]"
+
+        // Init stops and offsets
+        val stopOffset =
+            blocks.take(3).map { infra.blockInfra.getBlockLength(it).distance }.sumDistances() -
+                50.meters
+        val pathLength = blocks.map { infra.blockInfra.getBlockLength(it).distance }.sumDistances()
+        val stops = listOf(TrainStop(stopOffset.meters, stopDuration, SHORT_SLIP_STOP))
+
+        // Build path
+        path.extend(
+            PathFragment(
+                routes.toIdxList(),
+                blocks.toIdxList(),
+                stops = listOf(FragmentStop(Offset(stopOffset), SHORT_SLIP_STOP)),
+                containsStart = true,
+                containsEnd = true,
+                0.meters,
+                0.meters
+            )
+        )
+
+        // Init callbacks, one at the stop and one at the end
+        val callbacksAtStop =
+            makeCallbacks(stopOffset, false, train, stops, infiniteLastStop = true)
+        val fullCallbacks = makeCallbacks(pathLength, true, train, stops, infiniteLastStop = false)
+
+        // Automaton 1: two different calls, at the stop and at the end
+        val automaton =
+            SpacingRequirementAutomaton(
+                infra.rawInfra,
+                infra.loadedSignalInfra,
+                infra.blockInfra,
+                infra.signalingSimulator,
+                callbacksAtStop,
+                path
+            )
+        val incrementalResultAtStop =
+            (automaton.processPathUpdate() as SpacingRequirements).requirements
+        automaton.callbacks = fullCallbacks
+        val incrementalResultAtArrival =
+            (automaton.processPathUpdate() as SpacingRequirements).requirements
+
+        // For comparison, results with a single call
+        val oneShotResults =
+            SpacingRequirementAutomaton(
+                    infra.rawInfra,
+                    infra.loadedSignalInfra,
+                    infra.blockInfra,
+                    infra.signalingSimulator,
+                    fullCallbacks,
+                    path
+                )
+                .processPathUpdate() as SpacingRequirements
+        val stopDepartureTime =
+            callbacksAtStop.arrivalTimeInRange(Offset(stopOffset), Offset(stopOffset)) +
+                stopDuration
+
+        // Run assertions on the results
+        assert(incrementalResultAtStop.none { it.zone == zoneNameAfterStop }) {
+            "No requirement after the closed signal during the stop"
+        }
+        assert(incrementalResultAtStop.maxOf { it.endTime } == stopDepartureTime) {
+            "We still generate requirements during the full stop duration"
+        }
+        assert(
+            incrementalResultAtArrival.single { it.zone == zoneNameAfterStop } ==
+                oneShotResults.requirements.single { it.zone == zoneNameAfterStop }
+        ) {
+            "We generate the same requirements after the stop, even with incremental calls"
+        }
+        assert(
+            incrementalResultAtArrival.single { it.zone == zoneNameAfterStop }.beginTime ==
+                stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN
+        ) {
+            "We emit the requirement 20s before the departure time"
+        }
+    }
 }
 
 /** Returns an incremental requirement callback of the given length */
 private fun makeCallbacks(
     length: Distance,
     complete: Boolean,
-    rollingStock: PhysicsRollingStock = SimpleRollingStock.STANDARD_TRAIN
+    rollingStock: PhysicsRollingStock = SimpleRollingStock.STANDARD_TRAIN,
+    stops: List<TrainStop> = listOf(),
+    infiniteLastStop: Boolean = false,
 ): IncrementalRequirementCallbacks {
     val envelope =
         Envelope.make(
@@ -333,5 +425,11 @@ private fun makeCallbacks(
                 doubleArrayOf(30.0, 30.0)
             )
         )
-    return IncrementalRequirementEnvelopeAdapter(rollingStock, envelope, complete)
+    val withStops = EnvelopeStopWrapper(envelope, stops)
+    return IncrementalRequirementEnvelopeAdapter(
+        rollingStock,
+        withStops,
+        complete,
+        infiniteLastStop
+    )
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -231,10 +231,10 @@ class FullSTDCMTests {
     }
 
     /**
-     * Very long stop with an occupancy that starts after the stop end. The requested arrival time
-     * may make us stay longer at the stop location, to the point of causing a conflict. Not finding
-     * a solution is valid, we're looking for crashes (specifically postprocessing assertions).
-     * Reproduces a bug.
+     * Very long stop with an occupancy that starts after the stop end at the stop location. The
+     * requested arrival time may make us stay longer at the stop location, to the point of causing
+     * a conflict. Not finding a solution is valid, we're looking for crashes (specifically
+     * postprocessing assertions). Reproduces a bug.
      */
     @Test
     fun testConflictAtStop() {
@@ -264,6 +264,40 @@ class FullSTDCMTests {
             .setMaxRunTime(Double.POSITIVE_INFINITY)
             .setMaxDepartureDelay(0.0)
             .run() ?: return
+    }
+
+    /**
+     * The zone after the stop isn't available during the stop itself (and for a little while
+     * after). There is a solution if we lengthen the stop, but we need to properly account for the
+     * 20s margin where the signal must be green before the stop departure.
+     */
+    @Test
+    fun testConflictAfterStop() {
+        val infra =
+            Helpers.fullInfraFromRJS(Helpers.getExampleInfra("overlapping_routes/infra.json"))
+        val start = convertRouteLocation(infra, "rt.det.a1.nf->det.b1.nf", Offset(0.meters))
+        val stop =
+            convertRouteLocation(
+                infra,
+                "rt.det.a1.nf->det.b1.nf",
+                Offset(6_000.meters) // Within sight distance of a signal
+            )
+        val end = convertRouteLocation(infra, "rt.det.a1.nf->det.b1.nf", Offset(10_000.meters))
+        val zoneAfterStop = "zone.[det.center.2:INCREASING, det.center.3:DECREASING]"
+        val requirements =
+            listOf(SpacingRequirement(zoneAfterStop, 0.0, 7_000.0, true))
+        val res =
+            STDCMPathfindingBuilder()
+                .setInfra(infra)
+                .setStartTime(0.0)
+                .setStartLocations(start.blockLocations)
+                .addStep(STDCMStep(stop.blockLocations, 5_000.0, true))
+                .setEndLocations(end.blockLocations)
+                .setBlockAvailability(makeBlockAvailability(requirements))
+                .setMaxRunTime(Double.POSITIVE_INFINITY)
+                .setMaxDepartureDelay(0.0)
+                .run()!!
+        assertTrue(res.stopResults.first().duration > 5_000.0)
     }
 
     private fun plannedTimingDataArg(): Stream<Arguments> {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -296,7 +296,9 @@ class FullSTDCMTests {
                 .setMaxRunTime(Double.POSITIVE_INFINITY)
                 .setMaxDepartureDelay(0.0)
                 .run()!!
-        assertTrue(res.stopResults.first().duration > 5_000.0)
+        assertTrue(res.stopResults.first().duration > 5_000.0) {
+            "if a solution can be found without lengthening the stop, the test itself is broken"
+        }
     }
 
     private fun plannedTimingDataArg(): Stream<Arguments> {

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/FullSTDCMTests.kt
@@ -284,8 +284,7 @@ class FullSTDCMTests {
             )
         val end = convertRouteLocation(infra, "rt.det.a1.nf->det.b1.nf", Offset(10_000.meters))
         val zoneAfterStop = "zone.[det.center.2:INCREASING, det.center.3:DECREASING]"
-        val requirements =
-            listOf(SpacingRequirement(zoneAfterStop, 0.0, 7_000.0, true))
+        val requirements = listOf(SpacingRequirement(zoneAfterStop, 0.0, 7_000.0, true))
         val res =
             STDCMPathfindingBuilder()
                 .setInfra(infra)


### PR DESCRIPTION
Fix https://github.com/OpenRailAssociation/osrd/issues/11186

Fix this issue by:

1. Tweaking inputs for spacing resource requirements: infra explorers that end at stop don't generate requirements for anything after the stop itself
2. Tweaking `BlockAvailability` to account for this margin when identifying conflicts after a stop


I'm not 100% convinced this is the right approach, but it works. I'll leave it there, maybe not merge during the feature freeze, and see if we can come up with something better.

Also add two unit tests: one for STDCM that reproduces this precise case (and fails without the last commit), and another one for spacing ressource generation to properly identify its behavior around partial stops.

Most of the diff comes from new tests, the PR isn't as large as it seems. 