### PR TITLE
editoast: use const generics to declare maximum and default page size

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5359,8 +5359,6 @@ components:
       - $ref: '#/components/schemas/EditoastPacedTrainErrorDatabase'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorNotFound'
-      - $ref: '#/components/schemas/EditoastPaginationErrorInvalidPage'
-      - $ref: '#/components/schemas/EditoastPaginationErrorInvalidPageSize'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsEndingTrackLocationNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingViewErrorsInvalidNumberOfPaths'
@@ -5943,57 +5941,6 @@ components:
           type: string
           enum:
           - editoast:paced_train:NotFound
-    EditoastPaginationErrorInvalidPage:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - page
-          properties:
-            page:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 400
-        type:
-          type: string
-          enum:
-          - editoast:pagination:InvalidPage
-    EditoastPaginationErrorInvalidPageSize:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - max_page_size
-          - provided_page_size
-          properties:
-            max_page_size:
-              type: integer
-            provided_page_size:
-              type: integer
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 400
-        type:
-          type: string
-          enum:
-          - editoast:pagination:InvalidPageSize
     EditoastPathfindingErrorInfraNotFound:
       type: object
       required:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -195,8 +195,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 100
           nullable: true
+          maximum: 100
           minimum: 1
       responses:
         '200':
@@ -478,8 +479,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       responses:
         '200':
@@ -896,8 +898,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 100
           nullable: true
+          maximum: 100
           minimum: 1
       - name: level
         in: query
@@ -1617,8 +1620,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       responses:
         '200':
@@ -1903,8 +1907,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       - name: ordering
         in: query
@@ -2050,8 +2055,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       - name: ordering
         in: query
@@ -2228,8 +2234,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       - name: ordering
         in: query
@@ -2438,8 +2445,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 100
           nullable: true
+          maximum: 100
           minimum: 1
       responses:
         '200':
@@ -2874,8 +2882,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 1000
           nullable: true
+          maximum: 1000
           minimum: 1
       requestBody:
         content:
@@ -3007,6 +3016,7 @@ paths:
           format: int64
           default: 25
           nullable: true
+          maximum: 25
           minimum: 1
       responses:
         '200':
@@ -3175,6 +3185,7 @@ paths:
           format: int64
           default: 25
           nullable: true
+          maximum: 25
           minimum: 1
       responses:
         '200':
@@ -3446,6 +3457,7 @@ paths:
           format: int64
           default: 25
           nullable: true
+          maximum: 25
           minimum: 1
       responses:
         '200':
@@ -3514,8 +3526,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 50
           nullable: true
+          maximum: 50
           minimum: 1
       responses:
         '200':
@@ -3916,8 +3929,9 @@ paths:
         schema:
           type: integer
           format: int64
-          default: 25
+          default: 100
           nullable: true
