### PR TITLE
Revert "editoast: avoid unnecessary join on user search"

### DIFF
--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -619,6 +619,7 @@ pub(super) struct SearchResultItemProject {
 #[search(
     table = "search_user",
     migration(src_table = "authn_user"),
+    joins = "INNER JOIN authn_user ON authn_user.id = search_user.id",
     column(
         name = "identity_id",
         data_type = "TEXT",
@@ -634,11 +635,11 @@ pub(super) struct SearchResultItemProject {
 #[allow(unused)]
 /// A search result item for a query with `object = "user"`
 pub(super) struct SearchResultItemUser {
-    #[search(sql = "search_user.id")]
+    #[search(sql = "authn_user.id")]
     id: u64,
-    #[search(sql = "search_user.identity_id")]
+    #[search(sql = "authn_user.identity_id")]
     identity_id: String,
-    #[search(sql = "search_user.name")]
+    #[search(sql = "authn_user.name")]
     name: String,
 }
 


### PR DESCRIPTION
Reverts OpenRailAssociation/osrd#11252

This does not work. It returns the user name transformed by psql.

Example:

```json
[
  {
    "id": 2,
    "identity_id": "test2",
    "name": "smith\njohn" // Instead of "John Smith"
  },
  {
    "id": 3,
    "identity_id": "mock/mocked",
    "name": "example\nuser" // Instead of "Example User"
  }
]
```