### PR TITLE
front: avoid blinking with example DTO when launching NGE

### DIFF
--- a/front/src/applications/operationalStudies/components/NGE/NGE.tsx
+++ b/front/src/applications/operationalStudies/components/NGE/NGE.tsx
@@ -10,6 +10,7 @@ import ngeVendor from '@osrd-project/netzgrafik-frontend/dist/netzgrafik-fronten
 
 import i18n from 'i18n';
 
+import { EMPTY_DTO } from './consts';
 import type { NetzgrafikDto, NGEEvent } from './types';
 
 interface NGEElement extends HTMLElement {
@@ -53,7 +54,10 @@ const NGE = ({ dto, onOperation, onLoad }: NGEProps) => {
     const frame = frameRef.current!;
 
     const handleFrameLoad = () => {
+      // Set the initial DTO as an empty state to avoid blinking with the
+      // default sample nodes
       const ngeRoot = frame.contentDocument!.createElement('sbb-root') as NGEElement;
+      ngeRoot.netzgrafikDto = EMPTY_DTO;
       frame.contentDocument!.body.appendChild(ngeRoot);
       setNgeRootElement(ngeRoot);
 

--- a/front/src/applications/operationalStudies/components/NGE/consts.ts
+++ b/front/src/applications/operationalStudies/components/NGE/consts.ts
@@ -1,0 +1,22 @@
+/* eslint-disable import/prefer-default-export */
+
+import type { NetzgrafikDto } from './types';
+
+export const EMPTY_DTO: NetzgrafikDto = {
+  nodes: [],
+  trainruns: [],
+  trainrunSections: [],
+  resources: [],
+  metadata: {
+    netzgrafikColors: [],
+    trainrunCategories: [],
+    trainrunFrequencies: [],
+    trainrunTimeCategories: [],
+  },
+  labels: [],
+  labelGroups: [],
+  freeFloatingTexts: [],
+  filterData: {
+    filterSettings: [],
+  },
+};


### PR DESCRIPTION
NGE will use an example DTO (with Swiss train stations) if it's initialized without a specific DTO. Later, we set the DTO to the final state. There is a small time window where NGE displays the example data before the real data. This results in blinking.

Set NGE's initial DTO as an empty state to avoid this blinking.

Requires this NGE patch:
https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/419