### PR TITLE
front: bump react-pdf-renderer v4.3.0

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -24,7 +24,7 @@
         "@osrd-project/ui-charts": "0.0.1-dev",
         "@osrd-project/ui-core": "0.0.1-dev",
         "@osrd-project/ui-icons": "0.0.1-dev",
-        "@react-pdf/renderer": "^4.2.1",
+        "@react-pdf/renderer": "^4.3.0",
         "@redux-devtools/extension": "^3.3.0",
         "@reduxjs/toolkit": "^2.6.1",
         "@rjsf/core": "^5.24.8",
@@ -5687,50 +5687,68 @@
       "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.0.tgz",
       "integrity": "sha512-BjT7C/IeYlrF4Pevlrlo+fILhSxsWSm6Ka/rQrQzYsyQuOsqI6bmBzsTW+T6ghqrD5HLRKr1n8vjAaE9g4rFhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13"
       }
     },
     "node_modules/@react-pdf/font": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-3.0.2.tgz",
-      "integrity": "sha512-5fGlAc8uC1ls+Atdc1J4EGcProH72lcE47TL2+EX54OgChl5m5H1+yrw/VufLd3Ua1e4YSvr53rYXVD2PUFzWA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.2.tgz",
+      "integrity": "sha512-/dAWu7Y2RD1RxarDZ9SkYPHgBYOhmcDnet4W/qN/m8k+A2Hr3ja54GymSR7GGxWBtxjKtNauVKrTa9LS1n8WUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/types": "^2.7.1",
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/types": "^2.9.0",
         "fontkit": "^2.0.2",
         "is-url": "^1.2.4"
       }
     },
     "node_modules/@react-pdf/image": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.1.tgz",
-      "integrity": "sha512-Hd5F1LzjuzG4bL/ytaOYxwN/5ip8oFBYDHdpccOfYY87J/Ca7AL31SsuneLk9DtnwNM1BSAKXtBo/WDFY3r57A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.3.tgz",
+      "integrity": "sha512-lvP5ryzYM3wpbO9bvqLZYwEr5XBDX9jcaRICvtnoRqdJOo7PRrMnmB4MMScyb+Xw10mGeIubZAAomNAG5ONQZQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
         "@react-pdf/png-js": "^3.0.0",
-        "jay-peg": "^1.1.0"
+        "jay-peg": "^1.1.1"
       }
     },
     "node_modules/@react-pdf/layout": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.2.2.tgz",
-      "integrity": "sha512-PHX1yiRXF1nxtKtRgT7rKmA1D6QHaAaWfSQcCKumolsdD/KZnAX2jIRR6s8Sss03ak342K8gGs/udbZio17zhA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.0.tgz",
+      "integrity": "sha512-Aq+Cc6JYausWLoks2FvHe3PwK9cTuvksB2uJ0AnkKJEUtQbvCq8eCRb1bjbbwIji9OzFRTTzZij7LzkpKHjIeA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "3.1.0",
-        "@react-pdf/image": "^3.0.1",
-        "@react-pdf/pdfkit": "^4.0.1",
-        "@react-pdf/primitives": "^4.1.0",
-        "@react-pdf/stylesheet": "^5.2.2",
-        "@react-pdf/textkit": "^5.0.2",
-        "@react-pdf/types": "^2.7.1",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
         "emoji-regex": "^10.3.0",
         "queue": "^6.0.1",
         "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/layout/node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/layout/node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.0.tgz",
+      "integrity": "sha512-BGZ2sYNUp38VJUegjva/jsri3iiRGnVNjWI+G9dTwAvLNOmwFvSJzqaCsEnqQ/DW5mrTBk/577FhDY7pv6AidA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.0",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "node_modules/@react-pdf/layout/node_modules/emoji-regex": {
@@ -5740,9 +5758,9 @@
       "license": "MIT"
     },
     "node_modules/@react-pdf/pdfkit": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.1.tgz",
