### PR TITLE
front: fix console warning at first load of a non empty timetable

### DIFF
--- a/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
@@ -275,27 +275,22 @@ const TimetableToolbar = ({
             'with-details': isInSelection,
           })}
         >
-          {timetableItems.length === 0 ? (
-            <div className="train-count">
-              <Checkbox small readOnly label={t('timetable.noTrain')} />
-            </div>
-          ) : (
-            <div className="train-count">
-              <Checkbox
-                label={computedItemLabel()}
-                small
-                checked={
-                  selectedTimetableItemIds.length === timetableItemsWithDetails.length &&
-                  selectedTimetableItemIds.length > 0
-                }
-                isIndeterminate={
-                  selectedTimetableItemIds.length !== timetableItemsWithDetails.length &&
-                  selectedTimetableItemIds.length > 0
-                }
-                onChange={() => toggleAllTrainsSelecton()}
-              />
-            </div>
-          )}
+          <div className="train-count">
+            <Checkbox
+              label={timetableItems.length > 0 ? computedItemLabel() : t('timetable.noTrain')}
+              small
+              readOnly={timetableItems.length === 0}
+              checked={
+                selectedTimetableItemIds.length === timetableItemsWithDetails.length &&
+                selectedTimetableItemIds.length > 0
+              }
+              isIndeterminate={
+                selectedTimetableItemIds.length !== timetableItemsWithDetails.length &&
+                selectedTimetableItemIds.length > 0
+              }
+              onChange={() => toggleAllTrainsSelecton()}
+            />
+          </div>
 
           {timetableItems.length > 0 && (
             <div>


### PR DESCRIPTION
When loading the timetable of a scenario for the first time, while the timetable items are loading, we first displayed the checkbox corresponding to an empty timetable and then we switched to the other one.
As the initial checkbox had checked property non defined, React displayed the "uncontrolled" warning because he considered that the same checkbox was switching from an undefined state to a defined one.
Fix it by merging the two checkboxes.

fix #11257 