### PR TITLE
editoast, front: rename tsv2 errors

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -6434,7 +6434,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:InfraNotFound
+          - editoast:stdcm:InfraNotFound
     EditoastStdcmErrorInvalidConsistLength:
       type: object
       required:
@@ -6461,7 +6461,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:InvalidConsistLength
+          - editoast:stdcm:InvalidConsistLength
     EditoastStdcmErrorInvalidConsistMass:
       type: object
       required:
@@ -6488,7 +6488,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:InvalidConsistMass
+          - editoast:stdcm:InvalidConsistMass
     EditoastStdcmErrorInvalidPathItems:
       type: object
       required:
@@ -6512,7 +6512,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:InvalidPathItems
+          - editoast:stdcm:InvalidPathItems
     EditoastStdcmErrorRollingStockNotFound:
       type: object
       required:
@@ -6536,7 +6536,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:RollingStockNotFound
+          - editoast:stdcm:RollingStockNotFound
     EditoastStdcmErrorTimetableNotFound:
       type: object
       required:
@@ -6560,7 +6560,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:TimetableNotFound
+          - editoast:stdcm:TimetableNotFound
     EditoastStdcmErrorTowedRollingStockNotFound:
       type: object
       required:
@@ -6584,7 +6584,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:TowedRollingStockNotFound
+          - editoast:stdcm:TowedRollingStockNotFound
     EditoastStdcmErrorTrainSimulationFail:
       type: object
       required:
@@ -6603,7 +6603,7 @@ components:
         type:
           type: string
           enum:
-          - editoast:stdcm_v2:TrainSimulationFail
+          - editoast:stdcm:TrainSimulationFail
     EditoastStdcmLogErrorMissingIdAndTraceId:
       type: object
       required:

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -89,7 +89,7 @@ enum StdcmResponse {
 }
 
 #[derive(Debug, Error, EditoastError, Serialize)]
-#[editoast_error(base_id = "stdcm_v2")]
+#[editoast_error(base_id = "stdcm")]
 enum StdcmError {
     #[error("Infrastrcture {infra_id} does not exist")]
     InfraNotFound { infra_id: i64 },
@@ -992,7 +992,7 @@ mod tests {
 
         assert_eq!(
             stdcm_response.error_type,
-            "editoast:stdcm_v2:InvalidConsistMass".to_string()
+            "editoast:stdcm:InvalidConsistMass".to_string()
         );
         assert_eq!(
             stdcm_response.context["expected_min"].as_f64(),
@@ -1041,7 +1041,7 @@ mod tests {
 
         assert_eq!(
             stdcm_response.error_type,
-            "editoast:stdcm_v2:InvalidConsistLength".to_string()
+            "editoast:stdcm:InvalidConsistLength".to_string()
         );
         assert_eq!(stdcm_response.context["expected_min"].as_f64(), Some(400.0));
     }

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -194,14 +194,6 @@
       "UnknownSignalingSystem": "Unknown signaling system"
     },
     "stdcm": {
-      "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist"
-    },
-    "stdcm_log": {
-      "NotFound": "STDCM log entry '{{id}}' could not be found",
-      "TraceIdNotFound": "STDCM log entry '{{trace_id}}' could not be found",
-      "MissingIdAndTraceId": "STDCM log entry could not be found without specifying an 'id' or 'trace_id'"
-    },
-    "stdcm_v2": {
       "InfraNotFound": "Infrastructure '{{infra_id}}' does not exist",
       "InvalidPathItems": "Invalid waypoint(s) {{items}}",
       "RollingStockNotFound": "Rolling stock '{{rolling_stock_id}}' does not exist",
@@ -210,6 +202,11 @@
       "TimetableNotFound": "Timetable '{{timetable_id}}' does not exist",
       "InvalidConsistMass": "Invalid consist mass {{provided_consist_mass}}: it should be greater than '{{expected_min}}'",
       "InvalidConsistLength": "Invalid consist length {{provided_consist_length}}: it should be greater than '{{expected_min}}'"
+    },
+    "stdcm_log": {
+      "NotFound": "STDCM log entry '{{id}}' could not be found",
+      "TraceIdNotFound": "STDCM log entry '{{trace_id}}' could not be found",
+      "MissingIdAndTraceId": "STDCM log entry could not be found without specifying an 'id' or 'trace_id'"
     },
     "study": {
       "Database": "Internal error (database)",
@@ -233,13 +230,8 @@
       "PathNotFound": "Path '{{path_id}}' could not be found",
       "RollingStockNotFound": "Rolling Stock '{{rolling_stock_id}}' could not be found",
       "TimetableNotFound": "Timetable '{{timetable_id}}' could not be found",
-      "UnsimulatedTrainSchedule": "Train Schedule '{{train_schedule_id}}' is not simulated"
-    },
-    "train_schedule_v2": {
-      "BatchTrainScheduleNotFound": "'{{number}}' train schedule(s) could not be found",
-      "NotFound": "Train Schedule '{{train_schedule_id}}' could not be found",
-      "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
-      "InvalidQueryParams": "Invalid query params '{{message}}'"
+      "UnsimulatedTrainSchedule": "Train Schedule '{{train_schedule_id}}' is not simulated",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found"
     },
     "paced_train": {
       "Database": "Internal error (database)",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -196,14 +196,6 @@
       "UnknownSignalingSystem": "Système de signalisation inconnu"
     },
     "stdcm": {
-      "InfraNotFound": "Infrastructure {{infra_id}} non trouvée"
-    },
-    "stdcm_log": {
-      "NotFound": "STDCM Log '{{id}}' n'a pas pu être trouvée",
-      "TraceIdNotFound": "STDCM Log '{{trace_id}}' n'a pas pu être trouvée",
-      "MissingIdAndTraceId": "STDCM Log n'a pas pu être trouvée sans spécifier un 'id' ou un 'trace_id'"
-    },
-    "stdcm_v2": {
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "InvalidPathItems": "Point(s) de passage {{items}} invalide(s)",
       "RollingStockNotFound": "Matériel roulant '{{rolling_stock_id}}' non trouvé",
@@ -212,6 +204,11 @@
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée",
       "InvalidConsistMass": "Masse du convoi invalide {{provided_consist_mass}} : elle doit être supérieure à '{{expected_min}}",
       "InvalidConsistLength": "Longueur du convoi invalide {{provided_consist_length}} : doit être supérieure à '{{expected_min}}'"
+    },
+    "stdcm_log": {
+      "NotFound": "STDCM Log '{{id}}' n'a pas pu être trouvée",
+      "TraceIdNotFound": "STDCM Log '{{trace_id}}' n'a pas pu être trouvée",
+      "MissingIdAndTraceId": "STDCM Log n'a pas pu être trouvée sans spécifier un 'id' ou un 'trace_id'"
     },
     "study": {
       "Database": "Erreur interne (base de données)",


### PR DESCRIPTION
tsv1 has been removed from core. V2 has been removed from file names as well as endpoint names: remove last v2 remains from editoast/front, i.e. the error names.