### PR TITLE
core: return complete list of etcs braking curves in etcs braking simulator

### DIFF
--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.kt
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope/part/EnvelopePart.kt
@@ -5,6 +5,7 @@ import fr.sncf.osrd.envelope.EnvelopePhysics
 import fr.sncf.osrd.envelope.SearchableEnvelope
 import fr.sncf.osrd.envelope.part.EnvelopePart.Companion.generateTimes
 import fr.sncf.osrd.envelope_sim.EnvelopeProfile
+import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.arePositionsEqual
 import fr.sncf.osrd.envelope_utils.ExcludeFromGeneratedCodeCoverage
 import fr.sncf.osrd.utils.SelfTypeHolder
 import java.lang.Double.isNaN
@@ -686,9 +687,14 @@ fun minEnvelopeParts(
                         pos,
                         speedB
                     )
-                // Add intersection point
-                newPositions.add(intersection.position)
-                newSpeeds.add(intersection.speed)
+                // Add intersection point if it isn't either the previous or the current position.
+                if (
+                    !arePositionsEqual(intersection.position, pos) &&
+                        !arePositionsEqual(intersection.position, prevPos)
+                ) {
+                    newPositions.add(intersection.position)
+                    newSpeeds.add(intersection.speed)
+                }
             }
         }
         newPositions.add(pos)