+          maximum: 100
           minimum: 1
       - name: id
         in: path

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -264,10 +264,9 @@ async fn users_grants_for_resource_id(
     State(AppState { regulator, .. }): State<AppState>,
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams<100>>,
+    Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<Vec<SubjectGrant>>> {
     // Validate pagination params
-    let (page, page_size) = pagination_params.validate()?.unpack();
     let mut skip = (page - 1) * page_size;
 
     let mut result: Vec<SubjectGrant> = Vec::new();

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -12,7 +12,8 @@ use axum::response::IntoResponse;
 use axum::response::Json;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use strum::Display;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
@@ -254,7 +255,7 @@ struct ResourceIdParam {
     get,
     path = "",
     tag = "authz",
-    params(ResourceTypeParam, ResourceIdParam, PaginationQueryParams),
+    params(ResourceTypeParam, ResourceIdParam, PaginationQueryParams<100>),
     responses(
         (status = 200, description = "Get list of user that have access to the resource", body = inline(Vec<SubjectGrant>)),
     ),
@@ -263,10 +264,10 @@ async fn users_grants_for_resource_id(
     State(AppState { regulator, .. }): State<AppState>,
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<Vec<SubjectGrant>>> {
     // Validate pagination params
-    let (page, page_size) = pagination_params.validate(100)?.unpack();
+    let (page, page_size) = pagination_params.validate()?.unpack();
     let mut skip = (page - 1) * page_size;
 
     let mut result: Vec<SubjectGrant> = Vec::new();

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -65,7 +65,7 @@ pub(in crate::views) struct InfraErrorResponse {
 #[utoipa::path(
     get, path = "",
      tag = "infra",
-     params(InfraIdParam, PaginationQueryParams, ErrorListQueryParams),
+     params(InfraIdParam, PaginationQueryParams<100>, ErrorListQueryParams),
      responses(
          (status = 200, body = inline(ErrorListResponse), description = "A paginated list of errors"),
      ),
@@ -74,7 +74,7 @@ async fn list_errors(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<100>>,
     Query(ErrorListQueryParams {
         level,
         error_type,
@@ -89,10 +89,7 @@ async fn list_errors(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (page, page_size) = pagination_params
-        .validate(100)?
-        .warn_page_size(100)
-        .unpack();
+    let (page, page_size) = pagination_params.validate()?.warn_page_size(100).unpack();
     let (page, page_size) = (page as u64, page_size as u64);
 
     let error_type = match error_type.map(|et| InfraErrorTypeLabel::from_str(&et).ok()) {

--- a/editoast/src/views/infra/errors.rs
+++ b/editoast/src/views/infra/errors.rs
@@ -74,7 +74,7 @@ async fn list_errors(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(InfraIdParam { infra_id }): Path<InfraIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams<100>>,
+    Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<100>>,
     Query(ErrorListQueryParams {
         level,
         error_type,
@@ -88,9 +88,6 @@ async fn list_errors(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-
-    let (page, page_size) = pagination_params.validate()?.warn_page_size(100).unpack();
-    let (page, page_size) = (page as u64, page_size as u64);
 
     let error_type = match error_type.map(|et| InfraErrorTypeLabel::from_str(&et).ok()) {
         Some(None) => return Err(ListErrorsErrors::WrongErrorTypeProvided.into()),

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -232,10 +232,7 @@ async fn list(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let settings = pagination_params
-        .validate()?
-        .warn_page_size(100)
-        .into_selection_settings();
+    let settings = pagination_params.into_selection_settings();
 
     let (infras, stats) = {
         let conn = &mut db_pool.get().await?;

--- a/editoast/src/views/infra/mod.rs
+++ b/editoast/src/views/infra/mod.rs
@@ -210,7 +210,7 @@ struct InfraListResponse {
 #[utoipa::path(
     get, path = "",
     tag = "infra",
-    params(PaginationQueryParams),
+    params(PaginationQueryParams<1000>),
     responses(
         (status = 200, description = "All infras, paginated", body = inline(InfraListResponse))
     ),
@@ -222,7 +222,7 @@ async fn list(
         ..
     }): State<AppState>,
     Extension(auth): AuthenticationExt,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<InfraListResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
@@ -233,7 +233,7 @@ async fn list(
     }
 
     let settings = pagination_params
-        .validate(1000)?
+        .validate()?
         .warn_page_size(100)
         .into_selection_settings();
 

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use tracing::warn;
-use utoipa::IntoParams;
 use utoipa::ToSchema;
 
 use crate::ListAndCount;
@@ -15,8 +14,6 @@ use crate::error::Result;
 editoast_common::schemas! {
     PaginationStats,
 }
-
-const DEFAULT_PAGE_SIZE: u64 = 25;
 
 /// Statistics about a paginated editoast response
 ///
@@ -121,29 +118,72 @@ pub trait PaginatedList: ListAndCount + 'static {
 
 impl<T> PaginatedList for T where T: ListAndCount + 'static {}
 
-#[derive(Debug, Clone, Copy, Deserialize, IntoParams)]
-#[into_params(parameter_in = Query)]
-pub struct PaginationQueryParams {
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct PaginationQueryParams<const MAX_PAGE_SIZE: u64 = 25> {
     #[serde(default = "default_page")]
-    #[param(minimum = 1, default = 1)]
     pub page: u64,
-    #[param(minimum = 1, default = 25)]
     pub page_size: Option<u64>,
+}
+
+impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_PAGE_SIZE> {
+    fn into_params(
+        _parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>,
+    ) -> Vec<utoipa::openapi::path::Parameter> {
+        use serde_json::json;
+        use utoipa::openapi::KnownFormat;
+        use utoipa::openapi::ObjectBuilder;
+        use utoipa::openapi::Required;
+        use utoipa::openapi::SchemaFormat;
+        use utoipa::openapi::SchemaType;
+        use utoipa::openapi::path::ParameterBuilder;
+        use utoipa::openapi::path::ParameterIn;
+
+        [
+            ParameterBuilder::new()
+                .name("page")
+                .parameter_in(ParameterIn::Query)
+                .required(Required::False)
+                .schema(Some(
+                    ObjectBuilder::new()
+                        .schema_type(SchemaType::Integer)
+                        .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
+                        .minimum(Some(1f64))
+                        .default(Some(json!(default_page()))),
+                ))
+                .build(),
+            ParameterBuilder::new()
+                .name("page_size")
+                .parameter_in(ParameterIn::Query)
+                .required(Required::False)
+                .schema(Some(
+                    ObjectBuilder::new()
+                        .schema_type(SchemaType::Integer)
+                        .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
+                        .minimum(Some(1f64))
+                        .maximum(Some(MAX_PAGE_SIZE as f64))
+                        .default(Some(json!(MAX_PAGE_SIZE)))
+                        .nullable(true),
+                ))
+                .build(),
+        ]
+        .to_vec()
+    }
 }
 
 const fn default_page() -> u64 {
     1
 }
 
-impl PaginationQueryParams {
+impl<const MAX_PAGE_SIZE: u64> PaginationQueryParams<MAX_PAGE_SIZE> {
     /// Returns a pre-filled [SelectionSettings] from the pagination settings
     /// that can then be used to list or count models
     pub fn into_selection_settings<M: Model + 'static>(self) -> SelectionSettings<M> {
         self.into()
     }
 
-    pub fn validate(self, max_page_size: i64) -> Result<PaginationQueryParams> {
+    pub fn validate(self) -> Result<Self> {
         let (page, page_size) = self.unpack();
+        let max_page_size = MAX_PAGE_SIZE as i64;
         if page < 1 {
             return Err(PaginationError::InvalidPage { page }.into());
         }
@@ -157,7 +197,7 @@ impl PaginationQueryParams {
         Ok(self)
     }
 
-    pub fn warn_page_size(self, warn_page_size: i64) -> PaginationQueryParams {
+    pub fn warn_page_size(self, warn_page_size: i64) -> Self {
         let (_, page_size) = self.unpack();
         if page_size > warn_page_size {
             warn!(
@@ -169,14 +209,18 @@ impl PaginationQueryParams {
     }
 
     pub fn unpack(&self) -> (i64, i64) {
-        let page_size = self.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let page_size = self.page_size.unwrap_or(MAX_PAGE_SIZE);
         (self.page as i64, page_size as i64)
     }
 }
 
-impl<M: Model + 'static> From<PaginationQueryParams> for SelectionSettings<M> {
-    fn from(PaginationQueryParams { page, page_size }: PaginationQueryParams) -> Self {
-        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+impl<M: Model + 'static, const MAX_PAGE_SIZE: u64> From<PaginationQueryParams<MAX_PAGE_SIZE>>
+    for SelectionSettings<M>
+{
+    fn from(
+        PaginationQueryParams { page, page_size }: PaginationQueryParams<MAX_PAGE_SIZE>,
+    ) -> Self {
+        let page_size = page_size.unwrap_or(MAX_PAGE_SIZE);
         SelectionSettings::from_pagination_settings(page, page_size)
     }
 }

--- a/editoast/src/views/pagination.rs
+++ b/editoast/src/views/pagination.rs
@@ -1,9 +1,7 @@
-use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
 use serde::Deserialize;
 use serde::Serialize;
-use thiserror::Error;
-use tracing::warn;
+
 use utoipa::ToSchema;
 
 use crate::ListAndCount;
@@ -118,11 +116,41 @@ pub trait PaginatedList: ListAndCount + 'static {
 
 impl<T> PaginatedList for T where T: ListAndCount + 'static {}
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 pub struct PaginationQueryParams<const MAX_PAGE_SIZE: u64 = 25> {
-    #[serde(default = "default_page")]
     pub page: u64,
-    pub page_size: Option<u64>,
+    pub page_size: u64,
+}
+
+impl<'de, const MAX_PAGE_SIZE: u64> serde::de::Deserialize<'de>
+    for PaginationQueryParams<MAX_PAGE_SIZE>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Schema {
+            page: Option<u64>,
+            page_size: Option<u64>,
+        }
+        let Schema { page, page_size } = Schema::deserialize(deserializer)?;
+        let page = page.unwrap_or(1);
+        if page == 0 {
+            return Err(serde::de::Error::custom("invalid page 0, pages start at 1"));
+        }
+        if let Some(size) = page_size {
+            if !(0 < size && size <= MAX_PAGE_SIZE) {
+                return Err(serde::de::Error::custom(format!(
+                    "invalid page size ({size}), expected an integer 0 < page_size <= {MAX_PAGE_SIZE}",
+                )));
+            }
+        }
+        Ok(Self {
+            page,
+            page_size: page_size.unwrap_or(MAX_PAGE_SIZE),
+        })
+    }
 }
 
 impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_PAGE_SIZE> {
@@ -148,7 +176,7 @@ impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_
                         .schema_type(SchemaType::Integer)
                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
                         .minimum(Some(1f64))
-                        .default(Some(json!(default_page()))),
+                        .default(Some(json!(1))),
                 ))
                 .build(),
             ParameterBuilder::new()
@@ -170,47 +198,11 @@ impl<const MAX_PAGE_SIZE: u64> utoipa::IntoParams for PaginationQueryParams<MAX_
     }
 }
 
-const fn default_page() -> u64 {
-    1
-}
-
 impl<const MAX_PAGE_SIZE: u64> PaginationQueryParams<MAX_PAGE_SIZE> {
     /// Returns a pre-filled [SelectionSettings] from the pagination settings
     /// that can then be used to list or count models
     pub fn into_selection_settings<M: Model + 'static>(self) -> SelectionSettings<M> {
         self.into()
-    }
-
-    pub fn validate(self) -> Result<Self> {
-        let (page, page_size) = self.unpack();
-        let max_page_size = MAX_PAGE_SIZE as i64;
-        if page < 1 {
-            return Err(PaginationError::InvalidPage { page }.into());
-        }
-        if page_size > max_page_size || page_size < 1 {
-            return Err(PaginationError::InvalidPageSize {
-                provided_page_size: page_size,
-                max_page_size,
-            }
-            .into());
-        }
-        Ok(self)
-    }
-
-    pub fn warn_page_size(self, warn_page_size: i64) -> Self {
-        let (_, page_size) = self.unpack();
-        if page_size > warn_page_size {
-            warn!(
-                "Too many elements per page, should be lower or equal to {}.",
-                warn_page_size
-            );
-        }
-        self
-    }
-
-    pub fn unpack(&self) -> (i64, i64) {
-        let page_size = self.page_size.unwrap_or(MAX_PAGE_SIZE);
-        (self.page as i64, page_size as i64)
     }
 }
 
@@ -220,26 +212,8 @@ impl<M: Model + 'static, const MAX_PAGE_SIZE: u64> From<PaginationQueryParams<MA
     fn from(
         PaginationQueryParams { page, page_size }: PaginationQueryParams<MAX_PAGE_SIZE>,
     ) -> Self {
-        let page_size = page_size.unwrap_or(MAX_PAGE_SIZE);
         SelectionSettings::from_pagination_settings(page, page_size)
     }
-}
-
-/// Simple pagination error
-#[derive(Debug, Error, EditoastError)]
-#[editoast_error(base_id = "pagination")]
-pub enum PaginationError {
-    #[error(
-        "Invalid page size ({provided_page_size}), expected an integer 0 < page_size <= {max_page_size}"
-    )]
-    #[editoast_error(status = 400)]
-    InvalidPageSize {
-        provided_page_size: i64,
-        max_page_size: i64,
-    },
-    #[error("Invalid page ({page}), expected a positive integer ")]
-    #[editoast_error(status = 400)]
-    InvalidPage { page: i64 },
 }
 
 #[cfg(test)]

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -211,8 +211,6 @@ async fn list(
 
     let ordering = ordering_params.ordering;
     let settings = pagination_params
-        .validate()?
-        .warn_page_size(100)
         .into_selection_settings()
         .order_by(move || ordering.as_project_ordering());
 

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -190,7 +190,7 @@ struct ProjectWithStudyCountList {
 #[utoipa::path(
     get, path = "",
     tag = "projects",
-    params(PaginationQueryParams, OperationalStudiesOrderingParam),
+    params(PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
     responses(
         (status = 200, body = inline(ProjectWithStudyCountList), description = "The list of projects"),
     )
@@ -198,7 +198,7 @@ struct ProjectWithStudyCountList {
 async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(ordering_params): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<ProjectWithStudyCountList>> {
     let authorized = auth
@@ -211,7 +211,7 @@ async fn list(
 
     let ordering = ordering_params.ordering;
     let settings = pagination_params
-        .validate(1000)?
+        .validate()?
         .warn_page_size(100)
         .into_selection_settings()
         .order_by(move || ordering.as_project_ordering());

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -109,7 +109,7 @@ struct LightRollingStockWithLiveriesCountList {
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
-    params(PaginationQueryParams),
+    params(PaginationQueryParams<1000>),
     responses(
         (status = 200, body = inline(LightRollingStockWithLiveriesCountList)),
     )
@@ -117,7 +117,7 @@ struct LightRollingStockWithLiveriesCountList {
 async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(page_settings): Query<PaginationQueryParams>,
+    Query(page_settings): Query<PaginationQueryParams<1000>>,
 ) -> Result<Json<LightRollingStockWithLiveriesCountList>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
@@ -127,7 +127,7 @@ async fn list(
         return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
-        .validate(1000)?
+        .validate()?
         .warn_page_size(100)
         .into_selection_settings()
         .order_by(|| RollingStockModel::ID.asc());

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -127,8 +127,6 @@ async fn list(
         return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
-        .validate()?
-        .warn_page_size(100)
         .into_selection_settings()
         .order_by(|| RollingStockModel::ID.asc());
     let (rolling_stocks, stats) =
@@ -489,13 +487,6 @@ mod tests {
 
         let request = app.get("/light_rolling_stock/?page_size=1010");
 
-        let response: InternalError = app
-            .fetch(request)
-            .assert_status(StatusCode::BAD_REQUEST)
-            .json_into();
-
-        assert_eq!(response.error_type, "editoast:pagination:InvalidPageSize");
-        assert_eq!(response.context["provided_page_size"], 1010);
-        assert_eq!(response.context["max_page_size"], 1000);
+        app.fetch(request).assert_status(StatusCode::BAD_REQUEST);
     }
 }

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -199,7 +199,7 @@ struct TowedRollingStockCountList {
 #[utoipa::path(
     get, path = "",
     tag = "rolling_stock",
-    params(PaginationQueryParams),
+    params(PaginationQueryParams<50>),
     responses(
         (status = 200, body = inline(TowedRollingStockCountList)),
     )
@@ -207,7 +207,7 @@ struct TowedRollingStockCountList {
 async fn get_list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(page_settings): Query<PaginationQueryParams>,
+    Query(page_settings): Query<PaginationQueryParams<50>>,
 ) -> Result<Json<TowedRollingStockCountList>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
@@ -217,7 +217,7 @@ async fn get_list(
         return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
-        .validate(50)?
+        .validate()?
         .into_selection_settings()
         .order_by(|| TowedRollingStockModel::ID.asc());
     let (towed_rolling_stocks, stats) =

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -217,7 +217,6 @@ async fn get_list(
         return Err(AuthorizationError::Forbidden.into());
     }
     let settings = page_settings
-        .validate()?
         .into_selection_settings()
         .order_by(|| TowedRollingStockModel::ID.asc());
     let (towed_rolling_stocks, stats) =

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -486,8 +486,6 @@ async fn list(
     }
 
     let settings = pagination_params
-        .validate()?
-        .warn_page_size(100)
         .into_selection_settings()
         .order_by(move || ordering.as_scenario_ordering())
         .filter(move || Scenario::STUDY_ID.eq(study_id));

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -455,7 +455,7 @@ struct ListScenariosResponse {
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, PaginationQueryParams, OperationalStudiesOrderingParam),
+    params(ProjectIdParam, StudyIdParam, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
     responses(
         (status = 200, description = "A paginated list of scenarios", body = inline(ListScenariosResponse)),
         (status = 404, description = "Project or study doesn't exist")
@@ -465,7 +465,7 @@ async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id)): Path<(i64, i64)>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(OperationalStudiesOrderingParam { ordering }): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<ListScenariosResponse>> {
     let authorized = auth
@@ -486,7 +486,7 @@ async fn list(
     }
 
     let settings = pagination_params
-        .validate(1000)?
+        .validate()?
         .warn_page_size(100)
         .into_selection_settings()
         .order_by(move || ordering.as_scenario_ordering())

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -134,7 +134,7 @@ struct MacroNodeListResponse {
 #[utoipa::path(
     get, path = "",
     tag = "scenarios",
-    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams),
+    params(ProjectIdParam, StudyIdParam, ScenarioIdParam, PaginationQueryParams<100>),
     responses(
         (status = 200, body = MacroNodeListResponse, description = "List of macro nodes for the requested scenario"),
         (status = 404, body = InternalError, description = "The requested scenario was not found"),
@@ -144,7 +144,7 @@ async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path((project_id, study_id, scenario_id)): Path<(i64, i64, i64)>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<100>>,
 ) -> Result<Json<MacroNodeListResponse>> {
     // Checking role
     let authorized = auth
@@ -162,7 +162,7 @@ async fn list(
 
     // Ask the db
     let settings = pagination_params
-        .validate(100)?
+        .validate()?
         .into_selection_settings()
         .filter(move || MacroNode::SCENARIO_ID.eq(scenario_id));
     let (result, stats) = MacroNode::list_paginated(conn, settings).await?;

--- a/editoast/src/views/scenario/macro_nodes.rs
+++ b/editoast/src/views/scenario/macro_nodes.rs
@@ -162,7 +162,6 @@ async fn list(
 
     // Ask the db
     let settings = pagination_params
-        .validate()?
         .into_selection_settings()
         .filter(move || MacroNode::SCENARIO_ID.eq(scenario_id));
     let (result, stats) = MacroNode::list_paginated(conn, settings).await?;

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -338,7 +338,7 @@ struct SearchDBResult {
 #[utoipa::path(
     post, path = "",
     tag = "search",
-    params(PaginationQueryParams),
+    params(PaginationQueryParams<1000>),
     request_body = SearchPayload,
     responses(
         (status = 200, body = Vec<SearchResultItem>, description = "The search results"),
@@ -347,7 +347,7 @@ struct SearchDBResult {
 async fn search(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(query_params): Query<PaginationQueryParams>,
+    Query(query_params): Query<PaginationQueryParams<1000>>,
     Json(SearchPayload { object, query, dry }): Json<SearchPayload>,
 ) -> Result<Json<serde_json::Value>> {
     let roles: HashSet<Role> = match object.as_str() {
@@ -373,7 +373,7 @@ async fn search(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (page, per_page) = query_params.validate(1000)?.warn_page_size(100).unpack();
+    let (page, per_page) = query_params.validate()?.warn_page_size(100).unpack();
     let search_config =
         SearchConfigFinder::find(&object).ok_or_else(|| SearchApiError::ObjectType {
             object_type: object.to_owned(),

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -347,7 +347,7 @@ struct SearchDBResult {
 async fn search(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(query_params): Query<PaginationQueryParams<1000>>,
+    Query(PaginationQueryParams { page, page_size }): Query<PaginationQueryParams<1000>>,
     Json(SearchPayload { object, query, dry }): Json<SearchPayload>,
 ) -> Result<Json<serde_json::Value>> {
     let roles: HashSet<Role> = match object.as_str() {
@@ -373,14 +373,19 @@ async fn search(
         return Err(AuthorizationError::Forbidden.into());
     }
 
-    let (page, per_page) = query_params.validate()?.warn_page_size(100).unpack();
     let search_config =
         SearchConfigFinder::find(&object).ok_or_else(|| SearchApiError::ObjectType {
             object_type: object.to_owned(),
         })?;
-    let offset = (page - 1) * per_page;
-    let (sql, bindings) = query_into_sql(query, &search_config, per_page, offset, "result")
-        .map_err(SearchApiError::from)?;
+    let offset = (page - 1) * page_size;
+    let (sql, bindings) = query_into_sql(
+        query,
+        &search_config,
+        page_size as i64,
+        offset as i64,
+        "result",
+    )
+    .map_err(SearchApiError::from)?;
 
     let mut query = sql_query(sql).into_boxed();
     for string in bindings {

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -84,7 +84,7 @@ async fn list_stdcm_logs(
 
     let conn = &mut db_pool.get().await?;
 
-    let settings = pagination_params.validate()?.into_selection_settings();
+    let settings = pagination_params.into_selection_settings();
 
     let (stdcm_logs, stats) = StdcmLog::list_paginated(conn, settings).await?;
 

--- a/editoast/src/views/stdcm_logs.rs
+++ b/editoast/src/views/stdcm_logs.rs
@@ -64,7 +64,7 @@ struct StdcmLogListResponse {
 #[utoipa::path(
     get, path = "",
     tag = "stdcm_log",
-    params(PaginationQueryParams),
+    params(PaginationQueryParams<25>),
     responses(
         (status = 200, body = inline(StdcmLogListResponse), description = "The list of STDCM Logs"),
     )
@@ -72,7 +72,7 @@ struct StdcmLogListResponse {
 async fn list_stdcm_logs(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<StdcmLogListResponse>> {
     let authorized = auth
         .check_roles([Role::Admin].into())
@@ -84,7 +84,7 @@ async fn list_stdcm_logs(
 
     let conn = &mut db_pool.get().await?;
 
-    let settings = pagination_params.validate(25)?.into_selection_settings();
+    let settings = pagination_params.validate()?.into_selection_settings();
 
     let (stdcm_logs, stats) = StdcmLog::list_paginated(conn, settings).await?;
 

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -401,7 +401,7 @@ struct StudyListResponse {
 #[utoipa::path(
     get, path = "",
     tag = "studies",
-    params(ProjectIdParam, PaginationQueryParams, OperationalStudiesOrderingParam),
+    params(ProjectIdParam, PaginationQueryParams<1000>, OperationalStudiesOrderingParam),
     responses(
         (status = 200, body = inline(StudyListResponse), description = "The list of studies"),
     )
@@ -410,7 +410,7 @@ async fn list(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(project_id): Path<i64>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<1000>>,
     Query(ordering_params): Query<OperationalStudiesOrderingParam>,
 ) -> Result<Json<StudyListResponse>> {
     let authorized = auth
@@ -430,7 +430,7 @@ async fn list(
     }
 
     let settings = pagination_params
-        .validate(1000)?
+        .validate()?
         .warn_page_size(100)
         .into_selection_settings()
         .filter(move || Study::PROJECT_ID.eq(project_id))

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -430,8 +430,6 @@ async fn list(
     }
 
     let settings = pagination_params
-        .validate()?
-        .warn_page_size(100)
         .into_selection_settings()
         .filter(move || Study::PROJECT_ID.eq(project_id))
         .order_by(move || ordering.as_study_ordering());

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -144,7 +144,7 @@ struct ListTrainSchedulesResponse {
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
-    params(TimetableIdParam, PaginationQueryParams),
+    params(TimetableIdParam, PaginationQueryParams<25>),
     responses(
         (status = 200, description = "Timetable with train schedules ids", body = inline(ListTrainSchedulesResponse)),
         (status = 404, description = "Timetable not found"),
@@ -154,7 +154,7 @@ async fn get_train_schedules(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<ListTrainSchedulesResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
@@ -171,7 +171,7 @@ async fn get_train_schedules(
     }
 
     let settings = pagination_params
-        .validate(25)?
+        .validate()?
         .into_selection_settings()
         .filter(move || models::TrainSchedule::TIMETABLE_ID.eq(timetable_id));
 
@@ -340,7 +340,7 @@ struct ListPacedTrainsResponse {
 #[utoipa::path(
     get, path = "",
     tag = "timetable",
-    params(TimetableIdParam, PaginationQueryParams),
+    params(TimetableIdParam, PaginationQueryParams<25>),
     responses(
         (status = 200, description = "Timetable with paced train ids", body = inline(ListPacedTrainsResponse)),
         (status = 404, description = "Timetable not found"),
@@ -350,7 +350,7 @@ async fn get_paced_trains(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(TimetableIdParam { id: timetable_id }): Path<TimetableIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<25>>,
 ) -> Result<Json<ListPacedTrainsResponse>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
@@ -368,7 +368,7 @@ async fn get_paced_trains(
     }
 
     let settings = pagination_params
-        .validate(25)?
+        .validate()?
         .into_selection_settings()
         .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable_id));
 
@@ -791,11 +791,11 @@ mod tests {
 
         assert!(response.len() == 2);
 
-        let settings = PaginationQueryParams {
+        let settings = PaginationQueryParams::<25> {
             page: 1,
             page_size: Some(20),
         }
-        .validate(25)
+        .validate()
         .expect("Invalid pagination parameters")
         .into_selection_settings()
         .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable.id));

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -171,7 +171,6 @@ async fn get_train_schedules(
     }
 
     let settings = pagination_params
-        .validate()?
         .into_selection_settings()
         .filter(move || models::TrainSchedule::TIMETABLE_ID.eq(timetable_id));
 
@@ -368,7 +367,6 @@ async fn get_paced_trains(
     }
 
     let settings = pagination_params
-        .validate()?
         .into_selection_settings()
         .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable_id));
 
@@ -791,14 +789,10 @@ mod tests {
 
         assert!(response.len() == 2);
 
-        let settings = PaginationQueryParams::<25> {
-            page: 1,
-            page_size: Some(20),
-        }
-        .validate()
-        .expect("Invalid pagination parameters")
-        .into_selection_settings()
-        .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable.id));
+        let settings = SelectionSettings::default()
+            .filter(move || models::PacedTrain::TIMETABLE_ID.eq(timetable.id))
+            .limit(25)
+            .offset(0);
 
         let list_result = models::PacedTrain::list_paginated(&mut pool.get_ok(), settings)
             .await

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -485,7 +485,7 @@ pub struct WorkScheduleOrderingParam {
 #[utoipa::path(
     get, path = "",
     tag = "work_schedules",
-    params(PaginationQueryParams, WorkScheduleGroupIdParam, WorkScheduleOrderingParam),
+    params(PaginationQueryParams<100>, WorkScheduleGroupIdParam, WorkScheduleOrderingParam),
     responses(
         (status = 200, description = "The work schedules in the group", body = inline(GroupContentResponse)),
         (status = 404, description = "Work schedule group not found"),
@@ -495,7 +495,7 @@ async fn get_group(
     State(db_pool): State<DbConnectionPoolV2>,
     Extension(auth): AuthenticationExt,
     Path(WorkScheduleGroupIdParam { id: group_id }): Path<WorkScheduleGroupIdParam>,
-    Query(pagination_params): Query<PaginationQueryParams>,
+    Query(pagination_params): Query<PaginationQueryParams<100>>,
     Query(ordering_params): Query<WorkScheduleOrderingParam>,
 ) -> Result<Json<GroupContentResponse>> {
     let authorized = auth
@@ -508,7 +508,7 @@ async fn get_group(
 
     let ordering = ordering_params.ordering;
     let settings = pagination_params
-        .validate(100)?
+        .validate()?
         .into_selection_settings()
         .filter(move || WorkSchedule::WORK_SCHEDULE_GROUP_ID.eq(group_id))
         .order_by(move || ordering.as_work_schedule_ordering());

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -508,7 +508,6 @@ async fn get_group(
 
     let ordering = ordering_params.ordering;
     let settings = pagination_params
-        .validate()?
         .into_selection_settings()
         .filter(move || WorkSchedule::WORK_SCHEDULE_GROUP_ID.eq(group_id))
         .order_by(move || ordering.as_work_schedule_ordering());

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -129,10 +129,6 @@
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
       "NotFound": "Paced train '{{paced_train_id}}' could not be found"
     },
-    "pagination": {
-      "InvalidPage": "Invalid page number ({{page}})",
-      "InvalidPageSize": "Invalid page size ({{provided_page_size}}), expected an integer 0 < page_size <= {{max_page_size}}"
-    },
     "pathfinding": {
       "ElectricalProfilesOverlap": "Electrical Profile overlaps with others",
       "ElectrificationOverlap": "Electrification '{{electrification_id}}' overlaps with other electrifications",

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -129,10 +129,6 @@
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Mission '{{paced_train_id}}' non trouvée"
     },
-    "pagination": {
-      "InvalidPage": "Le numéro de page '{{page}}' est invalide",
-      "InvalidPageSize": "La taille de la page '{{provided_page_size}}' est invalide, il doit être un entier compris entre 0 et {{max_page_size}}"
-    },
     "pathfinding": {
       "ElectricalProfilesOverlap": "Des profils électriques se chevauchent",
       "ElectrificationOverlap": "Electrification {{electrification_id}} se supperpose avec d'autres",


### PR DESCRIPTION
**editoast: use const generics to declare maximum and default page size**

Introduces a subtle API breaking change: now the default page_size is
its maximum value. Before, we could have a default different (but lower)
than the maximum.

Rationale: if the maximum is correct, the amount of data queried and
sent back is reasonable. Therefore, using that as a default is fine
and reduces the amount of requests we receive. On the other hand, if
that `MAX_PAGE_SIZE` value is too high as a default value, it's likely
plain and simply too high.


**[editoast: simplify PaginationQueryParams API and error management](https://github.com/OpenRailAssociation/osrd/pull/11664/commits/3845fa4044cecb891c9ef436738158800286a309)
[3845fa4](https://github.com/OpenRailAssociation/osrd/pull/11664/commits/3845fa4044cecb891c9ef436738158800286a309)**

Paginations errors will be treated as serialization errors just like our
schemas.  That means they won't have a specific key to match for
translations in the frontend.  But since this is never a user error but
rather an API caller error/bug, it probably doesn't need translation
since it won't mean anything to the end user.
