### PR TITLE
front: refacto occurrence types for exceptions

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useAutoUpdateProjection.ts
+++ b/front/src/applications/operationalStudies/hooks/useAutoUpdateProjection.ts
@@ -13,7 +13,7 @@ import {
 import { useAppDispatch } from 'store';
 import {
   extractPacedTrainIdFromOccurrenceId,
-  formatEditoastTrainIdToOccurrenceId,
+  formatEditoastTrainIdToIndexedOccurrenceId,
   formatPacedTrainIdToEditoastTrainId,
   isPacedTrain,
   isTrainSchedule,
@@ -75,7 +75,7 @@ const useAutoUpdateProjection = (
       }
       if (isPacedTrain(firstValidTrain.id)) {
         const editoastPacedTrainId = formatPacedTrainIdToEditoastTrainId(firstValidTrain.id);
-        const occurrenceIdToSelect = formatEditoastTrainIdToOccurrenceId({
+        const occurrenceIdToSelect = formatEditoastTrainIdToIndexedOccurrenceId({
           pacedTrainId: editoastPacedTrainId,
           occurrenceIndex: 0,
         });

--- a/front/src/modules/trainschedule/components/Timetable/types.ts
+++ b/front/src/modules/trainschedule/components/Timetable/types.ts
@@ -80,8 +80,25 @@ export type TimetableFilters = {
 
 export type Occurrence = {
   id: OccurrenceId;
+  /**
+   * Field present only for a regular occurrence.
+   * An added exception can only be deleted, not disabled.
+   */
+  disabled?: boolean;
   trainName: string;
   rollingStock?: LightRollingStockWithLiveries;
   startTime: Date;
   arrivalTime: Date;
+  exceptionChangeGroups?: ExceptionChangeGroup[];
 };
+
+export type ExceptionChangeGroup =
+  | 'pathAndSchedule'
+  | 'convoy'
+  | 'name'
+  | 'speedLimitByTag'
+  | 'labels'
+  | 'departureTime'
+  | 'constraintDistribution'
+  | 'initialVelocity'
+  | 'electricalProfiles';

--- a/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
+++ b/front/src/reducers/osrdconf/operationalStudiesConf/__tests__/operationalStudiesConfReducer.spec.ts
@@ -41,7 +41,7 @@ describe('simulationConfReducer', () => {
   describe('selectTrainToEdit', () => {
     it('train schedule case', () => {
       const trainSchedule: TrainScheduleWithDetails = {
-        id: 'trainschedule-1' as TrainScheduleId,
+        id: 'trainschedule_1' as TrainScheduleId,
         name: 'train1',
         constraint_distribution: 'MARECO',
         rollingStock: { id: 1, name: 'rollingStock1' } as LightRollingStockWithLiveries,
@@ -101,7 +101,7 @@ describe('simulationConfReducer', () => {
 
     it('paced train case', () => {
       const pacedTrain: PacedTrainWithDetails = {
-        id: 'paced-1' as PacedTrainId,
+        id: 'paced_1' as PacedTrainId,
         name: 'train1',
         constraint_distribution: 'MARECO',
         rollingStock: { id: 1, name: 'rollingStock1' } as LightRollingStockWithLiveries,

--- a/front/src/reducers/osrdconf/types.ts
+++ b/front/src/reducers/osrdconf/types.ts
@@ -132,17 +132,29 @@ export type StdcmPathStep = {
 );
 
 /**
- * Each train schedule id should follow this syntax : train-{id}
+ * Each train schedule id should follow this syntax : trainschedule_{id}
  */
 export type TrainScheduleId = string & { readonly __type: unique symbol };
 
 /**
- * Each occurrence id should follow this syntax : paced-{id}-occurrence-{occurrenceIndex}
+ * Each regular occurrence id should follow this syntax : indexedoccurrence_{pacedTrainId}_{occurrenceIndex}
+ * A regular occurrence is an occurrence that was originally part of the paced train.
+ * It can have been disabled or turned into an exception by being modified (and disabled).
  */
-export type OccurrenceId = string & { readonly __type: unique symbol };
+export type IndexedOccurrenceId = string & { readonly __type: unique symbol };
 
 /**
- * Each paced train id should follow this syntax : paced-{id}
+ * Each added exception id should follow this syntax : exception_{pacedTrainId}_{exceptionId}
+ */
+export type AddedExceptionId = string & { readonly __type: unique symbol };
+
+/**
+ * Regroup any occurrence id whether it is a regular occurrence or any kind of exception
+ */
+export type OccurrenceId = IndexedOccurrenceId | AddedExceptionId;
+
+/**
+ * Each paced train id should follow this syntax : paced_{id}
  */
 export type PacedTrainId = string & { readonly __type: unique symbol };
 

--- a/front/src/utils/__tests__/batch.spec.ts
+++ b/front/src/utils/__tests__/batch.spec.ts
@@ -17,16 +17,16 @@ describe('getBatchPackage', () => {
     const lowerIndex = 0;
     const trainIdsPackage = getBatchPackage(lowerIndex, trainIds, BATCH_SIZE);
     expect(trainIdsPackage).toEqual([
-      'trainschedule-0',
-      'paced-1',
-      'trainschedule-2',
-      'paced-3',
-      'trainschedule-4',
-      'paced-5',
-      'trainschedule-6',
-      'paced-7',
-      'trainschedule-8',
-      'paced-9',
+      'trainschedule_0',
+      'paced_1',
+      'trainschedule_2',
+      'paced_3',
+      'trainschedule_4',
+      'paced_5',
+      'trainschedule_6',
+      'paced_7',
+      'trainschedule_8',
+      'paced_9',
     ]);
   });
 
@@ -34,16 +34,16 @@ describe('getBatchPackage', () => {
     const lowerIndex = 10;
     const trainIdsPackage = getBatchPackage(lowerIndex, trainIds, BATCH_SIZE);
     expect(trainIdsPackage).toEqual([
-      'trainschedule-10',
-      'paced-11',
-      'trainschedule-12',
-      'paced-13',
-      'trainschedule-14',
-      'paced-15',
-      'trainschedule-16',
-      'paced-17',
-      'trainschedule-18',
-      'paced-19',
+      'trainschedule_10',
+      'paced_11',
+      'trainschedule_12',
+      'paced_13',
+      'trainschedule_14',
+      'paced_15',
+      'trainschedule_16',
+      'paced_17',
+      'trainschedule_18',
+      'paced_19',
     ]);
   });
 
@@ -51,11 +51,11 @@ describe('getBatchPackage', () => {
     const lowerIndex = 20;
     const trainIdsPackage = getBatchPackage(lowerIndex, trainIds, BATCH_SIZE);
     expect(trainIdsPackage).toEqual([
-      'trainschedule-20',
-      'paced-21',
-      'trainschedule-22',
-      'paced-23',
-      'trainschedule-24',
+      'trainschedule_20',
+      'paced_21',
+      'trainschedule_22',
+      'paced_23',
+      'trainschedule_24',
     ]);
   });
 });

--- a/front/src/utils/__tests__/trainId.spec.ts
+++ b/front/src/utils/__tests__/trainId.spec.ts
@@ -4,7 +4,7 @@ import type { TrainScheduleId, OccurrenceId, PacedTrainId } from 'reducers/osrdc
 
 import {
   formatEditoastTrainIdToTrainScheduleId,
-  formatEditoastTrainIdToOccurrenceId,
+  formatEditoastTrainIdToIndexedOccurrenceId,
   formatTrainScheduleIdToEditoastTrainId,
   formatOccurrenceIdToEditoastTrainId,
   formatEditoastTrainIdToPacedTrainId,
@@ -12,13 +12,15 @@ import {
   getOccurrenceIndexFromOccurrenceId,
   formatPacedTrainIdToOccurrenceId,
   extractPacedTrainIdFromOccurrenceId,
+  formatEditoastTrainIdToExceptionId,
+  getExceptionIdFromOccurrenceId,
 } from '../trainId';
 
 describe('formatEditoastTrainIdToTrainScheduleId', () => {
   it('should format to a TrainScheduleId', () => {
     const trainId = 123;
     const result = formatEditoastTrainIdToTrainScheduleId(trainId);
-    expect(result).toEqual(`trainschedule-${trainId}`);
+    expect(result).toEqual(`trainschedule_${trainId}`);
   });
 });
 
@@ -26,35 +28,44 @@ describe('formatEditoastTrainIdToPacedTrainId', () => {
   it('should format to a PacedTrainId', () => {
     const trainId = 123;
     const result = formatEditoastTrainIdToPacedTrainId(trainId);
-    expect(result).toEqual(`paced-${trainId}`);
+    expect(result).toEqual(`paced_${trainId}`);
   });
 });
 
-describe('formatEditoastTrainIdToOccurrenceId', () => {
+describe('formatEditoastTrainIdToIndexedOccurrenceId', () => {
   it('should format a valid paced train ID and occurrence index correctly', () => {
     const pacedTrainId = 123;
     const occurrenceIndex = 1;
-    const result = formatEditoastTrainIdToOccurrenceId({ pacedTrainId, occurrenceIndex });
-    expect(result).toBe(`occurrence-${occurrenceIndex}-paced-${pacedTrainId}`);
+    const result = formatEditoastTrainIdToIndexedOccurrenceId({ pacedTrainId, occurrenceIndex });
+    expect(result).toBe(`indexedoccurrence_${pacedTrainId}_${occurrenceIndex}`);
+  });
+});
+
+describe('formatEditoastTrainIdToExceptionId', () => {
+  it('should format a valid paced train ID and occurrence index correctly', () => {
+    const pacedTrainId = 123;
+    const exceptionId = 'exception-uuid';
+    const result = formatEditoastTrainIdToExceptionId({ pacedTrainId, exceptionId });
+    expect(result).toBe(`exception_${pacedTrainId}_${exceptionId}`);
   });
 });
 
 describe('formatTrainScheduleIdToEditoastTrainId', () => {
   it('should return a valid editoast id', () => {
-    const trainScheduleId = 'trainschedule-123' as TrainScheduleId;
+    const trainScheduleId = 'trainschedule_123' as TrainScheduleId;
     const result = formatTrainScheduleIdToEditoastTrainId(trainScheduleId);
     expect(result).toBe(123);
   });
 
   it("should throw an error if the trainScheduleId doesn't start correctly", () => {
-    const trainScheduleId = 'invalid-123' as TrainScheduleId;
+    const trainScheduleId = 'invalid_123' as TrainScheduleId;
     expect(() => formatTrainScheduleIdToEditoastTrainId(trainScheduleId)).toThrow(
-      'The train schedule id should start with "trainschedule-"'
+      'The train schedule id should start with "trainschedule_"'
     );
   });
 
   it("should throw an error if the return train id isn't a number", () => {
-    const trainScheduleId = 'trainschedule-onetwo' as TrainScheduleId;
+    const trainScheduleId = 'trainschedule_onetwo' as TrainScheduleId;
     expect(() => formatTrainScheduleIdToEditoastTrainId(trainScheduleId)).toThrow(
       `Invalid train ID: ${trainScheduleId}`
     );
@@ -63,20 +74,20 @@ describe('formatTrainScheduleIdToEditoastTrainId', () => {
 
 describe('formatPacedTrainIdToEditoastTrainId', () => {
   it('should return a valid editoast id', () => {
-    const pacedTrainId = 'paced-123' as PacedTrainId;
+    const pacedTrainId = 'paced_123' as PacedTrainId;
     const result = formatPacedTrainIdToEditoastTrainId(pacedTrainId);
     expect(result).toBe(123);
   });
 
   it("should throw an error if the pacedTrainId doesn't start correctly", () => {
-    const pacedTrainId = 'invalid-123' as PacedTrainId;
+    const pacedTrainId = 'invalid_123' as PacedTrainId;
     expect(() => formatPacedTrainIdToEditoastTrainId(pacedTrainId)).toThrow(
-      'The paced train id should start with "paced-"'
+      'The paced train id should start with "paced_"'
     );
   });
 
   it("should throw an error if the return train id isn't a number", () => {
-    const pacedTrainId = 'paced-onetwo' as PacedTrainId;
+    const pacedTrainId = 'paced_onetwo' as PacedTrainId;
     expect(() => formatPacedTrainIdToEditoastTrainId(pacedTrainId)).toThrow(
       `Invalid paced train ID: ${pacedTrainId}`
     );
@@ -84,103 +95,108 @@ describe('formatPacedTrainIdToEditoastTrainId', () => {
 });
 
 describe('formatOccurrenceIdToEditoastTrainId', () => {
-  it('should return a valid editoast id', () => {
-    const occurrenceId = 'occurrence-1-paced-123' as OccurrenceId;
+  it('should return a valid editoast id for a regular occurrence', () => {
+    const occurrenceId = 'indexedoccurrence_123_1' as OccurrenceId;
     const result = formatOccurrenceIdToEditoastTrainId(occurrenceId);
     expect(result).toBe(123);
   });
 
-  it('should throw an error for an invalid pacedTrain key format', () => {
-    const occurrenceId = 'occurrence-1-invalid-123' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
-    );
+  it('should return a valid editoast id for an added exception', () => {
+    const occurrenceId = 'exception_123_1' as OccurrenceId;
+    const result = formatOccurrenceIdToEditoastTrainId(occurrenceId);
+    expect(result).toBe(123);
   });
 
   it('should throw an error for an invalid occurrence key format', () => {
-    const occurrenceId = 'train-1-paced-123' as OccurrenceId;
+    const occurrenceId = 'train_123_1' as OccurrenceId;
     expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+      'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}" or "exception_{pacedTrainId}_{exceptionId}"'
     );
   });
 
   it("should throw an error if the paced train id isn't a number", () => {
-    const occurrenceId = 'occurrence-3-paced-onetwo' as OccurrenceId;
+    const occurrenceId = 'indexedoccurrence_onetwo_3' as OccurrenceId;
     expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      `Invalid paced train ID or occurrence index: ${occurrenceId}`
-    );
-  });
-
-  it("should throw an error if the occurrence id isn't a number", () => {
-    const occurrenceId = 'occurrence-five-paced-2' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      `Invalid paced train ID or occurrence index: ${occurrenceId}`
+      `Invalid paced train ID : ${occurrenceId}`
     );
   });
 });
 
 describe('formatPacedTrainIdToOccurrenceId', () => {
   it('should return the occurrenceId', () => {
-    const pacedTrainId = 'paced-123' as PacedTrainId;
+    const pacedTrainId = 'paced_123' as PacedTrainId;
     const result = formatPacedTrainIdToOccurrenceId(pacedTrainId, 0);
-    expect(result).toBe('occurrence-0-paced-123');
+    expect(result).toBe('indexedoccurrence_123_0');
   });
 
   it('should throw if pacedTrainId is invalid', () => {
-    const pacedTrainId = 'invalid-paced-123' as PacedTrainId;
+    const pacedTrainId = 'invalid_paced_123' as PacedTrainId;
     expect(() => formatPacedTrainIdToOccurrenceId(pacedTrainId, 0)).toThrow(
-      'The paced train id should start with "paced-"'
+      'The paced train id should start with "paced_"'
     );
   });
 });
 
 describe('extractPacedTrainIdFromOccurrenceId', () => {
-  it('should return the pacedTrainId', () => {
-    const occurenceId = 'occurrence-0-paced-123' as OccurrenceId;
+  it('should return the pacedTrainId for a regular occurrence', () => {
+    const occurenceId = 'indexedoccurrence_123_0' as OccurrenceId;
     const result = extractPacedTrainIdFromOccurrenceId(occurenceId);
-    expect(result).toBe('paced-123');
+    expect(result).toBe('paced_123');
   });
 
-  it('should throw if occurrenceId is invalid', () => {
-    const occurenceId = 'invalid-occurrence-0-paced-123' as OccurrenceId;
+  it('should return the pacedTrainId for an added exception', () => {
+    const occurenceId = 'exception_123_0' as OccurrenceId;
+    const result = extractPacedTrainIdFromOccurrenceId(occurenceId);
+    expect(result).toBe('paced_123');
+  });
+
+  it('should throw if the key is invalid', () => {
+    const occurenceId = 'exception-indexedoccurrence_123_0' as OccurrenceId;
     expect(() => extractPacedTrainIdFromOccurrenceId(occurenceId)).toThrow(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+      'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}" or "exception_{pacedTrainId}_{exceptionId}"'
     );
   });
 });
 
 describe('getOccurrenceIndexFromOccurrenceId', () => {
   it('should return the occurrence index', () => {
-    const occurrenceId = 'occurrence-1-paced-123' as OccurrenceId;
+    const occurrenceId = 'indexedoccurrence_123_1' as OccurrenceId;
     const result = getOccurrenceIndexFromOccurrenceId(occurrenceId);
     expect(result).toBe(1);
   });
 
-  it('should throw an error for an invalid pacedTrain key format', () => {
-    const occurrenceId = 'occurrence-1-invalid-123' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+  it('should throw an error for an invalid key format', () => {
+    const occurrenceId = 'exception_123_1' as OccurrenceId;
+    expect(() => getOccurrenceIndexFromOccurrenceId(occurrenceId)).toThrow(
+      'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}"'
     );
   });
 
-  it('should throw an error for an invalid occurrence key format', () => {
-    const occurrenceId = 'train-1-paced-123' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+  it("should throw an error if the occurrence index isn't a number", () => {
+    const occurrenceId = 'indexedoccurrence_123_three' as OccurrenceId;
+    expect(() => getOccurrenceIndexFromOccurrenceId(occurrenceId)).toThrow(
+      `Invalid occurrence index: ${occurrenceId}`
     );
   });
+});
 
-  it("should throw an error if the paced train id isn't a number", () => {
-    const occurrenceId = 'occurrence-3-paced-onetwo' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      `Invalid paced train ID or occurrence index: ${occurrenceId}`
-    );
+describe('getExceptionIdFromOccurrenceId', () => {
+  it('should return the exception id', () => {
+    const occurrenceId = 'exception_123_exception-uuid' as OccurrenceId;
+    const result = getExceptionIdFromOccurrenceId(occurrenceId);
+    expect(result).toBe('exception-uuid');
   });
 
-  it("should throw an error if the occurrence id isn't a number", () => {
-    const occurrenceId = 'occurrence-five-paced-2' as OccurrenceId;
-    expect(() => formatOccurrenceIdToEditoastTrainId(occurrenceId)).toThrow(
-      `Invalid paced train ID or occurrence index: ${occurrenceId}`
+  it('should return the whole exception id if it contains underscores', () => {
+    const occurrenceId = 'exception_123_exception_uuid_with_underscores' as OccurrenceId;
+    const result = getExceptionIdFromOccurrenceId(occurrenceId);
+    expect(result).toBe('exception_uuid_with_underscores');
+  });
+
+  it('should throw an error for an invalid key format', () => {
+    const occurrenceId = 'indexedoccurrence_123_exception-uuid' as OccurrenceId;
+    expect(() => getExceptionIdFromOccurrenceId(occurrenceId)).toThrow(
+      'The occurrence id should match the format "exception_{pacedTrainId}_{exceptionId}"'
     );
   });
 });

--- a/front/src/utils/trainId.ts
+++ b/front/src/utils/trainId.ts
@@ -1,8 +1,11 @@
 import type {
   TimetableItemWithDetails,
   PacedTrainWithDetails,
+  Occurrence,
 } from 'modules/trainschedule/components/Timetable/types';
 import type {
+  AddedExceptionId,
+  IndexedOccurrenceId,
   OccurrenceId,
   PacedTrainId,
   PacedTrainResponseWithPacedTrainId,
@@ -11,18 +14,37 @@ import type {
   TrainScheduleId,
 } from 'reducers/osrdconf/types';
 
-export const isPacedTrain = (id: string): id is PacedTrainId => id.startsWith('paced-');
+export const isPacedTrain = (id: string): id is PacedTrainId => id.startsWith('paced_');
 
-export const isOccurrence = (id: string): id is OccurrenceId => {
-  const occurrenceSyntax = id.split('-')[0];
-  const pacedSyntax = id.split('-')[2];
-  return occurrenceSyntax === 'occurrence' && pacedSyntax === 'paced';
-};
+const isIndexedOccurrence = (id: string): id is IndexedOccurrenceId =>
+  id.startsWith('indexedoccurrence_');
+
+const isAddedException = (id: string): id is AddedExceptionId => id.startsWith('exception_');
+
+export const isOccurrence = (id: string): id is OccurrenceId =>
+  isIndexedOccurrence(id) || isAddedException(id);
 
 export const isTrainSchedule = (id: string): id is TrainScheduleId =>
-  id.startsWith('trainschedule-');
+  id.startsWith('trainschedule_');
 
 export const isTrainId = (id: string): id is TrainId => isOccurrence(id) || isTrainSchedule(id);
+
+/**
+ * Given an occurrence id, return the type of the exception.
+ * - An added exception is an occurrence created at the same time of a paced train creation/edition
+ * and will always be desynchronised with the paced train interval/time window.
+ * - An added exception that has been modified is still considered as an added exception.
+ */
+export const getExceptionType = (occurrence: Occurrence): 'added' | 'modified' | null => {
+  const { id, exceptionChangeGroups } = occurrence;
+  if (isAddedException(id)) {
+    return 'added';
+  }
+  if (isIndexedOccurrence(id) && exceptionChangeGroups && exceptionChangeGroups.length > 0) {
+    return 'modified';
+  }
+  return null;
+};
 
 export const isPacedTrainResponseWithPacedTrainId = (
   timetableItem: TimetableItemWithTimetableId
@@ -37,26 +59,39 @@ export const isPacedTrainWithDetails = (
  * returns the train id with a TrainScheduleId format (used across the front).
  */
 export const formatEditoastTrainIdToTrainScheduleId = (trainId: number): TrainScheduleId =>
-  `trainschedule-${trainId}` as TrainScheduleId;
+  `trainschedule_${trainId}` as TrainScheduleId;
 
 /**
  * Given a train id in the Editoast format (used for api),
  * returns the paced train id with a PacedTrainId format (used across the front).
  */
 export const formatEditoastTrainIdToPacedTrainId = (trainId: number): PacedTrainId =>
-  `paced-${trainId}` as PacedTrainId;
+  `paced_${trainId}` as PacedTrainId;
 
 /**
  * Given a paced train id in the Editoast format (used for api),
- * returns the occurrence id with a OccurrenceId format (used across the front).
+ * returns the occurrence id with an IndexedOccurrenceId format (used across the front).
  */
-export const formatEditoastTrainIdToOccurrenceId = ({
+export const formatEditoastTrainIdToIndexedOccurrenceId = ({
   pacedTrainId,
   occurrenceIndex,
 }: {
   pacedTrainId: number;
   occurrenceIndex: number;
-}): OccurrenceId => `occurrence-${occurrenceIndex}-paced-${pacedTrainId}` as OccurrenceId;
+}): IndexedOccurrenceId =>
+  `indexedoccurrence_${pacedTrainId}_${occurrenceIndex}` as IndexedOccurrenceId;
+
+/**
+ * Given a paced train id in the Editoast format (used for api) and an exception id,
+ * returns the added exception id with an AddedExceptionId format (used across the front).
+ */
+export const formatEditoastTrainIdToExceptionId = ({
+  pacedTrainId,
+  exceptionId,
+}: {
+  pacedTrainId: number;
+  exceptionId: string;
+}): AddedExceptionId => `exception_${pacedTrainId}_${exceptionId}` as AddedExceptionId;
 
 /**
  * Given a train id with a TrainScheduleId format (used across the front),
@@ -64,9 +99,9 @@ export const formatEditoastTrainIdToOccurrenceId = ({
  */
 export const formatTrainScheduleIdToEditoastTrainId = (trainId: TrainScheduleId): number => {
   if (!isTrainSchedule(trainId)) {
-    throw new Error('The train schedule id should start with "trainschedule-"');
+    throw new Error('The train schedule id should start with "trainschedule_"');
   }
-  const formattedTrainId = Number(trainId.split('-')[1]);
+  const formattedTrainId = Number(trainId.split('_')[1]);
 
   if (Number.isNaN(formattedTrainId)) {
     throw new Error(`Invalid train ID: ${trainId}`);
@@ -81,15 +116,15 @@ export const formatTrainScheduleIdToEditoastTrainId = (trainId: TrainScheduleId)
  */
 export const formatPacedTrainIdToEditoastTrainId = (pacedTrainId: PacedTrainId): number => {
   if (!isPacedTrain(pacedTrainId)) {
-    throw new Error('The paced train id should start with "paced-"');
+    throw new Error('The paced train id should start with "paced_"');
   }
-  const formattedTrainId = Number(pacedTrainId.split('-')[1]);
+  const formattedPacedTrainId = Number(pacedTrainId.split('_')[1]);
 
-  if (Number.isNaN(formattedTrainId)) {
+  if (Number.isNaN(formattedPacedTrainId)) {
     throw new Error(`Invalid paced train ID: ${pacedTrainId}`);
   }
 
-  return formattedTrainId;
+  return formattedPacedTrainId;
 };
 
 /**
@@ -99,18 +134,17 @@ export const formatPacedTrainIdToEditoastTrainId = (pacedTrainId: PacedTrainId):
 export const formatOccurrenceIdToEditoastTrainId = (occurrenceId: OccurrenceId): number => {
   if (!isOccurrence(occurrenceId)) {
     throw new Error(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+      'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}" or "exception_{pacedTrainId}_{exceptionId}"'
     );
   }
 
-  const formattedOccurrenceIndex = Number(occurrenceId.split('-')[1]);
-  const formattedTrainId = Number(occurrenceId.split('-')[3]);
+  const formattedPacedTrainId = Number(occurrenceId.split('_')[1]);
 
-  if (Number.isNaN(formattedOccurrenceIndex) || Number.isNaN(formattedTrainId)) {
-    throw new Error(`Invalid paced train ID or occurrence index: ${occurrenceId}`);
+  if (Number.isNaN(formattedPacedTrainId)) {
+    throw new Error(`Invalid paced train ID : ${occurrenceId}`);
   }
 
-  return formattedTrainId;
+  return formattedPacedTrainId;
 };
 
 /**
@@ -120,9 +154,12 @@ export const formatOccurrenceIdToEditoastTrainId = (occurrenceId: OccurrenceId):
 export const formatPacedTrainIdToOccurrenceId = (
   pacedTrainId: PacedTrainId,
   occurrenceIndex: number
-): OccurrenceId => {
+): IndexedOccurrenceId => {
   const editoastTrainId = formatPacedTrainIdToEditoastTrainId(pacedTrainId);
-  return formatEditoastTrainIdToOccurrenceId({ pacedTrainId: editoastTrainId, occurrenceIndex });
+  return formatEditoastTrainIdToIndexedOccurrenceId({
+    pacedTrainId: editoastTrainId,
+    occurrenceIndex,
+  });
 };
 
 /**
@@ -139,17 +176,34 @@ export const extractPacedTrainIdFromOccurrenceId = (occurrenceId: OccurrenceId):
  * returns the occurrence index.
  */
 export const getOccurrenceIndexFromOccurrenceId = (occurrenceId: OccurrenceId): number => {
-  if (!isOccurrence(occurrenceId)) {
+  if (!isIndexedOccurrence(occurrenceId)) {
     throw new Error(
-      'The occurrence id should match the format "occurrence-{occurrenceIndex}-paced-{trainId}"'
+      'The occurrence id should match the format "indexedoccurrence_{pacedTrainId}_{occurrenceIndex}"'
     );
   }
 
-  const formattedOccurrenceIndex = Number(occurrenceId.split('-')[1]);
+  const formattedOccurrenceIndex = Number(occurrenceId.split('_')[2]);
 
   if (Number.isNaN(formattedOccurrenceIndex)) {
-    throw new Error(`Invalid paced train ID or occurrence index: ${occurrenceId}`);
+    throw new Error(`Invalid occurrence index: ${occurrenceId}`);
   }
 
   return formattedOccurrenceIndex;
+};
+
+/**
+ * Given a occurrence id with an OccurrenceId format (used across the front),
+ * returns the exception id.
+ */
+export const getExceptionIdFromOccurrenceId = (occurrenceId: OccurrenceId): string => {
+  if (!isAddedException(occurrenceId)) {
+    throw new Error(
+      'The occurrence id should match the format "exception_{pacedTrainId}_{exceptionId}"'
+    );
+  }
+
+  const [_type, _pacedTrainId, ...exceptionId] = occurrenceId.split('_');
+
+  // Handle the case where exceptionId contains "_" itself
+  return exceptionId.join('_');
 };


### PR DESCRIPTION
Implement types of the front part of [exceptions issue](https://github.com/osrd-project/osrd-confidential/issues/980)

### Why change the format ?
This changes the format for all ids to have a better support for exception ids which will most of the time be in uuid format.
Changing for the format `xxx_${pacedTrainId}_${occurrenceIndex/exceptionId}` will help extract the ids with any kind of exception ids.

Ex: If somehow, we have an exception id from an import looking like this : `sdfg:s46g_fg-12`, keeping the old format would could lead to some errors because the `.split()` might be done in the middle of the exception id.
With the new format, the `.split(_)[1]` will always contain the paced train id (which will always be a number) and `.split(_)[2]` will always contain the occurrence index or the exception id regardless the format it will have.

### Why change the `-` ?
When using uuids, this could lead to ids looking like this `exception-143-14r4-124t-4536-b546` which is not very readable. `exception_143_14r4-124t-4536-b546` looked better for me but I'm opened for other character suggestion among the ones supported by the browsers : `$-_.+!*'(),` :)