### PR TITLE
core: stdcm: integrate step tracker into heuristic computation

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -20,12 +20,86 @@ import kotlin.math.min
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-/**
- * This typealias defines a function that can be used as a heuristic for an A* pathfinding. It takes
- * an edge, and offset on this edge, and a number of passed steps as input, and returns an
- * estimation of the remaining time needed to get to the end.
- */
-typealias STDCMAStarHeuristic = (STDCMEdge, Offset<Block>?, Int) -> Double
+data class STDCMAStarHeuristic(
+    val blockInfra: BlockInfra,
+    val steps: List<STDCMStep>,
+    val remainingTimeEstimations: List<MutableMap<BlockId, Double>>,
+    val mrspBuilder: CachedBlockMRSPBuilder,
+    val bestTravelTime: Double,
+) {
+    /**
+     * This function defines a function that can be used as a heuristic for an A* pathfinding. It
+     * takes an edge, and offset on this edge, and a number of passed steps as input, and returns an
+     * estimation of the remaining time needed to get to the end.
+     */
+    fun invoke(edge: STDCMEdge, offset: Offset<Block>?, nPassedSteps: Int): Double {
+        if (nPassedSteps >= steps.size - 1) return 0.0
+        val lookahead = edge.infraExplorer.getLookahead()
+        val currentBlock = edge.block
+        val allBlocks = mutableListOf(currentBlock)
+        allBlocks.addAll(lookahead)
+
+        // We don't consider the time of the last lookahead block to avoid issues
+        // if it contains the destination, and we don't need it (the destination is
+        // already locked-in).
+
+        // Account for the steps that will be passed in the lookahead
+        val expectedIndex =
+            getExpectedStepIndex(
+                allBlocks.dropLast(1),
+                offset ?: edge.blockOffsetFromEdge(edge.length),
+                nPassedSteps
+            )
+        if (expectedIndex >= remainingTimeEstimations.size) return 0.0
+
+        val timeAfterStartOfLastBlock =
+            remainingTimeEstimations[expectedIndex][allBlocks.last()]
+                ?: return Double.POSITIVE_INFINITY
+
+        // Compute the time it takes from the current point until the start
+        // of the last block of the lookahead, then from that point the destination.
+        var timeUntilStartOfLastBlock = 0.0
+        for (j in 0 until allBlocks.size - 1) {
+            timeUntilStartOfLastBlock += mrspBuilder.getBlockTime(allBlocks[j], null)
+        }
+        val timeSinceFirstBlock = mrspBuilder.getBlockTime(edge.block, offset)
+        timeUntilStartOfLastBlock -= timeSinceFirstBlock
+
+        val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
+
+        return remainingTime
+    }
+
+    /** Returns the numbers of passed waypoints at the end of the block list */
+    private fun getExpectedStepIndex(
+        blocks: List<BlockId>,
+        firstOffset: Offset<Block>,
+        currentIndex: Int
+    ): Int {
+        var stepIndex = currentIndex
+        var blockIndex = 0
+        var currentOffset = firstOffset
+        while (true) {
+            if (stepIndex >= steps.size - 2 || blockIndex >= blocks.size) {
+                return stepIndex
+            }
+            val nextLocations = steps[stepIndex + 1].locations
+            val locationOnBlock =
+                nextLocations.firstOrNull {
+                    it.edge == blocks[blockIndex] && it.offset >= currentOffset
+                }
+            if (locationOnBlock != null) {
+                // Step passed on the block
+                stepIndex++
+                currentOffset = locationOnBlock.offset
+            } else {
+                // Move on to the next block
+                blockIndex++
+                currentOffset = Offset(0.meters)
+            }
+        }
+    }
+}
 /**
  * This file implements the A* heuristic used by STDCM.
  *
@@ -51,7 +125,7 @@ class STDCMHeuristicBuilder(
 
     /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
     @WithSpan(value = "Initializing STDCM heuristic", kind = SpanKind.SERVER)
-    fun build(): Pair<STDCMAStarHeuristic, Double> {
+    fun build(): STDCMAStarHeuristic {
         logger.info("Start building STDCM heuristic...")
         // One map per number of reached pathfinding step
         // maps[n][block] = min time it takes to go from the start of the block to the destination,
@@ -90,42 +164,13 @@ class STDCMHeuristicBuilder(
             "STDCM heuristic built, best theoretical travel time = ${bestTravelTime.toInt()} seconds"
         )
 
-        val heuristic: STDCMAStarHeuristic = res@{ edge, offset, nPassedSteps ->
-            if (nPassedSteps >= steps.size - 1) return@res 0.0
-            val lookahead = edge.infraExplorer.getLookahead()
-            val currentBlock = edge.block
-            val allBlocks = mutableListOf(currentBlock)
-            allBlocks.addAll(lookahead)
-
-            // We don't consider the time of the last lookahead block to avoid issues
-            // if it contains the destination, and we don't need it (the destination is
-            // already locked-in).
-
-            // Account for the steps that will be passed in the lookahead
-            val expectedIndex =
-                getExpectedStepIndex(
-                    allBlocks.subList(0, allBlocks.size - 1),
-                    offset ?: edge.blockOffsetFromEdge(edge.length),
-                    nPassedSteps
-                )
-
-            val timeAfterStartOfLastBlock =
-                remainingTimeEstimations[expectedIndex][allBlocks.last()]
-                    ?: return@res Double.POSITIVE_INFINITY
-
-            // Compute the time it takes from the current point until the start
-            // of the last block of the lookahead, then from that point the destination.
-            var timeUntilStartOfLastBlock = 0.0
-            for (j in 0 until allBlocks.size - 1) timeUntilStartOfLastBlock +=
-                mrspBuilder.getBlockTime(allBlocks[j], null)
-            val timeSinceFirstBlock = mrspBuilder.getBlockTime(edge.block, offset)
-            timeUntilStartOfLastBlock -= timeSinceFirstBlock
-
-            val remainingTime = timeUntilStartOfLastBlock + timeAfterStartOfLastBlock
-
-            return@res remainingTime
-        }
-        return Pair(heuristic, bestTravelTime)
+        return STDCMAStarHeuristic(
+            blockInfra,
+            steps,
+            remainingTimeEstimations,
+            mrspBuilder,
+            bestTravelTime
+        )
     }
 
     /** Describes a pending block, ready to be added to the cached blocks. */
