### PR TITLE
osrd_schemas, railjson_generator: force the build backend

### DIFF
--- a/python/osrd_schemas/pyproject.toml
+++ b/python/osrd_schemas/pyproject.toml
@@ -9,3 +9,7 @@ dependencies = ["geojson-pydantic ~= 1.0.0", "pydantic ~= 2.6"]
 
 [project.optional-dependencies]
 check = ["pyright ~= 1.1.393", "ruff ~= 0.9.5"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/python/railjson_generator/pyproject.toml
+++ b/python/railjson_generator/pyproject.toml
@@ -20,3 +20,7 @@ include = ["../osrd_schemas"]
 
 [tool.uv.sources]
 osrd-schemas = { path = "../osrd_schemas", editable = true }
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
It seems that in some cases, `setuptools` is used by default and may fail. Notably, we have a `just run` in `railjson_generator` that creates an empty directory `small_infra_out` that `setuptools` tries to read as a Python directory, and fails to understand what to do with it. Forcing the build backend to `poetry` (since the entire project was created with Poetry at first, we know it works), seems to fix the problem.