### PR TITLE
front: fix Duration serialization in redux persist

### DIFF
--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -1,9 +1,8 @@
-import type { Action, Reducer, ReducersMapObject, AnyAction } from 'redux';
-import type { PersistConfig } from 'redux-persist';
-import { createTransform, persistCombineReducers, persistReducer } from 'redux-persist';
+import type { Action, ReducersMapObject } from 'redux';
+import { createTransform, persistCombineReducers } from 'redux-persist';
 import storage from 'redux-persist/lib/storage'; // defaults to localStorage
 import createCompressor from 'redux-persist-transform-compress';
-import { createFilter } from 'redux-persist-transform-filter';
+import { createFilter, createBlacklistFilter } from 'redux-persist-transform-filter';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { osrdGatewayApi } from 'common/api/osrdGatewayApi';
@@ -53,11 +52,18 @@ const userWhiteList = ['account', 'userPreferences', 'impersonatedUser'];
 
 const mainWhiteList = ['lastInterfaceVersion'];
 
-const saveMapFilter = createFilter('map', mapWhiteList);
+const operationalStudiesConfBlackList = ['usingSpeedLimits'];
 
-const saveUserFilter = createFilter('user', userWhiteList);
+const saveMapFilter = createFilter(mapSlice.name, mapWhiteList);
 
