### PR TITLE
core: stdcm: fix off-by-one in heuristic step count

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -23,7 +23,11 @@ import org.slf4j.LoggerFactory
 /**
  * This typealias defines a function that can be used as a heuristic for an A* pathfinding. It takes
  * an edge, and offset on this edge, and a number of passed steps as input, and returns an
- * estimation of the remaining time needed to get to the end.
+ * estimation of the remaining time needed to get to the end. The number of passed steps includes
+ * the train departure point.
+ *
+ * TODO: directly input `StepTracker` there (it will be required for takeovers as steps would be
+ *   dynamic). See issue #11285.
  */
 typealias STDCMAStarHeuristic = (STDCMEdge, Offset<Block>?, Int) -> Double
 /**
@@ -90,7 +94,8 @@ class STDCMHeuristicBuilder(
             "STDCM heuristic built, best theoretical travel time = ${bestTravelTime.toInt()} seconds"
         )
 
-        val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedSteps ->
+        val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedStepsIncludingFirst ->
+            val nPassedSteps = max(0, nPassedStepsIncludingFirst - 1)
             if (nPassedSteps >= steps.size - 1) return@res 0.0
             val lookahead = edge.infraExplorer.getLookahead()
             val currentBlock = edge.block

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -253,6 +253,10 @@ class STDCMHeuristicTests {
                 0.0,
                 null,
             )
-        return heuristic.invoke(defaultEdge, nodeOffsetOnEdge?.let { Offset(it) }, nbPassedSteps)
+        return heuristic.invoke(
+            defaultEdge,
+            nodeOffsetOnEdge?.let { Offset(it) },
+            nbPassedSteps + 1 // TODO: remove this +1 when we'll use StepTrackers directly
+        )
     }
 }


### PR DESCRIPTION
The new `StepTracker.nStepsExcludingLookahead`, when compared to the old `edge.nPassedSteps`, has one difference: it (generally) includes the departure location. This resulted in the heuristic returning `0` (i.e. being disabled) between the last intermediate step and the destination.

This caused timeouts.

We should ideally integrate `StepTracker` in the heuristic and we'll need to do that before overtakes. It should have been part of https://github.com/OpenRailAssociation/osrd/issues/8974 but I kind of forgot about it. I'll open a different issue: https://github.com/OpenRailAssociation/osrd/issues/11285