### PR TITLE
front: fix psl panels speed rounding in infra editor

### DIFF
--- a/front/src/applications/editor/tools/rangeEdition/speedSection/EditPSLSection.tsx
+++ b/front/src/applications/editor/tools/rangeEdition/speedSection/EditPSLSection.tsx
@@ -27,15 +27,14 @@ const getNewAnnouncementSign = (
   speedLimit: number
 ) => {
   const firstRange = trackRanges[0];
-  const speedInKmH = msToKmh(speedLimit);
-  const speedMultipleOfFive = Math.ceil(speedInKmH / 5) * 5;
+  const speedInKmH = Math.round(msToKmh(speedLimit));
   return {
     direction: 'START_TO_STOP',
     position: firstRange.begin,
     side: 'LEFT',
     track: firstRange.track,
     type: 'TIV_D',
-    value: `${speedMultipleOfFive}`,
+    value: `${speedInKmH}`,
     kp: '',
   } as PSLSign;
 };


### PR DESCRIPTION
Close #6547 

This is the simplest fix so that entering a speed that is already a multiple of 5 will give us the same value at the end. 

However if ceiling rather than rounding is an intended behavior we want to keep, we could either : 
- substract a small numerical value (-0.001 should dominate all float errors) before ceiling
- ensure we pass the actual value in km/h to the sign component without converting to ms first