@@ -197,35 +242,5 @@ class STDCMHeuristicBuilder(
             newIndex,
             remainingTimeWithStops + mrspBuilder.getBlockTime(block, offset)
         )
-    }
-
-    /** Returns the numbers of passed waypoints at the end of the block list */
-    private fun getExpectedStepIndex(
-        blocks: List<BlockId>,
-        firstOffset: Offset<Block>,
-        currentIndex: Int
-    ): Int {
-        var stepIndex = currentIndex
-        var blockIndex = 0
-        var currentOffset = firstOffset
-        while (true) {
-            if (stepIndex >= steps.size - 2 || blockIndex >= blocks.size) {
-                return stepIndex
-            }
-            val nextLocations = steps[stepIndex + 1].locations
-            val locationOnBlock =
-                nextLocations.firstOrNull {
-                    it.edge == blocks[blockIndex] && it.offset >= currentOffset
-                }
-            if (locationOnBlock != null) {
-                // Step passed on the block
-                stepIndex++
-                currentOffset = locationOnBlock.offset
-            } else {
-                // Move on to the next block
-                blockIndex++
-                currentOffset = Offset(0.meters)
-            }
-        }
     }
 }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -8,10 +8,10 @@ import fr.sncf.osrd.sim_infra.api.RawInfra
 import fr.sncf.osrd.sim_infra.impl.TemporarySpeedLimitManager
 import fr.sncf.osrd.sim_infra.utils.getBlockEntry
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
+import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
 import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
