### PR TITLE
front: bump nge version to 2.9.23

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,7 +12,7 @@
         "@nivo/core": "^0.88.0",
         "@nivo/line": "^0.88.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
+        "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2",
         "@osrd-project/ui-charts": "^0.0.70",
         "@osrd-project/ui-core": "^0.0.70",
         "@osrd-project/ui-icons": "^0.0.70",
@@ -1901,9 +1901,9 @@
       "license": "MIT"
     },
     "node_modules/@osrd-project/netzgrafik-frontend": {
-      "version": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
-      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729.tgz",
-      "integrity": "sha512-A2LpjlIvj67Jrkv1pRg9rynWwi7Zj6/QtqrQdf72WQokMj2a215sbU3orxHDA4XlTOEYRGdkpi28bizvcfoSQQ=="
+      "version": "0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2",
+      "resolved": "https://registry.npmjs.org/@osrd-project/netzgrafik-frontend/-/netzgrafik-frontend-0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2.tgz",
+      "integrity": "sha512-V/yZ0BvozDQxVuAH7WAtMikUrstifSSDqL+i3hFRmrqA6D+JvegQt74dmhFvQiezRlkLeFLJEE6tU5Pz+BPFwQ=="
     },
     "node_modules/@osrd-project/ui-charts": {
       "version": "0.0.70",

--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,7 @@
     "@nivo/core": "^0.88.0",
     "@nivo/line": "^0.88.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
-    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.90c0b8c5111ab498e0963758f6c306fe4f38d729",
+    "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2",
     "@osrd-project/ui-core": "^0.0.70",
     "@osrd-project/ui-icons": "^0.0.70",
     "@osrd-project/ui-charts": "^0.0.70",


### PR DESCRIPTION
Cannot be tested, but contains a [new feature](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/pull/434) that prevent a future bug to happen in our OSRD/NGE link
