### PR TITLE
front: bump the nivo group in /front with 2 updates

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -17,8 +17,8 @@
       ],
       "dependencies": {
         "@ag-media/react-pdf-table": "^2.0.2",
-        "@nivo/core": "^0.88.0",
-        "@nivo/line": "^0.88.0",
+        "@nivo/core": "^0.93.0",
+        "@nivo/line": "^0.93.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
         "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2",
         "@osrd-project/ui-charts": "0.0.1-dev",
@@ -3813,28 +3813,31 @@
       }
     },
     "node_modules/@nivo/annotations": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.88.0.tgz",
-      "integrity": "sha512-NXE+1oIUn+EGWMQpnpeRMLgi2wyuzhGDoJQY4OUHissCUiNotid2oNQ/PXJwN0toiu+/j9SyhzI32xr70OPi7Q==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.93.0.tgz",
+      "integrity": "sha512-qPb6jIZ4YN0/fOpf4KUwD5iVjrOkbyC4L3F03X9akj55Llr+HwC18FRhOwZaJ0YonVSSYHEQwwkUZgrgHepOvA==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
+        "@nivo/colors": "0.93.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/theming": "0.93.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/axes": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.88.0.tgz",
-      "integrity": "sha512-jF7aIxzTNayV5cI1J/b9Q1FfpMBxTXGk3OwSigXMSfYWlliskDn2u0qGRLiYhuXFdQAWIp4oXsO1GcAQ0eRVdg==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.93.0.tgz",
+      "integrity": "sha512-6cIEKx+qiOKWGliwJf54DxFilowJu4gAAdERXTXfik+61yZCa31xOwslXVwmkpaVcYYThLmw+MwuNf7CXTZWvQ==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/core": "0.88.0",
-        "@nivo/scales": "0.88.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/scales": "0.93.0",
+        "@nivo/text": "0.93.0",
+        "@nivo/theming": "0.93.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
         "@types/d3-format": "^1.4.1",
         "@types/d3-time-format": "^2.3.1",
@@ -3842,7 +3845,7 @@
         "d3-time-format": "^3.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/axes/node_modules/@types/d3-format": {
@@ -3858,33 +3861,33 @@
       "license": "MIT"
     },
     "node_modules/@nivo/colors": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.88.0.tgz",
-      "integrity": "sha512-IZ+leYIqAlo7dyLHmsQwujanfRgXyoQ5H7PU3RWLEn1PP0zxDKLgEjFEDADpDauuslh2Tx0L81GNkWR6QSP0Mw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.93.0.tgz",
+      "integrity": "sha512-f6mrCAxIH2S8yN7qCs5YowmkKMB4ddXFBr6/HYdBtNZk5Z2Xn8K7YRriYV8XDTojcl1qD+sRM4sELBUootGeMg==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/core": "0.88.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/theming": "0.93.0",
         "@types/d3-color": "^3.0.0",
         "@types/d3-scale": "^4.0.8",
         "@types/d3-scale-chromatic": "^3.0.0",
-        "@types/prop-types": "^15.7.2",
         "d3-color": "^3.1.0",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/core": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.88.0.tgz",
-      "integrity": "sha512-XjUkA5MmwjLP38bdrJwn36Gj7T5SYMKD55LYQp/1nIJPdxqJ38dUfE4XyBDfIEgfP6yrHOihw3C63cUdnUBoiw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.93.0.tgz",
+      "integrity": "sha512-fuspmWaVF1SAbFYWO2sYeGvGoSHcrr2tDRn7lM+f4dPJVN5w5waHpRHTfEfKg6Q++zsXs2QEPlnhpZsG4tbE0w==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/tooltip": "0.88.0",
+        "@nivo/theming": "0.93.0",
+        "@nivo/tooltip": "0.93.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
         "@types/d3-shape": "^3.1.6",
         "d3-color": "^3.1.0",
@@ -3894,62 +3897,67 @@
         "d3-scale-chromatic": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
+        "lodash": "^4.17.21"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/legends": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.88.0.tgz",
-      "integrity": "sha512-d4DF9pHbD8LmGJlp/Gp1cF4e8y2wfQTcw3jVhbZj9zkb7ZWB7JfeF60VHRfbXNux9bjQ9U78/SssQqueVDPEmg==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.93.0.tgz",
+      "integrity": "sha512-J6z+3r73MQtjnccc7rgvNxLuAkT4Bli5D2lwekHoljBv7NbUQOXCVg/c/uET1MMPoqunoBUWUuGUDZ6IiK1a4g==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
+        "@nivo/colors": "0.93.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/text": "0.93.0",
+        "@nivo/theming": "0.93.0",
         "@types/d3-scale": "^4.0.8",
         "d3-scale": "^4.0.2"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/line": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.88.0.tgz",
-      "integrity": "sha512-hFTyZ3BdAZvq2HwdwMj2SJGUeodjEW+7DLtFMIIoVIxmjZlAs3z533HcJ9cJd3it928fDm8SF/rgHs0TztYf9Q==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/line/-/line-0.93.0.tgz",
+      "integrity": "sha512-HFqf9RDgHrykJRf7ER9mhb5RruLnHuos0eoFC6VN6O+hxLkZfTFv8akDydA5BDl3pc7FtOpEKrGKJtiuZfgDNg==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/annotations": "0.88.0",
-        "@nivo/axes": "0.88.0",
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
-        "@nivo/legends": "0.88.0",
-        "@nivo/scales": "0.88.0",
-        "@nivo/tooltip": "0.88.0",
-        "@nivo/voronoi": "0.88.0",
+        "@nivo/annotations": "0.93.0",
+        "@nivo/axes": "0.93.0",
+        "@nivo/colors": "0.93.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/legends": "0.93.0",
+        "@nivo/scales": "0.93.0",
+        "@nivo/theming": "0.93.0",
+        "@nivo/tooltip": "0.93.0",
+        "@nivo/voronoi": "0.93.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
         "d3-shape": "^3.2.0"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/scales": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.88.0.tgz",
