### PR TITLE
editoast: refactor `core::simulation`

### DIFF
--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -26,10 +26,10 @@ use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use super::RawError;
 use super::pathfinding::TrackRange;
 use crate::core::AsCoreRequest;
 use crate::core::Json;
-use crate::error::InternalError;
 
 editoast_common::schemas! {
     CompleteReportTrain,
@@ -495,7 +495,7 @@ pub enum Response {
         electrical_profiles: ElectricalProfiles,
     },
     SimulationFailed {
-        core_error: InternalError,
+        core_error: RawError,
     },
 }
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -30,7 +30,6 @@ use super::pathfinding::TrackRange;
 use crate::core::AsCoreRequest;
 use crate::core::Json;
 use crate::error::InternalError;
-use crate::views::path::pathfinding::PathfindingFailure;
 
 editoast_common::schemas! {
     CompleteReportTrain,
@@ -40,7 +39,6 @@ editoast_common::schemas! {
     RoutingZoneRequirement,
     ZoneUpdate,
     ReportTrain,
-    SimulationResponse,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Derivative, ToSchema)]
@@ -480,7 +478,7 @@ pub struct SimulationRequest {
     pub electrical_profile_set_id: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 #[serde(tag = "status", rename_all = "snake_case")]
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
@@ -491,16 +489,10 @@ pub enum SimulationResponse {
         base: ReportTrain,
         /// Simulation that takes into account the regularity margins
         provisional: ReportTrain,
-        #[schema(inline)]
         /// User-selected simulation: can be base or provisional
         final_output: CompleteReportTrain,
-        #[schema(inline)]
         mrsp: SpeedLimitProperties,
-        #[schema(inline)]
         electrical_profiles: ElectricalProfiles,
-    },
-    PathfindingFailed {
-        pathfinding_failed: PathfindingFailure,
     },
     SimulationFailed {
         core_error: InternalError,
@@ -513,21 +505,6 @@ impl AsCoreRequest<Json<SimulationResponse>> for SimulationRequest {
 
     fn infra_id(&self) -> Option<i64> {
         Some(self.infra)
-    }
-}
-
-impl SimulationResponse {
-    pub fn simulation_run_time(&self) -> Option<u64> {
-        if let SimulationResponse::Success { provisional, .. } = self {
-            Some(
-                *provisional
-                    .times
-                    .last()
-                    .expect("core error: empty simulation result"),
-            )
-        } else {
-            None
-        }
     }
 }
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -461,7 +461,7 @@ pub struct SimulationPowerRestrictionRange {
 
 #[derive(Debug, Serialize, Derivative)]
 #[derivative(Hash)]
-pub struct SimulationRequest {
+pub struct Request {
     pub infra: i64,
     pub expected_version: i64,
     pub path: SimulationPath,
@@ -499,7 +499,7 @@ pub enum Response {
     },
 }
 
-impl AsCoreRequest<Json<Response>> for SimulationRequest {
+impl AsCoreRequest<Json<Response>> for Request {
     const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/standalone_simulation";
 

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -483,7 +483,7 @@ pub struct SimulationRequest {
 // We accepted the difference of memory size taken by variants
 // Since there is only on success and others are error cases
 #[allow(clippy::large_enum_variant)]
-pub enum SimulationResponse {
+pub enum Response {
     Success {
         /// Simulation without any regularity margins
         base: ReportTrain,
@@ -499,7 +499,7 @@ pub enum SimulationResponse {
     },
 }
 
-impl AsCoreRequest<Json<SimulationResponse>> for SimulationRequest {
+impl AsCoreRequest<Json<Response>> for SimulationRequest {
     const METHOD: reqwest::Method = reqwest::Method::POST;
     const URL_PATH: &'static str = "/standalone_simulation";
 

--- a/editoast/src/core/stdcm.rs
+++ b/editoast/src/core/stdcm.rs
@@ -14,8 +14,8 @@ use utoipa::ToSchema;
 use super::conflict_detection::TrainRequirements;
 use super::pathfinding::PathfindingResultSuccess;
 use super::pathfinding::TrackRange;
+use super::simulation;
 use super::simulation::PhysicsConsist;
-use super::simulation::SimulationResponse;
 use crate::core::AsCoreRequest;
 use crate::core::Json;
 
@@ -130,7 +130,7 @@ pub struct UndirectedTrackRange {
 #[allow(clippy::large_enum_variant)]
 pub enum Response {
     Success {
-        simulation: SimulationResponse,
+        simulation: simulation::Response,
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -78,7 +78,6 @@ use crate::core;
 use crate::core::AsCoreRequest;
 use crate::core::CoreClient;
 use crate::core::mq_client;
-use crate::core::simulation::SimulationResponse;
 use crate::core::version::CoreVersionRequest;
 use crate::error::InternalError;
 use crate::error::Result;
@@ -356,7 +355,7 @@ pub enum AppHealthError {
     #[error(transparent)]
     Openfga(anyhow::Error),
     #[error(transparent)]
-    Core(#[from] core::Error),
+    Core(#[from] crate::core::Error),
 }
 
 #[utoipa::path(

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -79,7 +79,6 @@ use crate::core::AsCoreRequest;
 use crate::core::CoreClient;
 use crate::core::mq_client;
 use crate::core::version::CoreVersionRequest;
-use crate::error::InternalError;
 use crate::error::Result;
 use crate::error::{self};
 use crate::generated_data;

--- a/editoast/src/views/projection.rs
+++ b/editoast/src/views/projection.rs
@@ -29,7 +29,6 @@ use crate::core::signal_projection::TrainSimulation;
 use crate::core::simulation::CompleteReportTrain;
 use crate::core::simulation::ReportTrain;
 use crate::core::simulation::SignalCriticalPosition;
-use crate::core::simulation::SimulationResponse;
 use crate::core::simulation::ZoneUpdate;
 use crate::error::Result;
 use crate::models;
@@ -40,6 +39,7 @@ use crate::models::train_schedule::TrainSchedule;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::projection::PathProjection;
 use crate::views::path::projection::TrackLocationFromPath;
+use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::train_simulation_batch;
 use crate::views::timetable::train_schedule::TrainScheduleError;
 
@@ -471,7 +471,7 @@ async fn retrieve_cached_projection(
 async fn extract_train_details(
     infra: &Infra,
     trains_schedules: &[TrainSchedule],
-    simulations: Vec<(SimulationResponse, PathfindingResult)>,
+    simulations: Vec<(simulation::Response, PathfindingResult)>,
     path: &ProjectPathInput,
 ) -> Result<(Vec<String>, Vec<TrainSimulationDetails>)> {
     let ProjectPathInput {
@@ -498,7 +498,7 @@ async fn extract_train_details(
             zone_updates,
             ..
         } = match sim {
-            SimulationResponse::Success { final_output, .. } => final_output,
+            simulation::Response::Success { final_output, .. } => final_output,
             _ => continue,
         };
         let ReportTrain {

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -175,7 +175,6 @@ mod tests {
     use crate::core::simulation::CompleteReportTrain;
     use crate::core::simulation::ElectricalProfiles;
     use crate::core::simulation::ReportTrain;
-    use crate::core::simulation::SimulationResponse;
     use crate::core::simulation::SpeedLimitProperties;
     use crate::models::fixtures::create_fast_rolling_stock;
     use crate::models::fixtures::create_small_infra;
@@ -280,8 +279,8 @@ mod tests {
         }
     }
 
-    fn simulation_response() -> SimulationResponse {
-        SimulationResponse::Success {
+    fn simulation_response() -> core::simulation::Response {
+        core::simulation::Response::Success {
             base: ReportTrain {
                 positions: vec![],
                 times: vec![],

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -45,7 +45,6 @@ use crate::core::conflict_detection::ConflictDetectionRequest;
 use crate::core::conflict_detection::ConflictRequirement;
 use crate::core::conflict_detection::ConflictType;
 use crate::core::conflict_detection::TrainRequirements;
-use crate::core::simulation::SimulationResponse;
 use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
@@ -596,8 +595,8 @@ async fn retrieve_simulations(
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,
 ) -> Result<(
-    Vec<(SimulationResponse, PathfindingResult)>,
-    Vec<(SimulationResponse, PathfindingResult)>,
+    Vec<(simulation::Response, PathfindingResult)>,
+    Vec<(simulation::Response, PathfindingResult)>,
 )> {
     let paced_train_to_ts = paced_trains
         .iter()
@@ -629,9 +628,9 @@ async fn retrieve_simulations(
 fn build_conflict_core_request(
     infra: Infra,
     trains: &[models::TrainSchedule],
-    train_simulations: Vec<(SimulationResponse, PathfindingResult)>,
+    train_simulations: Vec<(simulation::Response, PathfindingResult)>,
     paced_trains: &[models::PacedTrain],
-    paced_train_simulations: Vec<(SimulationResponse, PathfindingResult)>,
+    paced_train_simulations: Vec<(simulation::Response, PathfindingResult)>,
 ) -> ConflictDetectionRequest {
     let mut trains_requirements = HashMap::new();
 
@@ -639,7 +638,7 @@ fn build_conflict_core_request(
     for (train, sim) in trains.iter().zip(train_simulations) {
         let (sim, _) = sim;
         let final_output = match sim {
-            SimulationResponse::Success { final_output, .. } => final_output,
+            simulation::Response::Success { final_output, .. } => final_output,
             _ => continue,
         };
         let key = TrainId::TrainSchedule(train.id).to_string();
@@ -668,7 +667,7 @@ fn build_conflict_core_request(
 
         for (index, (sim, _)) in items.into_iter().enumerate() {
             let final_output = match sim {
-                SimulationResponse::Success { final_output, .. } => final_output,
+                simulation::Response::Success { final_output, .. } => final_output,
                 _ => continue,
             };
 

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -33,7 +33,7 @@ use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::timetable::simulation;
-use crate::views::timetable::simulation::SimulationSummaryResult;
+use crate::views::timetable::simulation::SummaryResponse;
 use crate::views::timetable::simulation::train_simulation_batch;
 
 crate::routes! {
@@ -242,7 +242,7 @@ async fn simulation_summary(
         electrical_profile_set_id,
         ids: paced_train_ids,
     }): Json<SimulationBatchForm>,
-) -> Result<Json<HashMap<i64, SimulationSummaryResult>>> {
+) -> Result<Json<HashMap<i64, SummaryResponse>>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -286,7 +286,7 @@ async fn simulation_summary(
     let simulation_summaries = paced_trains
         .into_iter()
         .zip(simulations)
-        .map(|(paced_train, (sim, _))| (paced_train.id, SimulationSummaryResult::from(sim)))
+        .map(|(paced_train, (sim, _))| (paced_train.id, SummaryResponse::from(sim)))
         .collect();
 
     Ok(Json(simulation_summaries))
@@ -520,7 +520,7 @@ mod tests {
     use crate::views::test_app::TestAppBuilder;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::paced_train::PacedTrainResponse;
-    use crate::views::timetable::simulation::SimulationSummaryResult;
+    use crate::views::timetable::simulation::SummaryResponse;
 
     #[rstest]
     async fn paced_train_post() {
@@ -728,12 +728,12 @@ mod tests {
             "infra_id": infra_id,
             "ids": vec![paced_train_id],
         }));
-        let response: HashMap<i64, SimulationSummaryResult> =
+        let response: HashMap<i64, SummaryResponse> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);
         assert_eq!(
             *response.get(&paced_train_id).unwrap(),
-            SimulationSummaryResult::Success {
+            SummaryResponse::Success {
                 length: 0,
                 time: 0,
                 energy_consumption: 0.0,

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -497,12 +497,12 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
+    use crate::core;
     use crate::core::mocking::MockingClient;
     use crate::core::pathfinding::PathfindingResultSuccess;
     use crate::core::simulation::CompleteReportTrain;
     use crate::core::simulation::ElectricalProfiles;
     use crate::core::simulation::ReportTrain;
-    use crate::core::simulation::SimulationResponse;
     use crate::core::simulation::SpeedLimitProperties;
     use crate::error::InternalError;
     use crate::models;
@@ -660,12 +660,12 @@ mod tests {
             )
             .as_str(),
         );
-        let response: SimulationResponse =
+        let response: core::simulation::Response =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
 
         assert_eq!(
             response,
-            SimulationResponse::Success {
+            core::simulation::Response::Success {
                 base: ReportTrain {
                     positions: vec![],
                     times: vec![],

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -19,7 +19,6 @@ use utoipa::ToSchema;
 
 use super::AppState;
 use super::AuthenticationExt;
-use crate::core::simulation::SimulationResponse;
 use crate::error::Result;
 use crate::models;
 use crate::models::Infra;
@@ -33,8 +32,9 @@ use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
 use crate::views::projection::compute_projected_train_paths;
+use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::SimulationSummaryResult;
-use crate::views::timetable::train_simulation_batch;
+use crate::views::timetable::simulation::train_simulation_batch;
 
 crate::routes! {
     "/paced_train" => {
@@ -373,7 +373,7 @@ async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-) -> Result<Json<SimulationResponse>> {
+) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -16,11 +16,11 @@ use crate::core::simulation::SimulationPath;
 use crate::core::simulation::SimulationPowerRestrictionItem;
 use crate::core::simulation::SimulationScheduleItem;
 use crate::core::simulation::SpeedLimitProperties;
+use crate::error::InternalError;
 use crate::error::Result;
 use crate::models;
 use crate::models::RollingStockModel;
 use crate::views::CoreClient;
-use crate::views::InternalError;
 use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding_from_train_batch;
 use crate::views::rolling_stock::RollingStockError;
@@ -45,7 +45,7 @@ pub const TRAIN_SIZE_BATCH: usize = 100;
 
 editoast_common::schemas! {
     Response,
-    SimulationSummaryResult,
+    SummaryResponse,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
@@ -119,7 +119,8 @@ impl From<crate::core::simulation::Response> for Response {
 #[derive(Debug, Serialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
 #[serde(tag = "status", rename_all = "snake_case")]
-pub enum SimulationSummaryResult {
+#[schema(as = SimulationSummaryResult)]
+pub enum SummaryResponse {
     /// Minimal information on a simulation's result
     Success {
         /// Length of a path in mm
@@ -148,7 +149,7 @@ pub enum SimulationSummaryResult {
     PathfindingInputError(PathfindingInputError),
 }
 
-impl From<simulation::Response> for SimulationSummaryResult {
+impl From<simulation::Response> for SummaryResponse {
     fn from(response: simulation::Response) -> Self {
         match response {
             simulation::Response::Success {

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -108,7 +108,9 @@ impl From<crate::core::simulation::Response> for Response {
                 electrical_profiles,
             },
             crate::core::simulation::Response::SimulationFailed { core_error } => {
-                Self::SimulationFailed { core_error }
+                Self::SimulationFailed {
+                    core_error: core_error.into(),
+                }
             }
         }
     }

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -1,6 +1,7 @@
 use crate::RetrieveBatchUnchecked;
 use crate::ValkeyClient;
 use crate::client::get_app_version;
+use crate::core;
 use crate::core::AsCoreRequest;
 use crate::core::pathfinding::PathfindingInputError;
 use crate::core::pathfinding::PathfindingNotFound;
@@ -13,7 +14,6 @@ use crate::core::simulation::ReportTrain;
 use crate::core::simulation::SimulationMargins;
 use crate::core::simulation::SimulationPath;
 use crate::core::simulation::SimulationPowerRestrictionItem;
-use crate::core::simulation::SimulationRequest;
 use crate::core::simulation::SimulationScheduleItem;
 use crate::core::simulation::SpeedLimitProperties;
 use crate::error::Result;
@@ -281,7 +281,7 @@ pub async fn consist_train_simulation_batch(
 
     let mut simulation_results = vec![None::<simulation::Response>; train_schedules.len()];
     let mut to_sim: HashMap<String, Vec<usize>> = HashMap::default();
-    let mut sim_request_map: HashMap<String, SimulationRequest> = HashMap::default();
+    let mut sim_request_map: HashMap<String, core::simulation::Request> = HashMap::default();
     for (index, (pathfinding, train_schedule)) in
         pathfinding_results.iter().zip(train_schedules).enumerate()
     {
@@ -409,7 +409,7 @@ fn build_simulation_request(
     path: SimulationPath,
     electrical_profile_set_id: Option<i64>,
     physics_consist: PhysicsConsist,
-) -> SimulationRequest {
+) -> core::simulation::Request {
     assert_eq!(path_item_positions.len(), train_schedule.path.len());
     // Project path items to path offset
     let path_items_to_position: HashMap<_, _> = train_schedule
@@ -456,7 +456,7 @@ fn build_simulation_request(
         })
         .collect();
 
-    SimulationRequest {
+    core::simulation::Request {
         infra: infra.id,
         expected_version: infra.version,
         path,
@@ -476,7 +476,7 @@ fn build_simulation_request(
 fn compute_train_simulation_hash_with_versioning(
     infra_id: i64,
     infra_version: i64,
-    simulation_input: &SimulationRequest,
+    simulation_input: &core::simulation::Request,
 ) -> String {
     let osrd_version = get_app_version().unwrap_or_default();
     let mut hasher = DefaultHasher::new();

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -91,10 +91,10 @@ impl Response {
     }
 }
 
-impl From<crate::core::simulation::SimulationResponse> for Response {
-    fn from(response: crate::core::simulation::SimulationResponse) -> Self {
+impl From<crate::core::simulation::Response> for Response {
+    fn from(response: crate::core::simulation::Response) -> Self {
         match response {
-            crate::core::simulation::SimulationResponse::Success {
+            crate::core::simulation::Response::Success {
                 base,
                 provisional,
                 final_output,
@@ -107,7 +107,7 @@ impl From<crate::core::simulation::SimulationResponse> for Response {
                 mrsp,
                 electrical_profiles,
             },
-            crate::core::simulation::SimulationResponse::SimulationFailed { core_error } => {
+            crate::core::simulation::Response::SimulationFailed { core_error } => {
                 Self::SimulationFailed { core_error }
             }
         }

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -1,31 +1,35 @@
 use crate::RetrieveBatchUnchecked;
 use crate::ValkeyClient;
 use crate::client::get_app_version;
-use crate::core;
 use crate::core::AsCoreRequest;
 use crate::core::pathfinding::PathfindingInputError;
 use crate::core::pathfinding::PathfindingNotFound;
 use crate::core::pathfinding::PathfindingResultSuccess;
+use crate::core::simulation::CompleteReportTrain;
+use crate::core::simulation::ElectricalProfiles;
 use crate::core::simulation::PhysicsConsist;
 use crate::core::simulation::PhysicsConsistParameters;
+use crate::core::simulation::ReportTrain;
 use crate::core::simulation::SimulationMargins;
 use crate::core::simulation::SimulationPath;
 use crate::core::simulation::SimulationPowerRestrictionItem;
 use crate::core::simulation::SimulationRequest;
 use crate::core::simulation::SimulationScheduleItem;
+use crate::core::simulation::SpeedLimitProperties;
 use crate::error::Result;
 use crate::models;
 use crate::models::RollingStockModel;
 use crate::views::CoreClient;
 use crate::views::InternalError;
-use crate::views::SimulationResponse;
 use crate::views::path::pathfinding::PathfindingFailure;
 use crate::views::path::pathfinding_from_train_batch;
 use crate::views::rolling_stock::RollingStockError;
 use crate::views::timetable::Infra;
 use crate::views::timetable::PathfindingResult;
+use crate::views::timetable::simulation;
 use editoast_models::DbConnection;
 use itertools::Itertools;
+use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::hash::DefaultHasher;
@@ -40,7 +44,74 @@ use utoipa::ToSchema;
 pub const TRAIN_SIZE_BATCH: usize = 100;
 
 editoast_common::schemas! {
+    Response,
     SimulationSummaryResult,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+// We accepted the difference of memory size taken by variants
+// Since there is only on success and others are error cases
+#[allow(clippy::large_enum_variant)]
+#[schema(as = SimulationResponse)]
+pub enum Response {
+    Success {
+        /// Simulation without any regularity margins
+        base: ReportTrain,
+        /// Simulation that takes into account the regularity margins
+        provisional: ReportTrain,
+        #[schema(inline)]
+        /// User-selected simulation: can be base or provisional
+        final_output: CompleteReportTrain,
+        #[schema(inline)]
+        mrsp: SpeedLimitProperties,
+        #[schema(inline)]
+        electrical_profiles: ElectricalProfiles,
+    },
+    PathfindingFailed {
+        pathfinding_failed: PathfindingFailure,
+    },
+    SimulationFailed {
+        core_error: InternalError,
+    },
+}
+
+impl Response {
+    pub fn simulation_run_time(&self) -> Option<u64> {
+        if let Response::Success { provisional, .. } = self {
+            Some(
+                *provisional
+                    .times
+                    .last()
+                    .expect("core error: empty simulation result"),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+impl From<crate::core::simulation::SimulationResponse> for Response {
+    fn from(response: crate::core::simulation::SimulationResponse) -> Self {
+        match response {
+            crate::core::simulation::SimulationResponse::Success {
+                base,
+                provisional,
+                final_output,
+                mrsp,
+                electrical_profiles,
+            } => Self::Success {
+                base,
+                provisional,
+                final_output,
+                mrsp,
+                electrical_profiles,
+            },
+            crate::core::simulation::SimulationResponse::SimulationFailed { core_error } => {
+                Self::SimulationFailed { core_error }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -75,10 +146,10 @@ pub enum SimulationSummaryResult {
     PathfindingInputError(PathfindingInputError),
 }
 
-impl From<core::simulation::SimulationResponse> for SimulationSummaryResult {
-    fn from(sim: SimulationResponse) -> Self {
-        match sim {
-            SimulationResponse::Success {
+impl From<simulation::Response> for SimulationSummaryResult {
+    fn from(response: simulation::Response) -> Self {
+        match response {
+            simulation::Response::Success {
                 final_output,
                 provisional,
                 base,
@@ -94,7 +165,7 @@ impl From<core::simulation::SimulationResponse> for SimulationSummaryResult {
                     path_item_times_base: base.path_item_times.clone(),
                 }
             }
-            SimulationResponse::PathfindingFailed { pathfinding_failed } => {
+            simulation::Response::PathfindingFailed { pathfinding_failed } => {
                 match pathfinding_failed {
                     PathfindingFailure::InternalError { core_error } => {
                         Self::PathfindingFailure { core_error }
@@ -109,7 +180,7 @@ impl From<core::simulation::SimulationResponse> for SimulationSummaryResult {
                     }
                 }
             }
-            SimulationResponse::SimulationFailed { core_error } => Self::SimulationFailed {
+            simulation::Response::SimulationFailed { core_error } => Self::SimulationFailed {
                 error_type: core_error.error_type,
             },
         }
@@ -126,7 +197,7 @@ pub async fn train_simulation_batch(
     train_schedules: &[models::TrainSchedule],
     infra: &Infra,
     electrical_profile_set_id: Option<i64>,
-) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
+) -> Result<Vec<(simulation::Response, PathfindingResult)>> {
     // Compute path
 
     let train_batches = train_schedules.chunks(TRAIN_SIZE_BATCH);
@@ -187,7 +258,7 @@ pub async fn consist_train_simulation_batch(
     train_schedules: &[models::TrainSchedule],
     consists: &[PhysicsConsistParameters],
     electrical_profile_set_id: Option<i64>,
-) -> Result<Vec<(SimulationResponse, PathfindingResult)>> {
+) -> Result<Vec<(simulation::Response, PathfindingResult)>> {
     let mut valkey_conn = valkey_client.get_connection().await?;
 
     let pathfinding_results = pathfinding_from_train_batch(
@@ -208,7 +279,7 @@ pub async fn consist_train_simulation_batch(
         .map(|consist| (&consist.traction_engine.name, consist))
         .collect();
 
-    let mut simulation_results = vec![None::<SimulationResponse>; train_schedules.len()];
+    let mut simulation_results = vec![None::<simulation::Response>; train_schedules.len()];
     let mut to_sim: HashMap<String, Vec<usize>> = HashMap::default();
     let mut sim_request_map: HashMap<String, SimulationRequest> = HashMap::default();
     for (index, (pathfinding, train_schedule)) in
@@ -231,7 +302,7 @@ pub async fn consist_train_simulation_batch(
                 path_item_positions,
             ),
             PathfindingResult::Failure(pathfinding_failed) => {
-                simulation_results[index] = Some(SimulationResponse::PathfindingFailed {
+                simulation_results[index] = Some(simulation::Response::PathfindingFailed {
                     pathfinding_failed: pathfinding_failed.clone(),
                 });
                 continue;
@@ -269,7 +340,7 @@ pub async fn consist_train_simulation_batch(
         nb_unique_sim = to_sim.len()
     );
     let cached_simulation_hash = to_sim.keys().collect::<Vec<_>>();
-    let cached_results: Vec<Option<SimulationResponse>> = valkey_conn
+    let cached_results: Vec<Option<simulation::Response>> = valkey_conn
         .compressed_get_bulk(&cached_simulation_hash)
         .await?;
 
@@ -306,13 +377,13 @@ pub async fn consist_train_simulation_batch(
                 to_cache.push((train_hash, sim_res.clone()));
                 train_indexes
                     .iter()
-                    .for_each(|index| simulation_results[*index] = Some(sim_res.clone()))
+                    .for_each(|index| simulation_results[*index] = Some(sim_res.clone().into()))
             }
 
             Err(core_error) => {
                 let error: InternalError = core_error.into();
                 train_indexes.iter().for_each(|index| {
-                    simulation_results[*index] = Some(SimulationResponse::SimulationFailed {
+                    simulation_results[*index] = Some(simulation::Response::SimulationFailed {
                         core_error: error.clone(),
                     })
                 })

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -563,6 +563,7 @@ mod tests {
     use uom::si::quantities::Mass;
     use uuid::Uuid;
 
+    use crate::core;
     use crate::core::conflict_detection::Conflict as CoreConflict;
     use crate::core::conflict_detection::ConflictDetectionResponse;
     use crate::core::conflict_detection::ConflictType;
@@ -571,7 +572,6 @@ mod tests {
     use crate::core::simulation::ElectricalProfiles;
     use crate::core::simulation::PhysicsConsist;
     use crate::core::simulation::ReportTrain;
-    use crate::core::simulation::SimulationResponse;
     use crate::core::simulation::SpeedLimitProperties;
     use crate::error::InternalError;
     use crate::models::fixtures::create_fast_rolling_stock;
@@ -677,8 +677,8 @@ mod tests {
         core
     }
 
-    fn simulation_response() -> SimulationResponse {
-        SimulationResponse::Success {
+    fn simulation_response() -> core::simulation::Response {
+        core::simulation::Response::Success {
             base: ReportTrain {
                 positions: vec![],
                 times: vec![],

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -42,7 +42,6 @@ use crate::core::pathfinding::InvalidPathItem;
 use crate::core::pathfinding::PathfindingResultSuccess;
 use crate::core::simulation::PhysicsConsistParameters;
 use crate::core::simulation::RoutingRequirement;
-use crate::core::simulation::SimulationResponse;
 use crate::core::simulation::SpacingRequirement;
 use crate::error::InternalError;
 use crate::error::Result;
@@ -57,6 +56,7 @@ use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::timetable::Conflict;
+use crate::views::timetable::simulation;
 use crate::views::timetable::simulation::consist_train_simulation_batch;
 use crate::views::timetable::train_simulation_batch;
 
@@ -76,7 +76,8 @@ crate::routes! {
 #[allow(clippy::large_enum_variant)]
 enum StdcmResponse {
     Success {
-        simulation: SimulationResponse,
+        #[schema(value_type = SimulationResponse)]
+        simulation: simulation::Response,
         path: PathfindingResultSuccess,
         departure_time: DateTime<Utc>,
     },
@@ -85,7 +86,8 @@ enum StdcmResponse {
         conflicts: Vec<Conflict>,
     },
     PreprocessingSimulationError {
-        error: SimulationResponse,
+        #[schema(value_type = SimulationResponse)]
+        error: simulation::Response,
     },
 }
 
@@ -350,7 +352,7 @@ async fn stdcm(
             path,
             departure_time,
         } => Ok(Json(StdcmResponse::Success {
-            simulation,
+            simulation: simulation.into(),
             path,
             departure_time,
         })),
@@ -376,14 +378,14 @@ async fn stdcm(
 /// that overlap with the possible simulation times.
 fn build_train_requirements(
     train_schedules: Vec<TrainSchedule>,
-    simulation_responses: Vec<SimulationResponse>,
+    simulation_responses: Vec<simulation::Response>,
     departure_time: DateTime<Utc>,
     latest_simulation_end: DateTime<Utc>,
 ) -> HashMap<String, TrainRequirements> {
     let mut trains_requirements = HashMap::new();
     for (train, sim) in train_schedules.iter().zip(simulation_responses) {
         let final_output = match sim {
-            SimulationResponse::Success { final_output, .. } => final_output,
+            simulation::Response::Success { final_output, .. } => final_output,
             _ => continue,
         };
 
@@ -458,7 +460,7 @@ fn is_resource_in_range(
 
 struct VirtualTrainRun {
     train_schedule: TrainSchedule,
-    simulation: SimulationResponse,
+    simulation: simulation::Response,
     pathfinding: PathfindingResult,
 }
 
@@ -569,6 +571,7 @@ mod tests {
     use crate::core::simulation::ElectricalProfiles;
     use crate::core::simulation::PhysicsConsist;
     use crate::core::simulation::ReportTrain;
+    use crate::core::simulation::SimulationResponse;
     use crate::core::simulation::SpeedLimitProperties;
     use crate::error::InternalError;
     use crate::models::fixtures::create_fast_rolling_stock;
@@ -951,7 +954,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response(),
+                    simulation: simulation_response().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime")
@@ -1094,7 +1097,7 @@ mod tests {
             assert_eq!(
                 stdcm_response,
                 StdcmResponse::Success {
-                    simulation: simulation_response(),
+                    simulation: simulation_response().into(),
                     path,
                     departure_time: DateTime::from_str("2024-01-02T00:00:00Z")
                         .expect("Failed to parse datetime")

--- a/editoast/src/views/timetable/stdcm/failure_handler.rs
+++ b/editoast/src/views/timetable/stdcm/failure_handler.rs
@@ -7,11 +7,11 @@ use crate::core::AsCoreRequest;
 use crate::core::CoreClient;
 use crate::core::conflict_detection::ConflictDetectionRequest;
 use crate::core::conflict_detection::WorkSchedulesRequest;
-use crate::core::simulation::SimulationResponse;
 use crate::error::Result;
 use crate::models::train_schedule::TrainSchedule;
 use crate::models::work_schedules::WorkSchedule;
 use crate::views::timetable::Conflict;
+use crate::views::timetable::simulation;
 use crate::views::timetable::stdcm::StdcmResponse;
 
 use super::VirtualTrainRun;
@@ -27,7 +27,7 @@ pub(super) struct SimulationFailureHandler {
     pub(super) infra_id: i64,
     pub(super) infra_version: i64,
     pub(super) train_schedules: Vec<TrainSchedule>,
-    pub(super) simulations: Vec<SimulationResponse>,
+    pub(super) simulations: Vec<simulation::Response>,
     pub(super) work_schedules: Vec<WorkSchedule>,
     pub(super) virtual_train_run: VirtualTrainRun,
     pub(super) earliest_departure_time: DateTime<Utc>,

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -18,11 +18,6 @@ use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::AppState;
-use crate::views::infra::InfraIdQueryParam;
-use crate::views::timetable::simulation::SimulationSummaryResult;
-
-use crate::core::simulation::SimulationResponse;
-
 use crate::error::Result;
 use crate::models;
 use crate::models::infra::Infra;
@@ -30,12 +25,15 @@ use crate::models::prelude::*;
 use crate::models::train_schedule::TrainScheduleChangeset;
 use crate::views::AuthenticationExt;
 use crate::views::AuthorizationError;
+use crate::views::infra::InfraIdQueryParam;
 use crate::views::path::PathfindingError;
 use crate::views::path::pathfinding::PathfindingResult;
 use crate::views::path::pathfinding::pathfinding_from_train;
 use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
 use crate::views::projection::compute_projected_train_paths;
+use crate::views::timetable::simulation;
+use crate::views::timetable::simulation::SimulationSummaryResult;
 
 use super::simulation::train_simulation_batch;
 
@@ -273,7 +271,7 @@ async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-) -> Result<Json<SimulationResponse>> {
+) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
         .await

--- a/editoast/src/views/timetable/train_schedule.rs
+++ b/editoast/src/views/timetable/train_schedule.rs
@@ -33,8 +33,8 @@ use crate::views::projection::ProjectPathForm;
 use crate::views::projection::ProjectPathTrainResult;
 use crate::views::projection::compute_projected_train_paths;
 use crate::views::timetable::simulation;
-use crate::views::timetable::simulation::SimulationSummaryResult;
 
+use super::simulation::SummaryResponse;
 use super::simulation::train_simulation_batch;
 
 crate::routes! {
@@ -342,7 +342,7 @@ async fn simulation_summary(
         electrical_profile_set_id,
         ids: train_schedule_ids,
     }): Json<SimulationBatchForm>,
-) -> Result<Json<HashMap<i64, SimulationSummaryResult>>> {
+) -> Result<Json<HashMap<i64, SummaryResponse>>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
         .await
@@ -380,7 +380,7 @@ async fn simulation_summary(
     let mut simulation_summaries = HashMap::new();
     for (train_schedule, sim) in train_schedules.iter().zip(simulations) {
         let (sim, _) = sim;
-        let simulation_summary_result = SimulationSummaryResult::from(sim);
+        let simulation_summary_result = SummaryResponse::from(sim);
         simulation_summaries.insert(train_schedule.id, simulation_summary_result);
     }
 


### PR DESCRIPTION
> [!WARNING]
> must be merged after https://github.com/OpenRailAssociation/osrd/pull/11486.

The commits improve clarity and structure. The views were updated to use the correct response type instead of `core::SimulationResponse`. `SimulationResponse` and `SimulationRequest` were renamed to `Response` and `Request` for consistency. The `InternalError` type was removed from `Response` to simplify handling. Lastly, `SimulationSummaryResult` was moved to `views::core::simulation` for better organization.

> [!TIP]
> Please review the PR one commit at a time for easier understanding and clearer context.