### PR TITLE
editoast: pass `osrd_version` to simulation hash function

### DIFF
--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::hash::DefaultHasher;
 use std::hash::Hash;
-use std::hash::Hasher;
 
 use derivative::Derivative;
 use editoast_common::units;
@@ -29,7 +27,6 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 use super::pathfinding::TrackRange;
-use crate::client::get_app_version;
 use crate::core::AsCoreRequest;
 use crate::core::Json;
 use crate::error::InternalError;
@@ -481,21 +478,6 @@ pub struct SimulationRequest {
     pub options: TrainScheduleOptions,
     pub physics_consist: PhysicsConsist,
     pub electrical_profile_set_id: Option<i64>,
-}
-
-impl SimulationRequest {
-    // Compute hash input of a simulation
-    pub fn compute_train_simulation_hash_with_versioning(
-        &self,
-        infra_id: i64,
-        infra_version: i64,
-    ) -> String {
-        let osrd_version = get_app_version().unwrap_or_default();
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        let hash_simulation_input = hasher.finish();
-        format!("simulation_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
-    }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, ToSchema)]

--- a/editoast/src/views/timetable/simulation.rs
+++ b/editoast/src/views/timetable/simulation.rs
@@ -1,5 +1,6 @@
 use crate::RetrieveBatchUnchecked;
 use crate::ValkeyClient;
+use crate::client::get_app_version;
 use crate::core;
 use crate::core::AsCoreRequest;
 use crate::core::pathfinding::PathfindingInputError;
@@ -26,6 +27,9 @@ use editoast_models::DbConnection;
 use itertools::Itertools;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::iter;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -244,8 +248,11 @@ pub async fn consist_train_simulation_batch(
         );
 
         // Compute unique hash of the simulation input
-        let simulation_hash = simulation_request
-            .compute_train_simulation_hash_with_versioning(infra.id, infra.version);
+        let simulation_hash = compute_train_simulation_hash_with_versioning(
+            infra.id,
+            infra.version,
+            &simulation_request,
+        );
         to_sim
             .entry(simulation_hash.clone())
             .or_default()
@@ -389,4 +396,16 @@ fn build_simulation_request(
         physics_consist,
         electrical_profile_set_id,
     }
+}
+
+fn compute_train_simulation_hash_with_versioning(
+    infra_id: i64,
+    infra_version: i64,
+    simulation_input: &SimulationRequest,
+) -> String {
+    let osrd_version = get_app_version().unwrap_or_default();
+    let mut hasher = DefaultHasher::new();
+    simulation_input.hash(&mut hasher);
+    let hash_simulation_input = hasher.finish();
+    format!("simulation_{osrd_version}.{infra_id}.{infra_version}.{hash_simulation_input}")
 }


### PR DESCRIPTION
I made this change following [Leo's feedback](https://github.com/OpenRailAssociation/osrd/pull/11202#discussion_r2017423363), to help separate the core crate and make it more independent.