### PR TITLE
editoast: add 'editoast user/group info' functionality

### DIFF
--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -126,6 +126,30 @@ impl<S: StorageDriver> Regulator<S> {
             .map_err(Error::Storage)
     }
 
+    /// Returns the IDs of the groups for the provided user
+    #[tracing::instrument(skip_all, fields(user_id, group_id), ret(level = Level::DEBUG), err)]
+    pub async fn user_groups(&self, user_id: i64) -> Result<HashSet<i64>, Error<S::Error>> {
+        if !self.user_exists(user_id).await? {
+            return Err(Error::UnknownSubject(user_id));
+        }
+        let user = fga!(User:user_id);
+        let groups = self
+            .openfga
+            .list_users(User::group().query_users(&user))
+            .await?;
+        Ok(groups
+            .users
+            .into_iter()
+            .filter_map(|Group(group)| match group.parse() {
+                Ok(id) => Some(id),
+                Err(_) => {
+                    tracing::error!(group, "unparsable group - skipping it");
+                    None
+                }
+            })
+            .collect())
+    }
+
     /// Returns the IDs of the users which are members of the provided group
     #[tracing::instrument(skip_all, fields(user_id, group_id), ret(level = Level::DEBUG), err)]
     pub async fn group_members(&self, group_id: i64) -> Result<HashSet<i64>, Error<S::Error>> {

--- a/editoast/src/client/group.rs
+++ b/editoast/src/client/group.rs
@@ -5,6 +5,7 @@ use clap::Subcommand;
 
 use editoast_authz::StorageDriver;
 use editoast_authz::subject::GroupInfo;
+use editoast_authz::subject::UserInfo;
 
 use editoast_models::DbConnectionPoolV2;
 use futures::TryStreamExt;
@@ -21,6 +22,8 @@ pub enum GroupCommand {
     Create(CreateArgs),
     /// List groups
     List,
+    /// Get a group's informations
+    Info(InfoArgs),
     /// Add members to a group
     Include(IncludeArgs),
     /// Remove members to a group
@@ -29,6 +32,12 @@ pub enum GroupCommand {
 
 #[derive(Debug, Args)]
 pub struct CreateArgs {
+    /// Group name
+    name: String,
+}
+
+#[derive(Debug, Args)]
+pub struct InfoArgs {
     /// Group name
     name: String,
 }
@@ -67,6 +76,36 @@ pub async fn list_group(pool: Arc<DbConnectionPoolV2>) -> anyhow::Result<()> {
     }
     for (id, GroupInfo { name }) in &groups {
         println!("[{}]: {}", id, name);
+    }
+    Ok(())
+}
+
+pub async fn group_info(
+    InfoArgs { name }: InfoArgs,
+    openfga_config: OpenfgaConfig,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    let regulator = openfga_config.into_regulator(pool).await?;
+    let driver = regulator.driver();
+    let Some(group_id) = driver.get_group_id(&name).await? else {
+        tracing::error!(name, "No such group");
+        return Ok(());
+    };
+    let Some(GroupInfo { name }) = driver.get_group_info(group_id).await? else {
+        tracing::error!(group.id = group_id, "No such group");
+        return Ok(());
+    };
+    let user_ids = regulator.group_members(group_id).await?;
+
+    println!("id     : {group_id}");
+    println!("name   : {name}");
+    println!("members:");
+    for user_id in user_ids {
+        let Some(UserInfo { identity, name }) = driver.get_user_info(user_id).await? else {
+            tracing::error!(user.id = user_id, "user not found, skipping it!");
+            continue;
+        };
+        println!("- [{user_id}] {identity} ({name})");
     }
     Ok(())
 }

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -1,8 +1,8 @@
+use anyhow::anyhow;
 use clap::Args;
 use clap::Subcommand;
 use editoast_authz::StorageDriver;
 use editoast_authz::subject::GroupInfo;
-use editoast_authz::subject::User;
 use editoast_authz::subject::UserInfo;
 use editoast_models::DbConnectionPoolV2;
 use futures::TryStreamExt;
@@ -41,8 +41,8 @@ pub struct AddArgs {
 
 #[derive(Debug, Args)]
 pub struct InfoArgs {
-    /// Identity of the user
-    identity: String,
+    /// Id or identity of the user
+    user: String,
 }
 
 /// List users
@@ -100,23 +100,25 @@ pub async fn add_user(args: AddArgs, pool: Arc<DbConnectionPoolV2>) -> anyhow::R
 
 /// Get a user
 pub async fn user_info(
-    InfoArgs { identity }: InfoArgs,
+    InfoArgs { user }: InfoArgs,
     openfga_config: OpenfgaConfig,
     pool: Arc<DbConnectionPoolV2>,
 ) -> anyhow::Result<()> {
     let regulator = openfga_config.into_regulator(pool).await?;
     let driver = regulator.driver();
-    let Some(User {
-        id,
-        info: UserInfo { identity, name },
-    }) = driver.get_user_info_by_identity(&identity).await?
-    else {
-        tracing::error!(user.identity = identity, "User not found");
+    let uid = if let Ok(id) = user.parse::<i64>() {
+        id
+    } else {
+        let uid = driver.get_user_id(&user).await?;
+        uid.ok_or_else(|| anyhow!("No user with identity '{user}' found"))?
+    };
+    let Some(UserInfo { identity, name }) = driver.get_user_info(uid).await? else {
+        tracing::error!(user.id = uid, "User not found");
         return Ok(());
     };
-    let group_ids = regulator.user_groups(id).await?;
+    let group_ids = regulator.user_groups(uid).await?;
 
-    println!("id      : {id}");
+    println!("id      : {uid}");
     println!("identity: {identity}");
     println!("name    : {name}");
     println!("groups  :");

--- a/editoast/src/client/user.rs
+++ b/editoast/src/client/user.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 use clap::Subcommand;
 use editoast_authz::StorageDriver;
+use editoast_authz::subject::GroupInfo;
+use editoast_authz::subject::User;
 use editoast_authz::subject::UserInfo;
 use editoast_models::DbConnectionPoolV2;
 use futures::TryStreamExt;
@@ -18,6 +20,8 @@ pub enum UserCommand {
     List(ListArgs),
     /// Add a user
     Add(AddArgs),
+    /// Get information about a user
+    Info(InfoArgs),
 }
 
 #[derive(Debug, Args)]
@@ -33,6 +37,12 @@ pub struct AddArgs {
     identity: String,
     /// Name of the user
     name: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct InfoArgs {
+    /// Identity of the user
+    identity: String,
 }
 
 /// List users
@@ -85,5 +95,41 @@ pub async fn add_user(args: AddArgs, pool: Arc<DbConnectionPoolV2>) -> anyhow::R
     };
     let subject_id = driver.ensure_user(&user_info).await?;
     println!("User added with id: {}", subject_id);
+    Ok(())
+}
+
+/// Get a user
+pub async fn user_info(
+    InfoArgs { identity }: InfoArgs,
+    openfga_config: OpenfgaConfig,
+    pool: Arc<DbConnectionPoolV2>,
+) -> anyhow::Result<()> {
+    let regulator = openfga_config.into_regulator(pool).await?;
+    let driver = regulator.driver();
+    let Some(User {
+        id,
+        info: UserInfo { identity, name },
+    }) = driver.get_user_info_by_identity(&identity).await?
+    else {
+        tracing::error!(user.identity = identity, "User not found");
+        return Ok(());
+    };
+    let group_ids = regulator.user_groups(id).await?;
+
+    println!("id      : {id}");
+    println!("identity: {identity}");
+    println!("name    : {name}");
+    println!("groups  :");
+    for group_id in group_ids {
+        let Some(GroupInfo { name }) = driver.get_group_info(group_id).await? else {
+            tracing::warn!(
+                group.id = group_id,
+                group.name = name,
+                "group not found, skipping it!"
+            );
+            continue;
+        };
+        println!("- [{group_id}] {name}");
+    }
     Ok(())
 }

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -214,6 +214,11 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
             GroupCommand::List => group::list_group(Arc::new(db_pool))
                 .await
                 .map_err(Into::into),
+            GroupCommand::Info(info_args) => {
+                group::group_info(info_args, openfga_config, Arc::new(db_pool))
+                    .await
+                    .map_err(Into::into)
+            }
             GroupCommand::Include(include_args) => {
                 group::include_group(include_args, openfga_config, Arc::new(db_pool))
                     .await

--- a/editoast/src/main.rs
+++ b/editoast/src/main.rs
@@ -234,6 +234,11 @@ async fn run() -> Result<(), Box<dyn Error + Send + Sync>> {
             UserCommand::Add(add_args) => user::add_user(add_args, Arc::new(db_pool))
                 .await
                 .map_err(Into::into),
+            UserCommand::Info(info_args) => {
+                user::user_info(info_args, openfga_config, Arc::new(db_pool))
+                    .await
+                    .map_err(Into::into)
+            }
         },
         Commands::Healthcheck(core_config) => {
             healthcheck_cmd(db_pool.into(), valkey_config, core_config, openfga_config)


### PR DESCRIPTION
When trying to debug some problems with user's authorizations with @clarani, we noticed these 2 functionalities would be useful:
- get some information about a user (and notably, all the groups the user is in)
- get some information about a group (and notably, all the members of the group)

```
❯ editoast group info dev
id     : 54
name   : dev
members:
- [53] my-home/woshilapin (Jean SIMARD)

❯ editoast user info dev
id      : 53
identity: my-home/woshilapin
name    : Jean SIMARD
groups  :
- [54] dev
```

Each functionality is split in a different commit.