### PR TITLE
front: fix disabled speed tag select in infra editor

### DIFF
--- a/front/src/applications/editor/components/LayersModal.tsx
+++ b/front/src/applications/editor/components/LayersModal.tsx
@@ -194,7 +194,7 @@ const LayersModal = ({ initialLayers, selection, frozenLayers, onChange }: Layer
             id="speedLimitTag"
             className="form-control"
             value={layersSettings.speedlimittag || DEFAULT_SPEED_LIMIT_TAG}
-            disabled={!isArray(allSpeedLimitTags) || !selectedLayers.has('speed_sections')}
+            disabled={!isArray(allSpeedLimitTags)}
             onChange={(e) => {
               const newTag = e.target.value !== DEFAULT_SPEED_LIMIT_TAG ? e.target.value : null;
               dispatch(


### PR DESCRIPTION
Close #7265

Alternatively, we could disable the select if both speed limits and permanent speed limits are not selected (and make it clearer through styling). Still, the issue implies we should remove this disable all together.