### PR TITLE
ui: fix ESLint enforcement in CI

### DIFF
--- a/front/ui/.eslintrc
+++ b/front/ui/.eslintrc
@@ -94,7 +94,7 @@
       "error",
       {
         "devDependencies": ["**/*.spec.ts", "**/__tests__/**"],
-        "packageDir": [".", ".."]
+        "packageDir": [".", "../base"]
       }
     ],
     "import/no-unresolved": [

--- a/front/ui/rollup-base.config.js
+++ b/front/ui/rollup-base.config.js
@@ -22,7 +22,10 @@ const generateRollupBaseConfig = () => ({
   })),
   plugins: [
     nodeResolve({ rootDir }),
-    eslint(),
+    eslint({
+      throwOnError: true,
+      throwOnWarning: true,
+    }),
     typescript(),
     postcss({
       extract: 'theme.css',


### PR DESCRIPTION
_See individual commits._

CI would be green even if ESLint was unhappy.

Reported by @clarani.