### PR TITLE
Refacto paced trains and train schedules modules

### DIFF
--- a/editoast/src/client/timetables_commands.rs
+++ b/editoast/src/client/timetables_commands.rs
@@ -14,8 +14,8 @@ use crate::models;
 use crate::models::prelude::*;
 use crate::models::timetable::Timetable;
 use crate::models::timetable::TimetableWithTrains;
-use crate::views::train_schedule::TrainScheduleForm;
-use crate::views::train_schedule::TrainScheduleResponse;
+use crate::views::timetable::train_schedule::TrainScheduleForm;
+use crate::views::timetable::train_schedule::TrainScheduleResponse;
 
 #[derive(Subcommand, Debug)]
 pub enum TimetablesCommands {

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -33,7 +33,6 @@ use client::user::UserCommand;
 use editoast_common::tracing::TracingConfig;
 use editoast_common::tracing::create_tracing_subscriber;
 use editoast_models::DbConnectionPoolV2;
-use models::RollingStockModel;
 use tracing_subscriber::util::SubscriberInitExt;
 pub use views::AppState;
 

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -84,6 +84,7 @@ crate::routes! {
 editoast_common::schemas! {
     pathfinding::schemas(),
     delimited_area::schemas(),
+    InfraIdQueryParam,
     InfraState,
     InfraWithState,
 }
@@ -99,6 +100,12 @@ pub enum InfraApiError {
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] model::Error),
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+pub(in crate::views) struct InfraIdQueryParam {
+    pub infra_id: i64,
 }
 
 #[derive(Debug, Deserialize, IntoParams)]

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -6,7 +6,6 @@ pub mod infra;
 mod layers;
 mod openapi;
 pub mod operational_studies;
-pub mod paced_train;
 pub mod pagination;
 pub mod params;
 pub mod path;
@@ -21,7 +20,6 @@ pub mod stdcm_search_environment;
 pub mod study;
 pub mod temporary_speed_limits;
 pub mod timetable;
-pub mod train_schedule;
 pub mod work_schedules;
 
 #[cfg(test)]
@@ -72,7 +70,6 @@ use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing::warn;
 use url::Url;
-use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::ValkeyClient;
@@ -81,8 +78,6 @@ use crate::core;
 use crate::core::AsCoreRequest;
 use crate::core::CoreClient;
 use crate::core::mq_client;
-use crate::core::pathfinding::PathfindingInputError;
-use crate::core::pathfinding::PathfindingNotFound;
 use crate::core::simulation::SimulationResponse;
 use crate::core::version::CoreVersionRequest;
 use crate::error::InternalError;
@@ -96,7 +91,6 @@ use crate::map::MapLayers;
 use crate::models;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
-use crate::views::path::pathfinding::PathfindingFailure;
 
 crate::routes! {
     fn router();
@@ -112,7 +106,6 @@ crate::routes! {
     &fonts,
     &infra,
     &layers,
-    &paced_train,
     &projects,
     &rolling_stock,
     &search,
@@ -120,7 +113,6 @@ crate::routes! {
     &stdcm_search_environment,
     &work_schedules,
     &temporary_speed_limits,
-    &train_schedule,
     &timetable,
     &path,
     &stdcm_logs,
@@ -129,15 +121,11 @@ crate::routes! {
 
 editoast_common::schemas! {
     Version,
-    SimulationSummaryResult,
-    InfraIdQueryParam,
-
     editoast_common::schemas(),
     editoast_schemas::schemas(),
     models::schemas(),
     core::schemas(),
     generated_data::schemas(),
-
     authz::schemas(),
     documents::schemas(),
     electrical_profiles::schemas(),
@@ -145,7 +133,6 @@ editoast_common::schemas! {
     infra::schemas(),
     operation::schemas(),
     operational_studies::schemas(),
-    paced_train::schemas(),
     pagination::schemas(),
     path::schemas(),
     projects::schemas(),
@@ -155,94 +142,9 @@ editoast_common::schemas! {
     scenario::macro_nodes::schemas(),
     search::schemas(),
     stdcm_search_environment::schemas(),
-    train_schedule::schemas(),
     timetable::schemas(),
     work_schedules::schemas(),
     stdcm_logs::schemas(),
-}
-
-#[derive(Debug, Deserialize, ToSchema)]
-struct ListId {
-    ids: HashSet<i64>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
-#[into_params(parameter_in = Query)]
-pub struct InfraIdQueryParam {
-    infra_id: i64,
-}
-
-#[derive(Debug, Serialize, ToSchema)]
-#[cfg_attr(test, derive(PartialEq, Deserialize))]
-#[serde(tag = "status", rename_all = "snake_case")]
-enum SimulationSummaryResult {
-    /// Minimal information on a simulation's result
-    Success {
-        /// Length of a path in mm
-        length: u64,
-        /// Travel time in ms
-        time: u64,
-        /// Total energy consumption of a train in kWh
-        energy_consumption: f64,
-        /// Final simulation time for each train schedule path item.
-        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
-        path_item_times_final: Vec<u64>,
-        /// Provisional simulation time for each train schedule path item.
-        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
-        path_item_times_provisional: Vec<u64>,
-        /// Base simulation time for each train schedule path item.
-        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
-        path_item_times_base: Vec<u64>,
-    },
-    /// Pathfinding not found
-    PathfindingNotFound(PathfindingNotFound),
-    /// An error has occurred during pathfinding
-    PathfindingFailure { core_error: InternalError },
-    /// An error has occurred during computing
-    SimulationFailed { error_type: String },
-    /// InputError
-    PathfindingInputError(PathfindingInputError),
-}
-
-impl From<core::simulation::SimulationResponse> for SimulationSummaryResult {
-    fn from(sim: SimulationResponse) -> Self {
-        match sim {
-            SimulationResponse::Success {
-                final_output,
-                provisional,
-                base,
-                ..
-            } => {
-                let report = final_output.report_train;
-                Self::Success {
-                    length: *report.positions.last().unwrap(),
-                    time: *report.times.last().unwrap(),
-                    energy_consumption: report.energy_consumption,
-                    path_item_times_final: report.path_item_times.clone(),
-                    path_item_times_provisional: provisional.path_item_times.clone(),
-                    path_item_times_base: base.path_item_times.clone(),
-                }
-            }
-            SimulationResponse::PathfindingFailed { pathfinding_failed } => {
-                match pathfinding_failed {
-                    PathfindingFailure::InternalError { core_error } => {
-                        Self::PathfindingFailure { core_error }
-                    }
-
-                    PathfindingFailure::PathfindingInputError(input_error) => {
-                        Self::PathfindingInputError(input_error)
-                    }
-
-                    PathfindingFailure::PathfindingNotFound(not_found) => {
-                        Self::PathfindingNotFound(not_found)
-                    }
-                }
-            }
-            SimulationResponse::SimulationFailed { core_error } => Self::SimulationFailed {
-                error_type: core_error.error_type,
-            },
-        }
-    }
 }
 
 /// Represents the bundle of information about the issuer of a request

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -32,6 +32,7 @@ use crate::core::simulation::SignalCriticalPosition;
 use crate::core::simulation::SimulationResponse;
 use crate::core::simulation::ZoneUpdate;
 use crate::error::Result;
+use crate::models;
 use crate::models::RollingStockModel;
 use crate::models::infra::Infra;
 use crate::models::prelude::*;
@@ -39,8 +40,8 @@ use crate::models::train_schedule::TrainSchedule;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::path::projection::TrackLocationFromPath;
-use crate::views::train_schedule::TrainScheduleError;
-use crate::views::train_schedule::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_batch;
+use crate::views::timetable::train_schedule::TrainScheduleError;
 
 editoast_common::schemas! {
     ProjectPathTrainResult,
@@ -326,7 +327,7 @@ pub async fn compute_projected_train_paths(
     valkey_client: Arc<ValkeyClient>,
     path: ProjectPathInput,
     infra_id: i64,
-    trains_schedules: Vec<TrainSchedule>,
+    trains_schedules: Vec<models::TrainSchedule>,
     electrical_profile_set_id: Option<i64>,
 ) -> Result<HashMap<i64, ProjectPathTrainResult>> {
     let path_projection = PathProjection::new(&path.track_section_ranges);

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -1,4 +1,7 @@
+pub mod paced_train;
+pub mod simulation;
 pub mod stdcm;
+pub mod train_schedule;
 
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -23,19 +26,19 @@ use editoast_schemas::paced_train::PacedTrain;
 use editoast_schemas::train_schedule::TrainSchedule;
 use itertools::Either;
 use itertools::Itertools;
+use paced_train::PacedTrainResponse;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::paced_train::PacedTrainResponse;
+use super::infra::InfraIdQueryParam;
 use super::pagination::PaginatedList as _;
 use super::pagination::PaginationQueryParams;
 use super::pagination::PaginationStats;
 use super::path::pathfinding::PathfindingResult;
 use crate::AppState;
-use crate::ValkeyClient;
 use crate::core::AsCoreRequest;
 use crate::core::conflict_detection::Conflict as CoreConflict;
 use crate::core::conflict_detection::ConflictDetectionRequest;
@@ -51,12 +54,14 @@ use crate::models::prelude::*;
 use crate::models::timetable::Timetable;
 use crate::models::timetable::TimetableWithTrains;
 use crate::models::train_schedule::TrainScheduleChangeset;
+
+use crate::ValkeyClient;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::CoreClient;
-use crate::views::train_schedule::TrainScheduleForm;
-use crate::views::train_schedule::TrainScheduleResponse;
-use crate::views::train_schedule::train_simulation_batch;
+use simulation::train_simulation_batch;
+use train_schedule::TrainScheduleForm;
+use train_schedule::TrainScheduleResponse;
 
 crate::routes! {
     "/timetable" => {
@@ -75,12 +80,17 @@ crate::routes! {
             &stdcm,
         },
     },
+    &paced_train,
+    &train_schedule,
 }
 
 editoast_common::schemas! {
     Conflict,
     TimetableResult,
     stdcm::schemas(),
+    paced_train::schemas(),
+    train_schedule::schemas(),
+    simulation::schemas(),
 }
 
 #[derive(Debug, Error, EditoastError)]
@@ -367,12 +377,6 @@ async fn get_paced_trains(
     let results = paced_trains.into_iter().map_into().collect();
 
     Ok(Json(ListPacedTrainsResponse { stats, results }))
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
-#[into_params(parameter_in = Query)]
-pub struct InfraIdQueryParam {
-    infra_id: i64,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -19,13 +19,6 @@ use utoipa::ToSchema;
 
 use super::AppState;
 use super::AuthenticationExt;
-use super::InfraIdQueryParam;
-use super::SimulationSummaryResult;
-use super::path::pathfinding::PathfindingResult;
-use super::path::pathfinding::pathfinding_from_train;
-use super::projection::ProjectPathForm;
-use super::projection::compute_projected_train_paths;
-use super::train_schedule::train_simulation_batch;
 use crate::core::simulation::SimulationResponse;
 use crate::error::Result;
 use crate::models;
@@ -34,8 +27,14 @@ use crate::models::paced_train::PacedTrainChangeset;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
 use crate::views::AuthorizationError;
-use crate::views::ListId;
+use crate::views::infra::InfraIdQueryParam;
+use crate::views::path::pathfinding::PathfindingResult;
+use crate::views::path::pathfinding::pathfinding_from_train;
+use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
+use crate::views::projection::compute_projected_train_paths;
+use crate::views::timetable::simulation::SimulationSummaryResult;
+use crate::views::timetable::train_simulation_batch;
 
 crate::routes! {
     "/paced_train" => {
@@ -174,11 +173,16 @@ async fn update_paced_train(
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+struct PacedTrainIds {
+    ids: HashSet<i64>,
+}
+
 /// Delete a paced train
 #[utoipa::path(
     delete, path = "",
     tag = "timetable,paced_train",
-    request_body = inline(ListId),
+    request_body = inline(PacedTrainIds),
     responses(
         (status = 204, description = "All paced_trains have been deleted")
     )
@@ -186,9 +190,9 @@ async fn update_paced_train(
 async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Json(ListId {
+    Json(PacedTrainIds {
         ids: paced_train_ids,
-    }): Json<ListId>,
+    }): Json<PacedTrainIds>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -505,12 +509,12 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::paced_train::PacedTrainChangeset;
     use crate::models::prelude::*;
-    use crate::views::SimulationSummaryResult;
-    use crate::views::paced_train::PacedTrainResponse;
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
+    use crate::views::timetable::paced_train::PacedTrainResponse;
+    use crate::views::timetable::simulation::SimulationSummaryResult;
 
     #[rstest]
     async fn paced_train_post() {
@@ -616,7 +620,7 @@ mod tests {
         let paced_train_base = PacedTrain {
             train_schedule_base: TrainSchedule {
                 rolling_stock_name: rolling_stock.name.clone(),
-                ..serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
+                ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
                     .expect("Unable to parse")
             },
             paced: Paced {
@@ -847,7 +851,7 @@ mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let train_schedule_base = TrainSchedule {
             rolling_stock_name: rolling_stock.name.clone(),
-            ..serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
+            ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
                 .expect("Unable to parse")
         };
         let paced_train_valid =

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -1,0 +1,392 @@
+use crate::RetrieveBatchUnchecked;
+use crate::ValkeyClient;
+use crate::core;
+use crate::core::AsCoreRequest;
+use crate::core::pathfinding::PathfindingInputError;
+use crate::core::pathfinding::PathfindingNotFound;
+use crate::core::pathfinding::PathfindingResultSuccess;
+use crate::core::simulation::PhysicsConsist;
+use crate::core::simulation::PhysicsConsistParameters;
+use crate::core::simulation::SimulationMargins;
+use crate::core::simulation::SimulationPath;
+use crate::core::simulation::SimulationPowerRestrictionItem;
+use crate::core::simulation::SimulationRequest;
+use crate::core::simulation::SimulationScheduleItem;
+use crate::error::Result;
+use crate::models;
+use crate::models::RollingStockModel;
+use crate::views::CoreClient;
+use crate::views::InternalError;
+use crate::views::SimulationResponse;
+use crate::views::path::pathfinding::PathfindingFailure;
+use crate::views::path::pathfinding_from_train_batch;
+use crate::views::timetable::Infra;
+use crate::views::timetable::PathfindingResult;
+use editoast_models::DbConnection;
+use itertools::Itertools;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::iter;
+use std::sync::Arc;
+use tracing::Instrument;
+use tracing::info;
+use utoipa::ToSchema;
+
+pub const TRAIN_SIZE_BATCH: usize = 100;
+
+editoast_common::schemas! {
+    SimulationSummaryResult,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SimulationSummaryResult {
+    /// Minimal information on a simulation's result
+    Success {
+        /// Length of a path in mm
+        length: u64,
+        /// Travel time in ms
+        time: u64,
+        /// Total energy consumption of a train in kWh
+        energy_consumption: f64,
+        /// Final simulation time for each train schedule path item.
+        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+        path_item_times_final: Vec<u64>,
+        /// Provisional simulation time for each train schedule path item.
+        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+        path_item_times_provisional: Vec<u64>,
+        /// Base simulation time for each train schedule path item.
+        /// The first value is always `0` (beginning of the path) and the last one, the total time of the simulation (end of the path)
+        path_item_times_base: Vec<u64>,
+    },
+    /// Pathfinding not found
+    PathfindingNotFound(PathfindingNotFound),
+    /// An error has occurred during pathfinding
+    PathfindingFailure { core_error: InternalError },
+    /// An error has occurred during computing
+    SimulationFailed { error_type: String },
+    /// InputError
+    PathfindingInputError(PathfindingInputError),
+}
+
+impl From<core::simulation::SimulationResponse> for SimulationSummaryResult {
+    fn from(sim: SimulationResponse) -> Self {
+        match sim {
+            SimulationResponse::Success {
+                final_output,
+                provisional,
+                base,
+                ..
+            } => {
+                let report = final_output.report_train;
+                Self::Success {
+                    length: *report.positions.last().unwrap(),
+                    time: *report.times.last().unwrap(),
+                    energy_consumption: report.energy_consumption,
+                    path_item_times_final: report.path_item_times.clone(),
+                    path_item_times_provisional: provisional.path_item_times.clone(),
+                    path_item_times_base: base.path_item_times.clone(),
+                }
+            }
+            SimulationResponse::PathfindingFailed { pathfinding_failed } => {
+                match pathfinding_failed {
+                    PathfindingFailure::InternalError { core_error } => {
+                        Self::PathfindingFailure { core_error }
+                    }
+
+                    PathfindingFailure::PathfindingInputError(input_error) => {
+                        Self::PathfindingInputError(input_error)
+                    }
+
+                    PathfindingFailure::PathfindingNotFound(not_found) => {
+                        Self::PathfindingNotFound(not_found)
+                    }
+                }
+            }
+            SimulationResponse::SimulationFailed { core_error } => Self::SimulationFailed {
+                error_type: core_error.error_type,
+            },
+        }
+    }
+}
+
+/// Compute in batch the simulation of a list of train schedule
+///
+/// Note: The order of the returned simulations is the same as the order of the train schedules.
+pub async fn train_simulation_batch(
+    conn: &mut DbConnection,
+    valkey_client: Arc<ValkeyClient>,
+    core: Arc<CoreClient>,
+    train_schedules: &[models::TrainSchedule],
+    infra: &Infra,
+    electrical_profile_set_id: Option<i64>,
+) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
+    // Compute path
+
+    let train_batches = train_schedules.chunks(TRAIN_SIZE_BATCH);
+
+    let rolling_stocks_ids = train_schedules
+        .iter()
+        .map::<String, _>(|t| t.rolling_stock_name.clone());
+
+    let rolling_stocks: Vec<_> =
+        RollingStockModel::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids).await?;
+
+    let consists: Vec<PhysicsConsistParameters> = rolling_stocks
+        .into_iter()
+        .map(|rs| PhysicsConsistParameters::from_traction_engine(rs.into()))
+        .collect();
+
+    let futures: Vec<_> = train_batches
+        .zip(iter::repeat(conn.clone()))
+        .map(|(chunk, conn)| {
+            let valkey_client = valkey_client.clone();
+            let core = core.clone();
+            let consists = consists.clone();
+            let infra = <Infra as Clone>::clone(infra);
+            let chunk = chunk.to_vec();
+            tokio::spawn(
+                async move {
+                    consist_train_simulation_batch(
+                        &mut conn.clone(),
+                        valkey_client.clone(),
+                        core.clone(),
+                        &infra,
+                        &chunk,
+                        &consists,
+                        electrical_profile_set_id,
+                    )
+                    .await
+                }
+                .in_current_span(),
+            )
+        })
+        .collect();
+
+    let results = futures::future::try_join_all(futures).await.unwrap();
+    results
+        .into_iter()
+        .flatten_ok()
+        .collect::<Result<Vec<_>, _>>()
+}
+
+#[tracing::instrument(skip_all, fields(nb_trains = train_schedules.len()))]
+pub async fn consist_train_simulation_batch(
+    conn: &mut DbConnection,
+    valkey_client: Arc<ValkeyClient>,
+    core: Arc<CoreClient>,
+    infra: &Infra,
+    train_schedules: &[models::TrainSchedule],
+    consists: &[PhysicsConsistParameters],
+    electrical_profile_set_id: Option<i64>,
+) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
+    let mut valkey_conn = valkey_client.get_connection().await?;
+
+    let pathfinding_results = pathfinding_from_train_batch(
+        conn,
+        &mut valkey_conn,
+        core.clone(),
+        infra,
+        train_schedules,
+        &consists
+            .iter()
+            .map(|consist| consist.traction_engine.clone())
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+
+    let consists: HashMap<_, _> = consists
+        .iter()
+        .map(|consist| (&consist.traction_engine.name, consist))
+        .collect();
+
+    let mut simulation_results = vec![SimulationResponse::default(); train_schedules.len()];
+    let mut to_sim: HashMap<String, Vec<usize>> = HashMap::default();
+    let mut sim_request_map: HashMap<String, SimulationRequest> = HashMap::default();
+    for (index, (pathfinding, train_schedule)) in
+        pathfinding_results.iter().zip(train_schedules).enumerate()
+    {
+        let (path, path_item_positions) = match pathfinding {
+            PathfindingResult::Success(PathfindingResultSuccess {
+                blocks,
+                routes,
+                track_section_ranges,
+                path_item_positions,
+                ..
+            }) => (
+                SimulationPath {
+                    blocks: blocks.clone(),
+                    routes: routes.clone(),
+                    track_section_ranges: track_section_ranges.clone(),
+                    path_item_positions: path_item_positions.clone(),
+                },
+                path_item_positions,
+            ),
+            PathfindingResult::Failure(pathfinding_failed) => {
+                simulation_results[index] = SimulationResponse::PathfindingFailed {
+                    pathfinding_failed: pathfinding_failed.clone(),
+                };
+                continue;
+            }
+        };
+
+        // Build simulation request
+        let physics_consist_parameters = consists[&train_schedule.rolling_stock_name].clone();
+
+        let simulation_request = build_simulation_request(
+            infra,
+            train_schedule,
+            path_item_positions,
+            path,
+            electrical_profile_set_id,
+            physics_consist_parameters.into(),
+        );
+
+        // Compute unique hash of the simulation input
+        let simulation_hash = simulation_request
+            .compute_train_simulation_hash_with_versioning(infra.id, infra.version);
+        to_sim
+            .entry(simulation_hash.clone())
+            .or_default()
+            .push(index);
+        sim_request_map
+            .entry(simulation_hash)
+            .or_insert(simulation_request);
+    }
+    info!(
+        nb_train_schedules = train_schedules.len(),
+        nb_unique_sim = to_sim.len()
+    );
+    let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();
+    let cached_results: Vec<Option<SimulationResponse>> = valkey_conn
+        .compressed_get_bulk(&cached_simulation_hash)
+        .await?;
+
+    let nb_hit = cached_results.iter().flatten().count();
+    let nb_miss = to_sim.len() - nb_hit;
+    info!(nb_hit, nb_miss, "Hit cache");
+
+    // Compute simulation from core
+    let mut futures = Vec::with_capacity(nb_miss);
+    let mut futures_hash = Vec::with_capacity(nb_miss);
+    for (train_hash, sim_cached) in cached_simulation_hash.iter().zip(cached_results) {
+        if let Some(sim_cached) = sim_cached {
+            let train_indexes = &to_sim[*train_hash];
+            for train_index in train_indexes {
+                simulation_results[*train_index] = sim_cached.clone();
+            }
+            continue;
+        }
+        let sim_request = &sim_request_map[*train_hash];
+        futures.push(Box::pin(sim_request.fetch(core.as_ref())));
+        futures_hash.push(train_hash);
+    }
+
+    let simulated: Vec<_> = futures::future::join_all(futures)
+        .await
+        .into_iter()
+        .collect();
+
+    let mut to_cache = vec![];
+    for (train_hash, sim_res) in futures_hash.iter().zip(simulated) {
+        let train_indexes = &to_sim[**train_hash];
+        match sim_res {
+            Ok(sim_res) => {
+                to_cache.push((train_hash, sim_res.clone()));
+                train_indexes
+                    .iter()
+                    .for_each(|index| simulation_results[*index] = sim_res.clone())
+            }
+
+            Err(core_error) => {
+                let error: InternalError = core_error.into();
+                train_indexes.iter().for_each(|index| {
+                    simulation_results[*index] = SimulationResponse::SimulationFailed {
+                        core_error: error.clone(),
+                    }
+                })
+            }
+        }
+    }
+
+    // Cache the simulation response
+    valkey_conn.compressed_set_bulk(&to_cache).await?;
+
+    // Return the response
+    Ok(simulation_results
+        .into_iter()
+        .zip(pathfinding_results)
+        .collect())
+}
+
+fn build_simulation_request(
+    infra: &Infra,
+    train_schedule: &models::TrainSchedule,
+    path_item_positions: &[u64],
+    path: SimulationPath,
+    electrical_profile_set_id: Option<i64>,
+    physics_consist: PhysicsConsist,
+) -> SimulationRequest {
+    assert_eq!(path_item_positions.len(), train_schedule.path.len());
+    // Project path items to path offset
+    let path_items_to_position: HashMap<_, _> = train_schedule
+        .path
+        .iter()
+        .map(|p| &p.id)
+        .zip(path_item_positions.iter().copied())
+        .collect();
+
+    let schedule = train_schedule
+        .schedule
+        .iter()
+        .map(|schedule_item| SimulationScheduleItem {
+            path_offset: path_items_to_position[&schedule_item.at],
+            arrival: schedule_item
+                .arrival
+                .as_ref()
+                .map(|t| t.num_milliseconds() as u64),
+            stop_for: schedule_item
+                .stop_for
+                .as_ref()
+                .map(|t| t.num_milliseconds() as u64),
+            reception_signal: schedule_item.reception_signal,
+        })
+        .collect();
+
+    let margins = SimulationMargins {
+        boundaries: train_schedule
+            .margins
+            .boundaries
+            .iter()
+            .map(|at| path_items_to_position[at])
+            .collect(),
+        values: train_schedule.margins.values.clone(),
+    };
+
+    let power_restrictions = train_schedule
+        .power_restrictions
+        .iter()
+        .map(|item| SimulationPowerRestrictionItem {
+            from: path_items_to_position[&item.from],
+            to: path_items_to_position[&item.to],
+            value: item.value.clone(),
+        })
+        .collect();
+
+    SimulationRequest {
+        infra: infra.id,
+        expected_version: infra.version,
+        path,
+        schedule,
+        margins,
+        initial_speed: train_schedule.initial_speed,
+        comfort: train_schedule.comfort,
+        constraint_distribution: train_schedule.constraint_distribution,
+        speed_limit_tag: train_schedule.speed_limit_tag.clone(),
+        power_restrictions,
+        options: train_schedule.options.clone(),
+        physics_consist,
+        electrical_profile_set_id,
+    }
+}

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -57,8 +57,8 @@ use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::timetable::Conflict;
-use crate::views::train_schedule::consist_train_simulation_batch;
-use crate::views::train_schedule::train_simulation_batch;
+use crate::views::timetable::simulation::consist_train_simulation_batch;
+use crate::views::timetable::train_simulation_batch;
 
 editoast_common::schemas! {
     request::schemas(),

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::iter;
-use std::sync::Arc;
 
 use axum::Extension;
 use axum::extract::Json;
@@ -11,36 +9,20 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
-use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::train_schedule::TrainSchedule;
-use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
-use tracing::Instrument;
-use tracing::info;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
-use super::SimulationSummaryResult;
-use super::projection::ProjectPathForm;
-use super::projection::compute_projected_train_paths;
 use crate::AppState;
-use crate::RollingStockModel;
-use crate::ValkeyClient;
-use crate::core::AsCoreRequest;
-use crate::core::CoreClient;
-use crate::core::pathfinding::PathfindingResultSuccess;
-use crate::core::simulation::PhysicsConsist;
-use crate::core::simulation::PhysicsConsistParameters;
-use crate::core::simulation::SimulationMargins;
-use crate::core::simulation::SimulationPath;
-use crate::core::simulation::SimulationPowerRestrictionItem;
-use crate::core::simulation::SimulationRequest;
+use crate::views::infra::InfraIdQueryParam;
+use crate::views::timetable::simulation::SimulationSummaryResult;
+
 use crate::core::simulation::SimulationResponse;
-use crate::core::simulation::SimulationScheduleItem;
-use crate::error::InternalError;
+
 use crate::error::Result;
 use crate::models;
 use crate::models::infra::Infra;
@@ -48,13 +30,14 @@ use crate::models::prelude::*;
 use crate::models::train_schedule::TrainScheduleChangeset;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
-use crate::views::InfraIdQueryParam;
-use crate::views::ListId;
 use crate::views::path::PathfindingError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::pathfinding::pathfinding_from_train;
-use crate::views::path::pathfinding_from_train_batch;
+use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
+use crate::views::projection::compute_projected_train_paths;
+
+use super::simulation::train_simulation_batch;
 
 crate::routes! {
     "/train_schedule" => {
@@ -76,8 +59,6 @@ editoast_common::schemas! {
     TrainScheduleResponse,
     ElectricalProfileSetIdQueryParam,
 }
-
-pub const TRAIN_SIZE_BATCH: usize = 100;
 
 #[derive(Debug, Error, EditoastError)]
 #[editoast_error(base_id = "train_schedule")]
@@ -187,11 +168,16 @@ async fn get(
     Ok(Json(train_schedule.into()))
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+struct TrainScheduleIds {
+    ids: HashSet<i64>,
+}
+
 /// Delete a train schedule and its result
 #[utoipa::path(
     delete, path = "",
     tag = "timetable,train_schedule",
-    request_body = inline(ListId),
+    request_body = inline(TrainScheduleIds),
     responses(
         (status = 204, description = "All train schedules have been deleted")
     )
@@ -199,7 +185,7 @@ async fn get(
 async fn delete(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Json(ListId { ids: train_ids }): Json<ListId>,
+    Json(TrainScheduleIds { ids: train_ids }): Json<TrainScheduleIds>,
 ) -> Result<impl IntoResponse> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -323,286 +309,6 @@ async fn simulation(
     .unwrap();
 
     Ok(Json(simulation))
-}
-
-/// Compute in batch the simulation of a list of train schedule
-///
-/// Note: The order of the returned simulations is the same as the order of the train schedules.
-pub async fn train_simulation_batch(
-    conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
-    core: Arc<CoreClient>,
-    train_schedules: &[models::TrainSchedule],
-    infra: &Infra,
-    electrical_profile_set_id: Option<i64>,
-) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
-    // Compute path
-
-    let train_batches = train_schedules.chunks(TRAIN_SIZE_BATCH);
-
-    let rolling_stocks_ids = train_schedules
-        .iter()
-        .map::<String, _>(|t| t.rolling_stock_name.clone());
-
-    let rolling_stocks: Vec<_> =
-        RollingStockModel::retrieve_batch_unchecked(&mut conn.clone(), rolling_stocks_ids).await?;
-
-    let consists: Vec<PhysicsConsistParameters> = rolling_stocks
-        .into_iter()
-        .map(|rs| PhysicsConsistParameters::from_traction_engine(rs.into()))
-        .collect();
-
-    let futures: Vec<_> = train_batches
-        .zip(iter::repeat(conn.clone()))
-        .map(|(chunk, conn)| {
-            let valkey_client = valkey_client.clone();
-            let core = core.clone();
-            let consists = consists.clone();
-            let infra = <Infra as Clone>::clone(infra);
-            let chunk = chunk.to_vec();
-            tokio::spawn(
-                async move {
-                    consist_train_simulation_batch(
-                        &mut conn.clone(),
-                        valkey_client.clone(),
-                        core.clone(),
-                        &infra,
-                        &chunk,
-                        &consists,
-                        electrical_profile_set_id,
-                    )
-                    .await
-                }
-                .in_current_span(),
-            )
-        })
-        .collect();
-
-    let results = futures::future::try_join_all(futures).await.unwrap();
-    results
-        .into_iter()
-        .flatten_ok()
-        .collect::<Result<Vec<_>, _>>()
-}
-
-#[tracing::instrument(skip_all, fields(nb_trains = train_schedules.len()))]
-pub async fn consist_train_simulation_batch(
-    conn: &mut DbConnection,
-    valkey_client: Arc<ValkeyClient>,
-    core: Arc<CoreClient>,
-    infra: &Infra,
-    train_schedules: &[models::TrainSchedule],
-    consists: &[PhysicsConsistParameters],
-    electrical_profile_set_id: Option<i64>,
-) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
-    let mut valkey_conn = valkey_client.get_connection().await?;
-
-    let pathfinding_results = pathfinding_from_train_batch(
-        conn,
-        &mut valkey_conn,
-        core.clone(),
-        infra,
-        train_schedules,
-        &consists
-            .iter()
-            .map(|consist| consist.traction_engine.clone())
-            .collect::<Vec<_>>(),
-    )
-    .await?;
-
-    let consists: HashMap<_, _> = consists
-        .iter()
-        .map(|consist| (&consist.traction_engine.name, consist))
-        .collect();
-
-    let mut simulation_results = vec![SimulationResponse::default(); train_schedules.len()];
-    let mut to_sim: HashMap<String, Vec<usize>> = HashMap::default();
-    let mut sim_request_map: HashMap<String, SimulationRequest> = HashMap::default();
-    for (index, (pathfinding, train_schedule)) in
-        pathfinding_results.iter().zip(train_schedules).enumerate()
-    {
-        let (path, path_item_positions) = match pathfinding {
-            PathfindingResult::Success(PathfindingResultSuccess {
-                blocks,
-                routes,
-                track_section_ranges,
-                path_item_positions,
-                ..
-            }) => (
-                SimulationPath {
-                    blocks: blocks.clone(),
-                    routes: routes.clone(),
-                    track_section_ranges: track_section_ranges.clone(),
-                    path_item_positions: path_item_positions.clone(),
-                },
-                path_item_positions,
-            ),
-            PathfindingResult::Failure(pathfinding_failed) => {
-                simulation_results[index] = SimulationResponse::PathfindingFailed {
-                    pathfinding_failed: pathfinding_failed.clone(),
-                };
-                continue;
-            }
-        };
-
-        // Build simulation request
-        let physics_consist_parameters = consists[&train_schedule.rolling_stock_name].clone();
-
-        let simulation_request = build_simulation_request(
-            infra,
-            train_schedule,
-            path_item_positions,
-            path,
-            electrical_profile_set_id,
-            physics_consist_parameters.into(),
-        );
-
-        // Compute unique hash of the simulation input
-        let simulation_hash = simulation_request
-            .compute_train_simulation_hash_with_versioning(infra.id, infra.version);
-        to_sim
-            .entry(simulation_hash.clone())
-            .or_default()
-            .push(index);
-        sim_request_map
-            .entry(simulation_hash)
-            .or_insert(simulation_request);
-    }
-    info!(
-        nb_train_schedules = train_schedules.len(),
-        nb_unique_sim = to_sim.len()
-    );
-    let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();
-    let cached_results: Vec<Option<SimulationResponse>> = valkey_conn
-        .compressed_get_bulk(&cached_simulation_hash)
-        .await?;
-
-    let nb_hit = cached_results.iter().flatten().count();
-    let nb_miss = to_sim.len() - nb_hit;
-    info!(nb_hit, nb_miss, "Hit cache");
-
-    // Compute simulation from core
-    let mut futures = Vec::with_capacity(nb_miss);
-    let mut futures_hash = Vec::with_capacity(nb_miss);
-    for (train_hash, sim_cached) in cached_simulation_hash.iter().zip(cached_results) {
-        if let Some(sim_cached) = sim_cached {
-            let train_indexes = &to_sim[*train_hash];
-            for train_index in train_indexes {
-                simulation_results[*train_index] = sim_cached.clone();
-            }
-            continue;
-        }
-        let sim_request = &sim_request_map[*train_hash];
-        futures.push(Box::pin(sim_request.fetch(core.as_ref())));
-        futures_hash.push(train_hash);
-    }
-
-    let simulated: Vec<_> = futures::future::join_all(futures)
-        .await
-        .into_iter()
-        .collect();
-
-    let mut to_cache = vec![];
-    for (train_hash, sim_res) in futures_hash.iter().zip(simulated) {
-        let train_indexes = &to_sim[**train_hash];
-        match sim_res {
-            Ok(sim_res) => {
-                to_cache.push((train_hash, sim_res.clone()));
-                train_indexes
-                    .iter()
-                    .for_each(|index| simulation_results[*index] = sim_res.clone())
-            }
-
-            Err(core_error) => {
-                let error: InternalError = core_error.into();
-                train_indexes.iter().for_each(|index| {
-                    simulation_results[*index] = SimulationResponse::SimulationFailed {
-                        core_error: error.clone(),
-                    }
-                })
-            }
-        }
-    }
-
-    // Cache the simulation response
-    valkey_conn.compressed_set_bulk(&to_cache).await?;
-
-    // Return the response
-    Ok(simulation_results
-        .into_iter()
-        .zip(pathfinding_results)
-        .collect())
-}
-
-fn build_simulation_request(
-    infra: &Infra,
-    train_schedule: &models::TrainSchedule,
-    path_item_positions: &[u64],
-    path: SimulationPath,
-    electrical_profile_set_id: Option<i64>,
-    physics_consist: PhysicsConsist,
-) -> SimulationRequest {
-    assert_eq!(path_item_positions.len(), train_schedule.path.len());
-    // Project path items to path offset
-    let path_items_to_position: HashMap<_, _> = train_schedule
-        .path
-        .iter()
-        .map(|p| &p.id)
-        .zip(path_item_positions.iter().copied())
-        .collect();
-
-    let schedule = train_schedule
-        .schedule
-        .iter()
-        .map(|schedule_item| SimulationScheduleItem {
-            path_offset: path_items_to_position[&schedule_item.at],
-            arrival: schedule_item
-                .arrival
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            stop_for: schedule_item
-                .stop_for
-                .as_ref()
-                .map(|t| t.num_milliseconds() as u64),
-            reception_signal: schedule_item.reception_signal,
-        })
-        .collect();
-
-    let margins = SimulationMargins {
-        boundaries: train_schedule
-            .margins
-            .boundaries
-            .iter()
-            .map(|at| path_items_to_position[at])
-            .collect(),
-        values: train_schedule.margins.values.clone(),
-    };
-
-    let power_restrictions = train_schedule
-        .power_restrictions
-        .iter()
-        .map(|item| SimulationPowerRestrictionItem {
-            from: path_items_to_position[&item.from],
-            to: path_items_to_position[&item.to],
-            value: item.value.clone(),
-        })
-        .collect();
-
-    SimulationRequest {
-        infra: infra.id,
-        expected_version: infra.version,
-        path,
-        schedule,
-        margins,
-        initial_speed: train_schedule.initial_speed,
-        comfort: train_schedule.comfort,
-        constraint_distribution: train_schedule.constraint_distribution,
-        speed_limit_tag: train_schedule.speed_limit_tag.clone(),
-        power_restrictions,
-        options: train_schedule.options.clone(),
-        physics_consist,
-        electrical_profile_set_id,
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -905,7 +611,7 @@ pub mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let train_schedule_base = TrainSchedule {
             rolling_stock_name: rolling_stock.name.clone(),
-            ..serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
+            ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
                 .expect("Unable to parse")
         };
         let train_schedule: Changeset<models::TrainSchedule> = TrainScheduleForm {
@@ -961,7 +667,7 @@ pub mod tests {
         let timetable = create_timetable(&mut db_pool.get_ok()).await;
         let train_schedule_base = TrainSchedule {
             rolling_stock_name: rolling_stock.name.clone(),
-            ..serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
+            ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
                 .expect("Unable to parse")
         };
         let train_schedule: Changeset<models::TrainSchedule> = TrainScheduleForm {


### PR DESCRIPTION
After discussions with @leovalais concerning the`timetable`, `paced trains` and `train schedule` modules, it was agreed that we needed to improve the editoast tree structure of these modules, as many structures and functions were used in timetable, paced trains and train schedule. 

We decided to put everything under: timetable.


##  Tree structure

here's the tree structure:    
       - views
          - mod.rs
          - timetable.rs
          - timetable
              - paced_train.rs
              - train_schedule.rs
              - simulation.rs   

- enum `SimulationSummaryResult` moves from `mod.rs` to `simulation.rs`
- functions `train_simulation_batch`, `consist_train_simulation_batch` and `build_simulation_request` move from  `train_schedule.rs` to `simulation.rs`
- struct `InfraIdQueryParam` moves from `views/mod.rs` to `views/infra.rs`
- struct `ListId` moves from `views/mod.rs` to `views/paced_train.rs` and `views/train_schedule.rs`
