### PR TITLE
front: fix translations in op studies

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -98,6 +98,7 @@
     "pacedTrainCountSelected_zero": "$t(main.pacedTrain, { 'count': {{totalCount}} })",
     "pacedTrainCount_one": "1/{{totalCount}} service",
     "pacedTrainCount_other": "{{count}}/{{totalCount}} services",
+    "pacedTrainCount_zero": "0/{{totalCount}} service",
     "pacedTrain_one": "1 service",
     "pacedTrain_other": "{{count}} services",
     "pacedTrain_zero": "0 service",
@@ -199,6 +200,7 @@
     "trainCountSelected_zero": "$t(main.train, { 'count': {{totalCount}} })",
     "trainCount_one": "1/{{totalCount}} train",
     "trainCount_other": "{{count}}/{{totalCount}} trains",
+    "trainCount_zero": "0/{{totalCount}} train",
     "train_one": "1 train",
     "train_other": "{{count}} trains",
     "train_zero": "0 train"

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -98,6 +98,7 @@
     "pacedTrainCountSelected_zero": "$t(main.pacedTrain, { 'count': {{totalCount}} })",
     "pacedTrainCount_one": "1/{{totalCount}} mission",
     "pacedTrainCount_other": "{{count}}/{{totalCount}} missions",
+    "pacedTrainCount_zero": "0/{{totalCount}} mission",
     "pacedTrain_one": "1 mission",
     "pacedTrain_other": "{{count}} missions",
     "pacedTrain_zero": "",
@@ -199,6 +200,7 @@
     "trainCountSelected_zero": "$t(main.train, { 'count': {{totalCount}} })",
     "trainCount_one": "1/{{totalCount}} train",
     "trainCount_other": "{{count}}/{{totalCount}} trains",
+    "trainCount_zero": "0/{{totalCount}} train",
     "train_one": "1 train",
     "train_other": "{{count}} trains",
     "train_zero": ""

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -351,7 +351,7 @@
     "open": "Ouvrir",
     "sort-by-latest": "Plus récents",
     "sort-by-name": "Tri par nom",
-    "unselect-all": "Déselectionner"
+    "unselect-all": "Désélectionner"
   },
   "project": {
     "addImage": "Ajouter une image",

--- a/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
+++ b/front/src/modules/trainschedule/components/Timetable/TimetableToolbar.tsx
@@ -251,7 +251,7 @@ const TimetableToolbar = ({
       return trainScheduleLabel;
     }
 
-    if (selectedTrainScheduleIds.length > 0 && selectedPacedTrainIds.length > 0) {
+    if (selectedTrainScheduleIds.length > 0 || selectedPacedTrainIds.length > 0) {
       return t('pacedTrainAndTrainCount', {
         pacedTrainCount: selectedPacedTrainIds.length,
         totalPacedTrainCount,


### PR DESCRIPTION
- Fix accentuation in the word "sélectionné"
- Change unclear count in scenario train toolbar label when only trains or missions selected. Before:

![image](https://github.com/user-attachments/assets/6594892c-6b40-45bc-a7e6-19702ecf9aa9)

After: 

![image](https://github.com/user-attachments/assets/bc544d47-a88a-4f41-a31b-1dc14d818935)

I will probably add another commit so that the word selected gets better gender/number agreement ^^''