### PR TITLE
front: fix infra json file input not accepting same file twice in chrome

### DIFF
--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -55,6 +55,7 @@ const InfraSelectorModalBodyEdition = ({
         setErrorMessage(undefined);
         setSelectedFile(event.target.files[0]);
       }
+      event.target.value = ''; // Resets the input value to let the onChange retrigger on consecutive inputs with the same file/path, necessary on chrome
     }
   };
 


### PR DESCRIPTION
Close #8113

The file input worked fine on firefox, but on chrome/ium it needs to be reset manually for the onChange event to trigger again when the same file is given again. It may be worth testing the input behavior on more exotic browsers.

Solution shamelessly stolen from https://stackoverflow.com/questions/42192346/how-to-reset-reactjs-file-input ^^