### PR TITLE
core: simulation: use blocks from pathfinding

### DIFF
--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/impl/DebugViewers.kt
@@ -2,7 +2,7 @@ package fr.sncf.osrd.sim_infra.impl
 
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
-import fr.sncf.osrd.sim_infra.utils.toList
+import fr.sncf.osrd.sim_infra.utils.toBlockList
 import fr.sncf.osrd.utils.Direction
 import fr.sncf.osrd.utils.indexing.DirStaticIdx
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
@@ -100,10 +100,9 @@ fun makeRoute(
     ids.add(id)
     return RouteViewer(
         rawInfra.getRouteName(id),
-        recoverBlocks(rawInfra, blockInfra, ids, null)[0]
-            .toList()
-            .map { blockPathElement -> blockPathElement.block }
-            .map { block -> makeBlock(rawInfra, blockInfra, block) },
+        recoverBlocks(rawInfra, blockInfra, ids, null)[0].toBlockList().map { block ->
+            makeBlock(rawInfra, blockInfra, block)
+        },
         id,
     )
 }

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/BlockRecovery.kt
@@ -10,23 +10,9 @@ data class BlockPathElement(
     val block: BlockId,
     // the index of the route in the path
     val routeIndex: Int,
-    // the position of the block in the route
-    val blockRouteOffset: Int,
-    // the offset of the block in the route's zones
-    val routeStartZoneOffset: Int,
-    // always equal to routeStartZoneOffset + number of zones in the block
+    // the offset of the block in the route's zones + number of zones in the block
     val routeEndZoneOffset: Int,
 )
