### PR TITLE
core: tools: reproduce requests using railjson infra file

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraManager.java
@@ -18,7 +18,7 @@ import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class InfraManager extends APIClient {
+public class InfraManager extends APIClient implements InfraProvider {
     static final Logger logger = LoggerFactory.getLogger(InfraManager.class);
 
     private final ConcurrentHashMap<String, InfraCacheEntry> infraCache = new ConcurrentHashMap<>();
@@ -198,7 +198,7 @@ public class InfraManager extends APIClient {
         return infraCache.remove(infraId);
     }
 
-    /** Get an infra given an id */
+    @Override
     public FullInfra getInfra(String infraId, String expectedVersion, DiagnosticRecorder diagnosticRecorder)
             throws OSRDError, InterruptedException {
         try {

--- a/core/src/main/java/fr/sncf/osrd/api/InfraProvider.java
+++ b/core/src/main/java/fr/sncf/osrd/api/InfraProvider.java
@@ -1,0 +1,9 @@
+package fr.sncf.osrd.api;
+
+import fr.sncf.osrd.reporting.warnings.DiagnosticRecorder;
+
+public interface InfraProvider {
+    /** Get an infra given an id */
+    FullInfra getInfra(String infraId, String expectedVersion, DiagnosticRecorder diagnosticRecorder)
+            throws InterruptedException;
+}

--- a/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/ReproduceRequest.kt
@@ -4,13 +4,18 @@ import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.squareup.moshi.JsonAdapter
 import fr.sncf.osrd.api.ElectricalProfileSetManager
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.InfraProvider
+import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.api.pathfinding.PathfindingBlocksEndpoint
 import fr.sncf.osrd.api.pathfinding.pathfindingRequestAdapter
 import fr.sncf.osrd.api.standalone_sim.SimulationEndpoint
 import fr.sncf.osrd.api.standalone_sim.SimulationRequest
 import fr.sncf.osrd.api.stdcm.STDCMEndpoint
 import fr.sncf.osrd.api.stdcm.stdcmRequestAdapter
+import fr.sncf.osrd.cli.ValidateInfra.parseRailJSONFromFile
+import fr.sncf.osrd.reporting.warnings.DiagnosticRecorder
 import fr.sncf.osrd.utils.jacoco.ExcludeFromGeneratedCodeCoverage
 import java.io.IOException
 import java.nio.file.Path
@@ -53,13 +58,20 @@ class ReproduceRequest : CliCommand {
         description = "The HTTP Authorization header sent to editoast"
     )
     private var editoastAuthorization = "x-osrd-skip-authz"
-    private val logger: Logger = LoggerFactory.getLogger("Pathfinding")
+    @Parameter(
+        names = ["--railjson"],
+        description = "Path to the railjson infra file, overriding the id given in the request"
+    )
+    private var railjson: String? = null
+    private val logger: Logger = LoggerFactory.getLogger("ReproduceRequest")
 
     @ExcludeFromGeneratedCodeCoverage
     override fun run(): Int {
         try {
             val httpClient = OkHttpClient.Builder().readTimeout(120, TimeUnit.SECONDS).build()
-            val infraManager = InfraManager(editoastUrl, editoastAuthorization, httpClient)
+            val infraManager =
+                if (railjson != null) FileInfraProvider(railjson!!)
+                else InfraManager(editoastUrl, editoastAuthorization, httpClient)
 
             fun <T> loadRequest(path: String, adapter: JsonAdapter<T>): T {
                 val fileSource = Path.of(path).source()
@@ -91,5 +103,21 @@ class ReproduceRequest : CliCommand {
             throw RuntimeException(e)
         }
         return 0
+    }
+}
+
+/**
+ * Implement the InfraProvider interface using a railjson file. Used to reproduce requests without
+ * needing to run any other part of the stack.
+ */
+data class FileInfraProvider(val path: String) : InfraProvider {
+    override fun getInfra(
+        infraId: String?,
+        expectedVersion: String?,
+        diagnosticRecorder: DiagnosticRecorder?
+    ): FullInfra {
+        val rjs = parseRailJSONFromFile(path)
+        val signalingSimulator = makeSignalingSimulator()
+        return FullInfra.fromRJSInfra(rjs, signalingSimulator)
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
+++ b/core/src/main/java/fr/sncf/osrd/cli/ValidateInfra.java
@@ -53,7 +53,7 @@ public class ValidateInfra implements CliCommand {
 
     /** Parse the RailJSON file at the given Path */
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification = "that's a spotbugs bug :)")
-    private static RJSInfra parseRailJSONFromFile(String path) throws IOException {
+    static RJSInfra parseRailJSONFromFile(String path) throws IOException {
         try (var fileSource = Okio.source(Path.of(path));
                 var bufferedSource = Okio.buffer(fileSource)) {
             var rjsRoot = RJSInfra.adapter.fromJson(bufferedSource);

--- a/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/conflicts/ConflictDetectionEndpoint.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.conflicts
 
 import fr.sncf.osrd.api.ExceptionHandler
-import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.InfraProvider
 import fr.sncf.osrd.api.parseTrainsRequirements
 import fr.sncf.osrd.api.parseWorkSchedulesRequest
 import fr.sncf.osrd.conflicts.Conflict
@@ -19,7 +19,7 @@ import org.takes.rs.RsText
 import org.takes.rs.RsWithBody
 import org.takes.rs.RsWithStatus
 
-class ConflictDetectionEndpoint(private val infraManager: InfraManager) : Take {
+class ConflictDetectionEndpoint(private val infraManager: InfraProvider) : Take {
     override fun act(req: Request?): Response {
         val recorder = DiagnosticRecorderImpl(false)
         return try {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/path_properties/PathPropEndpoint.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.path_properties
 
 import fr.sncf.osrd.api.ExceptionHandler
-import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.InfraProvider
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.utils.makePathProps
 import org.takes.Request
@@ -13,7 +13,7 @@ import org.takes.rs.RsText
 import org.takes.rs.RsWithBody
 import org.takes.rs.RsWithStatus
 
-class PathPropEndpoint(private val infraManager: InfraManager) : Take {
+class PathPropEndpoint(private val infraManager: InfraProvider) : Take {
     override fun act(req: Request?): Response {
         val recorder = DiagnosticRecorderImpl(false)
         return try {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.api.pathfinding
 
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.InfraProvider
 import fr.sncf.osrd.api.TrackLocation
 import fr.sncf.osrd.api.pathfinding.*
 import fr.sncf.osrd.graph.*
@@ -52,7 +52,7 @@ class NoPathFoundException(val response: PathfindingBlockResponse) : Exception()
 
 val pathfindingLogger: Logger = LoggerFactory.getLogger("Pathfinding")
 
-class PathfindingBlocksEndpoint(private val infraManager: InfraManager) : Take {
+class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take {
     override fun act(req: Request): Response {
         val body = RqPrint(req).printBody()
         val request =

--- a/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/project_signals/SignalProjectionEndpoint.kt
@@ -1,7 +1,7 @@
 package fr.sncf.osrd.api.project_signals
 
 import fr.sncf.osrd.api.ExceptionHandler
-import fr.sncf.osrd.api.InfraManager
+import fr.sncf.osrd.api.InfraProvider
 import fr.sncf.osrd.reporting.warnings.DiagnosticRecorderImpl
 import fr.sncf.osrd.signal_projection.projectSignals
 import fr.sncf.osrd.sim_infra.api.convertBlockPath
@@ -16,7 +16,7 @@ import org.takes.rs.RsText
 import org.takes.rs.RsWithBody
 import org.takes.rs.RsWithStatus
 
-class SignalProjectionEndpoint(private val infraManager: InfraManager) : Take {
+class SignalProjectionEndpoint(private val infraManager: InfraProvider) : Take {
     override fun act(req: Request?): Response {
         val recorder = DiagnosticRecorderImpl(false)
         return try {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -27,7 +27,7 @@ import org.takes.rs.RsWithBody
 import org.takes.rs.RsWithStatus
 
 class SimulationEndpoint(
-    private val infraManager: InfraManager,
+    private val infraManager: InfraProvider,
     private val electricalProfileSetManager: ElectricalProfileSetManager
 ) : Take {
     override fun act(req: Request): Response {

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableRangeMap
 import fr.sncf.osrd.api.*
 import fr.sncf.osrd.api.ExceptionHandler
 import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.api.InfraManager
 import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.runPathfindingBlockPostProcessing
 import fr.sncf.osrd.api.standalone_sim.*
@@ -61,7 +60,7 @@ import org.takes.rs.RsText
 import org.takes.rs.RsWithBody
 import org.takes.rs.RsWithStatus
 
-class STDCMEndpoint(private val infraManager: InfraManager) : Take {
+class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
     @Throws(OSRDError::class)
     override fun act(req: Request): Response {
         // Parse request input


### PR DESCRIPTION
Small quality of life improvement: this lets us reproduce request payloads without running any other service, infras can be fetched from railjson files using `--railjson infra.json` parameter