-      "integrity": "sha512-p76g0DQOG5t3yDymQYL4EHgbhTKvADTaK5J8DHNqhQGxwOi0qrkKbtfe21tgdzBm6xrTauoBp+teKtUn+jr/zA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.3.tgz",
+      "integrity": "sha512-k+Lsuq8vTwWsCqTp+CCB4+2N+sOTFrzwGA7aw3H9ix/PDWR9QksbmNg0YkzGbLAPI6CeawmiLHcf4trZ5ecLPQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -5765,15 +5783,16 @@
       }
     },
     "node_modules/@react-pdf/primitives": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.0.tgz",
-      "integrity": "sha512-ijzkIBdazFFiZFLWLPOK3wIqfJt276ZqvXgDkz+HTgT4hsRo+wOc8ykBoYfKUlAGnFVb/SOZaN3D2mSi4AM2AA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
       "license": "MIT"
     },
     "node_modules/@react-pdf/reconciler": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-1.1.3.tgz",
-      "integrity": "sha512-4vqY0klmUH32kTFvuqdAszkOpwfZYKMLO4VpJ5xZWTsoUOLQSyhC2QM2QCj9eaxpB2Nd5Kl9uW+KfyutvZnMzQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-1.1.4.tgz",
+      "integrity": "sha512-oTQDiR/t4Z/Guxac88IavpU2UgN7eR0RMI9DRKvKnvPz2DUasGjXfChAdMqDNmJJxxV26mMy9xQOUV2UU5/okg==",
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
         "scheduler": "0.25.0-rc-603e6108-20241029"
@@ -5783,16 +5802,16 @@
       }
     },
     "node_modules/@react-pdf/render": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.1.1.tgz",
-      "integrity": "sha512-F20HpVxgd666yKenH0sfMD2VbH8A7PT7iFZsMseY9/PDWB+u4eEDOYwo/j1qfxKwLybKMsGKdNv7ohc0APkHaw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.0.tgz",
+      "integrity": "sha512-MdWfWaqO6d7SZD75TZ2z5L35V+cHpyA43YNRlJNG0RJ7/MeVGDQv12y/BXOJgonZKkeEGdzM3EpAt9/g4E22WA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "3.1.0",
-        "@react-pdf/primitives": "^4.1.0",
-        "@react-pdf/textkit": "^5.0.2",
-        "@react-pdf/types": "^2.7.1",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.0",
         "abs-svg-path": "^0.1.1",
         "color-string": "^1.9.1",
         "normalize-svg-path": "^1.1.0",
@@ -5800,20 +5819,27 @@
         "svg-arc-to-cubic-bezier": "^3.2.0"
       }
     },
+    "node_modules/@react-pdf/render/node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
     "node_modules/@react-pdf/renderer": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.2.1.tgz",
-      "integrity": "sha512-rkwJSvkXGhDCkjWgomwsQZdLhIll1p2MBDwPdaqcprH+eZ4JVXoeJCw4rhDyY4NgyP+LaJuVzDTnFYlrIhs47A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.0.tgz",
+      "integrity": "sha512-28gpA69fU9ZQrDzmd5xMJa1bDf8t0PT3ApUKBl2PUpoE/x4JlvCB5X66nMXrfFrgF2EZrA72zWQAkvbg7TE8zw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/font": "^3.0.2",
-        "@react-pdf/layout": "^4.2.2",
-        "@react-pdf/pdfkit": "^4.0.1",
-        "@react-pdf/primitives": "^4.1.0",
-        "@react-pdf/reconciler": "^1.1.3",
-        "@react-pdf/render": "^4.1.1",
-        "@react-pdf/types": "^2.7.1",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/layout": "^4.4.0",
+        "@react-pdf/pdfkit": "^4.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^1.1.4",
+        "@react-pdf/render": "^4.3.0",
+        "@react-pdf/types": "^2.9.0",
         "events": "^3.3.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
