### PR TITLE
tests: convert to poetry 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,18 +348,11 @@ jobs:
         run: |
           cd tests
           poetry install
-      - name: Flake8
+      - name: Ruff
         run: |
           cd tests
-          poetry run pflake8 --config ./pyproject.toml
-      - name: Black
-        run: |
-          cd tests
-          poetry run black . --check
-      - name: Isort
-        run: |
-          cd tests
-          poetry run isort . --check
+          poetry run ruff check
+          poetry run ruff format --check
       - name: Pytype
         run: |
           cd tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,10 +353,10 @@ jobs:
           cd tests
           poetry run ruff check
           poetry run ruff format --check
-      - name: Pytype
+      - name: Pyright
         run: |
           cd tests
-          poetry run pytype -j auto
+          poetry run pyright
 
   check_osrd_schema:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Install railjson_generator dependencies
         run: |
           cd python/railjson_generator
-          poetry install --extras=check
+          poetry sync --extras=check --no-interaction
 
       - name: Ruff
         run: |
@@ -338,7 +338,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install 'poetry<2.0'
+        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -347,7 +347,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd tests
-          poetry install
+          poetry sync --extras=check --no-interaction
       - name: Ruff
         run: |
           cd tests
@@ -373,7 +373,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd python/osrd_schemas
-          poetry install --extras=check
+          poetry sync --extras=check --no-interaction
       - name: Ruff
         run: |
           cd python/osrd_schemas
@@ -413,7 +413,7 @@ jobs:
       - name: Check infra_schema.json sync
         run: |
           cd python/osrd_schemas
-          poetry install --no-interaction --no-root
+          poetry sync --no-interaction
           poetry run python -m osrd_schemas.infra_editor > current_infra_schema.json
           diff current_infra_schema.json ../../front/src/reducers/osrdconf/infra_schema.json
 
@@ -871,7 +871,7 @@ jobs:
           docker load --input ./osrd-core.tar
           docker load --input ./osrd-osrdyne.tar
       - name: Install poetry
-        run: pipx install 'poetry<2.0'
+        run: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -880,7 +880,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd tests
-          poetry install
+          poetry sync --no-interaction
 
       - name: Startup the test infrastructure
         id: start_integration_worker

--- a/python/railjson_generator/README.md
+++ b/python/railjson_generator/README.md
@@ -97,17 +97,15 @@ poetry run pytest
 
 ## Linting
 
-Use pflake8 and pyright to check for style issues and potential errors.
 Use ruff and pyright to check for style issues and potential errors.
 
 ```sh
-$ poetry run pflake8 --config ./pyproject.toml
+$ poetry run ruff check
 $ poetry run pyright
 ```
 
