### PR TITLE
editoast: update `pathfinding` to handle `OsrdError` from `core` service

### DIFF
--- a/editoast/src/core/mod.rs
+++ b/editoast/src/core/mod.rs
@@ -305,6 +305,21 @@ impl Display for StandardCoreError {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct RawError {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+    pub context: HashMap<String, serde_json::Value>,
+    pub cause: ErrorCause,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub enum ErrorCause {
+    Internal,
+    User,
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -7,8 +7,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::core::{AsCoreRequest, Json};
-use crate::error::InternalError;
+use crate::core::AsCoreRequest;
+use crate::core::Json;
+use crate::core::RawError;
 
 editoast_common::schemas! {
     IncompatibleConstraints,
@@ -99,7 +100,7 @@ pub enum PathfindingCoreResult {
         rolling_stock_name: String,
     },
     InternalError {
-        core_error: InternalError,
+        core_error: RawError,
     },
 }
 

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -379,4 +379,19 @@ impl ErrorDefinition {
     }
 }
 
+impl From<crate::core::RawError> for InternalError {
+    fn from(core_error: crate::core::RawError) -> Self {
+        let status = match core_error.cause {
+            core::ErrorCause::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+            core::ErrorCause::User => StatusCode::BAD_REQUEST,
+        };
+        Self {
+            status,
+            error_type: core_error.error_type,
+            context: core_error.context,
+            message: core_error.message,
+        }
+    }
+}
+
 inventory::collect!(ErrorDefinition);

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -155,7 +155,9 @@ impl From<PathfindingCoreResult> for PathfindingResult {
                 ))
             }
             PathfindingCoreResult::InternalError { core_error } => {
-                PathfindingResult::Failure(PathfindingFailure::InternalError { core_error })
+                PathfindingResult::Failure(PathfindingFailure::InternalError {
+                    core_error: core_error.into(),
+                })
             }
         }
     }


### PR DESCRIPTION
The `core` service returns `OsrdError`, so this update adds the correct `OsrdError` type and updates pathfinding to handle it properly.
It’s part of a larger refactor of core error handling. If this approach works well, I will apply the same changes to `core::simulation` (which requires more refactoring and a new structure for the core response, which is why it’s not included in this PR).