--- a/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
+++ b/core/envelope-sim/src/main/java/fr/sncf/osrd/envelope_sim/TrainPhysicsIntegrator.java
@@ -116,13 +116,12 @@ public final class TrainPhysicsIntegrator {
         var gradientAcceleration = getGradientAcceleration(grade);
         return switch (brakingType) {
                 // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.2.1.3.
-            case ETCS_EBD -> -rollingStock.getRJSEtcsBrakeParams().getSafeBrakingAcceleration(speed)
-                    + gradientAcceleration;
+            case EBD -> -rollingStock.getRJSEtcsBrakeParams().getSafeBrakingAcceleration(speed) + gradientAcceleration;
                 // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.3.1.3.
-            case ETCS_SBD -> -rollingStock.getRJSEtcsBrakeParams().getServiceBrakingAcceleration(speed)
+            case SBD -> -rollingStock.getRJSEtcsBrakeParams().getServiceBrakingAcceleration(speed)
                     + gradientAcceleration;
                 // See Subset referenced in RJSEtcsBrakeParams: §3.13.6.4.3.
-            case ETCS_GUI -> -rollingStock.getRJSEtcsBrakeParams().getNormalServiceBrakingAcceleration(speed)
+            case GUI -> -rollingStock.getRJSEtcsBrakeParams().getNormalServiceBrakingAcceleration(speed)
                     + gradientAcceleration
                     + rollingStock.getRJSEtcsBrakeParams().getGradientAccelerationCorrection(grade, speed);
             default -> throw new UnsupportedOperationException("Braking type not supported: " + brakingType);

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.*
+import fr.sncf.osrd.envelope_sim.etcs.BrakingCurveType.*
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
 import kotlin.math.max
 import kotlin.math.min
@@ -21,11 +22,14 @@ import org.slf4j.LoggerFactory
  * Formulas are found in `SUBSET-026-3v400.pdf` from the file at
  * https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip
  */
+data class ETCSBrakingCurve(val brakingCurveType: BrakingCurveType, val brakingCurve: Envelope)
+
 enum class BrakingCurveType {
     EBD, // Emergency Brake Deceleration
     EBI, // Emergency Brake Intervention
     SBD, // Service Brake Deceleration
-    SBI, // Service Brake Intervention
+    SBI_1, // Service Brake Intervention 1 - SBI curve computed from SBD
+    SBI_2, // Service Brake Intervention 2 - SBI curve computed from EBD
     GUI, // Guidance
     PS, // Permitted Speed
     IND // Indication
@@ -40,165 +44,30 @@ enum class BrakingType {
 
 val etcsBrakingCurvesLogger: Logger = LoggerFactory.getLogger("EtcsBrakingCurves")
 
-/** Compute braking curves at every end of authority. */
-fun addBrakingCurvesAtEOAs(
-    envelope: Envelope,
-    context: EnvelopeSimContext,
-    endsOfAuthority: Collection<EndOfAuthority>
-): Envelope {
-    val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
-    var beginPos = envelope.beginPos
-    val maxSpeedEnvelope = envelope.maxSpeed
-    val builder = OverlayEnvelopeBuilder.forward(envelope)
-    for (endOfAuthority in sortedEndsOfAuthority) {
-        val targetPosition = endOfAuthority.offsetEOA.distance.meters
-        assert(targetPosition > 0.0)
-        val targetSpeed = 0.0
-        val fullIndicationCurveEoa =
-            computeSbdFullIndicationCurve(context, targetPosition, maxSpeedEnvelope)
-        var fullIndicationCurveStop = Envelope.make(fullIndicationCurveEoa)
-
-        if (endOfAuthority.offsetSVL != null) {
-            val targetPositionSvl = endOfAuthority.offsetSVL.distance.meters
-            val fullIndicationCurveSvl =
-                computeEbdFullIndicationCurve(
-                    context,
-                    targetPositionSvl,
-                    targetSpeed,
-                    maxSpeedEnvelope
-                )
-            fullIndicationCurveStop =
-                computeMinSvlEoaIndCurve(fullIndicationCurveEoa, fullIndicationCurveSvl)
-        }
-
-        val indicationCurve =
-            keepBrakingCurveUnderOverlay(fullIndicationCurveStop, envelope, beginPos) ?: continue
-        assert(indicationCurve.beginPos >= beginPos && indicationCurve.endPos == targetPosition)
-        assert(
-            indicationCurve.beginSpeed <= maxSpeedEnvelope &&
-                indicationCurve.endSpeed == targetSpeed
-        )
-        builder.addPart(indicationCurve)
-
-        // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so, we
-        // shift the left position constraint, beginPos, to this EOA's target position.
-        beginPos = targetPosition
-    }
-    return builder.build()
-}
-
-private fun computeMinSvlEoaIndCurve(
-    fullIndicationCurveEoa: EnvelopePart,
-    fullIndicationCurveSvl: EnvelopePart
-): Envelope {
-    val targetPosition = fullIndicationCurveEoa.endPos
-    // SvL indication curve should have positions before target position, and speeds above the
-    // release speed. Otherwise, follow EoA indication curve.
-    if (
-        fullIndicationCurveSvl.beginPos >= targetPosition ||
-            fullIndicationCurveSvl.maxSpeed <= NATIONAL_RELEASE_SPEED
-    ) {
-        return Envelope.make(fullIndicationCurveEoa)
-    }
-
-    // Real SvL indication curve maintains release speed until the end.
-    val releaseSpeedPositionSvl = fullIndicationCurveSvl.interpolatePosition(NATIONAL_RELEASE_SPEED)
-    val indCurveSvlParts: MutableList<EnvelopePart>
-    if (releaseSpeedPositionSvl < targetPosition) {
-        indCurveSvlParts =
-            mutableListOf(
-                fullIndicationCurveSvl.sliceWithSpeeds(
-                    fullIndicationCurveSvl.beginPos,
-                    fullIndicationCurveSvl.beginSpeed,
-                    releaseSpeedPositionSvl,
-                    NATIONAL_RELEASE_SPEED
-                )!!,
-                EnvelopePart.generateTimes(
-                    listOf(EnvelopeProfile.CONSTANT_SPEED),
-                    doubleArrayOf(releaseSpeedPositionSvl, targetPosition),
-                    doubleArrayOf(NATIONAL_RELEASE_SPEED, NATIONAL_RELEASE_SPEED)
-                )
-            )
-    } else {
-        indCurveSvlParts =
-            mutableListOf(
-                fullIndicationCurveSvl.slice(fullIndicationCurveSvl.beginPos, targetPosition)!!
-            )
-    }
-
-    val minBeginPos = min(fullIndicationCurveEoa.beginPos, fullIndicationCurveSvl.beginPos)
-    val indCurveEoaParts = mutableListOf(fullIndicationCurveEoa)
-    for (curveParts in arrayOf(indCurveEoaParts, indCurveSvlParts)) {
-        val beginPart = curveParts.first()
-        if (beginPart.beginPos > minBeginPos) {
-            // Extend curve to min begin position.
-            curveParts.add(
-                0,
-                EnvelopePart.generateTimes(
-                    listOf(EnvelopeProfile.CONSTANT_SPEED),
-                    doubleArrayOf(minBeginPos, beginPart.beginPos),
-                    doubleArrayOf(beginPart.beginSpeed, beginPart.beginSpeed)
-                )
-            )
-        }
-    }
-    val indCurveEoa = Envelope.make(*indCurveEoaParts.toList().toTypedArray())
-    val indCurveSvl = Envelope.make(*indCurveSvlParts.toList().toTypedArray())
-
-    // The indication curve is the minimum of the SvL curve maintaining release speed and the EoA
-    // curve, between [minBeginPos, targetPosition]. We need the 2 envelopes to have the exact same
-    // position-range.
-    return minEnvelopes(indCurveEoa, indCurveSvl)
-}
-
-/** Compute braking curves at every limit of authority. */
+/**
+ * Compute braking curves at every limit of authority, and modify inputted envelope to take them
+ * into account.
+ */
 fun addBrakingCurvesAtLOAs(
-    envelope: Envelope,
+    maxSpeedEnvelope: Envelope,
     context: EnvelopeSimContext,
     limitsOfAuthority: Collection<LimitOfAuthority>
 ): Envelope {
     val sortedLimitsOfAuthority = limitsOfAuthority.sortedBy { it.offset }
-    val beginPos = envelope.beginPos
-    val maxSpeedEnvelope = envelope.maxSpeed
-    var envelopeWithLoaBrakingCurves = envelope
+    val beginPos = maxSpeedEnvelope.beginPos
+    var envelopeWithLoaBrakingCurves = maxSpeedEnvelope
     var builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
 
     for (limitOfAuthority in sortedLimitsOfAuthority) {
-        val targetPosition = limitOfAuthority.offset.distance.meters
-        assert(targetPosition > 0.0)
-        val targetSpeed = limitOfAuthority.speed
-        assert(targetSpeed > 0.0)
-        val fullIndicationCurve =
-            computeEbdFullIndicationCurve(context, targetPosition, targetSpeed, maxSpeedEnvelope)
-        val endOfIndicationCurve = fullIndicationCurve.endPos
-        assert(endOfIndicationCurve <= targetPosition)
-
-        val fullIndCurveWithMaintain: Envelope
-        if (endOfIndicationCurve < targetPosition) {
-            // Maintain target speed until target position, i.e. LOA.
-            val maintainTargetSpeedCurve =
-                EnvelopePart.generateTimes(
-                    listOf(EnvelopeProfile.CONSTANT_SPEED),
-                    doubleArrayOf(endOfIndicationCurve, targetPosition),
-                    doubleArrayOf(targetSpeed, targetSpeed)
-                )
-            fullIndCurveWithMaintain = Envelope.make(fullIndicationCurve, maintainTargetSpeedCurve)
-        } else {
-            fullIndCurveWithMaintain = Envelope.make(fullIndicationCurve)
-        }
-
-        val indicationCurve =
-            keepBrakingCurveUnderOverlay(
-                fullIndCurveWithMaintain,
+        val ebdBrakingCurves =
+            computeBrakingCurvesAtOneLOA(
+                limitOfAuthority,
+                context,
                 envelopeWithLoaBrakingCurves,
                 beginPos
-            ) ?: continue
-        assert(indicationCurve.beginPos >= beginPos && indicationCurve.endPos == targetPosition)
-        assert(
-            indicationCurve.beginSpeed <= maxSpeedEnvelope &&
-                indicationCurve.endSpeed == targetSpeed
-        )
-        builder.addPart(indicationCurve)
+            )
+        val indicationCurve = ebdBrakingCurves[IND] ?: continue
+        indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
 
         // We build the LOAs along the path, and they don't all have the same target speeds. To
         // handle intersections with the next LOA, it is needed to add this LOA braking curve to the
@@ -209,51 +78,180 @@ fun addBrakingCurvesAtLOAs(
     return envelopeWithLoaBrakingCurves
 }
 
-/** Compute SBD-based full indication curve. */
-private fun computeSbdFullIndicationCurve(
+/**
+ * Compute braking curves at every end of authority, and modify inputted envelope to take them into
+ * account.
+ */
+fun addBrakingCurvesAtEOAs(
+    envelope: Envelope,
+    context: EnvelopeSimContext,
+    endsOfAuthority: Collection<EndOfAuthority>
+): Envelope {
+    val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
+    var beginPos = envelope.beginPos
+    val builder = OverlayEnvelopeBuilder.forward(envelope)
+    for (endOfAuthority in sortedEndsOfAuthority) {
+        val eoaBrakingCurves =
+            computeBrakingCurvesAtOneEOA(endOfAuthority, context, envelope, beginPos)
+        val indicationCurve = eoaBrakingCurves[IND] ?: continue
+        indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
+
+        // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so, we
+        // shift the left position constraint, beginPos, to this EOA's target position.
+        beginPos = endOfAuthority.offsetEOA.distance.meters
+    }
+    return builder.build()
+}
+
+/**
+ * Compute braking curves at every limit of authority until their speed intersects with inputted
+ * envelope.
+ */
+fun computeBrakingCurvesAtLOAs(
+    envelope: Envelope,
+    context: EnvelopeSimContext,
+    limitsOfAuthority: Collection<LimitOfAuthority>
+): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
+    val sortedLimitsOfAuthority = limitsOfAuthority.sortedBy { it.offset }
+    val res = mutableListOf<Map<BrakingCurveType, ETCSBrakingCurve?>>()
+    for (limitOfAuthority in sortedLimitsOfAuthority) {
+        res.add(computeBrakingCurvesAtOneLOA(limitOfAuthority, context, envelope, 0.0))
+    }
+    return res
+}
+
+/**
+ * Compute braking curves at every end of authority until their speed intersects with inputted
+ * envelope.
+ */
+fun computeBrakingCurvesAtEOAs(
+    envelope: Envelope,
+    context: EnvelopeSimContext,
+    endsOfAuthority: Collection<EndOfAuthority>
+): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
+    val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
+    val res = mutableListOf<Map<BrakingCurveType, ETCSBrakingCurve?>>()
+    for (endOfAuthority in sortedEndsOfAuthority) {
+        res.add(computeBrakingCurvesAtOneEOA(endOfAuthority, context, envelope, 0.0))
+    }
+    return res
+}
+
+/** Compute LoA braking curves: compute EBD-based curves for LoA. */
+private fun computeBrakingCurvesAtOneLOA(
+    limitOfAuthority: LimitOfAuthority,
+    context: EnvelopeSimContext,
+    maxSpeedEnvelope: Envelope,
+    beginPos: Double
+): Map<BrakingCurveType, ETCSBrakingCurve?> {
+    val targetPosition = limitOfAuthority.offset.distance.meters
+    assert(targetPosition > 0.0)
+    val targetSpeed = limitOfAuthority.speed
+    assert(targetSpeed > 0.0)
+    val ebdBrakingCurves =
+        computeEbdBrakingCurves(context, targetPosition, targetSpeed, maxSpeedEnvelope, beginPos)
+    return ebdBrakingCurves
+}
+
+/**
+ * Compute EoA braking curves: compute SBD-based curves for EoA and EBD-based curves for SvL.
+ * Compute the minimum between EoA and SvL GUI, PS and IND.
+ */
+private fun computeBrakingCurvesAtOneEOA(
+    endOfAuthority: EndOfAuthority,
+    context: EnvelopeSimContext,
+    maxSpeedEnvelope: Envelope,
+    beginPos: Double
+): Map<BrakingCurveType, ETCSBrakingCurve?> {
+    val targetPosition = endOfAuthority.offsetEOA.distance.meters
+    assert(targetPosition > 0.0)
+    val targetSpeed = 0.0
+    val eoaBrakingCurves =
+        computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope, beginPos)
+    val svlBrakingCurves =
+        if (endOfAuthority.offsetSVL == null) mutableMapOf()
+        else
+            computeEbdBrakingCurves(
+                context,
+                endOfAuthority.offsetSVL.distance.meters,
+                targetSpeed,
+                maxSpeedEnvelope,
+                beginPos
+            )
+    val brakingCurves = svlBrakingCurves.plus(eoaBrakingCurves).toMutableMap()
+    // If there are SvL braking curves, compute the minimum curves between the common curves PS and
+    // IND. GUI should be the EoA GUI's curve, which is already the case here.
+    if (svlBrakingCurves.isNotEmpty()) {
+        // Compute PS only if EoA PS curve is not null.
+        if (brakingCurves[PS] != null)
+            brakingCurves[PS] =
+                computeMinETCSBrakingCurves(eoaBrakingCurves[PS], svlBrakingCurves[PS])
+        // Compute IND only if EoA IND curve is not null.
+        if (brakingCurves[IND] != null)
+            brakingCurves[IND] =
+                computeMinETCSBrakingCurves(eoaBrakingCurves[IND], svlBrakingCurves[IND])
+    }
+    return brakingCurves
+}
+
+/**
+ * Compute SBD-based braking curve set. The resulting curves stop at their respective intersections
+ * with maxSpeedEnvelope.
+ */
+private fun computeSbdBrakingCurves(
     context: EnvelopeSimContext,
     targetPosition: Double,
-    maxSpeedEnvelope: Double
-): EnvelopePart {
+    maxSpeedEnvelope: Envelope,
+    beginPos: Double
+): Map<BrakingCurveType, ETCSBrakingCurve?> {
     val targetSpeed = 0.0
+    val maxSpeed = maxSpeedEnvelope.maxSpeed
     val overhead =
         Envelope.make(
             EnvelopePart.generateTimes(
                 listOf(EnvelopeProfile.CONSTANT_SPEED),
                 doubleArrayOf(0.0, targetPosition),
-                doubleArrayOf(maxSpeedEnvelope, maxSpeedEnvelope)
+                doubleArrayOf(maxSpeed, maxSpeed)
             )
         )
-    val sbdCurve =
-        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_SBD)
-    assert(sbdCurve.beginPos >= 0 && sbdCurve.endPos == targetPosition)
-    assert(sbdCurve.endSpeed == targetSpeed)
+    val sbdCurve = computeBrakingCurve(context, overhead, targetPosition, targetSpeed, SBD)
+    assert(sbdCurve.brakingCurve.beginPos >= 0 && sbdCurve.brakingCurve.endPos == targetPosition)
+    assert(sbdCurve.brakingCurve.endSpeed == targetSpeed)
 
-    val guiCurve =
-        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_GUI)
-    assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
-    assert((guiCurve.beginSpeed == maxSpeedEnvelope || guiCurve.beginPos == 0.0))
-    assert(guiCurve.endSpeed == targetSpeed)
+    val guiCurve = computeBrakingCurve(context, overhead, targetPosition, targetSpeed, GUI)
+    assert(guiCurve.brakingCurve.beginPos >= 0.0 && guiCurve.brakingCurve.endPos == targetPosition)
+    assert((guiCurve.brakingCurve.beginSpeed == maxSpeed || guiCurve.brakingCurve.beginPos == 0.0))
+    assert(guiCurve.brakingCurve.endSpeed == targetSpeed)
 
-    val fullIndicationCurve =
-        computeIndicationBrakingCurveFromRef(context, sbdCurve, BrakingCurveType.SBD, guiCurve)
-    assert(fullIndicationCurve.endPos == targetPosition)
-    assert(fullIndicationCurve.endSpeed == targetSpeed)
-    return fullIndicationCurve
+    val sbdFullBrakingCurves =
+        computeBrakingCurvesFromRefs(context, sbdCurve, guiCurve).toMutableMap()
+    val fullIndicationCurve = sbdFullBrakingCurves[IND]!!
+    assert(fullIndicationCurve.brakingCurve.endPos == targetPosition)
+    assert(fullIndicationCurve.brakingCurve.endSpeed == targetSpeed)
+    sbdFullBrakingCurves[sbdCurve.brakingCurveType] = sbdCurve
+    sbdFullBrakingCurves[guiCurve.brakingCurveType] = guiCurve
+
+    val sbdBrakingCurves =
+        sbdFullBrakingCurves.mapValues { (_, etcsBrakingCurve) ->
+            keepBrakingCurveUnderOverlay(etcsBrakingCurve, maxSpeedEnvelope, beginPos)
+        }
+    return sbdBrakingCurves
 }
 
-/** Compute EBD-based full indication curve. */
-private fun computeEbdFullIndicationCurve(
+/** Compute EBD-based braking curves. */
+private fun computeEbdBrakingCurves(
     context: EnvelopeSimContext,
     targetPosition: Double,
     targetSpeed: Double,
-    maxSpeedEnvelope: Double
-): EnvelopePart {
+    maxSpeedEnvelope: Envelope,
+    beginPos: Double
+): Map<BrakingCurveType, ETCSBrakingCurve?> {
+    val maxSpeed = maxSpeedEnvelope.maxSpeed
     // Add maxBecDeltaSpeed to EBD curve overhead so it reaches a sufficiently high speed to
     // guarantee that, after the speed translation, the corresponding EBI curve does intersect
     // with envelope max speed.
     val maxBecDeltaSpeed = maxBecDeltaSpeed()
-    val maxSpeedEbd = maxSpeedEnvelope + maxBecDeltaSpeed
+    val maxSpeedEbd = maxSpeed + maxBecDeltaSpeed
     val overhead =
         Envelope.make(
             EnvelopePart.generateTimes(
@@ -263,23 +261,69 @@ private fun computeEbdFullIndicationCurve(
             )
         )
 
-    val ebdCurve =
-        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_EBD)
-    assert(ebdCurve.beginPos >= 0.0 && ebdCurve.endPos >= targetPosition)
-    assert((ebdCurve.beginSpeed == maxSpeedEbd || ebdCurve.beginPos == 0.0))
+    val ebdCurve = computeBrakingCurve(context, overhead, targetPosition, targetSpeed, EBD)
+    assert(ebdCurve.brakingCurve.beginPos >= 0.0 && ebdCurve.brakingCurve.endPos >= targetPosition)
+    assert(
+        (ebdCurve.brakingCurve.beginSpeed == maxSpeedEbd || ebdCurve.brakingCurve.beginPos == 0.0)
+    )
 
-    val guiCurve =
-        computeBrakingCurve(context, overhead, targetPosition, targetSpeed, BrakingType.ETCS_GUI)
-    assert(guiCurve.beginPos >= 0.0 && guiCurve.endPos == targetPosition)
-    assert((guiCurve.beginSpeed == maxSpeedEbd || guiCurve.beginPos == 0.0))
+    val guiCurve = computeBrakingCurve(context, overhead, targetPosition, targetSpeed, GUI)
+    assert(guiCurve.brakingCurve.beginPos >= 0.0 && guiCurve.brakingCurve.endPos == targetPosition)
+    assert(
+        (guiCurve.brakingCurve.beginSpeed == maxSpeedEbd || guiCurve.brakingCurve.beginPos == 0.0)
+    )
 
     val ebiCurve = computeEbiBrakingCurveFromEbd(context, ebdCurve, targetSpeed)
-    assert(ebiCurve.endSpeed == targetSpeed)
+    assert(ebiCurve.brakingCurve.endSpeed == targetSpeed)
 
-    val fullIndicationCurve =
-        computeIndicationBrakingCurveFromRef(context, ebiCurve, BrakingCurveType.EBI, guiCurve)
-    assert(fullIndicationCurve.endSpeed == targetSpeed)
-    return fullIndicationCurve
+    val ebdFullBrakingCurves =
+        computeBrakingCurvesFromRefs(context, ebiCurve, guiCurve).toMutableMap()
+    assert(ebdFullBrakingCurves[IND]!!.brakingCurve.endSpeed == targetSpeed)
+    ebdFullBrakingCurves[ebdCurve.brakingCurveType] = ebdCurve
+    ebdFullBrakingCurves[guiCurve.brakingCurveType] = guiCurve
+    ebdFullBrakingCurves[ebiCurve.brakingCurveType] = ebiCurve
+    // Add release speed for SvL or maintain speed until LoA
+    val maintainSpeed = if (targetSpeed == 0.0) NATIONAL_RELEASE_SPEED else targetSpeed
+    ebdFullBrakingCurves[PS] =
+        maintainSpeedUntil(ebdFullBrakingCurves[PS]!!, maintainSpeed, targetPosition)
+    ebdFullBrakingCurves[IND] =
+        maintainSpeedUntil(ebdFullBrakingCurves[IND]!!, maintainSpeed, targetPosition)
+
+    val ebdBrakingCurves =
+        ebdFullBrakingCurves.mapValues { (_, etcsBrakingCurve) ->
+            keepBrakingCurveUnderOverlay(etcsBrakingCurve, maxSpeedEnvelope, beginPos)
+        }
+    return ebdBrakingCurves
+}
+
+/**
+ * Once ETCS braking curve reaches target speed, maintain it until target position.
+ * - SvL: maintain release speed for PS and IND curves.
+ * - LoA: maintain target speed for PS and IND curves.
+ */
+private fun maintainSpeedUntil(
+    etcsBrakingCurve: ETCSBrakingCurve,
+    maintainSpeed: Double,
+    targetPosition: Double
+): ETCSBrakingCurve {
+    val brakingCurve = etcsBrakingCurve.brakingCurve.first()
+    assert(brakingCurve.beginPos < targetPosition && brakingCurve.endSpeed <= maintainSpeed)
+    val intersection = brakingCurve.interpolatePosition(maintainSpeed)
+    val brakingCurveWithMaintain =
+        Envelope.make(
+            brakingCurve.sliceWithSpeeds(
+                brakingCurve.beginPos,
+                brakingCurve.beginSpeed,
+                intersection,
+                maintainSpeed
+            )!!,
+            EnvelopePart.generateTimes(
+                listOf(EnvelopeProfile.CONSTANT_SPEED),
+                doubleArrayOf(intersection, targetPosition),
+                doubleArrayOf(maintainSpeed, maintainSpeed)
+            )
+        )
+    return ETCSBrakingCurve(etcsBrakingCurve.brakingCurveType, brakingCurveWithMaintain)
 }
 
 /** Compute braking curve: used to compute EBD, SBD or GUI. */
@@ -288,19 +332,21 @@ private fun computeBrakingCurve(
     envelope: Envelope,
     targetPosition: Double,
     targetSpeed: Double,
-    brakingType: BrakingType
-): Envelope {
-    assert(
-        brakingType == BrakingType.ETCS_EBD ||
-            brakingType == BrakingType.ETCS_SBD ||
-            brakingType == BrakingType.ETCS_GUI
-    )
+    brakingCurveType: BrakingCurveType
+): ETCSBrakingCurve {
+    val brakingType =
+        when (brakingCurveType) {
+            EBD -> BrakingType.ETCS_EBD
+            SBD -> BrakingType.ETCS_SBD
+            GUI -> BrakingType.ETCS_GUI
+            else ->
+                throw IllegalArgumentException(
+                    "Expected EBD, SBD or GUI braking curve type, found: $brakingCurveType"
+                )
+        }
     // If the stopPosition is after the end of the path, the input is invalid except if it is an
     // SVL, i.e. the target speed is 0 and the curve to compute is not an SBD.
-    if (
-        (targetPosition > context.path.length &&
-            (targetSpeed != 0.0 || brakingType == BrakingType.ETCS_SBD))
-    )
+    if ((targetPosition > context.path.length && (targetSpeed != 0.0 || brakingCurveType == SBD)))
         throw RuntimeException(
             String.format(
                 "Trying to compute ETCS braking curve from out of bounds ERTMS end/limit of authority: %s",
@@ -316,7 +362,7 @@ private fun computeBrakingCurve(
             SpeedConstraint(targetSpeed, EnvelopePartConstraintType.FLOOR),
             EnvelopeConstraint(envelope, EnvelopePartConstraintType.CEILING)
         )
-    if (brakingType == BrakingType.ETCS_EBD && targetSpeed != 0.0) {
+    if (brakingCurveType == EBD && targetSpeed != 0.0) {
         // When target is an LOA, EBD reaches target position at target speed + dVEbi. See Subset
         // 026: §3.13.8.3.1, figure 40.
         val dvEbi = dvEbi(targetSpeed)
@@ -350,7 +396,7 @@ private fun computeBrakingCurve(
             brakingType
         )
         val rightPart = rightPartBuilder.build()
-        return Envelope.make(leftPart, rightPart)
+        return ETCSBrakingCurve(brakingCurveType, Envelope.make(leftPart, rightPart))
     } else {
         // For every other case, the braking curve reaches the target position at the target speed.
         EnvelopeDeceleration.decelerate(
@@ -361,7 +407,7 @@ private fun computeBrakingCurve(
             -1.0,
             brakingType
         )
-        return Envelope.make(partBuilder.build())
+        return ETCSBrakingCurve(brakingCurveType, Envelope.make(partBuilder.build()))
     }
 }
 
@@ -370,10 +416,11 @@ private fun computeBrakingCurve(
  */
 private fun computeEbiBrakingCurveFromEbd(
     context: EnvelopeSimContext,
-    ebdCurve: Envelope,
+    ebdCurve: ETCSBrakingCurve,
     targetSpeed: Double
-): Envelope {
-    val ebdPoints = ebdCurve.iteratePoints().distinct()
+): ETCSBrakingCurve {
+    assert(ebdCurve.brakingCurveType == EBD)
+    val ebdPoints = ebdCurve.brakingCurve.iteratePoints().distinct()
     val pointCount = ebdPoints.size
     var newPositions = DoubleArray(pointCount)
     var newSpeeds = DoubleArray(pointCount)
@@ -400,76 +447,170 @@ private fun computeEbiBrakingCurveFromEbd(
 
     // Make EBI stop at target speed.
     val intersection = fullBrakingCurve.interpolatePosition(targetSpeed)
-    return Envelope.make(
-        fullBrakingCurve.sliceWithSpeeds(
-            fullBrakingCurve.beginPos,
-            fullBrakingCurve.beginSpeed,
-            intersection,
-            targetSpeed
-        )!!
+    return ETCSBrakingCurve(
+        EBI,
+        Envelope.make(
+            fullBrakingCurve.sliceWithSpeeds(
+                fullBrakingCurve.beginPos,
+                fullBrakingCurve.beginSpeed,
+                intersection,
+                targetSpeed
+            )!!
+        )
     )
 }
 
-/** Compute Indication curve: EBI/SBD -> SBI -> PS -> IND. See Subset 026: figures 45 and 46. */
-private fun computeIndicationBrakingCurveFromRef(
+/**
+ * Compute braking curves from ref. Braking curves are computed as follows (see Subset 026: figures
+ * 45 and 46):
+ * - EBI/SBD -> SBI
+ * - SBI -> PS
+ * - PS -> IND
+ */
+private fun computeBrakingCurvesFromRefs(
     context: EnvelopeSimContext,
-    refBrakingCurve: Envelope,
-    refBrakingCurveType: BrakingCurveType,
-    guiCurve: Envelope
-): EnvelopePart {
+    refBrakingCurve: ETCSBrakingCurve,
+    guiCurve: ETCSBrakingCurve
+): Map<BrakingCurveType, ETCSBrakingCurve> {
+    assert(guiCurve.brakingCurveType == GUI)
     val rollingStock = context.rollingStock
-    val tBs =
-        when (refBrakingCurveType) {
-            BrakingCurveType.EBI -> rollingStock.rjsEtcsBrakeParams.tBs2
-            BrakingCurveType.SBD -> rollingStock.rjsEtcsBrakeParams.tBs1
+    val (sbiBrakingCurveType, tBs) =
+        when (refBrakingCurve.brakingCurveType) {
+            SBD -> Pair(SBI_1, rollingStock.rjsEtcsBrakeParams.tBs1)
+            EBI -> Pair(SBI_2, rollingStock.rjsEtcsBrakeParams.tBs2)
             else ->
                 throw IllegalArgumentException(
-                    "Expected EBI or SBD reference braking curve type, found: $refBrakingCurveType"
+                    "Expected EBI or SBD reference braking curve type, found: ${refBrakingCurve.brakingCurveType}"
                 )
         }
 
-    val refBrakingPoints = refBrakingCurve.iteratePoints().distinct()
+    val refBrakingPoints = refBrakingCurve.brakingCurve.iteratePoints().distinct()
     val pointCount = refBrakingPoints.size
-    val newPositions = DoubleArray(pointCount)
+    val sbiPositions = DoubleArray(pointCount)
+    val psPositions = DoubleArray(pointCount)
+    val indPositions = DoubleArray(pointCount)
     val newSpeeds = DoubleArray(pointCount)
     for (i in 0 until pointCount) {
         val speed = refBrakingPoints[i].speed
-        val sbiPosition = getSbiPosition(refBrakingPoints[i].position, speed, tBs)
-        val permittedSpeedPosition = getPermittedSpeedPosition(sbiPosition, speed)
-        val adjustedPermittedSpeedPosition =
-            getAdjustedPermittedSpeedPosition(permittedSpeedPosition, speed, guiCurve)
-        val indicationPosition = getIndicationPosition(adjustedPermittedSpeedPosition, speed, tBs)
-        newPositions[i] = indicationPosition
+        sbiPositions[i] = getSbiPosition(refBrakingPoints[i].position, speed, tBs)
+        val prePSPosition = getPermittedSpeedPosition(sbiPositions[i], speed)
+        psPositions[i] = getAdjustedPermittedSpeedPosition(prePSPosition, speed, guiCurve)
+        indPositions[i] = getIndicationPosition(psPositions[i], speed, tBs)
         newSpeeds[i] = speed
     }
 
-    val brakingCurve =
-        EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), newPositions, newSpeeds)
+    val sbiCurve =
+        ETCSBrakingCurve(
+            sbiBrakingCurveType,
+            Envelope.make(
+                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), sbiPositions, newSpeeds)
+            )
+        )
+    val psCurve =
+        ETCSBrakingCurve(
+            PS,
+            Envelope.make(
+                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), psPositions, newSpeeds)
+            )
+        )
+    val indCurve =
+        ETCSBrakingCurve(
+            IND,
+            Envelope.make(
+                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), indPositions, newSpeeds)
+            )
+        )
 
-    return brakingCurve
+    return mutableMapOf(
+        Pair(sbiCurve.brakingCurveType, sbiCurve),
+        Pair(psCurve.brakingCurveType, psCurve),
+        Pair(indCurve.brakingCurveType, indCurve)
+    )
+}
+
+/**
+ * Computes the mininum ETCS braking curve. Both curves must have the same braking curve type.
+ * Should be used to compare EoA curves to SvL curves, for GUI, PS and IND.
+ */
+private fun computeMinETCSBrakingCurves(
+    etcsBrakingCurve1: ETCSBrakingCurve?,
+    etcsBrakingCurve2: ETCSBrakingCurve?
+): ETCSBrakingCurve? {
+    if (etcsBrakingCurve1 == null) return etcsBrakingCurve2
+    else if (etcsBrakingCurve2 == null) return etcsBrakingCurve1
+
+    val brakingCurveType1 = etcsBrakingCurve1.brakingCurveType
+    val brakingCurveType2 = etcsBrakingCurve2.brakingCurveType
+    assert(brakingCurveType1 == brakingCurveType2)
+
+    val endPos1 = etcsBrakingCurve1.brakingCurve.endPos
+    val endPos2 = etcsBrakingCurve2.brakingCurve.endPos
+    val beginPos1 = etcsBrakingCurve1.brakingCurve.beginPos
+    val beginPos2 = etcsBrakingCurve2.brakingCurve.beginPos
+    if (brakingCurveType1 == GUI)
+        return if (endPos2 >= endPos1) etcsBrakingCurve1 else etcsBrakingCurve2
+    else if (beginPos2 >= endPos1) return etcsBrakingCurve1
+    else if (beginPos1 >= endPos2) return etcsBrakingCurve2
+
+    // Compute min curve on intersecting range.
+    val intersectingRangeBegin = max(beginPos1, beginPos2)
+    val intersectingRangeEnd = min(endPos1, endPos2)
+    val curveOnIntersectingRange1 =
+        Envelope.make(
+            *etcsBrakingCurve1.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
+        )
+    val curveOnIntersectingRange2 =
+        Envelope.make(
+            *etcsBrakingCurve2.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
+        )
+    val minCurveOnIntersectingRange =
+        minEnvelopes(curveOnIntersectingRange1, curveOnIntersectingRange2)
+
+    // Add corresponding curve part before intersecting range.
+    val minCurve = minCurveOnIntersectingRange.stream().toList().toMutableList()
+    val isCurveAtBeginCurve1 =
+        etcsBrakingCurve1.brakingCurve.interpolateSpeed(intersectingRangeBegin) ==
+            minCurveOnIntersectingRange.beginSpeed
+    if (isCurveAtBeginCurve1 && beginPos1 < minCurveOnIntersectingRange.beginPos)
+        minCurve.addAll(
+            0,
+            etcsBrakingCurve1.brakingCurve.slice(beginPos1, intersectingRangeBegin).toList()
+        )
+    else if (!isCurveAtBeginCurve1 && beginPos2 < minCurveOnIntersectingRange.beginPos)
+        minCurve.addAll(
+            0,
+            etcsBrakingCurve2.brakingCurve.slice(beginPos2, intersectingRangeBegin).toList()
+        )
+
+    return ETCSBrakingCurve(brakingCurveType1, Envelope.make(*minCurve.toTypedArray()))
 }
 
 /**
  * Keep the part of the full braking curve which is located underneath the overlay and intersects
- * with it or with begin position. If the part has no intersection, return null.
+ * with it or with begin position. If the braking curve has no intersection, return null.
  */
 private fun keepBrakingCurveUnderOverlay(
-    fullBrakingCurve: Envelope,
+    etcsBrakingCurve: ETCSBrakingCurve,
     overlay: Envelope,
     beginPos: Double
-): EnvelopePart? {
-    if (fullBrakingCurve.beginPos >= overlay.endPos || fullBrakingCurve.endPos <= beginPos) {
+): ETCSBrakingCurve? {
+    var brakingCurve = etcsBrakingCurve.brakingCurve
+    if (brakingCurve.beginPos >= overlay.endPos || brakingCurve.endPos <= beginPos) {
         etcsBrakingCurvesLogger.warn(
-            "The position-range of the ETCS braking curve starting at (${fullBrakingCurve.beginPos}, ${fullBrakingCurve.beginSpeed}) and ending at (${fullBrakingCurve.endPos}, ${fullBrakingCurve.endSpeed}) does not intersect with the overlay envelope's position-range."
+            "The position-range of the ETCS braking curve starting at (${brakingCurve.beginPos}, ${brakingCurve.beginSpeed}) and ending at (${brakingCurve.endPos}, ${brakingCurve.endSpeed}) does not intersect with the overlay envelope's position-range."
         )
         return null
     }
+    if (brakingCurve.endPos > overlay.endPos) {
+        // Slice envelope to remove the braking curve part which is after the overlay.
+        brakingCurve = Envelope.make(*brakingCurve.slice(brakingCurve.beginPos, overlay.endPos))
+    }
     if (
-        fullBrakingCurve.minSpeed >
+        brakingCurve.minSpeed >
             Envelope.make(
                     *overlay.slice(
-                        max(fullBrakingCurve.beginPos, beginPos),
-                        min(fullBrakingCurve.endPos, overlay.endPos)
+                        max(brakingCurve.beginPos, beginPos),
+                        min(brakingCurve.endPos, overlay.endPos)
                     )
                 )
                 .maxSpeed
@@ -478,17 +619,17 @@ private fun keepBrakingCurveUnderOverlay(
         return null
     }
 
-    val points = fullBrakingCurve.iteratePoints().distinct()
+    val points = brakingCurve.iteratePoints().distinct()
     val positions = points.map { it.position }
     val speeds = points.map { it.speed }
-    val timeDeltas = fullBrakingCurve.flatMap { it.getTimeDeltas() }
+    val timeDeltas = brakingCurve.flatMap { it.getTimeDeltas() }
 
     val partBuilder = EnvelopePartBuilder()
     partBuilder.setAttr(EnvelopeProfile.BRAKING)
     val overlayBuilder =
         ConstrainedEnvelopePartBuilder(
             partBuilder,
-            PositionConstraint(max(beginPos, fullBrakingCurve.beginPos), overlay.endPos),
+            PositionConstraint(max(beginPos, brakingCurve.beginPos), overlay.endPos),
             EnvelopeConstraint(overlay, EnvelopePartConstraintType.CEILING)
         )
     val lastIndex = getIndexOfLastPointBeneathOverlay(positions, speeds, overlay)
@@ -498,7 +639,7 @@ private fun keepBrakingCurveUnderOverlay(
     for (i in lastIndex - 1 downTo 0) {
         if (!overlayBuilder.addStep(positions[i], speeds[i], timeDeltas[i])) break
     }
-    return partBuilder.build()
+    return ETCSBrakingCurve(etcsBrakingCurve.brakingCurveType, Envelope.make(partBuilder.build()))
 }
 
 /**
@@ -603,10 +744,11 @@ private fun getPermittedSpeedPosition(sbiPosition: Double, speed: Double): Doubl
 private fun getAdjustedPermittedSpeedPosition(
     permittedSpeedPosition: Double,
     speed: Double,
-    guiCurve: Envelope
+    guiCurve: ETCSBrakingCurve
 ): Double {
-    assert(guiCurve.stream().count() == 1L)
-    val guiPart = guiCurve.stream().findFirst().get()
+    assert(guiCurve.brakingCurveType == GUI)
+    assert(guiCurve.brakingCurve.stream().count() == 1L)
+    val guiPart = guiCurve.brakingCurve.stream().findFirst().get()
     val guiPosition =
         if (speed > guiPart.maxSpeed) guiPart.beginPos else guiPart.interpolatePosition(speed)
     // Interpolating adds a position inaccuracy. If both positions are equal, keep more accurate

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -307,24 +307,36 @@ private fun maintainSpeedUntil(
     maintainSpeed: Double,
     targetPosition: Double
 ): ETCSBrakingCurve {
-    val brakingCurve = etcsBrakingCurve.brakingCurve.first()
+    val brakingCurve = etcsBrakingCurve.brakingCurve
     assert(brakingCurve.beginPos < targetPosition && brakingCurve.endSpeed <= maintainSpeed)
-    val intersection = brakingCurve.interpolatePosition(maintainSpeed)
-    val brakingCurveWithMaintain =
-        Envelope.make(
-            brakingCurve.sliceWithSpeeds(
-                brakingCurve.beginPos,
-                brakingCurve.beginSpeed,
-                intersection,
-                maintainSpeed
-            )!!,
-            EnvelopePart.generateTimes(
-                listOf(EnvelopeProfile.CONSTANT_SPEED),
-                doubleArrayOf(intersection, targetPosition),
-                doubleArrayOf(maintainSpeed, maintainSpeed)
+    val brakingCurveWithMaintain = mutableListOf<EnvelopePart>()
+    for (currentPart in brakingCurve.stream()) {
+        if (currentPart.endSpeed > maintainSpeed) {
+            brakingCurveWithMaintain.add(currentPart)
+        } else {
+            val intersection = currentPart.interpolatePosition(maintainSpeed)
+            brakingCurveWithMaintain.add(
+                currentPart.sliceWithSpeeds(
+                    currentPart.beginPos,
+                    currentPart.beginSpeed,
+                    intersection,
+                    maintainSpeed
+                )!!
             )
-        )
-    return ETCSBrakingCurve(etcsBrakingCurve.brakingCurveType, brakingCurveWithMaintain)
+            brakingCurveWithMaintain.add(
+                EnvelopePart.generateTimes(
+                    listOf(EnvelopeProfile.CONSTANT_SPEED),
+                    doubleArrayOf(intersection, targetPosition),
+                    doubleArrayOf(maintainSpeed, maintainSpeed)
+                )
+            )
+            break
+        }
+    }
+    return ETCSBrakingCurve(
+        etcsBrakingCurve.brakingCurveType,
+        Envelope.make(*brakingCurveWithMaintain.toTypedArray())
+    )
 }
 
 /** Compute braking curve: used to compute EBD, SBD or GUI. */

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -31,6 +31,7 @@ enum class BrakingCurveType {
     SBI_1, // Service Brake Intervention 1 - SBI curve computed from SBD
     SBI_2, // Service Brake Intervention 2 - SBI curve computed from EBD
     GUI, // Guidance
+    PRE_PS, // Permitted Speed before applying minimum with guidance
     PS, // Permitted Speed
     IND // Indication
 }
@@ -464,7 +465,8 @@ private fun computeEbiBrakingCurveFromEbd(
  * Compute braking curves from ref. Braking curves are computed as follows (see Subset 026: figures
  * 45 and 46):
  * - EBI/SBD -> SBI
- * - SBI -> PS
+ * - SBI -> pre-PS
+ * - pre-PS + GUI -> PS
  * - PS -> IND
  */
 private fun computeBrakingCurvesFromRefs(
@@ -487,15 +489,12 @@ private fun computeBrakingCurvesFromRefs(
     val refBrakingPoints = refBrakingCurve.brakingCurve.iteratePoints().distinct()
     val pointCount = refBrakingPoints.size
     val sbiPositions = DoubleArray(pointCount)
-    val psPositions = DoubleArray(pointCount)
-    val indPositions = DoubleArray(pointCount)
+    val prePsPositions = DoubleArray(pointCount)
     val newSpeeds = DoubleArray(pointCount)
     for (i in 0 until pointCount) {
         val speed = refBrakingPoints[i].speed
         sbiPositions[i] = getSbiPosition(refBrakingPoints[i].position, speed, tBs)
-        val prePSPosition = getPermittedSpeedPosition(sbiPositions[i], speed)
-        psPositions[i] = getAdjustedPermittedSpeedPosition(prePSPosition, speed, guiCurve)
-        indPositions[i] = getIndicationPosition(psPositions[i], speed, tBs)
+        prePsPositions[i] = getPrePermittedSpeedPosition(sbiPositions[i], speed)
         newSpeeds[i] = speed
     }
 
@@ -506,18 +505,29 @@ private fun computeBrakingCurvesFromRefs(
                 EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), sbiPositions, newSpeeds)
             )
         )
-    val psCurve =
+
+    val prePsCurve =
         ETCSBrakingCurve(
-            PS,
+            PRE_PS,
             Envelope.make(
-                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), psPositions, newSpeeds)
+                EnvelopePart.generateTimes(
+                    listOf(EnvelopeProfile.BRAKING),
+                    prePsPositions,
+                    newSpeeds
+                )
             )
         )
+    val psCurve = computeMinETCSBrakingCurves(prePsCurve, guiCurve)!!
+
+    val psPoints = psCurve.brakingCurve.iteratePoints().distinct()
+    val indPositions =
+        psPoints.map { getIndicationPosition(it.position, it.speed, tBs) }.toDoubleArray()
+    val indSpeeds = psPoints.map { it.speed }.toDoubleArray()
     val indCurve =
         ETCSBrakingCurve(
             IND,
             Envelope.make(
-                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), indPositions, newSpeeds)
+                EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), indPositions, indSpeeds)
             )
         )
 
@@ -530,7 +540,9 @@ private fun computeBrakingCurvesFromRefs(
 
 /**
  * Computes the mininum ETCS braking curve. Both curves must have the same braking curve type.
- * Should be used to compare EoA curves to SvL curves, for GUI, PS and IND.
+ * Should be used to:
+ * - compare EoA curves to SvL curves, for GUI, PS and IND.
+ * - compare pre PS curve to GUI curve.
  */
 private fun computeMinETCSBrakingCurves(
     etcsBrakingCurve1: ETCSBrakingCurve?,
@@ -541,7 +553,15 @@ private fun computeMinETCSBrakingCurves(
 
     val brakingCurveType1 = etcsBrakingCurve1.brakingCurveType
     val brakingCurveType2 = etcsBrakingCurve2.brakingCurveType
-    assert(brakingCurveType1 == brakingCurveType2)
+    val brakingCurveType =
+        if (brakingCurveType1 == brakingCurveType2) brakingCurveType1
+        else {
+            assert(
+                (brakingCurveType1 == PRE_PS && brakingCurveType2 == GUI) ||
+                    (brakingCurveType1 == GUI && brakingCurveType2 == PRE_PS)
+            )
+            PS
+        }
 
     val endPos1 = etcsBrakingCurve1.brakingCurve.endPos
     val endPos2 = etcsBrakingCurve2.brakingCurve.endPos
@@ -582,7 +602,7 @@ private fun computeMinETCSBrakingCurves(
             etcsBrakingCurve2.brakingCurve.slice(beginPos2, intersectingRangeBegin).toList()
         )
 
-    return ETCSBrakingCurve(brakingCurveType1, Envelope.make(*minCurve.toTypedArray()))
+    return ETCSBrakingCurve(brakingCurveType, Envelope.make(*minCurve.toTypedArray()))
 }
 
 /**
@@ -736,26 +756,8 @@ private fun getSbiPosition(ebiOrSbdPosition: Double, speed: Double, tbs: Double)
 }
 
 /** See Subset 026: §3.13.9.3.5.1. */
-private fun getPermittedSpeedPosition(sbiPosition: Double, speed: Double): Double {
+private fun getPrePermittedSpeedPosition(sbiPosition: Double, speed: Double): Double {
     return getPreviousPosition(sbiPosition, speed, T_DRIVER)
-}
-
-/** See Subset 026: §3.13.9.3.5.4. */
-private fun getAdjustedPermittedSpeedPosition(
-    permittedSpeedPosition: Double,
-    speed: Double,
-    guiCurve: ETCSBrakingCurve
-): Double {
-    assert(guiCurve.brakingCurveType == GUI)
-    assert(guiCurve.brakingCurve.stream().count() == 1L)
-    val guiPart = guiCurve.brakingCurve.stream().findFirst().get()
-    val guiPosition =
-        if (speed > guiPart.maxSpeed) guiPart.beginPos else guiPart.interpolatePosition(speed)
-    // Interpolating adds a position inaccuracy. If both positions are equal, keep more accurate
-    // permitted speed position.
-    return if (TrainPhysicsIntegrator.arePositionsEqual(permittedSpeedPosition, guiPosition))
-        permittedSpeedPosition
-    else min(permittedSpeedPosition, guiPosition)
 }
 
 /** See Subset 026: §3.13.9.3.6.1 and §3.13.9.3.6.2. */

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingCurves.kt
@@ -1,7 +1,6 @@
 package fr.sncf.osrd.envelope_sim.etcs
 
 import fr.sncf.osrd.envelope.Envelope
-import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder
 import fr.sncf.osrd.envelope.minEnvelopes
 import fr.sncf.osrd.envelope.part.ConstrainedEnvelopePartBuilder
 import fr.sncf.osrd.envelope.part.EnvelopePart
@@ -11,8 +10,9 @@ import fr.sncf.osrd.envelope.part.constraints.EnvelopePartConstraintType
 import fr.sncf.osrd.envelope.part.constraints.PositionConstraint
 import fr.sncf.osrd.envelope.part.constraints.SpeedConstraint
 import fr.sncf.osrd.envelope_sim.*
-import fr.sncf.osrd.envelope_sim.etcs.BrakingCurveType.*
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.*
 import fr.sncf.osrd.envelope_sim.overlays.EnvelopeDeceleration
+import java.util.*
 import kotlin.math.max
 import kotlin.math.min
 import org.slf4j.Logger
@@ -22,9 +22,8 @@ import org.slf4j.LoggerFactory
  * Formulas are found in `SUBSET-026-3v400.pdf` from the file at
  * https://www.era.europa.eu/system/files/2023-09/index004_-_SUBSET-026_v400.zip
  */
-data class ETCSBrakingCurve(val brakingCurveType: BrakingCurveType, val brakingCurve: Envelope)
-
-enum class BrakingCurveType {
+enum class BrakingType {
+    CONSTANT, // Constant deceleration
     EBD, // Emergency Brake Deceleration
     EBI, // Emergency Brake Intervention
     SBD, // Service Brake Deceleration
@@ -36,115 +35,15 @@ enum class BrakingCurveType {
     IND // Indication
 }
 
-enum class BrakingType {
-    CONSTANT,
-    ETCS_EBD,
-    ETCS_SBD,
-    ETCS_GUI
-}
-
 val etcsBrakingCurvesLogger: Logger = LoggerFactory.getLogger("EtcsBrakingCurves")
 
-/**
- * Compute braking curves at every limit of authority, and modify inputted envelope to take them
- * into account.
- */
-fun addBrakingCurvesAtLOAs(
-    maxSpeedEnvelope: Envelope,
-    context: EnvelopeSimContext,
-    limitsOfAuthority: Collection<LimitOfAuthority>
-): Envelope {
-    val sortedLimitsOfAuthority = limitsOfAuthority.sortedBy { it.offset }
-    val beginPos = maxSpeedEnvelope.beginPos
-    var envelopeWithLoaBrakingCurves = maxSpeedEnvelope
-    var builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
-
-    for (limitOfAuthority in sortedLimitsOfAuthority) {
-        val ebdBrakingCurves =
-            computeBrakingCurvesAtOneLOA(
-                limitOfAuthority,
-                context,
-                envelopeWithLoaBrakingCurves,
-                beginPos
-            )
-        val indicationCurve = ebdBrakingCurves[IND] ?: continue
-        indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
-
-        // We build the LOAs along the path, and they don't all have the same target speeds. To
-        // handle intersections with the next LOA, it is needed to add this LOA braking curve to the
-        // overlay builder that will be used to compute the following LOAs.
-        envelopeWithLoaBrakingCurves = builder.build()
-        builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
-    }
-    return envelopeWithLoaBrakingCurves
-}
-
-/**
- * Compute braking curves at every end of authority, and modify inputted envelope to take them into
- * account.
- */
-fun addBrakingCurvesAtEOAs(
-    envelope: Envelope,
-    context: EnvelopeSimContext,
-    endsOfAuthority: Collection<EndOfAuthority>
-): Envelope {
-    val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
-    var beginPos = envelope.beginPos
-    val builder = OverlayEnvelopeBuilder.forward(envelope)
-    for (endOfAuthority in sortedEndsOfAuthority) {
-        val eoaBrakingCurves =
-            computeBrakingCurvesAtOneEOA(endOfAuthority, context, envelope, beginPos)
-        val indicationCurve = eoaBrakingCurves[IND] ?: continue
-        indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
-
-        // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so, we
-        // shift the left position constraint, beginPos, to this EOA's target position.
-        beginPos = endOfAuthority.offsetEOA.distance.meters
-    }
-    return builder.build()
-}
-
-/**
- * Compute braking curves at every limit of authority until their speed intersects with inputted
- * envelope.
- */
-fun computeBrakingCurvesAtLOAs(
-    envelope: Envelope,
-    context: EnvelopeSimContext,
-    limitsOfAuthority: Collection<LimitOfAuthority>
-): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
-    val sortedLimitsOfAuthority = limitsOfAuthority.sortedBy { it.offset }
-    val res = mutableListOf<Map<BrakingCurveType, ETCSBrakingCurve?>>()
-    for (limitOfAuthority in sortedLimitsOfAuthority) {
-        res.add(computeBrakingCurvesAtOneLOA(limitOfAuthority, context, envelope, 0.0))
-    }
-    return res
-}
-
-/**
- * Compute braking curves at every end of authority until their speed intersects with inputted
- * envelope.
- */
-fun computeBrakingCurvesAtEOAs(
-    envelope: Envelope,
-    context: EnvelopeSimContext,
-    endsOfAuthority: Collection<EndOfAuthority>
-): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
-    val sortedEndsOfAuthority = endsOfAuthority.sortedBy { it.offsetEOA }
-    val res = mutableListOf<Map<BrakingCurveType, ETCSBrakingCurve?>>()
-    for (endOfAuthority in sortedEndsOfAuthority) {
-        res.add(computeBrakingCurvesAtOneEOA(endOfAuthority, context, envelope, 0.0))
-    }
-    return res
-}
-
 /** Compute LoA braking curves: compute EBD-based curves for LoA. */
-private fun computeBrakingCurvesAtOneLOA(
+fun computeBrakingCurvesAtLOA(
     limitOfAuthority: LimitOfAuthority,
     context: EnvelopeSimContext,
     maxSpeedEnvelope: Envelope,
     beginPos: Double
-): Map<BrakingCurveType, ETCSBrakingCurve?> {
+): BrakingCurves {
     val targetPosition = limitOfAuthority.offset.distance.meters
     assert(targetPosition > 0.0)
     val targetSpeed = limitOfAuthority.speed
@@ -158,19 +57,19 @@ private fun computeBrakingCurvesAtOneLOA(
  * Compute EoA braking curves: compute SBD-based curves for EoA and EBD-based curves for SvL.
  * Compute the minimum between EoA and SvL GUI, PS and IND.
  */
-private fun computeBrakingCurvesAtOneEOA(
+fun computeBrakingCurvesAtEOA(
     endOfAuthority: EndOfAuthority,
     context: EnvelopeSimContext,
     maxSpeedEnvelope: Envelope,
     beginPos: Double
-): Map<BrakingCurveType, ETCSBrakingCurve?> {
+): BrakingCurves {
     val targetPosition = endOfAuthority.offsetEOA.distance.meters
     assert(targetPosition > 0.0)
     val targetSpeed = 0.0
     val eoaBrakingCurves =
         computeSbdBrakingCurves(context, targetPosition, maxSpeedEnvelope, beginPos)
-    val svlBrakingCurves =
-        if (endOfAuthority.offsetSVL == null) mutableMapOf()
+    val svlBrakingCurves: BrakingCurves =
+        if (endOfAuthority.offsetSVL == null) EnumMap(BrakingType::class.java)
         else
             computeEbdBrakingCurves(
                 context,
@@ -179,7 +78,10 @@ private fun computeBrakingCurvesAtOneEOA(
                 maxSpeedEnvelope,
                 beginPos
             )
-    val brakingCurves = svlBrakingCurves.plus(eoaBrakingCurves).toMutableMap()
+    val brakingCurves: BrakingCurves =
+        EnumMap<BrakingType, BrakingCurve?>(BrakingType::class.java).apply {
+            putAll(svlBrakingCurves.plus(eoaBrakingCurves))
+        }
     // If there are SvL braking curves, compute the minimum curves between the common curves PS and
     // IND. GUI should be the EoA GUI's curve, which is already the case here.
     if (svlBrakingCurves.isNotEmpty()) {
@@ -204,7 +106,7 @@ private fun computeSbdBrakingCurves(
     targetPosition: Double,
     maxSpeedEnvelope: Envelope,
     beginPos: Double
-): Map<BrakingCurveType, ETCSBrakingCurve?> {
+): BrakingCurves {
     val targetSpeed = 0.0
     val maxSpeed = maxSpeedEnvelope.maxSpeed
     val overhead =
@@ -224,18 +126,16 @@ private fun computeSbdBrakingCurves(
     assert((guiCurve.brakingCurve.beginSpeed == maxSpeed || guiCurve.brakingCurve.beginPos == 0.0))
     assert(guiCurve.brakingCurve.endSpeed == targetSpeed)
 
-    val sbdFullBrakingCurves =
-        computeBrakingCurvesFromRefs(context, sbdCurve, guiCurve).toMutableMap()
-    val fullIndicationCurve = sbdFullBrakingCurves[IND]!!
+    val sbdBrakingCurves = computeBrakingCurvesFromRefs(context, sbdCurve, guiCurve)
+    val fullIndicationCurve = sbdBrakingCurves[IND]!!
     assert(fullIndicationCurve.brakingCurve.endPos == targetPosition)
     assert(fullIndicationCurve.brakingCurve.endSpeed == targetSpeed)
-    sbdFullBrakingCurves[sbdCurve.brakingCurveType] = sbdCurve
-    sbdFullBrakingCurves[guiCurve.brakingCurveType] = guiCurve
-
-    val sbdBrakingCurves =
-        sbdFullBrakingCurves.mapValues { (_, etcsBrakingCurve) ->
-            keepBrakingCurveUnderOverlay(etcsBrakingCurve, maxSpeedEnvelope, beginPos)
-        }
+    sbdBrakingCurves[sbdCurve.brakingType] = sbdCurve
+    sbdBrakingCurves[guiCurve.brakingType] = guiCurve
+    // Keep all the braking curves under the max speed envelope.
+    for (entry in sbdBrakingCurves.entries) {
+        entry.setValue(keepBrakingCurveUnderOverlay(entry.value!!, maxSpeedEnvelope, beginPos))
+    }
     return sbdBrakingCurves
 }
 
@@ -246,7 +146,7 @@ private fun computeEbdBrakingCurves(
     targetSpeed: Double,
     maxSpeedEnvelope: Envelope,
     beginPos: Double
-): Map<BrakingCurveType, ETCSBrakingCurve?> {
+): BrakingCurves {
     val maxSpeed = maxSpeedEnvelope.maxSpeed
     // Add maxBecDeltaSpeed to EBD curve overhead so it reaches a sufficiently high speed to
     // guarantee that, after the speed translation, the corresponding EBI curve does intersect
@@ -277,23 +177,20 @@ private fun computeEbdBrakingCurves(
     val ebiCurve = computeEbiBrakingCurveFromEbd(context, ebdCurve, targetSpeed)
     assert(ebiCurve.brakingCurve.endSpeed == targetSpeed)
 
-    val ebdFullBrakingCurves =
-        computeBrakingCurvesFromRefs(context, ebiCurve, guiCurve).toMutableMap()
-    assert(ebdFullBrakingCurves[IND]!!.brakingCurve.endSpeed == targetSpeed)
-    ebdFullBrakingCurves[ebdCurve.brakingCurveType] = ebdCurve
-    ebdFullBrakingCurves[guiCurve.brakingCurveType] = guiCurve
-    ebdFullBrakingCurves[ebiCurve.brakingCurveType] = ebiCurve
+    val ebdBrakingCurves = computeBrakingCurvesFromRefs(context, ebiCurve, guiCurve)
+    assert(ebdBrakingCurves[IND]!!.brakingCurve.endSpeed == targetSpeed)
+    ebdBrakingCurves[ebdCurve.brakingType] = ebdCurve
+    ebdBrakingCurves[guiCurve.brakingType] = guiCurve
+    ebdBrakingCurves[ebiCurve.brakingType] = ebiCurve
     // Add release speed for SvL or maintain speed until LoA
     val maintainSpeed = if (targetSpeed == 0.0) NATIONAL_RELEASE_SPEED else targetSpeed
-    ebdFullBrakingCurves[PS] =
-        maintainSpeedUntil(ebdFullBrakingCurves[PS]!!, maintainSpeed, targetPosition)
-    ebdFullBrakingCurves[IND] =
-        maintainSpeedUntil(ebdFullBrakingCurves[IND]!!, maintainSpeed, targetPosition)
-
-    val ebdBrakingCurves =
-        ebdFullBrakingCurves.mapValues { (_, etcsBrakingCurve) ->
-            keepBrakingCurveUnderOverlay(etcsBrakingCurve, maxSpeedEnvelope, beginPos)
-        }
+    ebdBrakingCurves[PS] = maintainSpeedUntil(ebdBrakingCurves[PS]!!, maintainSpeed, targetPosition)
+    ebdBrakingCurves[IND] =
+        maintainSpeedUntil(ebdBrakingCurves[IND]!!, maintainSpeed, targetPosition)
+    // Keep all the braking curves under the max speed envelope.
+    for (entry in ebdBrakingCurves.entries) {
+        entry.setValue(keepBrakingCurveUnderOverlay(entry.value!!, maxSpeedEnvelope, beginPos))
+    }
     return ebdBrakingCurves
 }
 
@@ -303,10 +200,10 @@ private fun computeEbdBrakingCurves(
  * - LoA: maintain target speed for PS and IND curves.
  */
 private fun maintainSpeedUntil(
-    etcsBrakingCurve: ETCSBrakingCurve,
+    etcsBrakingCurve: BrakingCurve,
     maintainSpeed: Double,
     targetPosition: Double
-): ETCSBrakingCurve {
+): BrakingCurve {
     val brakingCurve = etcsBrakingCurve.brakingCurve
     assert(brakingCurve.beginPos < targetPosition && brakingCurve.endSpeed <= maintainSpeed)
     val brakingCurveWithMaintain = mutableListOf<EnvelopePart>()
@@ -333,8 +230,8 @@ private fun maintainSpeedUntil(
             break
         }
     }
-    return ETCSBrakingCurve(
-        etcsBrakingCurve.brakingCurveType,
+    return BrakingCurve(
+        etcsBrakingCurve.brakingType,
         Envelope.make(*brakingCurveWithMaintain.toTypedArray())
     )
 }
@@ -345,21 +242,16 @@ private fun computeBrakingCurve(
     envelope: Envelope,
     targetPosition: Double,
     targetSpeed: Double,
-    brakingCurveType: BrakingCurveType
-): ETCSBrakingCurve {
-    val brakingType =
-        when (brakingCurveType) {
-            EBD -> BrakingType.ETCS_EBD
-            SBD -> BrakingType.ETCS_SBD
-            GUI -> BrakingType.ETCS_GUI
-            else ->
-                throw IllegalArgumentException(
-                    "Expected EBD, SBD or GUI braking curve type, found: $brakingCurveType"
-                )
-        }
+    brakingType: BrakingType
+): BrakingCurve {
+    if (!listOf(EBD, SBD, GUI).contains(brakingType))
+        throw IllegalArgumentException(
+            "Expected EBD, SBD or GUI braking curve type, found: $brakingType"
+        )
+
     // If the stopPosition is after the end of the path, the input is invalid except if it is an
     // SVL, i.e. the target speed is 0 and the curve to compute is not an SBD.
-    if ((targetPosition > context.path.length && (targetSpeed != 0.0 || brakingCurveType == SBD)))
+    if ((targetPosition > context.path.length && (targetSpeed != 0.0 || brakingType == SBD)))
         throw RuntimeException(
             String.format(
                 "Trying to compute ETCS braking curve from out of bounds ERTMS end/limit of authority: %s",
@@ -375,7 +267,7 @@ private fun computeBrakingCurve(
             SpeedConstraint(targetSpeed, EnvelopePartConstraintType.FLOOR),
             EnvelopeConstraint(envelope, EnvelopePartConstraintType.CEILING)
         )
-    if (brakingCurveType == EBD && targetSpeed != 0.0) {
+    if (brakingType == EBD && targetSpeed != 0.0) {
         // When target is an LOA, EBD reaches target position at target speed + dVEbi. See Subset
         // 026: §3.13.8.3.1, figure 40.
         val dvEbi = dvEbi(targetSpeed)
@@ -409,7 +301,7 @@ private fun computeBrakingCurve(
             brakingType
         )
         val rightPart = rightPartBuilder.build()
-        return ETCSBrakingCurve(brakingCurveType, Envelope.make(leftPart, rightPart))
+        return BrakingCurve(brakingType, Envelope.make(leftPart, rightPart))
     } else {
         // For every other case, the braking curve reaches the target position at the target speed.
         EnvelopeDeceleration.decelerate(
@@ -420,7 +312,7 @@ private fun computeBrakingCurve(
             -1.0,
             brakingType
         )
-        return ETCSBrakingCurve(brakingCurveType, Envelope.make(partBuilder.build()))
+        return BrakingCurve(brakingType, Envelope.make(partBuilder.build()))
     }
 }
 
@@ -429,10 +321,10 @@ private fun computeBrakingCurve(
  */
 private fun computeEbiBrakingCurveFromEbd(
     context: EnvelopeSimContext,
-    ebdCurve: ETCSBrakingCurve,
+    ebdCurve: BrakingCurve,
     targetSpeed: Double
-): ETCSBrakingCurve {
-    assert(ebdCurve.brakingCurveType == EBD)
+): BrakingCurve {
+    assert(ebdCurve.brakingType == EBD)
     val ebdPoints = ebdCurve.brakingCurve.iteratePoints().distinct()
     val pointCount = ebdPoints.size
     var newPositions = DoubleArray(pointCount)
@@ -460,7 +352,7 @@ private fun computeEbiBrakingCurveFromEbd(
 
     // Make EBI stop at target speed.
     val intersection = fullBrakingCurve.interpolatePosition(targetSpeed)
-    return ETCSBrakingCurve(
+    return BrakingCurve(
         EBI,
         Envelope.make(
             fullBrakingCurve.sliceWithSpeeds(
@@ -483,18 +375,18 @@ private fun computeEbiBrakingCurveFromEbd(
  */
 private fun computeBrakingCurvesFromRefs(
     context: EnvelopeSimContext,
-    refBrakingCurve: ETCSBrakingCurve,
-    guiCurve: ETCSBrakingCurve
-): Map<BrakingCurveType, ETCSBrakingCurve> {
-    assert(guiCurve.brakingCurveType == GUI)
+    refBrakingCurve: BrakingCurve,
+    guiCurve: BrakingCurve
+): BrakingCurves {
+    assert(guiCurve.brakingType == GUI)
     val rollingStock = context.rollingStock
     val (sbiBrakingCurveType, tBs) =
-        when (refBrakingCurve.brakingCurveType) {
+        when (refBrakingCurve.brakingType) {
             SBD -> Pair(SBI_1, rollingStock.rjsEtcsBrakeParams.tBs1)
             EBI -> Pair(SBI_2, rollingStock.rjsEtcsBrakeParams.tBs2)
             else ->
                 throw IllegalArgumentException(
-                    "Expected EBI or SBD reference braking curve type, found: ${refBrakingCurve.brakingCurveType}"
+                    "Expected EBI or SBD reference braking curve type, found: ${refBrakingCurve.brakingType}"
                 )
         }
 
@@ -511,7 +403,7 @@ private fun computeBrakingCurvesFromRefs(
     }
 
     val sbiCurve =
-        ETCSBrakingCurve(
+        BrakingCurve(
             sbiBrakingCurveType,
             Envelope.make(
                 EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), sbiPositions, newSpeeds)
@@ -519,7 +411,7 @@ private fun computeBrakingCurvesFromRefs(
         )
 
     val prePsCurve =
-        ETCSBrakingCurve(
+        BrakingCurve(
             PRE_PS,
             Envelope.make(
                 EnvelopePart.generateTimes(
@@ -536,18 +428,18 @@ private fun computeBrakingCurvesFromRefs(
         psPoints.map { getIndicationPosition(it.position, it.speed, tBs) }.toDoubleArray()
     val indSpeeds = psPoints.map { it.speed }.toDoubleArray()
     val indCurve =
-        ETCSBrakingCurve(
+        BrakingCurve(
             IND,
             Envelope.make(
                 EnvelopePart.generateTimes(listOf(EnvelopeProfile.BRAKING), indPositions, indSpeeds)
             )
         )
 
-    return mutableMapOf(
-        Pair(sbiCurve.brakingCurveType, sbiCurve),
-        Pair(psCurve.brakingCurveType, psCurve),
-        Pair(indCurve.brakingCurveType, indCurve)
-    )
+    val brakingCurves = EnumMap<BrakingType, BrakingCurve?>(BrakingType::class.java)
+    brakingCurves[sbiCurve.brakingType] = sbiCurve
+    brakingCurves[psCurve.brakingType] = psCurve
+    brakingCurves[indCurve.brakingType] = indCurve
+    return brakingCurves
 }
 
 /**
@@ -557,14 +449,14 @@ private fun computeBrakingCurvesFromRefs(
  * - compare pre PS curve to GUI curve.
  */
 private fun computeMinETCSBrakingCurves(
-    etcsBrakingCurve1: ETCSBrakingCurve?,
-    etcsBrakingCurve2: ETCSBrakingCurve?
-): ETCSBrakingCurve? {
-    if (etcsBrakingCurve1 == null) return etcsBrakingCurve2
-    else if (etcsBrakingCurve2 == null) return etcsBrakingCurve1
+    brakingCurve1: BrakingCurve?,
+    brakingCurve2: BrakingCurve?
+): BrakingCurve? {
+    if (brakingCurve1 == null) return brakingCurve2
+    else if (brakingCurve2 == null) return brakingCurve1
 
-    val brakingCurveType1 = etcsBrakingCurve1.brakingCurveType
-    val brakingCurveType2 = etcsBrakingCurve2.brakingCurveType
+    val brakingCurveType1 = brakingCurve1.brakingType
+    val brakingCurveType2 = brakingCurve2.brakingType
     val brakingCurveType =
         if (brakingCurveType1 == brakingCurveType2) brakingCurveType1
         else {
@@ -575,25 +467,24 @@ private fun computeMinETCSBrakingCurves(
             PS
         }
 
-    val endPos1 = etcsBrakingCurve1.brakingCurve.endPos
-    val endPos2 = etcsBrakingCurve2.brakingCurve.endPos
-    val beginPos1 = etcsBrakingCurve1.brakingCurve.beginPos
-    val beginPos2 = etcsBrakingCurve2.brakingCurve.beginPos
-    if (brakingCurveType1 == GUI)
-        return if (endPos2 >= endPos1) etcsBrakingCurve1 else etcsBrakingCurve2
-    else if (beginPos2 >= endPos1) return etcsBrakingCurve1
-    else if (beginPos1 >= endPos2) return etcsBrakingCurve2
+    val endPos1 = brakingCurve1.brakingCurve.endPos
+    val endPos2 = brakingCurve2.brakingCurve.endPos
+    val beginPos1 = brakingCurve1.brakingCurve.beginPos
+    val beginPos2 = brakingCurve2.brakingCurve.beginPos
+    if (brakingCurveType1 == GUI) return if (endPos2 >= endPos1) brakingCurve1 else brakingCurve2
+    else if (beginPos2 >= endPos1) return brakingCurve1
+    else if (beginPos1 >= endPos2) return brakingCurve2
 
     // Compute min curve on intersecting range.
     val intersectingRangeBegin = max(beginPos1, beginPos2)
     val intersectingRangeEnd = min(endPos1, endPos2)
     val curveOnIntersectingRange1 =
         Envelope.make(
-            *etcsBrakingCurve1.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
+            *brakingCurve1.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
         )
     val curveOnIntersectingRange2 =
         Envelope.make(
-            *etcsBrakingCurve2.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
+            *brakingCurve2.brakingCurve.slice(intersectingRangeBegin, intersectingRangeEnd)
         )
     val minCurveOnIntersectingRange =
         minEnvelopes(curveOnIntersectingRange1, curveOnIntersectingRange2)
@@ -601,20 +492,20 @@ private fun computeMinETCSBrakingCurves(
     // Add corresponding curve part before intersecting range.
     val minCurve = minCurveOnIntersectingRange.stream().toList().toMutableList()
     val isCurveAtBeginCurve1 =
-        etcsBrakingCurve1.brakingCurve.interpolateSpeed(intersectingRangeBegin) ==
+        brakingCurve1.brakingCurve.interpolateSpeed(intersectingRangeBegin) ==
             minCurveOnIntersectingRange.beginSpeed
     if (isCurveAtBeginCurve1 && beginPos1 < minCurveOnIntersectingRange.beginPos)
         minCurve.addAll(
             0,
-            etcsBrakingCurve1.brakingCurve.slice(beginPos1, intersectingRangeBegin).toList()
+            brakingCurve1.brakingCurve.slice(beginPos1, intersectingRangeBegin).toList()
         )
     else if (!isCurveAtBeginCurve1 && beginPos2 < minCurveOnIntersectingRange.beginPos)
         minCurve.addAll(
             0,
-            etcsBrakingCurve2.brakingCurve.slice(beginPos2, intersectingRangeBegin).toList()
+            brakingCurve2.brakingCurve.slice(beginPos2, intersectingRangeBegin).toList()
         )
 
-    return ETCSBrakingCurve(brakingCurveType, Envelope.make(*minCurve.toTypedArray()))
+    return BrakingCurve(brakingCurveType, Envelope.make(*minCurve.toTypedArray()))
 }
 
 /**
@@ -622,10 +513,10 @@ private fun computeMinETCSBrakingCurves(
  * with it or with begin position. If the braking curve has no intersection, return null.
  */
 private fun keepBrakingCurveUnderOverlay(
-    etcsBrakingCurve: ETCSBrakingCurve,
+    etcsBrakingCurve: BrakingCurve,
     overlay: Envelope,
     beginPos: Double
-): ETCSBrakingCurve? {
+): BrakingCurve? {
     var brakingCurve = etcsBrakingCurve.brakingCurve
     if (brakingCurve.beginPos >= overlay.endPos || brakingCurve.endPos <= beginPos) {
         etcsBrakingCurvesLogger.warn(
@@ -671,7 +562,7 @@ private fun keepBrakingCurveUnderOverlay(
     for (i in lastIndex - 1 downTo 0) {
         if (!overlayBuilder.addStep(positions[i], speeds[i], timeDeltas[i])) break
     }
-    return ETCSBrakingCurve(etcsBrakingCurve.brakingCurveType, Envelope.make(partBuilder.build()))
+    return BrakingCurve(etcsBrakingCurve.brakingType, Envelope.make(partBuilder.build()))
 }
 
 /**

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -1,9 +1,12 @@
 package fr.sncf.osrd.envelope_sim.etcs
 
 import fr.sncf.osrd.envelope.Envelope
+import fr.sncf.osrd.envelope.OverlayEnvelopeBuilder
 import fr.sncf.osrd.envelope_sim.EnvelopeSimContext
+import fr.sncf.osrd.envelope_sim.etcs.BrakingType.IND
 import fr.sncf.osrd.sim_infra.api.TravelledPath
 import fr.sncf.osrd.utils.units.Offset
+import java.util.*
 
 /**
  * In charge of computing and adding the ETCS braking curves. Formulas are found in `SUBSET-026-3
@@ -35,30 +38,51 @@ interface ETCSBrakingSimulator {
     fun computeSlowdownBrakingCurves(
         mrsp: Envelope,
         limitsOfAuthority: Collection<LimitOfAuthority>
-    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>>
+    ): LOABrakingCurves
 
     /** Compute the ETCS braking curves for each EoA, ordered by EoA offset. */
     fun computeStopBrakingCurves(
         mrsp: Envelope,
         endsOfAuthority: Collection<EndOfAuthority>
-    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>>
+    ): EOABrakingCurves
 }
+
+typealias BrakingCurves = EnumMap<BrakingType, BrakingCurve?>
+
+typealias LOABrakingCurves = NavigableMap<LimitOfAuthority, BrakingCurves>
+
+typealias EOABrakingCurves = NavigableMap<EndOfAuthority, BrakingCurves>
+
+data class BrakingCurve(val brakingType: BrakingType, val brakingCurve: Envelope)
 
 data class LimitOfAuthority(
     val offset: Offset<TravelledPath>,
     val speed: Double,
-) {
+) : Comparable<LimitOfAuthority> {
     init {
         assert(speed > 0)
+    }
+
+    override fun compareTo(other: LimitOfAuthority): Int {
+        if (offset != other.offset) return offset.compareTo(other.offset)
+        return speed.compareTo(other.speed)
     }
 }
 
 data class EndOfAuthority(
     val offsetEOA: Offset<TravelledPath>,
     val offsetSVL: Offset<TravelledPath>?,
-) {
+) : Comparable<EndOfAuthority> {
     init {
         if (offsetSVL != null) assert(offsetSVL >= offsetEOA)
+    }
+
+    override fun compareTo(other: EndOfAuthority): Int {
+        if (offsetEOA != other.offsetEOA) return offsetEOA.compareTo(other.offsetEOA)
+        if (offsetSVL == null && other.offsetSVL == null) return 0
+        if (offsetSVL == null) return -1
+        if (other.offsetSVL == null) return 1
+        return offsetSVL.compareTo(other.offsetSVL)
     }
 }
 
@@ -67,27 +91,72 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         envelope: Envelope,
         limitsOfAuthority: Collection<LimitOfAuthority>
     ): Envelope {
-        return addBrakingCurvesAtLOAs(envelope, context, limitsOfAuthority)
+        val sortedLimitsOfAuthority = limitsOfAuthority.sorted()
+        val beginPos = envelope.beginPos
+        var envelopeWithLoaBrakingCurves = envelope
+        var builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
+
+        for (limitOfAuthority in sortedLimitsOfAuthority) {
+            val ebdBrakingCurves =
+                computeBrakingCurvesAtLOA(
+                    limitOfAuthority,
+                    context,
+                    envelopeWithLoaBrakingCurves,
+                    beginPos
+                )
+            val indicationCurve = ebdBrakingCurves[IND] ?: continue
+            indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
+
+            // We build the LOAs along the path, and they don't all have the same target speeds. To
+            // handle intersections with the next LOA, it is needed to add this LOA braking curve to
+            // the
+            // overlay builder that will be used to compute the following LOAs.
+            envelopeWithLoaBrakingCurves = builder.build()
+            builder = OverlayEnvelopeBuilder.forward(envelopeWithLoaBrakingCurves)
+        }
+        return envelopeWithLoaBrakingCurves
     }
 
     override fun addStopBrakingCurves(
         envelope: Envelope,
         endsOfAuthority: Collection<EndOfAuthority>
     ): Envelope {
-        return addBrakingCurvesAtEOAs(envelope, context, endsOfAuthority)
+        val sortedEndsOfAuthority = endsOfAuthority.sorted()
+        var beginPos = envelope.beginPos
+        val builder = OverlayEnvelopeBuilder.forward(envelope)
+        for (endOfAuthority in sortedEndsOfAuthority) {
+            val eoaBrakingCurves =
+                computeBrakingCurvesAtEOA(endOfAuthority, context, envelope, beginPos)
+            val indicationCurve = eoaBrakingCurves[IND] ?: continue
+            indicationCurve.brakingCurve.stream().forEach { builder.addPart(it) }
+
+            // We build EOAs along the path. We need to handle overlaps with the next EOA. To do so,
+            // we
+            // shift the left position constraint, beginPos, to this EOA's target position.
+            beginPos = endOfAuthority.offsetEOA.distance.meters
+        }
+        return builder.build()
     }
 
     override fun computeSlowdownBrakingCurves(
         mrsp: Envelope,
         limitsOfAuthority: Collection<LimitOfAuthority>
-    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
-        return computeBrakingCurvesAtLOAs(mrsp, context, limitsOfAuthority)
+    ): LOABrakingCurves {
+        val res: LOABrakingCurves = TreeMap()
+        for (limitOfAuthority in limitsOfAuthority) {
+            res[limitOfAuthority] = computeBrakingCurvesAtLOA(limitOfAuthority, context, mrsp, 0.0)
+        }
+        return res
     }
 
     override fun computeStopBrakingCurves(
         mrsp: Envelope,
         endsOfAuthority: Collection<EndOfAuthority>
-    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
-        return computeBrakingCurvesAtEOAs(mrsp, context, endsOfAuthority)
+    ): EOABrakingCurves {
+        val res: EOABrakingCurves = TreeMap()
+        for (endOfAuthority in endsOfAuthority) {
+            res[endOfAuthority] = computeBrakingCurvesAtEOA(endOfAuthority, context, mrsp, 0.0)
+        }
+        return res
     }
 }

--- a/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
+++ b/core/envelope-sim/src/main/kotlin/fr/sncf/osrd/envelope_sim/etcs/ETCSBrakingSimulator.kt
@@ -13,17 +13,35 @@ import fr.sncf.osrd.utils.units.Offset
 interface ETCSBrakingSimulator {
     val context: EnvelopeSimContext
 
-    /** Compute the ETCS braking envelope for each LOA. */
+    /**
+     * Compute the ETCS braking envelope for each LoA and return a new envelope taking said curves
+     * into account.
+     */
     fun addSlowdownBrakingCurves(
         envelope: Envelope,
         limitsOfAuthority: Collection<LimitOfAuthority>
     ): Envelope
 
-    /** Compute the ETCS braking envelope for each EOA. */
+    /**
+     * Compute the ETCS braking envelope for each EoA and return a new envelope taking said curves
+     * into account.
+     */
     fun addStopBrakingCurves(
         envelope: Envelope,
         endsOfAuthority: Collection<EndOfAuthority>
     ): Envelope
+
+    /** Compute the ETCS braking curves for each LoA, ordered by LoA offset. */
+    fun computeSlowdownBrakingCurves(
+        mrsp: Envelope,
+        limitsOfAuthority: Collection<LimitOfAuthority>
+    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>>
+
+    /** Compute the ETCS braking curves for each EoA, ordered by EoA offset. */
+    fun computeStopBrakingCurves(
+        mrsp: Envelope,
+        endsOfAuthority: Collection<EndOfAuthority>
+    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>>
 }
 
 data class LimitOfAuthority(
@@ -49,7 +67,6 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         envelope: Envelope,
         limitsOfAuthority: Collection<LimitOfAuthority>
     ): Envelope {
-        if (limitsOfAuthority.isEmpty()) return envelope
         return addBrakingCurvesAtLOAs(envelope, context, limitsOfAuthority)
     }
 
@@ -57,7 +74,20 @@ class ETCSBrakingSimulatorImpl(override val context: EnvelopeSimContext) : ETCSB
         envelope: Envelope,
         endsOfAuthority: Collection<EndOfAuthority>
     ): Envelope {
-        if (endsOfAuthority.isEmpty()) return envelope
         return addBrakingCurvesAtEOAs(envelope, context, endsOfAuthority)
+    }
+
+    override fun computeSlowdownBrakingCurves(
+        mrsp: Envelope,
+        limitsOfAuthority: Collection<LimitOfAuthority>
+    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
+        return computeBrakingCurvesAtLOAs(mrsp, context, limitsOfAuthority)
+    }
+
+    override fun computeStopBrakingCurves(
+        mrsp: Envelope,
+        endsOfAuthority: Collection<EndOfAuthority>
+    ): List<Map<BrakingCurveType, ETCSBrakingCurve?>> {
+        return computeBrakingCurvesAtEOAs(mrsp, context, endsOfAuthority)
     }
 }

--- a/tests/tests/test_train_schedule.py
+++ b/tests/tests/test_train_schedule.py
@@ -213,7 +213,7 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(
         )
         < 1
     )
-    offset_42_ms_brake_downhill = 27_365_028  # third stop is the end of the braking
+    offset_42_ms_brake_downhill = 27_318_065  # third stop is the end of the braking
     assert (
         abs(
             _get_current_or_next_speed_at(
@@ -235,32 +235,34 @@ def test_etcs_schedule_stop_brakes_result_never_reach_mrsp(
     #   dodges this limit and starts under "high" MRSP (288 km/h), and the guidance curve change at 220 km/h is also
     #   noticeable.
     # In practice, check noticeable points of the braking curves (with the stops already checked)
-    offset_first_high_speed = 14_509_017
-    offset_first_brake_220_kph_speed = 17_544_856
+    offset_start_first_brake_high_speed = 14_509_004
+    offset_bending_guidance_point_first_brake = 17_684_268
     _assert_equal_speeds(
-        _get_current_or_next_speed_at(simulation_final_output, offset_first_high_speed),
-        kph2ms(274.176),
+        _get_current_or_next_speed_at(
+            simulation_final_output, offset_start_first_brake_high_speed
+        ),
+        kph2ms(274.178),
     )
     _assert_equal_speeds(
         _get_current_or_next_speed_at(
-            simulation_final_output, offset_first_brake_220_kph_speed
+            simulation_final_output, offset_bending_guidance_point_first_brake
         ),
-        kph2ms(221.004),
+        kph2ms(217.970),
     )
 
-    offset_fourth_high_speed = 37_087_342
-    offset_fourth_brake_220_kph_speed = 37_661_601
+    offset_fourth_high_speed = 37_560_933
+    offset_fourth_brake_220_kph_speed = 37_819_833
     _assert_equal_speeds(
         _get_current_or_next_speed_at(
             simulation_final_output, offset_fourth_high_speed
         ),
-        kph2ms(230.976),
+        kph2ms(221.94),
     )
     _assert_equal_speeds(
         _get_current_or_next_speed_at(
             simulation_final_output, offset_fourth_brake_220_kph_speed
         ),
-        kph2ms(219.744),
+        kph2ms(215.7),
     )
 
 
@@ -366,7 +368,7 @@ def test_etcs_schedule_result_stop_brake_from_mrsp(
         )
         < speed_before_first_brake
     )
-    offset_start_second_brake = 40_663_532
+    offset_start_second_brake = 40_663_497
     speed_before_second_brake = _get_current_or_next_speed_at(
         simulation_final_output, offset_start_second_brake
     )
@@ -478,18 +480,18 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_same_location(
         < speed_before_first_brake
     )
     # Check a bending point for the first stop's braking curve (where the Guidance curve's influence stops).
-    offset_bending_guidance_point = 37_210_260
+    offset_bending_guidance_point = 37_313_980
     speed_at_bending_guidance_point = _get_current_or_next_speed_at(
         simulation_final_output, offset_bending_guidance_point
     )
-    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(224.447_943_6))
+    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(222.444_095))
     # Check that the release part (where the speed stays at 40km/h) starts and ends at the expected offsets.
-    offset_start_release_speed = 40_827_882
+    offset_start_release_speed = 40_827_738
     speed_at_start_release_speed = _get_current_or_next_speed_at(
         simulation_final_output, offset_start_release_speed
     )
     _assert_equal_speeds(speed_at_start_release_speed, RELEASE_SPEED_40)
-    offset_end_release_speed = 40_892_792
+    offset_end_release_speed = 40_892_587
     speed_at_end_release_speed = _get_current_or_next_speed_at(
         simulation_final_output, offset_end_release_speed
     )
@@ -597,25 +599,25 @@ def test_etcs_schedule_result_stop_with_eoa_and_svl_at_different_locations(
         < speed_before_first_brake
     )
     # Check the first bending point for the first stop's braking curve (where the Guidance curve's influence stops).
-    offset_bending_guidance_point = 37_240_601
+    offset_bending_guidance_point = 37_239_933
     speed_at_bending_guidance_point = _get_current_or_next_speed_at(
         simulation_final_output, offset_bending_guidance_point
     )
-    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(219.751_941_6))
+    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(221.94))
     # Check the second bending point for the first stop's braking curve, where the indication curve followed switches
     # from the EoA indication curve to the SvL indication curve.
-    offset_bending_point_eoa_to_svl = 39_122_786
+    offset_bending_point_eoa_to_svl = 39_005_481
     speed_at_bending_point_eoa_to_svl = _get_current_or_next_speed_at(
         simulation_final_output, offset_bending_point_eoa_to_svl
     )
-    _assert_equal_speeds(speed_at_bending_point_eoa_to_svl, kph2ms(154.238_039_8))
+    _assert_equal_speeds(speed_at_bending_point_eoa_to_svl, kph2ms(159.411_475_5))
     # Check the third bending point for the first stop's braking curve, where the indication curve followed switches
     # back from the SvL indication curve to the EoA indication curve.
-    offset_bending_point_svl_to_eoa = 40_626_547
+    offset_bending_point_svl_to_eoa = 40_617_604
     speed_at_bending_point_svl_to_eoa = _get_current_or_next_speed_at(
         simulation_final_output, offset_bending_point_svl_to_eoa
     )
-    _assert_equal_speeds(speed_at_bending_point_svl_to_eoa, kph2ms(59.212_766_74))
+    _assert_equal_speeds(speed_at_bending_point_svl_to_eoa, kph2ms(60.013_601_2))
 
 
 def test_etcs_schedule_result_slowdowns(
@@ -708,7 +710,7 @@ def test_etcs_schedule_result_slowdowns(
     # * the initial target for ETCS is the actual MRSP, not adding any anticipation from driver behavior.
 
     # First slowdown
-    offset_start_brake_288_to_142 = 35_151_922
+    offset_start_brake_288_to_142 = 35_151_913
     speed_before_brake_288_to_142 = _get_current_or_next_speed_at(
         simulation_final_output, offset_start_brake_288_to_142
     )
@@ -720,13 +722,13 @@ def test_etcs_schedule_result_slowdowns(
         < speed_before_brake_288_to_142
     )
 
-    offset_bending_guidance_point = 38_322_611
+    offset_bending_guidance_point = 38_296_384
     speed_at_bending_guidance_point = _get_current_or_next_speed_at(
         simulation_final_output, offset_bending_guidance_point
     )
     # Permitted Speed and Guidance intersect at speed ~65.8 m/s, testing a point of the curve close enough
-    # where speed is 65.307_740_6 m/s.
-    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(235.107_866_2))
+    # where speed is 65.499_773_3 m/s.
+    _assert_equal_speeds(speed_at_bending_guidance_point, kph2ms(235.799_184_0))
 
     offset_end_brake_288_to_142 = 40_824_370
     speed_after_brake_288_to_142 = _get_current_or_next_speed_at(
@@ -741,14 +743,14 @@ def test_etcs_schedule_result_slowdowns(
     _assert_equal_speeds(speed_after_brake_288_to_142, SPEED_LIMIT_142)
 
     # Second slowdown
-    offset_start_brake_142_to_120 = 44_413_857
+    offset_start_brake_142_to_112 = 44_413_825
     speed_before_brake_142_to_120 = _get_current_or_next_speed_at(
-        simulation_final_output, offset_start_brake_142_to_120
+        simulation_final_output, offset_start_brake_142_to_112
     )
     _assert_equal_speeds(speed_before_brake_142_to_120, SPEED_LIMIT_142)
     assert (
         _get_current_or_next_speed_at(
-            simulation_final_output, offset_start_brake_142_to_120 + 1
+            simulation_final_output, offset_start_brake_142_to_112 + 1
         )
         < speed_before_brake_142_to_120
     )
@@ -765,14 +767,14 @@ def test_etcs_schedule_result_slowdowns(
     _assert_equal_speeds(speed_after_brake_142_to_120, SPEED_LIMIT_112)
 
     # Slowdown for Safety Speed stop: should probably disappear for ETCS at some point.
-    offset_start_brake_120_to_30 = 45_635_550
+    offset_start_brake_112_to_30 = 45_635_533
     speed_before_brake_120_to_30 = _get_current_or_next_speed_at(
-        simulation_final_output, offset_start_brake_120_to_30
+        simulation_final_output, offset_start_brake_112_to_30
     )
     _assert_equal_speeds(speed_before_brake_120_to_30, SPEED_LIMIT_112)
     assert (
         _get_current_or_next_speed_at(
-            simulation_final_output, offset_start_brake_120_to_30 + 1
+            simulation_final_output, offset_start_brake_112_to_30 + 1
         )
         < speed_before_brake_120_to_30
     )
@@ -789,7 +791,7 @@ def test_etcs_schedule_result_slowdowns(
     _assert_equal_speeds(speed_after_brake_120_to_30, SAFE_SPEED_30)
 
     # Slowdown for short slip stop: should probably disappear for ETCS at some point.
-    offset_start_brake_30_to_10 = 46_697_503
+    offset_start_brake_30_to_10 = 46_697_340
     speed_before_brake_30_to_10 = _get_current_or_next_speed_at(
         simulation_final_output, offset_start_brake_30_to_10
     )
@@ -814,7 +816,7 @@ def test_etcs_schedule_result_slowdowns(
 
     # Final slowdown: EoA (complete stop) braking curve is applied.
     # Note: This should also be impacted if Safety Speed stop and short slip stop disappear for ETCS.
-    offset_start_brake_10_to_0 = 46_953_914
+    offset_start_brake_10_to_0 = 46_953_500
     speed_before_brake_10_to_0 = _get_current_or_next_speed_at(
         simulation_final_output, offset_start_brake_10_to_0
     )


### PR DESCRIPTION
Made a lot of methods more generic so that they would return the complete set of curves. The existing code now goes and picks the indication curve from said set.