### PR TITLE
core, editoast: rename v2 endpoints

### DIFF
--- a/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
+++ b/core/src/main/java/fr/sncf/osrd/cli/WorkerCommand.kt
@@ -61,7 +61,7 @@ class WorkerCommand : CliCommand {
         WORKER_KEY = if (ALL_INFRA) "all" else System.getenv("WORKER_KEY")
         WORKER_AMQP_URI =
             System.getenv("WORKER_AMQP_URI") ?: "amqp://osrd:password@127.0.0.1:5672/%2f"
-        WORKER_MAX_MSG_SIZE = getIntEnvvar("WORKER_MAX_MSG_SIZE") ?: 1024 * 1024 * 128 * 5
+        WORKER_MAX_MSG_SIZE = getIntEnvvar("WORKER_MAX_MSG_SIZE") ?: (1024 * 1024 * 128 * 5)
         WORKER_POOL = System.getenv("WORKER_POOL") ?: "core"
         WORKER_REQUESTS_QUEUE =
             System.getenv("WORKER_REQUESTS_QUEUE") ?: "$WORKER_POOL-req-$WORKER_KEY"
@@ -122,14 +122,14 @@ class WorkerCommand : CliCommand {
 
         val endpoints =
             mapOf(
-                "/v2/pathfinding/blocks" to PathfindingBlocksEndpoint(infraManager),
-                "/v2/path_properties" to PathPropEndpoint(infraManager),
-                "/v2/standalone_simulation" to
+                "/pathfinding/blocks" to PathfindingBlocksEndpoint(infraManager),
+                "/path_properties" to PathPropEndpoint(infraManager),
+                "/standalone_simulation" to
                     SimulationEndpoint(infraManager, electricalProfileSetManager),
-                "/v2/signal_projection" to SignalProjectionEndpoint(infraManager),
-                "/v2/conflict_detection" to ConflictDetectionEndpoint(infraManager),
+                "/signal_projection" to SignalProjectionEndpoint(infraManager),
+                "/conflict_detection" to ConflictDetectionEndpoint(infraManager),
                 "/version" to VersionEndpoint(),
-                "/v2/stdcm" to STDCMEndpoint(infraManager),
+                "/stdcm" to STDCMEndpoint(infraManager),
                 "/infra_load" to InfraLoadEndpoint(infraManager),
             )
 
@@ -147,8 +147,8 @@ class WorkerCommand : CliCommand {
         factory.setMaxInboundMessageBodySize(WORKER_MAX_MSG_SIZE)
         val connection = factory.newConnection()
 
-        connection.use { connection ->
-            connection.createChannel().use { channel -> reportActivity(channel, "started") }
+        connection.use {
+            it.createChannel().use { channel -> reportActivity(channel, "started") }
 
             if (!ALL_INFRA) {
                 try {

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathPropEndpointTest.kt
@@ -41,7 +41,7 @@ class PathPropEndpointTest : ApiTest() {
                 )
             )
         val rawResponse =
-            PathPropEndpoint(infraManager).act(RqFake("POST", "v2/path_properties", requestBody))
+            PathPropEndpoint(infraManager).act(RqFake("POST", "/path_properties", requestBody))
         val response = TakesUtils.readBodyResponse(rawResponse)
         val parsed = pathPropResponseAdapter.fromJson(response)!!
 

--- a/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/pathfinding/PathfindingTest.kt
@@ -40,7 +40,7 @@ class PathfindingTest : ApiTest() {
             )
         val rawResponse =
             PathfindingBlocksEndpoint(infraManager)
-                .act(RqFake("POST", "/v2/pathfinding/blocks", requestBody))
+                .act(RqFake("POST", "/pathfinding/blocks", requestBody))
         val response = TakesUtils.readBodyResponse(rawResponse)
         val parsed = (pathfindingResponseAdapter.fromJson(response) as? PathfindingBlockSuccess)!!
         AssertionsForClassTypes.assertThat(parsed.length.distance).isEqualTo(10250.meters)
@@ -100,7 +100,7 @@ class PathfindingTest : ApiTest() {
             )
         val unconstrainedRawResponse =
             PathfindingBlocksEndpoint(infraManager)
-                .act(RqFake("POST", "/v2/pathfinding/blocks", unconstrainedRequestBody))
+                .act(RqFake("POST", "/pathfinding/blocks", unconstrainedRequestBody))
         val unconstrainedResponse = TakesUtils.readBodyResponse(unconstrainedRawResponse)
         val unconstrainedParsed =
             (pathfindingResponseAdapter.fromJson(unconstrainedResponse)
@@ -123,7 +123,7 @@ class PathfindingTest : ApiTest() {
             )
         val rawResponse =
             PathfindingBlocksEndpoint(infraManager)
-                .act(RqFake("POST", "/v2/pathfinding/blocks", requestBody))
+                .act(RqFake("POST", "/pathfinding/blocks", requestBody))
         val response = TakesUtils.readBodyResponse(rawResponse)
         val parsed =
             (pathfindingResponseAdapter.fromJson(response)
@@ -171,7 +171,7 @@ class PathfindingTest : ApiTest() {
             )
         val unconstrainedRawResponse =
             PathfindingBlocksEndpoint(infraManager)
-                .act(RqFake("POST", "/v2/pathfinding/blocks", unconstrainedRequestBody))
+                .act(RqFake("POST", "/pathfinding/blocks", unconstrainedRequestBody))
         val unconstrainedResponse = TakesUtils.readBodyResponse(unconstrainedRawResponse)
         val unconstrainedParsed =
             (pathfindingResponseAdapter.fromJson(unconstrainedResponse)
@@ -194,7 +194,7 @@ class PathfindingTest : ApiTest() {
             )
         val rawResponse =
             PathfindingBlocksEndpoint(infraManager)
-                .act(RqFake("POST", "/v2/pathfinding/blocks", requestBody))
+                .act(RqFake("POST", "/pathfinding/blocks", requestBody))
         val response = TakesUtils.readBodyResponse(rawResponse)
         val parsed =
             (pathfindingResponseAdapter.fromJson(response)

--- a/editoast/src/core/conflict_detection.rs
+++ b/editoast/src/core/conflict_detection.rs
@@ -124,7 +124,7 @@ pub enum ConflictType {
 
 impl AsCoreRequest<Json<ConflictDetectionResponse>> for ConflictDetectionRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/conflict_detection";
+    const URL_PATH: &'static str = "/conflict_detection";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/core/path_properties.rs
+++ b/editoast/src/core/path_properties.rs
@@ -95,7 +95,7 @@ pub struct PropertyZoneValues {
 
 impl AsCoreRequest<Json<PathPropertiesResponse>> for PathPropertiesRequest<'_> {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/path_properties";
+    const URL_PATH: &'static str = "/path_properties";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -287,7 +287,7 @@ impl TrackRangeOffset<'_> {
 
 impl AsCoreRequest<Json<PathfindingCoreResult>> for PathfindingRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/pathfinding/blocks";
+    const URL_PATH: &'static str = "/pathfinding/blocks";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/core/signal_projection.rs
+++ b/editoast/src/core/signal_projection.rs
@@ -63,7 +63,7 @@ pub struct SignalUpdatesResponse {
 
 impl AsCoreRequest<Json<SignalUpdatesResponse>> for SignalUpdatesRequest<'_> {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/signal_projection";
+    const URL_PATH: &'static str = "/signal_projection";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -534,7 +534,7 @@ impl Default for SimulationResponse {
 
 impl AsCoreRequest<Json<SimulationResponse>> for SimulationRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/standalone_simulation";
+    const URL_PATH: &'static str = "/standalone_simulation";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/core/stdcm.rs
+++ b/editoast/src/core/stdcm.rs
@@ -144,7 +144,7 @@ pub enum Response {
 
 impl AsCoreRequest<Json<Response>> for Request {
     const METHOD: reqwest::Method = reqwest::Method::POST;
-    const URL_PATH: &'static str = "/v2/stdcm";
+    const URL_PATH: &'static str = "/stdcm";
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -804,7 +804,7 @@ mod tests {
     #[cfg(test)]
     pub fn mocked_core_pathfinding_sim_and_proj(train_id: i64) -> MockingClient {
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
@@ -816,7 +816,7 @@ mod tests {
                 "status": "success"
             }))
             .finish();
-        core.stub("/v2/standalone_simulation")
+        core.stub("/standalone_simulation")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
@@ -856,7 +856,7 @@ mod tests {
                 }
             }))
             .finish();
-        core.stub("/v2/signal_projection")
+        core.stub("/signal_projection")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({

--- a/editoast/src/views/paced_train.rs
+++ b/editoast/src/views/paced_train.rs
@@ -792,7 +792,7 @@ mod tests {
     async fn get_paced_train_path() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -493,7 +493,7 @@ pub mod tests {
     async fn pathfinding_fails_when_core_responds_with_zero_length_path() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({
@@ -632,7 +632,7 @@ pub mod tests {
     async fn pathfinding_with_valid_path_items_returns_successful_result() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -245,17 +245,17 @@ mod tests {
 
     fn core_mocking_client() -> CoreClient {
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .finish();
-        core.stub("/v2/standalone_simulation")
+        core.stub("/standalone_simulation")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(simulation_response())
             .finish();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(core::stdcm::Response::Success {

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -657,12 +657,12 @@ mod tests {
 
     fn core_mocking_client() -> MockingClient {
         let mut core = MockingClient::new();
-        core.stub("/v2/pathfinding/blocks")
+        core.stub("/pathfinding/blocks")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(PathfindingResult::Success(pathfinding_result_success()))
             .finish();
-        core.stub("/v2/standalone_simulation")
+        core.stub("/standalone_simulation")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(simulation_response())
@@ -914,7 +914,7 @@ mod tests {
     async fn stdcm_return_success() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(crate::core::stdcm::Response::Success {
@@ -960,7 +960,7 @@ mod tests {
     async fn stdcm_request_mass_validation() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(crate::core::stdcm::Response::Success {
@@ -1004,7 +1004,7 @@ mod tests {
     async fn stdcm_request_length_validation() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(crate::core::stdcm::Response::Success {
@@ -1050,7 +1050,7 @@ mod tests {
     async fn stdcm_request_validation_success() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(crate::core::stdcm::Response::Success {
@@ -1103,12 +1103,12 @@ mod tests {
     async fn stdcm_return_conflicts() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(json!({"status": "path_not_found"}))
             .finish();
-        core.stub("/v2/conflict_detection")
+        core.stub("/conflict_detection")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(ConflictDetectionResponse {
@@ -1177,12 +1177,12 @@ mod tests {
             .collect();
 
         let mut core = core_mocking_client();
-        core.stub("/v2/stdcm")
+        core.stub("/stdcm")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(crate::core::stdcm::Response::PathNotFound)
             .finish();
-        core.stub("/v2/conflict_detection")
+        core.stub("/conflict_detection")
             .method(reqwest::Method::POST)
             .response(StatusCode::OK)
             .json(ConflictDetectionResponse {


### PR DESCRIPTION
Remove v2 from tsv2 endpoint names.

This rename does not impact ~the DB table object names nor~ (I'm a moron, those were the migrations haha) the error names, which still end with _v2. ~The subject is on the table though, talk this through between yourselves editoast maintainers (to be done in another PR though if the go-ahead is given).~ -> TBD in another PR.