### PR TITLE
core: telemetry: log payload file in span data

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/pathfinding/PathfindingBlocksEndpoint.kt
@@ -26,6 +26,7 @@ import fr.sncf.osrd.utils.indexing.*
 import fr.sncf.osrd.utils.units.Length
 import fr.sncf.osrd.utils.units.Offset
 import fr.sncf.osrd.utils.units.meters
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.io.File
@@ -65,7 +66,9 @@ class PathfindingBlocksEndpoint(private val infraManager: InfraProvider) : Take 
         if (logRequest?.equals("true", ignoreCase = true) == true) {
             val time = LocalDateTime.now()
             val formatted = time.format(DateTimeFormatter.ofPattern("MM-dd-HH:mm:ss:SSS"))
-            File("pathfinding-$formatted.json").printWriter().use {
+            val filename = "pathfinding-$formatted.json"
+            Span.current()?.setAttribute("request-file", filename)
+            File(filename).printWriter().use {
                 it.println(pathfindingRequestAdapter.indent("    ").toJson(request))
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/standalone_sim/SimulationEndpoint.kt
@@ -14,6 +14,7 @@ import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.indexing.StaticIdxList
 import fr.sncf.osrd.utils.indexing.mutableStaticIdxArrayListOf
 import fr.sncf.osrd.utils.makeChunkPath
+import io.opentelemetry.api.trace.Span
 import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -41,7 +42,9 @@ class SimulationEndpoint(
         if (logRequest?.equals("true", ignoreCase = true) == true) {
             val time = LocalDateTime.now()
             val formatted = time.format(DateTimeFormatter.ofPattern("MM-dd-HH:mm:ss:SSS"))
-            File("simulation-$formatted.json").printWriter().use {
+            val filename = "simulation-$formatted.json"
+            Span.current()?.setAttribute("request-file", filename)
+            File(filename).printWriter().use {
                 it.println(SimulationRequest.adapter.indent("    ").toJson(request))
             }
         }

--- a/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/api/stdcm/STDCMEndpoint.kt
@@ -41,6 +41,7 @@ import fr.sncf.osrd.utils.DistanceRangeMap.RangeMapEntry
 import fr.sncf.osrd.utils.distanceRangeMapOf
 import fr.sncf.osrd.utils.toIdxList
 import fr.sncf.osrd.utils.units.*
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.io.File
@@ -68,7 +69,9 @@ class STDCMEndpoint(private val infraManager: InfraProvider) : Take {
         if (logRequest?.equals("true", ignoreCase = true) == true) {
             val time = LocalDateTime.now()
             val formatted = time.format(DateTimeFormatter.ofPattern("MM-dd-HH:mm:ss:SSS"))
-            File("stdcm-$formatted.json").printWriter().use {
+            val filename = "stdcm-$formatted.json"
+            Span.current()?.setAttribute("request-file", filename)
+            File(filename).printWriter().use {
                 it.println(stdcmRequestAdapter.indent("    ").toJson(request))
             }
         }


### PR DESCRIPTION
Little quality of life change for local debugging: this makes it easier (for example) to track which payloads were too slow in a batch import.

I *tried* to include metadata such as train names in the span on editoast side, but that kind of metadata is removed from the relevant data way too early in the pipeline. 