-Use black and isort to fix formatting.
+Use ruff to fix formatting.
 
 ```sh
-$ poetry run black .
-$ poetry run isort .
+$ poetry run ruff format
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 ### Run the tests
 
-To run tests `poetry run pytest` after starting docker containers (`docker compose up` at the root of the project) and installing dependencies (`poetry install`, see [poetry doc](https://python-poetry.org/docs/)).
+To run tests `poetry run pytest` after starting docker containers (`docker compose up` at the root of the project) and installing dependencies (`poetry sync`, see [poetry doc](https://python-poetry.org/docs/)).
 
 To run a list of specific tests, run `poetry run pytest -k test_name_1 test_name_2 ...`.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Mapping, Optional
+from collections.abc import Iterable, Iterator, Mapping
 
 import pytest
 import requests
@@ -171,8 +171,8 @@ TestRollingStock.__test__ = False
 
 def create_rolling_stock(
     rolling_stock_json_path: Path,
-    test_rolling_stocks: Optional[List[TestRollingStock]] = None,
-) -> List[int]:
+    test_rolling_stocks: list[TestRollingStock] | None = None,
+) -> list[int]:
     if test_rolling_stocks is None:
         payload = json.loads(rolling_stock_json_path.read_text())
         response = requests.post(f"{EDITOAST_URL}rolling_stock/", json=payload)
@@ -253,7 +253,7 @@ def west_to_south_east_path(
 def west_to_south_east_simulation(
     small_scenario: Scenario,
     fast_rolling_stock: int,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
     response = requests.post(
@@ -280,7 +280,7 @@ def west_to_south_east_simulation(
 def west_to_south_east_paced_train(
     small_scenario: Scenario,
     fast_rolling_stock: int,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
     response = requests.post(
@@ -311,7 +311,7 @@ def west_to_south_east_paced_train(
 def west_to_south_east_paced_trains(
     small_scenario: Scenario,
     fast_rolling_stock: int,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
 
@@ -362,7 +362,7 @@ def west_to_south_east_paced_trains(
 def west_to_south_east_etcs_simulation(
     etcs_scenario: Scenario,
     etcs_rolling_stock: int,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     rolling_stock_response = requests.get(
         EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
     )
@@ -390,7 +390,7 @@ def west_to_south_east_etcs_simulation(
 def west_to_south_east_simulations(
     small_scenario: Scenario,
     fast_rolling_stock: int,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,9 @@ def _load_generated_infra(name: str) -> int:
     infra_path = Path(__file__).parent / f"data/infras/{name}/infra.json"
     with infra_path.open() as json_infra:
         infra_json = json.load(json_infra)
-    res = requests.post(EDITOAST_URL + f"infra/railjson?name={name}&generate_data=true", json=infra_json)
+    res = requests.post(
+        EDITOAST_URL + f"infra/railjson?name={name}&generate_data=true", json=infra_json
+    )
     res.raise_for_status()
     return res.json()["infra"]
 
@@ -71,26 +73,46 @@ def foo_study_id(foo_project_id: int) -> Iterator[int]:
         "business_code": "BBB",
         "tags": [],
     }
-    res = requests.post(EDITOAST_URL + f"projects/{foo_project_id}/studies/", json=payload)
+    res = requests.post(
+        EDITOAST_URL + f"projects/{foo_project_id}/studies/", json=payload
+    )
     yield res.json()["id"]
 
 
 @pytest.fixture
-def tiny_scenario(tiny_infra: Infra, foo_project_id: int, foo_study_id: int) -> Iterator[Scenario]:
-    scenario_id, timetable_id = create_scenario(EDITOAST_URL, tiny_infra.id, foo_project_id, foo_study_id)
-    yield Scenario(foo_project_id, foo_study_id, scenario_id, tiny_infra.id, timetable_id)
+def tiny_scenario(
+    tiny_infra: Infra, foo_project_id: int, foo_study_id: int
+) -> Iterator[Scenario]:
+    scenario_id, timetable_id = create_scenario(
+        EDITOAST_URL, tiny_infra.id, foo_project_id, foo_study_id
+    )
+    yield Scenario(
+        foo_project_id, foo_study_id, scenario_id, tiny_infra.id, timetable_id
+    )
 
 
 @pytest.fixture
-def small_scenario(small_infra: Infra, foo_project_id: int, foo_study_id: int) -> Iterator[Scenario]:
-    scenario_id, timetable_id = create_scenario(EDITOAST_URL, small_infra.id, foo_project_id, foo_study_id)
-    yield Scenario(foo_project_id, foo_study_id, scenario_id, small_infra.id, timetable_id)
+def small_scenario(
+    small_infra: Infra, foo_project_id: int, foo_study_id: int
+) -> Iterator[Scenario]:
+    scenario_id, timetable_id = create_scenario(
+        EDITOAST_URL, small_infra.id, foo_project_id, foo_study_id
+    )
+    yield Scenario(
+        foo_project_id, foo_study_id, scenario_id, small_infra.id, timetable_id
+    )
 
 
 @pytest.fixture
-def etcs_scenario(etcs_infra: Infra, foo_project_id: int, foo_study_id: int) -> Iterator[Scenario]:
-    scenario_id, timetable_id = create_scenario(EDITOAST_URL, etcs_infra.id, foo_project_id, foo_study_id)
-    yield Scenario(foo_project_id, foo_study_id, scenario_id, etcs_infra.id, timetable_id)
+def etcs_scenario(
+    etcs_infra: Infra, foo_project_id: int, foo_study_id: int
+) -> Iterator[Scenario]:
+    scenario_id, timetable_id = create_scenario(
+        EDITOAST_URL, etcs_infra.id, foo_project_id, foo_study_id
+    )
+    yield Scenario(
+        foo_project_id, foo_study_id, scenario_id, etcs_infra.id, timetable_id
+    )
 
 
 def get_rolling_stock(editoast_url: str, rolling_stock_name: str) -> int:
@@ -103,7 +125,10 @@ def get_rolling_stock(editoast_url: str, rolling_stock_name: str) -> int:
     page = 1
     while page is not None:
         # TODO: feel free to reduce page_size when https://github.com/OpenRailAssociation/osrd/issues/5350 is fixed
-        r = requests.get(editoast_url + "light_rolling_stock/", params={"page": page, "page_size": 1_000})
+        r = requests.get(
+            editoast_url + "light_rolling_stock/",
+            params={"page": page, "page_size": 1_000},
+        )
         if r.status_code // 100 != 2:
             raise RuntimeError(f"Rolling stock error {r.status_code}: {r.content}")
         rjson = r.json()
@@ -114,11 +139,21 @@ def get_rolling_stock(editoast_url: str, rolling_stock_name: str) -> int:
     raise ValueError(f"Unable to find rolling stock {rolling_stock_name}")
 
 
-FAST_ROLLING_STOCK_JSON_PATH = Path(__file__).parents[1] / "editoast" / "src" / "tests" / "example_rolling_stock_1.json"
+FAST_ROLLING_STOCK_JSON_PATH = (
+    Path(__file__).parents[1]
+    / "editoast"
+    / "src"
+    / "tests"
+    / "example_rolling_stock_1.json"
+)
 
 # Rolling-stock derived from fast rolling stock, but able to travel under ETCS signaling
 ETCS_ROLLING_STOCK_JSON_PATH = (
-    Path(__file__).parents[1] / "tests" / "data" / "rolling_stocks" / "etcs_level2_rolling_stock.json"
+    Path(__file__).parents[1]
+    / "tests"
+    / "data"
+    / "rolling_stocks"
+    / "etcs_level2_rolling_stock.json"
 )
 
 
@@ -134,7 +169,8 @@ TestRollingStock.__test__ = False
 
 
 def create_rolling_stock(
-    rolling_stock_json_path: Path, test_rolling_stocks: Optional[List[TestRollingStock]] = None
+    rolling_stock_json_path: Path,
+    test_rolling_stocks: Optional[List[TestRollingStock]] = None,
 ) -> List[int]:
     if test_rolling_stocks is None:
         payload = json.loads(rolling_stock_json_path.read_text())
@@ -149,14 +185,17 @@ def create_rolling_stock(
         payload = json.loads(rs.base_path.read_text())
         payload["name"] = rs.name
         payload["metadata"] = rs.metadata
-        ids.append(requests.post(f"{EDITOAST_URL}rolling_stock/", json=payload).json()["id"])
+        ids.append(
+            requests.post(f"{EDITOAST_URL}rolling_stock/", json=payload).json()["id"]
+        )
     return ids
 
 
 @pytest.fixture
 def fast_rolling_stocks(request: pytest.FixtureRequest) -> Iterator[Iterable[int]]:
     ids = create_rolling_stock(
-        FAST_ROLLING_STOCK_JSON_PATH, request.node.get_closest_marker("names_and_metadata").args[0]
+        FAST_ROLLING_STOCK_JSON_PATH,
+        request.node.get_closest_marker("names_and_metadata").args[0],
     )
     yield ids
     for id in ids:
@@ -178,7 +217,9 @@ def etcs_rolling_stock() -> Iterator[int]:
 
 
 @pytest.fixture
-def west_to_south_east_path(small_infra: Infra, fast_rolling_stock: int) -> Iterator[TrainPath]:
+def west_to_south_east_path(
+    small_infra: Infra, fast_rolling_stock: int
+) -> Iterator[TrainPath]:
     """west_to_south_east_path screenshot in `tests/README.md`"""
     requests.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
     response = requests.post(
@@ -191,7 +232,13 @@ def west_to_south_east_path(small_infra: Infra, fast_rolling_stock: int) -> Iter
             "rolling_stock_is_thermal": True,
             "rolling_stock_loading_gauge": "G1",
             "rolling_stock_supported_electrifications": [],
-            "rolling_stock_supported_signaling_systems": ["BAL", "BAPR", "TVM300", "TVM430", "ETCS_LEVEL2"],
+            "rolling_stock_supported_signaling_systems": [
+                "BAL",
+                "BAPR",
+                "TVM300",
+                "TVM430",
+                "ETCS_LEVEL2",
+            ],
             "rolling_stock_maximum_speed": 200,
             "rolling_stock_length": 100000,
         },
@@ -204,7 +251,6 @@ def west_to_south_east_simulation(
     small_scenario: Scenario,
     fast_rolling_stock: int,
 ) -> Iterator[Dict]:
-
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
     response = requests.post(
@@ -232,7 +278,6 @@ def west_to_south_east_paced_train(
     small_scenario: Scenario,
     fast_rolling_stock: int,
 ) -> Iterator[Dict]:
-
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
     response = requests.post(
@@ -264,7 +309,6 @@ def west_to_south_east_paced_trains(
     small_scenario: Scenario,
     fast_rolling_stock: int,
 ) -> Iterator[Dict]:
-
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
 
@@ -316,8 +360,9 @@ def west_to_south_east_etcs_simulation(
     etcs_scenario: Scenario,
     etcs_rolling_stock: int,
 ) -> Iterator[Dict]:
-
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -343,7 +388,6 @@ def west_to_south_east_simulations(
     small_scenario: Scenario,
     fast_rolling_stock: int,
 ) -> Iterator[Dict]:
-
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,7 @@ class TestRollingStock:
     name: str
     metadata: Mapping
     base_path: Path
+    __test__: bool
 
 
 # Mark the class as not a test class
@@ -193,9 +194,11 @@ def create_rolling_stock(
 
 @pytest.fixture
 def fast_rolling_stocks(request: pytest.FixtureRequest) -> Iterator[Iterable[int]]:
+    closest_marker = request.node.get_closest_marker("names_and_metadata")
+    assert closest_marker is not None
     ids = create_rolling_stock(
         FAST_ROLLING_STOCK_JSON_PATH,
-        request.node.get_closest_marker("names_and_metadata").args[0],
+        closest_marker.args[0],
     )
     yield ids
     for id in ids:

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -42,9 +42,9 @@ def run(
     scenario_ttl: int = 20,
     n_test: int = 1000,
     log_folder: Optional[Path] = None,
-    infra_name: Optional[str] = None,
     seed: Optional[int] = None,
     rolling_stock_name: Optional[str] = None,
+    infra_name: str = _INFRA_NAME,
 ):
     """
     Runs every test
@@ -153,7 +153,9 @@ class _TrackEndpoint:
 
     @staticmethod
     def from_dict(obj: Dict) -> "_TrackEndpoint":
-        return _TrackEndpoint(obj["track"], _Endpoint._member_map_[obj["endpoint"]])
+        return _TrackEndpoint(
+            obj["track"], _Endpoint(_Endpoint._member_map_[obj["endpoint"]])
+        )
 
 
 @dataclass
@@ -354,13 +356,13 @@ def _get_random_rolling_stock(editoast_url: str) -> _RollingStock:
     return _RollingStock(rolling_stock["name"], rolling_stock["id"])
 
 
-def _make_graph(editoast_url: str, infra: int) -> _InfraGraph:
+def _make_graph(editoast_url: str, infra_id: int) -> _InfraGraph:
     """
     Makes a graph from the infra
     :param editoast_url: editoast url
     :param infra: infra id
     """
-    url = editoast_url + f"infra/{infra}/railjson/"
+    url = editoast_url + f"infra/{infra_id}/railjson/"
     r = _get_with_timeout(url)
     infra = r.json()
     graph = _InfraGraph(infra)

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -71,7 +71,14 @@ def run(
         time.sleep(0.1)
 
         try:
-            _run_test(infra_graph, editoast_url, scenario, infra_name, prelude, rolling_stock_name)
+            _run_test(
+                infra_graph,
+                editoast_url,
+                scenario,
+                infra_name,
+                prelude,
+                rolling_stock_name,
+            )
         except Exception as e:
             if log_folder is None:
                 raise e
@@ -79,7 +86,12 @@ def run(
                 print(e)
                 log_folder.mkdir(exist_ok=True)
                 with open(str(log_folder / f"{i}.json"), "w") as f:
-                    print(json.dumps(e.args[0], indent=4, default=lambda o: "<not serializable>"), file=f)
+                    print(
+                        json.dumps(
+                            e.args[0], indent=4, default=lambda o: "<not serializable>"
+                        ),
+                        file=f,
+                    )
 
         # Let's reset the scenario (empty timetable) so we can keep a
         # manageable/reproducible state.
@@ -148,7 +160,9 @@ class _TrackEndpoint:
 class _InfraGraph:
     RJSInfra: Dict
     tracks: Dict[str, Dict] = field(default_factory=dict)
-    links: Dict[_TrackEndpoint, List[_TrackEndpoint]] = field(default_factory=lambda: defaultdict(list))
+    links: Dict[_TrackEndpoint, List[_TrackEndpoint]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
 
     def link(self, a: _TrackEndpoint, b: _TrackEndpoint):
         self.links[a].append(b)
@@ -210,7 +224,9 @@ def _run_test(
     path = _make_valid_path(infra)
 
     if random.randint(0, 1) == 1:
-        _test_new_train(editoast_url, scenario, rolling_stock.name, infra_name, path, prelude)
+        _test_new_train(
+            editoast_url, scenario, rolling_stock.name, infra_name, path, prelude
+        )
     else:
         _test_stdcm(editoast_url, scenario, rolling_stock.id, infra_name, path, prelude)
 
@@ -241,7 +257,9 @@ def _test_new_train(
         )
 
     sim_id = r.json()[0]["id"]
-    r = _get_with_timeout(editoast_url + f"/train_schedule/{sim_id}/simulation/?infra_id={scenario.infra}")
+    r = _get_with_timeout(
+        editoast_url + f"/train_schedule/{sim_id}/simulation/?infra_id={scenario.infra}"
+    )
     if r.status_code // 100 != 2 or r.json().get("status", "") != "success":
         _make_error(
             _ErrorType.RESULT,
@@ -268,14 +286,21 @@ def _test_stdcm(
     print("testing stdcm")
     stdcm_payload = _make_stdcm_payload(path, rolling_stock)
     r = _post_with_timeout(
-        editoast_url + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}", json=stdcm_payload
+        editoast_url + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}",
+        json=stdcm_payload,
     )
     if r.status_code // 100 != 2:
         content = r.content.decode("utf-8")
         if r.status_code // 100 == 4 and "No path could be found" in content:
             print("ignore: no path found")
             return
-        _make_error(_ErrorType.STDCM, r, infra_name, stdcm_payload=stdcm_payload, prelude=prelude)
+        _make_error(
+            _ErrorType.STDCM,
+            r,
+            infra_name,
+            stdcm_payload=stdcm_payload,
+            prelude=prelude,
+        )
     print("test PASSED")
 
 
@@ -309,7 +334,9 @@ def _get_rolling_stock(editoast_url: str, rolling_stock_name: str) -> _RollingSt
     :param rolling_stock_name: name of the rolling stock
     :return: ID the rolling stock
     """
-    return _RollingStock(rolling_stock_name, conftest.get_rolling_stock(editoast_url, rolling_stock_name))
+    return _RollingStock(
+        rolling_stock_name, conftest.get_rolling_stock(editoast_url, rolling_stock_name)
+    )
 
 
 def _get_random_rolling_stock(editoast_url: str) -> _RollingStock:
@@ -358,7 +385,9 @@ def _random_set_element(s: Iterable[U]) -> U:
     return random.choice(list(s))
 
 
-def _make_steps_on_track(track: Dict, endpoint: _Endpoint, number: float) -> List[float]:
+def _make_steps_on_track(
+    track: Dict, endpoint: _Endpoint, number: float
+) -> List[float]:
     """
     Generates a random list of steps on a route
     :return: Iterable of (edge id, edge offset, offset from the start)
@@ -416,7 +445,9 @@ def _make_path(infra: _InfraGraph) -> Tuple[List[Tuple[str, float]], float]:
             tmp_path_length += track["length"]
 
         # Find next track
-        neighbors: List[_TrackEndpoint] = infra.links[_TrackEndpoint(track_id, endpoint)]
+        neighbors: List[_TrackEndpoint] = infra.links[
+            _TrackEndpoint(track_id, endpoint)
+        ]
         if len(neighbors) == 0:
             break
         neighbor: _TrackEndpoint = _random_set_element(neighbors)
@@ -464,7 +495,9 @@ def _convert_stop(stop: Tuple[str, float], i: int) -> Dict:
 def _reset_timetable(editoast_url: str, scenario: Scenario) -> Scenario:
     """Deletes the current timetable and creates a new one."""
     # Delete the current timetable
-    _raise_if_error(_delete_with_timeout(editoast_url + f"/timetable/{scenario.timetable}/"))
+    _raise_if_error(
+        _delete_with_timeout(editoast_url + f"/timetable/{scenario.timetable}/")
+    )
 
     # Create a timetable
     r = _post_with_timeout(editoast_url + "/timetable/", json={})
@@ -523,7 +556,9 @@ def _make_random_time():
     """
     Generate a random datetime. All values will be within the same 24h
     """
-    start = datetime.datetime(year=2024, month=1, day=1, tzinfo=datetime.timezone.utc)  # Arbitrary date
+    start = datetime.datetime(
+        year=2024, month=1, day=1, tzinfo=datetime.timezone.utc
+    )  # Arbitrary date
     date = start + datetime.timedelta(seconds=(random.randint(0, 3600 * 24)))
     return date.isoformat()
 
@@ -564,7 +599,9 @@ def _raise_if_error(response: Response) -> Response:
     Similar to response.raise_for_status(), but includes the response content in the message
     """
     if response.status_code // 100 != 2:
-        raise RuntimeError(f"status code: {response.status_code}, content: {response.content.decode('UTF-8')}")
+        raise RuntimeError(
+            f"status code: {response.status_code}, content: {response.content.decode('UTF-8')}"
+        )
     return response
 
 
@@ -582,7 +619,9 @@ if __name__ == "__main__":
         try:
             _get_rolling_stock(_EDITOAST_URL, _ROLLING_STOCK_NAME)
         except ValueError:
-            conftest.create_rolling_stock(conftest.FAST_ROLLING_STOCK_JSON_PATH, test_rolling_stocks=None)
+            conftest.create_rolling_stock(
+                conftest.FAST_ROLLING_STOCK_JSON_PATH, test_rolling_stocks=None
+            )
     run(
         _EDITOAST_URL,
         new_scenario,

--- a/tests/fuzzer/fuzzer.py
+++ b/tests/fuzzer/fuzzer.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from functools import cache
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple, TypeVar
+from typing import TypeVar
+from collections.abc import Iterable
 
 import requests
 from osrd_schemas.switch_type import builtin_node_types
@@ -41,10 +42,10 @@ def run(
     scenario: Scenario,
     scenario_ttl: int = 20,
     n_test: int = 1000,
-    log_folder: Optional[Path] = None,
-    seed: Optional[int] = None,
-    rolling_stock_name: Optional[str] = None,
+    log_folder: Path | None = None,
     infra_name: str = _INFRA_NAME,
+    seed: int | None = None,
+    rolling_stock_name: str | None = None,
 ):
     """
     Runs every test
@@ -152,7 +153,7 @@ class _TrackEndpoint:
     endpoint: _Endpoint
 
     @staticmethod
-    def from_dict(obj: Dict) -> "_TrackEndpoint":
+    def from_dict(obj: dict[str, str]) -> "_TrackEndpoint":
         return _TrackEndpoint(
             obj["track"], _Endpoint(_Endpoint._member_map_[obj["endpoint"]])
         )
@@ -160,9 +161,9 @@ class _TrackEndpoint:
 
 @dataclass
 class _InfraGraph:
-    RJSInfra: Dict
-    tracks: Dict[str, Dict] = field(default_factory=dict)
-    links: Dict[_TrackEndpoint, List[_TrackEndpoint]] = field(
+    RJSInfra: dict
+    tracks: dict[str, dict] = field(default_factory=dict)
+    links: dict[_TrackEndpoint, list[_TrackEndpoint]] = field(
         default_factory=lambda: defaultdict(list)
     )
 
@@ -206,8 +207,8 @@ def _run_test(
     editoast_url: str,
     scenario: Scenario,
     infra_name: str,
-    prelude: List,
-    rolling_stock_name: Optional[str],
+    prelude: list,
+    rolling_stock_name: str | None,
 ):
     """
     Runs a single random test
@@ -238,8 +239,8 @@ def _test_new_train(
     scenario: Scenario,
     rolling_stock: str,
     infra_name: str,
-    path: List[Tuple[str, float]],
-    prelude: List,
+    path: list[tuple[str, float]],
+    prelude: list,
 ):
     """
     Try to create a new train on the given path.
@@ -278,8 +279,8 @@ def _test_stdcm(
     scenario: Scenario,
     rolling_stock: int,
     infra_name: str,
-    path: List[Tuple[str, float]],
-    prelude: List,
+    path: list[tuple[str, float]],
+    prelude: list,
 ):
     """
     Try to run an STDCM search on the given path.
@@ -306,7 +307,7 @@ def _test_stdcm(
     print("test PASSED")
 
 
-def _make_stdcm_payload(path: List[Tuple[str, float]], rolling_stock: int) -> Dict:
+def _make_stdcm_payload(path: list[tuple[str, float]], rolling_stock: int) -> dict:
     """
     Creates a payload for an STDCM request
     """
@@ -388,8 +389,8 @@ def _random_set_element(s: Iterable[U]) -> U:
 
 
 def _make_steps_on_track(
-    track: Dict, endpoint: _Endpoint, number: float
-) -> List[float]:
+    track: dict, endpoint: _Endpoint, number: float
+) -> list[float]:
     """
     Generates a random list of steps on a route
     :return: Iterable of (edge id, edge offset, offset from the start)
@@ -404,7 +405,7 @@ def _make_steps_on_track(
     return res
 
 
-def _make_path(infra: _InfraGraph) -> Tuple[List[Tuple[str, float]], float]:
+def _make_path(infra: _InfraGraph) -> tuple[list[tuple[str, float]], float]:
     """
     Generates a path in the infra following the route graph. The path may only have a single element
     :param infra: infra
@@ -447,7 +448,7 @@ def _make_path(infra: _InfraGraph) -> Tuple[List[Tuple[str, float]], float]:
             tmp_path_length += track["length"]
 
         # Find next track
-        neighbors: List[_TrackEndpoint] = infra.links[
+        neighbors: list[_TrackEndpoint] = infra.links[
             _TrackEndpoint(track_id, endpoint)
         ]
         if len(neighbors) == 0:
@@ -459,7 +460,7 @@ def _make_path(infra: _InfraGraph) -> Tuple[List[Tuple[str, float]], float]:
     return res, total_path_length
 
 
-def _make_valid_path(infra: _InfraGraph) -> List[Tuple[str, float]]:
+def _make_valid_path(infra: _InfraGraph) -> list[tuple[str, float]]:
     """
     Generates a path with at least two steps
     :param infra: infra graph
@@ -471,7 +472,7 @@ def _make_valid_path(infra: _InfraGraph) -> List[Tuple[str, float]]:
             return path
 
 
-def _convert_stop_stdcm(stop: Tuple[str, float]) -> Dict:
+def _convert_stop_stdcm(stop: tuple[str, float]) -> dict:
     """
     Converts a stop to be in the stdcm payload
     :param stop: (track, offset)
@@ -484,7 +485,7 @@ def _convert_stop_stdcm(stop: Tuple[str, float]) -> Dict:
     }
 
 
-def _convert_stop(stop: Tuple[str, float], i: int) -> Dict:
+def _convert_stop(stop: tuple[str, float], i: int) -> dict:
     """
     Converts a stop to be in the schedule payload
     :param stop: (track, offset)
@@ -513,7 +514,7 @@ def _make_random_margin_value() -> str:
     return f"{random.randint(0, 7)}min/100km"
 
 
-def _make_random_margins(n_steps: int) -> Dict:
+def _make_random_margins(n_steps: int) -> dict:
     transitions = []
     i = 1
     while i < n_steps - 3:
@@ -527,9 +528,9 @@ def _make_random_margins(n_steps: int) -> Dict:
 
 
 def _make_payload_schedule(
-    path: List[Tuple[str, float]],
+    path: list[tuple[str, float]],
     rolling_stock: str,
-) -> List:
+) -> list:
     """
     Makes the payload for the simulation
     :param path: path id

--- a/tests/fuzzer/fuzzer_stdcm_single_timetable.py
+++ b/tests/fuzzer/fuzzer_stdcm_single_timetable.py
@@ -100,7 +100,9 @@ def _get_train_ids(editoast_url: str, scenario: Scenario) -> List[int]:
     page = 1
     res = []
     while page is not None:
-        r = requests.get(f"{editoast_url}/timetable/{scenario.timetable}/train_schedules/?page={page}")
+        r = requests.get(
+            f"{editoast_url}/timetable/{scenario.timetable}/train_schedules/?page={page}"
+        )
         r.raise_for_status()
         parsed = r.json()
         for schedule in parsed["results"]:
@@ -120,7 +122,9 @@ def _build_timetable_range(editoast_url, scenario) -> TimetableTimeRange:
     for train_id in train_ids:
         r = requests.get(f"{editoast_url}/train_schedule/{train_id}")
         r.raise_for_status()
-        start_time = datetime.datetime.strptime(r.json()["start_time"], "%Y-%m-%dT%H:%M:%SZ")
+        start_time = datetime.datetime.strptime(
+            r.json()["start_time"], "%Y-%m-%dT%H:%M:%SZ"
+        )
         start_time = start_time.astimezone(datetime.timezone.utc)
         train_times.append(start_time)
     if not train_times:
@@ -130,7 +134,9 @@ def _build_timetable_range(editoast_url, scenario) -> TimetableTimeRange:
             end=t,
         )
     else:
-        return TimetableTimeRange(start=min(train_times), end=max(train_times) + datetime.timedelta(hours=3))
+        return TimetableTimeRange(
+            start=min(train_times), end=max(train_times) + datetime.timedelta(hours=3)
+        )
 
 
 def _make_op_list(editoast_url, infra) -> Iterable[int]:
@@ -142,7 +148,12 @@ def _make_op_list(editoast_url, infra) -> Iterable[int]:
         yield op["extensions"]["identifier"]["uic"]
 
 
-def _test_stdcm(editoast_url: str, op_list: List[int], scenario: Scenario, timetable_range: TimetableTimeRange):
+def _test_stdcm(
+    editoast_url: str,
+    op_list: List[int],
+    scenario: Scenario,
+    timetable_range: TimetableTimeRange,
+):
     """
     Run a single test instance
     """
@@ -151,13 +162,16 @@ def _test_stdcm(editoast_url: str, op_list: List[int], scenario: Scenario, timet
         rolling_stock = _get_random_rolling_stock(editoast_url)
         stdcm_payload = _make_stdcm_payload(op_list, rolling_stock.id, timetable_range)
         r = requests.post(
-            editoast_url + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}",
+            editoast_url
+            + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}",
             json=stdcm_payload,
             timeout=_TIMEOUT,
         )
         if r.status_code // 100 != 2:
             is_json = "application/json" in r.headers.get("Content-Type", "")
-            raise STDCMException(error=r.json() if is_json else r.content, status_code=r.status_code)
+            raise STDCMException(
+                error=r.json() if is_json else r.content, status_code=r.status_code
+            )
     except STDCMException as e:
         e.payload = stdcm_payload
         raise e
@@ -166,7 +180,9 @@ def _test_stdcm(editoast_url: str, op_list: List[int], scenario: Scenario, timet
     print("test PASSED")
 
 
-def _make_stdcm_payload(op_list: List[int], rolling_stock: int, timetable_range: TimetableTimeRange) -> Dict:
+def _make_stdcm_payload(
+    op_list: List[int], rolling_stock: int, timetable_range: TimetableTimeRange
+) -> Dict:
     """
     Generate a random stdcm payload
     """

--- a/tests/fuzzer/fuzzer_stdcm_single_timetable.py
+++ b/tests/fuzzer/fuzzer_stdcm_single_timetable.py
@@ -3,7 +3,7 @@ import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Union
+from collections.abc import Iterable
 
 import requests
 
@@ -37,9 +37,9 @@ Usage: `poetry run python -m fuzzer.fuzzer_stdcm_single_timetable`
 
 @dataclass
 class STDCMException(Exception):
-    error: Union[str, Dict]
-    status_code: Optional[int] = None
-    payload: Optional[Dict] = None
+    error: str | dict
+    status_code: int | None = None
+    payload: dict | None = None
 
 
 @dataclass
@@ -57,8 +57,8 @@ def run(
     editoast_url: str,
     scenario: Scenario,
     n_test: int = 1000,
-    log_folder: Optional[Path] = None,
-    seed: Optional[int] = None,
+    log_folder: Path | None = None,
+    seed: int | None = None,
 ):
     """
     Run the given number of tests, logging errors in the given folder as json files
@@ -93,7 +93,7 @@ def run(
                     )
 
 
-def _get_train_ids(editoast_url: str, scenario: Scenario) -> List[int]:
+def _get_train_ids(editoast_url: str, scenario: Scenario) -> list[int]:
     """
     Fetch all the train IDs in the scenario
     """
@@ -150,7 +150,7 @@ def _make_op_list(editoast_url, infra) -> Iterable[int]:
 
 def _test_stdcm(
     editoast_url: str,
-    op_list: List[int],
+    op_list: list[int],
     scenario: Scenario,
     timetable_range: TimetableTimeRange,
 ):
@@ -182,8 +182,8 @@ def _test_stdcm(
 
 
 def _make_stdcm_payload(
-    op_list: List[int], rolling_stock: int, timetable_range: TimetableTimeRange
-) -> Dict:
+    op_list: list[int], rolling_stock: int, timetable_range: TimetableTimeRange
+) -> dict:
     """
     Generate a random stdcm payload
     """
@@ -196,7 +196,7 @@ def _make_stdcm_payload(
     return res
 
 
-def _make_steps(op_list: List[int], timetable_range: TimetableTimeRange) -> List[Dict]:
+def _make_steps(op_list: list[int], timetable_range: TimetableTimeRange) -> list[dict]:
     """
     Generate steps for the stdcm payloads
     """

--- a/tests/fuzzer/fuzzer_stdcm_single_timetable.py
+++ b/tests/fuzzer/fuzzer_stdcm_single_timetable.py
@@ -170,7 +170,8 @@ def _test_stdcm(
         if r.status_code // 100 != 2:
             is_json = "application/json" in r.headers.get("Content-Type", "")
             raise STDCMException(
-                error=r.json() if is_json else r.content, status_code=r.status_code
+                error=r.json() if is_json else str(r.content),
+                status_code=r.status_code,
             )
     except STDCMException as e:
         e.payload = stdcm_payload

--- a/tests/infra-scripts/circle_infra.py
+++ b/tests/infra-scripts/circle_infra.py
@@ -16,9 +16,13 @@ track_c = builder.add_track_section(length=200, label="track_c")
 track_d = builder.add_track_section(length=200, label="track_d")
 link = builder.add_link(track_d.end(), track_a.begin())
 
-switch1 = builder.add_point_switch(track_a.end(), track_b.begin(), track_c.begin(), label="switch1")
+switch1 = builder.add_point_switch(
+    track_a.end(), track_b.begin(), track_c.begin(), label="switch1"
+)
 
-switch2 = builder.add_point_switch(track_d.begin(), track_b.end(), track_c.end(), label="switch2")
+switch2 = builder.add_point_switch(
+    track_d.begin(), track_b.end(), track_c.end(), label="switch2"
+)
 
 # Build infra
 infra = builder.build()

--- a/tests/infra-scripts/etcs_infra.py
+++ b/tests/infra-scripts/etcs_infra.py
@@ -4,6 +4,7 @@
 This script generates an infrastructure containing ERTMS ETCS Level 2 signals.
 This is derived from small_infra.
 """
+
 from railjson_generator import get_output_dir
 from small_infra_creator import create_small_infra
 

--- a/tests/infra-scripts/example_script.py
+++ b/tests/infra-scripts/example_script.py
@@ -16,8 +16,12 @@ tracks = [builder.add_track_section(length=1000) for _ in range(7)]
 
 # Create switches
 switch_0 = builder.add_point_switch(tracks[2].begin(), tracks[1].end(), tracks[0].end())
-switch_1 = builder.add_point_switch(tracks[2].end(), tracks[3].begin(), tracks[4].begin())
-switch_2 = builder.add_point_switch(tracks[4].end(), tracks[5].begin(), tracks[6].begin())
+switch_1 = builder.add_point_switch(
+    tracks[2].end(), tracks[3].begin(), tracks[4].begin()
+)
+switch_2 = builder.add_point_switch(
+    tracks[4].end(), tracks[5].begin(), tracks[6].begin()
+)
 
 # Set coordinates (optional)
 
@@ -37,17 +41,25 @@ tracks[0].add_buffer_stop(position=100, label="Custom Buffer Stop")
 for i in (2, 3, 4, 5, 6):
     track = tracks[i]
     detector = track.add_detector(position=200)
-    signal = track.add_signal(detector.position - 25, Direction.START_TO_STOP, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position - 25, Direction.START_TO_STOP, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
-    signal = track.add_signal(detector.position + 25, Direction.STOP_TO_START, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position + 25, Direction.STOP_TO_START, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
 for i in (0, 1, 2, 4):
     track = tracks[i]
     detector = track.add_detector(position=800)
-    signal = track.add_signal(detector.position - 25, Direction.START_TO_STOP, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position - 25, Direction.START_TO_STOP, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
-    signal = track.add_signal(detector.position + 25, Direction.STOP_TO_START, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position + 25, Direction.STOP_TO_START, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
 

--- a/tests/infra-scripts/nested_switches.py
+++ b/tests/infra-scripts/nested_switches.py
@@ -85,13 +85,24 @@ for track, length in (
 # Create switches
 
 left, right, static = "A_B1", "A_B2", "STATIC"
-s1 = builder.add_point_switch(tracks["T1"].end(), tracks["TD1"].begin(), tracks["T1bis"].begin(), label="S1")
-s2 = builder.add_point_switch(tracks["TD1"].end(), tracks["TD2"].begin(), tracks["T2"].begin(), label="S2")
-s3 = builder.add_point_switch(tracks["T3"].end(), tracks["TD3"].begin(), tracks["T3bis"].begin(), label="S3")
-s3bis = builder.add_point_switch(
-    tracks["T3bis"].end(), tracks["TD3bis"].begin(), tracks["T3ter"].begin(), label="S3bis"
+s1 = builder.add_point_switch(
+    tracks["T1"].end(), tracks["TD1"].begin(), tracks["T1bis"].begin(), label="S1"
 )
-s4 = builder.add_point_switch(tracks["T4bis"].begin(), tracks["TD3bis"].end(), tracks["T4"].end(), label="S4")
+s2 = builder.add_point_switch(
+    tracks["TD1"].end(), tracks["TD2"].begin(), tracks["T2"].begin(), label="S2"
+)
+s3 = builder.add_point_switch(
+    tracks["T3"].end(), tracks["TD3"].begin(), tracks["T3bis"].begin(), label="S3"
+)
+s3bis = builder.add_point_switch(
+    tracks["T3bis"].end(),
+    tracks["TD3bis"].begin(),
+    tracks["T3ter"].begin(),
+    label="S3bis",
+)
+s4 = builder.add_point_switch(
+    tracks["T4bis"].begin(), tracks["TD3bis"].end(), tracks["T4"].end(), label="S4"
+)
 
 # Create links
 
@@ -129,9 +140,38 @@ routes = [
     (bs1, det, "BS1 -> DETECTOR", []),
     (det, bs1bis, "1 -> 1'", [(s1, right)]),
     (det, bs2, "1 -> 2", [(s1, left), (s2, right)]),
-    (det, bs3ter, "1 -> 3", [(s1, left), (s2, left), (td2_t3, static), (s3, right), (s3bis, right)]),
-    (det, bs4bis, "1 -> 4", [(s1, left), (s2, left), (td2_t3, static), (s3, left), (td3_t4, static), (s4, right)]),
-    (det, bs4bis, "1 -> 4'", [(s1, left), (s2, left), (td2_t3, static), (s3, right), (s3bis, left), (s4, left)]),
+    (
+        det,
+        bs3ter,
+        "1 -> 3",
+        [(s1, left), (s2, left), (td2_t3, static), (s3, right), (s3bis, right)],
+    ),
+    (
+        det,
+        bs4bis,
+        "1 -> 4",
+        [
+            (s1, left),
+            (s2, left),
+            (td2_t3, static),
+            (s3, left),
+            (td3_t4, static),
+            (s4, right),
+        ],
+    ),
+    (
+        det,
+        bs4bis,
+        "1 -> 4'",
+        [
+            (s1, left),
+            (s2, left),
+            (td2_t3, static),
+            (s3, right),
+            (s3bis, left),
+            (s4, left),
+        ],
+    ),
 ]
 
 for bs_in, bs_out, route_id, switches_directions in routes:
@@ -140,7 +180,9 @@ for bs_in, bs_out, route_id, switches_directions in routes:
             label=route_id,
             waypoints=[bs_in, bs_out],
             entry_point_direction=Direction.START_TO_STOP,
-            switches_directions={s.label: direction for s, direction in switches_directions},
+            switches_directions={
+                s.label: direction for s, direction in switches_directions
+            },
             release_waypoints=[],
         )
     )
@@ -152,20 +194,27 @@ builder.add_speed_section(50, label="sp/50/t1...t1bis").add_applicable_track_ran
 )
 
 builder.add_speed_section(40, label="sp/40/td1..td3_t4").add_applicable_track_ranges(
-    tracks["TD1"].forwards(), tracks["TD2"].forwards(), tracks["T3"].forwards(), tracks["TD3"].forwards()
+    tracks["TD1"].forwards(),
+    tracks["TD2"].forwards(),
+    tracks["T3"].forwards(),
+    tracks["TD3"].forwards(),
 )
 
 # Speed sections on routes
 
-builder.add_speed_section(42, label="sp/42/1 -> 1'", on_routes=["1 -> 1'"]).add_applicable_track_ranges(
-    tracks["T1"].forwards(), tracks["T1bis"].forwards()
-)
+builder.add_speed_section(
+    42, label="sp/42/1 -> 1'", on_routes=["1 -> 1'"]
+).add_applicable_track_ranges(tracks["T1"].forwards(), tracks["T1bis"].forwards())
 
-builder.add_speed_section(60, label="sp/60/1 -> 2", on_routes=["1 -> 2"]).add_applicable_track_ranges(
+builder.add_speed_section(
+    60, label="sp/60/1 -> 2", on_routes=["1 -> 2"]
+).add_applicable_track_ranges(
     tracks["T1"].forwards(), tracks["TD1"].forwards(), tracks["T2"].forwards()
 )
 
-builder.add_speed_section(30, label="sp/30/1 -> 3", on_routes=["1 -> 3"]).add_applicable_track_ranges(
+builder.add_speed_section(
+    30, label="sp/30/1 -> 3", on_routes=["1 -> 3"]
+).add_applicable_track_ranges(
     tracks["T1"].forwards(),
     tracks["TD1"].forwards(),
     tracks["TD2"].forwards(),
@@ -174,7 +223,9 @@ builder.add_speed_section(30, label="sp/30/1 -> 3", on_routes=["1 -> 3"]).add_ap
     tracks["T3ter"].forwards(),
 )
 
-builder.add_speed_section(80, label="sp/80/1 -> 4", on_routes=["1 -> 4"]).add_applicable_track_ranges(
+builder.add_speed_section(
+    80, label="sp/80/1 -> 4", on_routes=["1 -> 4"]
+).add_applicable_track_ranges(
     tracks["T1"].forwards(),
     tracks["TD1"].forwards(),
     tracks["TD2"].forwards(),
@@ -184,7 +235,9 @@ builder.add_speed_section(80, label="sp/80/1 -> 4", on_routes=["1 -> 4"]).add_ap
     tracks["T4bis"].forwards(),
 )
 
-builder.add_speed_section(30, label="sp/30/1 -> 4'", on_routes=["1 -> 4'"]).add_applicable_track_ranges(
+builder.add_speed_section(
+    30, label="sp/30/1 -> 4'", on_routes=["1 -> 4'"]
+).add_applicable_track_ranges(
     tracks["T1"].forwards(),
     tracks["TD1"].forwards(),
     tracks["TD2"].forwards(),

--- a/tests/infra-scripts/one_line.py
+++ b/tests/infra-scripts/one_line.py
@@ -24,15 +24,21 @@ for i, track in enumerate(tracks):
 # Add links
 for first_track, second_track in zip(tracks[:-1], tracks[1:]):
     first_endpoint = first_track.begin() if first_track.inverted else first_track.end()
-    second_endpoint = second_track.end() if second_track.inverted else second_track.begin()
+    second_endpoint = (
+        second_track.end() if second_track.inverted else second_track.begin()
+    )
     builder.add_link(first_endpoint, second_endpoint)
 
 # Add detector and signals
 for track in tracks:
     detector = track.add_detector(position=500)
-    signal = track.add_signal(detector.position, ApplicableDirection.START_TO_STOP, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position, ApplicableDirection.START_TO_STOP, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
-    signal = track.add_signal(detector.position, ApplicableDirection.STOP_TO_START, is_route_delimiter=True)
+    signal = track.add_signal(
+        detector.position, ApplicableDirection.STOP_TO_START, is_route_delimiter=True
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
 # Build infra

--- a/tests/infra-scripts/overlapping_routes.py
+++ b/tests/infra-scripts/overlapping_routes.py
@@ -76,14 +76,18 @@ raw_signals: List[Signal] = [
 ]
 signals = []
 for raw_signal in raw_signals:
-    detector = raw_signal.track.add_detector(label=f"det.{raw_signal.name[2:]}", position=raw_signal.position)
+    detector = raw_signal.track.add_detector(
+        label=f"det.{raw_signal.name[2:]}", position=raw_signal.position
+    )
     signal = raw_signal.track.add_signal(
         label=raw_signal.name,
         position=raw_signal.position,
         direction=Direction.START_TO_STOP,
         is_route_delimiter=raw_signal.is_route_delimiter,
     )
-    signal.add_logical_signal("BAL", settings={"Nf": "true" if raw_signal.is_route_delimiter else "false"})
+    signal.add_logical_signal(
+        "BAL", settings={"Nf": "true" if raw_signal.is_route_delimiter else "false"}
+    )
     signals.append(signal)
 
 # Add links

--- a/tests/infra-scripts/overlapping_routes.py
+++ b/tests/infra-scripts/overlapping_routes.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from dataclasses import dataclass
-from typing import List
 
 from railjson_generator import Direction, InfraBuilder, get_output_dir
 from railjson_generator.schema.infra.track_section import TrackSection
@@ -65,7 +64,7 @@ class Signal:
     is_route_delimiter: bool
 
 
-raw_signals: List[Signal] = [
+raw_signals: list[Signal] = [
     Signal("s.a1.nf", t_a1, 900, True),
     Signal("s.a2.nf", t_a2, 900, True),
     Signal("s.center.1", t_center, 4_000, False),

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -33,9 +33,10 @@ def place_regular_signals_detectors(
     In the prefered direction, every <period> meters,
     in the opposite direction, every 3 *<period> meters."""
     if max_offset is None:
-        max_offset = track_section.length
+        max_offset = float(track_section.length)
     elif max_offset < 0:
-        max_offset = track_section.length + max_offset
+        max_offset = float(track_section.length) + max_offset
+    assert isinstance(max_offset, float)
 
     if prefered_direction is None:
         is_prefered = [True, True]
@@ -47,7 +48,7 @@ def place_regular_signals_detectors(
         ]
         is_reverse = [not pref for pref in is_prefered]
 
-    n_detectors = ((max_offset - min_offset) // period) - 1
+    n_detectors = int((max_offset - min_offset) // period) - 1
     detector_step = (max_offset - min_offset) / (n_detectors + 1)
     for i in range(1, n_detectors + 1):
         track_section.add_detector(
@@ -188,10 +189,10 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     ta5.add_detector(label="DA9", position=ta5.length / 2)
     # Extra signals
     place_regular_signals_detectors(
-        ta6, "A6", signaling_system, Direction.START_TO_STOP, 200, -200
+        ta6, "A6", signaling_system, Direction.START_TO_STOP, 200.0, -200.0
     )
     place_regular_signals_detectors(
-        ta7, "A7", signaling_system, Direction.STOP_TO_START, 200, -200
+        ta7, "A7", signaling_system, Direction.STOP_TO_START, 200.0, -200.0
     )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=2)
@@ -378,10 +379,10 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     )
     pd1.set_coords(-0.172, LAT_1)
     place_regular_signals_detectors(
-        td0, "D0", signaling_system, Direction.START_TO_STOP, 200, -200
+        td0, "D0", signaling_system, Direction.START_TO_STOP, 200.0, -200.0
     )
     place_regular_signals_detectors(
-        td1, "D1", signaling_system, Direction.STOP_TO_START, 200, -200
+        td1, "D1", signaling_system, Direction.STOP_TO_START, 200.0, -200.0
     )
     # Station
     mid_east = builder.add_operational_point(
@@ -497,7 +498,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     south = builder.add_operational_point(label="South_station", trigram="SS", uic=6)
     south.add_part(tf1, 4300)
     place_regular_signals_detectors(
-        tf1, "F1", signaling_system, min_offset=200, max_offset=4300
+        tf1, "F1", signaling_system, min_offset=200.0, max_offset=4300.0
     )
     # Curves
     tf1.add_curve(begin=3100, end=4400, curve=9500)
@@ -545,7 +546,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     north_east.add_part(tg4, 1550)
     north_east.add_part(tg5, 1500)
     place_regular_signals_detectors(
-        tg1, "G1", signaling_system, min_offset=200, max_offset=-200
+        tg1, "G1", signaling_system, min_offset=200.0, max_offset=-200.0
     )
     # ================================
     #  Around station H: South-East
@@ -555,7 +556,7 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     th1 = builder.add_track_section(
         length=5000, label="TH1", **V1, **south_east_parking
     )
-    place_regular_signals_detectors(th1, "H1", signaling_system, min_offset=200)
+    place_regular_signals_detectors(th1, "H1", signaling_system, min_offset=200.0)
     # switches
     ph0 = builder.add_double_slip_switch(
         label="PH0",

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -6,7 +6,8 @@ For more information, and a diagram of this infrastructure, see:
 https://osrd.fr/en/docs/explanation/models/data-models-full-example/
 """
 
-from typing import Mapping, NamedTuple, Optional, Tuple
+from typing import NamedTuple
+from collections.abc import Mapping
 
 from osrd_schemas.infra import LoadingGaugeType, Switch
 from railjson_generator import (
@@ -24,9 +25,9 @@ def place_regular_signals_detectors(
     track_section: TrackSection,
     label_suffix: str,
     signaling_system: str,
-    prefered_direction: Optional[Direction] = None,
+    prefered_direction: Direction | None = None,
     min_offset: float = 0,
-    max_offset: Optional[float] = None,
+    max_offset: float | None = None,
     period: float = 1500,
 ):
     """Place signals and detectors regularly on the track section.
@@ -70,7 +71,7 @@ def place_regular_signals_detectors(
 
 
 def add_signal_on_ports(
-    switch: Switch, ports: Mapping[str, Tuple[str, str]], signaling_system: str
+    switch: Switch, ports: Mapping[str, tuple[str, str]], signaling_system: str
 ):
     """Add signals and detectors to given ports.
     Args:

--- a/tests/infra-scripts/small_infra_creator/__init__.py
+++ b/tests/infra-scripts/small_infra_creator/__init__.py
@@ -5,6 +5,7 @@ This script generates an infrastructure of reasonable size containing all object
 For more information, and a diagram of this infrastructure, see:
 https://osrd.fr/en/docs/explanation/models/data-models-full-example/
 """
+
 from typing import Mapping, NamedTuple, Optional, Tuple
 
 from osrd_schemas.infra import LoadingGaugeType, Switch
@@ -67,7 +68,9 @@ def place_regular_signals_detectors(
             signal.add_logical_signal(signaling_system, settings={"Nf": "false"})
 
 
-def add_signal_on_ports(switch: Switch, ports: Mapping[str, Tuple[str, str]], signaling_system: str):
+def add_signal_on_ports(
+    switch: Switch, ports: Mapping[str, Tuple[str, str]], signaling_system: str
+):
     """Add signals and detectors to given ports.
     Args:
         ports: A dictionary of port names to (detector_label, signal_label) pairs.
@@ -78,8 +81,12 @@ def add_signal_on_ports(switch: Switch, ports: Mapping[str, Tuple[str, str]], si
 
     for port, (det_label, sig_label) in ports.items():
         switch.add_detector_on_port(port, DETECTOR_TO_SWITCH, label=det_label)
-        signal = switch.add_signal_on_port(port, SIGNAL_TO_SWITCH, label=sig_label, is_route_delimiter=True)
-        signal.add_logical_signal(signaling_system=signaling_system, settings={"Nf": "true"})
+        signal = switch.add_signal_on_port(
+            port, SIGNAL_TO_SWITCH, label=sig_label, is_route_delimiter=True
+        )
+        signal.add_logical_signal(
+            signaling_system=signaling_system, settings={"Nf": "true"}
+        )
 
 
 class ScenarioData(NamedTuple):
@@ -115,14 +122,26 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     # track sections
     ta0 = builder.add_track_section(length=2000, label="TA0", **V1, **west_parking)
     ta1 = builder.add_track_section(length=1950, label="TA1", **V2, **west_parking)
-    ta2 = builder.add_track_section(length=1950, label="TA2", track_name="A", track_number=3, **west_parking)
-    ta3 = builder.add_track_section(length=50, label="TA3", track_name="J1", track_number=4, **west_parking)
+    ta2 = builder.add_track_section(
+        length=1950, label="TA2", track_name="A", track_number=3, **west_parking
+    )
+    ta3 = builder.add_track_section(
+        length=50, label="TA3", track_name="J1", track_number=4, **west_parking
+    )
     ta4 = builder.add_track_section(length=50, label="TA4", **V2, **west_parking)
-    ta5 = builder.add_track_section(length=50, label="TA5", track_name="J2", track_number=3, **west_parking)
-    ta6 = builder.add_track_section(length=10000, label="TA6", **V1, **west_to_east_road)
-    ta7 = builder.add_track_section(length=10000, label="TA7", **V2, **west_to_east_road)
+    ta5 = builder.add_track_section(
+        length=50, label="TA5", track_name="J2", track_number=3, **west_parking
+    )
+    ta6 = builder.add_track_section(
+        length=10000, label="TA6", **V1, **west_to_east_road
+    )
+    ta7 = builder.add_track_section(
+        length=10000, label="TA7", **V2, **west_to_east_road
+    )
     # I create this track section here to be able to add points using it
-    tb0 = builder.add_track_section(length=3000, label="TB0", track_name="A", track_number=1, **south_west_parking)
+    tb0 = builder.add_track_section(
+        length=3000, label="TB0", track_name="A", track_number=1, **south_west_parking
+    )
     # switches
     pa0 = builder.add_point_switch(
         label="PA0",
@@ -138,7 +157,9 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         left=tb0.end(),
         right=ta2.end(),
     )
-    add_signal_on_ports(pa1, {"B1": ("DB0", "SB0"), "B2": ("DA1", "SA1")}, signaling_system)
+    add_signal_on_ports(
+        pa1, {"B1": ("DB0", "SB0"), "B2": ("DA1", "SA1")}, signaling_system
+    )
     pa1.set_coords(-0.37, LAT_1 - LAT_LINE_SPACE)
     pa2 = builder.add_point_switch(
         label="PA2",
@@ -146,7 +167,9 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         left=ta3.end(),
         right=ta0.end(),
     )
-    add_signal_on_ports(pa2, {"A": ("DA3", "SA3"), "B2": ("DA2", "SA2")}, signaling_system)
+    add_signal_on_ports(
+        pa2, {"A": ("DA3", "SA3"), "B2": ("DA2", "SA2")}, signaling_system
+    )
     pa2.set_coords(-0.365, LAT_0)
     pa3 = builder.add_point_switch(
         label="PA3",
@@ -164,8 +187,12 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     ta4.add_detector(label="DA8", position=ta4.length / 2)
     ta5.add_detector(label="DA9", position=ta5.length / 2)
     # Extra signals
-    place_regular_signals_detectors(ta6, "A6", signaling_system, Direction.START_TO_STOP, 200, -200)
-    place_regular_signals_detectors(ta7, "A7", signaling_system, Direction.STOP_TO_START, 200, -200)
+    place_regular_signals_detectors(
+        ta6, "A6", signaling_system, Direction.START_TO_STOP, 200, -200
+    )
+    place_regular_signals_detectors(
+        ta7, "A7", signaling_system, Direction.STOP_TO_START, 200, -200
+    )
     # Station
     west = builder.add_operational_point(label="West_station", trigram="WS", uic=2)
     west.add_part(ta0, 700)
@@ -192,19 +219,37 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     #  Around station B: South-West
     # ================================
     tb0.set_remaining_coords([(-0.4, 49.49), (-0.373, 49.49), (-0.37, 49.492)])
-    south_west = builder.add_operational_point(label="South_West_station", trigram="SWS", uic=1)
+    south_west = builder.add_operational_point(
+        label="South_West_station", trigram="SWS", uic=1
+    )
     south_west.add_part(tb0, 500)
     # ================================
     #  Around station C: Mid - West
     # ================================
     # track sections
-    tc0 = builder.add_track_section(length=1050, label="TC0", track_name="V1bis", track_number=3, **west_to_east_road)
+    tc0 = builder.add_track_section(
+        length=1050,
+        label="TC0",
+        track_name="V1bis",
+        track_number=3,
+        **west_to_east_road,
+    )
     tc1 = builder.add_track_section(length=1000, label="TC1", **V1, **west_to_east_road)
     tc2 = builder.add_track_section(length=1000, label="TC2", **V2, **west_to_east_road)
-    tc3 = builder.add_track_section(length=1050, label="TC3", track_name="V2bis", track_number=4, **west_to_east_road)
+    tc3 = builder.add_track_section(
+        length=1050,
+        label="TC3",
+        track_name="V2bis",
+        track_number=4,
+        **west_to_east_road,
+    )
     # I have to create them here in order to create switches
-    td0 = builder.add_track_section(length=25000, label="TD0", **V1, **west_to_east_road)
-    td1 = builder.add_track_section(length=25000, label="TD1", **V2, **west_to_east_road)
+    td0 = builder.add_track_section(
+        length=25000, label="TD0", **V1, **west_to_east_road
+    )
+    td1 = builder.add_track_section(
+        length=25000, label="TD1", **V2, **west_to_east_road
+    )
     # Switches
     pc0 = builder.add_point_switch(
         label="PC0",
@@ -270,10 +315,16 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         signaling_system,
     )
     pc3.set_coords(-0.296, LAT_1)
-    tc0.set_remaining_coords([(-0.309, LAT_0 + LAT_LINE_SPACE), (-0.297, LAT_0 + LAT_LINE_SPACE)])
-    tc3.set_remaining_coords([(-0.309, LAT_1 - LAT_LINE_SPACE), (-0.297, LAT_1 - LAT_LINE_SPACE)])
+    tc0.set_remaining_coords(
+        [(-0.309, LAT_0 + LAT_LINE_SPACE), (-0.297, LAT_0 + LAT_LINE_SPACE)]
+    )
+    tc3.set_remaining_coords(
+        [(-0.309, LAT_1 - LAT_LINE_SPACE), (-0.297, LAT_1 - LAT_LINE_SPACE)]
+    )
     # Station
-    mid_west = builder.add_operational_point(label="Mid_West_station", trigram="MWS", uic=3)
+    mid_west = builder.add_operational_point(
+        label="Mid_West_station", trigram="MWS", uic=3
+    )
     mid_west.add_part(tc0, 550)
     mid_west.add_part(tc1, 550)
     mid_west.add_part(tc2, 450)
@@ -284,9 +335,13 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     # track sections
     td2 = builder.add_track_section(length=2000, label="TD2", **V1, **west_to_east_road)
     td3 = builder.add_track_section(length=3000, label="TD3", **V2, **west_to_east_road)
-    te0 = builder.add_track_section(length=1500, label="TE0", **V1, **north_to_south_loop)
+    te0 = builder.add_track_section(
+        length=1500, label="TE0", **V1, **north_to_south_loop
+    )
     tf0 = builder.add_track_section(length=3, label="TF0", **V1, **north_to_south_loop)
-    tf1 = builder.add_track_section(length=6500, label="TF1", **V1, **north_to_south_loop)
+    tf1 = builder.add_track_section(
+        length=6500, label="TF1", **V1, **north_to_south_loop
+    )
     # switches
     pd0 = builder.add_crossing(
         label="PD0",
@@ -322,10 +377,16 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         signaling_system,
     )
     pd1.set_coords(-0.172, LAT_1)
-    place_regular_signals_detectors(td0, "D0", signaling_system, Direction.START_TO_STOP, 200, -200)
-    place_regular_signals_detectors(td1, "D1", signaling_system, Direction.STOP_TO_START, 200, -200)
+    place_regular_signals_detectors(
+        td0, "D0", signaling_system, Direction.START_TO_STOP, 200, -200
+    )
+    place_regular_signals_detectors(
+        td1, "D1", signaling_system, Direction.STOP_TO_START, 200, -200
+    )
     # Station
-    mid_east = builder.add_operational_point(label="Mid_East_station", trigram="MES", uic=4)
+    mid_east = builder.add_operational_point(
+        label="Mid_East_station", trigram="MES", uic=4
+    )
     mid_east.add_part(td0, 14000)
     mid_east.add_part(td1, 14000)
     # Slopes
@@ -345,9 +406,19 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     #  Around station E: North
     # ================================
     # track sections
-    te1 = builder.add_track_section(length=2000, label="TE1", track_name="V1bis", track_number=2, **north_to_south_loop)
-    te2 = builder.add_track_section(length=2050, label="TE2", **V1, **north_to_south_loop)
-    te3 = builder.add_track_section(length=2000, label="TE3", **V1, **north_to_south_loop)
+    te1 = builder.add_track_section(
+        length=2000,
+        label="TE1",
+        track_name="V1bis",
+        track_number=2,
+        **north_to_south_loop,
+    )
+    te2 = builder.add_track_section(
+        length=2050, label="TE2", **V1, **north_to_south_loop
+    )
+    te3 = builder.add_track_section(
+        length=2000, label="TE3", **V1, **north_to_south_loop
+    )
     tg0 = builder.add_track_section(length=1000, label="TG0", **V1, **west_to_east_road)
     # switches
     pe0 = builder.add_point_switch(
@@ -425,7 +496,9 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     tf1.set_remaining_coords([(-0.172, 49.47), (-0.167, 49.466), (-0.135, 49.466)])
     south = builder.add_operational_point(label="South_station", trigram="SS", uic=6)
     south.add_part(tf1, 4300)
-    place_regular_signals_detectors(tf1, "F1", signaling_system, min_offset=200, max_offset=4300)
+    place_regular_signals_detectors(
+        tf1, "F1", signaling_system, min_offset=200, max_offset=4300
+    )
     # Curves
     tf1.add_curve(begin=3100, end=4400, curve=9500)
     # ================================
@@ -434,16 +507,24 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     # track sections
     tg1 = builder.add_track_section(length=4000, label="TG1", **V1, **north_east_road)
     tg2 = builder.add_track_section(length=3000, label="TG2", **V2, **north_east_road)
-    tg3 = builder.add_track_section(length=50, label="TG3", track_name="J4", track_number=3, **north_east_parking)
-    tg4 = builder.add_track_section(length=2000, label="TG4", **V1, **north_east_parking)
-    tg5 = builder.add_track_section(length=2000, label="TG5", **V2, **north_east_parking)
+    tg3 = builder.add_track_section(
+        length=50, label="TG3", track_name="J4", track_number=3, **north_east_parking
+    )
+    tg4 = builder.add_track_section(
+        length=2000, label="TG4", **V1, **north_east_parking
+    )
+    tg5 = builder.add_track_section(
+        length=2000, label="TG5", **V2, **north_east_parking
+    )
     pg0 = builder.add_point_switch(
         label="PG0",
         base=tg1.end(),
         left=tg4.begin(),
         right=tg3.begin(),
     )
-    add_signal_on_ports(pg0, {"A": ("DG3", "SG3"), "B1": ("DG5", "SG5")}, signaling_system)
+    add_signal_on_ports(
+        pg0, {"A": ("DG3", "SG3"), "B1": ("DG5", "SG5")}, signaling_system
+    )
     pg0.set_coords(-0.1082, LAT_4)
     pg1 = builder.add_point_switch(
         label="PG1",
@@ -451,21 +532,29 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         left=tg2.end(),
         right=tg3.end(),
     )
-    add_signal_on_ports(pg1, {"A": ("DG6", "SG6"), "B1": ("DG4", "SG4")}, signaling_system)
+    add_signal_on_ports(
+        pg1, {"A": ("DG6", "SG6"), "B1": ("DG4", "SG4")}, signaling_system
+    )
     pg1.set_coords(-0.108, LAT_4 - LAT_LINE_SPACE)
     tg4.set_remaining_coords([(-0.09, LAT_4)])
     tg5.set_remaining_coords([(-0.09, LAT_4 - LAT_LINE_SPACE)])
     tg3.add_detector(label="DG7", position=tg3.length / 2)
-    north_east = builder.add_operational_point(label="North_East_station", trigram="NES", uic=7)
+    north_east = builder.add_operational_point(
+        label="North_East_station", trigram="NES", uic=7
+    )
     north_east.add_part(tg4, 1550)
     north_east.add_part(tg5, 1500)
-    place_regular_signals_detectors(tg1, "G1", signaling_system, min_offset=200, max_offset=-200)
+    place_regular_signals_detectors(
+        tg1, "G1", signaling_system, min_offset=200, max_offset=-200
+    )
     # ================================
     #  Around station H: South-East
     # ================================
     # track sections
     th0 = builder.add_track_section(length=1000, label="TH0", **V2, **west_to_east_road)
-    th1 = builder.add_track_section(length=5000, label="TH1", **V1, **south_east_parking)
+    th1 = builder.add_track_section(
+        length=5000, label="TH1", **V1, **south_east_parking
+    )
     place_regular_signals_detectors(th1, "H1", signaling_system, min_offset=200)
     # switches
     ph0 = builder.add_double_slip_switch(
@@ -522,41 +611,65 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
         ]
     )
     th0.set_remaining_coords([(-0.1346, LAT_1)])
-    th1.set_remaining_coords([(-0.115, 49.497), (-0.115, 49.487), (-0.11, 49.484), (-0.09, 49.484)])
+    th1.set_remaining_coords(
+        [(-0.115, 49.497), (-0.115, 49.487), (-0.11, 49.484), (-0.09, 49.484)]
+    )
     # Station
-    south_east = builder.add_operational_point(label="South_East_station", trigram="SES", uic=8)
+    south_east = builder.add_operational_point(
+        label="South_East_station", trigram="SES", uic=8
+    )
     south_east.add_part(th1, 4400)
     # ================================
     #  Speed sections
     # ================================
-    speed_0 = builder.add_speed_section(300 / 3.6, speed_limit_by_tag={"HLP": 250 / 3.6})
+    speed_0 = builder.add_speed_section(
+        300 / 3.6, speed_limit_by_tag={"HLP": 250 / 3.6}
+    )
     for track_section in builder.infra.track_sections:
-        speed_0.add_track_range(track_section, 0, track_section.length, ApplicableDirection.BOTH)
-    speed_1 = builder.add_speed_section(142 / 3.6, speed_limit_by_tag={"E32C": 100 / 3.6})
+        speed_0.add_track_range(
+            track_section, 0, track_section.length, ApplicableDirection.BOTH
+        )
+    speed_1 = builder.add_speed_section(
+        142 / 3.6, speed_limit_by_tag={"E32C": 100 / 3.6}
+    )
     speed_1.add_track_range(th0, 500, 1000, ApplicableDirection.BOTH)
     speed_1.add_track_range(th1, 0, 4000, ApplicableDirection.BOTH)
-    speed_2 = builder.add_speed_section(112 / 3.6, speed_limit_by_tag={"MA100": 80 / 3.6})
+    speed_2 = builder.add_speed_section(
+        112 / 3.6, speed_limit_by_tag={"MA100": 80 / 3.6}
+    )
     speed_2.add_track_range(th1, 3500, 4400, ApplicableDirection.BOTH)
     # ================================
     #  Electrifications
     # ================================
-    electrified_tracks_25000 = [t for t in builder.infra.track_sections if t not in {td1, ta0}]
-    builder.infra.electrifications.append(Electrification("electrification_25k", "25000V", electrified_tracks_25000))
-    builder.infra.electrifications.append(Electrification("electrification_1.5k", "1500V", [ta0]))
+    electrified_tracks_25000 = [
+        t for t in builder.infra.track_sections if t not in {td1, ta0}
+    ]
+    builder.infra.electrifications.append(
+        Electrification("electrification_25k", "25000V", electrified_tracks_25000)
+    )
+    builder.infra.electrifications.append(
+        Electrification("electrification_1.5k", "1500V", [ta0])
+    )
     # ================================
     #  Neutral sections
     # ================================
     lower_pantograph_section_1 = builder.add_neutral_section(lower_pantograph=True)
-    lower_pantograph_section_1.add_announcement_track_range(tg1, 3500, tg1.length, Direction.START_TO_STOP)
+    lower_pantograph_section_1.add_announcement_track_range(
+        tg1, 3500, tg1.length, Direction.START_TO_STOP
+    )
     lower_pantograph_section_1.add_track_range(tg4, 0, 500, Direction.START_TO_STOP)
     lower_pantograph_section_1.add_track_range(ta6, 0, 10, Direction.START_TO_STOP)
     lower_pantograph_section_2 = builder.add_neutral_section(lower_pantograph=True)
-    lower_pantograph_section_2.add_announcement_track_range(ta0, 1850, 1960, Direction.START_TO_STOP)
+    lower_pantograph_section_2.add_announcement_track_range(
+        ta0, 1850, 1960, Direction.START_TO_STOP
+    )
     lower_pantograph_section_2.add_track_range(ta0, 1960, 2000, Direction.START_TO_STOP)
     keep_pantograph_section_3 = builder.add_neutral_section(lower_pantograph=False)
     keep_pantograph_section_3.add_track_range(ta6, 8500, 8600, Direction.START_TO_STOP)
     keep_pantograph_section_4 = builder.add_neutral_section(lower_pantograph=False)
-    keep_pantograph_section_4.add_announcement_track_range(ta0, 1990, 2000, Direction.STOP_TO_START)
+    keep_pantograph_section_4.add_announcement_track_range(
+        ta0, 1990, 2000, Direction.STOP_TO_START
+    )
     keep_pantograph_section_4.add_track_range(ta0, 1850, 1990, Direction.STOP_TO_START)
     # ================================
     # Produce the railjson
@@ -582,7 +695,8 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     for power_class, boundaries in ep_boundaries.items():
         for i, (start, end) in enumerate(boundaries):
             ep = external_inputs.add_electrical_profile(
-                value=EP_VALUES[min(i, len(boundaries) - i - 1)], power_class=power_class
+                value=EP_VALUES[min(i, len(boundaries) - i - 1)],
+                power_class=power_class,
             )
             ep.add_track_range(ta6, start * 1000, end * 1000)
 
@@ -590,7 +704,10 @@ def create_small_infra(signaling_system: str) -> ScenarioData:
     ep_o.add_track_range(ta0, 0, ta0.length)
     # We voluntarily leave ta0 empty for other power classes
 
-    other_eps = [external_inputs.add_electrical_profile(value="25000V", power_class=str(i)) for i in range(1, 6)]
+    other_eps = [
+        external_inputs.add_electrical_profile(value="25000V", power_class=str(i))
+        for i in range(1, 6)
+    ]
     for track_section in electrified_tracks_25000:
         if track_section is ta6:
             continue

--- a/tests/infra-scripts/takeover.py
+++ b/tests/infra-scripts/takeover.py
@@ -39,7 +39,9 @@ builder = InfraBuilder()
 # Create operational points
 op_start = builder.add_operational_point("op.start", trigram="STA", uic=0, weight=1)
 op_center = builder.add_operational_point("op.center", trigram="CEN", uic=1, weight=0.5)
-op_takeover = builder.add_operational_point("op.takeover", trigram="TAK", uic=3, weight=0.5)
+op_takeover = builder.add_operational_point(
+    "op.takeover", trigram="TAK", uic=3, weight=0.5
+)
 op_end = builder.add_operational_point("op.end", trigram="END", uic=2, weight=1)
 
 # Create track sections
@@ -58,7 +60,9 @@ op_takeover.add_part(t_takeover, 1_500)
 t_1.add_buffer_stop(label="bf.1", position=0)
 t_3.add_buffer_stop(label="bf.3", position=20_000)
 
-builder.infra.electrifications.append(Electrification("electrification_1500", "1500V", [t_1, t_2, t_3, t_takeover]))
+builder.infra.electrifications.append(
+    Electrification("electrification_1500", "1500V", [t_1, t_2, t_3, t_takeover])
+)
 
 speed_limit = builder.add_speed_section(30 / 3.6)
 speed_limit.add_track_range(t_takeover, 0, t_takeover.length, ApplicableDirection.BOTH)
@@ -99,7 +103,9 @@ for offset in range(0, 20_000, 2_000):
 
 signals = []
 for raw_signal in raw_signals:
-    detector = raw_signal.track.add_detector(label=f"det.{raw_signal.name[2:]}", position=raw_signal.position)
+    detector = raw_signal.track.add_detector(
+        label=f"det.{raw_signal.name[2:]}", position=raw_signal.position
+    )
     signal = raw_signal.track.add_signal(
         label=raw_signal.name,
         position=raw_signal.position,
@@ -107,7 +113,9 @@ for raw_signal in raw_signals:
         is_route_delimiter=raw_signal.is_route_delimiter,
         sight_distance=raw_signal.sight_distance,
     )
-    signal.add_logical_signal("BAL", settings={"Nf": "true" if raw_signal.is_route_delimiter else "false"})
+    signal.add_logical_signal(
+        "BAL", settings={"Nf": "true" if raw_signal.is_route_delimiter else "false"}
+    )
     signals.append(signal)
 
 # Add links

--- a/tests/infra-scripts/takeover.py
+++ b/tests/infra-scripts/takeover.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from dataclasses import dataclass
-from typing import List
 
 from railjson_generator import (
     ApplicableDirection,
@@ -81,7 +80,7 @@ class Signal:
     sight_distance: int = default_sight_distance
 
 
-raw_signals: List[Signal] = [
+raw_signals: list[Signal] = [
     Signal("s.2.1500", t_2, 1_500, False),
     Signal("s.takeover.start.1", t_takeover, 1, True),
     # start.1 -> start.2 : needs to be at least as long as the new train

--- a/tests/infra-scripts/three_trains.py
+++ b/tests/infra-scripts/three_trains.py
@@ -15,8 +15,12 @@ tracks = [builder.add_track_section(length=1000) for _ in range(7)]
 
 # Create switches
 switch_0 = builder.add_point_switch(tracks[2].begin(), tracks[1].end(), tracks[0].end())
-switch_1 = builder.add_point_switch(tracks[2].end(), tracks[3].begin(), tracks[4].begin())
-switch_2 = builder.add_point_switch(tracks[4].end(), tracks[5].begin(), tracks[6].begin())
+switch_1 = builder.add_point_switch(
+    tracks[2].end(), tracks[3].begin(), tracks[4].begin()
+)
+switch_2 = builder.add_point_switch(
+    tracks[4].end(), tracks[5].begin(), tracks[6].begin()
+)
 
 # Set coordinates
 
@@ -33,17 +37,33 @@ switch_2.set_coords(3030, -250)
 for i in (2, 3, 4, 5, 6):
     track = tracks[i]
     detector = track.add_detector(position=200)
-    signal = track.add_signal(detector.position - 25, ApplicableDirection.START_TO_STOP, is_route_delimiter=False)
+    signal = track.add_signal(
+        detector.position - 25,
+        ApplicableDirection.START_TO_STOP,
+        is_route_delimiter=False,
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "false"})
-    signal = track.add_signal(detector.position + 25, ApplicableDirection.STOP_TO_START, is_route_delimiter=False)
+    signal = track.add_signal(
+        detector.position + 25,
+        ApplicableDirection.STOP_TO_START,
+        is_route_delimiter=False,
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "false"})
 
 for i in (0, 1, 2, 4):
     track = tracks[i]
     detector = track.add_detector(position=800)
-    signal = track.add_signal(detector.position - 25, ApplicableDirection.START_TO_STOP, is_route_delimiter=False)
+    signal = track.add_signal(
+        detector.position - 25,
+        ApplicableDirection.START_TO_STOP,
+        is_route_delimiter=False,
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "false"})
-    signal = track.add_signal(detector.position + 25, ApplicableDirection.STOP_TO_START, is_route_delimiter=False)
+    signal = track.add_signal(
+        detector.position + 25,
+        ApplicableDirection.STOP_TO_START,
+        is_route_delimiter=False,
+    )
     signal.add_logical_signal("BAL", settings={"Nf": "false"})
 
 # Build infra: Generate BufferStops, TVDSections and Routes

--- a/tests/infra-scripts/tiny_infra.py
+++ b/tests/infra-scripts/tiny_infra.py
@@ -23,9 +23,14 @@ ne_micro_foo_a = builder.add_track_section(length=200, label="ne.micro.foo_a")
 ne_micro_foo_a.add_curve(0, 200, 2000)
 station_foo.add_part(ne_micro_foo_a, 100)
 ne_micro_foo_a.add_buffer_stop(label="buffer_stop_a", position=0)
-tde_foo_a_switch_foo = ne_micro_foo_a.add_detector(label="tde.foo_a-switch_foo", position=175)
+tde_foo_a_switch_foo = ne_micro_foo_a.add_detector(
+    label="tde.foo_a-switch_foo", position=175
+)
 signal = ne_micro_foo_a.add_signal(
-    label="il.sig.C1", position=150, direction=Direction.START_TO_STOP, is_route_delimiter=True
+    label="il.sig.C1",
+    position=150,
+    direction=Direction.START_TO_STOP,
+    is_route_delimiter=True,
 )
 signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
@@ -34,9 +39,14 @@ ne_micro_foo_b.add_slope(0, 200, 10)
 ne_micro_foo_b.add_curve(0, 200, 2000)
 station_foo.add_part(ne_micro_foo_b, 100)
 ne_micro_foo_b.add_buffer_stop(label="buffer_stop_b", position=0)
-tde_foo_b_switch_foo = ne_micro_foo_b.add_detector(label="tde.foo_b-switch_foo", position=175)
+tde_foo_b_switch_foo = ne_micro_foo_b.add_detector(
+    label="tde.foo_b-switch_foo", position=175
+)
 signal = ne_micro_foo_b.add_signal(
-    label="il.sig.C3", position=150, direction=Direction.START_TO_STOP, is_route_delimiter=True
+    label="il.sig.C3",
+    position=150,
+    direction=Direction.START_TO_STOP,
+    is_route_delimiter=True,
 )
 signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
@@ -45,25 +55,40 @@ station_bar.add_part(ne_micro_bar_a, 100)
 ne_micro_bar_a.add_buffer_stop(label="buffer_stop_c", position=200)
 tde_track_bar = ne_micro_bar_a.add_detector(label="tde.track-bar", position=25)
 signal = ne_micro_bar_a.add_signal(
-    label="il.sig.C2", position=50, direction=Direction.STOP_TO_START, is_route_delimiter=True
+    label="il.sig.C2",
+    position=50,
+    direction=Direction.STOP_TO_START,
+    is_route_delimiter=True,
 )
 signal.add_logical_signal("BAL", settings={"Nf": "true"})
 signal = ne_micro_bar_a.add_signal(
-    label="il.sig.S7", position=0, direction=Direction.START_TO_STOP, is_route_delimiter=False
+    label="il.sig.S7",
+    position=0,
+    direction=Direction.START_TO_STOP,
+    is_route_delimiter=False,
 )
 signal.add_logical_signal("BAL", settings={"Nf": "false"})
 
-ne_micro_foo_to_bar = builder.add_track_section(length=10000, label="ne.micro.foo_to_bar")
+ne_micro_foo_to_bar = builder.add_track_section(
+    length=10000, label="ne.micro.foo_to_bar"
+)
 ne_micro_foo_to_bar.add_slope(0, 5000, 10)
 ne_micro_foo_to_bar.add_slope(5000, 10000, -10)
-tde_switch_foo_track = ne_micro_foo_to_bar.add_detector(label="tde.switch_foo-track", position=25)
+tde_switch_foo_track = ne_micro_foo_to_bar.add_detector(
+    label="tde.switch_foo-track", position=25
+)
 signal = ne_micro_foo_to_bar.add_signal(
-    label="il.sig.C6", position=50, direction=Direction.STOP_TO_START, is_route_delimiter=True
+    label="il.sig.C6",
+    position=50,
+    direction=Direction.STOP_TO_START,
+    is_route_delimiter=True,
 )
 signal.add_logical_signal("BAL", settings={"Nf": "true"})
 
 speed_section = builder.add_speed_section(60.0 / 3.6)
-speed_section.add_track_range(ne_micro_foo_to_bar, 2_000, 6_000, ApplicableDirection.BOTH)
+speed_section.add_track_range(
+    ne_micro_foo_to_bar, 2_000, 6_000, ApplicableDirection.BOTH
+)
 
 # TODO electrifications on ne_micro_foo_to_bar
 
@@ -71,7 +96,10 @@ speed_section.add_track_range(ne_micro_foo_to_bar, 2_000, 6_000, ApplicableDirec
 # Add links
 link = builder.add_link(ne_micro_foo_to_bar.end(), ne_micro_bar_a.begin())
 switch = builder.add_point_switch(
-    ne_micro_foo_to_bar.begin(), ne_micro_foo_b.end(), ne_micro_foo_a.end(), label="il.switch_foo"
+    ne_micro_foo_to_bar.begin(),
+    ne_micro_foo_b.end(),
+    ne_micro_foo_a.end(),
+    label="il.switch_foo",
 )
 
 # Set coordinates

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -13,6 +13,26 @@ files = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.3.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
+    {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
+]
+
+[package.extras]
+benchmark = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+cov = ["cloudpickle ; platform_python_implementation == \"CPython\"", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+dev = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier"]
+tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
+
+[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -250,9 +270,10 @@ files = [
 name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main"]
+markers = "extra == \"check\""
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -266,7 +287,7 @@ optional = false
 python-versions = ">= 3.11"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
 geojson-pydantic = ">=1.0.0,<1.1.0"
@@ -423,9 +444,10 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 name = "pyright"
 version = "1.1.393"
 description = "Command line wrapper for pyright"
-optional = false
+optional = true
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main"]
+markers = "extra == \"check\""
 files = [
     {file = "pyright-1.1.393-py3-none-any.whl", hash = "sha256:8320629bb7a44ca90944ba599390162bf59307f3d9fb6e27da3b7011b8c17ae5"},
     {file = "pyright-1.1.393.tar.gz", hash = "sha256:aeeb7ff4e0364775ef416a80111613f91a05c8e01e58ecfefc370ca0db7aed9c"},
@@ -442,24 +464,25 @@ nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.2.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
+    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
 ]
 
 [package.dependencies]
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -488,7 +511,7 @@ optional = false
 python-versions = ">= 3.11"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
 osrd-schemas = {path = "../osrd_schemas"}
@@ -526,9 +549,10 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "ruff"
 version = "0.11.2"
 description = "An extremely fast Python linter and code formatter, written in Rust."
-optional = false
+optional = true
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main"]
+markers = "extra == \"check\""
 files = [
     {file = "ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477"},
     {file = "ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272"},
@@ -556,7 +580,7 @@ version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
@@ -580,7 +604,10 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[extras]
+check = ["pyright", "ruff"]
+
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11,<3.13"
-content-hash = "cd967352f665b55a01acaa489b5b2e82a01ca6e783d8519d6436a0773058108e"
+python-versions = ">=3.11"
+content-hash = "214e516d24966c74a121280ea508a0a4d58aaa7c5365ee914d2f89615ba93d1b"

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -13,26 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "attrs"
-version = "23.1.0"
-description = "Classes Without Boilerplate"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
-]
-
-[package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.1.1) ; platform_python_implementation == \"CPython\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-xdist[psutil]"]
-
-[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -255,22 +235,6 @@ files = [
 ]
 
 [[package]]
-name = "importlab"
-version = "0.8.1"
-description = "A library to calculate python dependency graphs."
-optional = false
-python-versions = ">=3.6.0"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "importlab-0.8.1-py2.py3-none-any.whl", hash = "sha256:124cfa00e8a34fefe8aac1a5e94f56c781b178c9eb61a1d3f60f7e03b77338d3"},
-    {file = "importlab-0.8.1.tar.gz", hash = "sha256:b3893853b1f6eb027da509c3b40e6787e95dd66b4b66f1b3613aad77556e1465"},
-]
-
-[package.dependencies]
-networkx = ">=2"
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -283,206 +247,16 @@ files = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.1.6"
-description = "A very fast and expressive template engine."
+name = "nodeenv"
+version = "1.9.1"
+description = "Node.js virtual environment builder"
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "sys_platform == \"linux\""
 files = [
-    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
-    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
 ]
-
-[package.dependencies]
-MarkupSafe = ">=2.0"
-
-[package.extras]
-i18n = ["Babel (>=2.7)"]
-
-[[package]]
-name = "libcst"
-version = "1.1.0"
-description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10 programs."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "libcst-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:63f75656fd733dc20354c46253fde3cf155613e37643c3eaf6f8818e95b7a3d1"},
-    {file = "libcst-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ae11eb1ea55a16dc0cdc61b41b29ac347da70fec14cc4381248e141ee2fbe6c"},
-    {file = "libcst-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bc745d0c06420fe2644c28d6ddccea9474fb68a2135904043676deb4fa1e6bc"},
-    {file = "libcst-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c1f2da45f1c45634090fd8672c15e0159fdc46853336686959b2d093b6e10fa"},
-    {file = "libcst-1.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:003e5e83a12eed23542c4ea20fdc8de830887cc03662432bb36f84f8c4841b81"},
-    {file = "libcst-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:3ebbb9732ae3cc4ae7a0e97890bed0a57c11d6df28790c2b9c869f7da653c7c7"},
-    {file = "libcst-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d68c34e3038d3d1d6324eb47744cbf13f2c65e1214cf49db6ff2a6603c1cd838"},
-    {file = "libcst-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9dffa1795c2804d183efb01c0f1efd20a7831db6a21a0311edf90b4100d67436"},
-    {file = "libcst-1.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc9b6ac36d7ec9db2f053014ea488086ca2ed9c322be104fbe2c71ca759da4bb"},
-    {file = "libcst-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78b7a38ec4c1c009ac39027d51558b52851fb9234669ba5ba62283185963a31c"},
-    {file = "libcst-1.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5297a16e575be8173185e936b7765c89a3ca69d4ae217a4af161814a0f9745a7"},
-    {file = "libcst-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:7ccaf53925f81118aeaadb068a911fac8abaff608817d7343da280616a5ca9c1"},
-    {file = "libcst-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:75816647736f7e09c6120bdbf408456f99b248d6272277eed9a58cf50fb8bc7d"},
-    {file = "libcst-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8f26250f87ca849a7303ed7a4fd6b2c7ac4dec16b7d7e68ca6a476d7c9bfcdb"},
-    {file = "libcst-1.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d37326bd6f379c64190a28947a586b949de3a76be00176b0732c8ee87d67ebe"},
-    {file = "libcst-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3d8cf974cfa2487b28f23f56c4bff90d550ef16505e58b0dca0493d5293784b"},
-    {file = "libcst-1.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82d1271403509b0a4ee6ff7917c2d33b5a015f44d1e208abb1da06ba93b2a378"},
-    {file = "libcst-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bca1841693941fdd18371824bb19a9702d5784cd347cb8231317dbdc7062c5bc"},
-    {file = "libcst-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f36f592e035ef84f312a12b75989dde6a5f6767fe99146cdae6a9ee9aff40dd0"},
-    {file = "libcst-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f561c9a84eca18be92f4ad90aa9bd873111efbea995449301719a1a7805dbc5c"},
-    {file = "libcst-1.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97fbc73c87e9040e148881041fd5ffa2a6ebf11f64b4ccb5b52e574b95df1a15"},
-    {file = "libcst-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99fdc1929703fd9e7408aed2e03f58701c5280b05c8911753a8d8619f7dfdda5"},
-    {file = "libcst-1.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bf69cbbab5016d938aac4d3ae70ba9ccb3f90363c588b3b97be434e6ba95403"},
-    {file = "libcst-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:fe41b33aa73635b1651f64633f429f7aa21f86d2db5748659a99d9b7b1ed2a90"},
-    {file = "libcst-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:73c086705ed34dbad16c62c9adca4249a556c1b022993d511da70ea85feaf669"},
-    {file = "libcst-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3a07ecfabbbb8b93209f952a365549e65e658831e9231649f4f4e4263cad24b1"},
-    {file = "libcst-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c653d9121d6572d8b7f8abf20f88b0a41aab77ff5a6a36e5a0ec0f19af0072e8"},
-    {file = "libcst-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f1cd308a4c2f71d5e4eec6ee693819933a03b78edb2e4cc5e3ad1afd5fb3f07"},
-    {file = "libcst-1.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8afb6101b8b3c86c5f9cec6b90ab4da16c3c236fe7396f88e8b93542bb341f7c"},
-    {file = "libcst-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:d22d1abfe49aa60fc61fa867e10875a9b3024ba5a801112f4d7ba42d8d53242e"},
-    {file = "libcst-1.1.0.tar.gz", hash = "sha256:0acbacb9a170455701845b7e940e2d7b9519db35a86768d86330a0b0deae1086"},
-]
-
-[package.dependencies]
-pyyaml = ">=5.2"
-typing-extensions = ">=3.7.4.2"
-typing-inspect = ">=0.4.0"
-
-[package.extras]
-dev = ["Sphinx (>=5.1.1)", "black (==23.9.1)", "build (>=0.10.0)", "coverage (>=4.5.4)", "fixit (==2.0.0.post1)", "flake8 (>=3.7.8,<5)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jinja2 (==3.1.2)", "jupyter (>=1.0.0)", "maturin (>=0.8.3,<0.16)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "pyre-check (==0.9.18) ; platform_system != \"Windows\"", "setuptools-rust (>=1.5.2)", "setuptools-scm (>=6.0.1)", "slotscheck (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.2.0)", "usort (==1.0.7)"]
-
-[[package]]
-name = "markupsafe"
-version = "2.1.3"
-description = "Safely add untrusted strings to HTML/XML markup."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-win32.whl", hash = "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431"},
-    {file = "MarkupSafe-2.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
-    {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-win32.whl", hash = "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0"},
-    {file = "MarkupSafe-2.1.3-cp37-cp37m-win_amd64.whl", hash = "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-win32.whl", hash = "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5"},
-    {file = "MarkupSafe-2.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-win32.whl", hash = "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"},
-    {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
-    {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
-name = "networkx"
-version = "3.1"
-description = "Python package for creating and manipulating graphs and networks"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "networkx-3.1-py3-none-any.whl", hash = "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36"},
-    {file = "networkx-3.1.tar.gz", hash = "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61"},
-]
-
-[package.extras]
-default = ["matplotlib (>=3.4)", "numpy (>=1.20)", "pandas (>=1.3)", "scipy (>=1.8)"]
-developer = ["mypy (>=1.1)", "pre-commit (>=3.2)"]
-doc = ["nb2plots (>=0.6)", "numpydoc (>=1.5)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.13)", "sphinx (>=6.1)", "sphinx-gallery (>=0.12)", "texext (>=0.6.7)"]
-extra = ["lxml (>=4.6)", "pydot (>=1.4.2)", "pygraphviz (>=1.10)", "sympy (>=1.10)"]
-test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
-
-[[package]]
-name = "ninja"
-version = "1.11.1.1"
-description = "Ninja is a small build system with a focus on speed"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "ninja-1.11.1.1-py2.py3-none-macosx_10_9_universal2.macosx_10_9_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:376889c76d87b95b5719fdd61dd7db193aa7fd4432e5d52d2e44e4c497bdbbee"},
-    {file = "ninja-1.11.1.1-py2.py3-none-manylinux1_i686.manylinux_2_5_i686.whl", hash = "sha256:ecf80cf5afd09f14dcceff28cb3f11dc90fb97c999c89307aea435889cb66877"},
-    {file = "ninja-1.11.1.1-py2.py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:84502ec98f02a037a169c4b0d5d86075eaf6afc55e1879003d6cab51ced2ea4b"},
-    {file = "ninja-1.11.1.1-py2.py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:73b93c14046447c7c5cc892433d4fae65d6364bec6685411cb97a8bcf815f93a"},
-    {file = "ninja-1.11.1.1-py2.py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:18302d96a5467ea98b68e1cae1ae4b4fb2b2a56a82b955193c637557c7273dbd"},
-    {file = "ninja-1.11.1.1-py2.py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aad34a70ef15b12519946c5633344bc775a7656d789d9ed5fdb0d456383716ef"},
-    {file = "ninja-1.11.1.1-py2.py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:d491fc8d89cdcb416107c349ad1e3a735d4c4af5e1cb8f5f727baca6350fdaea"},
-    {file = "ninja-1.11.1.1-py2.py3-none-musllinux_1_1_i686.whl", hash = "sha256:7563ce1d9fe6ed5af0b8dd9ab4a214bf4ff1f2f6fd6dc29f480981f0f8b8b249"},
-    {file = "ninja-1.11.1.1-py2.py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:9df724344202b83018abb45cb1efc22efd337a1496514e7e6b3b59655be85205"},
-    {file = "ninja-1.11.1.1-py2.py3-none-musllinux_1_1_s390x.whl", hash = "sha256:3e0f9be5bb20d74d58c66cc1c414c3e6aeb45c35b0d0e41e8d739c2c0d57784f"},
-    {file = "ninja-1.11.1.1-py2.py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:76482ba746a2618eecf89d5253c0d1e4f1da1270d41e9f54dfbd91831b0f6885"},
-    {file = "ninja-1.11.1.1-py2.py3-none-win32.whl", hash = "sha256:fa2ba9d74acfdfbfbcf06fad1b8282de8a7a8c481d9dee45c859a8c93fcc1082"},
-    {file = "ninja-1.11.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:95da904130bfa02ea74ff9c0116b4ad266174fafb1c707aa50212bc7859aebf1"},
-    {file = "ninja-1.11.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:185e0641bde601e53841525c4196278e9aaf4463758da6dd1e752c0a0f54136a"},
-    {file = "ninja-1.11.1.1.tar.gz", hash = "sha256:9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c"},
-]
-
-[package.extras]
-test = ["codecov (>=2.0.5)", "coverage (>=4.2)", "flake8 (>=3.0.4)", "pytest (>=4.5.0)", "pytest-cov (>=2.7.1)", "pytest-runner (>=5.1)", "pytest-virtualenv (>=1.7.0)", "virtualenv (>=15.0.3)"]
 
 [[package]]
 name = "osrd-schemas"
@@ -532,19 +306,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "pycnite"
-version = "2023.10.11"
-description = "Python bytecode utilities"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "pycnite-2023.10.11-py3-none-any.whl", hash = "sha256:7d02eb0ec4b405d8812ce053434dacfc2335dcd458ab58a1a8bf64f72d40bd76"},
-    {file = "pycnite-2023.10.11.tar.gz", hash = "sha256:ad8616982beecc39f2090999aa8fe0b044b1f6733ec39484cb5e0900b3c88aa1"},
-]
 
 [[package]]
 name = "pydantic"
@@ -659,36 +420,25 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
-name = "pydot"
-version = "1.4.2"
-description = "Python interface to Graphviz's Dot"
+name = "pyright"
+version = "1.1.393"
+description = "Command line wrapper for pyright"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 groups = ["dev"]
-markers = "sys_platform == \"linux\""
 files = [
-    {file = "pydot-1.4.2-py2.py3-none-any.whl", hash = "sha256:66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451"},
-    {file = "pydot-1.4.2.tar.gz", hash = "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d"},
+    {file = "pyright-1.1.393-py3-none-any.whl", hash = "sha256:8320629bb7a44ca90944ba599390162bf59307f3d9fb6e27da3b7011b8c17ae5"},
+    {file = "pyright-1.1.393.tar.gz", hash = "sha256:aeeb7ff4e0364775ef416a80111613f91a05c8e01e58ecfefc370ca0db7aed9c"},
 ]
 
 [package.dependencies]
-pyparsing = ">=2.1.4"
-
-[[package]]
-name = "pyparsing"
-version = "3.1.1"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = false
-python-versions = ">=3.6.8"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "pyparsing-3.1.1-py3-none-any.whl", hash = "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb"},
-    {file = "pyparsing-3.1.1.tar.gz", hash = "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"},
-]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -729,105 +479,6 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
-
-[[package]]
-name = "pytype"
-version = "2023.10.31"
-description = "Python type inferencer"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "pytype-2023.10.31-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:79e8e0b25bfc99f401cc50d8e6e9b70f5fe0e8a6f0c741416679f1c16837178c"},
-    {file = "pytype-2023.10.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2db027c5647a65654049e6ca9ca94eda902142a525af75b19881cd916f512f3e"},
-    {file = "pytype-2023.10.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a34fbf27e4e0ddc2c2e7ededd86462c08cc29f4a70d73c4949a4c498f448aecd"},
-    {file = "pytype-2023.10.31-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b5152c1f79a9753b92b68b7c455126a1034d6ef4458c5aec4cfc33c52fc61def"},
-    {file = "pytype-2023.10.31-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87788ba9bba0617fc32936387b08835ff871acec42180366822fdd82fd4c4e6b"},
-    {file = "pytype-2023.10.31-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14879cce0bb7272d7ca338d0100a7917298be689b6bd96422d086673e52497a2"},
-    {file = "pytype-2023.10.31-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:55f84c50b8d5ea51d7f62bcb80558217121a94aa5c47b672b297d6b2c6e04880"},
-    {file = "pytype-2023.10.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fe39d2f3d8340876159bdcd96e5e2d8c0ffc629baa230a3f872f10c23e863d3"},
-    {file = "pytype-2023.10.31-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d22d7e537dbdfc96bc160affedf73ca01d38ed1d4443d3a199b1c60ad7c94b"},
-    {file = "pytype-2023.10.31-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e511df775148fef46940e99ddded327ed24c882742d98d5ad7b5adf86533f9db"},
-    {file = "pytype-2023.10.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6f99b28e1d61d18df6411010d49e3e9dce07e7a091b5ae246cad371afab254f"},
-    {file = "pytype-2023.10.31-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a9148c5b928485fb29e2f0b0af5565d355dcd400df87e44b4f358d159ee5eb"},
-    {file = "pytype-2023.10.31.tar.gz", hash = "sha256:a032cb85a7cf33ea34ce04fdd100de75206d6e0d44d2ed9ce68c07c76d7e8f05"},
-]
-
-[package.dependencies]
-attrs = ">=21.4.0"
-importlab = ">=0.8"
-jinja2 = ">=3.1.2"
-libcst = ">=1.0.1"
-networkx = "<3.2"
-ninja = ">=1.10.0.post2"
-pycnite = ">=2023.10.11"
-pydot = ">=1.4.2"
-tabulate = ">=0.8.10"
-toml = ">=0.10.2"
-typing-extensions = ">=4.3.0"
-
-[[package]]
-name = "pyyaml"
-version = "6.0.1"
-description = "YAML parser and emitter for Python"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
-]
 
 [[package]]
 name = "railjson-generator"
@@ -900,35 +551,6 @@ files = [
 ]
 
 [[package]]
-name = "tabulate"
-version = "0.9.0"
-description = "Pretty-print tabular data"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
-    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
-]
-
-[package.extras]
-widechars = ["wcwidth"]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -939,24 +561,6 @@ files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
-markers = {dev = "sys_platform == \"linux\""}
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-description = "Runtime inspection utilities for typing module."
-optional = false
-python-versions = "*"
-groups = ["dev"]
-markers = "sys_platform == \"linux\""
-files = [
-    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
-    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
-]
-
-[package.dependencies]
-mypy-extensions = ">=0.3.0"
-typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "urllib3"
@@ -979,4 +583,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "dc9016cfee93f0141e7be19c07504d319a1ed6d821ea37445dcca5ea600f5d70"
+content-hash = "cd967352f665b55a01acaa489b5b2e82a01ca6e783d8519d6436a0773058108e"

--- a/tests/poetry.lock
+++ b/tests/poetry.lock
@@ -33,42 +33,6 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothesis", "mypy (>=1.1.1) ; platform_python_implementation == \"CPython\"", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version < \"3.11\"", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -181,32 +145,17 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\"", dev = "platform_system == \"Windows\""}
 
 [[package]]
 name = "coverage"
@@ -270,44 +219,8 @@ files = [
     {file = "coverage-7.3.4.tar.gz", hash = "sha256:020d56d2da5bc22a0e00a5b0d54597ee91ad72446fa4cf1b97c35022f6b6dbf0"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.1.3"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "python_version < \"3.11\""
-files = [
-    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
-    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
-
-[[package]]
-name = "flake8"
-version = "6.1.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-groups = ["dev"]
-files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
 
 [[package]]
 name = "geojson-pydantic"
@@ -370,30 +283,13 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-groups = ["dev"]
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "sys_platform == \"linux\""
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -462,6 +358,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
+markers = "sys_platform == \"linux\""
 files = [
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa"},
     {file = "MarkupSafe-2.1.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57"},
@@ -526,24 +423,13 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = false
 python-versions = ">=3.5"
 groups = ["dev"]
+markers = "sys_platform == \"linux\""
 files = [
     {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
     {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
@@ -600,17 +486,20 @@ test = ["codecov (>=2.0.5)", "coverage (>=4.2)", "flake8 (>=3.0.4)", "pytest (>=
 
 [[package]]
 name = "osrd-schemas"
-version = "0.8.12"
+version = "0.8.17"
 description = ""
 optional = false
-python-versions = ">=3.9,<3.13"
+python-versions = ">= 3.11"
 groups = ["main"]
 files = []
 develop = true
 
 [package.dependencies]
-geojson-pydantic = "^1.0.0"
-pydantic = "^2.1.1"
+geojson-pydantic = ">=1.0.0,<1.1.0"
+pydantic = ">=2.6,<3.0"
+
+[package.extras]
+check = ["pyright (>=1.1.393,<1.2.0)", "ruff (>=0.9.5,<0.10.0)"]
 
 [package.source]
 type = "directory"
@@ -627,34 +516,6 @@ files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
-
-[[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.0.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
-    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
-]
-
-[package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
 name = "pluggy"
@@ -683,18 +544,6 @@ markers = "sys_platform == \"linux\""
 files = [
     {file = "pycnite-2023.10.11-py3-none-any.whl", hash = "sha256:7d02eb0ec4b405d8812ce053434dacfc2335dcd458ab58a1a8bf64f72d40bd76"},
     {file = "pycnite-2023.10.11.tar.gz", hash = "sha256:ad8616982beecc39f2090999aa8fe0b044b1f6733ec39484cb5e0900b3c88aa1"},
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
 ]
 
 [[package]]
@@ -826,18 +675,6 @@ files = [
 pyparsing = ">=2.1.4"
 
 [[package]]
-name = "pyflakes"
-version = "3.1.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
-]
-
-[[package]]
 name = "pyparsing"
 version = "3.1.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -854,22 +691,6 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyproject-flake8"
-version = "6.1.0"
-description = "pyproject-flake8 (`pflake8`), a monkey patching wrapper to connect flake8 with pyproject.toml configuration"
-optional = false
-python-versions = ">=3.8.1"
-groups = ["dev"]
-files = [
-    {file = "pyproject_flake8-6.1.0-py3-none-any.whl", hash = "sha256:86ea5559263c098e1aa4f866776aa2cf45362fd91a576b9fd8fbbbb55db12c4e"},
-    {file = "pyproject_flake8-6.1.0.tar.gz", hash = "sha256:6da8e5a264395e0148bc11844c6fb50546f1fac83ac9210f7328664135f9e70f"},
-]
-
-[package.dependencies]
-flake8 = "6.1.0"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "pytest"
 version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
@@ -883,11 +704,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -1012,18 +831,19 @@ files = [
 
 [[package]]
 name = "railjson-generator"
-version = "0.4.8"
+version = "0.4.9"
 description = ""
 optional = false
-python-versions = ">=3.9,<3.13"
+python-versions = ">= 3.11"
 groups = ["main"]
 files = []
 develop = true
 
 [package.dependencies]
 osrd-schemas = {path = "../osrd_schemas"}
-pytest = "^7.4.3"
-pytest-cov = "^4.1.0"
+
+[package.extras]
+check = ["pyright (>=1.1.393,<1.2.0)", "pytest (>=7.4.3,<7.5.0)", "pytest-cov (>=4.1.0,<4.2.0)", "ruff (>=0.9.5,<0.10.0)"]
 
 [package.source]
 type = "directory"
@@ -1050,6 +870,34 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "ruff"
+version = "0.11.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477"},
+    {file = "ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272"},
+    {file = "ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147"},
+    {file = "ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630"},
+    {file = "ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f"},
+    {file = "ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc"},
+    {file = "ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080"},
+    {file = "ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4"},
+    {file = "ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94"},
+]
 
 [[package]]
 name = "tabulate"
@@ -1081,19 +929,6 @@ files = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-groups = ["main", "dev"]
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-markers = {main = "python_full_version <= \"3.11.0a6\"", dev = "python_full_version < \"3.11.0a7\""}
-
-[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1104,7 +939,7 @@ files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
-markers = {dev = "python_version < \"3.10\" or sys_platform == \"linux\""}
+markers = {dev = "sys_platform == \"linux\""}
 
 [[package]]
 name = "typing-inspect"
@@ -1143,5 +978,5 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<3.13"
-content-hash = "26391cadf167a8965068f57eeef6066feac345e249553265cc2bd4b4adaa1754"
+python-versions = ">=3.11,<3.13"
+content-hash = "dc9016cfee93f0141e7be19c07504d319a1ed6d821ea37445dcca5ea600f5d70"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -14,10 +14,10 @@ requests = "^2.32.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.11.2"
-pytype = { platform = "linux", version = "^2023.10.17" }
+pyright = "1.1.393"
 
-[tool.pytype]
-inputs = ["fuzzer", "infra-scripts", "tests"]
+[tool.pyright]
+include = ["../python/osrd_schemas"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -8,27 +8,13 @@ authors = ["OSRD <contact@osrd.fr>"]
 osrd-schemas = { path = "../python/osrd_schemas/", develop = true }
 pytest = "^7.2.2"
 pytest-cov = "^4.1.0"
-python = ">=3.9,<3.13"
+python = ">=3.11,<3.13"
 railjson-generator = { path = "../python/railjson_generator/", develop = true }
 requests = "^2.32.2"
 
 [tool.poetry.group.dev.dependencies]
-black = "^22.12.0"
-isort = "^5.12.0"
-pyproject-flake8 = "^6.0.0.post1"
+ruff = "0.11.2"
 pytype = { platform = "linux", version = "^2023.10.17" }
-
-[tool.flake8]
-ignore = "W503,E203"
-max-line-length = 120
-exclude = [".venv/"]
-
-[tool.black]
-line-length = 120
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
 
 [tool.pytype]
 inputs = ["fuzzer", "infra-scripts", "tests"]

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,20 +1,20 @@
-[tool.poetry]
+[project]
 name = "tests"
 version = "0.1.1"
 description = "Integration tests"
-authors = ["OSRD <contact@osrd.fr>"]
+authors = [{ name = "OSRD Contributors", email = "<contact@osrd.fr>" }]
+requires-python = ">=3.11"
 
-[tool.poetry.dependencies]
-osrd-schemas = { path = "../python/osrd_schemas/", develop = true }
-pytest = "^7.2.2"
-pytest-cov = "^4.1.0"
-python = ">=3.11,<3.13"
-railjson-generator = { path = "../python/railjson_generator/", develop = true }
-requests = "^2.32.2"
+dependencies = [
+  "osrd-schemas @ ../python/osrd_schemas/",
+  "pytest ~= 7.2.2",
+  "pytest-cov ~= 4.1.0",
+  "railjson-generator @ ../python/railjson_generator/",
+  "requests ~= 2.32.2",
+]
 
-[tool.poetry.group.dev.dependencies]
-ruff = "0.11.2"
-pyright = "1.1.393"
+[project.optional-dependencies]
+check = ["pyright ~= 1.1.393", "ruff ~= 0.11.2"]
 
 [tool.pyright]
 include = ["../python/osrd_schemas"]

--- a/tests/tests/path.py
+++ b/tests/tests/path.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable
 
 
 @dataclass(frozen=True)

--- a/tests/tests/test_infra.py
+++ b/tests/tests/test_infra.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any
+from collections.abc import Iterable, Mapping
 
 import pytest
 import requests
@@ -13,7 +14,7 @@ class _InfraDetails:
     name: str
     railjson_version: str
     version: str
-    generated_version: Optional[str]
+    generated_version: str | None
     locked: bool
     created: str
     modified: str
@@ -26,8 +27,8 @@ class _InfraResponse:
     page_size: int
     page_count: int
     current: int
-    previous: Optional[int]
-    next: Optional[int]
+    previous: int | None
+    next: int | None
     results: Iterable[Mapping[str, Any]]
 
 

--- a/tests/tests/test_paced_train.py
+++ b/tests/tests/test_paced_train.py
@@ -20,31 +20,49 @@ def _update_simulation_with_mareco_allowances(editoast_url, paced_train_id):
     paced_train["constraint_distribution"] = "MARECO"
     r = requests.put(editoast_url + f"/paced_train/{paced_train_id}", json=paced_train)
     if r.status_code // 102 != 2:
-        raise RuntimeError(f"Paced train error {r.status_code}: {r.content}, payload={json.dumps(paced_train)}")
+        raise RuntimeError(
+            f"Paced train error {r.status_code}: {r.content}, payload={json.dumps(paced_train)}"
+        )
     r = requests.get(editoast_url + f"/paced_train/{paced_train_id}/")
     body = r.json()
     assert body["constraint_distribution"] == "MARECO"
     return body
 
 
-def test_get_and_update_paced_train_result(west_to_south_east_paced_train: Sequence[Any], small_infra: Infra):
+def test_get_and_update_paced_train_result(
+    west_to_south_east_paced_train: Sequence[Any], small_infra: Infra
+):
     paced_train = west_to_south_east_paced_train[0]
     paced_train_id = paced_train["id"]
     response = requests.get(f"{EDITOAST_URL}paced_train/{paced_train_id}/")
     if response.status_code // 100 != 2:
-        raise RuntimeError(f"Paced train error {response.status_code}: {response.content}, id={paced_train_id}")
-    response = requests.get(f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}")
+        raise RuntimeError(
+            f"Paced train error {response.status_code}: {response.content}, id={paced_train_id}"
+        )
+    response = requests.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}"
+    )
     simulation_report = response.json()
-    assert simulation_report["base"]["energy_consumption"] == simulation_report["final_output"]["energy_consumption"]
+    assert (
+        simulation_report["base"]["energy_consumption"]
+        == simulation_report["final_output"]["energy_consumption"]
+    )
 
     response = _update_simulation_with_mareco_allowances(EDITOAST_URL, paced_train_id)
     response = requests.get(f"{EDITOAST_URL}paced_train/{paced_train_id}/")
     if response.status_code // 100 != 2:
-        raise RuntimeError(f"Paced train error {response.status_code}: {response.content}, id={paced_train_id}")
+        raise RuntimeError(
+            f"Paced train error {response.status_code}: {response.content}, id={paced_train_id}"
+        )
 
-    response = requests.get(f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}")
+    response = requests.get(
+        f"{EDITOAST_URL}paced_train/{paced_train_id}/simulation?infra_id={small_infra.id}"
+    )
     simulation_report = response.json()
-    assert simulation_report["base"]["energy_consumption"] != simulation_report["final_output"]["energy_consumption"]
+    assert (
+        simulation_report["base"]["energy_consumption"]
+        != simulation_report["final_output"]["energy_consumption"]
+    )
     assert (
         simulation_report["provisional"]["energy_consumption"]
         == simulation_report["final_output"]["energy_consumption"]
@@ -56,7 +74,9 @@ def test_editoast_delete(west_to_south_east_paced_trains: Sequence[Any]):
     paced_trains_ids = [paced_train["id"] for paced_train in paced_trains]
     r = requests.delete(f"{EDITOAST_URL}paced_train/", json={"ids": paced_trains_ids})
     if r.status_code // 100 != 2:
-        raise RuntimeError(f"Paced train error {r.status_code}: {r.content}, payload={json.dumps(paced_trains_ids)}")
+        raise RuntimeError(
+            f"Paced train error {r.status_code}: {r.content}, payload={json.dumps(paced_trains_ids)}"
+        )
     r = requests.get(
         f"{EDITOAST_URL}paced_train/{paced_trains_ids[0]}/",
     )

--- a/tests/tests/test_pathfinding.py
+++ b/tests/tests/test_pathfinding.py
@@ -36,14 +36,54 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
             "rt.DH2->buffer_stop.7",
         ],
         "track_section_ranges": [
-            {"track_section": "TA2", "begin": 837034, "end": 1950000, "direction": "START_TO_STOP"},
-            {"track_section": "TA5", "begin": 0, "end": 50000, "direction": "START_TO_STOP"},
-            {"track_section": "TA7", "begin": 0, "end": 10000000, "direction": "START_TO_STOP"},
-            {"track_section": "TC2", "begin": 0, "end": 1000000, "direction": "START_TO_STOP"},
-            {"track_section": "TD1", "begin": 0, "end": 25000000, "direction": "START_TO_STOP"},
-            {"track_section": "TD3", "begin": 0, "end": 3000000, "direction": "START_TO_STOP"},
-            {"track_section": "TH0", "begin": 0, "end": 1000000, "direction": "START_TO_STOP"},
-            {"track_section": "TH1", "begin": 0, "end": 4386000, "direction": "START_TO_STOP"},
+            {
+                "track_section": "TA2",
+                "begin": 837034,
+                "end": 1950000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TA5",
+                "begin": 0,
+                "end": 50000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TA7",
+                "begin": 0,
+                "end": 10000000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TC2",
+                "begin": 0,
+                "end": 1000000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TD1",
+                "begin": 0,
+                "end": 25000000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TD3",
+                "begin": 0,
+                "end": 3000000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TH0",
+                "begin": 0,
+                "end": 1000000,
+                "direction": "START_TO_STOP",
+            },
+            {
+                "track_section": "TH1",
+                "begin": 0,
+                "end": 4386000,
+                "direction": "START_TO_STOP",
+            },
         ],
         "length": 45548966,
         "path_item_positions": [0, 45548966],
@@ -51,11 +91,16 @@ _EXPECTED_WEST_TO_SOUTH_EAST_PATH = Path(
 )
 
 
-def assert_track_ranges_are_equals(track_ranges: Sequence[Any], expected_track_ranges: Sequence[Any]):
+def assert_track_ranges_are_equals(
+    track_ranges: Sequence[Any], expected_track_ranges: Sequence[Any]
+):
     assert len(track_ranges) == len(expected_track_ranges)
 
     for i in range(len(track_ranges)):
-        assert track_ranges[i]["track_section"] == expected_track_ranges[i]["track_section"]
+        assert (
+            track_ranges[i]["track_section"]
+            == expected_track_ranges[i]["track_section"]
+        )
         assert track_ranges[i]["begin"] == expected_track_ranges[i]["begin"]
         assert track_ranges[i]["end"] == expected_track_ranges[i]["end"]
         assert track_ranges[i]["direction"] == expected_track_ranges[i]["direction"]
@@ -63,10 +108,16 @@ def assert_track_ranges_are_equals(track_ranges: Sequence[Any], expected_track_r
 
 def test_west_to_south_east_path(west_to_south_east_path: Path):
     assert west_to_south_east_path.status == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.status
-    assert west_to_south_east_path.length == pytest.approx(_EXPECTED_WEST_TO_SOUTH_EAST_PATH.length, rel=1e-3)
+    assert west_to_south_east_path.length == pytest.approx(
+        _EXPECTED_WEST_TO_SOUTH_EAST_PATH.length, rel=1e-3
+    )
     assert west_to_south_east_path.routes == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.routes
     assert west_to_south_east_path.blocks == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.blocks
-    assert west_to_south_east_path.path_item_positions == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.path_item_positions
+    assert (
+        west_to_south_east_path.path_item_positions
+        == _EXPECTED_WEST_TO_SOUTH_EAST_PATH.path_item_positions
+    )
     assert_track_ranges_are_equals(
-        west_to_south_east_path.track_section_ranges, _EXPECTED_WEST_TO_SOUTH_EAST_PATH.track_section_ranges
+        west_to_south_east_path.track_section_ranges,
+        _EXPECTED_WEST_TO_SOUTH_EAST_PATH.track_section_ranges,
     )

--- a/tests/tests/test_regressions.py
+++ b/tests/tests/test_regressions.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Dict, List, Optional
 
 import pytest
 import requests
@@ -34,8 +33,8 @@ def _load_infra(editoast_url: str, infra_id: int):
 
 
 def _schedule_with_payload(
-    editoast_url: str, payload: Dict, accept_400: bool, scenario: Scenario
-) -> Optional[int]:
+    editoast_url: str, payload: dict, accept_400: bool, scenario: Scenario
+) -> int | None:
     """
     Send a schedule request with the given payload, raises an error if the request failed (unless we accept 400s).
     Returns the schedule id.
@@ -50,7 +49,7 @@ def _schedule_with_payload(
     return r.json()[0]["id"]
 
 
-def _stdcm_with_payload(editoast_url: str, payload: Dict, scenario: Scenario):
+def _stdcm_with_payload(editoast_url: str, payload: dict, scenario: Scenario):
     """
     Send a stdcm request with the given payload, raises an error if the request failed.
     """
@@ -82,7 +81,7 @@ def _check_result(editoast_url: str, schedule_id: int, infra_id: int):
         )
 
 
-def _apply_prelude(prelude: List, editoast_url: str, scenario: Scenario):
+def _apply_prelude(prelude: list, editoast_url: str, scenario: Scenario):
     """
     Send the requests from the test prelude to fill the timetable with trains
     """

--- a/tests/tests/test_regressions.py
+++ b/tests/tests/test_regressions.py
@@ -33,12 +33,16 @@ def _load_infra(editoast_url: str, infra_id: int):
         raise RuntimeError(f"Infra load {r.status_code}: {r.content}")
 
 
-def _schedule_with_payload(editoast_url: str, payload: Dict, accept_400: bool, scenario: Scenario) -> Optional[int]:
+def _schedule_with_payload(
+    editoast_url: str, payload: Dict, accept_400: bool, scenario: Scenario
+) -> Optional[int]:
     """
     Send a schedule request with the given payload, raises an error if the request failed (unless we accept 400s).
     Returns the schedule id.
     """
-    r = requests.post(editoast_url + f"/timetable/{scenario.timetable}/train_schedules/", json=payload)
+    r = requests.post(
+        editoast_url + f"/timetable/{scenario.timetable}/train_schedules/", json=payload
+    )
     if r.status_code // 100 != 2:
         if r.status_code // 100 == 4 and accept_400:
             return None
@@ -50,7 +54,9 @@ def _stdcm_with_payload(editoast_url: str, payload: Dict, scenario: Scenario):
     """
     Send a stdcm request with the given payload, raises an error if the request failed.
     """
-    url = editoast_url + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}"
+    url = (
+        editoast_url + f"/timetable/{scenario.timetable}/stdcm/?infra={scenario.infra}"
+    )
     r = requests.post(url, json=payload)
     if r.status_code // 100 != 2:
         raise RuntimeError(f"stdcm error {r.status_code}: {r.content}")
@@ -67,9 +73,13 @@ def _check_result(editoast_url: str, schedule_id: int, infra_id: int):
     """
     Get the /result/ of the given train id. The function doesn't return anything, it just raises any error
     """
-    r = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation/?infra_id={infra_id}")
+    r = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation/?infra_id={infra_id}"
+    )
     if r.status_code // 100 != 2 or r.json().get("status", "") != "success":
-        raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, id={schedule_id}")
+        raise RuntimeError(
+            f"Schedule error {r.status_code}: {r.content}, id={schedule_id}"
+        )
 
 
 def _apply_prelude(prelude: List, editoast_url: str, scenario: Scenario):
@@ -80,7 +90,9 @@ def _apply_prelude(prelude: List, editoast_url: str, scenario: Scenario):
         assert "schedule_payload" in train
 
         schedule_payload = train["schedule_payload"]
-        schedule_id = _schedule_with_payload(editoast_url, schedule_payload, accept_400=False, scenario=scenario)
+        schedule_id = _schedule_with_payload(
+            editoast_url, schedule_payload, accept_400=False, scenario=scenario
+        )
 
         _check_result(editoast_url, schedule_id, scenario.infra)
 
@@ -106,7 +118,9 @@ def _reproduce_test(path_to_json: Path, scenario: Scenario, rolling_stock_id: in
     stop_after_schedule = fuzzer_output["error_type"] == "SCHEDULE"
 
     payload = fuzzer_output["schedule_payload"]
-    schedule_id = _schedule_with_payload(EDITOAST_URL, payload, stop_after_schedule, scenario)
+    schedule_id = _schedule_with_payload(
+        EDITOAST_URL, payload, stop_after_schedule, scenario
+    )
     if stop_after_schedule:
         return
 
@@ -115,4 +129,6 @@ def _reproduce_test(path_to_json: Path, scenario: Scenario, rolling_stock_id: in
 
 @pytest.mark.parametrize("file_name", REGRESSION_TESTS_JSON_FILES)
 def test_regressions(file_name: str, small_scenario: Scenario, fast_rolling_stock: int):
-    _reproduce_test(REGRESSION_TESTS_DATA_FOLDER / file_name, small_scenario, fast_rolling_stock)
+    _reproduce_test(
+        REGRESSION_TESTS_DATA_FOLDER / file_name, small_scenario, fast_rolling_stock
+    )

--- a/tests/tests/test_regressions.py
+++ b/tests/tests/test_regressions.py
@@ -93,6 +93,7 @@ def _apply_prelude(prelude: List, editoast_url: str, scenario: Scenario):
         schedule_id = _schedule_with_payload(
             editoast_url, schedule_payload, accept_400=False, scenario=scenario
         )
+        assert schedule_id is not None
 
         _check_result(editoast_url, schedule_id, scenario.infra)
 
@@ -121,6 +122,7 @@ def _reproduce_test(path_to_json: Path, scenario: Scenario, rolling_stock_id: in
     schedule_id = _schedule_with_payload(
         EDITOAST_URL, payload, stop_after_schedule, scenario
     )
+    assert schedule_id is not None
     if stop_after_schedule:
         return
 

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -71,7 +71,10 @@ def test_get_scenario(small_scenario: Scenario):
         del res["project"]
         del res["study"]
         scenario = _ScenarioResponse(
-            **res, project=_Project(**project), study=_Study(**study), electrical_profile_set_id=None
+            **res,
+            project=_Project(**project),
+            study=_Study(**study),
+            electrical_profile_set_id=None,
         )
         assert scenario.name == "_@Test integration scenario"
     else:

--- a/tests/tests/test_scenario.py
+++ b/tests/tests/test_scenario.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import requests
 
@@ -18,7 +17,7 @@ class _Project:
     creation_date: str
     last_modification: str
     tags: list[str]
-    image: Optional[int]
+    image: int | None
 
 
 @dataclass(frozen=True)
@@ -30,9 +29,9 @@ class _Study:
     service_code: str
     creation_date: str
     last_modification: str
-    start_date: Optional[str]
-    expected_end_date: Optional[str]
-    actual_end_date: Optional[str]
+    start_date: str | None
+    expected_end_date: str | None
+    actual_end_date: str | None
     budget: int
     tags: list[str]
     state: str
@@ -48,7 +47,7 @@ class _ScenarioResponse:
     description: str
     timetable_id: int
     infra_id: int
-    electrical_profile_set_id: Optional[int]
+    electrical_profile_set_id: int | None
     trains_count: int
     paced_trains_count: int
     creation_date: str

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, Dict
+from typing import Any
 
 import requests
 
@@ -435,7 +435,7 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
     }
 
 
-def _get_stdcm_response(infra: Infra, timetable_id: int, stdcm_payload: Dict[str, Any]):
+def _get_stdcm_response(infra: Infra, timetable_id: int, stdcm_payload: dict[str, Any]):
     stdcm_response = requests.post(
         f"{EDITOAST_URL}/timetable/{timetable_id}/stdcm/?infra={infra.id}",
         json=stdcm_payload,

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -15,7 +15,9 @@ _MIDDLE = {"track": "TA5", "offset": 0}
 _STOP = {"track": "TH1", "offset": 0}
 
 
-def _add_train(editoast_url: str, scenario: Scenario, rolling_stock_name: str, start_time: str):
+def _add_train(
+    editoast_url: str, scenario: Scenario, rolling_stock_name: str, start_time: str
+):
     schedule_payload = [
         {
             "constraint_distribution": "STANDARD",
@@ -29,16 +31,25 @@ def _add_train(editoast_url: str, scenario: Scenario, rolling_stock_name: str, s
             "start_time": start_time,
         }
     ]
-    r = requests.post(editoast_url + f"/timetable/{scenario.timetable}/train_schedules/", json=schedule_payload)
+    r = requests.post(
+        editoast_url + f"/timetable/{scenario.timetable}/train_schedules/",
+        json=schedule_payload,
+    )
     if r.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(schedule_payload)}")
+        raise RuntimeError(
+            f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(schedule_payload)}"
+        )
     schedule_id = r.json()[0]
     return schedule_id
 
 
-def test_empty_timetable(small_infra: Infra, foo_project_id: int, fast_rolling_stock: int):
+def test_empty_timetable(
+    small_infra: Infra, foo_project_id: int, fast_rolling_stock: int
+):
     op_study = create_op_study(EDITOAST_URL, foo_project_id)
-    _, timetable = create_scenario(EDITOAST_URL, small_infra.id, foo_project_id, op_study)
+    _, timetable = create_scenario(
+        EDITOAST_URL, small_infra.id, foo_project_id, op_study
+    )
     requests.post(EDITOAST_URL + f"infra/{small_infra.id}/load")
     payload = {
         "rolling_stock_id": fast_rolling_stock,
@@ -53,14 +64,21 @@ def test_empty_timetable(small_infra: Infra, foo_project_id: int, fast_rolling_s
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
     }
-    r = requests.post(EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}", json=payload)
+    r = requests.post(
+        EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}",
+        json=payload,
+    )
     assert r.status_code == 200
 
 
 # TO ADAPT
-def test_empty_timetable_with_stop(small_infra: Infra, foo_project_id: int, fast_rolling_stock: int):
+def test_empty_timetable_with_stop(
+    small_infra: Infra, foo_project_id: int, fast_rolling_stock: int
+):
     op_study = create_op_study(EDITOAST_URL, foo_project_id)
-    _, timetable = create_scenario(EDITOAST_URL, small_infra.id, foo_project_id, op_study)
+    _, timetable = create_scenario(
+        EDITOAST_URL, small_infra.id, foo_project_id, op_study
+    )
     payload = {
         "rolling_stock_id": fast_rolling_stock,
         "timetable_id": timetable,
@@ -75,15 +93,28 @@ def test_empty_timetable_with_stop(small_infra: Infra, foo_project_id: int, fast
         "maximum_departure_delay": 7200000,
         "maximum_run_time": 43200000,
     }
-    r = requests.post(EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}", json=payload)
+    r = requests.post(
+        EDITOAST_URL + f"/timetable/{timetable}/stdcm?infra={small_infra.id}",
+        json=payload,
+    )
     assert r.status_code == 200
 
 
 def test_between_trains(small_scenario: Scenario, fast_rolling_stock: int):
     response = requests.get(EDITOAST_URL + f"light_rolling_stock/{fast_rolling_stock}")
     fast_rolling_stock_name = response.json()["name"]
-    _add_train(EDITOAST_URL, small_scenario, fast_rolling_stock_name, "2024-08-13T22:31:36.377Z")
-    _add_train(EDITOAST_URL, small_scenario, fast_rolling_stock_name, "2024-08-13T23:31:36.377Z")
+    _add_train(
+        EDITOAST_URL,
+        small_scenario,
+        fast_rolling_stock_name,
+        "2024-08-13T22:31:36.377Z",
+    )
+    _add_train(
+        EDITOAST_URL,
+        small_scenario,
+        fast_rolling_stock_name,
+        "2024-08-13T23:31:36.377Z",
+    )
     payload = {
         "rolling_stock_id": fast_rolling_stock,
         "timetable_id": small_scenario.timetable,
@@ -99,7 +130,9 @@ def test_between_trains(small_scenario: Scenario, fast_rolling_stock: int):
         "maximum_run_time": 43200000,
     }
     r = requests.post(
-        EDITOAST_URL + f"/timetable/{small_scenario.timetable}/stdcm?infra={small_scenario.infra}", json=payload
+        EDITOAST_URL
+        + f"/timetable/{small_scenario.timetable}/stdcm?infra={small_scenario.infra}",
+        json=payload,
     )
     if r.status_code // 100 != 2:
         raise RuntimeError(f"STDCM error {r.status_code}: {r.content}")
@@ -121,7 +154,9 @@ def test_work_schedules(small_scenario: Scenario, fast_rolling_stock: int):
                     "start_date_time": start_time.isoformat(),
                     "end_date_time": end_time.isoformat(),
                     "obj_id": "string",
-                    "track_ranges": [{"begin": 0, "end": 100000, "track": _START["track"]}],
+                    "track_ranges": [
+                        {"begin": 0, "end": 100000, "track": _START["track"]}
+                    ],
                     "work_schedule_type": "CATENARY",
                 }
             ],
@@ -148,7 +183,9 @@ def test_work_schedules(small_scenario: Scenario, fast_rolling_stock: int):
     r = requests.post(url, json=payload)
     assert r.status_code == 200
     response = r.json()
-    departure_time = datetime.datetime.fromisoformat(response["departure_time"].replace("Z", "+00:00"))
+    departure_time = datetime.datetime.fromisoformat(
+        response["departure_time"].replace("Z", "+00:00")
+    )
     assert departure_time >= end_time.astimezone(departure_time.tzinfo)
 
 
@@ -179,8 +216,14 @@ def test_mrsp_sources(
     assert content["simulation"]["mrsp"] == {
         "boundaries": [4180000, 4580000],
         "values": [
-            {"speed": 27.778, "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"}},
-            {"speed": 22.222, "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"}},
+            {
+                "speed": 27.778,
+                "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"},
+            },
+            {
+                "speed": 22.222,
+                "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"},
+            },
             {"speed": 80.0, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
@@ -217,10 +260,18 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
                    [                             ] < departure time window
     """
     requests.post(EDITOAST_URL + f"infra/{small_scenario.infra}/load")
-    origin_start_time = datetime.datetime(2024, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
-    origin_end_time = datetime.datetime(2025, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
-    destination_start_time = datetime.datetime(2023, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
-    destination_end_time = datetime.datetime(2024, 1, 1, 16, 0, 0, tzinfo=datetime.timezone.utc)
+    origin_start_time = datetime.datetime(
+        2024, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    origin_end_time = datetime.datetime(
+        2025, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    destination_start_time = datetime.datetime(
+        2023, 1, 1, 8, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    destination_end_time = datetime.datetime(
+        2024, 1, 1, 16, 0, 0, tzinfo=datetime.timezone.utc
+    )
     # TODO: we cannot delete work schedules for now, so let's give a unique name
     # to avoid collisions
     now = datetime.datetime.now()
@@ -233,14 +284,18 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
                     "start_date_time": origin_start_time.isoformat(),
                     "end_date_time": origin_end_time.isoformat(),
                     "obj_id": "string",
-                    "track_ranges": [{"begin": 0, "end": 100000, "track": _START["track"]}],
+                    "track_ranges": [
+                        {"begin": 0, "end": 100000, "track": _START["track"]}
+                    ],
                     "work_schedule_type": "CATENARY",
                 },
                 {
                     "start_date_time": destination_start_time.isoformat(),
                     "end_date_time": destination_end_time.isoformat(),
                     "obj_id": "string",
-                    "track_ranges": [{"begin": 0, "end": 100000, "track": _STOP["track"]}],
+                    "track_ranges": [
+                        {"begin": 0, "end": 100000, "track": _STOP["track"]}
+                    ],
                     "work_schedule_type": "CATENARY",
                 },
             ],
@@ -327,14 +382,54 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
             ],
             "status": "success",
             "track_section_ranges": [
-                {"begin": 0, "end": 1950000, "track_section": "TA2", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 50000, "track_section": "TA5", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 10000000, "track_section": "TA7", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 1000000, "track_section": "TC2", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 25000000, "track_section": "TD1", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 3000000, "track_section": "TD3", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 1000000, "track_section": "TH0", "direction": "START_TO_STOP"},
-                {"begin": 0, "end": 0, "track_section": "TH1", "direction": "START_TO_STOP"},
+                {
+                    "begin": 0,
+                    "end": 1950000,
+                    "track_section": "TA2",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 50000,
+                    "track_section": "TA5",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 10000000,
+                    "track_section": "TA7",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 1000000,
+                    "track_section": "TC2",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 25000000,
+                    "track_section": "TD1",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 3000000,
+                    "track_section": "TD3",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 1000000,
+                    "track_section": "TH0",
+                    "direction": "START_TO_STOP",
+                },
+                {
+                    "begin": 0,
+                    "end": 0,
+                    "track_section": "TH1",
+                    "direction": "START_TO_STOP",
+                },
             ],
         },
     }
@@ -342,7 +437,8 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
 
 def _get_stdcm_response(infra: Infra, timetable_id: int, stdcm_payload: Dict[str, Any]):
     stdcm_response = requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/stdcm/?infra={infra.id}", json=stdcm_payload
+        f"{EDITOAST_URL}/timetable/{timetable_id}/stdcm/?infra={infra.id}",
+        json=stdcm_payload,
     )
     stdcm_response.raise_for_status()
     content = stdcm_response.json()

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 import requests
@@ -284,7 +284,7 @@ def test_mrsp_sources(
 
 
 def _get_train_schedule_simulation_response(
-    infra: Infra, timetable_id: int, train_schedules_payload: List[Dict[str, Any]]
+    infra: Infra, timetable_id: int, train_schedules_payload: list[dict[str, Any]]
 ):
     ts_response = requests.post(
         f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -18,7 +18,11 @@ def test_get_timetable(
 
 @pytest.mark.parametrize(
     ["reception_signal", "expected_conflict_types"],
-    [("OPEN", {"Spacing", "Routing"}), ("STOP", {"Spacing"}), ("SHORT_SLIP_STOP", {"Spacing"})],
+    [
+        ("OPEN", {"Spacing", "Routing"}),
+        ("STOP", {"Spacing"}),
+        ("SHORT_SLIP_STOP", {"Spacing"}),
+    ],
 )
 def test_conflicts(
     small_infra: Infra,
@@ -46,7 +50,11 @@ def test_conflicts(
                 {
                     "at": "start",
                 },
-                {"at": "stop", "reception_signal": reception_signal, "stop_for": "PT10M"},
+                {
+                    "at": "stop",
+                    "reception_signal": reception_signal,
+                    "stop_for": "PT10M",
+                },
                 {
                     "at": "end",
                 },
@@ -58,7 +66,8 @@ def test_conflicts(
     ]
 
     stopping_train_schedule_response = requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules", json=stopping_train_schedule_payload
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
+        json=stopping_train_schedule_payload,
     )
 
     stopping_paced_train_payload = stopping_train_schedule_payload[0]
@@ -66,7 +75,8 @@ def test_conflicts(
     stopping_paced_train_payload["paced"] = {"duration": "PT2H", "step": "PT15M"}
 
     stopping_paced_train_response = requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/paced_trains", json=[stopping_paced_train_payload]
+        f"{EDITOAST_URL}/timetable/{timetable_id}/paced_trains",
+        json=[stopping_paced_train_payload],
     )
     stopping_paced_train_response.raise_for_status()
 
@@ -97,12 +107,17 @@ def test_conflicts(
         }
     ]
     requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules", json=train_schedule_payload
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
+        json=train_schedule_payload,
     ).raise_for_status()
 
-    conflicts_response = requests.get(f"{EDITOAST_URL}/timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}")
+    conflicts_response = requests.get(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}"
+    )
     conflicts_response.raise_for_status()
-    actual_conflicts = {conflict["conflict_type"] for conflict in conflicts_response.json()}
+    actual_conflicts = {
+        conflict["conflict_type"] for conflict in conflicts_response.json()
+    }
     assert actual_conflicts == expected_conflict_types
 
     # Check GET reservation block starts at the right time for the signal protecting switch.
@@ -110,7 +125,9 @@ def test_conflicts(
     # The free-block requirement must start at the same time as the spacing requirement of the switch's zone
     # (signal sight for OPEN reception, or 20s before restart for STOP/SHORT_SLIP_STOP reception).
     train_id = stopping_train_schedule_response.json()[0]["id"]
-    simu_response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={small_infra.id}")
+    simu_response = requests.get(
+        f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={small_infra.id}"
+    )
     simu_response.raise_for_status()
     simu_response_json = simu_response.json()
     switch_zone_spacing_requirement = [
@@ -119,7 +136,9 @@ def test_conflicts(
         if r["zone"] == "zone.[DC4:INCREASING, DC5:INCREASING, DD0:DECREASING]"
     ]
     assert len(switch_zone_spacing_requirement) == 1
-    path_response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/path/?infra_id={small_infra.id}")
+    path_response = requests.get(
+        f"{EDITOAST_URL}/train_schedule/{train_id}/path/?infra_id={small_infra.id}"
+    )
     path_response.raise_for_status()
     path_response_json = path_response.json()
     project_path_payload = {
@@ -131,7 +150,9 @@ def test_conflicts(
             "track_section_ranges": path_response_json["track_section_ranges"],
         },
     }
-    response_project_path = requests.post(f"{EDITOAST_URL}/train_schedule/project_path", json=project_path_payload)
+    response_project_path = requests.post(
+        f"{EDITOAST_URL}/train_schedule/project_path", json=project_path_payload
+    )
     response_project_path.raise_for_status()
     switch_signal_free_block_update = [
         u
@@ -139,7 +160,10 @@ def test_conflicts(
         if (u["signal_id"] == "SC4" and u["aspect_label"] == "VL")
     ]
     assert len(switch_signal_free_block_update) == 1
-    assert switch_signal_free_block_update[0]["time_start"] == switch_zone_spacing_requirement[0]["begin_time"]
+    assert (
+        switch_signal_free_block_update[0]["time_start"]
+        == switch_zone_spacing_requirement[0]["begin_time"]
+    )
 
 
 def test_scheduled_points_with_incompatible_margins(
@@ -176,10 +200,15 @@ def test_scheduled_points_with_incompatible_margins(
             "train_name": "name",
         }
     ]
-    response = requests.post(f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules", json=train_schedule_payload)
+    response = requests.post(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
+        json=train_schedule_payload,
+    )
     response.raise_for_status()
     train_id = response.json()[0]["id"]
-    response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={small_infra.id}")
+    response = requests.get(
+        f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={small_infra.id}"
+    )
     response.raise_for_status()
     content = response.json()
     sim_output = content["final_output"]
@@ -222,18 +251,28 @@ def test_mrsp_sources(
             "train_name": "name",
         }
     ]
-    content = _get_train_schedule_simulation_response(small_infra, timetable_id, train_schedule_payload)
+    content = _get_train_schedule_simulation_response(
+        small_infra, timetable_id, train_schedule_payload
+    )
     assert content["mrsp"] == {
         "boundaries": [4180000, 4580000],
         "values": [
-            {"speed": 27.778, "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"}},
-            {"speed": 22.222, "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"}},
+            {
+                "speed": 27.778,
+                "source": {"speed_limit_source_type": "given_train_tag", "tag": "E32C"},
+            },
+            {
+                "speed": 22.222,
+                "source": {"speed_limit_source_type": "fallback_tag", "tag": "MA100"},
+            },
             {"speed": 80, "source": {"speed_limit_source_type": "unknown_tag"}},
         ],
     }
 
     train_schedule_payload[0]["speed_limit_tag"] = "MA80"
-    content = _get_train_schedule_simulation_response(small_infra, timetable_id, train_schedule_payload)
+    content = _get_train_schedule_simulation_response(
+        small_infra, timetable_id, train_schedule_payload
+    )
     assert content["mrsp"] == {
         "boundaries": [3680000, 4580000],
         "values": [
@@ -248,11 +287,14 @@ def _get_train_schedule_simulation_response(
     infra: Infra, timetable_id: int, train_schedules_payload: List[Dict[str, Any]]
 ):
     ts_response = requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules", json=train_schedules_payload
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
+        json=train_schedules_payload,
     )
     ts_response.raise_for_status()
     train_id = ts_response.json()[0]["id"]
-    sim_response = requests.get(f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={infra.id}")
+    sim_response = requests.get(
+        f"{EDITOAST_URL}/train_schedule/{train_id}/simulation/?infra_id={infra.id}"
+    )
     sim_response.raise_for_status()
     content = sim_response.json()
     return content

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -32,33 +32,53 @@ def _update_simulation_with_mareco_allowances(editoast_url, train_Schedule_id):
         "values": ["3%"],
     }
     train_schedule["constraint_distribution"] = "MARECO"
-    r = requests.put(editoast_url + f"/train_schedule/{train_Schedule_id}", json=train_schedule)
+    r = requests.put(
+        editoast_url + f"/train_schedule/{train_Schedule_id}", json=train_schedule
+    )
     if r.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(train_schedule)}")
+        raise RuntimeError(
+            f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(train_schedule)}"
+        )
     r = requests.get(editoast_url + f"/train_schedule/{train_Schedule_id}/")
     body = r.json()
     assert body["constraint_distribution"] == "MARECO"
     return body
 
 
-def test_get_and_update_schedule_result(west_to_south_east_simulation: Sequence[Any], small_infra: Infra):
+def test_get_and_update_schedule_result(
+    west_to_south_east_simulation: Sequence[Any], small_infra: Infra
+):
     schedule = west_to_south_east_simulation[0]
     schedule_id = schedule["id"]
     response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
     if response.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {response.status_code}: {response.content}, id={schedule_id}")
-    response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={small_infra.id}")
+        raise RuntimeError(
+            f"Schedule error {response.status_code}: {response.content}, id={schedule_id}"
+        )
+    response = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={small_infra.id}"
+    )
     simulation_report = response.json()
-    assert simulation_report["base"]["energy_consumption"] == simulation_report["final_output"]["energy_consumption"]
+    assert (
+        simulation_report["base"]["energy_consumption"]
+        == simulation_report["final_output"]["energy_consumption"]
+    )
 
     response = _update_simulation_with_mareco_allowances(EDITOAST_URL, schedule_id)
     response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/")
     if response.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {response.status_code}: {response.content}, id={schedule_id}")
+        raise RuntimeError(
+            f"Schedule error {response.status_code}: {response.content}, id={schedule_id}"
+        )
 
-    response = requests.get(f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={small_infra.id}")
+    response = requests.get(
+        f"{EDITOAST_URL}train_schedule/{schedule_id}/simulation?infra_id={small_infra.id}"
+    )
     simulation_report = response.json()
-    assert simulation_report["base"]["energy_consumption"] != simulation_report["final_output"]["energy_consumption"]
+    assert (
+        simulation_report["base"]["energy_consumption"]
+        != simulation_report["final_output"]["energy_consumption"]
+    )
     assert (
         simulation_report["provisional"]["energy_consumption"]
         == simulation_report["final_output"]["energy_consumption"]
@@ -70,7 +90,9 @@ def test_editoast_delete(west_to_south_east_simulations: Sequence[Any]):
     trains_ids = [train["id"] for train in trains]
     r = requests.delete(f"{EDITOAST_URL}train_schedule/", json={"ids": trains_ids})
     if r.status_code // 100 != 2:
-        raise RuntimeError(f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(trains_ids)}")
+        raise RuntimeError(
+            f"Schedule error {r.status_code}: {r.content}, payload={json.dumps(trains_ids)}"
+        )
     r = requests.get(
         f"{EDITOAST_URL}train_schedule/{trains_ids[0]}/",
     )
@@ -81,8 +103,12 @@ def test_editoast_delete(west_to_south_east_simulations: Sequence[Any]):
     assert r.status_code == 404
 
 
-def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(etcs_scenario: Scenario, etcs_rolling_stock: int):
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(
+    etcs_scenario: Scenario, etcs_rolling_stock: int
+):
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     ts_response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -127,7 +153,9 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(etcs_scenario: Scenar
     )
     simulation_final_output = simu_response.json()["final_output"]
 
-    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
 
     # To debug this test: please add a breakpoint then use front to display speed-space chart
     # (activate Context for Slopes and Speed limits).
@@ -159,8 +187,12 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(etcs_scenario: Scenar
     for offset_index in range(1, len(stop_offsets) - 1):
         accelerating = True
         prev_speed = 0
-        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
-        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
         for pos_index in range(start_pos_index, end_pos_index):
             current_speed = simulation_final_output["speeds"][pos_index]
             if accelerating:
@@ -172,9 +204,25 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(etcs_scenario: Scenar
 
     # Check that the uphill brake is shorter than downhill brake.
     offset_42_ms_brake_uphill = 19_332_051  # first stop is the end of the braking
-    assert abs(_get_current_or_next_speed_at(simulation_final_output, offset_42_ms_brake_uphill) - 42) < 1
+    assert (
+        abs(
+            _get_current_or_next_speed_at(
+                simulation_final_output, offset_42_ms_brake_uphill
+            )
+            - 42
+        )
+        < 1
+    )
     offset_42_ms_brake_downhill = 27_365_028  # third stop is the end of the braking
-    assert abs(_get_current_or_next_speed_at(simulation_final_output, offset_42_ms_brake_downhill) - 42) < 1
+    assert (
+        abs(
+            _get_current_or_next_speed_at(
+                simulation_final_output, offset_42_ms_brake_downhill
+            )
+            - 42
+        )
+        < 1
+    )
     uphill_brake_distance = first_stop_offset - offset_42_ms_brake_uphill
     downhill_brake_distance = third_stop_offset - offset_42_ms_brake_downhill
     # make sure that there is at least 100m difference
@@ -190,24 +238,38 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(etcs_scenario: Scenar
     offset_first_high_speed = 14_509_017
     offset_first_brake_220_kph_speed = 17_544_856
     _assert_equal_speeds(
-        _get_current_or_next_speed_at(simulation_final_output, offset_first_high_speed), kph2ms(274.176)
+        _get_current_or_next_speed_at(simulation_final_output, offset_first_high_speed),
+        kph2ms(274.176),
     )
     _assert_equal_speeds(
-        _get_current_or_next_speed_at(simulation_final_output, offset_first_brake_220_kph_speed), kph2ms(221.004)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_first_brake_220_kph_speed
+        ),
+        kph2ms(221.004),
     )
 
     offset_fourth_high_speed = 37_087_342
     offset_fourth_brake_220_kph_speed = 37_661_601
     _assert_equal_speeds(
-        _get_current_or_next_speed_at(simulation_final_output, offset_fourth_high_speed), kph2ms(230.976)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_fourth_high_speed
+        ),
+        kph2ms(230.976),
     )
     _assert_equal_speeds(
-        _get_current_or_next_speed_at(simulation_final_output, offset_fourth_brake_220_kph_speed), kph2ms(219.744)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_fourth_brake_220_kph_speed
+        ),
+        kph2ms(219.744),
     )
 
 
-def test_etcs_schedule_result_stop_brake_from_mrsp(etcs_scenario: Scenario, etcs_rolling_stock: int):
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+def test_etcs_schedule_result_stop_brake_from_mrsp(
+    etcs_scenario: Scenario, etcs_rolling_stock: int
+):
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     ts_response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -248,7 +310,9 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(etcs_scenario: Scenario, etcs
     )
     simulation_final_output = simu_response.json()["final_output"]
 
-    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
 
     # To debug this test: please add a breakpoint then use front to display speed-space chart
     # (activate Context for Slopes and Speed limits).
@@ -275,8 +339,12 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(etcs_scenario: Scenario, etcs
     for offset_index in range(1, len(stop_offsets) - 1):
         accelerating = True
         prev_speed = 0
-        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
-        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
         for pos_index in range(start_pos_index, end_pos_index):
             current_speed = simulation_final_output["speeds"][pos_index]
             if accelerating:
@@ -288,22 +356,35 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(etcs_scenario: Scenario, etcs
 
     # Check that the braking curves from the MRSP for the first and second stops start at the expected offset
     offset_start_first_brake = 21_467_192
-    speed_before_first_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake)
+    speed_before_first_brake = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_first_brake
+    )
     _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake + 1) < speed_before_first_brake
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_first_brake + 1
+        )
+        < speed_before_first_brake
     )
     offset_start_second_brake = 40_663_532
-    speed_before_second_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_second_brake)
+    speed_before_second_brake = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_second_brake
+    )
     _assert_equal_speeds(speed_before_second_brake, SPEED_LIMIT_142)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_second_brake + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_second_brake + 1
+        )
         < speed_before_second_brake
     )
 
 
-def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenario: Scenario, etcs_rolling_stock: int):
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(
+    etcs_scenario: Scenario, etcs_rolling_stock: int
+):
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     ts_response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -342,7 +423,9 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenar
     )
     simulation_final_output = simu_response.json()["final_output"]
 
-    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
 
     # To debug this test: please add a breakpoint then use front to display speed-space chart
     # (activate Context for Slopes and Speed limits).
@@ -367,8 +450,12 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenar
     for offset_index in range(1, len(stop_offsets) - 1):
         accelerating = True
         prev_speed = 0
-        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
-        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
         for pos_index in range(start_pos_index, end_pos_index):
             current_speed = simulation_final_output["speeds"][pos_index]
             if accelerating:
@@ -380,10 +467,15 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenar
 
     # Check that the braking curve starts and ends at the expected offsets.
     offset_start_first_brake = 33_461_530
-    speed_before_first_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake)
+    speed_before_first_brake = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_first_brake
+    )
     _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake + 1) < speed_before_first_brake
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_first_brake + 1
+        )
+        < speed_before_first_brake
     )
     # Check a bending point for the first stop's braking curve (where the Guidance curve's influence stops).
     offset_bending_guidance_point = 37_210_260
@@ -393,17 +485,23 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(etcs_scenar
     _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(224.447_943_6))
     # Check that the release part (where the speed stays at 40km/h) starts and ends at the expected offsets.
     offset_start_release_speed = 40_827_882
-    speed_at_start_release_speed = _get_current_or_next_speed_at(simulation_final_output, offset_start_release_speed)
+    speed_at_start_release_speed = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_release_speed
+    )
     _assert_equal_speeds(speed_at_start_release_speed, RELEASE_SPEED_40)
     offset_end_release_speed = 40_892_792
-    speed_at_end_release_speed = _get_current_or_next_speed_at(simulation_final_output, offset_end_release_speed)
+    speed_at_end_release_speed = _get_current_or_next_speed_at(
+        simulation_final_output, offset_end_release_speed
+    )
     _assert_equal_speeds(speed_at_end_release_speed, RELEASE_SPEED_40)
 
 
 def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
     etcs_scenario: Scenario, etcs_rolling_stock: int
 ):
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     ts_response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -442,7 +540,9 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
     )
     simulation_final_output = simu_response.json()["final_output"]
 
-    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
 
     # To debug this test: please add a breakpoint then use front to display speed-space chart
     # (activate Context for Slopes and Speed limits).
@@ -469,8 +569,12 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
     for offset_index in range(1, len(stop_offsets) - 1):
         accelerating = True
         prev_speed = 0
-        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
-        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
         for pos_index in range(start_pos_index, end_pos_index):
             current_speed = simulation_final_output["speeds"][pos_index]
             if accelerating:
@@ -482,10 +586,15 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
 
     # Check that the braking curve starts and ends at the expected offsets.
     offset_start_first_brake = 33_361_530
-    speed_before_first_brake = _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake)
+    speed_before_first_brake = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_first_brake
+    )
     _assert_equal_speeds(speed_before_first_brake, MAX_SPEED_288)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_first_brake + 1) < speed_before_first_brake
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_first_brake + 1
+        )
+        < speed_before_first_brake
     )
     # Check the first bending point for the first stop's braking curve (where the Guidance curve's influence stops).
     offset_bending_guidance_point = 37_240_601
@@ -509,8 +618,12 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
     _assert_equal_speeds(speed_at_bending_point_svl_to_eoa, kph2ms(59.212_766_74))
 
 
-def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_stock: int):
-    rolling_stock_response = requests.get(EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}")
+def test_etcs_schedule_result_slowdowns(
+    etcs_scenario: Scenario, etcs_rolling_stock: int
+):
+    rolling_stock_response = requests.get(
+        EDITOAST_URL + f"light_rolling_stock/{etcs_rolling_stock}"
+    )
     etcs_rolling_stock_name = rolling_stock_response.json()["name"]
     ts_response = requests.post(
         f"{EDITOAST_URL}timetable/{etcs_scenario.timetable}/train_schedules/",
@@ -547,7 +660,9 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     )
     simulation_final_output = simu_response.json()["final_output"]
 
-    assert len(simulation_final_output["positions"]) == len(simulation_final_output["speeds"])
+    assert len(simulation_final_output["positions"]) == len(
+        simulation_final_output["speeds"]
+    )
 
     # To debug this test: please add a breakpoint then use front to display speed-space chart
     # (activate Context for Slopes and Speed limits).
@@ -569,8 +684,12 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     for offset_index in range(1, len(stop_offsets) - 1):
         accelerating = True
         prev_speed = 0
-        start_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index - 1])
-        end_pos_index = bisect.bisect_left(simulation_final_output["positions"], stop_offsets[offset_index])
+        start_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index - 1]
+        )
+        end_pos_index = bisect.bisect_left(
+            simulation_final_output["positions"], stop_offsets[offset_index]
+        )
         for pos_index in range(start_pos_index, end_pos_index):
             current_speed = simulation_final_output["speeds"][pos_index]
             if accelerating:
@@ -595,7 +714,9 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     )
     _assert_equal_speeds(speed_before_brake_288_to_142, MAX_SPEED_288)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_288_to_142 + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_288_to_142 + 1
+        )
         < speed_before_brake_288_to_142
     )
 
@@ -608,9 +729,13 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(235.107_866_2))
 
     offset_end_brake_288_to_142 = 40_824_370
-    speed_after_brake_288_to_142 = _get_current_or_next_speed_at(simulation_final_output, offset_end_brake_288_to_142)
+    speed_after_brake_288_to_142 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_end_brake_288_to_142
+    )
     assert (
-        _get_current_or_prev_speed_at(simulation_final_output, offset_end_brake_288_to_142 - 1)
+        _get_current_or_prev_speed_at(
+            simulation_final_output, offset_end_brake_288_to_142 - 1
+        )
         > speed_after_brake_288_to_142
     )
     _assert_equal_speeds(speed_after_brake_288_to_142, SPEED_LIMIT_142)
@@ -622,45 +747,67 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     )
     _assert_equal_speeds(speed_before_brake_142_to_120, SPEED_LIMIT_142)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_142_to_120 + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_142_to_120 + 1
+        )
         < speed_before_brake_142_to_120
     )
     offset_end_brake_142_to_120 = 44_948_022
-    speed_after_brake_142_to_120 = _get_current_or_next_speed_at(simulation_final_output, offset_end_brake_142_to_120)
+    speed_after_brake_142_to_120 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_end_brake_142_to_120
+    )
     assert (
-        _get_current_or_prev_speed_at(simulation_final_output, offset_end_brake_142_to_120 - 1)
+        _get_current_or_prev_speed_at(
+            simulation_final_output, offset_end_brake_142_to_120 - 1
+        )
         > speed_after_brake_142_to_120
     )
     _assert_equal_speeds(speed_after_brake_142_to_120, SPEED_LIMIT_112)
 
     # Slowdown for Safety Speed stop: should probably disappear for ETCS at some point.
     offset_start_brake_120_to_30 = 45_635_550
-    speed_before_brake_120_to_30 = _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_120_to_30)
+    speed_before_brake_120_to_30 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_brake_120_to_30
+    )
     _assert_equal_speeds(speed_before_brake_120_to_30, SPEED_LIMIT_112)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_120_to_30 + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_120_to_30 + 1
+        )
         < speed_before_brake_120_to_30
     )
     offset_end_brake_120_to_30 = 46_654_236
-    speed_after_brake_120_to_30 = _get_current_or_next_speed_at(simulation_final_output, offset_end_brake_120_to_30)
+    speed_after_brake_120_to_30 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_end_brake_120_to_30
+    )
     assert (
-        _get_current_or_prev_speed_at(simulation_final_output, offset_end_brake_120_to_30 - 1)
+        _get_current_or_prev_speed_at(
+            simulation_final_output, offset_end_brake_120_to_30 - 1
+        )
         > speed_after_brake_120_to_30
     )
     _assert_equal_speeds(speed_after_brake_120_to_30, SAFE_SPEED_30)
 
     # Slowdown for short slip stop: should probably disappear for ETCS at some point.
     offset_start_brake_30_to_10 = 46_697_503
-    speed_before_brake_30_to_10 = _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_30_to_10)
+    speed_before_brake_30_to_10 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_brake_30_to_10
+    )
     _assert_equal_speeds(speed_before_brake_30_to_10, SAFE_SPEED_30)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_30_to_10 + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_30_to_10 + 1
+        )
         < speed_before_brake_30_to_10
     )
     offset_end_brake_30_to_10 = 46_848_695
-    speed_after_brake_30_to_10 = _get_current_or_next_speed_at(simulation_final_output, offset_end_brake_30_to_10)
+    speed_after_brake_30_to_10 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_end_brake_30_to_10
+    )
     assert (
-        _get_current_or_prev_speed_at(simulation_final_output, offset_end_brake_30_to_10 - 1)
+        _get_current_or_prev_speed_at(
+            simulation_final_output, offset_end_brake_30_to_10 - 1
+        )
         > speed_after_brake_30_to_10
     )
     _assert_equal_speeds(speed_after_brake_30_to_10, SHORT_SLIP_SPEED_10)
@@ -668,10 +815,14 @@ def test_etcs_schedule_result_slowdowns(etcs_scenario: Scenario, etcs_rolling_st
     # Final slowdown: EoA (complete stop) braking curve is applied.
     # Note: This should also be impacted if Safety Speed stop and short slip stop disappear for ETCS.
     offset_start_brake_10_to_0 = 46_953_914
-    speed_before_brake_10_to_0 = _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_10_to_0)
+    speed_before_brake_10_to_0 = _get_current_or_next_speed_at(
+        simulation_final_output, offset_start_brake_10_to_0
+    )
     _assert_equal_speeds(speed_before_brake_10_to_0, SHORT_SLIP_SPEED_10)
     assert (
-        _get_current_or_next_speed_at(simulation_final_output, offset_start_brake_10_to_0 + 1)
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_brake_10_to_0 + 1
+        )
         < speed_before_brake_10_to_0
     )
 
@@ -680,12 +831,16 @@ def _assert_equal_speeds(left, right):
     assert abs(left - right) < 1e-2
 
 
-def _get_current_or_next_speed_at(simulation_final_output: Dict[str, Any], position: int) -> int:
+def _get_current_or_next_speed_at(
+    simulation_final_output: Dict[str, Any], position: int
+) -> int:
     idx = bisect.bisect_left(simulation_final_output["positions"], position)
     return simulation_final_output["speeds"][idx]
 
 
-def _get_current_or_prev_speed_at(simulation_final_output: Dict[str, Any], position: int) -> int:
+def _get_current_or_prev_speed_at(
+    simulation_final_output: Dict[str, Any], position: int
+) -> int:
     idx = bisect.bisect_left(simulation_final_output["positions"], position)
     if simulation_final_output["positions"][idx] > position and idx > 0:
         return simulation_final_output["speeds"][idx - 1]

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -1,7 +1,7 @@
 import bisect
 import json
 from collections.abc import Sequence
-from typing import Any, Dict
+from typing import Any
 
 import requests
 
@@ -832,14 +832,14 @@ def _assert_equal_speeds(left, right):
 
 
 def _get_current_or_next_speed_at(
-    simulation_final_output: Dict[str, Any], position: int
+    simulation_final_output: dict[str, Any], position: int
 ) -> int:
     idx = bisect.bisect_left(simulation_final_output["positions"], position)
     return simulation_final_output["speeds"][idx]
 
 
 def _get_current_or_prev_speed_at(
-    simulation_final_output: Dict[str, Any], position: int
+    simulation_final_output: dict[str, Any], position: int
 ) -> int:
     idx = bisect.bisect_left(simulation_final_output["positions"], position)
     if simulation_final_output["positions"][idx] > position and idx > 0:

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -1,5 +1,4 @@
 import json
-from typing import Tuple
 
 import requests
 
@@ -20,7 +19,7 @@ def create_op_study(editoast_url, project_id: int) -> int:
 
 def create_scenario(
     editoast_url: str, infra_id: int, project_id: int, op_study_id: int
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     # Create the timetable
     r = requests.post(editoast_url + "/timetable/")
     if r.status_code // 100 != 2:

--- a/tests/tests/utils/timetable.py
+++ b/tests/tests/utils/timetable.py
@@ -5,7 +5,12 @@ import requests
 
 
 def create_op_study(editoast_url, project_id: int) -> int:
-    payload = {"name": "foo", "state": "Starting", "service_code": "AAA", "business_code": "BBB"}
+    payload = {
+        "name": "foo",
+        "state": "Starting",
+        "service_code": "AAA",
+        "business_code": "BBB",
+    }
     res = requests.post(editoast_url + f"projects/{project_id}/studies/", json=payload)
     if res.status_code // 100 != 2:
         err = f"Error creating operational study {res.status_code}: {res.content}, payload={json.dumps(payload)}"
@@ -13,7 +18,9 @@ def create_op_study(editoast_url, project_id: int) -> int:
     return res.json()["id"]
 
 
-def create_scenario(editoast_url: str, infra_id: int, project_id: int, op_study_id: int) -> Tuple[int, int]:
+def create_scenario(
+    editoast_url: str, infra_id: int, project_id: int, op_study_id: int
+) -> Tuple[int, int]:
     # Create the timetable
     r = requests.post(editoast_url + "/timetable/")
     if r.status_code // 100 != 2:
@@ -27,6 +34,9 @@ def create_scenario(editoast_url: str, infra_id: int, project_id: int, op_study_
         "infra_id": infra_id,
         "timetable_id": timetable_id,
     }
-    r = requests.post(editoast_url + f"/projects/{project_id}/studies/{op_study_id}/scenarios/", json=scenario_payload)
+    r = requests.post(
+        editoast_url + f"/projects/{project_id}/studies/{op_study_id}/scenarios/",
+        json=scenario_payload,
+    )
     r.raise_for_status()
     return r.json()["id"], timetable_id


### PR DESCRIPTION
Note that a few preliminary operations have been done to convert to modern `pyproject.toml` format (should probably be reviewed commit by commit):

- use `ruff` instead of `black`, `isort` and `flake8` (82b121d0ecc4aa8432e2c62c6bb43396d984fddf)
- replace `pytype` by `pyright` (3667cb30bd197628d254b9fe8a0ebc18391b067d)
- remove deprecated types (26a2ac2914ae873710ec6279b06e3f749176b869)
- finally move to the new format for `pyproject.toml` (3a139e8022f67e519bce54b843112a817ba1bb32)

Some side effects, now the project doesn't support Python 3.9 and 3.10 anymore (but I feel this is probably ok).