### PR TITLE
Prepare Model Retrieve error refactoring

### DIFF
--- a/editoast/editoast_derive/src/model/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/exists_impl.rs
@@ -31,7 +31,7 @@ impl ToTokens for ExistsImpl {
                 async fn exists(
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> crate::error::Result<bool> {
+                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -40,7 +40,7 @@ impl ToTokens for ExistsImpl {
                     diesel::select(diesel::dsl::exists(dsl::#table_name.#(filter(#eqs)).*))
                         .get_result(conn.write().await.deref_mut())
                         .await
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -70,14 +70,14 @@ impl ToTokens for RetrieveBatchImpl {
                 .select((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map(|s| {
-                    s.map_ok(|row| {
-                        let model = <#model as Model>::from_row(row);
-                        (model.get_id(), model)
-                    })
-                    .try_collect::<Vec<_>>()
-                })?
-                .await?
+                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_ok(|row| {
+                    let model = <#model as Model>::from_row(row);
+                    (model.get_id(), model)
+                })
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
         });
 
         tokens.extend(quote! {
@@ -109,7 +109,7 @@ impl ToTokens for RetrieveBatchImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C> {
+                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use #table_mod::dsl;

--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -53,8 +53,11 @@ impl ToTokens for RetrieveBatchImpl {
                     .select((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map(|s| s.map_ok(<#model as Model>::from_row).try_collect::<Vec<_>>())?
-                    .await?
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_ok(<#model as Model>::from_row)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
@@ -87,7 +90,7 @@ impl ToTokens for RetrieveBatchImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C> {
+                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use diesel::prelude::*;

--- a/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
@@ -32,10 +32,10 @@ impl ToTokens for RetrieveImpl {
             #[automatically_derived]
             impl crate::models::Retrieve<#ty> for #model {
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
-                async fn retrieve(
-                    conn: &mut editoast_models::DbConnection,
+                async fn retrieve_real(
+                    conn: editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> crate::error::Result<Option<#model>> {
+                ) -> std::result::Result<Option<#model>, <#model as crate::models::Model>::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
@@ -46,9 +46,9 @@ impl ToTokens for RetrieveImpl {
                         .select((#(dsl::#columns,)*))
                         .first::<#row>(conn.write().await.deref_mut())
                         .await
-                        .map(Into::into)
+                        .map(#model::from)
                         .optional()
-                        .map_err(Into::into)
+                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -297,10 +297,13 @@ impl crate::models::Retrieve<(String)> for Document {
         err,
         fields(query_id)
     )]
-    async fn retrieve(
-        conn: &mut editoast_models::DbConnection,
+    async fn retrieve_real(
+        conn: editoast_models::DbConnection,
         content_type: (String),
-    ) -> crate::error::Result<Option<Document>> {
+    ) -> std::result::Result<
+        Option<Document>,
+        <Document as crate::models::Model>::Error,
+    > {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -312,9 +315,11 @@ impl crate::models::Retrieve<(String)> for Document {
             .select((dsl::id, dsl::content_type, dsl::data))
             .first::<DocumentRow>(conn.write().await.deref_mut())
             .await
-            .map(Into::into)
+            .map(Document::from)
             .optional()
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]
@@ -325,10 +330,13 @@ impl crate::models::Retrieve<(i64)> for Document {
         err,
         fields(query_id)
     )]
-    async fn retrieve(
-        conn: &mut editoast_models::DbConnection,
+    async fn retrieve_real(
+        conn: editoast_models::DbConnection,
         id_: (i64),
-    ) -> crate::error::Result<Option<Document>> {
+    ) -> std::result::Result<
+        Option<Document>,
+        <Document as crate::models::Model>::Error,
+    > {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -339,9 +347,11 @@ impl crate::models::Retrieve<(i64)> for Document {
             .select((dsl::id, dsl::content_type, dsl::data))
             .first::<DocumentRow>(conn.write().await.deref_mut())
             .await
-            .map(Into::into)
+            .map(Document::from)
             .optional()
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -781,7 +781,10 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -806,12 +809,15 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Document as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Document as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -879,7 +885,10 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<Document> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -904,12 +913,15 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Document as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Document as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -246,7 +246,7 @@ impl crate::models::Exists<(String)> for Document {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -260,7 +260,9 @@ impl crate::models::Exists<(String)> for Document {
             )
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]
@@ -275,7 +277,7 @@ impl crate::models::Exists<(i64)> for Document {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -286,7 +288,9 @@ impl crate::models::Exists<(i64)> for Document {
             )
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(Into::into)
+            .map_err(|e| <Document as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -833,7 +833,10 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (String)> + Send,
         C: Default + std::iter::Extend<((String), Document)> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -859,14 +862,18 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }
@@ -937,7 +944,10 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<((i64), Document)> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -963,14 +973,18 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Document as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Document as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -376,7 +376,10 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
     async fn retrieve_batch_with_key_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<((i64), Timetable)> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Timetable as crate::models::Model>::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::timetable::dsl;
@@ -402,14 +405,18 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s.map_ok(|row| {
-                                    let model = <Timetable as Model>::from_row(row);
-                                    (model.get_id(), model)
-                                })
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(|row| {
+                            let model = <Timetable as Model>::from_row(row);
+                            (model.get_id(), model)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -100,7 +100,7 @@ impl crate::models::Exists<(i64)> for Timetable {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         id: (i64),
-    ) -> crate::error::Result<bool> {
+    ) -> std::result::Result<bool, <Timetable as crate::models::Model>::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -109,7 +109,9 @@ impl crate::models::Exists<(i64)> for Timetable {
         diesel::select(diesel::dsl::exists(dsl::timetable.filter(dsl::id.eq(id))))
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(Into::into)
+            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -324,7 +324,10 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
     async fn retrieve_batch_unchecked<
         I: std::iter::IntoIterator<Item = (i64)> + Send,
         C: Default + std::iter::Extend<Timetable> + Send + std::fmt::Debug,
-    >(conn: &mut editoast_models::DbConnection, ids: I) -> crate::error::Result<C> {
+    >(
+        conn: &mut editoast_models::DbConnection,
+        ids: I,
+    ) -> std::result::Result<C, <Timetable as crate::models::Model>::Error> {
         use crate::models::Model;
         use editoast_models::tables::timetable::dsl;
         use diesel::prelude::*;
@@ -349,12 +352,15 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map(|s| {
-                            s
-                                .map_ok(<Timetable as Model>::from_row)
-                                .try_collect::<Vec<_>>()
-                        })?
-                        .await?
+                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
+                        .map_ok(<Timetable as Model>::from_row)
+                        .try_collect::<Vec<_>>()
+                        .await
+                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                            editoast_models::model::Error::from(e),
+                        ))?
                 };
                 result.extend(chunk_result);
             }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -120,10 +120,13 @@ impl crate::models::Retrieve<(i64)> for Timetable {
         err,
         fields(query_id)
     )]
-    async fn retrieve(
-        conn: &mut editoast_models::DbConnection,
+    async fn retrieve_real(
+        conn: editoast_models::DbConnection,
         id: (i64),
-    ) -> crate::error::Result<Option<Timetable>> {
+    ) -> std::result::Result<
+        Option<Timetable>,
+        <Timetable as crate::models::Model>::Error,
+    > {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::timetable::dsl;
@@ -134,9 +137,11 @@ impl crate::models::Retrieve<(i64)> for Timetable {
             .select((dsl::id,))
             .first::<TimetableRow>(conn.write().await.deref_mut())
             .await
-            .map(Into::into)
+            .map(Timetable::from)
             .optional()
-            .map_err(Into::into)
+            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                editoast_models::model::Error::from(e),
+            ))
     }
 }
 #[automatically_derived]

--- a/editoast/src/client/import_rolling_stock.rs
+++ b/editoast/src/client/import_rolling_stock.rs
@@ -48,6 +48,7 @@ pub async fn import_rolling_stock(
                         .unwrap_or("rolling stock without name")
                         .bold()
                 );
+                #[expect(deprecated)]
                 let existing_rolling_stock =
                     RollingStockModel::retrieve(&mut conn, rolling_stock_name.clone()).await?;
                 match (existing_rolling_stock, args.force) {
@@ -199,6 +200,7 @@ mod tests {
                 result.is_ok(),
                 "import should succeed, as raise_panto and startup are not required for non electric",
             );
+            #[expect(deprecated)]
             let created_rs =
                 RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
@@ -226,6 +228,7 @@ mod tests {
 
             // THEN
             assert!(result.is_ok(), "import should succeed");
+            #[expect(deprecated)]
             let created_rs =
                 RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
@@ -263,6 +266,7 @@ mod tests {
                 result.is_err(),
                 "import should fail, as raise_panto and startup are required for electric"
             );
+            #[expect(deprecated)]
             let created_rs =
                 RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
@@ -288,6 +292,7 @@ mod tests {
 
             // THEN
             assert!(result.is_ok(), "import should succeed");
+            #[expect(deprecated)]
             let created_rs =
                 RollingStockModel::retrieve(&mut db_pool.get_ok(), rolling_stock_name.to_string())
                     .await
@@ -336,6 +341,7 @@ mod tests {
                 result.is_ok(),
                 "import should succeed, but result as skipped, as a rolling stock already exists and --force is disabled"
             );
+            #[expect(deprecated)]
             let rolling_stock = RollingStockModel::retrieve(
                 &mut db_pool.get_ok(),
                 existing_rolling_stock_name.to_string(),
@@ -379,6 +385,7 @@ mod tests {
                 result.is_ok(),
                 "import should succeed, but result as skipped, as a rolling stock already exists and --force is disabled"
             );
+            #[expect(deprecated)]
             let rolling_stock = RollingStockModel::retrieve(
                 &mut db_pool.get_ok(),
                 existing_rolling_stock_name.to_string(),
@@ -435,6 +442,7 @@ mod tests {
 
             // THEN
             assert!(result.is_ok());
+            #[expect(deprecated)]
             let created_rs = TowedRollingStockModel::retrieve(
                 &mut db_pool.get_ok(),
                 towed_rolling_stock_name.to_string(),

--- a/editoast/src/client/infra_commands.rs
+++ b/editoast/src/client/infra_commands.rs
@@ -72,6 +72,7 @@ pub async fn clone_infra(
     infra_args: InfraCloneArgs,
     db_pool: Arc<DbConnectionPoolV2>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    #[expect(deprecated)]
     let infra = Infra::retrieve(&mut db_pool.get().await?, infra_args.id as i64)
         .await?
         .ok_or_else(|| {

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -79,6 +79,7 @@ async fn set_stdcm_search_env_from_scenario(
             .await?;
     }
 
+    #[expect(deprecated)]
     let scenario_option = Scenario::retrieve(conn, args.scenario_id).await?;
 
     let scenario = scenario_option.ok_or_else(|| {
@@ -232,13 +233,13 @@ async fn show_stdcm_search_env(
 
 #[cfg(test)]
 mod tests {
-    use crate::Create;
     use crate::models::fixtures::create_electrical_profile_set;
     use crate::models::fixtures::create_empty_infra;
     use crate::models::fixtures::create_scenario_fixtures_set;
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::create_work_schedule_group;
     use crate::models::fixtures::simple_train_schedule_changeset;
+    use crate::models::prelude::*;
 
     use super::*;
     use chrono::DateTime;

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -41,11 +41,15 @@ pub async fn handle_stdcm_search_env_command(
     }
 }
 
-async fn check_exists<T: Exists<i64>>(
+async fn check_exists<T>(
     conn: &mut DbConnection,
     object_id: i64,
     readable_name: &str,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
+) -> Result<(), Box<dyn Error + Send + Sync>>
+where
+    T: Exists<i64>,
+    <T as Model>::Error: Sync + 'static,
+{
     if !T::exists(conn, object_id).await? {
         let err_msg = format!("❌ {0} not found, id: {1}", readable_name, object_id);
         return Err(Box::new(CliError::new(1, err_msg)));

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -46,7 +46,7 @@ pub async fn trains_export(
     args: ExportTimetableArgs,
     db_pool: Arc<DbConnectionPoolV2>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let train_ids = match TimetableWithTrains::retrieve(&mut db_pool.get().await?, args.id).await? {
+    let train_ids = match TimetableWithTrains::retrieve(db_pool.get().await?, args.id).await? {
         Some(timetable) => timetable.train_ids,
         None => {
             let error = CliError::new(1, format!("❌ Timetable not found, id: {0}", args.id));

--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -91,6 +91,7 @@ pub async fn trains_import(
     };
 
     let timetable = match args.id {
+        #[expect(deprecated)]
         Some(timetable) => match Timetable::retrieve(&mut db_pool.get().await?, timetable).await? {
             Some(timetable) => timetable,
             None => {

--- a/editoast/src/models/macro_node.rs
+++ b/editoast/src/models/macro_node.rs
@@ -52,6 +52,7 @@ pub mod test {
             .expect("Failed to create macro node");
 
         // Retrieve the created node
+        #[expect(deprecated)]
         let node = MacroNode::retrieve(&mut db_pool.get_ok(), created.id)
             .await
             .expect("Failed to retrieve node")

--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let ids = docs.iter().map(|d| d.id).collect::<Vec<_>>();
         assert_eq!(
-            Document::retrieve(&mut pool.get_ok(), ids[0])
+            Document::retrieve_real(pool.get_ok(), ids[0])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")
@@ -214,7 +214,7 @@ mod tests {
             Data::Prefixed(0x43)
         );
         assert_eq!(
-            Document::retrieve(&mut pool.get_ok(), ids[1])
+            Document::retrieve_real(pool.get_ok(), ids[1])
                 .await
                 .expect("Failed to retrieve document")
                 .expect("Document not found")

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -1,32 +1,66 @@
 use std::fmt::Debug;
 
+use axum::http::StatusCode;
 use editoast_models::DbConnection;
 
 use crate::error::EditoastError;
+use crate::error::InternalError;
 use crate::error::Result;
+
+use super::Model;
 
 /// Describes how a [Model](super::Model) can be retrieved from the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-pub trait Retrieve<K>: Sized
+pub trait Retrieve<K>: Model
 where
     K: Send,
     Self: Send,
 {
-    /// Retrieves the row #`id` and deserializes it as a model instance
-    async fn retrieve(conn: &mut DbConnection, id: K) -> Result<Option<Self>>;
+    #[deprecated = "use Retrieve::retrieve_real instead"]
+    async fn retrieve(conn: &mut DbConnection, id: K) -> Result<Option<Self>> {
+        match Self::retrieve_real(conn.clone(), id).await {
+            Ok(model) => Ok(model),
+            // TODO: this is a temporary hack to ease the Retrieve error migration
+            // This implementation will be removed in the future and `retrieve_real`
+            // will become `retrieve`.
+            Err(model_error) => Err(InternalError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                error_type: "editoast:model:retrieve".to_owned(),
+                context: Default::default(),
+                message: model_error.to_string(),
+            }),
+        }
+    }
 
-    /// Just like [Retrieve::retrieve] but returns `Err(fail())` if the row was not found
+    /// Retrieves the row #`id` and deserializes it as a model instance
+    async fn retrieve_real(conn: DbConnection, id: K) -> Result<Option<Self>, Self::Error>;
+
+    #[deprecated = "use Retrieve::retrieve_real_or_fail instead"]
     async fn retrieve_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<Self>
     where
         E: EditoastError,
         F: FnOnce() -> E + Send,
     {
+        #[expect(deprecated)]
         match Self::retrieve(conn, id).await {
             Ok(Some(obj)) => Ok(obj),
             Ok(None) => Err(fail().into()),
             Err(e) => Err(e),
+        }
+    }
+
+    /// Just like [Retrieve::retrieve] but returns `Err(fail())` if the row was not found
+    async fn retrieve_real_or_fail<E, F>(conn: DbConnection, id: K, fail: F) -> Result<Self, E>
+    where
+        E: From<Self::Error>,
+        F: FnOnce() -> E + Send,
+    {
+        match Self::retrieve_real(conn, id).await {
+            Ok(Some(obj)) => Ok(obj),
+            Ok(None) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -9,7 +9,7 @@ use crate::error::Result;
 
 use super::Model;
 
-/// Describes how a [Model](super::Model) can be retrieved from the database
+/// Describes how a [Model] can be retrieved from the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
@@ -65,7 +65,7 @@ where
     }
 }
 
-/// Describes how to check for the existence of a [Model](super::Model) in the database
+/// Describes how to check for the existence of a [Model] in the database
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
@@ -91,9 +91,9 @@ where
     }
 }
 
-/// Unchecked batch retrieval of a [Model](super::Model) from the database
+/// Unchecked batch retrieval of a [Model] from the database
 ///
-/// Any [Model](super::Model) that implement this trait also implement [RetrieveBatch].
+/// Any [Model] that implement this trait also implement [RetrieveBatch].
 /// Unless you know what you're doing, you should use [RetrieveBatch] instead.
 ///
 /// You can implement this type manually but its recommended to use the `Model`
@@ -131,10 +131,10 @@ where
     >(
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C>;
+    ) -> Result<C, Self::Error>;
 }
 
-/// Describes how a [Model](super::Model) can be retrieved from the database given a batch of keys
+/// Describes how a [Model] can be retrieved from the database given a batch of keys
 ///
 /// This trait is automatically implemented for all models that implement
 /// [RetrieveBatchUnchecked]. [RetrieveBatchUnchecked] is a lower-level trait
@@ -162,7 +162,7 @@ where
     async fn retrieve_batch<I, C>(
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>)>
+    ) -> Result<(C, std::collections::HashSet<K>), Self::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -198,7 +198,7 @@ where
     async fn retrieve_batch_with_key<I, C>(
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>)>
+    ) -> Result<(C, std::collections::HashSet<K>), Self::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -239,7 +239,7 @@ where
         conn: &mut DbConnection,
         ids: I,
         fail: F,
-    ) -> Result<C>
+    ) -> Result<C, E>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -247,14 +247,14 @@ where
             + std::iter::Extend<Self>
             + std::iter::FromIterator<Self>
             + std::iter::IntoIterator<Item = Self>,
-        E: EditoastError,
+        E: From<Self::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = Self::retrieve_batch::<_, C>(conn, ids).await?;
         if missing.is_empty() {
             Ok(result)
         } else {
-            Err(fail(missing).into())
+            Err(fail(missing))
         }
     }
 
@@ -270,7 +270,7 @@ where
         conn: &mut DbConnection,
         ids: I,
         fail: F,
-    ) -> Result<C>
+    ) -> Result<C, E>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -278,14 +278,14 @@ where
             + std::iter::Extend<(K, Self)>
             + std::iter::FromIterator<(K, Self)>
             + std::iter::IntoIterator<Item = (K, Self)>,
-        E: EditoastError,
+        E: From<Self::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = Self::retrieve_batch_with_key::<_, C>(conn, ids).await?;
         if missing.is_empty() {
             Ok(result)
         } else {
-            Err(fail(missing).into())
+            Err(fail(missing))
         }
     }
 }

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -69,24 +69,24 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-pub trait Exists<K>: Sized
+pub trait Exists<K>: Model
 where
     K: Send,
     Self: Send,
 {
     /// Returns whether the row #`id` exists in the database
-    async fn exists(conn: &mut DbConnection, id: K) -> Result<bool>;
+    async fn exists(conn: &mut DbConnection, id: K) -> Result<bool, Self::Error>;
 
     /// Just like [Exists::exists] but returns `Err(fail())` if the row doesn't exist
-    async fn exists_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<()>
+    async fn exists_or_fail<E, F>(conn: &mut DbConnection, id: K, fail: F) -> Result<(), E>
     where
-        E: EditoastError,
+        E: From<Self::Error>,
         F: FnOnce() -> E + Send,
     {
         match Self::exists(conn, id).await {
             Ok(true) => Ok(()),
-            Ok(false) => Err(fail().into()),
-            Err(e) => Err(e),
+            Ok(false) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -98,7 +98,7 @@ where
 ///
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
-pub trait RetrieveBatchUnchecked<K>: Sized + Debug
+pub trait RetrieveBatchUnchecked<K>: Model
 where
     K: Send + Debug,
     Self: Send,
@@ -116,7 +116,7 @@ where
     >(
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C>;
+    ) -> Result<C, Self::Error>;
 
     /// Just like [RetrieveBatchUnchecked::retrieve_batch_unchecked] but the returned models are paired with their key
     ///

--- a/editoast/src/models/projects.rs
+++ b/editoast/src/models/projects.rs
@@ -164,6 +164,7 @@ impl Project {
     {
         conn.transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let mut project = Self::retrieve_or_fail(&mut conn, project_id, || {
                     ProjectError::NotFound { project_id }
                 })
@@ -214,6 +215,7 @@ pub mod tests {
         let created_project = create_project(&mut db_pool.get_ok(), "test_project_name").await;
 
         // Get a project
+        #[expect(deprecated)]
         let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")
@@ -239,6 +241,7 @@ pub mod tests {
             .await
             .expect("Failed to update project");
 
+        #[expect(deprecated)]
         let project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")

--- a/editoast/src/models/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock_livery.rs
@@ -73,13 +73,13 @@ pub mod tests {
             create_rolling_stock_livery_fixture(&mut db_pool.get_ok(), "rs_livery_name").await;
 
         assert!(
-            RollingStockLiveryModel::retrieve(&mut db_pool.get_ok(), rs_livery.id)
+            RollingStockLiveryModel::retrieve_real(db_pool.get_ok(), rs_livery.id)
                 .await
                 .is_ok()
         );
 
         assert!(
-            Document::retrieve(&mut db_pool.get_ok(), image.id)
+            Document::retrieve_real(db_pool.get_ok(), image.id)
                 .await
                 .is_ok()
         );
@@ -92,14 +92,14 @@ pub mod tests {
         );
 
         assert!(
-            RollingStockLiveryModel::retrieve(&mut db_pool.get_ok(), rs_livery.id)
+            RollingStockLiveryModel::retrieve_real(db_pool.get_ok(), rs_livery.id)
                 .await
                 .expect("Failed to retrieve rolling stock livery")
                 .is_none()
         );
 
         assert!(
-            Document::retrieve(&mut db_pool.get_ok(), image.id)
+            Document::retrieve_real(db_pool.get_ok(), image.id)
                 .await
                 .expect("Failed to retrieve document")
                 .is_none()

--- a/editoast/src/models/scenario.rs
+++ b/editoast/src/models/scenario.rs
@@ -92,6 +92,7 @@ impl Scenario {
     {
         conn.transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let mut scenario = Self::retrieve_or_fail(&mut conn, scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })

--- a/editoast/src/models/study.rs
+++ b/editoast/src/models/study.rs
@@ -92,6 +92,7 @@ impl Study {
     {
         conn.transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let mut study = Self::retrieve_or_fail(&mut conn, study_id, || {
                     StudyError::NotFound { study_id }
                 })
@@ -151,6 +152,7 @@ pub mod tests {
             create_study(&mut db_pool.get_ok(), study_name, created_project.id).await;
 
         // Retrieve a study
+        #[expect(deprecated)]
         let study = Study::retrieve(&mut db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -10,6 +10,7 @@ use editoast_derive::Model;
 use futures_util::stream::TryStreamExt;
 use std::ops::DerefMut;
 
+use crate::error::EditoastError;
 use crate::error::Result;
 use crate::models::Retrieve;
 use crate::models::prelude::*;
@@ -117,8 +118,8 @@ pub struct TimetableWithTrains {
     pub paced_train_ids: Vec<i64>,
 }
 
-impl Retrieve<i64> for TimetableWithTrains {
-    async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
+impl TimetableWithTrains {
+    pub async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
         let result = sql_query(
             "SELECT timetable.*,
         array_remove(array_agg(train_schedule.id), NULL) as train_ids,
@@ -136,6 +137,18 @@ impl Retrieve<i64> for TimetableWithTrains {
             Ok(result) => Ok(Some(result)),
             Err(diesel::result::Error::NotFound) => Ok(None),
             Err(err) => Err(err.into()),
+        }
+    }
+
+    pub async fn retrieve_or_fail<E, F>(conn: &mut DbConnection, id: i64, fail: F) -> Result<Self>
+    where
+        E: EditoastError,
+        F: FnOnce() -> E + Send,
+    {
+        match Self::retrieve(conn, id).await {
+            Ok(Some(obj)) => Ok(obj),
+            Ok(None) => Err(fail().into()),
+            Err(e) => Err(e),
         }
     }
 }

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -7,10 +7,10 @@ use diesel::sql_types::BigInt;
 use diesel::sql_types::Timestamptz;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use editoast_models::DatabaseError;
 use futures_util::stream::TryStreamExt;
 use std::ops::DerefMut;
 
-use crate::error::EditoastError;
 use crate::error::Result;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
@@ -118,7 +118,10 @@ pub struct TimetableWithTrains {
 }
 
 impl TimetableWithTrains {
-    pub async fn retrieve(conn: &mut DbConnection, timetable_id: i64) -> Result<Option<Self>> {
+    pub async fn retrieve(
+        conn: DbConnection,
+        timetable_id: i64,
+    ) -> Result<Option<Self>, DatabaseError> {
         let result = sql_query(
             "SELECT timetable.*,
         array_remove(array_agg(train_schedule.id), NULL) as train_ids,
@@ -139,15 +142,15 @@ impl TimetableWithTrains {
         }
     }
 
-    pub async fn retrieve_or_fail<E, F>(conn: &mut DbConnection, id: i64, fail: F) -> Result<Self>
+    pub async fn retrieve_or_fail<E, F>(conn: DbConnection, id: i64, fail: F) -> Result<Self, E>
     where
-        E: EditoastError,
+        E: From<DatabaseError>,
         F: FnOnce() -> E + Send,
     {
         match Self::retrieve(conn, id).await {
             Ok(Some(obj)) => Ok(obj),
-            Ok(None) => Err(fail().into()),
-            Err(e) => Err(e),
+            Ok(None) => Err(fail()),
+            Err(e) => Err(E::from(e)),
         }
     }
 }

--- a/editoast/src/models/timetable.rs
+++ b/editoast/src/models/timetable.rs
@@ -12,7 +12,6 @@ use std::ops::DerefMut;
 
 use crate::error::EditoastError;
 use crate::error::Result;
-use crate::models::Retrieve;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
 use editoast_models::DbConnection;

--- a/editoast/src/views/documents.rs
+++ b/editoast/src/views/documents.rs
@@ -70,6 +70,7 @@ async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let doc = Document::retrieve_or_fail(conn, document_id, || DocumentErrors::NotFound {
         document_key: document_id,
     })
@@ -199,6 +200,7 @@ mod tests {
         let new_doc = response.json::<PostDocumentResponse>().document_key;
 
         // Get create document
+        #[expect(deprecated)]
         let document = Document::retrieve(&mut pool.get_ok(), new_doc)
             .await
             .expect("Failed to retrieve document")

--- a/editoast/src/views/electrical_profiles.rs
+++ b/editoast/src/views/electrical_profiles.rs
@@ -95,6 +95,7 @@ async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
         ElectricalProfilesError::NotFound {
             electrical_profile_set_id,
@@ -134,6 +135,7 @@ async fn get_level_order(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let ep_set = ElectricalProfileSet::retrieve_or_fail(conn, electrical_profile_set_id, || {
         ElectricalProfilesError::NotFound {
             electrical_profile_set_id,
@@ -353,6 +355,7 @@ mod tests {
         response.assert_status(StatusCode::OK);
         let created_ep: ElectricalProfileSet = response.json();
 
+        #[expect(deprecated)]
         let created_ep = ElectricalProfileSet::retrieve(&mut pool.get_ok(), created_ep.id)
             .await
             .expect("Failed to retrieve created electrical profile set")

--- a/editoast/src/views/infra/attached.rs
+++ b/editoast/src/views/infra/attached.rs
@@ -82,6 +82,7 @@ async fn attached(
 
     let mut conn = db_pool.get().await?;
     // TODO: lock for share
+    #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(&mut conn, infra_id, || InfraApiError::NotFound { infra_id })
             .await?;

--- a/editoast/src/views/infra/auto_fixes/mod.rs
+++ b/editoast/src/views/infra/auto_fixes/mod.rs
@@ -102,6 +102,7 @@ async fn list_auto_fixes(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
 

--- a/editoast/src/views/infra/delimited_area.rs
+++ b/editoast/src/views/infra/delimited_area.rs
@@ -154,6 +154,7 @@ async fn delimited_area(
     // Retrieve the infra
 
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
     let infra_cache = InfraCache::get_or_load(conn, &infra_caches, &infra).await?;

--- a/editoast/src/views/infra/edition.rs
+++ b/editoast/src/views/infra/edition.rs
@@ -93,6 +93,7 @@ async fn edit(
     }
 
     // TODO: lock for update
+    #[expect(deprecated)]
     let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -154,6 +155,7 @@ pub async fn split_track_section(
     );
 
     // Check the infra
+    #[expect(deprecated)]
     let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -102,6 +102,7 @@ async fn list_errors(
     };
 
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
 

--- a/editoast/src/views/infra/lines.rs
+++ b/editoast/src/views/infra/lines.rs
@@ -61,6 +61,7 @@ async fn get_line_bbox(
     let line_code: i32 = line_code.try_into().unwrap();
 
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let infra =
         Infra::retrieve_or_fail(conn, infra_id, || InfraApiError::NotFound { infra_id }).await?;
     let infra_cache = InfraCache::get_or_load(conn, &infra_caches, &infra).await?;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -329,6 +329,7 @@ async fn get(
     }
 
     let infra_id = infra.infra_id;
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -412,6 +413,7 @@ async fn clone(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, params.infra_id, || InfraApiError::NotFound {
         infra_id: params.infra_id,
     })
@@ -538,6 +540,7 @@ async fn get_switch_types(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
         infra_id: infra.infra_id,
     })
@@ -580,6 +583,7 @@ async fn get_speed_limit_tags(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra.infra_id, || InfraApiError::NotFound {
         infra_id: infra.infra_id,
     })
@@ -626,6 +630,7 @@ async fn get_voltages(
     }
 
     let include_rolling_stock_modes = param.include_rolling_stock_modes;
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra.infra_id, || {
         InfraApiError::NotFound {
             infra_id: infra.infra_id,
@@ -664,6 +669,7 @@ async fn get_all_voltages(
 }
 
 async fn set_locked(infra_id: i64, locked: bool, db_pool: DbConnectionPoolV2) -> Result<()> {
+    #[expect(deprecated)]
     let mut infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -755,6 +761,7 @@ async fn load(
     }
 
     let infra_id = path.infra_id;
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -853,6 +860,7 @@ pub mod tests {
             app.post(format!("/infra/{}/clone/?name=cloned_infra", empty_infra.id).as_str());
 
         let cloned_infra_id: i64 = app.fetch(request).assert_status(StatusCode::OK).json_into();
+        #[expect(deprecated)]
         let cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
@@ -898,6 +906,7 @@ pub mod tests {
             .assert_status(StatusCode::OK)
             .json_into();
 
+        #[expect(deprecated)]
         let _cloned_infra = Infra::retrieve(&mut db_pool.get_ok(), cloned_infra_id)
             .await
             .unwrap()
@@ -1203,6 +1212,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
+        #[expect(deprecated)]
         let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()
@@ -1215,6 +1225,7 @@ pub mod tests {
         app.fetch(req).assert_status(StatusCode::NO_CONTENT);
 
         // Check lock
+        #[expect(deprecated)]
         let infra = Infra::retrieve(&mut db_pool.get_ok(), empty_infra.id)
             .await
             .unwrap()

--- a/editoast/src/views/infra/objects.rs
+++ b/editoast/src/views/infra/objects.rs
@@ -76,6 +76,7 @@ async fn get_objects(
         return Err(GetObjectsErrors::DuplicateIdsProvided.into());
     }
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -142,6 +143,7 @@ async fn list_objects_ids(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -126,6 +126,7 @@ async fn pathfinding_view(
     }
 
     // TODO: lock for share
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/infra/railjson.rs
+++ b/editoast/src/views/infra/railjson.rs
@@ -57,6 +57,7 @@ async fn get_railjson(
     }
 
     let infra_id = infra.infra_id;
+    #[expect(deprecated)]
     let infra_meta = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })

--- a/editoast/src/views/infra/routes.rs
+++ b/editoast/src/views/infra/routes.rs
@@ -80,6 +80,7 @@ async fn get_routes_from_waypoint(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, path.infra_id, || InfraApiError::NotFound {
         infra_id: path.infra_id,
     })
@@ -165,6 +166,7 @@ async fn get_routes_track_ranges(
     let db_pool = db_pool.clone();
     let infra_caches = infra_caches.clone();
     let infra_id = infra;
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         InfraApiError::NotFound { infra_id }
     })
@@ -227,6 +229,7 @@ async fn get_routes_nodes(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, params.infra_id, || {
         InfraApiError::NotFound {
             infra_id: params.infra_id,

--- a/editoast/src/views/path.rs
+++ b/editoast/src/views/path.rs
@@ -34,6 +34,7 @@ pub enum PathfindingError {
 }
 
 async fn retrieve_infra_version(conn: &mut DbConnection, infra_id: i64) -> Result<i64> {
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
         infra_id,
     })

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -208,6 +208,7 @@ async fn post(
 
     let conn = &mut db_pool.get().await?;
     let mut valkey_conn = valkey.get_connection().await?;
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
         infra_id,
     })
@@ -388,6 +389,7 @@ pub async fn pathfinding_from_train(
     infra: &Infra,
     train_schedule: TrainSchedule,
 ) -> Result<PathfindingResult> {
+    #[expect(deprecated)]
     let rolling_stock: Vec<RollingStock> =
         RollingStockModel::retrieve(conn, train_schedule.rolling_stock_name.clone())
             .await?

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -334,6 +334,7 @@ pub async fn compute_projected_train_paths(
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     // 1. Retrieve infra and rolling stock data
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || TrainScheduleError::InfraNotFound {
         infra_id,
     })

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -43,6 +43,8 @@ use crate::views::path::projection::TrackLocationFromPath;
 use crate::views::timetable::simulation::train_simulation_batch;
 use crate::views::timetable::train_schedule::TrainScheduleError;
 
+use super::rolling_stock::RollingStockError;
+
 editoast_common::schemas! {
     ProjectPathTrainResult,
     ProjectPathForm,
@@ -346,7 +348,8 @@ pub async fn compute_projected_train_paths(
             .iter()
             .map::<String, _>(|t| t.rolling_stock_name.clone()),
     )
-    .await?;
+    .await
+    .map_err(RollingStockError::from)?;
 
     let rolling_stock_length: HashMap<_, _> = rolling_stocks
         .into_iter()

--- a/editoast/src/views/projects.rs
+++ b/editoast/src/views/projects.rs
@@ -111,6 +111,7 @@ impl From<ProjectCreateForm> for Changeset<Project> {
 }
 
 async fn check_image_content(conn: &mut DbConnection, document_key: i64) -> Result<()> {
+    #[expect(deprecated)]
     let doc = Document::retrieve_or_fail(conn, document_key, || ProjectError::ImageNotFound {
         document_key,
     })
@@ -260,6 +261,7 @@ async fn get(
         return Err(AuthorizationError::Forbidden.into());
     }
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let project =
         Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
             .await?;
@@ -294,6 +296,7 @@ async fn delete(
         .await?
         .transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let project = Project::retrieve_or_fail(&mut conn, project_id, || {
                     ProjectError::NotFound { project_id }
                 })
@@ -450,6 +453,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let project = Project::retrieve(&mut pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
@@ -548,6 +552,7 @@ pub mod tests {
         let response: ProjectWithStudyCount =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let project = Project::retrieve(&mut db_pool.get_ok(), response.project.id)
             .await
             .expect("Failed to retrieve project")
@@ -567,6 +572,7 @@ pub mod tests {
         let project = create_project(&mut db_pool.get_ok(), &app.name("project")).await;
 
         let check_image = |mut conn: DbConnection, image_id: Option<i64>| async move {
+            #[expect(deprecated)]
             let p = Project::retrieve(&mut conn, project.id)
                 .await
                 .expect("Failed to retrieve project")

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -371,6 +371,7 @@ async fn update(
         .await?
         .transaction::<_, InternalError, _>(|conn| {
             async move {
+                #[expect(deprecated)]
                 let previous_rolling_stock = RollingStockModel::retrieve_or_fail(
                     &mut conn.clone(),
                     rolling_stock_id,
@@ -443,6 +444,7 @@ async fn delete(
     }
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let rolling_stock = RollingStockModel::retrieve_or_fail(conn, rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
@@ -650,6 +652,7 @@ pub async fn get_usage(
 ) -> Result<Json<Vec<ScenarioReference>>> {
     let mut conn = db_pool.get().await?;
 
+    #[expect(deprecated)]
     let rolling_stock = RollingStockModel::retrieve_or_fail(&mut conn, rolling_stock_id, || {
         RollingStockError::KeyNotFound {
             rolling_stock_key: RollingStockKey::Id(rolling_stock_id),
@@ -668,13 +671,17 @@ pub async fn retrieve_existing_rolling_stock(
     rolling_stock_key: RollingStockKey,
 ) -> Result<RollingStockModel> {
     match rolling_stock_key.clone() {
-        RollingStockKey::Id(id) => {
+        RollingStockKey::Id(id) =>
+        {
+            #[expect(deprecated)]
             RollingStockModel::retrieve_or_fail(conn, id, || RollingStockError::KeyNotFound {
                 rolling_stock_key: rolling_stock_key.clone(),
             })
             .await
         }
-        RollingStockKey::Name(name) => {
+        RollingStockKey::Name(name) =>
+        {
+            #[expect(deprecated)]
             RollingStockModel::retrieve_or_fail(conn, name, || RollingStockError::KeyNotFound {
                 rolling_stock_key,
             })
@@ -836,6 +843,7 @@ pub mod tests {
         // THEN
         let response: RollingStockModel = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database
+        #[expect(deprecated)]
         let rolling_stock = RollingStockModel::retrieve(&mut db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
@@ -867,6 +875,7 @@ pub mod tests {
         // THEN
         let response: RollingStockModel = raw_response.assert_status(StatusCode::OK).json_into();
         // Check if the rolling stock was created in the database with locked = true
+        #[expect(deprecated)]
         let rolling_stock = RollingStockModel::retrieve(&mut db_pool.get_ok(), response.id)
             .await
             .expect("Failed to retrieve rolling stock")
@@ -1146,6 +1155,7 @@ pub mod tests {
         // THEN
         raw_response.assert_status(StatusCode::OK);
 
+        #[expect(deprecated)]
         let updated_rolling_stock: RollingStockModel =
             RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1200,6 +1210,7 @@ pub mod tests {
         // THEN
         raw_response.assert_status(StatusCode::OK);
 
+        #[expect(deprecated)]
         let updated_rolling_stock: RollingStockModel =
             RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1249,6 +1260,7 @@ pub mod tests {
             "The primary_category cannot be listed in other_categories for rolling stocks."
         );
 
+        #[expect(deprecated)]
         let updated_rolling_stock: RollingStockModel =
             RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1353,6 +1365,7 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
+        #[expect(deprecated)]
         let fast_rolling_stock: RollingStockModel =
             RollingStockModel::retrieve(&mut db_pool.get_ok(), fast_rolling_stock.id)
                 .await
@@ -1383,6 +1396,7 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
+        #[expect(deprecated)]
         let fast_rolling_stock: RollingStockModel =
             RollingStockModel::retrieve(&mut db_pool.get_ok(), locked_fast_rolling_stock.id)
                 .await

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -169,6 +169,7 @@ async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
+    #[expect(deprecated)]
     let rolling_stock = RollingStockModel::retrieve_or_fail(
         &mut db_pool.get().await?,
         light_rolling_stock_id,
@@ -203,6 +204,7 @@ async fn get_by_name(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
+    #[expect(deprecated)]
     let rolling_stock = RollingStockModel::retrieve_or_fail(
         &mut db_pool.get().await?,
         light_rolling_stock_name.clone(),

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -260,6 +260,7 @@ async fn get_by_id(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    #[expect(deprecated)]
     let towed_rolling_stock = TowedRollingStockModel::retrieve_or_fail(
         &mut db_pool.get().await?,
         towed_rolling_stock_id,
@@ -301,6 +302,7 @@ async fn patch_by_id(
         .await?
         .transaction::<_, InternalError, _>(|conn| {
             async move {
+                #[expect(deprecated)]
                 let existing_rolling_stock = TowedRollingStockModel::retrieve_or_fail(
                     &mut conn.clone(),
                     towed_rolling_stock_id,

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -266,6 +266,7 @@ async fn delete(
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
+                #[expect(deprecated)]
                 let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
@@ -406,10 +407,12 @@ async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let project = Project::retrieve_or_fail(&mut conn, project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
+                #[expect(deprecated)]
                 let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
                     study_id,
                 })
@@ -418,6 +421,7 @@ async fn get(
                     return Err(ProjectError::NotFound { project_id }.into());
                 }
 
+                #[expect(deprecated)]
                 let scenario = Scenario::retrieve_or_fail(&mut conn, scenario_id, || {
                     ScenarioError::NotFound { scenario_id }
                 })
@@ -474,6 +478,7 @@ async fn list(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let study =
         Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
     if study.project_id != project_id {
@@ -617,6 +622,7 @@ mod tests {
         assert_eq!(response.scenario.timetable_id, study_timetable_id);
         assert_eq!(response.scenario.tags, study_tags);
 
+        #[expect(deprecated)]
         let created_scenario = Scenario::retrieve(&mut pool.get_ok(), response.scenario.id)
             .await
             .expect("Failed to retrieve scenario")

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -293,6 +293,7 @@ async fn update(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
+                #[expect(deprecated)]
                 let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
@@ -353,6 +354,7 @@ async fn delete(
         scenario_id,
         move |mut conn, scenario, study, project| {
             async move {
+                #[expect(deprecated)]
                 let node = MacroNode::retrieve_or_fail(&mut conn, node_id, || {
                     MacroNodeError::NotFound { node_id }
                 })
@@ -388,9 +390,11 @@ async fn check_project_study_scenario(
     study_id: i64,
     scenario_id: i64,
 ) -> Result<(Project, Study, Scenario)> {
+    #[expect(deprecated)]
     let project =
         Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
             .await?;
+    #[expect(deprecated)]
     let study =
         Study::retrieve_or_fail(conn, study_id, || StudyError::NotFound { study_id }).await?;
 
@@ -398,6 +402,7 @@ async fn check_project_study_scenario(
         return Err(StudyError::NotFound { study_id }.into());
     }
 
+    #[expect(deprecated)]
     let scenario = Scenario::retrieve_or_fail(conn, scenario_id, || ScenarioError::NotFound {
         scenario_id,
     })
@@ -414,6 +419,7 @@ async fn retrieve_macro_node_and_check_scenario(
     scenario_id: i64,
     node_id: i64,
 ) -> Result<MacroNode> {
+    #[expect(deprecated)]
     let node = MacroNode::retrieve_or_fail(&mut conn.clone(), node_id, || {
         MacroNodeError::NotFound { node_id }
     })
@@ -489,6 +495,7 @@ pub mod test {
         let response: MacroNodeResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let node = MacroNode::retrieve_or_fail(&mut db_pool.get_ok(), response.id, || {
             MacroNodeError::NotFound {
                 node_id: response.id,
@@ -525,6 +532,7 @@ pub mod test {
         let response: MacroNodeResponse =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let node = MacroNode::retrieve_or_fail(&mut db_pool.get_ok(), fixtures.nodes[0].id, || {
             MacroNodeError::NotFound {
                 node_id: response.id,

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -130,12 +130,14 @@ async fn stdcm_log_by_id_or_trace_id(
     let conn = &mut db_pool.get().await?;
 
     if id.is_some() {
+        #[expect(deprecated)]
         let stdcm_log = StdcmLog::retrieve_or_fail(conn, id.unwrap(), || StdcmLogError::NotFound {
             id: id.unwrap(),
         })
         .await?;
         Ok(Json(stdcm_log))
     } else if trace_id.is_some() {
+        #[expect(deprecated)]
         let stdcm_log = StdcmLog::retrieve_or_fail(conn, Some(trace_id.clone().unwrap()), || {
             StdcmLogError::TraceIdNotFound {
                 trace_id: trace_id.unwrap(),

--- a/editoast/src/views/stdcm_search_environment.rs
+++ b/editoast/src/views/stdcm_search_environment.rs
@@ -220,6 +220,7 @@ pub mod tests {
             .json_into::<StdcmSearchEnvironment>();
 
         // THEN
+        #[expect(deprecated)]
         let stdcm_search_env_in_db =
             StdcmSearchEnvironment::retrieve(&mut pool.get_ok(), stdcm_search_env.id)
                 .await

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -29,6 +29,7 @@ use crate::models::Project;
 use crate::models::Study;
 use crate::models::Tags;
 use crate::models::prelude::*;
+use crate::models::projects;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::projects::ProjectError;
@@ -421,8 +422,11 @@ async fn list(
     }
 
     let ordering = ordering_params.ordering;
-    if !Project::exists(&mut db_pool.get().await?, project_id).await? {
-        return Err(ProjectError::NotFound { project_id }.into());
+    match Project::exists(&mut db_pool.get().await?, project_id).await {
+        Ok(true) => (),
+        Ok(false) => return Err(ProjectError::NotFound { project_id }.into()),
+        Err(projects::Error::Legacy(err)) => return Err(err),
+        Err(projects::Error::Database(err)) => return Err(err.into()),
     }
 
     let settings = pagination_params

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -247,10 +247,12 @@ async fn get(
         .await?
         .transaction(|mut conn| {
             async move {
+                #[expect(deprecated)]
                 let project = Project::retrieve_or_fail(&mut conn, project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
+                #[expect(deprecated)]
                 let study = Study::retrieve_or_fail(&mut conn, study_id, || StudyError::NotFound {
                     study_id,
                 })
@@ -474,6 +476,7 @@ pub mod tests {
             }));
         let response: StudyResponse = app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let study = Study::retrieve(&mut db_pool.get_ok(), response.study.id)
             .await
             .expect("Failed to retrieve study")
@@ -597,11 +600,13 @@ pub mod tests {
 
         app.fetch(request).assert_status(StatusCode::OK);
 
+        #[expect(deprecated)]
         let updated_study = Study::retrieve(&mut db_pool.get_ok(), created_study.id)
             .await
             .expect("Failed to retrieve study")
             .expect("Study not found");
 
+        #[expect(deprecated)]
         let updated_project = Project::retrieve(&mut db_pool.get_ok(), created_project.id)
             .await
             .expect("Failed to retrieve project")

--- a/editoast/src/views/temporary_speed_limits.rs
+++ b/editoast/src/views/temporary_speed_limits.rs
@@ -309,6 +309,7 @@ mod tests {
 
         let TemporarySpeedLimitCreateResponse { group_id } =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
+        #[expect(deprecated)]
         let created_group = TemporarySpeedLimitGroup::retrieve(&mut pool.get_ok(), group_id)
             .await
             .expect("Failed to retrieve the created temporary speed limit group")

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -93,7 +93,7 @@ editoast_common::schemas! {
     simulation::schemas(),
 }
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "timetable")]
 enum TimetableError {
     #[error("Timetable '{timetable_id}', could not be found")]
@@ -103,8 +103,9 @@ enum TimetableError {
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
     #[error(transparent)]
+    #[from(forward)]
     #[editoast_error(status = 500)]
-    Database(#[from] editoast_models::model::Error),
+    Database(editoast_models::model::Error),
     #[error("Failed to parse train_id '{train_id}'")]
     #[editoast_error(status = 500)]
     ParseError { train_id: String },
@@ -526,14 +527,15 @@ async fn conflicts(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    let mut conn = db_pool.get().await?;
+
     #[expect(deprecated)]
-    let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
-        TimetableError::InfraNotFound { infra_id }
+    let infra = Infra::retrieve_or_fail(&mut conn, infra_id, || TimetableError::InfraNotFound {
+        infra_id,
     })
     .await?;
 
-    let (trains, paced_trains) =
-        retrieve_trains_and_paced_trains(&mut db_pool.get().await?, timetable_id).await?;
+    let (trains, paced_trains) = retrieve_trains_and_paced_trains(conn, timetable_id).await?;
 
     let (train_simulations, paced_train_simulations) = retrieve_simulations(
         &mut db_pool.get().await?,
@@ -565,20 +567,21 @@ async fn conflicts(
 }
 
 async fn retrieve_trains_and_paced_trains(
-    conn: &mut DbConnection,
+    mut conn: DbConnection,
     timetable_id: i64,
 ) -> Result<(Vec<models::TrainSchedule>, Vec<models::PacedTrain>)> {
-    let timetable_trains = TimetableWithTrains::retrieve_or_fail(conn, timetable_id, || {
-        TimetableError::NotFound { timetable_id }
-    })
-    .await?;
+    let timetable_trains =
+        TimetableWithTrains::retrieve_or_fail(conn.clone(), timetable_id, || {
+            TimetableError::NotFound { timetable_id }
+        })
+        .await?;
     let mut conn_clone = conn.clone();
     let (trains, paced_trains): (Vec<_>, Vec<_>) = tokio::try_join!(
-        models::TrainSchedule::retrieve_batch_unchecked(
+        models::TrainSchedule::retrieve_batch_unchecked(&mut conn, timetable_trains.train_ids),
+        models::PacedTrain::retrieve_batch_unchecked(
             &mut conn_clone,
-            timetable_trains.train_ids
-        ),
-        models::PacedTrain::retrieve_batch_unchecked(conn, timetable_trains.paced_train_ids)
+            timetable_trains.paced_train_ids
+        )
     )?;
 
     Ok((trains, paced_trains))

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -526,6 +526,7 @@ async fn conflicts(
         return Err(AuthorizationError::Forbidden.into());
     }
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         TimetableError::InfraNotFound { infra_id }
     })
@@ -738,6 +739,7 @@ mod tests {
         let created_timetable: TimetableResult =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
+        #[expect(deprecated)]
         let retrieved_timetable =
             Timetable::retrieve(&mut pool.get_ok(), created_timetable.timetable_id)
                 .await

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -128,6 +128,7 @@ async fn get_by_id(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let paced_train = models::PacedTrain::retrieve_or_fail(conn, paced_train_id, || {
         PacedTrainError::NotFound { paced_train_id }
     })
@@ -252,6 +253,7 @@ async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PacedTrainError::InfraNotFound {
         infra_id,
     })
@@ -321,10 +323,12 @@ async fn get_path(
     let conn = &mut db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PacedTrainError::InfraNotFound {
         infra_id,
     })
     .await?;
+    #[expect(deprecated)]
     let paced_train = models::PacedTrain::retrieve_or_fail(conn, paced_train_id, || {
         PacedTrainError::NotFound { paced_train_id }
     })
@@ -379,12 +383,14 @@ async fn simulation(
     }
 
     // Retrieve infra or fail
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         PacedTrainError::InfraNotFound { infra_id }
     })
     .await?;
 
     // Retrieve paced_train or fail
+    #[expect(deprecated)]
     let paced_train =
         models::PacedTrain::retrieve_or_fail(&mut db_pool.get().await?, paced_train_id, || {
             PacedTrainError::NotFound { paced_train_id }
@@ -551,6 +557,7 @@ mod tests {
 
         app.fetch(request).assert_status(StatusCode::NO_CONTENT);
 
+        #[expect(deprecated)]
         let updated_paced_train = models::PacedTrain::retrieve(&mut pool.get_ok(), paced_train.id)
             .await
             .expect("Failed to retrieve updated paced train")

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -20,6 +20,7 @@ use crate::views::InternalError;
 use crate::views::SimulationResponse;
 use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding_from_train_batch;
+use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::Infra;
 use crate::views::timetable::PathfindingResult;
 use editoast_models::DbConnection;
@@ -131,7 +132,9 @@ pub async fn train_simulation_batch(
         .map::<String, _>(|t| t.rolling_stock_name.clone());
 
     let rolling_stocks: Vec<_> =
-        RollingStockModel::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids).await?;
+        RollingStockModel::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids)
+            .await
+            .map_err(RollingStockError::from)?;
 
     let consists: Vec<PhysicsConsistParameters> = rolling_stocks
         .into_iter()

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -182,11 +182,13 @@ async fn stdcm(
 
     // 1.  Infra / Timetable / Trains / Simulation / Rolling Stock
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut conn, infra_id, || StdcmError::InfraNotFound {
         infra_id,
     })
     .await?;
 
+    #[expect(deprecated)]
     let rolling_stock =
         RollingStockModel::retrieve_or_fail(&mut conn, stdcm_request.rolling_stock_id, || {
             StdcmError::RollingStockNotFound {
@@ -233,6 +235,7 @@ async fn stdcm(
     let earliest_departure_time = stdcm_request.get_earliest_departure_time(simulation_run_time);
     let latest_simulation_end = stdcm_request.get_latest_simulation_end(simulation_run_time);
 
+    #[expect(deprecated)]
     let timetable = Timetable::retrieve_or_fail(&mut conn, timetable_id, || {
         StdcmError::TimetableNotFound { timetable_id }
     })

--- a/editoast/src/views/timetable/stdcm/request.rs
+++ b/editoast/src/views/timetable/stdcm/request.rs
@@ -291,6 +291,7 @@ impl Request {
         }
 
         let towed_rolling_stock_id = self.towed_rolling_stock_id.unwrap();
+        #[expect(deprecated)]
         let towed_rolling_stock =
             TowedRollingStockModel::retrieve_or_fail(conn, towed_rolling_stock_id, || {
                 StdcmError::TowedRollingStockNotFound {

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -161,6 +161,7 @@ async fn get(
     }
 
     let conn = &mut db_pool.get().await?;
+    #[expect(deprecated)]
     let train_schedule = models::TrainSchedule::retrieve_or_fail(conn, train_schedule_id, || {
         TrainScheduleError::NotFound { train_schedule_id }
     })
@@ -282,12 +283,14 @@ async fn simulation(
     }
 
     // Retrieve infra or fail
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(&mut db_pool.get().await?, infra_id, || {
         TrainScheduleError::InfraNotFound { infra_id }
     })
     .await?;
 
     // Retrieve train_schedule or fail
+    #[expect(deprecated)]
     let train_schedule = models::TrainSchedule::retrieve_or_fail(
         &mut db_pool.get().await?,
         train_schedule_id,
@@ -352,6 +355,7 @@ async fn simulation_summary(
 
     let conn = &mut db_pool.get().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || TrainScheduleError::InfraNotFound {
         infra_id,
     })
@@ -419,10 +423,12 @@ async fn get_path(
     let conn = &mut db_pool.get().await?;
     let mut valkey_conn = valkey_client.get_connection().await?;
 
+    #[expect(deprecated)]
     let infra = Infra::retrieve_or_fail(conn, infra_id, || PathfindingError::InfraNotFound {
         infra_id,
     })
     .await?;
+    #[expect(deprecated)]
     let train_schedule = models::TrainSchedule::retrieve_or_fail(conn, train_schedule_id, || {
         TrainScheduleError::NotFound { train_schedule_id }
     })

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -444,6 +444,7 @@ async fn put_in_group(
     conn.transaction(|conn| {
         Box::pin(async move {
             // Check that the group exists
+            #[expect(deprecated)]
             WorkScheduleGroup::retrieve_or_fail(&mut conn.clone(), group_id, || {
                 WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
             })
@@ -515,6 +516,7 @@ async fn get_group(
     let conn = &mut db_pool.get().await?;
 
     // Check that the group exists
+    #[expect(deprecated)]
     WorkScheduleGroup::retrieve_or_fail(conn, group_id, || {
         WorkScheduleError::WorkScheduleGroupNotFound { id: group_id }
     })
@@ -564,6 +566,7 @@ pub mod tests {
             .json_into::<WorkScheduleCreateResponse>();
 
         // THEN
+        #[expect(deprecated)]
         let created_group = WorkScheduleGroup::retrieve(
             &mut pool.get_ok(),
             work_schedule_response.work_schedule_group_id,


### PR DESCRIPTION
- **editoast: add Retrieve::retrieve_real for real error forwarding**
- **editoast: allow deperecate retrieve**
- **editoast: remove InternalError dependency for Model Exist**
- **editoast: remove InternalError dependency for retrieve_batch_unchecked**
- **editoast: remove InteralError dependency for RetrieveBatch**
