### PR TITLE
core: pathfinding: add some telemetry trace spans

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -26,6 +26,8 @@ import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.io.File
 import java.time.Duration
 import java.time.Instant
@@ -71,6 +73,7 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
         return run(request)
     }
 
+    @WithSpan(value = "Processing pathfinding request", kind = SpanKind.SERVER)
     fun run(request: PathfindingBlockRequest): Response {
         val recorder = DiagnosticRecorderImpl(false)
         try {
@@ -268,6 +271,7 @@ private fun getTargetsOnEdges(
     return targetsOnEdges
 }
 
+@WithSpan(value = "Identifying why no path was found")
 private fun throwNoPathFoundException(
     infra: FullInfra,
     waypoints: ArrayList<Collection<PathfindingEdgeLocationId<Block>>>,
@@ -407,6 +411,7 @@ private fun getBlockOffset(
     )
 }
 
+@WithSpan(value = "Building heuristic")
 private fun makeHeuristicsForPathfindingEdges(
     infra: FullInfra,
     waypoints: List<Collection<PathfindingEdgeLocationId<Block>>>,

--- a/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/pathfinding/Pathfinding.kt
@@ -9,6 +9,8 @@ import fr.sncf.osrd.reporting.exceptions.OSRDError
 import fr.sncf.osrd.utils.indexing.StaticIdx
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
 import java.time.Instant
 import java.util.*
@@ -186,6 +188,7 @@ class Pathfinding<NodeT : Any, EdgeT : Any, OffsetType>(
      * Dijkstra algorithm by default, but can be changed to an A* by specifying a function to
      * estimate the remaining distance, using `setRemainingDistanceEstimator`
      */
+    @WithSpan(value = "Running core pathfinding algorithm", kind = SpanKind.SERVER)
     fun runPathfinding(
         starts: Collection<EdgeLocation<EdgeT, OffsetType>>,
         targetsOnEdges: List<TargetsOnEdge<EdgeT, OffsetType>>


### PR DESCRIPTION
I haven't *really* tested, it's difficult to test datadog related code locally (I don't know if it's even possible). But it shouldn't work differently from the spans in stdcm, it's pretty straightforward. 