### PR TITLE
front: turn STDCM feedback button into a link

### DIFF
--- a/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@osrd-project/ui-core';
 import { Comment } from '@osrd-project/ui-icons';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
@@ -59,10 +58,6 @@ ${separator}
 
   const mailtoLink = `mailto:${stdcmFeedbackMail}?subject=${subject}&body=${body}`;
 
-  const handleEmailClick = () => {
-    window.open(mailtoLink, '_blank');
-  };
-
   return (
     <div className="feedback-card" data-testid="feedback-card">
       <div className="feedback-separator" />
@@ -74,15 +69,13 @@ ${separator}
       </div>
       <p className="feedback-card-text" data-testid="feedback-card-text">
         {t('mailFeedback.description')}
+        <br />
+        <strong>
+          <a data-testid="feedback-button" href={mailtoLink}>
+            {t('mailFeedback.writeButton')}
+          </a>
+        </strong>
       </p>
-      <Button
-        data-testid="feedback-button"
-        label={t('mailFeedback.writeButton')}
-        variant="Cancel"
-        size="medium"
-        onClick={handleEmailClick}
-        data-mailto={mailtoLink} // Expose mailto link for easier E2E testing
-      />
     </div>
   );
 };

--- a/front/tests/pages/stdcm/simulation-results-page.ts
+++ b/front/tests/pages/stdcm/simulation-results-page.ts
@@ -224,7 +224,7 @@ class SimulationResultPage extends STDCMPage {
     expectedBody: string,
     expectedEmail: string
   ) {
-    const mailtoUrl = await this.feedbackButton.getAttribute('data-mailto');
+    const mailtoUrl = await this.feedbackButton.getAttribute('href');
 
     const decodedUrl = decodeURIComponent(mailtoUrl!);
 


### PR DESCRIPTION
Thibaut said there is no form here so a button makes more sense.

Fixes a popup on Safari: "This website has been blocked from automatically composing an email". `window.open()` is blocked, while a regular link is not.

Mockup from Thibaut:

![image](https://github.com/user-attachments/assets/a086aa73-0672-4ceb-afa7-7f8d3896ce9a)
