### PR TITLE
front: improve the new scenario header

### DIFF
--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,6 +1,7 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 
 import { X, ChevronDown, Question } from '@osrd-project/ui-icons';
+import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import useAuth from 'utils/hooks/useAuth';
@@ -12,8 +13,18 @@ type ScenarioHeaderProps = {
 const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
   const { username } = useAuth();
   const { t } = useTranslation('common');
+  const [activeBoards, setActiveBoards] = useState<string[]>([]);
 
   const boards = ['Traits', 'Map', 'Macro', 'STD', 'SDD', 'Table', 'Conflicts'];
+
+  const toggleBoard = (selectedBoard: string) => {
+    setActiveBoards((prevBoards) => {
+      if (prevBoards.includes(selectedBoard)) {
+        return prevBoards.filter((b) => b !== selectedBoard);
+      }
+      return [...prevBoards, selectedBoard];
+    });
+  };
 
   return (
     <header className="scenario-header">
@@ -42,7 +53,15 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
         <div className="board-btns">
           {boards.map((board, index) => (
             <Fragment key={board}>
-              <button className="board-btn" type="button">
+              <button
+                className={cx('board-btn', {
+                  on: activeBoards.includes(board),
+                })}
+                type="button"
+                onClick={() => {
+                  toggleBoard(board);
+                }}
+              >
                 {board}
               </button>
               {index < boards.length - 1 && <div className="board-separator" />}

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 
 import { X, ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import InfraLoadingState from 'applications/operationalStudies/components/Scenario/InfraLoadingState';
 import type { InfraWithState, ScenarioResponse } from 'common/api/osrdEditoastApi';
@@ -19,6 +20,7 @@ type ScenarioHeaderProps = {
 const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
   const { username } = useAuth();
   const { openModal } = useModal();
+  const navigate = useNavigate();
 
   const { t } = useTranslation(['translation', 'common', 'operational-studies']);
   const [activeBoards, setActiveBoards] = useState<string[]>([]);
@@ -58,6 +60,10 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
     setAreScenarioDetailsVisible((prev) => !prev);
   };
 
+  const closeScenario = () => {
+    navigate(`/operational-studies/projects/${scenario.project.id}/studies/${scenario.study.id}`);
+  };
+
   useEffect(() => {
     const checkTruncation = () => {
       setIsTruncated((prev) => ({
@@ -81,7 +87,7 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
       <div className="scenario-header">
         {/* scenario info */}
         <div className="scenario-info">
-          <button className="close-btn" type="button">
+          <button className="close-btn" type="button" onClick={closeScenario}>
             <X />
           </button>
 

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState } from 'react';
 
-import { X, ChevronDown, Question } from '@osrd-project/ui-icons';
+import { X, ChevronDown } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
@@ -74,11 +74,10 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
 
       {/* user informations */}
       <div className="user-info">
-        <span className="user-name" title={username}>
+        <div className="spacer" />
+
+        <button className="user-name" type="button">
           {username}
-        </span>
-        <button className="help-icon" type="button">
-          <Question />
         </button>
       </div>
     </header>

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -34,15 +34,20 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
           <X />
         </button>
 
-        <div className="spacer" />
+        <div className="inactive-area" />
 
         <span className="close-label">{t('close')}</span>
 
         <div className="scenario-name-container">
           <span className="scenario-name-label">{scenarioName}</span>
-          <button className="chevron-btn" type="button">
-            <ChevronDown />
-          </button>
+
+          <div className="chevron-container">
+            <button className="chevron-btn" type="button">
+              <ChevronDown />
+            </button>
+
+            <div className="spacer" />
+          </div>
         </div>
       </div>
 
@@ -64,7 +69,7 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
               >
                 {board}
               </button>
-              {index < boards.length - 1 && <div className="board-separator" />}
+              {index < boards.length - 1 && <div className="inactive-area" />}
             </Fragment>
           ))}
         </div>

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,28 +1,49 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 
-import { X, ChevronDown } from '@osrd-project/ui-icons';
+import { X, ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import InfraLoadingState from 'applications/operationalStudies/components/Scenario/InfraLoadingState';
+import type { InfraWithState, ScenarioResponse } from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
+import { useModal } from 'common/BootstrapSNCF/ModalSNCF';
+import AddAndEditScenarioModal from 'modules/scenario/components/AddOrEditScenarioModal';
 import useAuth from 'utils/hooks/useAuth';
 
 type ScenarioHeaderProps = {
-  scenarioName: string;
+  scenario: ScenarioResponse;
+  infra: InfraWithState;
 };
 
-const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
+const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
   const { username } = useAuth();
-  const { t } = useTranslation('common');
+  const { openModal } = useModal();
+
+  const { t } = useTranslation(['translation', 'common', 'operational-studies']);
   const [activeBoards, setActiveBoards] = useState<string[]>([]);
   const [isTruncated, setIsTruncated] = useState({
     scenarioName: false,
     username: false,
   });
+  const [areScenarioDetailsVisible, setAreScenarioDetailsVisible] = useState(false);
 
   const scenarioNameRef = useRef<HTMLSpanElement>(null);
   const usernameRef = useRef<HTMLButtonElement>(null);
 
   const boards = ['Traits', 'Map', 'Macro', 'STD', 'SDD', 'Table', 'Conflicts'];
+
+  const { electricalProfileSet } = osrdEditoastApi.endpoints.getElectricalProfileSet.useQuery(
+    undefined,
+    {
+      selectFromResult: (response) => ({
+        ...response,
+        electricalProfileSet: response.data?.find(
+          (profile) => profile.id === scenario.electrical_profile_set_id
+        ),
+      }),
+    }
+  );
 
   const toggleBoard = (selectedBoard: string) => {
     setActiveBoards((prevBoards) => {
@@ -31,6 +52,10 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
       }
       return [...prevBoards, selectedBoard];
     });
+  };
+
+  const toggleScenarioDetails = () => {
+    setAreScenarioDetailsVisible((prev) => !prev);
   };
 
   useEffect(() => {
@@ -52,73 +77,130 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
   }, []);
 
   return (
-    <header className="scenario-header">
-      {/* scenario info */}
-      <div className="scenario-info">
-        <button className="close-btn" type="button">
-          <X />
-        </button>
+    <header className="scenario-header-container">
+      <div className="scenario-header">
+        {/* scenario info */}
+        <div className="scenario-info">
+          <button className="close-btn" type="button">
+            <X />
+          </button>
 
-        <div className="inactive-area" />
+          <div className="inactive-area" />
 
-        <span className="close-label">{t('close')}</span>
+          <span className="close-label">{t('translation:common.close')}</span>
 
-        <div className="scenario-name-container">
-          <span
-            ref={scenarioNameRef}
-            className={cx('scenario-name-label', { 'is-truncated': isTruncated.scenarioName })}
+          <div
+            className="scenario-name-container"
+            role="button"
+            tabIndex={0}
+            onClick={toggleScenarioDetails}
           >
-            {scenarioName}
-          </span>
+            <span
+              ref={scenarioNameRef}
+              className={cx('scenario-name-label', { 'is-truncated': isTruncated.scenarioName })}
+            >
+              {scenario.name}
+            </span>
 
-          <div className="chevron-container">
-            <button className="chevron-btn" type="button">
-              <ChevronDown />
-            </button>
+            <div className="chevron-container">
+              <button className="chevron-btn" type="button">
+                {areScenarioDetailsVisible ? <ChevronUp /> : <ChevronDown />}
+              </button>
 
-            <div className="spacer" />
+              <div className="spacer" />
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* board display management */}
-      <nav className="board-bar">
-        <div className="spacer" />
+        {/* board display management */}
+        <nav className="board-bar">
+          <div className="spacer" />
 
-        <div className="board-btns">
-          {boards.map((board, index) => (
-            <Fragment key={board}>
-              <button
-                className={cx('board-btn', {
-                  on: activeBoards.includes(board),
-                })}
-                type="button"
-                onClick={() => {
-                  toggleBoard(board);
-                }}
-              >
-                {board}
-              </button>
-              {index < boards.length - 1 && <div className="inactive-area" />}
-            </Fragment>
-          ))}
+          <div className="board-btns">
+            {boards.map((board, index) => (
+              <Fragment key={board}>
+                <button
+                  className={cx('board-btn', {
+                    on: activeBoards.includes(board),
+                  })}
+                  type="button"
+                  onClick={() => {
+                    toggleBoard(board);
+                  }}
+                >
+                  {board}
+                </button>
+                {index < boards.length - 1 && <div className="inactive-area" />}
+              </Fragment>
+            ))}
+          </div>
+
+          <div className="spacer" />
+        </nav>
+
+        {/* user informations */}
+        <div className="user-info">
+          <div className="spacer" />
+
+          <button
+            ref={usernameRef}
+            className={cx('user-name', { 'is-truncated': isTruncated.username })}
+            type="button"
+          >
+            {username}
+          </button>
         </div>
-
-        <div className="spacer" />
-      </nav>
-
-      {/* user informations */}
-      <div className="user-info">
-        <div className="spacer" />
-
-        <button
-          ref={usernameRef}
-          className={cx('user-name', { 'is-truncated': isTruncated.username })}
-          type="button"
-        >
-          {username}
-        </button>
       </div>
+
+      {/* scenario details */}
+      {areScenarioDetailsVisible && (
+        <div className="scenario-details">
+          <span className="scenario-description"> {scenario.description} </span>
+
+          <div className="scenario-details-infra-name">
+            {t('operational-studies:main.infrastructure')} :&nbsp;
+            {infra && <InfraLoadingState infra={infra} />}
+            &nbsp;
+            <span className="scenario-infra-name">{scenario.infra_name}</span>&nbsp;| ID
+            {scenario.infra_id}
+          </div>
+
+          <div className="scenario-details-electrical-profile-set">
+            {scenario.electrical_profile_set_id ? (
+              <span>
+                {electricalProfileSet?.name
+                  ? t('operational-studies:main.description.electricalProfileWithName', {
+                      name: electricalProfileSet.name,
+                      id: scenario.electrical_profile_set_id,
+                    })
+                  : t('operational-studies:main.description.electricalProfileWithId', {
+                      id: scenario.electrical_profile_set_id,
+                    })}
+              </span>
+            ) : (
+              t('operational-studies:main.noElectricalProfileSet')
+            )}
+          </div>
+
+          <div className="edit-scenario-container">
+            <button
+              className="edit-scenario"
+              type="button"
+              aria-label={t('operational-studies:main.editScenario')}
+              onClick={() =>
+                openModal(
+                  <AddAndEditScenarioModal editionMode scenario={scenario} />,
+                  'xl',
+                  'no-close-modal'
+                )
+              }
+              title={t('operational-studies:main.editScenario')}
+            >
+              {t('translation:common.edit')}
+            </button>
+          </div>
+        </div>
+      )}
     </header>
   );
 };

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -22,7 +22,7 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
   const { openModal } = useModal();
   const navigate = useNavigate();
 
-  const { t } = useTranslation(['translation', 'common', 'operational-studies']);
+  const { t } = useTranslation('operational-studies');
   const [activeBoards, setActiveBoards] = useState<string[]>([]);
   const [isTruncated, setIsTruncated] = useState({
     scenarioName: false,
@@ -162,7 +162,7 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
           <span className="scenario-description"> {scenario.description} </span>
 
           <div className="scenario-details-infra-name">
-            {t('operational-studies:main.infrastructure')} :&nbsp;
+            {t('main.infrastructure')} :&nbsp;
             {infra && <InfraLoadingState infra={infra} />}
             &nbsp;
             <span className="scenario-infra-name">{scenario.infra_name}</span>&nbsp;| ID
@@ -173,16 +173,16 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
             {scenario.electrical_profile_set_id ? (
               <span>
                 {electricalProfileSet?.name
-                  ? t('operational-studies:main.description.electricalProfileWithName', {
+                  ? t('main.description.electricalProfileWithName', {
                       name: electricalProfileSet.name,
                       id: scenario.electrical_profile_set_id,
                     })
-                  : t('operational-studies:main.description.electricalProfileWithId', {
+                  : t('main.description.electricalProfileWithId', {
                       id: scenario.electrical_profile_set_id,
                     })}
               </span>
             ) : (
-              t('operational-studies:main.noElectricalProfileSet')
+              t('main.noElectricalProfileSet')
             )}
           </div>
 
@@ -190,7 +190,7 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
             <button
               className="edit-scenario"
               type="button"
-              aria-label={t('operational-studies:main.editScenario')}
+              aria-label={t('main.editScenario')}
               onClick={() =>
                 openModal(
                   <AddAndEditScenarioModal editionMode scenario={scenario} />,
@@ -198,7 +198,7 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
                   'no-close-modal'
                 )
               }
-              title={t('operational-studies:main.editScenario')}
+              title={t('main.editScenario')}
             >
               {t('translation:common.edit')}
             </button>

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { X, ChevronDown, Question } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -35,11 +37,20 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
 
       {/* board display management */}
       <nav className="board-bar">
-        {boards.map((board) => (
-          <button key={board} className="board-btn" type="button">
-            {board}
-          </button>
-        ))}
+        <div className="spacer" />
+
+        <div className="board-btns">
+          {boards.map((board, index) => (
+            <Fragment key={board}>
+              <button className="board-btn" type="button">
+                {board}
+              </button>
+              {index < boards.length - 1 && <div className="board-separator" />}
+            </Fragment>
+          ))}
+        </div>
+
+        <div className="spacer" />
       </nav>
 
       {/* user informations */}

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -19,6 +19,8 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
           <X />
         </button>
 
+        <div className="spacer" />
+
         <span className="scenario-name">{scenarioName}</span>
 
         <button className="chevron-btn" type="button">

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,4 +1,5 @@
 import { X, ChevronDown, Question } from '@osrd-project/ui-icons';
+import { useTranslation } from 'react-i18next';
 
 import useAuth from 'utils/hooks/useAuth';
 
@@ -8,6 +9,7 @@ type ScenarioHeaderProps = {
 
 const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
   const { username } = useAuth();
+  const { t } = useTranslation('common');
 
   const boards = ['Traits', 'Map', 'Macro', 'STD', 'SDD', 'Table', 'Conflicts'];
 
@@ -21,11 +23,14 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
 
         <div className="spacer" />
 
-        <span className="scenario-name">{scenarioName}</span>
+        <span className="close-label">{t('close')}</span>
 
-        <button className="chevron-btn" type="button">
-          <ChevronDown />
-        </button>
+        <div className="scenario-name-container">
+          <span className="scenario-name-label">{scenarioName}</span>
+          <button className="chevron-btn" type="button">
+            <ChevronDown />
+          </button>
+        </div>
       </div>
 
       {/* board display management */}

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 
 import { X, ChevronDown } from '@osrd-project/ui-icons';
 import cx from 'classnames';
@@ -14,6 +14,13 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
   const { username } = useAuth();
   const { t } = useTranslation('common');
   const [activeBoards, setActiveBoards] = useState<string[]>([]);
+  const [isTruncated, setIsTruncated] = useState({
+    scenarioName: false,
+    username: false,
+  });
+
+  const scenarioNameRef = useRef<HTMLSpanElement>(null);
+  const usernameRef = useRef<HTMLButtonElement>(null);
 
   const boards = ['Traits', 'Map', 'Macro', 'STD', 'SDD', 'Table', 'Conflicts'];
 
@@ -25,6 +32,24 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
       return [...prevBoards, selectedBoard];
     });
   };
+
+  useEffect(() => {
+    const checkTruncation = () => {
+      setIsTruncated((prev) => ({
+        scenarioName: scenarioNameRef.current
+          ? scenarioNameRef.current.scrollWidth > scenarioNameRef.current.clientWidth
+          : prev.scenarioName,
+        username: usernameRef.current
+          ? usernameRef.current.scrollWidth > usernameRef.current.clientWidth
+          : prev.username,
+      }));
+    };
+    checkTruncation();
+    window.addEventListener('resize', checkTruncation);
+    return () => {
+      window.removeEventListener('resize', checkTruncation);
+    };
+  }, []);
 
   return (
     <header className="scenario-header">
@@ -39,7 +64,12 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
         <span className="close-label">{t('close')}</span>
 
         <div className="scenario-name-container">
-          <span className="scenario-name-label">{scenarioName}</span>
+          <span
+            ref={scenarioNameRef}
+            className={cx('scenario-name-label', { 'is-truncated': isTruncated.scenarioName })}
+          >
+            {scenarioName}
+          </span>
 
           <div className="chevron-container">
             <button className="chevron-btn" type="button">
@@ -81,7 +111,11 @@ const ScenarioHeader = ({ scenarioName }: ScenarioHeaderProps) => {
       <div className="user-info">
         <div className="spacer" />
 
-        <button className="user-name" type="button">
+        <button
+          ref={usernameRef}
+          className={cx('user-name', { 'is-truncated': isTruncated.username })}
+          type="button"
+        >
           {username}
         </button>
       </div>

--- a/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
+++ b/front/src/applications/operationalStudies/v2/components/ScenarioHeader.tsx
@@ -108,14 +108,12 @@ const ScenarioHeader = ({ scenario, infra }: ScenarioHeaderProps) => {
               {scenario.name}
             </span>
 
-            <div className="chevron-container">
-              <button className="chevron-btn" type="button">
-                {areScenarioDetailsVisible ? <ChevronUp /> : <ChevronDown />}
-              </button>
-
-              <div className="spacer" />
-            </div>
+            <button className="chevron-btn" type="button">
+              {areScenarioDetailsVisible ? <ChevronUp /> : <ChevronDown />}
+            </button>
           </div>
+
+          <div className="spacer" />
         </div>
 
         {/* board display management */}

--- a/front/src/applications/operationalStudies/views/ScenarioV2.tsx
+++ b/front/src/applications/operationalStudies/views/ScenarioV2.tsx
@@ -22,7 +22,7 @@ const ScenarioV2 = () => {
 
   return (
     <ScenarioContextProvider infraId={infra.id}>
-      <ScenarioHeader scenarioName={scenario.name} />
+      <ScenarioHeader scenario={scenario} infra={infra} />
     </ScenarioContextProvider>
   );
 };

--- a/front/src/styles/scss/applications/operationalStudies/_scenario.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenario.scss
@@ -255,14 +255,6 @@
       }
     }
 
-    .infra-loaded {
-      width: 8px;
-      height: 8px;
-      background-color: var(--success30);
-      border-radius: 50%;
-      margin-block: 5px 3px;
-    }
-
     .scenario-details-infra-error {
       color: var(--error60);
       background-color: var(--error5);

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -127,28 +127,28 @@
           &.on {
             color: var(--grey80);
             background-color: var(--ambientB5);
-  
+
             &:hover {
               color: var(--black100);
               background-color: var(--white100);
             }
-  
+
             &:active {
               color: var(--grey20);
               background-color: var(--ambientB15);
             }
           }
-  
+
           // Off state
-          &:not(.on)  {
+          &:not(.on) {
             color: var(--grey30);
             background-color: var(--ambientB15);
-  
+
             &:hover {
               color: var(--grey30);
               background-color: var(--white100);
             }
-  
+
             &:active {
               color: var(--grey50);
               background-color: var(--ambientB5);

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -21,7 +21,6 @@
 
   .spacer {
     width: 32px;
-    border: 1px solid red;
   }
 
   .scenario-info {
@@ -32,6 +31,8 @@
     letter-spacing: 0px;
     position: relative;
     height: 100%;
+    flex: 1;
+    overflow: hidden;
 
     .close-btn {
       padding: 8px 0px 8px 8px;
@@ -54,7 +55,6 @@
 
     .close-label,
     .scenario-name-container {
-      position: absolute;
       transition: opacity 0.3s ease-in-out;
       left: 32px;
       font-size: 0.875rem;
@@ -62,6 +62,7 @@
     }
 
     .close-label {
+      position: absolute;
       text-transform: capitalize;
       opacity: 0;
     }
@@ -72,6 +73,14 @@
       opacity: 1;
       height: 100%;
       color: var(--grey50);
+      min-width: 0;
+
+      .scenario-name-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
 
       .chevron-container {
         display: flex;
@@ -162,12 +171,19 @@
     align-items: center;
     height: 100%;
     margin-right: 8px;
+    overflow: hidden;
+    flex: 1;
+    justify-content: end;
 
     .user-name {
       color: var(--grey30);
       font-size: 0.875rem;
       text-align: right;
       line-height: 20px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
     }
   }
 }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -107,11 +107,44 @@
 
       .board-btn {
         padding: 1px 8px 3px 8px;
-        color: var(--grey80);
-        font-size: 0, 750rem;
+        font-size: 0.750rem;
         line-height: 16px;
         border-radius: 4px;
-        background-color: var(--ambientB5);
+
+        // START HANDLE BOARD STATE
+
+        // On state
+        &.on {
+          color: var(--grey80);
+          background-color: var(--ambientB5);
+
+          &:hover {
+            color: var(--black100);
+            background-color: var(--white100);
+          }
+
+          &:active {
+            color: var(--grey20);
+            background-color: var(--ambientB15);
+          }
+        }
+
+        // Off state
+        &:not(.on)  {
+          color: var(--grey30);
+          background-color: var(--ambientB15);
+
+          &:hover {
+            color: var(--grey30);
+            background-color: var(--white100);
+          }
+
+          &:active {
+            color: var(--grey50);
+            background-color: var(--ambientB5);
+          }
+        }
+        // END HANDLE BOARD STATE
       }
 
       .board-separator {

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -52,6 +52,7 @@
       position: absolute;
       transition: opacity 0.3s ease-in-out;
       left: 32px;
+      font-size: 0.875rem;
     }
 
     .close-label {
@@ -90,14 +91,34 @@
   }
 
   .board-bar {
-    .board-btn {
-      padding: 1px 8px 3px 8px;
-      margin-right: 8px;
-      color: var(--grey80);
-      font-size: 0.75rem;
-      line-height: 16px;
-      border-radius: 4px;
-      background-color: var(--ambientB5);
+    display: flex;
+    align-items: center;
+    height: 100%;
+
+    .spacer {
+      width: 32px;
+      height: 100%;
+    }
+
+    .board-btns {
+      display: flex;
+      align-items: center;
+      height: 100%;
+
+      .board-btn {
+        padding: 1px 8px 3px 8px;
+        color: var(--grey80);
+        font-size: 0, 750rem;
+        line-height: 16px;
+        border-radius: 4px;
+        background-color: var(--ambientB5);
+      }
+
+      .board-separator {
+        width: 8px;
+        height: 100%;
+        background-color: var(--ambientB20);
+      }
     }
   }
 

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -15,12 +15,12 @@
   }
 
   .inactive-area {
-    width: 8px;
+    min-width: 8px;
     pointer-events: none;
   }
 
   .spacer {
-    width: 32px;
+    min-width: 32px;
   }
 
   .scenario-info {
@@ -47,7 +47,7 @@
 
         & ~ .close-label {
           text-transform: capitalize;
-          opacity: 1;
+          display: block;
           color: var(--warning60);
         }
       }
@@ -64,7 +64,7 @@
     .close-label {
       position: absolute;
       text-transform: capitalize;
-      opacity: 0;
+      display: none;
     }
 
     .scenario-name-container {
@@ -184,6 +184,34 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       min-width: 0;
+    }
+  }
+
+  &:has(.scenario-name-label.is-truncated:hover) {
+    .scenario-info {
+      flex: 2;
+    }
+
+    .board-bar {
+      display: none;
+    }
+
+    .user-info {
+      flex: 1;
+    }
+  }
+
+  &:has(.user-name.is-truncated:hover) {
+    .scenario-info {
+      flex: 1;
+    }
+
+    .board-bar {
+      display: none;
+    }
+
+    .user-info {
+      flex: 2;
     }
   }
 }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -8,9 +8,20 @@
     0px 2px 2px -1px rgba(255, 171, 88, 0.27);
   background-color: var(--ambientB10);
   margin-bottom: 8px;
+  min-width: 780px;
 
   button:focus {
     outline: none;
+  }
+
+  .inactive-area {
+    width: 8px;
+    pointer-events: none;
+  }
+
+  .spacer {
+    width: 32px;
+    border: 1px solid red;
   }
 
   .scenario-info {
@@ -19,8 +30,8 @@
     font-size: 0.875rem;
     line-height: 20px;
     letter-spacing: 0px;
-    margin-right: 32px;
     position: relative;
+    height: 100%;
 
     .close-btn {
       padding: 8px 0px 8px 8px;
@@ -41,18 +52,13 @@
       }
     }
 
-    .spacer {
-      width: 8px;
-      height: 32px;
-      pointer-events: none;
-    }
-
     .close-label,
     .scenario-name-container {
       position: absolute;
       transition: opacity 0.3s ease-in-out;
       left: 32px;
       font-size: 0.875rem;
+      text-align: left;
     }
 
     .close-label {
@@ -64,11 +70,18 @@
       display: flex;
       align-items: center;
       opacity: 1;
+      height: 100%;
       color: var(--grey50);
 
-      .chevron-btn {
-        padding: 4px;
-        color: var(--black25);
+      .chevron-container {
+        display: flex;
+        align-items: center;
+        height: 100%;
+
+        .chevron-btn {
+          padding: 4px;
+          color: var(--black25);
+        }
       }
 
       &:hover {
@@ -94,11 +107,6 @@
     display: flex;
     align-items: center;
     height: 100%;
-
-    .spacer {
-      width: 32px;
-      height: 100%;
-    }
 
     .board-btns {
       display: flex;
@@ -146,12 +154,6 @@
         }
         // END HANDLE BOARD STATE
       }
-
-      .board-separator {
-        width: 8px;
-        height: 100%;
-        background-color: var(--ambientB20);
-      }
     }
   }
 
@@ -160,11 +162,6 @@
     align-items: center;
     height: 100%;
     margin-right: 8px;
-
-    .spacer {
-      width: 32px;
-      height: 100%;
-    }
 
     .user-name {
       color: var(--grey30);

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -19,10 +19,17 @@
     font-size: 0.875rem;
     line-height: 20px;
     letter-spacing: 0px;
+    margin-right: 32px;
 
     .close-btn {
-      padding: 8px;
+      padding: 8px 0px 8px 8px;
       color: var(--black25);
+    }
+
+    .spacer {
+      width: 8px;
+      height: 32px;
+      pointer-events: none;
     }
 
     .scenario-name {

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -107,7 +107,7 @@
 
       .board-btn {
         padding: 1px 8px 3px 8px;
-        font-size: 0.750rem;
+        font-size: 0.75rem;
         line-height: 16px;
         border-radius: 4px;
 
@@ -156,20 +156,21 @@
   }
 
   .user-info {
+    display: flex;
+    align-items: center;
+    height: 100%;
     margin-right: 8px;
+
+    .spacer {
+      width: 32px;
+      height: 100%;
+    }
+
     .user-name {
       color: var(--grey30);
       font-size: 0.875rem;
-      font-weight: 400;
-      letter-spacing: 0px;
       text-align: right;
       line-height: 20px;
-      margin-right: 8px;
-    }
-
-    .help-icon {
-      padding: 8px;
-      color: var(--grey30);
     }
   }
 }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -1,217 +1,256 @@
-.scenario-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 32px;
-  box-shadow:
-    0px 1px 2px rgba(0, 0, 0, 0.16),
-    0px 2px 2px -1px rgba(255, 171, 88, 0.27);
-  background-color: var(--ambientB10);
+.scenario-header-container {
   margin-bottom: 8px;
-  min-width: 780px;
 
-  button:focus {
-    outline: none;
-  }
-
-  .inactive-area {
-    min-width: 8px;
-    pointer-events: none;
-  }
-
-  .spacer {
-    min-width: 32px;
-  }
-
-  .scenario-info {
+  .scenario-header {
     display: flex;
+    justify-content: space-between;
     align-items: center;
-    font-size: 0.875rem;
-    line-height: 20px;
-    letter-spacing: 0px;
-    position: relative;
-    height: 100%;
-    flex: 1;
-    overflow: hidden;
+    height: 32px;
+    box-shadow:
+      0px 1px 2px rgba(0, 0, 0, 0.16),
+      0px 2px 2px -1px rgba(255, 171, 88, 0.27);
+    background-color: var(--ambientB10);
+    min-width: 780px;
 
-    .close-btn {
-      padding: 8px 0px 8px 8px;
-      color: var(--black25);
+    button:focus {
+      outline: none;
+    }
 
-      &:hover {
-        color: var(--black100);
+    .inactive-area {
+      min-width: 8px;
+      pointer-events: none;
+    }
 
-        & ~ .scenario-name-container {
-          opacity: 0;
+    .spacer {
+      min-width: 32px;
+    }
+
+    .scenario-info {
+      display: flex;
+      align-items: center;
+      font-size: 0.875rem;
+      line-height: 20px;
+      letter-spacing: 0px;
+      position: relative;
+      height: 100%;
+      flex: 1;
+      overflow: hidden;
+
+      .close-btn {
+        padding: 8px 0px 8px 8px;
+        color: var(--black25);
+
+        &:hover {
+          color: var(--black100);
+
+          & ~ .scenario-name-container {
+            opacity: 0;
+          }
+
+          & ~ .close-label {
+            display: block;
+            color: var(--warning60);
+          }
+        }
+      }
+
+      .close-label,
+      .scenario-name-container {
+        transition: opacity 0.3s ease-in-out;
+        left: 32px;
+        font-size: 0.875rem;
+        text-align: left;
+      }
+
+      .close-label {
+        position: absolute;
+        text-transform: capitalize;
+        display: none;
+      }
+
+      .scenario-name-container {
+        display: flex;
+        align-items: center;
+        opacity: 1;
+        height: 100%;
+        color: var(--grey50);
+        min-width: 0;
+
+        .scenario-name-label {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          min-width: 0;
         }
 
-        & ~ .close-label {
-          text-transform: capitalize;
-          display: block;
-          color: var(--warning60);
+        .chevron-container {
+          display: flex;
+          align-items: center;
+          height: 100%;
+
+          .chevron-btn {
+            padding: 4px;
+            color: var(--black25);
+          }
+        }
+
+        &:hover {
+          cursor: pointer;
+          .scenario-name-label {
+            // validate the following color used when hovering over the scenario name
+            color: var(--black100);
+          }
+
+          .chevron-btn {
+            color: var(--black100);
+          }
+        }
+      }
+
+      .chevron-btn {
+        padding: 4px;
+        color: var(--black25);
+      }
+    }
+
+    .board-bar {
+      display: flex;
+      align-items: center;
+      height: 100%;
+
+      .board-btns {
+        display: flex;
+        align-items: center;
+        height: 100%;
+
+        .board-btn {
+          padding: 1px 8px 3px 8px;
+          font-size: 0.75rem;
+          line-height: 16px;
+          border-radius: 4px;
+
+          // START HANDLE BOARD STATE
+
+          // On state
+          &.on {
+            color: var(--grey80);
+            background-color: var(--ambientB5);
+  
+            &:hover {
+              color: var(--black100);
+              background-color: var(--white100);
+            }
+  
+            &:active {
+              color: var(--grey20);
+              background-color: var(--ambientB15);
+            }
+          }
+  
+          // Off state
+          &:not(.on)  {
+            color: var(--grey30);
+            background-color: var(--ambientB15);
+  
+            &:hover {
+              color: var(--grey30);
+              background-color: var(--white100);
+            }
+  
+            &:active {
+              color: var(--grey50);
+              background-color: var(--ambientB5);
+            }
+          }
+          // END HANDLE BOARD STATE
         }
       }
     }
 
-    .close-label,
-    .scenario-name-container {
-      transition: opacity 0.3s ease-in-out;
-      left: 32px;
-      font-size: 0.875rem;
-      text-align: left;
-    }
-
-    .close-label {
-      position: absolute;
-      text-transform: capitalize;
-      display: none;
-    }
-
-    .scenario-name-container {
+    .user-info {
       display: flex;
       align-items: center;
-      opacity: 1;
       height: 100%;
-      color: var(--grey50);
-      min-width: 0;
+      overflow: hidden;
+      flex: 1;
+      margin-right: 8px;
+      justify-content: end;
 
-      .scenario-name-label {
+      .user-name {
+        color: var(--grey30);
+        font-size: 0.875rem;
+        text-align: right;
+        line-height: 20px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
         min-width: 0;
       }
+    }
 
-      .chevron-container {
-        display: flex;
-        align-items: center;
-        height: 100%;
-
-        .chevron-btn {
-          padding: 4px;
-          color: var(--black25);
-        }
+    // START HANDLE SCENARIO NAME AND USER NAME HOVER WHEN TRUNCATED
+    &:has(.scenario-name-label.is-truncated:hover) {
+      .scenario-info {
+        flex: 2;
       }
 
-      &:hover {
-        cursor: pointer;
-        .scenario-name-label {
-          // validate the following color used when hovering over the scenario name
-          color: var(--black100);
-        }
+      .board-bar {
+        display: none;
+      }
 
-        .chevron-btn {
-          color: var(--black100);
-        }
+      .user-info {
+        flex: 1;
       }
     }
 
-    .chevron-btn {
-      padding: 4px;
-      color: var(--black25);
+    &:has(.user-name.is-truncated:hover) {
+      .scenario-info {
+        flex: 1;
+      }
+
+      .board-bar {
+        display: none;
+      }
+
+      .user-info {
+        flex: 2;
+      }
     }
+    // END HANDLE SCENARIO NAME AND USER NAME HOVER WHEN TRUNCATED
   }
 
-  .board-bar {
+  .scenario-details {
     display: flex;
-    align-items: center;
-    height: 100%;
+    flex-direction: column;
+    background-color: var(--ambientB10);
+    color: var(--grey80);
+    box-shadow:
+      inset 0 1px 2px rgba(255, 255, 255, 1),
+      0 1px 2px rgba(0, 0, 0, 0.16),
+      0 2px 2px -1px rgba(255, 171, 88, 0.27);
+    padding: 30px 32px;
+    width: 100%;
+    overflow-wrap: break-word;
 
-    .board-btns {
+    .scenario-description {
+      display: inline;
+      max-width: 480px;
+      margin-bottom: 28px;
+    }
+
+    .scenario-details-infra-name {
       display: flex;
-      align-items: center;
-      height: 100%;
+      flex-direction: row;
+      margin-bottom: 4px;
+    }
 
-      .board-btn {
-        padding: 1px 8px 3px 8px;
-        font-size: 0.75rem;
-        line-height: 16px;
-        border-radius: 4px;
+    .edit-scenario-container {
+      margin-top: 28px;
+      color: var(--primary60);
 
-        // START HANDLE BOARD STATE
-
-        // On state
-        &.on {
-          color: var(--grey80);
-          background-color: var(--ambientB5);
-
-          &:hover {
-            color: var(--black100);
-            background-color: var(--white100);
-          }
-
-          &:active {
-            color: var(--grey20);
-            background-color: var(--ambientB15);
-          }
-        }
-
-        // Off state
-        &:not(.on)  {
-          color: var(--grey30);
-          background-color: var(--ambientB15);
-
-          &:hover {
-            color: var(--grey30);
-            background-color: var(--white100);
-          }
-
-          &:active {
-            color: var(--grey50);
-            background-color: var(--ambientB5);
-          }
-        }
-        // END HANDLE BOARD STATE
+      button:focus {
+        outline: none;
       }
-    }
-  }
-
-  .user-info {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    margin-right: 8px;
-    overflow: hidden;
-    flex: 1;
-    justify-content: end;
-
-    .user-name {
-      color: var(--grey30);
-      font-size: 0.875rem;
-      text-align: right;
-      line-height: 20px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      min-width: 0;
-    }
-  }
-
-  &:has(.scenario-name-label.is-truncated:hover) {
-    .scenario-info {
-      flex: 2;
-    }
-
-    .board-bar {
-      display: none;
-    }
-
-    .user-info {
-      flex: 1;
-    }
-  }
-
-  &:has(.user-name.is-truncated:hover) {
-    .scenario-info {
-      flex: 1;
-    }
-
-    .board-bar {
-      display: none;
-    }
-
-    .user-info {
-      flex: 2;
     }
   }
 }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -48,7 +48,7 @@
           }
 
           & ~ .close-label {
-            display: block;
+            opacity: 1;
             color: var(--warning60);
           }
         }
@@ -65,7 +65,7 @@
       .close-label {
         position: absolute;
         text-transform: capitalize;
-        display: none;
+        opacity: 0;
       }
 
       .scenario-name-container {
@@ -90,13 +90,15 @@
 
         &:hover {
           cursor: pointer;
-          .scenario-name-label, .chevron-btn{
+          .scenario-name-label,
+          .chevron-btn {
             color: var(--black100);
           }
         }
 
         &:active {
-          .scenario-name-label, .chevron-btn{
+          .scenario-name-label,
+          .chevron-btn {
             color: var(--grey70);
           }
         }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -83,15 +83,9 @@
           min-width: 0;
         }
 
-        .chevron-container {
-          display: flex;
-          align-items: center;
-          height: 100%;
-
-          .chevron-btn {
-            padding: 4px;
-            color: var(--black25);
-          }
+        .chevron-btn {
+          padding: 4px;
+          color: var(--black25);
         }
 
         &:hover {
@@ -185,7 +179,7 @@
     }
 
     // START HANDLE SCENARIO NAME AND USER NAME HOVER WHEN TRUNCATED
-    &:has(.scenario-name-label.is-truncated:hover) {
+    &:has(.scenario-name-container:hover .scenario-name-label.is-truncated) {
       .scenario-info {
         flex: 2;
       }

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -20,10 +20,25 @@
     line-height: 20px;
     letter-spacing: 0px;
     margin-right: 32px;
+    position: relative;
 
     .close-btn {
       padding: 8px 0px 8px 8px;
       color: var(--black25);
+
+      &:hover {
+        color: var(--black100);
+
+        & ~ .scenario-name-container {
+          opacity: 0;
+        }
+
+        & ~ .close-label {
+          text-transform: capitalize;
+          opacity: 1;
+          color: var(--warning60);
+        }
+      }
     }
 
     .spacer {
@@ -32,8 +47,40 @@
       pointer-events: none;
     }
 
-    .scenario-name {
+    .close-label,
+    .scenario-name-container {
+      position: absolute;
+      transition: opacity 0.3s ease-in-out;
+      left: 32px;
+    }
+
+    .close-label {
+      text-transform: capitalize;
+      opacity: 0;
+    }
+
+    .scenario-name-container {
+      display: flex;
+      align-items: center;
+      opacity: 1;
       color: var(--grey50);
+
+      .chevron-btn {
+        padding: 4px;
+        color: var(--black25);
+      }
+
+      &:hover {
+        cursor: pointer;
+        .scenario-name-label {
+          // validate the following color used when hovering over the scenario name
+          color: var(--black100);
+        }
+
+        .chevron-btn {
+          color: var(--black100);
+        }
+      }
     }
 
     .chevron-btn {

--- a/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
+++ b/front/src/styles/scss/applications/operationalStudies/_scenarioV2.scss
@@ -96,20 +96,16 @@
 
         &:hover {
           cursor: pointer;
-          .scenario-name-label {
-            // validate the following color used when hovering over the scenario name
-            color: var(--black100);
-          }
-
-          .chevron-btn {
+          .scenario-name-label, .chevron-btn{
             color: var(--black100);
           }
         }
-      }
 
-      .chevron-btn {
-        padding: 4px;
-        color: var(--black25);
+        &:active {
+          .scenario-name-label, .chevron-btn{
+            color: var(--grey70);
+          }
+        }
       }
     }
 

--- a/front/src/styles/scss/common/components/_infraLoadingState.scss
+++ b/front/src/styles/scss/common/components/_infraLoadingState.scss
@@ -11,6 +11,14 @@
     color: var(--info60);
   }
 
+  .infra-loaded {
+    width: 8px;
+    height: 8px;
+    background-color: var(--success30);
+    border-radius: 50%;
+    margin-block: 5px 3px;
+  }
+
   .infra-loader:first-child {
     animation: dot-flashing 0.5s infinite linear alternate;
     animation-delay: 0s;


### PR DESCRIPTION
This PR is the continuation of the work started in [this preview PR](https://github.com/OpenRailAssociation/osrd/pull/11627) on the header of the new scenario view.

It fully implements the header according to the specifications detailed in [this mockup](https://www.sketch.com/s/008d6980-d719-4bdc-bb2a-b4c2dda0dc1e/f/69619A0B-E473-4AB5-81BF-97BC06FB02FE#Inspect).

You can [browse the commits](https://github.com/OpenRailAssociation/osrd/pull/11658/commits) to follow the step-by-step implementation process.

To test the behavior with long labels, you can manually set a very long string as a user name or label (e.g., "_super_long_name_for_testing_purposes") and verify that ellipsis is applied to prevent collisions. Hovering over the truncated label should reveal its full content and temporarily hide the board display management component.