### PR TITLE
editoast: rename TrainScheduleResult to TrainScheduleResponse

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -3376,7 +3376,7 @@ paths:
                     results:
                       type: array
                       items:
-                        $ref: '#/components/schemas/TrainScheduleResult'
+                        $ref: '#/components/schemas/TrainScheduleResponse'
         '404':
           description: Timetable not found
     post:
@@ -3408,7 +3408,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TrainScheduleResult'
+                  $ref: '#/components/schemas/TrainScheduleResponse'
   /towed_rolling_stock:
     get:
       tags:
@@ -3631,7 +3631,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrainScheduleResult'
+                $ref: '#/components/schemas/TrainScheduleResponse'
     put:
       tags:
       - train_schedule
@@ -3657,7 +3657,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TrainScheduleResult'
+                $ref: '#/components/schemas/TrainScheduleResponse'
   /train_schedule/{id}/path:
     get:
       tags:
@@ -12567,7 +12567,7 @@ components:
         use_speed_limits_for_simulation:
           type: boolean
       additionalProperties: false
-    TrainScheduleResult:
+    TrainScheduleResponse:
       allOf:
       - $ref: '#/components/schemas/TrainScheduleBase'
       - type: object

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -6,13 +6,12 @@ use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::train_schedule::TrainScheduleBase;
 
 use crate::models::prelude::*;
+use crate::models::timetable::Timetable;
+use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainSchedule;
 use crate::views::train_schedule::TrainScheduleForm;
