### PR TITLE
ui-charts: fix useManchetteWithSpaceTimeChart() errors with zero waypoints

### DIFF
--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -365,6 +365,7 @@ const useManchetteWithSpaceTimeChart = ({
 
     // Constant scale:
     if (isProportional) {
+      if (baseScales.length === 0) return baseScales;
       const baseScale = baseScales[0];
       const coefficient: number =
         'coefficient' in baseScale && typeof baseScale.coefficient === 'number'
@@ -445,10 +446,13 @@ const useManchetteWithSpaceTimeChart = ({
   const { manchetteContents, manchetteHeight } = useMemo(() => {
     const spaceScaleTree = spaceScalesToBinaryTree(spaceOrigin, spaceScales);
     const getSpacePixel = getSpaceToPixel(0, spaceScaleTree);
-    const totalManchetteHeight = Math.max(
-      getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT,
-      height - FOOTER_HEIGHT
-    );
+    let totalManchetteHeight = height - FOOTER_HEIGHT;
+    if (spaceScales.length > 0) {
+      totalManchetteHeight = Math.max(
+        totalManchetteHeight,
+        getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT
+      );
+    }
 
     if (!splitPoints)
       return {

--- a/front/ui/ui-charts/src/manchette/utils/index.ts
+++ b/front/ui/ui-charts/src/manchette/utils/index.ts
@@ -7,7 +7,7 @@ export const positionMmToKm = (position: number) => Math.round((position / 10000
 
 export const msToS = (time: number) => time / 1000;
 
-export const calcTotalDistance = <T extends { position: number }>(ops: T[]) => {
+export const calcTotalDistance = (ops: { position: number }[]) => {
   if (ops.length === 0) {
     return 0;
   }

--- a/front/ui/ui-charts/src/manchette/utils/index.ts
+++ b/front/ui/ui-charts/src/manchette/utils/index.ts
@@ -7,8 +7,12 @@ export const positionMmToKm = (position: number) => Math.round((position / 10000
 
 export const msToS = (time: number) => time / 1000;
 
-export const calcTotalDistance = <T extends { position: number }>(ops: T[]) =>
-  ops.at(-1)!.position - ops.at(0)!.position;
+export const calcTotalDistance = <T extends { position: number }>(ops: T[]) => {
+  if (ops.length === 0) {
+    return 0;
+  }
+  return ops.at(-1)!.position - ops.at(0)!.position;
+};
 
 type Point = {
   x: number;


### PR DESCRIPTION
In multiple spots the hook assumed there is at least one waypoint in list. Add guards to avoid crashing with errors when that's the case.

Reported by @Castavo