### PR TITLE
front, editoast: stdcm: allow use of GB loading gauge

### DIFF
--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -284,7 +284,9 @@ async fn stdcm(
     let stdcm_request = core_client::stdcm::Request {
         infra: infra.id,
         expected_version: infra.version,
-        rolling_stock_loading_gauge: physics_consist_parameters.traction_engine.loading_gauge,
+        rolling_stock_loading_gauge: stdcm_request
+            .loading_gauge_type
+            .unwrap_or(physics_consist_parameters.traction_engine.loading_gauge),
         rolling_stock_supported_signaling_systems: physics_consist_parameters
             .traction_engine
             .supported_signaling_systems

--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -86,6 +86,7 @@
     "formattedDateScenario": "Simulation sheet generated on {{day}}/{{month}}/{{year}} at {{hours}}:{{minutes}}",
     "from": "from",
     "length": "length",
+    "loadingGauge": "loading gauge",
     "maxLength": "max. length",
     "maxSpeed": "max. speed",
     "maxWeight": "max. weight",

--- a/front/public/locales/en/stdcm.json
+++ b/front/public/locales/en/stdcm.json
@@ -28,6 +28,7 @@
       "totalMass": "The weight has been updated to reflect the new consist data."
     },
     "length": "Length",
+    "loadingGauge": "Loading gauge",
     "maxSpeed": "Max speed",
     "tonnage": "Tonnage",
     "towedRollingStock": "Towed rolling stock",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -28,6 +28,7 @@
       "totalMass": "Le poids a été mis à jour en fonction des nouvelles données de convoi."
     },
     "length": "Longueur",
+    "loadingGauge": "Gabarit",
     "maxSpeed": "Vitesse max.",
     "tonnage": "Tonnage",
     "towedRollingStock": "Matériel remorqué",

--- a/front/public/locales/fr/stdcm.json
+++ b/front/public/locales/fr/stdcm.json
@@ -86,6 +86,7 @@
     "formattedDateScenario": "Fiche de simulation générée le {{day}}/{{month}}/{{year}} à {{hours}}:{{minutes}}",
     "from": "du",
     "length": "longueur",
+    "loadingGauge": "gabarit",
     "maxLength": "longueur max.",
     "maxSpeed": "vitesse max.",
     "maxWeight": "tonnage max.",

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -31,6 +31,7 @@ import {
   getStdcmRollingStockID,
   getStdcmSpeedLimitByTag,
 } from 'reducers/osrdconf/stdcmConf/selectors';
+import { getIsSuperUser } from 'reducers/user/userSelectors';
 import { useAppDispatch } from 'store';
 import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