-import fr.sncf.osrd.utils.units.meters
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.util.*
@@ -22,18 +22,17 @@ import org.slf4j.LoggerFactory
 
 data class STDCMAStarHeuristic(
     val blockInfra: BlockInfra,
-    val steps: List<STDCMStep>,
     val remainingTimeEstimations: List<MutableMap<BlockId, Double>>,
+    val nPlannedSteps: Int,
     val mrspBuilder: CachedBlockMRSPBuilder,
     val bestTravelTime: Double,
 ) {
     /**
-     * This function defines a function that can be used as a heuristic for an A* pathfinding. It
-     * takes an edge, and offset on this edge, and a number of passed steps as input, and returns an
-     * estimation of the remaining time needed to get to the end.
+     * Defines a function that can be used as a heuristic for an A* pathfinding. It takes an edge,
+     * and offset on this edge, and a step tracker as input, and returns an estimation of the
+     * remaining time needed to get to the end.
      */
-    fun invoke(edge: STDCMEdge, offset: Offset<Block>?, nPassedSteps: Int): Double {
-        if (nPassedSteps >= steps.size - 1) return 0.0
+    fun invoke(edge: STDCMEdge, offset: Offset<Block>?, stepTracker: StepTracker): Double {
         val lookahead = edge.infraExplorer.getLookahead()
         val currentBlock = edge.block
         val allBlocks = mutableListOf(currentBlock)
@@ -47,8 +46,7 @@ data class STDCMAStarHeuristic(
         val expectedIndex =
             getExpectedStepIndex(
                 allBlocks.dropLast(1),
-                offset ?: edge.blockOffsetFromEdge(edge.length),
-                nPassedSteps
+                stepTracker,
             )
         if (expectedIndex >= remainingTimeEstimations.size) return 0.0
 
@@ -73,35 +71,20 @@ data class STDCMAStarHeuristic(
     /** Returns the numbers of passed waypoints at the end of the block list */
     private fun getExpectedStepIndex(
         blocks: List<BlockId>,
-        firstOffset: Offset<Block>,
-        currentIndex: Int
+        stepTracker: StepTracker,
     ): Int {
-        var stepIndex = currentIndex
-        var blockIndex = 0
-        var currentOffset = firstOffset
-        while (true) {
-            if (stepIndex >= steps.size - 2 || blockIndex >= blocks.size) {
-                return stepIndex
-            }
-            val nextLocations = steps[stepIndex + 1].locations
-            val locationOnBlock =
-                nextLocations.firstOrNull {
-                    it.edge == blocks[blockIndex] && it.offset >= currentOffset
-                }
-            if (locationOnBlock != null) {
-                // Step passed on the block
-                stepIndex++
-                currentOffset = locationOnBlock.offset
-            } else {
-                // Move on to the next block
-                blockIndex++
-                currentOffset = Offset(0.meters)
-            }
+        val stepTrackerCopy = stepTracker.clone()
+        for (block in blocks) {
+            stepTrackerCopy.moveForward(block, Offset.zero(), blockInfra.getBlockLength(block))
         }
+        val nPlannedSteps = stepTrackerCopy.getReachedSteps().count { it.isPlanned }
+        val res = max(0, nPlannedSteps - 1) // Accounts for the departure step
+        return res
     }
 }
+
 /**
- * This file implements the A* heuristic used by STDCM.
+ * This class builds the A* heuristic used by STDCM.
  *
  * Starting at the destination and going backwards in every direction, we cache for each block the
  * minimum time it would take to reach the destination. The remaining time is estimated using the
@@ -166,10 +149,10 @@ class STDCMHeuristicBuilder(
 
         return STDCMAStarHeuristic(
             blockInfra,
-            steps,
             remainingTimeEstimations,
+            steps.size,
             mrspBuilder,
-            bestTravelTime
+            bestTravelTime,
         )
     }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMEdge.kt
@@ -74,11 +74,7 @@ data class STDCMEdge(
                 null,
                 null,
                 previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(
-                    this,
-                    null,
-                    stepTracker.nStepsExcludingLookahead
-                ),
+                graph.remainingTimeEstimator.invoke(this, null, stepTracker),
             )
         } else {
             // New edge on the same block, after a stop
@@ -102,11 +98,7 @@ data class STDCMEdge(
                 stopDuration,
                 nextStop.originalStep.plannedTimingData,
                 previousPlannedNodeRelativeTimeDiff,
-                graph.remainingTimeEstimator.invoke(
-                    this,
-                    locationOnEdge,
-                    stepTracker.nStepsExcludingLookahead
-                ),
+                graph.remainingTimeEstimator.invoke(this, locationOnEdge, stepTracker),
             )
         }
     }

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -62,7 +62,7 @@ class STDCMGraph(
         assert(standardAllowance !is FixedTime) {
             "Standard allowance cannot be a flat time for STDCM trains"
         }
-        val heuristicBuilderResult =
+        remainingTimeEstimator =
             STDCMHeuristicBuilder(
                     fullInfra.blockInfra,
                     fullInfra.rawInfra,
@@ -72,8 +72,7 @@ class STDCMGraph(
                     temporarySpeedLimitManager,
                 )
                 .build()
-        remainingTimeEstimator = heuristicBuilderResult.first
-        bestPossibleTime = heuristicBuilderResult.second
+        bestPossibleTime = remainingTimeEstimator.bestTravelTime
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/StepTracker.kt
@@ -98,6 +98,11 @@ class StepTracker(private val inputSteps: List<STDCMStep>) {
         return seenSteps.drop(nStepsExcludingLookahead)
     }
 
+    /** Returns all the steps excluding lookahead, in order. */
+    fun getReachedSteps(): List<LocatedStep> {
+        return getSeenSteps().take(nStepsExcludingLookahead)
+    }
+
     fun clone(): StepTracker {
         // If clone() performances become an issue,
         // reachedSteps can be changed to an AppendOnlyLinkedList
@@ -113,6 +118,7 @@ data class LocatedStep(
     val travelledPathOffset: Offset<TravelledPath>,
     val location: PathfindingEdgeLocationId<Block>,
     val originalStep: STDCMStep,
+    val isPlanned: Boolean = true, // Set to false for overtakes (when implemented)
 ) {
     init {
         assert(originalStep.locations.contains(location))

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -74,7 +74,6 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
-                .first
 
         assertEquals(
             400.0 - 50.0,
@@ -154,7 +153,6 @@ class STDCMHeuristicTests {
                     SimpleRollingStock.STANDARD_TRAIN,
                 )
                 .build()
-                .first
 
         for (i in 1 until blocks.size) {
             val lookahead = mutableListOf<BlockId>()

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -1,29 +1,28 @@
 package fr.sncf.osrd.stdcm.preprocessing
 
+import fr.sncf.osrd.conflicts.IncrementalRequirementEnvelopeAdapter
+import fr.sncf.osrd.conflicts.SpacingRequirementAutomaton
 import fr.sncf.osrd.envelope_sim.SimpleRollingStock
+import fr.sncf.osrd.envelope_sim.SimpleRollingStock.STANDARD_TRAIN
 import fr.sncf.osrd.graph.PathfindingEdgeLocationId
-import fr.sncf.osrd.sim_infra.api.BlockId
 import fr.sncf.osrd.stdcm.STDCMAStarHeuristic
 import fr.sncf.osrd.stdcm.STDCMHeuristicBuilder
 import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.TimeData
-import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
-import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
+import fr.sncf.osrd.stdcm.infra_exploration.*
 import fr.sncf.osrd.utils.DummyInfra
+import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.cactoos.list.ListOf
-import org.junit.jupiter.api.Disabled
 
 class STDCMHeuristicTests {
 
-    @Disabled // TODO
     @Test
     fun multipleStepsTest() {
         /*
@@ -79,34 +78,32 @@ class STDCMHeuristicTests {
                 )
                 .build()
 
-        assertEquals(
-            400.0 - 50.0,
-            getLocationRemainingTime(infra, blocks[0], 50.meters, 0, heuristic)
-        )
-        assertEquals(
-            400.0 - 85.0,
-            getLocationRemainingTime(infra, blocks[0], 85.meters, 0, heuristic)
-        )
+        // Current block = 0
+        var explorer =
+            initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
+
+        assertEquals(400.0 - 50.0, getLocationRemainingTime(infra, explorer, 50.meters, heuristic))
+        assertEquals(400.0 - 85.0, getLocationRemainingTime(infra, explorer, 85.meters, heuristic))
+
+        // Current block = 1
+        explorer = explorer.cloneAndExtendLookahead().single().moveForward()
         assertEquals(
             400.0 - 100.0 - 25.0,
-            getLocationRemainingTime(infra, blocks[1], 25.meters, 1, heuristic)
+            getLocationRemainingTime(infra, explorer, 25.meters, heuristic)
         )
         assertEquals(
             400.0 - 100.0 - 75.0,
-            getLocationRemainingTime(infra, blocks[1], 75.meters, 2, heuristic)
+            getLocationRemainingTime(infra, explorer, 75.meters, heuristic)
         )
-        assertEquals(
-            400.0 - 200.0,
-            getLocationRemainingTime(infra, blocks[2], 0.meters, 3, heuristic)
-        )
-        assertEquals(0.0, getLocationRemainingTime(infra, blocks[3], null, 3, heuristic))
-        assertEquals(
-            Double.POSITIVE_INFINITY,
-            getLocationRemainingTime(infra, blocks[3], 0.meters, 0, heuristic)
-        )
+
+        // Current block = 2
+        explorer = explorer.cloneAndExtendLookahead().single().moveForward()
+        assertEquals(400.0 - 200.0, getLocationRemainingTime(infra, explorer, 0.meters, heuristic))
+
+        explorer = explorer.cloneAndExtendLookahead().single().moveForward()
+        assertEquals(0.0, getLocationRemainingTime(infra, explorer, null, heuristic))
     }
 
-    @Disabled // TODO
     @Test
     fun lookaheadTest() {
         /*
@@ -159,35 +156,45 @@ class STDCMHeuristicTests {
                 )
                 .build()
 
+        var explorer =
+            initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
+
         for (i in 1 until blocks.size) {
-            val lookahead = mutableListOf<BlockId>()
-            for (j in 1 ..< i) {
-                lookahead.add(blocks[j])
-            }
+            explorer =
+                explorer
+                    .cloneAndExtendLookahead()
+                    .filter { candidate -> candidate.getLookahead().all { blocks.contains(it) } }
+                    .single()
+
             // While the lookahead is on the right path, the remaining distance shouldn't change
             assertEquals(
                 400.0 - 50.0 - 50.0,
                 getLocationRemainingTime(
                     infra,
-                    blocks[0],
+                    explorer,
                     50.meters,
-                    0,
                     heuristics,
-                    lookahead = lookahead
                 )
             )
         }
 
+        var wrongPathExplorer =
+            initInfraExplorer(infra, infra, steps.first().locations.first(), steps).single()
+        for (i in 0 ..< 2) {
+            wrongPathExplorer =
+                wrongPathExplorer
+                    .cloneAndExtendLookahead()
+                    .filter { explorer -> explorer.getLookahead().last() != blocks[1] }
+                    .single()
+        }
         // Lookahead on the wrong path, no possible result
         assertEquals(
             Double.POSITIVE_INFINITY,
             getLocationRemainingTime(
                 infra,
-                blocks[0],
+                wrongPathExplorer,
                 50.meters,
-                0,
                 heuristics,
-                lookahead = listOf(alternativeBlocks.first())
             )
         )
     }
@@ -198,28 +205,10 @@ class STDCMHeuristicTests {
      */
     private fun getLocationRemainingTime(
         infra: DummyInfra,
-        block: BlockId,
-        nodeOffsetOnEdge: Distance?,
-        nbPassedSteps: Int,
+        infraExplorer: InfraExplorer,
+        offset: Distance?,
         heuristic: STDCMAStarHeuristic,
-        lookahead: List<BlockId> = listOf()
     ): Double {
-        var explorer =
-            initInfraExplorerWithEnvelope(
-                    infra.fullInfra(),
-                    PathfindingEdgeLocationId(block, Offset(0.meters)),
-                    SimpleRollingStock.STANDARD_TRAIN
-                )
-                .first()
-
-        // Extend the lookahead to include the blocks given as parameters
-        while (!lookahead.all { explorer.getLookahead().contains(it) }) {
-            explorer =
-                explorer.cloneAndExtendLookahead().first { newExplorer ->
-                    newExplorer.getLookahead().all { lookahead.contains(it) }
-                }
-        }
-
         val defaultTimeData =
             TimeData(
                 earliestReachableTime = 0.0,
@@ -230,11 +219,25 @@ class STDCMHeuristicTests {
                 stopTimeData = listOf(),
                 maxFirstDepartureDelaying = 0.0,
             )
+        val withEnvelope =
+            InfraExplorerWithEnvelopeImpl(
+                infraExplorer,
+                appendOnlyLinkedListOf(),
+                SpacingRequirementAutomaton(
+                    infra,
+                    infra.fullInfra().loadedSignalInfra,
+                    infra,
+                    infra.fullInfra().signalingSimulator,
+                    IncrementalRequirementEnvelopeAdapter(STANDARD_TRAIN, null, false),
+                    infraExplorer.getIncrementalPath(),
+                ),
+                STANDARD_TRAIN,
+            )
         val defaultNode =
             STDCMNode(
                 defaultTimeData,
                 0.0,
-                explorer,
+                withEnvelope,
                 null,
                 Offset(0.meters),
                 null,
@@ -245,8 +248,8 @@ class STDCMHeuristicTests {
         val defaultEdge =
             STDCMEdge(
                 defaultTimeData,
-                explorer,
-                explorer,
+                withEnvelope,
+                withEnvelope,
                 defaultNode,
                 Offset(0.meters),
                 false,
@@ -257,18 +260,18 @@ class STDCMHeuristicTests {
                 null,
             )
 
-        val dummySteps =
-            List(nbPassedSteps) {
-                STDCMStep(ListOf(PathfindingEdgeLocationId(BlockId(0U), Offset.zero())))
-            }
-        val dummyStepTracker = StepTracker(dummySteps)
-        dummyStepTracker.exploreBlockRange(BlockId(0U), Offset.zero(), Offset.zero())
-        dummyStepTracker.moveForward(BlockId(0U), Offset.zero(), Offset.zero())
+        val stepTracker = infraExplorer.getStepTracker().clone()
+        for (block in infraExplorer.getPredecessorBlocks().toList()) {
+            stepTracker.moveForward(block, Offset.zero(), infra.getBlockLength(block))
+        }
+        val blockOffset =
+            offset?.let { Offset(it) } ?: infra.getBlockLength(infraExplorer.getCurrentBlock())
+        stepTracker.moveForward(infraExplorer.getCurrentBlock(), Offset.zero(), blockOffset)
 
         return heuristic.invoke(
             defaultEdge,
-            nodeOffsetOnEdge?.let { Offset(it) },
-            dummyStepTracker,
+            offset?.let { Offset(it) },
+            stepTracker,
         )
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -9,6 +9,7 @@ import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.TimeData
+import fr.sncf.osrd.stdcm.infra_exploration.StepTracker
 import fr.sncf.osrd.stdcm.infra_exploration.initInfraExplorerWithEnvelope
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.Distance
@@ -17,9 +18,12 @@ import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.cactoos.list.ListOf
+import org.junit.jupiter.api.Disabled
 
 class STDCMHeuristicTests {
 
+    @Disabled // TODO
     @Test
     fun multipleStepsTest() {
         /*
@@ -102,6 +106,7 @@ class STDCMHeuristicTests {
         )
     }
 
+    @Disabled // TODO
     @Test
     fun lookaheadTest() {
         /*
@@ -251,6 +256,19 @@ class STDCMHeuristicTests {
                 0.0,
                 null,
             )
-        return heuristic.invoke(defaultEdge, nodeOffsetOnEdge?.let { Offset(it) }, nbPassedSteps)
+
+        val dummySteps =
+            List(nbPassedSteps) {
+                STDCMStep(ListOf(PathfindingEdgeLocationId(BlockId(0U), Offset.zero())))
+            }
+        val dummyStepTracker = StepTracker(dummySteps)
+        dummyStepTracker.exploreBlockRange(BlockId(0U), Offset.zero(), Offset.zero())
+        dummyStepTracker.moveForward(BlockId(0U), Offset.zero(), Offset.zero())
+
+        return heuristic.invoke(
+            defaultEdge,
+            nodeOffsetOnEdge?.let { Offset(it) },
+            dummyStepTracker,
+        )
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/OpenRailAssociation/osrd/pull/11286

Fix https://github.com/OpenRailAssociation/osrd/issues/11285

Fix https://github.com/OpenRailAssociation/osrd/issues/11290

Can be reviewed by commit:

1. Small refactoring to have a proper class instead of a typealias on a function type. No functional change but lots of code moving, can interfere when reading the diff all commits at once
2. Use `StepTracker` instead of raw number of passed steps as function input
3. Adapt unit tests

Because the new tests use an `InfraExplorer` directly, the previous bug would have been catched there (it was an "integration" bug between infra explorer / step tracker / heuristic). 