### PR TITLE
tests: add justfile

### DIFF
--- a/tests/justfile
+++ b/tests/justfile
@@ -1,0 +1,29 @@
+#!/usr/bin/env just --justfile
+
+# Display available recipes
+help:
+    @just --list --unsorted
+
+run:
+    @echo "This component is only about test (see `just test`)"
+
+# Install required dependencies
+install:
+    uv sync --all-extras
+
+# Run the tests
+test:
+    uv run pytest
+
+# Format the source code
+format:
+    uv run ruff format
+
+# Verify code lints without applying any fix
+lint:
+    uv run ruff check
+    uv run pyright .
+
+# Fix all the lints that can be automatically applied
+fix-lint:
+    uv run ruff check --fix


### PR DESCRIPTION
Justfile in `tests/` have been not included in https://github.com/OpenRailAssociation/osrd/pull/11174 because `tests/` was not yet ready (see https://github.com/OpenRailAssociation/osrd/pull/11174#discussion_r2005573128). But `tests/` have been updated since in https://github.com/OpenRailAssociation/osrd/pull/11287. 