### PR TITLE
osrd_schemas, railjson_generator: add gitignore for build files

### DIFF
--- a/python/osrd_schemas/.gitignore
+++ b/python/osrd_schemas/.gitignore
@@ -1,1 +1,2 @@
-osrd_schemas.egg-info
+build/
+osrd_schemas.egg-info/

--- a/python/railjson_generator/.gitignore
+++ b/python/railjson_generator/.gitignore
@@ -1,1 +1,2 @@
-railjson_generator.egg-info
+build/
+railjson_generator.egg-info/


### PR DESCRIPTION
Since we moved to the new standard for `pyproject.toml`, some build commands of Python packages creates local build files that should be ignored.