### PR TITLE
front: display 0 duration stops as stops in stdcm sim report

### DIFF
--- a/front/src/applications/stdcm/utils/__tests__/simulationReportSheet.spec.ts
+++ b/front/src/applications/stdcm/utils/__tests__/simulationReportSheet.spec.ts
@@ -24,12 +24,18 @@ describe('getStopDurationTime', () => {
 
 describe('getStopDurationBetweenTwoPositions', () => {
   it('should return stop duration correctly', () => {
-    const trainPositions = [1, 2, 2, 3];
-    const trainTimes = [10000, 120000, 180000];
-    expect(getStopDurationAtPosition(2, trainPositions, trainTimes)).toEqual(
-      new Duration({ milliseconds: 60000 })
-    );
-    expect(getStopDurationAtPosition(1, trainPositions, trainTimes)).toBeNull();
+    const train = {
+      positions: [1, 2, 2, 3, 4, 5],
+      times: [0, 120000, 180000, 200000, 220000, 230000],
+      speeds: [0, 0, 2, 0, 2, 0],
+      departureHour: 1,
+      departureMinute: 2,
+    };
+    expect(getStopDurationAtPosition(1, train)).toBeNull(); // departure
+    expect(getStopDurationAtPosition(2, train)).toEqual(new Duration({ milliseconds: 60000 })); // standard stop
+    expect(getStopDurationAtPosition(3, train)).toEqual(new Duration({ milliseconds: 0 })); // zero duration stop
+    expect(getStopDurationAtPosition(4, train)).toBeNull(); // non stop
+    expect(getStopDurationAtPosition(5, train)).toBeNull(); // arrival
   });
 });
 
@@ -49,7 +55,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'A',
     positionOnPath: 0,
     time: '10:00',
-    duration: 0,
+    duration: null,
     stopEndTime: '10:00',
     stopRequested: false,
   };
@@ -57,7 +63,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'B',
     positionOnPath: 50,
     time: '10:10',
-    duration: 0,
+    duration: null,
     stopEndTime: '10:10',
     stopRequested: false,
   };
@@ -65,7 +71,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'C',
     positionOnPath: 100,
     time: '10:20',
-    duration: 0,
+    duration: null,
     stopEndTime: '10:20',
     stopRequested: false,
   };
@@ -73,7 +79,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     opId: 'D',
     positionOnPath: 150,
     time: '10:30',
-    duration: 0,
+    duration: null,
     stopEndTime: '10:30',
     stopRequested: false,
   };
@@ -89,6 +95,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     const train = {
       positions: [0, 0, 50, 100, 100, 150, 150],
       times: [0, 60000, 600000, 1200000, 1380000, 1800000, 1920000],
+      speeds: [0, 2, 2, 0, 2, 2, 0],
       departureHour: 10,
       departureMinute: 0,
     };
@@ -105,6 +112,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     const train = {
       positions: [0, 2, 2, 50, 100, 101, 101, 150, 154, 154],
       times: [0, 2000, 62000, 600000, 1200000, 1202000, 1382000, 1800000, 1840000, 2140000],
+      speeds: [0, 0, 2, 2, 2, 0, 2, 2, 2, 0],
       departureHour: 10,
       departureMinute: 0,
     };