-use crate::{
-    models::timetable::{Timetable, TimetableWithTrains},
-    views::train_schedule::TrainScheduleResult,
-    CliError,
-};
+use crate::views::train_schedule::TrainScheduleResponse;
+use crate::CliError;
 
 #[derive(Subcommand, Debug)]
 pub enum TimetablesCommands {
@@ -58,7 +57,7 @@ pub async fn trains_export(
 
     let train_schedules: Vec<TrainScheduleBase> = train_schedules
         .into_iter()
-        .map(|ts| Into::<TrainScheduleResult>::into(ts).train_schedule)
+        .map(|ts| Into::<TrainScheduleResponse>::into(ts).train_schedule)
         .collect();
 
     let file = File::create(args.path.clone())?;

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -49,7 +49,7 @@ use crate::models::train_schedule::TrainScheduleChangeset;
 use crate::models::Infra;
 use crate::views::train_schedule::train_simulation_batch;
 use crate::views::train_schedule::TrainScheduleForm;
-use crate::views::train_schedule::TrainScheduleResult;
+use crate::views::train_schedule::TrainScheduleResponse;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::AppState;
@@ -121,8 +121,8 @@ struct TimetableIdParam {
 #[derive(Serialize, ToSchema, Debug)]
 #[cfg_attr(test, derive(Deserialize))]
 struct ListTrainSchedulesResponse {
-    #[schema(value_type = Vec<TrainScheduleResult>)]
-    results: Vec<TrainScheduleResult>,
+    #[schema(value_type = Vec<TrainScheduleResponse>)]
+    results: Vec<TrainScheduleResponse>,
     #[serde(flatten)]
     stats: PaginationStats,
 }
@@ -234,7 +234,7 @@ async fn delete(
     params(TimetableIdParam),
     request_body = Vec<TrainScheduleBase>,
     responses(
-        (status = 200, description = "The created train schedules", body = Vec<TrainScheduleResult>)
+        (status = 200, description = "The created train schedules", body = Vec<TrainScheduleResponse>)
     )
 )]
 async fn post_train_schedule(
@@ -242,7 +242,7 @@ async fn post_train_schedule(
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
     Json(train_schedules): Json<Vec<TrainScheduleBase>>,
-) -> Result<Json<Vec<TrainScheduleResult>>> {
+) -> Result<Json<Vec<TrainScheduleResponse>>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await

--- a/editoast/src/views/train_schedule.rs
+++ b/editoast/src/views/train_schedule.rs
@@ -73,7 +73,7 @@ crate::routes! {
 editoast_common::schemas! {
     TrainScheduleBase,
     TrainScheduleForm,
-    TrainScheduleResult,
+    TrainScheduleResponse,
     ElectricalProfileSetIdQueryParam,
 }
 
@@ -104,14 +104,14 @@ struct TrainScheduleIdParam {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, ToSchema)]
-pub struct TrainScheduleResult {
+pub struct TrainScheduleResponse {
     id: i64,
     timetable_id: i64,
     #[serde(flatten)]
     pub train_schedule: TrainScheduleBase,
 }
 
-impl From<TrainSchedule> for TrainScheduleResult {
+impl From<TrainSchedule> for TrainScheduleResponse {
     fn from(value: TrainSchedule) -> Self {
         Self {
             id: value.id,
@@ -160,7 +160,7 @@ impl From<TrainScheduleForm> for TrainScheduleChangeset {
     tag = "train_schedule",
     params(TrainScheduleIdParam),
     responses(
-        (status = 200, description = "The train schedule", body = TrainScheduleResult)
+        (status = 200, description = "The train schedule", body = TrainScheduleResponse)
     )
 )]
 async fn get(
@@ -169,7 +169,7 @@ async fn get(
     Path(TrainScheduleIdParam {
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
-) -> Result<Json<TrainScheduleResult>> {
+) -> Result<Json<TrainScheduleResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
         .await
@@ -225,7 +225,7 @@ async fn delete(
     request_body = TrainScheduleForm,
     params(TrainScheduleIdParam),
     responses(
-        (status = 200, description = "The train schedule have been updated", body = TrainScheduleResult)
+        (status = 200, description = "The train schedule have been updated", body = TrainScheduleResponse)
     )
 )]
 async fn put(
@@ -235,7 +235,7 @@ async fn put(
         id: train_schedule_id,
     }): Path<TrainScheduleIdParam>,
     Json(train_schedule_form): Json<TrainScheduleForm>,
-) -> Result<Json<TrainScheduleResult>> {
+) -> Result<Json<TrainScheduleResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -819,7 +819,7 @@ pub mod tests {
         let response = app
             .fetch(request)
             .assert_status(StatusCode::OK)
-            .json_into::<TrainScheduleResult>();
+            .json_into::<TrainScheduleResponse>();
 
         assert_eq!(train_schedule.id, response.id);
         assert_eq!(train_schedule.timetable_id, response.timetable_id);
@@ -842,7 +842,7 @@ pub mod tests {
             .post(format!("/timetable/{}/train_schedules", timetable.id).as_str())
             .json(&json!(vec![train_schedule_base]));
 
-        let response: Vec<TrainScheduleResult> =
+        let response: Vec<TrainScheduleResponse> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);
     }
@@ -888,7 +888,7 @@ pub mod tests {
             .put(format!("/train_schedule/{}", train_schedule.id).as_str())
             .json(&json!(update_train_schedule_form));
 
-        let response: TrainScheduleResult =
+        let response: TrainScheduleResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         assert_eq!(
             response.train_schedule.rolling_stock_name,

--- a/front/src/applications/operationalStudies/__tests__/sampleData.ts
+++ b/front/src/applications/operationalStudies/__tests__/sampleData.ts
@@ -13,7 +13,7 @@ import type {
   SimulationSummaryResult,
   TrainScheduleBase,
 } from 'common/api/osrdEditoastApi';
-import type { TrainScheduleId, TrainScheduleResultWithTrainId } from 'reducers/osrdconf/types';
+import type { TrainScheduleId, TrainScheduleResponseWithTrainId } from 'reducers/osrdconf/types';
 
 export const pathLength = 4000;
 
@@ -352,7 +352,7 @@ export const electrificationRangesLarge: ElectrificationRange[] = [
   },
 ];
 
-export const trainScheduleTooFast: TrainScheduleResultWithTrainId = {
+export const trainScheduleTooFast: TrainScheduleResponseWithTrainId = {
   id: 'trainschedule-98' as TrainScheduleId,
   timetable_id: 10,
   train_name: 'tooFast',
@@ -419,7 +419,7 @@ export const trainSummaryTooFast: Extract<SimulationSummaryResult, { status: 'su
   path_item_times_base: [0, 1444453, 2491479],
 };
 
-export const trainScheduleNotHonored: TrainScheduleResultWithTrainId = {
+export const trainScheduleNotHonored: TrainScheduleResponseWithTrainId = {
   id: 'trainschedule-96' as TrainScheduleId,
   timetable_id: 10,
   train_name: 'notHonored',
@@ -486,7 +486,7 @@ export const trainSummaryNotHonored: Extract<SimulationSummaryResult, { status: 
   path_item_times_base: [0, 1425534, 2186885],
 };
 
-export const trainScheduleHonored: TrainScheduleResultWithTrainId = {
+export const trainScheduleHonored: TrainScheduleResponseWithTrainId = {
   id: 'trainschedule-95' as TrainScheduleId,
   timetable_id: 10,
   train_name: 'normal',
@@ -530,12 +530,12 @@ export const trainScheduleHonored: TrainScheduleResultWithTrainId = {
   },
 };
 
-export const trainScheduleNoSchedule: TrainScheduleResultWithTrainId = {
+export const trainScheduleNoSchedule: TrainScheduleResponseWithTrainId = {
   ...trainScheduleHonored,
   schedule: undefined,
 };
 
-export const trainScheduleNoMatch: TrainScheduleResultWithTrainId = {
+export const trainScheduleNoMatch: TrainScheduleResponseWithTrainId = {
   ...trainScheduleHonored,
   schedule: [
     {

--- a/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/MacroEditorState.ts
@@ -4,7 +4,7 @@ import type {
   MacroNodeResponse,
   ScenarioResponse,
   SearchResultItemOperationalPoint,
-  TrainScheduleResult,
+  TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { TimetableItemId } from 'reducers/osrdconf/types';
 
@@ -23,7 +23,7 @@ export default class MacroEditorState {
   /**
    * Train schedules
    */
-  trainSchedules: TrainScheduleResult[];
+  trainSchedules: TrainScheduleResponse[];
 
   /**
    * Nodes storage
@@ -65,7 +65,7 @@ export default class MacroEditorState {
   /**
    * Default constructor
    */
-  constructor(scenario: ScenarioResponse, trainSchedules: TrainScheduleResult[]) {
+  constructor(scenario: ScenarioResponse, trainSchedules: TrainScheduleResponse[]) {
     // Empty
     this.nodeLabels = new Set<string>([]);
     this.trainrunLabels = new Set<string>([]);
@@ -208,7 +208,7 @@ export default class MacroEditorState {
   /**
    * Given an path step, returns its pathKey
    */
-  static getPathKey(item: TrainScheduleResult['path'][0]): string {
+  static getPathKey(item: TrainScheduleResponse['path'][0]): string {
     if ('trigram' in item)
       return `trigram:${item.trigram}${item.secondary_code ? `/${item.secondary_code}` : ''}`;
     if ('operational_point' in item) return `op_id:${item.operational_point}`;

--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -8,7 +8,7 @@ import {
 import type {
   TimetableItemId,
   TrainScheduleId,
-  TrainScheduleResultWithTrainId,
+  TrainScheduleResponseWithTrainId,
 } from 'reducers/osrdconf/types';
 import type { AppDispatch } from 'store';
 import { Duration } from 'utils/duration';
@@ -279,7 +279,7 @@ const handleUpdateTrainSchedule = async ({
   trainrun: TrainrunDto;
   dispatch: AppDispatch;
   infraId: number;
-  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResultWithTrainId[]) => void;
+  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
   state: MacroEditorState;
 }) => {
   const { nodes, labels } = netzgrafikDto;
@@ -315,7 +315,7 @@ const handleUpdateTrainSchedule = async ({
       },
     })
   ).unwrap();
-  const formattedNewTrainSchedule: TrainScheduleResultWithTrainId = {
+  const formattedNewTrainSchedule: TrainScheduleResponseWithTrainId = {
     ...newTrainSchedule,
     id: formatEditoastTrainIdToTrainScheduleId(newTrainSchedule.id),
   };
@@ -339,7 +339,7 @@ const handleTrainrunOperation = async ({
   infraId: number;
   timeTableId: number;
   netzgrafikDto: NetzgrafikDto;
-  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResultWithTrainId[]) => void;
+  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
   addDeletedTrainIds: (trainIds: TimetableItemId[]) => void;
   state: MacroEditorState;
 }) => {
@@ -372,7 +372,7 @@ const handleTrainrunOperation = async ({
         })
       ).unwrap();
       // TODO Paced train : Adapt to handle paced trains in issue https://github.com/OpenRailAssociation/osrd/issues/10612
-      const formattedNewTrainSchedules: TrainScheduleResultWithTrainId[] = newTrainSchedules.map(
+      const formattedNewTrainSchedules: TrainScheduleResponseWithTrainId[] = newTrainSchedules.map(
         (trainSchedule) => ({
           ...trainSchedule,
           id: formatEditoastTrainIdToTrainScheduleId(trainSchedule.id),
@@ -512,7 +512,7 @@ const handleLabelOperation = async ({
   netzgrafikDto: NetzgrafikDto;
   dispatch: AppDispatch;
   infraId: number;
-  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResultWithTrainId[]) => void;
+  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
   state: MacroEditorState;
 }) => {
   const { trainruns } = netzgrafikDto;
@@ -555,7 +555,7 @@ const handleOperation = async ({
   infraId: number;
   timeTableId: number;
   netzgrafikDto: NetzgrafikDto;
-  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResultWithTrainId[]) => void;
+  addUpsertedTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
   addDeletedTrainIds: (trainIds: TimetableItemId[]) => void;
 }) => {
   const { type } = event;

--- a/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
+++ b/front/src/applications/operationalStudies/components/Scenario/ScenarioContent.tsx
@@ -22,7 +22,7 @@ import { Loader } from 'common/Loaders';
 import ScenarioLoaderMessage from 'modules/scenario/components/ScenarioLoaderMessage';
 import TimetableManageTrainSchedule from 'modules/trainschedule/components/ManageTrainSchedule/TimetableManageTrainSchedule';
 import Timetable from 'modules/trainschedule/components/Timetable';
-import type { TimetableItemId, TrainScheduleResultWithTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItemId, TrainScheduleResponseWithTrainId } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 
 import ScenarioDescription from './ScenarioDescription';
@@ -102,7 +102,7 @@ const ScenarioContent = ({
       infraId: infra.id,
       timeTableId: scenario.timetable_id,
       netzgrafikDto,
-      addUpsertedTrainSchedules: (upsertedTrainSchedules: TrainScheduleResultWithTrainId[]) => {
+      addUpsertedTrainSchedules: (upsertedTrainSchedules: TrainScheduleResponseWithTrainId[]) => {
         upsertTimetableItems(upsertedTrainSchedules);
       },
       addDeletedTrainIds: (trainIds: TimetableItemId[]) => {

--- a/front/src/applications/operationalStudies/hooks/useScenarioData.ts
+++ b/front/src/applications/operationalStudies/hooks/useScenarioData.ts
@@ -16,7 +16,7 @@ import type {
   TimetableItemId,
   TimetableItemWithTimetableId,
   TrainScheduleId,
-  TrainScheduleResultWithTrainId,
+  TrainScheduleResponseWithTrainId,
 } from 'reducers/osrdconf/types';
 import { getTrainIdUsedForProjection } from 'reducers/simulationResults/selectors';
 import { getShowPacedTrains } from 'reducers/user/userSelectors';
@@ -259,7 +259,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
         throw new Error('Train non trouvé');
       }
 
-      const trainScheduleResult = await putTrainScheduleById({
+      const trainScheduleResponse = await putTrainScheduleById({
         id: editoastTrainId,
         trainScheduleForm: {
           ...trainSchedule,
@@ -267,15 +267,15 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
         },
       }).unwrap();
 
-      const updatedTrainScheduleResult: TrainScheduleResultWithTrainId = {
-        ...trainScheduleResult,
-        id: formatEditoastTrainIdToTrainScheduleId(trainScheduleResult.id),
+      const updatedTrainScheduleResponse: TrainScheduleResponseWithTrainId = {
+        ...trainScheduleResponse,
+        id: formatEditoastTrainIdToTrainScheduleId(trainScheduleResponse.id),
       };
 
       setProjectedTrainsById((prev) => {
         const newProjectedTrainsById = new Map(prev);
-        newProjectedTrainsById.set(updatedTrainScheduleResult.id, {
-          ...newProjectedTrainsById.get(updatedTrainScheduleResult.id)!,
+        newProjectedTrainsById.set(updatedTrainScheduleResponse.id, {
+          ...newProjectedTrainsById.get(updatedTrainScheduleResponse.id)!,
           departureTime: newDeparture,
         });
         return newProjectedTrainsById;
@@ -284,7 +284,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
       setTimetableItems((prev) => {
         const newTrainSchedulesById = {
           ...keyBy(prev, 'id'),
-          ...keyBy([updatedTrainScheduleResult], 'id'),
+          ...keyBy([updatedTrainScheduleResponse], 'id'),
         };
         return sortBy(Object.values(newTrainSchedulesById), 'start_time');
       });
@@ -307,7 +307,7 @@ const useScenarioData = (scenario: ScenarioResponse, infra: InfraWithState) => {
       const summaries = formatTimetableItemSummaries(
         [trainId],
         formattedRawSummaries,
-        mapBy([updatedTrainScheduleResult], 'id'),
+        mapBy([updatedTrainScheduleResponse], 'id'),
         rollingStocks!
       );
       setTimetableItemSummariesById((prev) => {

--- a/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
+++ b/front/src/applications/stdcm/hooks/useProjectedTrainsForStdcm.ts
@@ -13,7 +13,7 @@ import {
   getStdcmInfraID,
   getStdcmTimetableID,
 } from 'reducers/osrdconf/stdcmConf/selectors';
-import type { TimetableItemId, TrainScheduleResultWithTrainId } from 'reducers/osrdconf/types';
+import type { TimetableItemId, TrainScheduleResponseWithTrainId } from 'reducers/osrdconf/types';
 import { Duration, addDurationToDate } from 'utils/duration';
 import { formatEditoastTrainIdToTrainScheduleId } from 'utils/trainId';
 
@@ -79,7 +79,7 @@ const useProjectedTrainsForStdcm = (stdcmResponse?: StdcmSuccessResponse) => {
     [trainIds]
   );
 
-  const formattedTrainSchedules: TrainScheduleResultWithTrainId[] | undefined = useMemo(
+  const formattedTrainSchedules: TrainScheduleResponseWithTrainId[] | undefined = useMemo(
     () =>
       timetable?.map((trainSchedule) => ({
         ...trainSchedule,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -2010,7 +2010,7 @@ export type PostTimetableByIdStdcmApiArg = {
 };
 export type GetTimetableByIdTrainSchedulesApiResponse =
   /** status 200 Timetable with train schedules ids */ PaginationStats & {
-    results: TrainScheduleResult[];
+    results: TrainScheduleResponse[];
   };
 export type GetTimetableByIdTrainSchedulesApiArg = {
   /** A timetable ID */
@@ -2019,7 +2019,7 @@ export type GetTimetableByIdTrainSchedulesApiArg = {
   pageSize?: number | null;
 };
 export type PostTimetableByIdTrainSchedulesApiResponse =
-  /** status 200 The created train schedules */ TrainScheduleResult[];
+  /** status 200 The created train schedules */ TrainScheduleResponse[];
 export type PostTimetableByIdTrainSchedulesApiArg = {
   /** A timetable ID */
   id: number;
@@ -2077,13 +2077,13 @@ export type PostTrainScheduleSimulationSummaryApiArg = {
   };
 };
 export type GetTrainScheduleByIdApiResponse =
-  /** status 200 The train schedule */ TrainScheduleResult;
+  /** status 200 The train schedule */ TrainScheduleResponse;
 export type GetTrainScheduleByIdApiArg = {
   /** A train schedule ID */
   id: number;
 };
 export type PutTrainScheduleByIdApiResponse =
-  /** status 200 The train schedule have been updated */ TrainScheduleResult;
+  /** status 200 The train schedule have been updated */ TrainScheduleResponse;
 export type PutTrainScheduleByIdApiArg = {
   /** A train schedule ID */
   id: number;
@@ -4012,7 +4012,7 @@ export type PathfindingItem = {
     arrival_time_tolerance_before: number;
   } | null;
 };
-export type TrainScheduleResult = TrainScheduleBase & {
+export type TrainScheduleResponse = TrainScheduleBase & {
   id: number;
   timetable_id: number;
 };

--- a/front/src/common/api/osrdEditoastApi.ts
+++ b/front/src/common/api/osrdEditoastApi.ts
@@ -5,7 +5,7 @@ import {
   type GetSpritesSignalingSystemsApiResponse,
   generatedEditoastApi,
   type Property,
-  type TrainScheduleResult,
+  type TrainScheduleResponse,
   type PacedTrainResponse,
 } from './generatedEditoastApi';
 
@@ -16,14 +16,14 @@ const osrdEditoastApi = generatedEditoastApi
   .injectEndpoints({
     endpoints: (builder) => ({
       getAllTimetableByIdTrainSchedules: builder.query<
-        TrainScheduleResult[],
+        TrainScheduleResponse[],
         { timetableId: number }
       >({
         queryFn: async ({ timetableId }, { dispatch }) => {
           const pageSize = 25;
           let page = 1;
           let reachEnd = false;
-          const result: TrainScheduleResult[] = [];
+          const result: TrainScheduleResponse[] = [];
           while (!reachEnd) {
             const promise = dispatch(
               osrdEditoastApi.endpoints.getTimetableByIdTrainSchedules.initiate(

--- a/front/src/modules/scenario/helpers/__tests__/scenario.spec.ts
+++ b/front/src/modules/scenario/helpers/__tests__/scenario.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 
 import { getScenarioDatetimeWindow } from '../utils';
 
@@ -21,7 +21,7 @@ describe('getScenarioDatetimeWindow', () => {
       { start_time: '2023-10-01T08:00:00Z' },
     ];
 
-    const result = getScenarioDatetimeWindow(trainsDetails as TrainScheduleResult[]);
+    const result = getScenarioDatetimeWindow(trainsDetails as TrainScheduleResponse[]);
 
     expect(result).toEqual({
       begin: new Date('2023-10-01T08:00:00Z'),
@@ -32,7 +32,7 @@ describe('getScenarioDatetimeWindow', () => {
   it('should handle a single train detail correctly', () => {
     const trainsDetails = [{ start_time: '2023-10-01T10:00:00Z' }];
 
-    const result = getScenarioDatetimeWindow(trainsDetails as TrainScheduleResult[]);
+    const result = getScenarioDatetimeWindow(trainsDetails as TrainScheduleResponse[]);
 
     expect(result).toEqual({
       begin: new Date('2023-10-01T10:00:00Z'),

--- a/front/src/modules/scenario/helpers/utils.ts
+++ b/front/src/modules/scenario/helpers/utils.ts
@@ -1,15 +1,15 @@
 import { isInvalidName } from 'applications/operationalStudies/utils';
-import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 import { SMALL_TEXT_AREA_MAX_LENGTH, isInvalidString } from 'utils/strings';
 
 import type { ScenarioForm } from '../components/AddOrEditScenarioModal';
 
 /**
  * Retrieves the datetime window of a scenario based on the provided train details.
- * @param trainsDetails - An array of TrainScheduleResult objects containing train details.
+ * @param trainsDetails - An array of TrainScheduleResponse objects containing train details.
  * @returns An object representing the datetime window of the scenario, with `begin` and `end` properties.
  */
-export const getScenarioDatetimeWindow = (trainsDetails: TrainScheduleResult[]) => {
+export const getScenarioDatetimeWindow = (trainsDetails: TrainScheduleResponse[]) => {
   if (trainsDetails.length === 0) {
     return {
       begin: new Date(new Date().setHours(0, 0, 0, 0)),

--- a/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -19,7 +19,7 @@ import { setFailure, setSuccess } from 'reducers/main';
 import type {
   PacedTrainResponseWithPacedTrainId,
   TimetableItemWithTimetableId,
-  TrainScheduleResultWithTrainId,
+  TrainScheduleResponseWithTrainId,
 } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import {
@@ -104,7 +104,7 @@ const ImportTimetableItemTrainsList = ({
         trainSchedulePayloads = generateTrainSchedulesPayloads(formattedTrainsList, false);
       }
 
-      let formattedTrainSchedules: TrainScheduleResultWithTrainId[] = [];
+      let formattedTrainSchedules: TrainScheduleResponseWithTrainId[] = [];
 
       if (trainSchedulePayloads.length) {
         const trainSchedules = await postTrainSchedule({

--- a/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
+++ b/front/src/modules/trainschedule/components/ManageTrainSchedule/AddTrainScheduleButton.tsx
@@ -11,7 +11,7 @@ import { getOperationalStudiesConf } from 'reducers/osrdconf/operationalStudiesC
 import type {
   PacedTrainResponseWithPacedTrainId,
   TimetableItemWithTimetableId,
-  TrainScheduleResultWithTrainId,
+  TrainScheduleResponseWithTrainId,
 } from 'reducers/osrdconf/types';
 import { getUserPreferences } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
@@ -105,7 +105,7 @@ const AddTrainScheduleButton = ({
           }).unwrap();
 
           // We can only add one train schedule at a time
-          const formattedNewTrainSchedule: TrainScheduleResultWithTrainId = {
+          const formattedNewTrainSchedule: TrainScheduleResponseWithTrainId = {
             ...newTrainSchedule.at(0)!,
             id: formatEditoastTrainIdToTrainScheduleId(newTrainSchedule.at(0)!.id),
           };
@@ -149,7 +149,7 @@ const AddTrainScheduleButton = ({
           body: trainScheduleParams,
         }).unwrap();
 
-        const formattedNewTrainSchedule: TrainScheduleResultWithTrainId[] = newTrainSchedules.map(
+        const formattedNewTrainSchedule: TrainScheduleResponseWithTrainId[] = newTrainSchedules.map(
           (trainSchedule) => ({
             ...trainSchedule,
             id: formatEditoastTrainIdToTrainScheduleId(trainSchedule.id),

--- a/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TrainScheduleItem.tsx
@@ -16,7 +16,7 @@ import type {
   TimetableItemId,
   TrainId,
   TrainScheduleId,
-  TrainScheduleResultWithTrainId,
+  TrainScheduleResponseWithTrainId,
 } from 'reducers/osrdconf/types';
 import { updateTrainIdUsedForProjection, updateSelectedTrainId } from 'reducers/simulationResults';
 import { useAppDispatch } from 'store';
@@ -36,7 +36,7 @@ type TrainScheduleItemProps = {
   isSelected: boolean;
   isModified?: boolean;
   handleSelectTrain: (trainId: TrainScheduleId) => void;
-  upsertTrainSchedules: (trainSchedules: TrainScheduleResultWithTrainId[]) => void;
+  upsertTrainSchedules: (trainSchedules: TrainScheduleResponseWithTrainId[]) => void;
   removeTrains: (trainIds: TimetableItemId[]) => void;
   projectionPathIsUsed: boolean;
   dtoImport: () => void;
@@ -128,15 +128,15 @@ const TrainScheduleItem = ({
       };
 
       try {
-        const [trainScheduleResult] = await postTrainSchedule({
+        const [trainScheduleResponse] = await postTrainSchedule({
           id: trainDetail.timetable_id,
           body: [newTrain],
         }).unwrap();
-        const formattedTrainScheduleResult: TrainScheduleResultWithTrainId = {
-          ...trainScheduleResult,
-          id: formatEditoastTrainIdToTrainScheduleId(trainScheduleResult.id),
+        const formattedTrainScheduleResponse: TrainScheduleResponseWithTrainId = {
+          ...trainScheduleResponse,
+          id: formatEditoastTrainIdToTrainScheduleId(trainScheduleResponse.id),
         };
-        upsertTrainSchedules([formattedTrainScheduleResult]);
+        upsertTrainSchedules([formattedTrainScheduleResponse]);
         dtoImport();
         dispatch(
           setSuccess({

--- a/front/src/modules/trainschedule/components/Timetable/types.ts
+++ b/front/src/modules/trainschedule/components/Timetable/types.ts
@@ -3,7 +3,7 @@ import type {
   PathfindingInputError,
   PathfindingNotFound,
   SimulationSummaryResult,
-  TrainScheduleResult,
+  TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { OccurrenceId, PacedTrainId, TrainScheduleId } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -17,7 +17,7 @@ export type TrainTypeFilter = 'both' | 'pacedTrain' | 'trainSchedule';
 type SimulationSummaryResultSuccess = Extract<SimulationSummaryResult, { status: 'success' }>;
 
 type TimetableItemWithSummaries = Omit<
-  TrainScheduleResult,
+  TrainScheduleResponse,
   'id' | 'train_name' | 'rolling_stock_name' | 'timetable_id' | 'start_time'
 > & {
   name: string;

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -16,7 +16,7 @@ import type {
   PacedTrainResponse,
   PathItemLocation,
   ReceptionSignal,
-  TrainScheduleResult,
+  TrainScheduleResponse,
 } from 'common/api/osrdEditoastApi';
 import type { InfraState } from 'reducers/infra';
 import type { LayersSettings } from 'reducers/map';
@@ -149,7 +149,7 @@ export type PacedTrainId = string & { readonly __type: unique symbol };
 export type TrainId = TrainScheduleId | OccurrenceId;
 export type TimetableItemId = TrainScheduleId | PacedTrainId;
 
-export type TrainScheduleResultWithTrainId = Omit<TrainScheduleResult, 'id'> & {
+export type TrainScheduleResponseWithTrainId = Omit<TrainScheduleResponse, 'id'> & {
   id: TrainScheduleId;
 };
 
@@ -158,5 +158,5 @@ export type PacedTrainResponseWithPacedTrainId = Omit<PacedTrainResponse, 'id'> 
 };
 
 export type TimetableItemWithTimetableId =
-  | TrainScheduleResultWithTrainId
+  | TrainScheduleResponseWithTrainId
   | PacedTrainResponseWithPacedTrainId;

--- a/front/tests/utils/train-schedule.ts
+++ b/front/tests/utils/train-schedule.ts
@@ -1,6 +1,6 @@
 import type { APIRequestContext, APIResponse } from '@playwright/test';
 
-import type { TrainScheduleResult } from 'common/api/osrdEditoastApi';
+import type { TrainScheduleResponse } from 'common/api/osrdEditoastApi';
 
 import { getApiContext, handleErrorResponse } from './api-utils';
 
@@ -9,9 +9,12 @@ import { getApiContext, handleErrorResponse } from './api-utils';
  *
  * @param timetableId - The ID of the timetable for which the train schedules are being sent.
  * @param body - The request payload containing train schedule data.
- * @returns {Promise<TrainScheduleResult[]>} - The API response containing the train schedule results.
+ * @returns {Promise<TrainScheduleResponse[]>} - The API response containing the train schedule results.
  */
-async function sendTrainSchedules(timetableId: number, body: JSON): Promise<TrainScheduleResult[]> {
+async function sendTrainSchedules(
+  timetableId: number,
+  body: JSON
+): Promise<TrainScheduleResponse[]> {
   const apiContext: APIRequestContext = await getApiContext();
   const trainSchedulesResponse: APIResponse = await apiContext.post(
     `/api/timetable/${timetableId}/train_schedules/`,
@@ -23,7 +26,7 @@ async function sendTrainSchedules(timetableId: number, body: JSON): Promise<Trai
     }
   );
   handleErrorResponse(trainSchedulesResponse, 'Failed to send train schedule');
-  const responseData = (await trainSchedulesResponse.json()) as TrainScheduleResult[];
+  const responseData = (await trainSchedulesResponse.json()) as TrainScheduleResponse[];
 
   return responseData;
 }


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/11249

Rename TrainScheduleResult to TrainScheduleResponse

This is only a part of the ticket to facilitate the review. I will submit another PR for renaming TrainScheduleBase.