### PR TITLE
tests, railjson_generator: make python practice more consistent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Generate railjson
         run: |
           mkdir /tmp/generated_infras
-          uv --directory python/railjson_generator/ run python -m railjson_generator /tmp/generated_infras $(pwd)/tests/infra-scripts/*.py
+          uv --directory python/railjson_generator/ run -m railjson_generator /tmp/generated_infras $(pwd)/tests/infra-scripts/*.py
 
       - name: Ensure generated infrastructures are up to date
         run: diff -r -u tests/data/infras /tmp/generated_infras

--- a/python/railjson_generator/README.md
+++ b/python/railjson_generator/README.md
@@ -12,13 +12,13 @@ To run a generation script, pass its output directory as its first argument:
 
 ```sh
 mkdir small_infra_out
-uv run scripts/small_infra.py small_infra_out
+uv run ../../tests/infra-scripts/small_infra.py small_infra_out
 ```
 
 This library provides an helper to generate multiple infrastructures at once:
 
 ```sh
-uv run python3 -m railjson_generator /tmp/all_infras scripts/*.py
+uv run -m railjson_generator ../../tests/data/infras ../../tests/infra-scripts/*.py
 ```
 
 ## API

--- a/python/railjson_generator/README.md
+++ b/python/railjson_generator/README.md
@@ -3,7 +3,7 @@
 Use uv to install dependencies:
 
 ```sh
-uv sync
+uv sync --all-extras
 ```
 
 ## Running generation scripts

--- a/python/railjson_generator/justfile
+++ b/python/railjson_generator/justfile
@@ -4,10 +4,9 @@
 help:
     @just --list --unsorted
 
-# Generate small infra
+# Update (regenerate) tests infras
 run:
-    mkdir -p small_infra_out
-    uv run scripts/small_infra.py small_infra_out
+    uv run -m railjson_generator ../../tests/data/infras ../../tests/infra-scripts/*.py
 
 # Install required dependencies
 install:

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -24,3 +24,6 @@ osrd-schemas = { path = "../osrd_schemas", editable = true }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 ### Run the tests
 
-To run tests `uv run pytest` after starting docker containers (`docker compose up` at the root of the project) and installing dependencies (`uv sync`, see [uv doc](https://docs.astral.sh/uv/)).
+To run tests `uv run pytest` after starting docker containers (`docker compose up` at the root of the project) and installing dependencies (`uv sync --all-extras`, see [uv doc](https://docs.astral.sh/uv/)).
 
 To run a list of specific tests, run `uv run pytest -k test_name_1 test_name_2 ...`.
 

--- a/tests/infra-scripts/README.md
+++ b/tests/infra-scripts/README.md
@@ -2,6 +2,6 @@
 
 Run the following commands at the root of the project:
 ```sh
-uv --directory python/railjson_generator install
+uv --directory python/railjson_generator sync --all-extras
 uv --directory python/railjson_generator run python -m railjson_generator tests/data/infras tests/infra-scripts/*.py
 ```

--- a/tests/infra-scripts/README.md
+++ b/tests/infra-scripts/README.md
@@ -1,7 +1,8 @@
 :warning: When an infrastructure script is changed, test data has to be rebuilt :warning:
 
 Run the following commands at the root of the project:
+
 ```sh
 uv --directory python/railjson_generator sync --all-extras
-uv --directory python/railjson_generator run python -m railjson_generator tests/data/infras tests/infra-scripts/*.py
+uv --directory python/railjson_generator run -m railjson_generator "$PWD"/tests/data/infras "$PWD"/tests/infra-scripts/*.py
 ```

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -26,3 +26,6 @@ railjson_generator = { path = "../python/railjson_generator/", editable = true }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"


### PR DESCRIPTION
* advertize `uv sync --all-extras`
* default to including doctests in pytest (even if none exists currently)
* update infra-script sync command in doc (previous not working anymore on my setup)