@@ -67,6 +68,8 @@ const StdcmConsist = ({
   setConsistErrors,
 }: StdcmConsistProps) => {
   const { t } = useTranslation('stdcm');
+
+  const isSuperUser = useSelector(getIsSuperUser);
 
   const speedLimitByTag = useSelector(getStdcmSpeedLimitByTag);
   const { speedLimitsByTags, dispatchUpdateSpeedLimitByTag } =
@@ -254,20 +257,22 @@ const StdcmConsist = ({
           narrow
         />
       </div>
-      <div className="loading-gauge">
-        <Select
-          id="loading-gauge-selector"
-          value={loadingGauge}
-          label={t('consist.loadingGauge')}
-          onChange={(e) => {
-            if (e) {
-              onLoadingGaugeChange(e);
-            }
-          }}
-          {...createStandardSelectOptions(GAUGE_LIST)}
-          narrow
-        />
-      </div>
+      {isSuperUser && (
+        <div className="loading-gauge">
+          <Select
+            id="loading-gauge-selector"
+            value={loadingGauge}
+            label={t('consist.loadingGauge')}
+            onChange={(e) => {
+              if (e) {
+                onLoadingGaugeChange(e);
+              }
+            }}
+            {...createStandardSelectOptions(GAUGE_LIST)}
+            narrow
+          />
+        </div>
+      )}
       <div className="stdcm-consist__properties">
         <Input
           id="tonnage"

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmConsist.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { Input, ComboBox, useDefaultComboBox } from '@osrd-project/ui-core';
+import { Input, ComboBox, useDefaultComboBox, Select } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
@@ -14,7 +14,11 @@ import {
   validateTotalLength,
   validateTotalMass,
 } from 'applications/stdcm/utils/consistValidation';
-import type { LightRollingStockWithLiveries, TowedRollingStock } from 'common/api/osrdEditoastApi';
+import type {
+  LightRollingStockWithLiveries,
+  LoadingGaugeType,
+  TowedRollingStock,
+} from 'common/api/osrdEditoastApi';
 import { useOsrdConfActions } from 'common/osrdContext';
 import SpeedLimitByTagSelector from 'common/SpeedLimitByTagSelector';
 import { useStoreDataForSpeedLimitByTagSelector } from 'common/SpeedLimitByTagSelector/useStoreDataForSpeedLimitByTagSelector';
@@ -28,6 +32,7 @@ import {
   getStdcmSpeedLimitByTag,
 } from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
+import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import StdcmCard from './StdcmCard';
 import useStdcmConsist from '../../hooks/useStdcmConsist';
@@ -52,6 +57,8 @@ export type StdcmConsistProps = {
   consistErrors: ConsistErrors;
   setConsistErrors: React.Dispatch<React.SetStateAction<ConsistErrors>>;
 };
+
+const GAUGE_LIST: LoadingGaugeType[] = ['GA', 'GB'];
 
 const StdcmConsist = ({
   isDebugMode,
@@ -85,6 +92,8 @@ const StdcmConsist = ({
     onTotalLengthChange,
     maxSpeed,
     onMaxSpeedChange,
+    loadingGauge,
+    onLoadingGaugeChange,
     prefillConsist,
     statusWithMessage,
     setMaxSpeedChanged,
@@ -242,6 +251,20 @@ const StdcmConsist = ({
           {...towedRollingStockComboBoxDefaultProps}
           autoComplete="off"
           disabled={disabled}
+          narrow
+        />
+      </div>
+      <div className="loading-gauge">
+        <Select
+          id="loading-gauge-selector"
+          value={loadingGauge}
+          label={t('consist.loadingGauge')}
+          onChange={(e) => {
+            if (e) {
+              onLoadingGaugeChange(e);
+            }
+          }}
+          {...createStandardSelectOptions(GAUGE_LIST)}
           narrow
         />
       </div>

--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOpSchedule.tsx
@@ -10,7 +10,7 @@ import type { StdcmPathStep } from 'reducers/osrdconf/types';
 import { useAppDispatch } from 'store';
 import { formatDateString } from 'utils/date';
 import { Duration } from 'utils/duration';
-import { createStringSelectOptions } from 'utils/uiCoreHelpers';
+import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 import type { ArrivalTimeTypes, ScheduleConstraint } from '../../types';
 
@@ -95,7 +95,7 @@ const StdcmOpSchedule = ({ disabled, pathStep, opId, isOrigin = false }: StdcmOp
               onArrivalTypeChange(e as ArrivalTimeTypes);
             }
           }}
-          {...createStringSelectOptions(
+          {...createStandardSelectOptions(
             isOrigin
               ? ['preciseTime', 'respectDestinationSchedule']
               : ['preciseTime', 'asSoonAsPossible']

--- a/front/src/applications/stdcm/components/StdcmResults/SimulationReportSheet.tsx
+++ b/front/src/applications/stdcm/components/StdcmResults/SimulationReportSheet.tsx
@@ -122,6 +122,10 @@ const SimulationReportSheet = ({
                 <Text style={styles.consistAndRoute.consistInfoData}>
                   {`${Math.floor(consistMaxSpeed)} km/h`}
                 </Text>
+                <Text style={styles.consistAndRoute.consistInfoData}>
+                  {t('reportSheet.loadingGauge')}
+                </Text>
+                <Text style={styles.consistAndRoute.consistInfoData}>{consist?.loadingGauge}</Text>
               </View>
               <View style={styles.consistAndRoute.consistInfoBox2}>
                 <Text style={styles.consistAndRoute.consistInfoTitles}>

--- a/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
+++ b/front/src/applications/stdcm/hooks/useStaticPathfinding.ts
@@ -11,7 +11,11 @@ import {
 import usePathProperties from 'modules/pathfinding/hooks/usePathProperties';
 import { getPathfindingQuery } from 'modules/pathfinding/utils';
 import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/components/RollingStockSelector/useStoreDataForRollingStockSelector';
-import { getStdcmPathSteps, getStdcmRollingStockID } from 'reducers/osrdconf/stdcmConf/selectors';
+import {
+  getStdcmPathSteps,
+  getStdcmRollingStockID,
+  getLoadingGauge,
+} from 'reducers/osrdconf/stdcmConf/selectors';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 
 /**
@@ -29,6 +33,7 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
 
   const rollingStockId = useSelector(getStdcmRollingStockID);
   const { rollingStock } = useStoreDataForRollingStockSelector({ rollingStockId });
+  const loadingGauge = useSelector(getLoadingGauge);
 
   const [pathfinding, setPathfinding] = useState<PathfindingResult>();
 
@@ -72,6 +77,7 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
         infraId: infra.id,
         rollingStock,
         pathSteps: pathStepsLocations,
+        loadingGauge,
       });
 
       if (payload === null) {
@@ -84,7 +90,7 @@ const useStaticPathfinding = (infra?: InfraWithState) => {
     };
 
     launchPathfinding();
-  }, [pathStepsLocations, rollingStock, infra]);
+  }, [pathStepsLocations, rollingStock, loadingGauge, infra]);
 
   const result = useMemo(
     () =>

--- a/front/src/applications/stdcm/hooks/useStdcmConsist.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmConsist.ts
@@ -4,9 +4,23 @@ import type { InputProps } from '@osrd-project/ui-core';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import type { LightRollingStockWithLiveries, TowedRollingStock } from 'common/api/osrdEditoastApi';
-import { updateTotalMass, updateTotalLength, updateMaxSpeed } from 'reducers/osrdconf/stdcmConf';
-import { getTotalMass, getTotalLength, getMaxSpeed } from 'reducers/osrdconf/stdcmConf/selectors';
+import type {
+  LightRollingStockWithLiveries,
+  LoadingGaugeType,
+  TowedRollingStock,
+} from 'common/api/osrdEditoastApi';
+import {
+  updateTotalMass,
+  updateTotalLength,
+  updateMaxSpeed,
+  updateLoadingGauge,
+} from 'reducers/osrdconf/stdcmConf';
+import {
+  getTotalMass,
+  getTotalLength,
+  getMaxSpeed,
+  getLoadingGauge,
+} from 'reducers/osrdconf/stdcmConf/selectors';
 import { useAppDispatch } from 'store';
 import { kgToT } from 'utils/physics';
 
@@ -45,6 +59,11 @@ const useStdcmConsist = () => {
     const totalMaxSpeed = Number(e.target.value);
     setMaxSpeedChanged(true);
     dispatch(updateMaxSpeed(totalMaxSpeed === 0 ? undefined : totalMaxSpeed));
+  };
+
+  const loadingGauge = useSelector(getLoadingGauge);
+  const onLoadingGaugeChange = (option: LoadingGaugeType) => {
+    dispatch(updateLoadingGauge(option));
   };
 
   const prefillConsist = (
@@ -96,6 +115,8 @@ const useStdcmConsist = () => {
     onTotalLengthChange,
     maxSpeed,
     onMaxSpeedChange,
+    loadingGauge,
+    onLoadingGaugeChange,
     prefillConsist,
     statusWithMessage,
     setMaxSpeedChanged,

--- a/front/src/applications/stdcm/hooks/useStdcmForm.ts
+++ b/front/src/applications/stdcm/hooks/useStdcmForm.ts
@@ -7,6 +7,7 @@ import { useStoreDataForRollingStockSelector } from 'modules/rollingStock/compon
 import {
   getLinkedTrains,
   getMaxSpeed,
+  getLoadingGauge,
   getStdcmOrigin,
   getStdcmPathSteps,
   getStdcmRollingStockID,
@@ -24,6 +25,7 @@ const useStdcmForm = (): StdcmSimulationInputs => {
   const totalMass = useSelector(getTotalMass);
   const totalLength = useSelector(getTotalLength);
   const maxSpeed = useSelector(getMaxSpeed);
+  const loadingGauge = useSelector(getLoadingGauge);
   const linkedTrains = useSelector(getLinkedTrains);
   const origin = useSelector(getStdcmOrigin);
   const rollingStockId = useSelector(getStdcmRollingStockID);
@@ -43,6 +45,7 @@ const useStdcmForm = (): StdcmSimulationInputs => {
         totalMass,
         totalLength,
         maxSpeed,
+        loadingGauge,
         speedLimitByTag,
       },
       linkedTrains,
@@ -55,6 +58,7 @@ const useStdcmForm = (): StdcmSimulationInputs => {
     totalMass,
     totalLength,
     maxSpeed,
+    loadingGauge,
     linkedTrains,
   ]);
 

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -9,6 +9,7 @@ import type {
   SimulationResponse,
   TowedRollingStock,
   PathProperties,
+  LoadingGaugeType,
 } from 'common/api/osrdEditoastApi';
 import type {
   PathOperationalPoint,

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -127,6 +127,7 @@ export type StdcmSimulationInputs = {
     totalLength?: number;
     /** In km/s */
     maxSpeed?: number;
+    loadingGauge: LoadingGaugeType;
     speedLimitByTag?: string;
   };
   linkedTrains: LinkedTrains;

--- a/front/src/applications/stdcm/utils/formatStdcmConf.ts
+++ b/front/src/applications/stdcm/utils/formatStdcmConf.ts
@@ -2,7 +2,11 @@ import type { TFunction } from 'i18next';
 import { compact } from 'lodash';
 import type { Dispatch } from 'redux';
 
-import type { PathfindingItem, PostTimetableByIdStdcmApiArg } from 'common/api/osrdEditoastApi';
+import type {
+  LoadingGaugeType,
+  PathfindingItem,
+  PostTimetableByIdStdcmApiArg,
+} from 'common/api/osrdEditoastApi';
 import getStepLocation from 'modules/pathfinding/helpers/getStepLocation';
 import { setFailure } from 'reducers/main';
 import type { OsrdStdcmConfState, StandardAllowance } from 'reducers/osrdconf/types';
@@ -23,6 +27,7 @@ type ValidStdcmConfig = {
   totalMass?: number;
   totalLength?: number;
   maxSpeed?: number;
+  loadingGauge: LoadingGaugeType;
   margin?: StandardAllowance;
   gridMarginBefore?: Duration;
   gridMarginAfter?: Duration;
@@ -51,6 +56,7 @@ export const checkStdcmConf = (
     totalLength,
     totalMass,
     maxSpeed,
+    loadingGauge,
   } = osrdconf;
   let error = false;
 
@@ -190,6 +196,7 @@ export const checkStdcmConf = (
     totalMass,
     totalLength,
     maxSpeed,
+    loadingGauge,
     towedRollingStockID,
     margin: standardAllowance,
     gridMarginBefore,
@@ -220,6 +227,6 @@ export const formatStdcmPayload = (
     work_schedule_group_id: validConfig.workScheduleGroupId,
     temporary_speed_limit_group_id: validConfig.temporarySpeedLimitGroupId,
     electrical_profile_set_id: validConfig.electricalProfileSetId,
-    loading_gauge_type: 'GA', // default value as the user can't select one
+    loading_gauge_type: validConfig.loadingGauge,
   },
 });

--- a/front/src/common/SpeedLimitByTagSelector/SpeedLimitByTagSelector.tsx
+++ b/front/src/common/SpeedLimitByTagSelector/SpeedLimitByTagSelector.tsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import { isEmpty } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { createStringSelectOptions } from 'utils/uiCoreHelpers';
+import { createStandardSelectOptions } from 'utils/uiCoreHelpers';
 
 type SpeedLimitByTagSelectorProps = {
   condensed?: boolean;
@@ -60,7 +60,7 @@ export default function SpeedLimitByTagSelector({
               dispatchUpdateSpeedLimitByTag(null);
             }
           }}
-          {...createStringSelectOptions(speedLimitsTagsList)}
+          {...createStandardSelectOptions(speedLimitsTagsList)}
           narrow={narrow}
         />
       </div>

--- a/front/src/modules/pathfinding/utils.ts
+++ b/front/src/modules/pathfinding/utils.ts
@@ -2,6 +2,7 @@ import { compact } from 'lodash';
 
 import type {
   GeoJsonLineString,
+  LoadingGaugeType,
   PathItemLocation,
   PathProperties,
   PathfindingInput,
@@ -59,10 +60,12 @@ export const getPathfindingQuery = ({
   infraId,
   rollingStock,
   pathSteps,
+  loadingGauge,
 }: {
   infraId?: number;
   rollingStock?: RollingStockWithLiveries;
   pathSteps: (PathItemLocation | null)[];
+  loadingGauge?: LoadingGaugeType;
 }): PostInfraByInfraIdPathfindingBlocksApiArg | null => {
   const origin = pathSteps.at(0);
   const destination = pathSteps.at(-1);
@@ -77,7 +80,7 @@ export const getPathfindingQuery = ({
       pathfindingInput: {
         path_items: pathItems,
         rolling_stock_is_thermal: isThermal(rollingStock.effort_curves.modes),
-        rolling_stock_loading_gauge: rollingStock.loading_gauge,
+        rolling_stock_loading_gauge: loadingGauge ?? rollingStock.loading_gauge,
         rolling_stock_supported_electrifications: getSupportedElectrification(
           rollingStock.effort_curves.modes
         ),

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -58,6 +58,7 @@ export const stdcmConfInitialState: OsrdStdcmConfState = {
   totalMass: undefined,
   totalLength: undefined,
   maxSpeed: undefined,
+  loadingGauge: 'GA',
   towedRollingStockID: undefined,
   linkedTrains: {
     anteriorTrain: undefined,
@@ -126,6 +127,12 @@ export const stdcmConfSlice = createSlice({
       action: PayloadAction<OsrdStdcmConfState['maxSpeed']>
     ) {
       state.maxSpeed = action.payload;
+    },
+    updateLoadingGauge(
+      state: Draft<OsrdStdcmConfState>,
+      action: PayloadAction<OsrdStdcmConfState['loadingGauge']>
+    ) {
+      state.loadingGauge = action.payload;
     },
     updateTowedRollingStockID(
       state: Draft<OsrdStdcmConfState>,
@@ -313,6 +320,7 @@ export const {
   updateTotalMass,
   updateTotalLength,
   updateMaxSpeed,
+  updateLoadingGauge,
   updateTowedRollingStockID,
   resetMargins,
   updateGridMarginAfter,

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -76,6 +76,7 @@ const updateSimulationState = (state: Draft<OsrdStdcmConfState>, simulation: Std
   state.totalLength = consist?.totalLength;
   state.totalMass = consist?.totalMass;
   state.maxSpeed = consist?.maxSpeed;
+  state.loadingGauge = consist?.loadingGauge ?? 'GA';
   state.speedLimitByTag = consist?.speedLimitByTag;
   state.stdcmPathSteps = pathSteps;
 };

--- a/front/src/reducers/osrdconf/stdcmConf/selectors.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/selectors.ts
@@ -43,6 +43,7 @@ const buildStdcmConfSelectors = () => {
     getTotalMass: makeOsrdConfSelector('totalMass'),
     getTotalLength: makeOsrdConfSelector('totalLength'),
     getMaxSpeed: makeOsrdConfSelector('maxSpeed'),
+    getLoadingGauge: makeOsrdConfSelector('loadingGauge'),
     getTowedRollingStockID: makeOsrdConfSelector('towedRollingStockID'),
 
     getStdcmPathSteps,
@@ -98,6 +99,7 @@ export const {
   getTotalMass,
   getTotalLength,
   getMaxSpeed,
+  getLoadingGauge,
   getTowedRollingStockID,
   getStdcmPathSteps,
   getStdcmOrigin,

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -7,6 +7,7 @@ import {
   type LinkedTrains,
   type StdcmSimulation,
 } from 'applications/stdcm/types';
+import type { LoadingGaugeType } from 'common/api/osrdEditoastApi';
 import {
   stdcmConfInitialState,
   stdcmConfSlice,
@@ -230,6 +231,7 @@ describe('stdcmConfReducers', () => {
         totalMass: 100,
         totalLength: 50,
         maxSpeed: 25,
+        loadingGauge: 'GA' as LoadingGaugeType,
         speedLimitByTag: 'new-tag',
       },
     };
@@ -253,6 +255,7 @@ describe('stdcmConfReducers', () => {
             totalMass: 75,
             totalLength: 20,
             maxSpeed: 10,
+            loadingGauge: 'GA',
             speedLimitByTag: 'new-tag',
           },
         },

--- a/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/stdcmConfReducers.spec.ts
@@ -23,6 +23,7 @@ import {
   retainSimulation,
   selectSimulation,
   addStdcmSimulations,
+  updateLoadingGauge,
 } from 'reducers/osrdconf/stdcmConf';
 import type { OsrdStdcmConfState, StandardAllowance, StdcmPathStep } from 'reducers/osrdconf/types';
 import { createStoreWithoutMiddleware } from 'store';
@@ -169,6 +170,11 @@ describe('stdcmConfReducers', () => {
       store.dispatch(updateTowedRollingStockID(11));
       const state = store.getState()[stdcmConfSlice.name];
       expect(state.towedRollingStockID).toEqual(11);
+    });
+    it('should handle loadingGauge', () => {
+      store.dispatch(updateLoadingGauge('GB'));
+      const state = store.getState()[stdcmConfSlice.name];
+      expect(state.loadingGauge).toEqual('GB');
     });
   });
 

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -12,6 +12,7 @@ import type {
 import type {
   Comfort,
   Distribution,
+  LoadingGaugeType,
   OperationalPointReference,
   PacedTrainResponse,
   PathItemLocation,
@@ -66,6 +67,7 @@ export type OsrdStdcmConfState = OsrdConfState & {
   totalMass?: number;
   totalLength?: number;
   maxSpeed?: number;
+  loadingGauge: LoadingGaugeType;
   towedRollingStockID?: number;
   linkedTrains: LinkedTrains;
   simulations: StdcmSimulation[];

--- a/front/src/styles/scss/applications/stdcm/_card.scss
+++ b/front/src/styles/scss/applications/stdcm/_card.scss
@@ -114,7 +114,8 @@
         }
       }
 
-      .towed-rolling-stock {
+      .towed-rolling-stock,
+      .loading-gauge {
         margin-top: 14px;
       }
 

--- a/front/src/utils/uiCoreHelpers.ts
+++ b/front/src/utils/uiCoreHelpers.ts
@@ -9,10 +9,10 @@ type SelectFixedOption =
 // Utility to create standardized options for <Select> components.
 // `getOptionLabel`: Displays the option or a placeholder if empty.
 // `getOptionValue`: Uses the option itself as the value.
-export const createStringSelectOptions = (opts: string[]) => ({
+export const createStandardSelectOptions = <T>(opts: T[]) => ({
   options: opts,
-  getOptionLabel: (option: string) => option,
-  getOptionValue: (option: string) => option,
+  getOptionLabel: (option: T) => option,
+  getOptionValue: (option: T) => option,
 });
 
 // Utility function for handling fixed label-value object arrays

--- a/front/tests/assets/infrastructure/infra.json
+++ b/front/tests/assets/infrastructure/infra.json
@@ -917,7 +917,7 @@
         {
           "end": 185.8499999999999,
           "begin": 0,
-          "category": "G1"
+          "category": "GA"
         }
       ]
     },
@@ -1023,7 +1023,7 @@
         {
           "end": 1714.15,
           "begin": 200,
-          "category": "G1"
+          "category": "GA"
         },
         {
           "end": 1500,


### PR DESCRIPTION
Here is the sketch mockup :
![433899507-62f25a54-2fe2-4dfa-a364-884a328a03fc](https://github.com/user-attachments/assets/8f7e065c-5bdf-46bd-b60d-1186667781b2)
 
This is about adding the loading gauge, so :
- I added a Select on the front (only for GA (default) and GB). The pathfinding is updated when we change loading gauge, it is then used for stdcm request and added into the simulation sheet
- Editoast receive the loading gauge and use it for the core request (instead of the rolling stock loading gauge, discussed in the ticket). Core already use the loading gauge so nothing changed for core.
- This change involved a modification of tests because the small_infra used for the tests had G1 section (updated to GA)

closes #11448 #11449