### PR TITLE
editoast: resolve `doc_overindented_list_items` warning

### DIFF
--- a/editoast/editoast_derive/src/lib.rs
+++ b/editoast/editoast_derive/src/lib.rs
@@ -163,18 +163,18 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// Model struct `Model`:
 ///
 /// * `struct ModelRow`: a struct nearly identical to your model by default, used to
-///     read rows from the database
+///   read rows from the database
 /// * `struct ModelChangeset`: a struct that represents a possibly incomplete
-///     set of changes to apply to a row in the database
+///   set of changes to apply to a row in the database
 /// * `impl Model` that references both structs above
 /// * `impl From<ModelRow> for Model`: a conversion from the row struct to your model
 /// * `impl From<Model> for ModelChangeset`: a conversion from your model to the changeset
 /// * `impl Identifiable<T> for Model` / `impl PreferredId<T> for Model` according to your model specifications,
-///     more about that below
+///   more about that below
 /// * `impl ModelChangeset`: that contains builder functions in order to conveniently
-///     populate the changeset
+///   populate the changeset
 /// * `impl Patch<'a, Model>`: the same builder functions as the changeset, but
-///     for a `Patch` in order to have a better interface
+///   for a `Patch` in order to have a better interface
 /// * `impl Retrieve<T> for Model`: if `Model: Identifiable<T>`
 /// * `impl Create<T, Model> for ModelChangeset`: if `Model: Identifiable<T>`
 /// * `impl Update<T, Model> for ModelChangeset`: if `Model: Identifiable<T>`
@@ -196,15 +196,15 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// * `#[model(changeset(derive(ADDITIONAL_DERIVES*,)))]`: additional derives for the changeset struct (always implicitly derives `Default, Queryable, QueryableByName, AsChangeset, Insertable`)
 /// * `#[model(changeset(public))]`: make the changeset struct fields `pub` (private by default)
 /// * `#[model(identifier = IDENTIFIER)]` (multiple): just like `#[model(identifier)]` for fields, but at the struct level.
-///     `IDENTIFIER` can be a compound identifier with the syntax `(field1, field2, ...)` (e.g.: `#[model(identifier = (infra_id, obj_id))]`).
-///     This option can be specified multiple times. The same rules applies as for fields.
+///   `IDENTIFIER` can be a compound identifier with the syntax `(field1, field2, ...)` (e.g.: `#[model(identifier = (infra_id, obj_id))]`).
+///   This option can be specified multiple times. The same rules applies as for fields.
 /// * `#[model(preferred = PREFERRED)]`: just like `#[model(preferred)]` for fields, but at the struct level.
-///     Compound identifier syntax is supported. This option can be specified only once, including at field level.
-///     It is NOT NECESSARY to also specify `#[model(identifier = PREFERRED)]`.
+///   Compound identifier syntax is supported. This option can be specified only once, including at field level.
+///   It is NOT NECESSARY to also specify `#[model(identifier = PREFERRED)]`.
 /// * `#[model(batch_chunk_size_limit = usize)]` (default: [model::DEFAULT_BATCH_CHUNK_SIZE_LIMIT]): there seem to be a bug from either diesel or libpq that causes
-///     a stack overflow for large batch chunk sizes. Until a better solution is found, this option allows to limit the
-///     size of each chunk on a per-model basis. Increasing this value could lead to stack overflows, decreasing it
-///     might degrade the performance of batch operations.
+///   a stack overflow for large batch chunk sizes. Until a better solution is found, this option allows to limit the
+///   size of each chunk on a per-model basis. Increasing this value could lead to stack overflows, decreasing it
+///   might degrade the performance of batch operations.
 ///
 /// ### Field-level options
 ///
@@ -212,7 +212,7 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// * `#[model(builder_fn = function_name)]`: the name of the builder function for this field (defaults to the field name)
 /// * `#[model(builder_skip)]`: skip this field in the builder
 /// * `#[model(identifier)]`: this field can be used to uniquely identify a the model row in the database ; generates `impl Identifiable<T> for Model`
-///     This field will be excluded from the changeset and the changeset/patch builder.
+///   This field will be excluded from the changeset and the changeset/patch builder.
 /// * `#[model(preferred)]`: implies `identifier` ; also generates `impl PreferredId<T> for Model`
 /// * `#[model(primary)]`: implies `identifier` ; marks the field as the primary key of the table
 /// * `#[model(json)]`: wraps the row field with `diesel_jsonb::JsonValue` (diesel column type: `diesel_jsonb::Json<T>`)
@@ -225,11 +225,11 @@ pub fn search_config_store(input: proc_macro::TokenStream) -> proc_macro::TokenS
 /// #### A note on identifiers
 ///
 /// * *When no `primary` field is specified*, if there is a field named `id`,
-///     *it will be assumed to be the primary key* regardless of its type
+///   *it will be assumed to be the primary key* regardless of its type
 /// * Every model **MUST** have a `primary` field (explicit or not)
 /// * There can only be one `primary` field
 /// * The `primary` field **MUST** be represent the column of the primary key in the database