@@ -5823,11 +5849,18 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@react-pdf/renderer/node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
     "node_modules/@react-pdf/stylesheet": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-5.2.2.tgz",
       "integrity": "sha512-oHP+hZakETrecnZCSRPqNvFhSyBgoZSDOkonY9WJOxRkUb6P6A+mAVSOWBaNt2eM4FHMDpYDeR9stx+gAWn6gg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/fns": "3.1.0",
@@ -5839,23 +5872,53 @@
       }
     },
     "node_modules/@react-pdf/textkit": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-5.0.2.tgz",
-      "integrity": "sha512-vZoXznaZTQ/6ISpbCwAatZ6UNieUp12ByY4hlEXQ108VA3WDmcYm2usqk63LhZJiwE6ag+VyEus7R3CgDcxoMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.0.0.tgz",
+      "integrity": "sha512-fDt19KWaJRK/n2AaFoVm31hgGmpygmTV7LsHGJNGZkgzXcFyLsx+XUl63DTDPH3iqxj3xUX128t104GtOz8tTw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "3.1.0",
+        "@react-pdf/fns": "3.1.2",
         "bidi-js": "^1.0.2",
         "hyphen": "^1.6.4",
         "unicode-properties": "^1.4.1"
       }
     },
-    "node_modules/@react-pdf/types": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.7.1.tgz",
-      "integrity": "sha512-MyjR1u+6SclQ/Tx6NP3/yoYZw7reXgC4OHFOrdMh/zeZ+ezfdGyovB+jdmVQuMe7Fsh64v7PUkO5tnsXHyCFWQ==",
+    "node_modules/@react-pdf/textkit/node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
       "license": "MIT"
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ckj80vZLlvl9oYrQ4tovEaqKWP3O06Eb1D48/jQWbdwz1Yh7Y9v1cEmwlP8ET+a1Whp8xfdM0xduMexkuPANCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.0"
+      }
+    },
+    "node_modules/@react-pdf/types/node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/types/node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.0.tgz",
+      "integrity": "sha512-BGZ2sYNUp38VJUegjva/jsri3iiRGnVNjWI+G9dTwAvLNOmwFvSJzqaCsEnqQ/DW5mrTBk/577FhDY7pv6AidA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.0",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
     },
     "node_modules/@react-spring/animated": {
       "version": "9.4.5",
@@ -30536,7 +30599,8 @@
     "node_modules/scheduler": {
       "version": "0.25.0-rc-603e6108-20241029",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
-      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "1.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -20,7 +20,7 @@
     "@osrd-project/ui-charts": "0.0.1-dev",
     "@osrd-project/ui-core": "0.0.1-dev",
     "@osrd-project/ui-icons": "0.0.1-dev",
-    "@react-pdf/renderer": "^4.2.1",
+    "@react-pdf/renderer": "^4.3.0",
     "@redux-devtools/extension": "^3.3.0",
     "@reduxjs/toolkit": "^2.6.1",
     "@rjsf/core": "^5.24.8",

--- a/front/src/applications/stdcm/components/StdcmResults/SimulationReportStyleSheet.ts
+++ b/front/src/applications/stdcm/components/StdcmResults/SimulationReportStyleSheet.ts
@@ -266,7 +266,7 @@ const styles = {
       width: '912',
     },
     stopTable: {
-      border: 'none',
+      border: '0',
     },
     stopTableIndexWidth: {
       width: '40',
@@ -439,7 +439,7 @@ const styles = {
       paddingBottom: '16',
     },
     table: {
-      border: 'none',
+      border: '0',
     },
     th: {
       fontSize: '14',


### PR DESCRIPTION
Part of [migration](https://github.com/OpenRailAssociation/osrd/issues/10338#issue-2783926033) to React v19

Change how to styler the `border: none` otherwise we got this error when generating the pdf : `Error: Invalid border width: none`