### PR TITLE
editoast: add `primary_category` and `other_categories` in light rolling stock endpoints

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8094,6 +8094,8 @@ components:
       - power_restrictions
       - energy_sources
       - supported_signaling_systems
+      - primary_category
+      - other_categories
       properties:
         base_power_class:
           type: string
@@ -8145,10 +8147,14 @@ components:
           nullable: true
         name:
           type: string
+        other_categories:
+          $ref: '#/components/schemas/RollingStockCategories'
         power_restrictions:
           type: object
           additionalProperties:
             type: string
+        primary_category:
+          $ref: '#/components/schemas/RollingStockCategory'
         railjson_version:
           type: string
         rolling_resistance:

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -14,6 +14,8 @@ use editoast_common::units::quantities::Time;
 use editoast_common::units::quantities::Velocity;
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
+use editoast_models::rolling_stock::RollingStockCategories;
+use editoast_models::rolling_stock::RollingStockCategory;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::EnergySource;
 use editoast_schemas::rolling_stock::EtcsBrakeParams;
@@ -250,6 +252,8 @@ struct LightRollingStock {
     power_restrictions: HashMap<String, String>,
     energy_sources: Vec<EnergySource>,
     supported_signaling_systems: RollingStockSupportedSignalingSystems,
+    primary_category: RollingStockCategory,
+    other_categories: RollingStockCategories,
 }
 
 impl From<RollingStockModel> for LightRollingStock {
@@ -276,6 +280,8 @@ impl From<RollingStockModel> for LightRollingStock {
             energy_sources,
             locked,
             supported_signaling_systems,
+            primary_category,
+            other_categories,
             ..
         }: RollingStockModel,
     ) -> Self {
@@ -301,6 +307,8 @@ impl From<RollingStockModel> for LightRollingStock {
             power_restrictions,
             energy_sources,
             supported_signaling_systems,
+            primary_category,
+            other_categories,
         }
     }
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3086,6 +3086,18 @@ export type RollingStockMetadata = {
   type: string;
   unit: string;
 };
+export type RollingStockCategory =
+  | 'HIGH_SPEED_TRAIN'
+  | 'INTERCITY_TRAIN'
+  | 'REGIONAL_TRAIN'
+  | 'NIGHT_TRAIN'
+  | 'COMMUTER_TRAIN'
+  | 'FREIGHT_TRAIN'
+  | 'FAST_FREIGHT_TRAIN'
+  | 'TRAM_TRAIN'
+  | 'TOURISTIC_TRAIN'
+  | 'WORK_TRAIN';
+export type RollingStockCategories = RollingStockCategory[];
 export type RollingResistance = {
   /** Solid friction
     Solid Friction in N */
@@ -3121,9 +3133,11 @@ export type LightRollingStock = {
   max_speed: number;
   metadata: RollingStockMetadata | null;
   name: string;
+  other_categories: RollingStockCategories;
   power_restrictions: {
     [key: string]: string;
   };
+  primary_category: RollingStockCategory;
   railjson_version: string;
   rolling_resistance: RollingResistance;
   /** Acceleration in m·s⁻² */
@@ -3573,18 +3587,6 @@ export type EffortCurves = {
     [key: string]: ModeEffortCurves;
   };
 };
-export type RollingStockCategory =
-  | 'HIGH_SPEED_TRAIN'
-  | 'INTERCITY_TRAIN'
-  | 'REGIONAL_TRAIN'
-  | 'NIGHT_TRAIN'
-  | 'COMMUTER_TRAIN'
-  | 'FREIGHT_TRAIN'
-  | 'FAST_FREIGHT_TRAIN'
-  | 'TRAM_TRAIN'
-  | 'TOURISTIC_TRAIN'
-  | 'WORK_TRAIN';
-export type RollingStockCategories = RollingStockCategory[];
 export type RollingStock = {
   base_power_class: string | null;
   /** Acceleration in m·s⁻² */


### PR DESCRIPTION
part of https://github.com/OpenRailAssociation/osrd/issues/11507