@@ -126,6 +134,7 @@ describe('insertsMissingStopsInOperationalPointsWithTimes', () => {
     const train = {
       positions: [0, 50, 75, 75, 100, 125, 125, 150],
       times: [0, 600000, 900000, 960000, 1200000, 1500000, 1560000, 1800000],
+      speeds: [0, 2, 0, 2, 0, 0, 2, 0],
       departureHour: 10,
       departureMinute: 0,
     };

--- a/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
+++ b/front/src/applications/stdcm/utils/formatSimulationReportSheet.ts
@@ -45,12 +45,14 @@ function durationToHHMM(duration: Duration): string {
 /**
  * @property positions List of positions of a train in mm
  * @property times List of times in milliseconds corresponding to the train positions
+ * @property speeds List of speeds in m/s corresponding to the train positions
  * @property departureHour Hour of the train departure (24h format)
  * @property departureMinute Minute of the train departure
  */
 type TrainSimulation = {
   positions: number[];
   times: number[];
+  speeds: number[];
   departureHour: number;
   departureMinute: number;
 };
@@ -80,20 +82,23 @@ function getTimeAtPosition(position: number, train: TrainSimulation): Duration {
 
 /**
  * @param position Distance from the beginning of the path in mm
- * @param positionsList List of positions of a train in mm.
- * @param timesList List of times in milliseconds corresponding to the positions in trainPositions.
- * @returns The duration in milliseconds between the first and last occurrence of the position in the trainPositions array
+ * @param train Object containing simulated train positions, times, and departure time
+ * @returns The duration in milliseconds between the first and last occurrence of the position in the train simulation, or null if the position is not a stop.
+ *
+ * Here we do not consider the train departure and arrival as stops unless the stop duration at these points is non zero.
  */
 export function getStopDurationAtPosition(
   position: number,
-  positionsList: number[],
-  timesList: number[]
+  train: TrainSimulation
 ): Duration | null {
-  const firstIndex = positionsList.indexOf(position);
-  const lastIndex = positionsList.lastIndexOf(position);
-  if (firstIndex !== -1 && lastIndex !== -1 && firstIndex !== lastIndex) {
-    return new Duration({ milliseconds: timesList[lastIndex] - timesList[firstIndex] });
+  const firstIndex = train.positions.indexOf(position);
+  const lastIndex = train.positions.lastIndexOf(position);
+  if (firstIndex === -1) return null;
+  if (firstIndex !== lastIndex) {
+    return new Duration({ milliseconds: train.times[lastIndex] - train.times[firstIndex] });
   }
+  if (train.speeds[firstIndex] === 0 && firstIndex && lastIndex !== train.positions.length - 1)
+    return new Duration({ milliseconds: 0 });
   return null;
 }
 
@@ -108,7 +113,7 @@ function formatMinimalOperationalPointWithTimes(
 ): StdcmResultsOperationalPoint {
   const stopBegin = getTimeAtPosition(op.positionOnPath, train);
 
-  const duration = getStopDurationAtPosition(op.positionOnPath, train.positions, train.times);
+  const duration = getStopDurationAtPosition(op.positionOnPath, train);
   const durationInSeconds = duration !== null ? duration.total('second') : null;
   const stopEnd = stopBegin.add(duration || Duration.zero);
 
@@ -206,7 +211,7 @@ export function insertMissingStopsInOperationalPointsWithTimes(
       },
       train
     );
-    if (lastAddedOp.stopRequested && !lastAddedOp.duration) {
+    if (lastAddedOp.stopRequested && lastAddedOp.duration === null) {
       // If a stop was requested at the last op and no stop was performed,
       // we assume the current stop actually corresponds to the last op
       lastAddedOp.duration = formattedStop.duration;
@@ -279,7 +284,7 @@ export function getOperationalPointsWithTimes(
   const formattedOps = operationalPoints.map((op) =>
     formatOperationalPointWithTimes(
       op,
-      { positions, times, departureHour, departureMinute },
+      { positions, times, speeds, departureHour, departureMinute },
       simulationPathSteps
     )
   );
@@ -288,7 +293,7 @@ export function getOperationalPointsWithTimes(
   const formattedOpsWithAllStops = insertMissingStopsInOperationalPointsWithTimes(
     formattedOps,
     stopPositions,
-    { positions, times, departureHour, departureMinute }
+    { positions, times, speeds, departureHour, departureMinute }
   );
   return consolidateOvertakesToSingleSteps(formattedOpsWithAllStops);
 }


### PR DESCRIPTION
When a 0 duration stop gets requested as

![image](https://github.com/user-attachments/assets/0a9a1ea1-9516-427a-87b1-7e880d74c6d8)

we do not display it currently in a different way than a non stop waypoint (beyond the stop type field).

Before :

![image](https://github.com/user-attachments/assets/d9aced32-7388-4c23-9f10-f92b33880cd3)
![image](https://github.com/user-attachments/assets/95003e3d-cf29-40c5-8bfe-0374225b868b)

After :

![image](https://github.com/user-attachments/assets/8d1d0018-f0c0-4e3f-852e-a3ad1cc43282)
![image](https://github.com/user-attachments/assets/a35b4bcd-eb8d-43c4-93fa-da2cef3be1a5)