-
-fun BlockPathElement.toList(): List<BlockPathElement> {
-    val res = mutableListOf(this)
-    var cur = this.prev
-    while (cur != null) {
-        res.add(cur)
-        cur = cur.prev
-    }
-    return res.reversed()
-}
 
 fun BlockPathElement.toBlockList(): StaticIdxList<Block> {
     val res = mutableStaticIdxArrayListOf(this.block)
@@ -95,16 +81,7 @@ private fun findRouteBlocks(
             filterBlocks(allowedSignalingSystems, blockInfra, blocks, routePath, routeOffset)
         for (block in blocksOnRoute) {
             val blockSize = blockInfra.getBlockZonePaths(block).size
-            addPath(
-                BlockPathElement(
-                    prevPath,
-                    block,
-                    routeIndex,
-                    prevPath.blockRouteOffset + 1,
-                    routeOffset,
-                    routeOffset + blockSize
-                )
-            )
+            addPath(BlockPathElement(prevPath, block, routeIndex, routeOffset + blockSize))
         }
     }
 
@@ -115,7 +92,7 @@ private fun findRouteBlocks(
         val blocksOnRoute = filterBlocks(allowedSignalingSystems, blockInfra, blocks, routePath, 0)
         for (block in blocksOnRoute) {
             val blockPath = blockInfra.getBlockZonePaths(block)
-            addPath(BlockPathElement(null, block, routeIndex, 0, 0, blockPath.size))
+            addPath(BlockPathElement(null, block, routeIndex, blockPath.size))
         }
     } else {
         for (prevPath in previousPaths) findNextBlocks(prevPath, 0)

--- a/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
+++ b/core/kt-osrd-sim-infra/src/main/kotlin/fr/sncf/osrd/sim_infra/utils/InfraUtils.kt
@@ -3,7 +3,10 @@ package fr.sncf.osrd.sim_infra.utils
 import fr.sncf.osrd.reporting.exceptions.ErrorType
 import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.utils.indexing.*
+import fr.sncf.osrd.utils.indexing.DirStaticIdxList
+import fr.sncf.osrd.utils.indexing.StaticIdxList
+import fr.sncf.osrd.utils.indexing.mutableDirStaticIdxArrayListOf
+import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 
 fun TrackNetworkInfra.getNextTrackSections(
     trackSection: DirTrackSectionId
@@ -60,12 +63,6 @@ fun BlockInfra.routesOnBlock(rawInfra: RawInfra, block: BlockId): StaticIdxList<
     return res
 }
 
-/** Returns the blocks that follow the given one */
-fun BlockInfra.getNextBlocks(infra: RawSignalingInfra, blockId: BlockId): Set<BlockId> {
-    val entry = getBlockExit(infra, blockId)
-    return getBlocksStartingAtDetector(entry).toSet()
-}
-
 /** Returns the block's entry detector */
 fun BlockInfra.getBlockEntry(rawInfra: RawInfra, block: BlockId): DirDetectorId {
     val blockZonePaths: StaticIdxList<ZonePath> = getBlockZonePaths(block)
@@ -78,12 +75,6 @@ fun BlockInfra.getBlockExit(rawInfra: RawInfra, block: BlockId): DirDetectorId {
     val blockZonePaths: StaticIdxList<ZonePath> = getBlockZonePaths(block)
     val lastZonePath: ZonePathId = blockZonePaths[blockZonePaths.size - 1]
     return rawInfra.getZonePathExit(lastZonePath)
-}
-
-/** Returns the blocks that lead into the given one */
-fun BlockInfra.getPreviousBlocks(infra: RawSignalingInfra, blockId: BlockId): Set<BlockId> {
-    val entry = getBlockEntry(infra, blockId)
-    return getBlocksEndingAtDetector(entry).toSet()
 }
 
 /** Returns the route's corresponding blocks */

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -11,16 +11,12 @@ import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.routesOnBlock
-import fr.sncf.osrd.standalone_sim.result.ResultPosition
-import fr.sncf.osrd.standalone_sim.result.ResultSpeed
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingZoneRequirement
 import fr.sncf.osrd.train.RollingStock
-import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.units.*
 import kotlin.collections.set
-import kotlin.math.abs
 
 // Reserve clear track with a margin for the reaction time of the driver
 const val CLOSED_SIGNAL_RESERVATION_MARGIN = 20.0
@@ -463,34 +459,5 @@ fun pathSignalsInRange(
 ): List<PathSignal> {
     return pathSignals(pathOffsetBuilder, blockPath, blockInfra).filter { signal ->
         signal.pathOffset.distance in rangeStart..rangeEnd
-    }
-}
-
-fun simplifyPositions(positions: ArrayList<ResultPosition>): ArrayList<ResultPosition> {
-    return CurveSimplification.rdp(positions, 5.0) {
-        point: ResultPosition,
-        start: ResultPosition,
-        end: ResultPosition ->
-        if (abs(start.time - end.time) < 0.000001)
-            return@rdp abs(point.pathOffset - start.pathOffset)
-        val proj =
-            start.pathOffset +
-                (point.time - start.time) * (end.pathOffset - start.pathOffset) /
-                    (end.time - start.time)
-        abs(point.pathOffset - proj)
-    }
-}
-
-fun simplifySpeeds(speeds: ArrayList<ResultSpeed>): ArrayList<ResultSpeed> {
-    return CurveSimplification.rdp(speeds, 0.2) {
-        point: ResultSpeed,
-        start: ResultSpeed,
-        end: ResultSpeed ->
-        if (abs(start.position - end.position) < 0.000001) return@rdp abs(point.speed - start.speed)
-        val proj =
-            start.speed +
-                (point.position - start.position) * (end.speed - start.speed) /
-                    (end.position - start.position)
-        abs(point.speed - proj)
     }
 }

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -2,8 +2,7 @@
 
 package fr.sncf.osrd.standalone_sim
 
-import fr.sncf.osrd.api.FullInfra
-import fr.sncf.osrd.conflicts.*
+import fr.sncf.osrd.conflicts.PathStop
 import fr.sncf.osrd.envelope.EnvelopeInterpolate
 import fr.sncf.osrd.envelope.EnvelopeTimeInterpolate
 import fr.sncf.osrd.signaling.SigSystemManager
@@ -11,8 +10,7 @@ import fr.sncf.osrd.signaling.SignalingSimulator
 import fr.sncf.osrd.signaling.SignalingTrainState
 import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.utils.BlockPathElement
-import fr.sncf.osrd.sim_infra.utils.recoverBlocks
+import fr.sncf.osrd.sim_infra.utils.routesOnBlock
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
@@ -20,7 +18,6 @@ import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingZoneRequirement
 import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.units.*
 import kotlin.collections.set
 import kotlin.math.abs
@@ -39,38 +36,40 @@ class PathOffsetBuilder(val startOffset: Distance) {
     }
 }
 
-// TODO: remove this function as blockPath is provided by the pathfinding and
-//   must not be reprocessed later (leading to possible inconsistencies, especially
-//   with multiple signaling systems)
-fun deprecatedRecoverBlockPath(
-    simulator: SignalingSimulator,
-    fullInfra: FullInfra,
+// For a path (sequence of blocks and matching sequence of routes)
+// Wrap information about a block, to be used in a lookup table (sorted by block index in
+// block-path).
+private data class BlockInfo(
+    val block: BlockId,
+    // the index of the route in the path
+    val routeIndex: Int,
+)
+
+private fun buildBlockInfoTable(
+    blockInfra: BlockInfra,
+    rawInfra: RawInfra,
     routePath: StaticIdxList<Route>,
-): List<BlockPathElement> {
-    val sigSystemManager = simulator.sigModuleManager
-    val bal = sigSystemManager.findSignalingSystemOrThrow("BAL")
-    val bapr = sigSystemManager.findSignalingSystemOrThrow("BAPR")
-    val tvm300 = sigSystemManager.findSignalingSystemOrThrow("TVM300")
-    val tvm430 = sigSystemManager.findSignalingSystemOrThrow("TVM430")
-    val etcsLevel2 = sigSystemManager.findSignalingSystemOrThrow("ETCS_LEVEL2")
+    blockPath: StaticIdxList<Block>
+): List<BlockInfo> {
+    val detailedBlocks = mutableListOf<BlockInfo>()
 
-    val blockPaths =
-        // TODO: probably remove that function too
-        recoverBlocks(
-            fullInfra.rawInfra,
-            fullInfra.blockInfra,
-            routePath,
-            mutableStaticIdxArrayListOf(bal, bapr, tvm300, tvm430, etcsLevel2)
-        )
-    assert(blockPaths.isNotEmpty())
+    var currentRouteIdx = 0
 
-    val res = mutableListOf(blockPaths[0]) // TODO: have a better way to choose the block path
-    var cur = blockPaths[0].prev
-    while (cur != null) {
-        res.add(cur)
-        cur = cur.prev
+    for (blockId in blockPath) {
+
+        val blockRoutes = blockInfra.routesOnBlock(rawInfra, blockId)
+        if (!blockRoutes.contains(routePath[currentRouteIdx])) {
+            currentRouteIdx++
+        }
+        assert(currentRouteIdx < routePath.size)
+        val routeId = routePath[currentRouteIdx]
+        assert(blockRoutes.contains(routeId))
+
+        val element = BlockInfo(blockId, currentRouteIdx)
+        detailedBlocks.add(element)
     }
-    return res.reversed()
+
+    return detailedBlocks
 }
 
 fun getBlockOffsets(
@@ -93,7 +92,6 @@ fun routingRequirements(
     simulator: SignalingSimulator,
     routePath: StaticIdxList<Route>,
     blockPath: StaticIdxList<Block>,
-    detailedBlockPath: List<BlockPathElement>,
     sortedClosedSignalStops: List<PathStop>,
     loadedSignalInfra: LoadedSignalInfra,
     blockInfra: BlockInfra,
@@ -104,16 +102,19 @@ fun routingRequirements(
     // count the number of zones in the path
     val zoneCount = routePath.sumOf { rawInfra.getRoutePath(it).size }
 
+    // recover blocks info from the route and block paths into a lookup table
+    val blockInfoTable = buildBlockInfoTable(blockInfra, rawInfra, routePath, blockPath)
+
     // fill a lookup table mapping route indices to the index of the route's first block
     val routeBlockBounds = IntArray(routePath.size + 1)
     var lastRoute = -1
-    for (blockIndex in detailedBlockPath.indices) {
-        val block = detailedBlockPath[blockIndex]
+    for (blockIndex in blockInfoTable.indices) {
+        val block = blockInfoTable[blockIndex]
         if (block.routeIndex == lastRoute) continue
         lastRoute = block.routeIndex
         routeBlockBounds[lastRoute] = blockIndex
     }
-    routeBlockBounds[routePath.size] = detailedBlockPath.size
+    routeBlockBounds[routePath.size] = blockInfoTable.size
 
     val blockOffsets = getBlockOffsets(blockPath, pathOffsetBuilder, blockInfra)
 
@@ -159,7 +160,7 @@ fun routingRequirements(
 
         // find the first block of the route
         val routeStartBlockIndex = routeBlockBounds[routeIndex]
-        val firstRouteBlock = detailedBlockPath[routeStartBlockIndex].block
+        val firstRouteBlock = blockInfoTable[routeStartBlockIndex].block
 
         // find the entry signal for this route. if there is no entry signal,
         // the set deadline is the start of the simulation

--- a/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
+++ b/core/src/main/java/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractor.kt
@@ -13,7 +13,6 @@ import fr.sncf.osrd.signaling.ZoneStatus
 import fr.sncf.osrd.sim_infra.api.*
 import fr.sncf.osrd.sim_infra.utils.BlockPathElement
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
-import fr.sncf.osrd.sim_infra.utils.toList
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
 import fr.sncf.osrd.standalone_sim.result.ResultTrain.RoutingRequirement
@@ -64,7 +63,14 @@ fun deprecatedRecoverBlockPath(
             mutableStaticIdxArrayListOf(bal, bapr, tvm300, tvm430, etcsLevel2)
         )
     assert(blockPaths.isNotEmpty())
-    return blockPaths[0].toList() // TODO: have a better way to choose the block path
+
+    val res = mutableListOf(blockPaths[0]) // TODO: have a better way to choose the block path
+    var cur = blockPaths[0].prev
+    while (cur != null) {
+        res.add(cur)
+        cur = cur.prev
+    }
+    return res.reversed()
 }
 
 fun getBlockOffsets(

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -2,8 +2,6 @@ package fr.sncf.osrd.api.stdcm
 
 import com.google.common.collect.ImmutableRangeMap
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.api.ExceptionHandler
-import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.pathfinding.findWaypointBlocks
 import fr.sncf.osrd.api.pathfinding.runPathfindingBlockPostProcessing
 import fr.sncf.osrd.api.standalone_sim.*
@@ -187,6 +185,7 @@ class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
                 path.chunkPath,
                 infra,
                 path.routePath.toIdxList(),
+                path.blocks.ranges.map { it.edge }.toIdxList(),
                 rollingStock,
                 scheduleItems,
                 listOf(),

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -291,7 +291,7 @@ fun buildTemporarySpeedLimitManager(
                         }
                     )
                 } else {
-                    outputSpeedLimits.put(dirTrackChunkId, chunkSpeedLimitRangeMap)
+                    outputSpeedLimits[dirTrackChunkId] = chunkSpeedLimitRangeMap
                 }
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.standalone_sim
 
 import fr.sncf.osrd.api.*
-import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.standalone_sim.CompleteReportTrain
 import fr.sncf.osrd.api.standalone_sim.ReportTrain
 import fr.sncf.osrd.api.standalone_sim.SimulationScheduleItem
@@ -9,7 +8,10 @@ import fr.sncf.osrd.conflicts.*
 import fr.sncf.osrd.envelope.Envelope
 import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope_sim_infra.EnvelopeTrainPath
-import fr.sncf.osrd.sim_infra.api.*
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.PathProperties
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.sim_infra.impl.ChunkPath
 import fr.sncf.osrd.standalone_sim.result.ResultPosition
 import fr.sncf.osrd.standalone_sim.result.ResultSpeed
@@ -150,9 +152,9 @@ fun runScheduleMetadataExtractor(
             }
 
             val stopDepartureTime =
-                envelopeWithStops.interpolateDepartureFrom(closedSignalStopOffset.distance.meters)
+                envelopeWithStops.interpolateDepartureFrom(closedSignalStopOffset!!.distance.meters)
             if (signalCriticalTime < stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN) {
-                signalCriticalOffset = closedSignalStopOffset!!
+                signalCriticalOffset = closedSignalStopOffset
                 signalCriticalTime = stopDepartureTime - CLOSED_SIGNAL_RESERVATION_MARGIN
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/ScheduleMetadataExtractorV2.kt
@@ -18,7 +18,6 @@ import fr.sncf.osrd.train.RollingStock
 import fr.sncf.osrd.train.TrainStop
 import fr.sncf.osrd.utils.CurveSimplification
 import fr.sncf.osrd.utils.indexing.StaticIdxList
-import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.trainPathBlockOffset
 import fr.sncf.osrd.utils.units.*
 import kotlin.math.abs
@@ -30,6 +29,7 @@ fun runScheduleMetadataExtractor(
     chunkPath: ChunkPath,
     fullInfra: FullInfra,
     routePath: StaticIdxList<Route>,
+    blockPath: StaticIdxList<Block>,
     rollingStock: RollingStock,
     schedule: List<SimulationScheduleItem>,
     pathItemPositions: List<Offset<TravelledPath>>,
@@ -47,13 +47,6 @@ fun runScheduleMetadataExtractor(
     val loadedSignalInfra = fullInfra.loadedSignalInfra
     val blockInfra = fullInfra.blockInfra
     val simulator = fullInfra.signalingSimulator
-
-    // get a new generation route path
-
-    // recover blocks from the route paths
-    val detailedBlockPath = deprecatedRecoverBlockPath(simulator, fullInfra, routePath)
-    val blockPath = mutableStaticIdxArrayListOf<Block>()
-    for (block in detailedBlockPath) blockPath.add(block.block)
 
     // Compute speeds, head and tail positions
     val envelopeWithStops = EnvelopeStopWrapper(envelope, legacyStops)
@@ -208,7 +201,6 @@ fun runScheduleMetadataExtractor(
             simulator,
             routePath,
             blockPath,
-            detailedBlockPath,
             closedSignalStops,
             loadedSignalInfra,
             blockInfra,

--- a/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/standalone_sim/StandaloneSimulation.kt
@@ -179,6 +179,7 @@ fun runStandaloneSimulation(
             chunkPath,
             infra,
             routes,
+            blockPath,
             rollingStock,
             schedule,
             pathItemPositions,

--- a/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/utils/Helpers.kt
@@ -3,18 +3,21 @@ package fr.sncf.osrd.utils
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import fr.sncf.osrd.api.*
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.api.TrackLocation
+import fr.sncf.osrd.api.makeSignalingSimulator
 import fr.sncf.osrd.api.standalone_sim.PhysicsConsistModel
 import fr.sncf.osrd.pathfinding.PathfindingEdgeLocationId
 import fr.sncf.osrd.railjson.schema.external_generated_inputs.RJSElectricalProfileSet
 import fr.sncf.osrd.railjson.schema.infra.RJSInfra
 import fr.sncf.osrd.railjson.schema.rollingstock.RJSRollingResistance
 import fr.sncf.osrd.reporting.exceptions.OSRDError
-import fr.sncf.osrd.sim_infra.api.*
-import fr.sncf.osrd.sim_infra.utils.BlockPathElement
+import fr.sncf.osrd.sim_infra.api.Block
+import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.Route
+import fr.sncf.osrd.sim_infra.api.SignalingSystem
 import fr.sncf.osrd.sim_infra.utils.recoverBlocks
-import fr.sncf.osrd.sim_infra.utils.toList
+import fr.sncf.osrd.sim_infra.utils.toBlockList
 import fr.sncf.osrd.utils.indexing.MutableStaticIdxArrayList
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.indexing.StaticIdxList
@@ -109,7 +112,9 @@ object Helpers {
         val candidates =
             recoverBlocks(infra.rawInfra, infra.blockInfra, routes, getSignalingSystems(infra))
         assert(candidates.isNotEmpty())
-        for (candidate in candidates) res.addAll(candidate.toList().map(BlockPathElement::block))
+        for (candidate in candidates) {
+            res.addAll(candidate.toBlockList())
+        }
         return res
     }
 

--- a/tests/tests/test_stdcm.py
+++ b/tests/tests/test_stdcm.py
@@ -344,11 +344,6 @@ def test_max_running_time(small_scenario: Scenario, fast_rolling_stock: int):
                         "end_time": "2024-01-01T16:00:00Z",
                         "zone": "zone.[DH1_1:DECREASING, DH3:INCREASING]",
                     },
-                    {
-                        "start_time": "2023-01-01T08:00:00Z",
-                        "end_time": "2024-01-01T16:00:00Z",
-                        "zone": "zone.[DH1_1:INCREASING, DH1_2:DECREASING]",
-                    },
                 ],
             }
         ],


### PR DESCRIPTION
Previously, the block path was recomputed, possibly leading to inconsistent results.

fix https://github.com/OpenRailAssociation/osrd/issues/10297

🔍 please review by commit (the 3rd one was just used for test and is going to be squashed with the 4th)

Note: `ScheduleMetadataExtractor.kt` and `ScheduleMetadataExtractorV2.kt` are going to be merged in a separate PR.