### PR TITLE
front: fix flaky e2e tests

### DIFF
--- a/front/tests/pages/operational-studies/operational-studies-page.ts
+++ b/front/tests/pages/operational-studies/operational-studies-page.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PACED_TRAIN_SETTINGS,
   PACED_TRAIN_SETTINGS_TEST,
 } from '../../assets/constants/operational-studies-const';
+import { createDateInSpecialTimeZone } from '../../utils/date-utils';
 import type { ManageTrainScheduleTranslations, PacedTrainDetails } from '../../utils/types';
 import CommonPage from '../common-page';
 
@@ -186,9 +187,11 @@ class OperationalStudiesPage extends CommonPage {
     await expect(this.definePacedTrainCheckbox).not.toBeChecked();
     await expect(this.returnSimulationResultButton).toBeVisible();
     await expect(this.trainNameInput).toBeVisible();
-
     await expect(this.startTimeField).toBeVisible();
-    const startTimeDate = new Date(await this.startTimeField.inputValue());
+    const startTimeDate = createDateInSpecialTimeZone(
+      await this.startTimeField.inputValue(),
+      'Europe/Paris'
+    ).toDate();
     const scenarioCreationDate = new Date(date);
     const isSameDate =
       startTimeDate.getFullYear() === scenarioCreationDate.getFullYear() &&

--- a/front/tests/pages/stdcm/via-section.ts
+++ b/front/tests/pages/stdcm/via-section.ts
@@ -105,6 +105,7 @@ class ViaSection extends STDCMPage {
       await expect(this.getViaCI(viaNumber)).toBeVisible();
       await this.getViaCI(viaNumber).fill(ciSearchText);
       await selectedSuggestion.waitFor();
+      await this.page.waitForTimeout(EXPLICIT_UI_STABILITY_TIMEOUT); // TODO: Remove the timeout and find a better alternative
       await selectedSuggestion.click();
       await this.getViaCH(viaNumber).click({ trial: true });
       await expect(this.getViaCH(viaNumber)).toHaveValue(DEFAULT_DETAILS.chValue);


### PR DESCRIPTION
First commit : Fix flaky test 005 due to timzone handling which fail the test if the time is between 00:00 and 02:00
Build exemples : 

- https://github.com/OpenRailAssociation/osrd/actions/runs/14183706020/job/39735126795
- https://github.com/OpenRailAssociation/osrd/actions/runs/14183583170/job/39734797539
- https://github.com/OpenRailAssociation/osrd/actions/runs/14183385709/job/39734243081

Second commit : Temporarily fix flakiness in test 006. A more robust solution will be implemented after further investigation into the code #11326
Build exemples : 

- https://github.com/OpenRailAssociation/osrd/actions/runs/14133966954/job/39601252699
- https://github.com/OpenRailAssociation/osrd/actions/runs/14135636767/job/39606749687