-const saveMainFilter = createFilter('main', mainWhiteList);
+const saveUserFilter = createFilter(userSlice.name, userWhiteList);
+
+const saveMainFilter = createFilter(mainSlice.name, mainWhiteList);
+
+const operationalStudiesFilter = createBlacklistFilter(
+  operationalStudiesConfSlice.name,
+  operationalStudiesConfBlackList
+);
 
 // Deserialize date strings coming from local storage
 const operationalStudiesDateTransform = createTransform(
@@ -66,23 +72,19 @@ const operationalStudiesDateTransform = createTransform(
     startTime,
     interval,
     timeWindow,
+    pathSteps,
     ...outboundState
   }: {
     startTime: string;
     interval: string;
     timeWindow: string;
+    pathSteps: ({ arrival: string; stopFor: string } | null)[];
   }) => ({
     ...outboundState,
     startTime: new Date(startTime),
     interval: Duration.parse(interval),
     timeWindow: Duration.parse(timeWindow),
-  }),
-  { whitelist: ['operationalStudiesConf'] }
-);
-const pathStepsTransform = createTransform(
-  null,
-  (pathSteps: ({ arrival: string; stopFor: string } | null)[]) =>
-    pathSteps.map((pathStep) => {
+    pathSteps: pathSteps.map((pathStep) => {
       if (!pathStep) return null;
 
       return {
@@ -91,25 +93,24 @@ const pathStepsTransform = createTransform(
         stopFor: pathStep.stopFor ? Duration.parse(pathStep.stopFor) : null,
       };
     }),
-  { whitelist: ['pathSteps'] }
+  }),
+  {
+    whitelist: [operationalStudiesConfSlice.name],
+  }
 );
-
-// Useful to only blacklist a sub-propertie of osrdconf
-const buildOsrdConfPersistConfig = <T extends OperationalStudiesConfState | OsrdStdcmConfState>(
-  slice: ConfSlice
-): PersistConfig<T> => ({
-  key: slice.name,
-  storage,
-  transforms: [operationalStudiesDateTransform, pathStepsTransform],
-  blacklist: ['usingSpeedLimits'],
-});
 
 export const persistConfig = {
   key: 'root',
   storage,
-  transforms: [compressor, saveMapFilter, saveUserFilter, saveMainFilter],
-  blacklist: [stdcmConfSlice.name, operationalStudiesConfSlice.name],
-  whitelist: ['user', 'map', 'main', 'simulation', 'mapViewer'],
+  transforms: [
+    compressor,
+    saveMapFilter,
+    saveUserFilter,
+    saveMainFilter,
+    operationalStudiesFilter,
+    operationalStudiesDateTransform,
+  ],
+  blacklist: [stdcmConfSlice.name],
 };
 
 type AllActions = Action;
@@ -156,13 +157,10 @@ export const rootReducer: ReducersMapObject<RootState> = {
   [userSlice.name]: userReducer,
   [mapSlice.name]: mapReducer,
   [mapViewerSlice.name]: mapViewerReducer,
-  [editorSlice.name]: editorReducer as Reducer<EditorState, AnyAction>,
+  [editorSlice.name]: editorReducer,
   [mainSlice.name]: mainReducer,
   [stdcmConfSlice.name]: stdcmConfReducer,
-  [operationalStudiesConfSlice.name]: persistReducer(
-    buildOsrdConfPersistConfig<OperationalStudiesConfState>(operationalStudiesConfSlice),
-    operationalStudiesConfReducer
-  ) as unknown as Reducer<OperationalStudiesConfState, AnyAction>,
+  [operationalStudiesConfSlice.name]: operationalStudiesConfReducer,
   [simulationResultsSlice.name]: simulationReducer,
   [osrdEditoastApi.reducerPath]: osrdEditoastApi.reducer,
   [osrdGatewayApi.reducerPath]: osrdGatewayApi.reducer,

--- a/front/tests/003-study-management.spec.ts
+++ b/front/tests/003-study-management.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { Project, Study } from 'common/api/osrdEditoastApi';
@@ -108,11 +109,6 @@ test.describe('Validate the Study creation workflow', () => {
       tags: ['update-tag'],
     });
 
-    // Navigate back to the project page
-    await page.goto(`/operational-studies/projects/${project.id}`);
-
-    // Reopen the updated study and validate the updated data
-    await studyPage.openStudyByTestId(`${study.name} (updated)`);
     await studyPage.validateStudyData({
       name: `${study.name} (updated)`,
       description: `${study.description} (updated)`,
@@ -127,6 +123,12 @@ test.describe('Validate the Study creation workflow', () => {
       tags: ['update-tag'],
       isUpdate: true, // Indicate that this is an update
     });
+
+    // Navigate back to the project page
+    await page.goto(`/operational-studies/projects/${project.id}`);
+
+    await expect(page.getByTestId(`${study.name} (updated)`).first()).toBeVisible();
+
     await deleteStudy(project.id, `${study.name} (updated)`);
   });
 

--- a/front/tests/004-scenario-management.spec.ts
+++ b/front/tests/004-scenario-management.spec.ts
@@ -5,7 +5,7 @@ import type { ElectricalProfileSet, Project, Scenario, Study } from 'common/api/
 import { infrastructureName } from './assets/constants/project-const';
 import test from './logging-fixture';
 import ScenarioPage from './pages/operational-studies/scenario-page';
-import { generateUniqueName } from './utils';
+import { generateUniqueName, waitForInfraStateToBeCached } from './utils';
 import { deleteApiRequest, getProject, getStudy, setElectricalProfile } from './utils/api-utils';
 import readJsonFile from './utils/file-utils';
 import createScenario from './utils/scenario';
@@ -70,12 +70,24 @@ test.describe('Validate the Scenario creation workflow', () => {
     await page.goto(`/operational-studies/projects/${project.id}/studies/${study.id}`);
     await scenarioPage.openScenarioByTestId(scenario.name);
 
+    // Wait for infra to be in 'CACHED' state before proceeding
+    await waitForInfraStateToBeCached(scenario.infra_id);
+
     // Update the scenario with new details
     const updatedScenarioName = generateUniqueName(`${scenarioData.name}(updated)`);
     await scenarioPage.updateScenario({
       name: updatedScenarioName,
       description: `${scenario.description} (updated)`,
       tags: ['update-tag'],
+    });
+
+    // TODO: check another way to wait for the scenario to be updated
+    await page.waitForTimeout(500);
+
+    await scenarioPage.validateScenarioData({
+      name: updatedScenarioName,
+      description: `${scenario.description} (updated)`,
+      infraName: infrastructureName,
     });
 
     // Navigate back to the study page to verify the updated tags
@@ -85,14 +97,6 @@ test.describe('Validate the Scenario creation workflow', () => {
     expect(await scenarioPage.getScenarioTags(updatedScenarioName).textContent()).toContain(
       `${scenarioData.tags.join('')}update-tag`
     );
-
-    // Reopen the updated scenario and validate the updated data
-    await scenarioPage.openScenarioByTestId(updatedScenarioName);
-    await scenarioPage.validateScenarioData({
-      name: updatedScenarioName,
-      description: `${scenario.description} (updated)`,
-      infraName: infrastructureName,
-    });
 
     // Delete the scenario
     await deleteScenario(project.id, study.id, updatedScenarioName);


### PR DESCRIPTION
closes #11277
The bug occurred because of two conflicting persistence configurations:
- One at root level in persistConfig
- One at slice level with persistReducer

This caused Duration objects to not be properly serialized when stored in localStorage, leading to runtime errors when trying to call Duration methds on non-Duration objects.

Solution:
- Remove slice level persistence
- Keep only root level persistence with transforms