### PR TITLE
front: fix paced train occurrences inverted names

### DIFF
--- a/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceItem.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/PacedTrain/OccurrenceItem.tsx
@@ -60,8 +60,8 @@ const OccurrenceItem = ({
       <div className="occurrence-item-dot">
         <Dot variant="fill" />
       </div>
-      <div className="occurrence-item-name" title={trainName}>
-        {trainName}
+      <div className="occurrence-item-name">
+        <span title={trainName}>{trainName}</span>
       </div>
       <div className="rolling-stock">
         {rollingStock && <RollingStock2Img rollingStock={rollingStock} />}

--- a/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_pacedTrain.scss
@@ -144,19 +144,20 @@
         border-bottom: 1px solid var(--black50);
       }
       &-name {
-        white-space: nowrap;
         overflow: hidden;
-        /* "overflow" value must be different from "visible" */
+        white-space: nowrap;
         text-overflow: ellipsis;
-        width: 56px;
         direction: rtl;
-        text-align: left;
+        width: 56px;
         height: 24px;
         line-height: 24px;
-        min-width: 56px;
         margin-inline: 8px;
-      }
 
+        span {
+          unicode-bidi: embed;
+          direction: ltr;
+        }
+      }
       &:last-child {
         border-bottom: none;
       }


### PR DESCRIPTION
closes #11548 

`Reverted ellipsis` doesn't exist, so we use a little trickery to display the name correctly when we have a combination of numbers + letters. As for the title, we can't keep it as it is; we have to stylize it so that it returns the right value.