### PR TITLE
railjson_generator: update the justfile to the latest tools

### DIFF
--- a/python/osrd_schemas/justfile
+++ b/python/osrd_schemas/justfile
@@ -4,7 +4,6 @@
 help:
     @just --list --unsorted
 
-# Generate small infra
 run:
     @echo "This component is a library"
 

--- a/python/railjson_generator/justfile
+++ b/python/railjson_generator/justfile
@@ -19,15 +19,13 @@ test:
 
 # Format the source code
 format:
-    poetry run black .
-    poetry run isort .
+    poetry run ruff format
 
 # Verify code lints without applying any fix
 lint:
-    poetry run pflake8 --config ./pyproject.toml
-    poetry run pytype -j auto
+    poetry run ruff check
+    poetry run pyright .
 
 # Fix all the lints that can be automatically applied
 fix-lint:
-    poetry run black .
-    poetry run isort .
+    @echo "No linter can automatically fix"


### PR DESCRIPTION
When https://github.com/OpenRailAssociation/osrd/pull/11174 have been merged, it was defined with the old way of checking the project. A month before, https://github.com/OpenRailAssociation/osrd/pull/10730 converted `railjson_generator` to `ruff` and `pyright`. However, the `README` was not modified at the time (which might have led to this outdated version of the `justfile`). The `README` was fixed later in https://github.com/OpenRailAssociation/osrd/pull/11287, which was after the PR introducing the `justfiles`.