### PR TITLE
editoast: fix rs inertia coefficient type

### DIFF
--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -39,7 +39,6 @@ pub mod quantities {
     pub use uom::si::f64::Acceleration;
     pub use uom::si::f64::Length;
     pub use uom::si::f64::Mass;
-    pub use uom::si::f64::Ratio;
     pub use uom::si::f64::Time;
     pub use uom::si::f64::Velocity;
     pub type SolidFriction = uom::si::f64::Force;
@@ -81,9 +80,6 @@ macro_rules! quantity_to_path {
     };
     (Time, $unit:ident) => {
         uom::si::time::$unit
-    };
-    (Ratio, $unit:ident) => {
-        uom::si::ratio::$unit
     };
 }
 
@@ -221,4 +217,3 @@ define_unit!(kilogram_per_meter, AerodynamicDrag);
 define_unit!(per_meter, AerodynamicDragPerWeight);
 define_unit!(second, Time);
 define_unit!(millisecond, Time);
-define_unit!(ratio, Ratio);

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -221,4 +221,4 @@ define_unit!(kilogram_per_meter, AerodynamicDrag);
 define_unit!(per_meter, AerodynamicDragPerWeight);
 define_unit!(second, Time);
 define_unit!(millisecond, Time);
-define_unit!(basis_point, Ratio);
+define_unit!(ratio, Ratio);

--- a/editoast/editoast_derive/src/annotate_units.rs
+++ b/editoast/editoast_derive/src/annotate_units.rs
@@ -41,7 +41,6 @@ fn get_abbreviation(value: &str) -> Option<&'static str> {
         "kilogram_per_meter" => Some("Aerodynamic drag in kg·m⁻¹"),
         "kilogram_per_second" => Some("Viscosity friction in kg·s⁻¹"),
         "per_meter" => Some("Aerodynamic drag per kg in m⁻¹"),
-        "ratio" => Some("Ratio 1:1"),
         _ => None,
     }
 }

--- a/editoast/editoast_derive/src/annotate_units.rs
+++ b/editoast/editoast_derive/src/annotate_units.rs
@@ -41,7 +41,7 @@ fn get_abbreviation(value: &str) -> Option<&'static str> {
         "kilogram_per_meter" => Some("Aerodynamic drag in kg·m⁻¹"),
         "kilogram_per_second" => Some("Viscosity friction in kg·s⁻¹"),
         "per_meter" => Some("Aerodynamic drag per kg in m⁻¹"),
-        "basis_point" => Some("Ratio 1:1"),
+        "ratio" => Some("Ratio 1:1"),
         _ => None,
     }
 }

