### PR TITLE
front: add build and test directories to tsconfig exclude

### DIFF
--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "include": ["."],
-  "exclude": ["node_modules", "ui"],
+  "exclude": ["node_modules", "ui", "build", "test-results", "playwright-report"],
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Without this, TypeScript tries to go and type check files in these directories.