### PR TITLE
front: improve osrdmenu positioning

### DIFF
--- a/front/src/common/AnchoredMenu.tsx
+++ b/front/src/common/AnchoredMenu.tsx
@@ -1,0 +1,78 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { createPortal } from 'react-dom';
+
+import useModalFocusTrap from '../utils/hooks/useModalFocusTrap';
+
+type AnchoreMenuParams = {
+  children?: React.ReactNode;
+  anchorRef: React.RefObject<HTMLElement>;
+  onDismiss: () => void;
+};
+
+/**
+ * Creates an overlay on the viewport and displays a menu.
+ *
+ * It takes in the children to be rendered, a reference to the anchor element, and a callback function to dismiss the menu.
+ *
+ * Clicking outside the menu will trigger the onDismiss callback (most of the time to close the menu).
+ *
+ * The focus is trapped inside the menu when it is open, and the first focusable element is focused when the menu opens.
+ *
+ * It handles the space needed by the menu to know if the children should be positioned above or below the anchor element.
+ */
+const AnchoredMenu = ({ children, anchorRef, onDismiss }: AnchoreMenuParams) => {
+  const [menuPosition, setMenuPosition] = useState<{
+    top?: number;
+    left: number;
+    bottom?: number;
+  }>();
+
+  const menuRef = useRef<HTMLDivElement>(null);
+  const shouldDisplayMenu = Boolean(children);
+
+  useLayoutEffect(() => {
+    const anchorRefBoundingRect = anchorRef.current?.getBoundingClientRect();
+    const menuRefBoundingRect = menuRef.current?.getBoundingClientRect();
+
+    if (anchorRefBoundingRect && menuRefBoundingRect) {
+      // Check if there is enough space below the anchor element
+      const isSpaceBelow =
+        window.innerHeight - anchorRefBoundingRect.bottom > menuRefBoundingRect.height;
+
+      setMenuPosition({
+        top: isSpaceBelow ? anchorRefBoundingRect.bottom : undefined,
+        left: anchorRefBoundingRect.left,
+        bottom: isSpaceBelow ? undefined : window.innerHeight - anchorRefBoundingRect.top,
+      });
+    }
+  }, [anchorRef, shouldDisplayMenu]);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) onDismiss();
+  };
+
+  useModalFocusTrap(menuRef, onDismiss, { focusOnFirstElement: true });
+
+  if (!shouldDisplayMenu) return null;
+
+  return createPortal(
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="menu-overlay" onClick={handleClick}>
+      <div
+        style={{
+          top: menuPosition?.top,
+          left: menuPosition?.left,
+          bottom: menuPosition?.bottom,
+          position: 'fixed',
+        }}
+        ref={menuRef}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default AnchoredMenu;

--- a/front/src/common/OSRDMenu.tsx
+++ b/front/src/common/OSRDMenu.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import cx from 'classnames';
+
 export type OSRDMenuItem = {
   title: string;
   icon: React.ReactNode;
@@ -11,10 +13,11 @@ export type OSRDMenuItem = {
 type OSRDMenuProps = {
   menuRef: React.RefObject<HTMLDivElement>;
   items: OSRDMenuItem[];
+  className?: string;
 };
 
-const OSRDMenu = ({ menuRef, items }: OSRDMenuProps) => (
-  <div ref={menuRef} className="osrd-menu">
+const OSRDMenu = ({ menuRef, items, className }: OSRDMenuProps) => (
+  <div ref={menuRef} className={cx('osrd-menu', className)}>
     {items.map(({ title, icon, disabled, disabledMessage, onClick }) => (
       <button
         disabled={disabled}

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -14,7 +14,6 @@ import {
   WorkScheduleLayer,
   OccupancyBlockLayer,
   Manchette,
-  type WaypointMenuData,
   isSegmentPickingElement,
   isPointPickingElement,
   usePaths,
@@ -24,12 +23,10 @@ import { Slider } from '@osrd-project/ui-core';
 import { KebabHorizontal, Iterations, ZoomIn } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { compact } from 'lodash';
-import { createPortal } from 'react-dom';
 
 import type { OperationalPoint } from 'applications/operationalStudies/types';
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import type { PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
-import OSRDMenu from 'common/OSRDMenu';
 import cutSpaceTimeRect from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
 import type {
@@ -88,8 +85,8 @@ const ManchetteWithSpaceTimeChartWrapper = ({
 }: ManchetteWithSpaceTimeChartProps) => {
   const dispatch = useAppDispatch();
 
-  const manchetteWithSpaceTimeCharWrappertRef = useRef<HTMLDivElement>(null);
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
+  const activeWaypointRef = useRef<HTMLDivElement>(null);
 
   const [hoveredItem, setHoveredItem] = useState<null | HoveredItem>(null);
   const [draggingState, setDraggingState] = useState<{
@@ -322,7 +319,10 @@ const ManchetteWithSpaceTimeChartWrapper = ({
     }
   };
 
-  const waypointMenuData = useWaypointMenu(waypointsPanelData);
+  const { waypointMenu, activeWaypointId, handleWaypointClick } = useWaypointMenu(
+    activeWaypointRef,
+    waypointsPanelData
+  );
 
   const manchettePropsWithWaypointMenu = useMemo(
     () => ({
@@ -331,17 +331,14 @@ const ManchetteWithSpaceTimeChartWrapper = ({
         isInteractiveWaypoint(content)
           ? {
               ...content,
-              onClick: waypointMenuData.handleWaypointClick,
+              onClick: handleWaypointClick,
             }
           : content
       ),
-      waypointMenuData: {
-        menu: <OSRDMenu menuRef={waypointMenuData.menuRef} items={waypointMenuData.menuItems} />,
-        activeWaypointId: waypointMenuData.activeWaypointId,
-        manchetteWrapperRef: manchetteWithSpaceTimeCharWrappertRef,
-      } as WaypointMenuData,
+      activeWaypointId,
+      activeWaypointRef,
     }),
-    [manchetteProps, waypointMenuData]
+    [manchetteProps, activeWaypointId, handleWaypointClick]
   );
 
   const handleHoveredChildUpdate: SpaceTimeChartProps['onHoveredChildUpdate'] = useCallback(
@@ -367,25 +364,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   };
 
   return (
-    <div
-      ref={manchetteWithSpaceTimeCharWrappertRef}
-      data-testid="manchette-space-time-chart"
-      className="manchette-space-time-chart-wrapper"
-    >
-      {waypointMenuData.activeWaypointId &&
-        manchetteWithSpaceTimeCharWrappertRef.current &&
-        createPortal(
-          <div
-            style={{
-              width: '100%',
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              bottom: 0,
-            }}
-          />,
-          manchetteWithSpaceTimeCharWrappertRef.current
-        )}
+    <div data-testid="manchette-space-time-chart" className="manchette-space-time-chart-wrapper">
       <div className="header">
         {waypointsPanelData && (
           <>
@@ -410,13 +389,12 @@ const ManchetteWithSpaceTimeChartWrapper = ({
       <div className="header-separator" />
       <div
         ref={manchetteWithSpaceTimeChartRef}
-        className={cx('manchette flex', {
-          'no-scroll': !!waypointMenuData.activeWaypointId,
-        })}
+        className="manchette flex"
         style={{ height }}
         onScroll={handleScroll}
       >
         <Manchette {...manchettePropsWithWaypointMenu} />
+        {waypointMenu}
         <div
           ref={spaceTimeChartRef}
           data-testid="space-time-chart-container"

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/ManchetteMenuButton.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/ManchetteMenuButton.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Eye, KebabHorizontal } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import AnchoredMenu from 'common/AnchoredMenu';
 import type { OSRDMenuItem } from 'common/OSRDMenu';
 import OSRDMenu from 'common/OSRDMenu';
-import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
 type ManchetteMenuButtonProps = {
   setWaypointsPanelIsOpen: (waypointsModalOpen: boolean) => void;
@@ -32,29 +32,13 @@ const ManchetteMenuButton = ({ setWaypointsPanelIsOpen }: ManchetteMenuButtonPro
     },
   ];
 
-  useModalFocusTrap(menuRef, closeMenu, { focusOnFirstElement: true });
-
-  useEffect(() => {
-    // TODO : refacto useOutsideClick to accept a list of refs and use the hook here
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        !menuRef.current?.contains(event.target as Node) &&
-        !menuButtonRef.current?.contains(event.target as Node)
-      ) {
-        closeMenu();
-      }
-    };
-
-    if (isMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isMenuOpen]);
+  const manchetteMenu = AnchoredMenu({
+    children: isMenuOpen && (
+      <OSRDMenu menuRef={menuRef} items={menuItems} className="manchette-menu" />
+    ),
+    anchorRef: menuButtonRef,
+    onDismiss: closeMenu,
+  });
 
   return (
     <>
@@ -68,7 +52,7 @@ const ManchetteMenuButton = ({ setWaypointsPanelIsOpen }: ManchetteMenuButtonPro
       >
         <KebabHorizontal />
       </button>
-      {isMenuOpen && <OSRDMenu menuRef={menuRef} items={menuItems} />}
+      {manchetteMenu}
     </>
   );
 };

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
@@ -4,11 +4,16 @@ import { EyeClosed } from '@osrd-project/ui-icons';
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
+import AnchoredMenu from 'common/AnchoredMenu';
 import type { OSRDMenuItem } from 'common/OSRDMenu';
+import OSRDMenu from 'common/OSRDMenu';
 import type { WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 
-const useWaypointMenu = (waypointsPanelData?: WaypointsPanelData) => {
+const useWaypointMenu = (
+  activeWaypointRef: React.RefObject<HTMLDivElement>,
+  waypointsPanelData?: WaypointsPanelData
+) => {
   const { filteredWaypoints, setFilteredWaypoints, projectionPath, timetableId } =
     waypointsPanelData || {};
   const { t } = useTranslation('simulation');
@@ -72,11 +77,19 @@ const useWaypointMenu = (waypointsPanelData?: WaypointsPanelData) => {
     },
   ];
 
+  const waypointMenu = AnchoredMenu({
+    children: activeWaypointId && (
+      <OSRDMenu menuRef={menuRef} items={menuItems} className="waypoint-menu" />
+    ),
+    anchorRef: activeWaypointRef,
+    onDismiss: closeMenu,
+  });
+
   const handleWaypointClick = (id: string) => {
     setActiveWaypointId(id);
   };
 
-  return { menuRef, menuItems, activeWaypointId, handleWaypointClick };
+  return { activeWaypointId, handleWaypointClick, waypointMenu };
 };
 
 export default useWaypointMenu;

--- a/front/src/styles/scss/_body.scss
+++ b/front/src/styles/scss/_body.scss
@@ -1,5 +1,18 @@
+html:has(> body > .menu-overlay) {
+  overflow: hidden;
+}
+
 body {
   min-height: 100vh;
+}
+
+.menu-overlay {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 9999;
 }
 
 .mastcontainer-map {

--- a/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
@@ -40,10 +40,6 @@
     overflow-y: auto;
     overflow-x: hidden;
 
-    &.no-scroll {
-      overflow-y: clip;
-    }
-
     .osrd-menu {
       width: 305px;
       transform: translateY(-2px);
@@ -66,4 +62,9 @@
 .manchette-menu {
   margin-left: -4px;
   margin-top: -5px;
+}
+
+.osrd-menu.waypoint-menu {
+  margin-top: -2px;
+  width: 305px;
 }

--- a/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
+++ b/front/src/styles/scss/common/components/_manchetteWithSpaceTimeChart.scss
@@ -62,3 +62,8 @@
     z-index: 10;
   }
 }
+
+.manchette-menu {
+  margin-left: -4px;
+  margin-top: -5px;
+}

--- a/front/src/styles/scss/common/components/_osrdMenu.scss
+++ b/front/src/styles/scss/common/components/_osrdMenu.scss
@@ -1,9 +1,6 @@
 .osrd-menu {
-  position: absolute;
-  z-index: 10;
-  background-color: var(--grey5);
   width: 368px;
-  left: 0;
+  background-color: var(--grey5);
   border: 1px solid var(--grey30);
   border-radius: 8px;
   box-shadow:

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/AnchoredMenu.tsx
@@ -1,0 +1,68 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+
+import { createPortal } from 'react-dom';
+
+type AnchoreMenuParams = {
+  children?: React.ReactNode;
+  anchorRef: React.RefObject<HTMLElement>;
+  onDismiss: () => void;
+};
+
+/**
+ * Creates an overlay on the viewport and displays a menu.
+ *
+ * It takes in the children to be rendered, a reference to the anchor element, and a callback function to dismiss the menu.
+ *
+ * Clicking outside the menu will trigger the onDismiss callback (most of the time to close the menu).
+ *
+ */
+const AnchoredMenu = ({ children, anchorRef, onDismiss }: AnchoreMenuParams) => {
+  const [menuPosition, setMenuPosition] = useState<{
+    top?: number;
+    left: number;
+    bottom?: number;
+  }>();
+
+  const menuRef = useRef<HTMLDivElement>(null);
+  const shouldDisplayMenu = Boolean(children);
+
+  useLayoutEffect(() => {
+    const anchorRefBoundingRect = anchorRef.current?.getBoundingClientRect();
+    const menuRefBoundingRect = menuRef.current?.getBoundingClientRect();
+
+    if (anchorRefBoundingRect && menuRefBoundingRect) {
+      setMenuPosition({
+        top: anchorRefBoundingRect.bottom,
+        left: anchorRefBoundingRect.left,
+      });
+    }
+  }, [anchorRef, shouldDisplayMenu]);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) onDismiss();
+  };
+
+  if (!shouldDisplayMenu) return null;
+
+  return createPortal(
+    <div
+      style={{ width: '100%', position: 'absolute', top: 0, left: 0, bottom: 0, zIndex: 9999 }}
+      onClick={handleClick}
+    >
+      <div
+        style={{
+          top: menuPosition?.top,
+          left: menuPosition?.left,
+          bottom: menuPosition?.bottom,
+          position: 'fixed',
+        }}
+        ref={menuRef}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default AnchoredMenu;

--- a/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
+++ b/front/ui/storybook/stories/ui-charts/manchetteWithSpaceTimeChart/base-with-waypoint-menu.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   SpaceTimeChart,
@@ -14,9 +14,8 @@ import { EyeClosed, Telescope } from '@osrd-project/ui-icons';
 import type { Meta } from '@storybook/react';
 import '@osrd-project/ui-core/dist/theme.css';
 import '@osrd-project/ui-charts/dist/theme.css';
-import cx from 'classnames';
-import { createPortal } from 'react-dom';
 
+import AnchoredMenu from './AnchoredMenu';
 import { SAMPLE_PATHS_DATA, SAMPLE_WAYPOINTS } from './assets/sampleData';
 import Menu, { type MenuItem } from './Menu';
 
@@ -40,12 +39,11 @@ const ManchetteWithSpaceTimeWrapper = ({
   selectedTrain,
 }: ManchetteWithSpaceTimeWrapperProps) => {
   const manchetteWithSpaceTimeChartRef = useRef<HTMLDivElement>(null);
-  // Allow us to compute the position of the menu in Manchette component
-  const manchetteWithSpaceTimeCharWrappertRef = useRef<HTMLDivElement>(null);
   // Allow us to know which waypoint has been clicked and change its style
   const [activeWaypointId, setActiveWaypointId] = useState<string>();
 
   const menuRef = useRef<HTMLDivElement>(null);
+  const activeWaypointRef = useRef<HTMLDivElement>(null);
 
   const menuItems: MenuItem[] = [
     {
@@ -66,6 +64,12 @@ const ManchetteWithSpaceTimeWrapper = ({
     },
   ];
 
+  const waypointMenu = AnchoredMenu({
+    children: activeWaypointId && <Menu menuRef={menuRef} items={menuItems} />,
+    anchorRef: activeWaypointRef,
+    onDismiss: () => setActiveWaypointId(undefined),
+  });
+
   const handleWaypointClick = (waypointId: string) => {
     setActiveWaypointId(waypointId);
   };
@@ -77,54 +81,17 @@ const ManchetteWithSpaceTimeWrapper = ({
     defaultTimeOrigin: Math.min(...projectPathTrainResult.map((p) => +p.departureTime)),
   });
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      // Close the menu if the user clicks outside of it
-      if (!menuRef.current?.contains(event.target as Node)) {
-        setActiveWaypointId(undefined);
-      }
-    };
-
-    if (activeWaypointId) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [activeWaypointId]);
-
   const selectedPath = paths[selectedTrain].id;
 
   return (
-    // Ref needs to be on the parent on the scrollable element (.manchette) and have a position
-    // relative so the menu can properly overflow the manchette
-    <div ref={manchetteWithSpaceTimeCharWrappertRef} className="manchette-space-time-chart-wrapper">
-      {activeWaypointId &&
-        manchetteWithSpaceTimeCharWrappertRef.current &&
-        createPortal(
-          <div
-            style={{
-              width: '100%',
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              bottom: 0,
-            }}
-          />,
-          manchetteWithSpaceTimeCharWrappertRef.current
-        )}
+    <div className="manchette-space-time-chart-wrapper">
       <div
         className="header bg-ambientB-5 w-full border-b border-grey-30"
         style={{ height: '40px' }}
       ></div>
       <div
         ref={manchetteWithSpaceTimeChartRef}
-        className={cx('manchette flex', {
-          'no-scroll': activeWaypointId,
-        })}
+        className="manchette flex"
         style={{ height: `${DEFAULT_HEIGHT}px` }}
         onScroll={handleScroll}
       >
@@ -138,12 +105,10 @@ const ManchetteWithSpaceTimeWrapper = ({
                 }
               : op
           )}
-          waypointMenuData={{
-            menu: <Menu menuRef={menuRef} items={menuItems} />,
-            activeWaypointId,
-            manchetteWrapperRef: manchetteWithSpaceTimeCharWrappertRef,
-          }}
+          activeWaypointId={activeWaypointId}
+          activeWaypointRef={activeWaypointRef}
         />
+        {waypointMenu}
         <div className="space-time-chart-container w-full sticky">
           <SpaceTimeChart
             className="inset-0 absolute h-full"

--- a/front/ui/ui-charts/src/manchette/components/Manchette.tsx
+++ b/front/ui/ui-charts/src/manchette/components/Manchette.tsx
@@ -1,16 +1,17 @@
-import React, { Fragment, useLayoutEffect, useRef, useState } from 'react';
+import React, { Fragment } from 'react';
 
 import { ZoomIn, ZoomOut } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 
 import { INITIAL_OP_LIST_HEIGHT, MAX_ZOOM_Y, MIN_ZOOM_Y } from '../consts';
-import type { InteractiveWaypoint, WaypointMenuData } from '../types';
+import type { InteractiveWaypoint } from '../types';
 import Waypoint from './Waypoint';
 import { isInteractiveWaypoint } from '../utils/helpers';
 
 export type ManchetteProps = {
   contents: (InteractiveWaypoint | React.ReactNode)[];
-  waypointMenuData?: WaypointMenuData;
+  activeWaypointId?: string;
+  activeWaypointRef?: React.RefObject<HTMLDivElement>;
   zoomYIn: () => void;
   zoomYOut: () => void;
   resetZoom: () => void;
@@ -27,105 +28,67 @@ const Manchette = ({
   resetZoom,
   yZoom = 1,
   contents,
-  waypointMenuData,
+  activeWaypointId,
+  activeWaypointRef,
   isProportional = true,
   toggleMode,
   children,
   height = INITIAL_OP_LIST_HEIGHT,
-}: ManchetteProps) => {
-  const [menuPosition, setMenuPosition] = useState<number>();
-  const activeWaypointRef = useRef<HTMLDivElement>(null);
-
-  // Allow to track the menu position after we might have scrolled in the page
-  useLayoutEffect(() => {
-    const manchetteWrapperPosition =
-      waypointMenuData?.manchetteWrapperRef?.current?.getBoundingClientRect().top;
-    const waypointPosition = activeWaypointRef?.current?.getBoundingClientRect().top;
-
-    if (!manchetteWrapperPosition || !waypointPosition) {
-      setMenuPosition(undefined);
-    } else {
-      setMenuPosition(waypointPosition - manchetteWrapperPosition);
-    }
-  }, [waypointMenuData]);
-
-  return (
-    <div className="manchette-container">
-      {waypointMenuData?.menu && waypointMenuData.activeWaypointId && (
-        <div className="menu-wrapper" style={{ top: menuPosition }}>
-          {waypointMenuData.menu}
-        </div>
-      )}
-      <div
-        className="bg-white-100 border-r border-grey-30 relative"
-        style={{ minHeight: `${height}px` }}
-      >
-        <div className="waypoints-list">
-          {contents.map((content, index) =>
-            isInteractiveWaypoint(content) ? (
-              <div
-                key={index}
-                className="waypoint-wrapper flex justify-start"
-                style={content.styles}
-              >
-                <Waypoint
-                  waypoint={content}
-                  nameRef={
-                    waypointMenuData?.activeWaypointId === content.id
-                      ? activeWaypointRef
-                      : undefined
-                  }
-                  isActive={waypointMenuData?.activeWaypointId === content.id}
-                  isMenuActive={!!waypointMenuData?.activeWaypointId}
-                />
-              </div>
-            ) : (
-              <Fragment key={index}>{content}</Fragment>
-            )
-          )}
-          {children}
-        </div>
-      </div>
-      <div className="manchette-actions">
-        <div className="zoom-buttons">
-          <button
-            className="zoom-out"
-            onClick={zoomYOut}
-            disabled={yZoom <= MIN_ZOOM_Y || !!waypointMenuData?.activeWaypointId}
-          >
-            <ZoomOut />
-          </button>
-          <button
-            className="zoom-in"
-            onClick={zoomYIn}
-            disabled={yZoom >= MAX_ZOOM_Y || !!waypointMenuData?.activeWaypointId}
-          >
-            <ZoomIn />
-          </button>
-          <button
-            disabled={!!waypointMenuData?.activeWaypointId}
-            className="zoom-reset"
-            onClick={resetZoom}
-          >
-            Fit
-          </button>
-        </div>
-        <div className="flex items-center ml-auto text-sans font-semibold">
-          <button
-            disabled={!!waypointMenuData?.activeWaypointId}
-            className="toggle-mode"
-            onClick={toggleMode}
-          >
-            <div className="flex flex-col items-end pr-2">
-              <span className={cx({ 'text-grey-30': !isProportional })}>Km</span>
-
-              <span className={cx({ 'text-grey-30': isProportional })}>Linéaire</span>
+}: ManchetteProps) => (
+  <div className="manchette-container">
+    <div
+      className="bg-white-100 border-r border-grey-30 relative"
+      style={{ minHeight: `${height}px` }}
+    >
+      <div className="waypoints-list">
+        {contents.map((content, index) =>
+          isInteractiveWaypoint(content) ? (
+            <div key={index} className="waypoint-wrapper flex justify-start" style={content.styles}>
+              <Waypoint
+                waypoint={content}
+                waypointRef={activeWaypointId === content.id ? activeWaypointRef : undefined}
+                isActive={activeWaypointId === content.id}
+                isMenuActive={!!activeWaypointId}
+              />
             </div>
-          </button>
-        </div>
+          ) : (
+            <Fragment key={index}>{content}</Fragment>
+          )
+        )}
+        {children}
       </div>
     </div>
-  );
-};
+    <div className="manchette-actions">
+      <div className="zoom-buttons">
+        <button
+          className="zoom-out"
+          onClick={zoomYOut}
+          disabled={yZoom <= MIN_ZOOM_Y || !!activeWaypointId}
+        >
+          <ZoomOut />
+        </button>
+        <button
+          className="zoom-in"
+          onClick={zoomYIn}
+          disabled={yZoom >= MAX_ZOOM_Y || !!activeWaypointId}
+        >
+          <ZoomIn />
+        </button>
+        <button disabled={!!activeWaypointId} className="zoom-reset" onClick={resetZoom}>
+          Fit
+        </button>
+      </div>
+      <div className="flex items-center ml-auto text-sans font-semibold">
+        <button disabled={!!activeWaypointId} className="toggle-mode" onClick={toggleMode}>
+          <div className="flex flex-col items-end pr-2">
+            <span className={cx({ 'text-grey-30': !isProportional })}>Km</span>
+
+            <span className={cx({ 'text-grey-30': isProportional })}>Linéaire</span>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+);
 
 export default Manchette;

--- a/front/ui/ui-charts/src/manchette/components/Waypoint.tsx
+++ b/front/ui/ui-charts/src/manchette/components/Waypoint.tsx
@@ -7,14 +7,14 @@ import { positionMmToKm } from '../utils';
 
 type WaypointProps = {
   waypoint: InteractiveWaypoint;
-  nameRef?: React.RefObject<HTMLDivElement>;
+  waypointRef?: React.RefObject<HTMLDivElement>;
   isActive: boolean;
   isMenuActive?: boolean;
 };
 
 const Waypoint = ({
   waypoint: { name, secondaryCode, id, position, onClick },
-  nameRef,
+  waypointRef,
   isActive,
   isMenuActive,
 }: WaypointProps) => (
@@ -24,15 +24,14 @@ const Waypoint = ({
       'menu-active': isMenuActive,
     })}
     id={id}
+    ref={waypointRef}
     onClick={() => {
       if (onClick && !isMenuActive) onClick(id);
     }}
   >
     <div className="waypoint-position justify-self-start text-end">{positionMmToKm(position)}</div>
 
-    <div ref={nameRef} className="waypoint-name mx-2 justify-self-start">
-      {name}
-    </div>
+    <div className="waypoint-name mx-2 justify-self-start">{name}</div>
     <div className="waypoint-separator"></div>
     <div className="waypoint-ch font-mono justify-self-end">{secondaryCode}</div>
     <div className="waypoint-separator"></div>

--- a/front/ui/ui-charts/src/manchette/index.ts
+++ b/front/ui/ui-charts/src/manchette/index.ts
@@ -13,12 +13,7 @@ export { DEFAULT_ZOOM_MS_PER_PX } from './consts';
 export { default as useManchetteWithSpaceTimeChart } from './hooks/useManchetteWithSpaceTimeChart';
 export { default as usePaths } from './hooks/usePaths';
 
-export type {
-  WaypointMenuData,
-  Waypoint,
-  ProjectPathTrainResult,
-  InteractiveWaypoint,
-} from './types';
+export type { Waypoint, ProjectPathTrainResult, InteractiveWaypoint } from './types';
 
 export { positionMmToKm } from './utils';
 export { timeScaleToZoomValue, isInteractiveWaypoint } from './utils/helpers';

--- a/front/ui/ui-charts/src/manchette/types.ts
+++ b/front/ui/ui-charts/src/manchette/types.ts
@@ -13,12 +13,6 @@ export type InteractiveWaypoint = Waypoint & {
   onClick?: (waypointId: string) => void;
 };
 
-export type WaypointMenuData = {
-  menu: React.ReactNode;
-  activeWaypointId?: string;
-  manchetteWrapperRef: React.RefObject<HTMLDivElement>;
-};
-
 export type ProjectPathTrainResult = {
   id: string;
   name: string;


### PR DESCRIPTION
Add a new custom hook to handle menu positioning to harmonize their position across the app.

To test : 
- manchette menu and waypoints menu are still displayed properly according the mockup
- overlay around the menu : interaction / scroll with the rest of the page is blocked, clicking outside the menu closes it