--- a/editoast/editoast_schemas/src/fixtures.rs
+++ b/editoast/editoast_schemas/src/fixtures.rs
@@ -19,7 +19,7 @@ pub fn simple_rolling_stock() -> RollingStock {
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
         comfort_acceleration: units::meter_per_second_squared::new(0.1),
-        inertia_coefficient: units::ratio::new(1.10),
+        inertia_coefficient: 1.10,
         startup_acceleration: units::meter_per_second_squared::new(0.04),
         startup_time: units::second::new(1.0),
         effort_curves: EffortCurves::default(),
@@ -56,7 +56,7 @@ pub fn towed_rolling_stock() -> TowedRollingStock {
         length: units::meter::new(30.0),
         comfort_acceleration: units::meter_per_second_squared::new(0.2),
         startup_acceleration: units::meter_per_second_squared::new(0.06),
-        inertia_coefficient: units::ratio::new(1.05),
+        inertia_coefficient: 1.05,
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
             // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight

--- a/editoast/editoast_schemas/src/fixtures.rs
+++ b/editoast/editoast_schemas/src/fixtures.rs
@@ -19,7 +19,7 @@ pub fn simple_rolling_stock() -> RollingStock {
         supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
         base_power_class: None,
         comfort_acceleration: units::meter_per_second_squared::new(0.1),
-        inertia_coefficient: units::basis_point::new(1.10),
+        inertia_coefficient: units::ratio::new(1.10),
         startup_acceleration: units::meter_per_second_squared::new(0.04),
         startup_time: units::second::new(1.0),
         effort_curves: EffortCurves::default(),
@@ -56,7 +56,7 @@ pub fn towed_rolling_stock() -> TowedRollingStock {
         length: units::meter::new(30.0),
         comfort_acceleration: units::meter_per_second_squared::new(0.2),
         startup_acceleration: units::meter_per_second_squared::new(0.06),
-        inertia_coefficient: units::basis_point::new(1.05),
+        inertia_coefficient: units::ratio::new(1.05),
         rolling_resistance: RollingResistancePerWeight {
             rolling_resistance_type: "davis".to_string(),
             // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -88,7 +88,7 @@ pub struct RollingStock {
     #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::basis_point")]
+    #[serde(with = "units::ratio")]
     pub inertia_coefficient: Ratio,
     #[serde(with = "units::kilogram")]
     pub mass: Mass,

--- a/editoast/editoast_schemas/src/rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock.rs
@@ -45,7 +45,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Time;
 use editoast_common::units::quantities::Velocity;
 use serde::Deserialize;
@@ -88,8 +87,7 @@ pub struct RollingStock {
     #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     #[serde(with = "units::kilogram")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -4,7 +4,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Velocity;
 
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -20,8 +19,7 @@ pub struct TowedRollingStock {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "units::ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     pub rolling_resistance: RollingResistancePerWeight,
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system

--- a/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/towed_rolling_stock.rs
@@ -20,7 +20,7 @@ pub struct TowedRollingStock {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "units::basis_point")]
+    #[serde(with = "units::ratio")]
     pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
     /// The constant gamma braking coefficient used when NOT circulating

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -8243,7 +8243,6 @@ components:
         inertia_coefficient:
           type: number
           format: double
-          description: Ratio 1:1
         length:
           type: number
           format: double
@@ -10139,7 +10138,6 @@ components:
         inertia_coefficient:
           type: number
           format: double
-          description: Ratio 1:1
         length:
           type: number
           format: double
@@ -10248,7 +10246,6 @@ components:
         inertia_coefficient:
           type: number
           format: double
-          description: Ratio 1:1
         length:
           type: number
           format: double
@@ -12342,7 +12339,6 @@ components:
         inertia_coefficient:
           type: number
           format: double
-          description: Ratio 1:1
         label:
           type: string
         length:
@@ -12406,7 +12402,6 @@ components:
         inertia_coefficient:
           type: number
           format: double
-          description: Ratio 1:1
         label:
           type: string
         length:

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -8,7 +8,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Time;
 use editoast_common::units::quantities::Velocity;
 use editoast_schemas::primitives::Identifier;
@@ -75,10 +74,8 @@ pub struct PhysicsConsist {
     #[schema(value_type = f64)]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[derivative(Hash(hash_with = "units::ratio::hash"))]
-    #[serde(with = "units::ratio")]
-    #[schema(value_type = f64)]
-    pub inertia_coefficient: Ratio,
+    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    pub inertia_coefficient: f64,
     /// Mass of the rolling stock
     #[derivative(Hash(hash_with = "units::kilogram::hash"))]
     #[serde(with = "units::kilogram::u64")]
@@ -172,7 +169,7 @@ impl PhysicsConsistParameters {
             .unwrap_or(self.traction_engine.comfort_acceleration)
     }
 
-    pub fn compute_inertia_coefficient(&self) -> Ratio {
+    pub fn compute_inertia_coefficient(&self) -> f64 {
         if let (Some(towed_rolling_stock), Some(total_mass)) =
             (self.towed_rolling_stock.as_ref(), self.total_mass)
         {
@@ -180,7 +177,7 @@ impl PhysicsConsistParameters {
             let traction_engine_inertia =
                 self.traction_engine.mass * self.traction_engine.inertia_coefficient;
             let towed_inertia = towed_mass * towed_rolling_stock.inertia_coefficient;
-            (traction_engine_inertia + towed_inertia) / total_mass
+            ((traction_engine_inertia + towed_inertia) / total_mass).into()
         } else {
             self.traction_engine.inertia_coefficient
         }
@@ -653,16 +650,10 @@ mod tests {
     fn physics_consist_compute_inertia_coefficient() {
         let mut physics_consist = create_physics_consist();
 
-        approx::assert_relative_eq!(
-            units::ratio::from(physics_consist.compute_inertia_coefficient()),
-            1.065
-        );
+        approx::assert_relative_eq!(physics_consist.compute_inertia_coefficient(), 1.065);
 
         physics_consist.towed_rolling_stock = None;
-        assert_eq!(
-            physics_consist.compute_inertia_coefficient(),
-            units::ratio::new(1.10,)
-        );
+        assert_eq!(physics_consist.compute_inertia_coefficient(), 1.10,);
     }
 
     #[test]

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -75,8 +75,8 @@ pub struct PhysicsConsist {
     #[schema(value_type = f64)]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[derivative(Hash(hash_with = "units::basis_point::hash"))]
-    #[serde(with = "units::basis_point")]
+    #[derivative(Hash(hash_with = "units::ratio::hash"))]
+    #[serde(with = "units::ratio")]
     #[schema(value_type = f64)]
     pub inertia_coefficient: Ratio,
     /// Mass of the rolling stock
@@ -654,14 +654,14 @@ mod tests {
         let mut physics_consist = create_physics_consist();
 
         approx::assert_relative_eq!(
-            units::basis_point::from(physics_consist.compute_inertia_coefficient()),
+            units::ratio::from(physics_consist.compute_inertia_coefficient()),
             1.065
         );
 
         physics_consist.towed_rolling_stock = None;
         assert_eq!(
             physics_consist.compute_inertia_coefficient(),
-            units::basis_point::new(1.10,)
+            units::ratio::new(1.10,)
         );
     }
 

--- a/editoast/src/models/rolling_stock.rs
+++ b/editoast/src/models/rolling_stock.rs
@@ -76,8 +76,8 @@ pub struct RollingStock {
     #[model(json)]
     #[schema(required)]
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::basis_point")]
-    #[model(uom_unit = "units::basis_point")]
+    #[serde(with = "units::ratio")]
+    #[model(uom_unit = "units::ratio")]
     pub inertia_coefficient: Ratio,
     #[schema(required)]
     pub base_power_class: Option<String>,

--- a/editoast/src/models/rolling_stock.rs
+++ b/editoast/src/models/rolling_stock.rs
@@ -8,7 +8,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Time;
 use editoast_common::units::quantities::Velocity;
 use editoast_derive::Model;
@@ -76,9 +75,7 @@ pub struct RollingStock {
     #[model(json)]
     #[schema(required)]
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::ratio")]
-    #[model(uom_unit = "units::ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     #[schema(required)]
     pub base_power_class: Option<String>,
     #[serde(with = "units::kilogram")]

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -3,7 +3,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Velocity;
 use editoast_derive::Model;
 use editoast_schemas::rolling_stock::RollingResistancePerWeight;
@@ -44,9 +43,7 @@ pub struct TowedRollingStockModel {
     #[model(uom_unit = "units::meter_per_second_squared")]
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[model(uom_unit = "units::ratio")]
-    #[serde(with = "units::ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     #[model(json)]
     pub rolling_resistance: RollingResistancePerWeight,
     #[model(uom_unit = "units::meter_per_second_squared")]

--- a/editoast/src/models/towed_rolling_stock.rs
+++ b/editoast/src/models/towed_rolling_stock.rs
@@ -44,8 +44,8 @@ pub struct TowedRollingStockModel {
     #[model(uom_unit = "units::meter_per_second_squared")]
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[model(uom_unit = "units::basis_point")]
-    #[serde(with = "units::basis_point")]
+    #[model(uom_unit = "units::ratio")]
+    #[serde(with = "units::ratio")]
     pub inertia_coefficient: Ratio,
     #[model(json)]
     pub rolling_resistance: RollingResistancePerWeight,

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -39,7 +39,7 @@ pub struct RollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,
-    #[serde(with = "basis_point")]
+    #[serde(with = "ratio")]
     pub inertia_coefficient: Ratio,
     #[serde(with = "kilogram")]
     pub mass: Mass,

--- a/editoast/src/views/rolling_stock/form.rs
+++ b/editoast/src/views/rolling_stock/form.rs
@@ -39,8 +39,7 @@ pub struct RollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "meter_per_second_squared")]
     pub const_gamma: Deceleration,
-    #[serde(with = "ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     #[serde(with = "kilogram")]
     pub mass: Mass,
     pub rolling_resistance: RollingResistance,

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -236,7 +236,7 @@ struct LightRollingStock {
     const_gamma: Deceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::basis_point")]
+    #[serde(with = "units::ratio")]
     inertia_coefficient: Ratio,
     #[serde(with = "units::kilogram")]
     mass: Mass,

--- a/editoast/src/views/rolling_stock/light.rs
+++ b/editoast/src/views/rolling_stock/light.rs
@@ -9,7 +9,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Time;
 use editoast_common::units::quantities::Velocity;
 use editoast_models::DbConnection;
@@ -236,8 +235,7 @@ struct LightRollingStock {
     const_gamma: Deceleration,
     #[schema(required)]
     etcs_brake_params: Option<EtcsBrakeParams>,
-    #[serde(with = "units::ratio")]
-    inertia_coefficient: Ratio,
+    inertia_coefficient: f64,
     #[serde(with = "units::kilogram")]
     mass: Mass,
     rolling_resistance: RollingResistance,

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -70,7 +70,7 @@ struct TowedRollingStock {
     comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     startup_acceleration: Acceleration,
-    #[serde(with = "units::basis_point")]
+    #[serde(with = "units::ratio")]
     inertia_coefficient: Ratio,
     rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "units::meter_per_second_squared")]
@@ -130,7 +130,7 @@ pub struct TowedRollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "units::basis_point")]
+    #[serde(with = "units::ratio")]
     pub inertia_coefficient: Ratio,
     pub rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "units::meter_per_second_squared")]

--- a/editoast/src/views/rolling_stock/towed.rs
+++ b/editoast/src/views/rolling_stock/towed.rs
@@ -20,7 +20,6 @@ use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
 use editoast_common::units::quantities::Length;
 use editoast_common::units::quantities::Mass;
-use editoast_common::units::quantities::Ratio;
 use editoast_common::units::quantities::Velocity;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
@@ -70,8 +69,7 @@ struct TowedRollingStock {
     comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     startup_acceleration: Acceleration,
-    #[serde(with = "units::ratio")]
-    inertia_coefficient: Ratio,
+    inertia_coefficient: f64,
     rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "units::meter_per_second_squared")]
     const_gamma: Deceleration,
@@ -130,8 +128,7 @@ pub struct TowedRollingStockForm {
     pub comfort_acceleration: Acceleration,
     #[serde(with = "units::meter_per_second_squared")]
     pub startup_acceleration: Acceleration,
-    #[serde(with = "units::ratio")]
-    pub inertia_coefficient: Ratio,
+    pub inertia_coefficient: f64,
     pub rolling_resistance: RollingResistancePerWeight,
     #[serde(with = "units::meter_per_second_squared")]
     pub const_gamma: Deceleration,

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -722,7 +722,7 @@ mod tests {
         let mut rolling_stock = simple_rolling_stock();
         rolling_stock.mass = units::kilogram::new(100000.0);
         rolling_stock.length = units::meter::new(20.0);
-        rolling_stock.inertia_coefficient = units::basis_point::new(1.10);
+        rolling_stock.inertia_coefficient = units::ratio::new(1.10);
         rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.1);
         rolling_stock.startup_acceleration = units::meter_per_second_squared::new(0.04);
         rolling_stock.rolling_resistance = RollingResistance {
@@ -750,7 +750,7 @@ mod tests {
 
         assert_eq!(
             physics_consist.inertia_coefficient,
-            units::basis_point::new(1.075)
+            units::ratio::new(1.075)
         );
 
         assert_eq!(

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -722,7 +722,7 @@ mod tests {
         let mut rolling_stock = simple_rolling_stock();
         rolling_stock.mass = units::kilogram::new(100000.0);
         rolling_stock.length = units::meter::new(20.0);
-        rolling_stock.inertia_coefficient = units::ratio::new(1.10);
+        rolling_stock.inertia_coefficient = 1.10;
         rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.1);
         rolling_stock.startup_acceleration = units::meter_per_second_squared::new(0.04);
         rolling_stock.rolling_resistance = RollingResistance {
@@ -748,10 +748,7 @@ mod tests {
 
         assert_eq!(physics_consist.mass, total_mass);
 
-        assert_eq!(
-            physics_consist.inertia_coefficient,
-            units::ratio::new(1.075)
-        );
+        assert_eq!(physics_consist.inertia_coefficient, 1.075);
 
         assert_eq!(
             physics_consist.rolling_resistance,

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3145,7 +3145,6 @@ export type LightRollingStock = {
   energy_sources: EnergySource[];
   etcs_brake_params: EtcsBrakeParams | null;
   id: number;
-  /** Ratio 1:1 */
   inertia_coefficient: number;
   /** Length in m */
   length: number;
@@ -3624,7 +3623,6 @@ export type RollingStock = {
   energy_sources: EnergySource[];
   etcs_brake_params: EtcsBrakeParams | null;
   id: number;
-  /** Ratio 1:1 */
   inertia_coefficient: number;
   /** Length in m */
   length: number;
@@ -3664,7 +3662,6 @@ export type RollingStockForm = {
   electrical_power_startup_time?: number | null;
   energy_sources?: EnergySource[];
   etcs_brake_params?: EtcsBrakeParams | null;
-  /** Ratio 1:1 */
   inertia_coefficient: number;
   /** Length in m */
   length: number;
@@ -4063,7 +4060,6 @@ export type TowedRollingStock = {
   /** Acceleration in m·s⁻² */
   const_gamma: number;
   id: number;
-  /** Ratio 1:1 */
   inertia_coefficient: number;
   label: string;
   /** Length in m */
@@ -4084,7 +4080,6 @@ export type TowedRollingStockForm = {
   comfort_acceleration: number;
   /** Acceleration in m·s⁻² */
   const_gamma: number;
-  /** Ratio 1:1 */
   inertia_coefficient: number;
   label: string;
   /** Length in m */

--- a/front/tests/assets/rolling-stock/rolling-stock-details.json
+++ b/front/tests/assets/rolling-stock/rolling-stock-details.json
@@ -89,7 +89,7 @@
     { "id": "startupTime", "value": "4s" },
     { "id": "startupAcceleration", "value": "0.11m/s²" },
     { "id": "comfortAcceleration", "value": "0.99m/s²" },
-    { "id": "inertiaCoefficient", "value": "1.3000000000000005" },
+    { "id": "inertiaCoefficient", "value": "1.3" },
     { "id": "constGamma", "value": "1.1m/s²" },
     { "id": "basePowerClass", "value": "6" },
     { "id": "rollingResistanceA", "value": "13kN" },


### PR DESCRIPTION
First commit close #11575 for the time being, although the issue isn't fundamentally fixed and could arise again. But using basis_point (an alias to per ten thousand) was incorrect here.

Second commit is optional, see the commit message.