### PR TITLE
editoast: fix `/authz/me/grants` for admins

### DIFF
--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -358,11 +358,6 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user_id));
         }
 
-        // Bypass if user is an admin
-        if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
-        }
-
         // Calling openfga
         let user = fga!(User:user_id);
         let infra = fga!(Infra:infra_id);
@@ -393,11 +388,6 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user_id));
         }
 
-        // Bypass if user is an admin
-        if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
-        }
-
         // Calling openfga
         let user = fga!(User:user_id);
         let infra = fga!(Infra:infra_id);
@@ -426,11 +416,6 @@ impl<S: StorageDriver> Regulator<S> {
         // Check if user exists
         if !self.user_exists(user_id).await? {
             return Err(Error::UnknownSubject(user_id));
-        }
-
-        // Bypass if user is an admin
-        if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
         }
 
         // Calling openfga


### PR DESCRIPTION
<details open id=prdesc>

- 3ec8e01ca *editoast: fix `/authz/me/grants` for admins*
    ```
    Confusion in the Regulator between privileges and grants.  The `Admin`
    role simulates fake privileges, but must not make up grants.
    
    The endpoint response, when queried by an admin, now doesn't return any
    grant if the admin doesn't have one.  The admin is still able to
    use the resource (by design).
    
    Only the checks have been removed, but these functions will be merged
    later so the Regulator won't stay in this state for long.  Let's fix the
    bug asap nonetheless.
    ```

</details>