### PR TITLE
front: add padding right to infralist items

### DIFF
--- a/front/src/modules/infra/styles/_infraSelector.scss
+++ b/front/src/modules/infra/styles/_infraSelector.scss
@@ -108,7 +108,7 @@
       }
     }
     .infraslist-item-choice-main {
-      padding: 0 4px;
+      padding: 0 16px 0 4px;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -122,7 +122,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 4px 4px 0;
+      padding: 4px 16px 0 4px;
       font-size: 0.6rem;
       height: 16px;
       line-height: 20px;


### PR DESCRIPTION
Before this PR, infra list items look like this:
![Capture d'écran 2025-05-05 112917](https://github.com/user-attachments/assets/2b733218-d895-426e-9389-7d620119f6e6)

After this PR:
![Capture d'écran 2025-05-05 112939](https://github.com/user-attachments/assets/9021b730-a4a8-4e73-b7b9-c435be656a46)

The benefit is that the scroll bar doesn't hide the status of the infra