-///    and be the `diesel_table::PrimaryKey`
+///   and be the `diesel_table::PrimaryKey`
 /// * There can only be one `preferred` field
 /// * If no `preferred` field is provided, the `primary` field will be used
 /// * There can be as many `identifier` fields as you want (as long as it makes sense ofc)

--- a/editoast/editoast_search/src/searchast.rs
+++ b/editoast/editoast_search/src/searchast.rs
@@ -29,7 +29,7 @@ pub enum SearchAstError {
 /// * Strings
 /// * Arrays
 ///     * `["column"]`: represents the value of a column (differs from `"column"`
-///        which is just a plain string)
+///       which is just a plain string)
 ///     * `["function", arg1, arg2, ...]`: a function call where `argN` are sub-queries
 ///
 /// Note that the empty array `[]` and all objects `{...}` are invalid queries.

--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -5,13 +5,13 @@
 //! This library mainly provides two things:
 //!
 //! 1. A way to modelize OpenFGA objects and relations in a type-safe way. Types are regular Rust structures
-//!     and relations are any type implementing the trait [model::Relation]. Are also provided a few macros
-//!     to define and manipulate relations in a declarative way, close to OpenFGA syntax.
+//!    and relations are any type implementing the trait [model::Relation]. Are also provided a few macros
+//!    to define and manipulate relations in a declarative way, close to OpenFGA syntax.
 //! 2. A [client::Client] allowing to interact with an OpenFGA server **over HTTP only**. It doesn't cover all the
-//!     OpenFGA API at the moment but the most common operations are implemented. This client supports the setup
-//!     of stores and authorization models, writing tuples, performing queries such as permission checks, and more.
-//!     The high-level API interfaces with the high-level modelization of OpenFGA objects and relations
-//!     available in this library through the [model] module.
+//!    OpenFGA API at the moment but the most common operations are implemented. This client supports the setup
+//!    of stores and authorization models, writing tuples, performing queries such as permission checks, and more.
+//!    The high-level API interfaces with the high-level modelization of OpenFGA objects and relations
+//!    available in this library through the [model] module.
 //!
 //! # High-level modelization of OpenFGA objects
 //!

--- a/editoast/src/models/prelude/update.rs
+++ b/editoast/src/models/prelude/update.rs
@@ -13,11 +13,11 @@ use super::ModelError;
 /// This struct is useful for several things:
 ///
 /// * Provides a function [Patch::apply] that applies the changeset to the model
-///     row and updates the model instance with the new values
+///   row and updates the model instance with the new values
 /// * Takes the model instance as a mutable reference ensuring no concurrent
-///     modification can be made to the instance
+///   modification can be made to the instance
 /// * The `Model` derive macro generates a builder similar to the changeset
-///     for `Patch<'a, YourModel>` as well making this struct easier to use.
+///   for `Patch<'a, YourModel>` as well making this struct easier to use.
 ///
 /// # Example
 ///

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -135,21 +135,21 @@
 //! Before turning the query into SQL code, we need to make sure of two things:
 //!
 //! 1. The query needs to typecheck. For instance, we disallow using the AND
-//!     operator with an operand that is not either a boolean of `null`.
-//!     The same goes for the LIKE operator that expects as a second operand
-//!     only `null` or a string.
+//!    operator with an operand that is not either a boolean of `null`.
+//!    The same goes for the LIKE operator that expects as a second operand
+//!    only `null` or a string.
 //! 2. The query needs to represent a constraint that can be inserted as a WHERE
-//!     clause in the final SQL query. Therefore, the type of the whole query
-//!     needs to be a boolean, or `null`.
+//!    clause in the final SQL query. Therefore, the type of the whole query
+//!    needs to be a boolean, or `null`.
 //!
 //! However, to accurately determine the type of every part of the request, we
 //! need some extra information:
 //!
 //! - The type of each column involved in the request: `["=", ["col"], 12]` only
-//!     makes sense if the column `col` represents an integer.
+//!   makes sense if the column `col` represents an integer.
 //! - The signature of each function in the query: `["like", ["name"], 12]` doesn't
-//!     makes sense because the SQL LIKE operator expects a string pattern and
-//!     not an integer.
+//!   makes sense because the SQL LIKE operator expects a string pattern and
+//!   not an integer.
 //!
 //! The structure that represents that context is [editoast_search::QueryContext] which provides
 //! the function [editoast_search::QueryContext::typecheck_search_query()]. The functions the
@@ -166,8 +166,8 @@
 //!
 //! - The list of expected columns and their type. That data is extracted from `search.yml`.
 //! - The name of the search table (e.g.: `search_operational_point`). That
-//!     information is useful to prevent ambiguities in the SQL query because of
-//!     column name conflicts.
+//!   information is useful to prevent ambiguities in the SQL query because of
+//!   column name conflicts.
 //! - The list of functions (or operators) the query can use, their type signatures
 //!   (with possible overloads) and their definition.
 //!


### PR DESCRIPTION
This PR fixes the `doc_overindented_list_items` warning in Cargo by adjusting the indentation in documentation comments. No functional code changes were made.