### PR TITLE
ui-charts: fix spacetimechart crashing when no waypoints provided

### DIFF
--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -361,6 +361,8 @@ const useManchetteWithSpaceTimeChart = ({
       maxZoomMillimeterPerPx
     );
 
+    if (baseScales.length === 0) return [];
+
     if (!splitPoints) return baseScales;
 
     // Constant scale:
@@ -446,7 +448,9 @@ const useManchetteWithSpaceTimeChart = ({
     const spaceScaleTree = spaceScalesToBinaryTree(spaceOrigin, spaceScales);
     const getSpacePixel = getSpaceToPixel(0, spaceScaleTree);
     const totalManchetteHeight = Math.max(
-      getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT,
+      spaceScales.length !== 0
+        ? getSpacePixel(spaceScales.at(-1)!.to, true) + BASE_WAYPOINT_HEIGHT
+        : BASE_WAYPOINT_HEIGHT,
       height - FOOTER_HEIGHT
     );
 

--- a/front/ui/ui-charts/src/manchette/utils/helpers.ts
+++ b/front/ui/ui-charts/src/manchette/utils/helpers.ts
@@ -29,9 +29,11 @@ export const timeScaleToZoomValue = (timeScale: number) =>
 export const getExtremaScales = (
   drawingHeightWithoutTopPadding: number,
   drawingHeightWithoutBothPadding: number,
-  pathLengthMillimeter: number
+  pathLengthMillimeter?: number
 ) => ({
-  minZoomMillimeterPerPx: pathLengthMillimeter / drawingHeightWithoutBothPadding,
+  minZoomMillimeterPerPx:
+    (pathLengthMillimeter ?? MAX_ZOOM_MANCHETTE_HEIGHT_MILLIMETER) /
+    drawingHeightWithoutBothPadding,
   maxZoomMillimeterPerPx: MAX_ZOOM_MANCHETTE_HEIGHT_MILLIMETER / drawingHeightWithoutTopPadding,
 });
 
@@ -116,7 +118,7 @@ export const selectWaypointsToDisplay = (
   // display all waypoints in linear mode
   if (!isProportional) return waypoints;
 
-  const totalDistance = calcTotalDistance(waypoints);
+  const totalDistance = calcTotalDistance(waypoints)!;
   const manchetteHeight = getHeightWithoutLastWaypoint(height);
 
   // in proportional mode, hide some waypoints to avoid collisions

--- a/front/ui/ui-charts/src/manchette/utils/index.ts
+++ b/front/ui/ui-charts/src/manchette/utils/index.ts
@@ -7,8 +7,10 @@ export const positionMmToKm = (position: number) => Math.round((position / 10000
 
 export const msToS = (time: number) => time / 1000;
 
-export const calcTotalDistance = <T extends { position: number }>(ops: T[]) =>
-  ops.at(-1)!.position - ops.at(0)!.position;
+export const calcTotalDistance = <T extends { position: number }>(ops: T[]) => {
+  if (ops.length == 0) return undefined;
+  return ops.at(-1)!.position - ops.at(0)!.position;
+};
 
 type Point = {
   x: number;


### PR DESCRIPTION
Avoid frequent crashes when loading scenarios

Perhaps close #10496
