### PR TITLE
front: use customized name for STDCM in email feedback

### DIFF
--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -53,10 +53,10 @@
     "posterior": "Indicate posterior train"
   },
   "mailFeedback": {
-    "body": "We invite you to send us a message.\nAs soon as you have a concern or a remark,\neven if it's not perfectly worded.\n\nThank you in advance,\nThe LMR project team\n\n(you may delete this message)",
-    "description": "Help us improve ST DCM by sending us your feedback and suggestions.",
+    "body": "We invite you to send us a message.\nAs soon as you have a concern or a remark,\neven if it's not perfectly worded.\n\nThank you in advance,\nThe {{stdcmName}} project team\n\n(you may delete this message)",
+    "description": "Help us improve {{stdcmName}} by sending us your feedback and suggestions.",
     "simulationDetails": "Simulation details",
-    "subject": "LMR - feedback, suggestions",
+    "subject": "{{stdcmName}} - feedback, suggestions",
     "title": "Any feedback or suggestions?",
     "writeButton": "Write"
   },

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -53,10 +53,10 @@
     "posterior": "Indiquer le sillon postérieur"
   },
   "mailFeedback": {
-    "body": "Nous vous invitons à nous envoyer un message.\nDès que vous avez une gêne ou une remarque,\nmême si vous n'y mettez pas la forme.\n\nMerci à vous par avance,\nL'équipe du projet LMR\n\n(vous pouvez effacer ce message)",
-    "description": "Aidez-nous à améliorer ST DCM en transmettant vos critiques et propositions à l’équipe.",
+    "body": "Nous vous invitons à nous envoyer un message.\nDès que vous avez une gêne ou une remarque,\nmême si vous n'y mettez pas la forme.\n\nMerci à vous par avance,\nL'équipe du projet {{stdcmName}}\n\n(vous pouvez effacer ce message)",
+    "description": "Aidez-nous à améliorer {{stdcmName}} en transmettant vos critiques et propositions à l’équipe.",
     "simulationDetails": "Détails de la simulation",
-    "subject": "LMR - remarques, suggestions",
+    "subject": "{{stdcmName}} - remarques, suggestions",
     "title": "Une remarque, une suggestion ?",
     "writeButton": "Écrire"
   },

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmFeedback.tsx
@@ -6,13 +6,11 @@ import { useSelector } from 'react-redux';
 import type { StdcmResultsOutput } from 'applications/stdcm/types';
 import { getSelectedSimulation } from 'reducers/osrdconf/stdcmConf/selectors';
 import { dateTimeFormatting } from 'utils/date';
+import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
-type StdcmFeedbackProps = {
-  stdcmFeedbackMail?: string;
-};
-
-const StdcmFeedback = ({ stdcmFeedbackMail }: StdcmFeedbackProps) => {
+const StdcmFeedback = () => {
   const { t } = useTranslation('stdcm');
+  const { stdcmName, stdcmFeedbackMail } = useDeploymentSettings() ?? { stdcmName: 'STDCM' };
   const selectedSimulation = useSelector(getSelectedSimulation);
 
   const resultsOutput = selectedSimulation.outputs as StdcmResultsOutput;
@@ -29,7 +27,7 @@ const StdcmFeedback = ({ stdcmFeedbackMail }: StdcmFeedbackProps) => {
     dayjs.utc(resultsOutput.results.departure_time).toDate()
   );
 
-  const subject = encodeURIComponent(t('mailFeedback.subject'));
+  const subject = encodeURIComponent(t('mailFeedback.subject', { stdcmName }));
   const separator = '********';
 
   const messageContent = `
@@ -49,7 +47,7 @@ ${t('departureTime')}: ${departureTime}
 
 ${separator}
 
-${t('mailFeedback.body')}
+${t('mailFeedback.body', { stdcmName })}
 
 ${separator}
 `;
@@ -68,7 +66,7 @@ ${separator}
         </h3>
       </div>
       <p className="feedback-card-text" data-testid="feedback-card-text">
-        {t('mailFeedback.description')}
+        {t('mailFeedback.description', { stdcmName })}
         <br />
         <strong>
           <a data-testid="feedback-button" href={mailtoLink}>

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -160,9 +160,7 @@ const StdcmResults = ({
                     />
                   </div>
                 )}
-                {selectedSimulation && (
-                  <FeedbackCard stdcmFeedbackMail={deploymentSettings?.stdcmFeedbackMail} />
-                )}
+                {selectedSimulation && <FeedbackCard />}
               </div>
             ) : (
               <div className="simulation-failure">

--- a/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/StdcmResults.tsx
@@ -23,7 +23,7 @@ import useDeploymentSettings from 'utils/hooks/useDeploymentSettings';
 
 import SimulationReportSheet from './SimulationReportSheet';
 import StdcmDebugResults from './StdcmDebugResults';
-import FeedbackCard from './StdcmFeedback';
+import StdcmFeedback from './StdcmFeedback';
 import StcdmResultsTable from './StdcmResultsTable';
 import StdcmSimulationNavigator from './StdcmSimulationNavigator';
 
@@ -160,7 +160,7 @@ const StdcmResults = ({
                     />
                   </div>
                 )}
-                {selectedSimulation && <FeedbackCard />}
+                {selectedSimulation && <StdcmFeedback />}
               </div>
             ) : (
               <div className="simulation-failure">

--- a/front/tests/assets/constants/mail-feedback-const.ts
+++ b/front/tests/assets/constants/mail-feedback-const.ts
@@ -20,7 +20,7 @@ const getMailFeedbackData = () => {
     fr: frTranslations,
   });
 
-  const expectedSubject = translations.mailFeedback.subject;
+  const expectedSubject = translations.mailFeedback.subject.replace('{{stdcmName}}', 'Stdcm');
 
   const expectedBody = `
 ********
@@ -39,7 +39,7 @@ ${translations.departureTime}: ${departureTime}
 
 ********
 
-${translations.mailFeedback.body}
+${translations.mailFeedback.body.replace('{{stdcmName}}', 'Stdcm')}
 
 ********
 `;


### PR DESCRIPTION
PR #11394 has fixed one place, but missed another. While at it, stop hardcoding "LMR" in the translation files.

Closes: https://github.com/OpenRailAssociation/osrd/issues/11327