-      "integrity": "sha512-HbpxkQp6tHCltZ1yDGeqdLcaJl5ze54NPjurfGtx/Uq+H5IQoBd4Tln49bUar5CsFAMsXw8yF1HQvASr7I1SIA==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.93.0.tgz",
+      "integrity": "sha512-0pS8geE/j/214F+EnbiIJPUM/EJYlAfvQXTEzj3juq9alsxgrcLM1CY7nc2ClkbBCzTXMI63uQQ0iLg8caG1iA==",
       "license": "MIT",
       "dependencies": {
+        "@types/d3-interpolate": "^3.0.4",
         "@types/d3-scale": "^4.0.8",
         "@types/d3-time": "^1.1.1",
         "@types/d3-time-format": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-time": "^1.0.11",
         "d3-time-format": "^3.0.0",
@@ -3974,34 +3982,58 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@nivo/tooltip": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
-      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
+    "node_modules/@nivo/text": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.93.0.tgz",
+      "integrity": "sha512-yhA3spFtPJJIllNPViwmye/OnwthK1DqMZtUdoznU5I83zXdXUjl2HSBo+RbwGn2luOUIsd5zLkQfYe0iTdCeA==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/core": "0.88.0",
+        "@nivo/theming": "0.93.0",
         "@react-spring/web": "9.4.5 || ^9.7.2"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.93.0.tgz",
+      "integrity": "sha512-kT2Dc4bz+QXwNB3yIYQ7PwgTQ1cwSgWOBW6xWf9CAO8e4DBf0eBfmvKY0ILnYe1S083F9hxiyG4Ozhu5RagIkQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 20.0.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.93.0.tgz",
+      "integrity": "sha512-6rrJsi+2kA/wUGV5zqE4PMhVNekTpage6AQv/+/EX7V+zGEwRhZTGHFvwU0HVmpZwApMM39WxlCgU30WlAt1/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.93.0",
+        "@nivo/theming": "0.93.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nivo/voronoi": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.88.0.tgz",
-      "integrity": "sha512-MyiNLvODthFoMjQ7Wjp693nogbTmVEx8Yn/7QkJhyPQbFyyA37TF/D1a/ox4h2OslXtP6K9QFN+42gB/zu7ixw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.93.0.tgz",
+      "integrity": "sha512-lsYtQVOH1MhIu31T+ph4O/gHwBoIDyKE7vJ8cWwtCgcpSUL6MPf1WiGRmCYsiM19ezEK0pQwf3oDYOp067J/Mg==",
       "license": "MIT",
       "dependencies": {
-        "@nivo/core": "0.88.0",
-        "@nivo/tooltip": "0.88.0",
+        "@nivo/core": "0.93.0",
+        "@nivo/theming": "0.93.0",
+        "@nivo/tooltip": "0.93.0",
         "@types/d3-delaunay": "^6.0.4",
         "@types/d3-scale": "^4.0.8",
         "d3-delaunay": "^6.0.4",
         "d3-scale": "^4.0.2"
       },
       "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
+        "react": ">= 16.14.0 < 20.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8712,7 +8744,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"

--- a/front/package.json
+++ b/front/package.json
@@ -13,8 +13,8 @@
   ],
   "dependencies": {
     "@ag-media/react-pdf-table": "^2.0.2",
-    "@nivo/core": "^0.88.0",
-    "@nivo/line": "^0.88.0",
+    "@nivo/core": "^0.93.0",
+    "@nivo/line": "^0.93.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
     "@osrd-project/netzgrafik-frontend": "0.0.0-snapshot.21444a36752da16654093e6840a8534048ec3ab2",
     "@osrd-project/ui-charts": "0.0.1-dev",

--- a/front/src/modules/rollingStock/components/RollingStockCurve.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockCurve.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { ResponsiveLine } from '@nivo/line';
-import type { PointTooltipProps } from '@nivo/line';
+import type { LineSeries, PointTooltipProps } from '@nivo/line';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +13,8 @@ import type { ParsedCurve, TransformedCurves } from 'modules/rollingStock/types'
 import { geti18nKeyForNull } from 'utils/strings';
 
 import { getCurveName } from '../helpers/curves';
+
+type CustomPointTooltipProps = PointTooltipProps<LineSeries>;
 
 // Format RollingStock Curves to NIVO format
 const parseData = (
@@ -215,8 +217,8 @@ export default function RollingStockCurve({
   const [comfortsStates, setComfortsStates] = useState(initialComfortsState(curvesComfortList));
   const [curvesVisibility, setCurvesVisibility] = useState(setupCurvesVisibility(transformedData));
 
-  const formatTooltip = (tooltip: PointTooltipProps) => {
-    const transformedCurve = transformedData[tooltip.point.serieId];
+  const formatTooltip = (tooltip: CustomPointTooltipProps) => {
+    const transformedCurve = transformedData[tooltip.point.seriesId];
     const editionModeTooltipLabel =
       isOnEditionMode && showPowerRestriction
         ? geti18nKeyForNull(transformedCurve?.powerRestriction)


### PR DESCRIPTION
Following the @nivo/line version upgrade, the signature of the PointTooltipProps type has evolved: it is now generic and requires a type argument to describe the form of the data

closes https://github.com/OpenRailAssociation/osrd/pull/11596

Recette : test rolling stock curves are still working in rolling stock selector / editor