### PR TITLE
editoast: authz: improve error management and simplify API

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1130,6 +1130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5015,6 +5016,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4.41", default-features = false, features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 darling = "0.20"
 derivative = "2.2.0"
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more = { version = "2.0.1", features = ["debug", "display", "from"] }
 diesel = { version = "2.2", default-features = false, features = [
   "32-column-tables",
   "chrono",

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -85,33 +85,6 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn check_infra_privilege_can_share_read(
-        &self,
-        infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_privilege_can_share_read(self.user_id, infra_id)
-            .await
-    }
-
-    pub async fn check_infra_privilege_can_write(
-        &self,
-        infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_privilege_can_share_write(self.user_id, infra_id)
-            .await
-    }
-
-    pub async fn check_infra_privilege_can_share_ownership(
-        &self,
-        infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
-        self.regulator
-            .check_infra_privilege_can_share_ownership(self.user_id, infra_id)
-            .await
-    }
-
     pub async fn grant_infra_reader(
         &self,
         user_id: i64,

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -90,33 +90,30 @@ impl<S: StorageDriver> Authorizer<S> {
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
             .grant_infra_reader(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
+            .await
     }
 
     pub async fn grant_infra_writer(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
             .grant_infra_writer(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
+            .await
     }
 
     pub async fn grant_infra_owner(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
             .grant_infra_owner(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
+            .await
     }
 
     pub async fn revoke_infra_reader(

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use tracing::Level;
 use tracing::debug;
 
+use crate::Authorization;
 use crate::Error;
 use crate::Regulator;
 use crate::Role;
@@ -76,12 +77,12 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn check_infra_privilege_can_read(
+    pub async fn authorize_infra_read(
         &self,
         infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
-            .check_infra_privilege_can_read(self.user_id, infra_id)
+            .authorize_infra_read(self.user_id, infra_id)
             .await
     }
 

--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -116,37 +116,14 @@ impl<S: StorageDriver> Authorizer<S> {
             .await
     }
 
-    pub async fn revoke_infra_reader(
+    pub async fn revoke_infra_grants(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         self.regulator
-            .revoke_infra_reader(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn revoke_infra_writer(
-        &self,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        self.regulator
-            .revoke_infra_writer(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn revoke_infra_owner(
-        &self,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        self.regulator
-            .revoke_infra_owner(self.user_id, user_id, infra_id)
-            .await?;
-        Ok(())
+            .revoke_infra_grants(self.user_id, user_id, infra_id)
+            .await
     }
 }
 

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -72,6 +72,45 @@ impl<StorageError: std::error::Error> From<fga::client::QueryError> for Error<St
     }
 }
 
+/// A representation of an authorization decision over some resource
+#[derive(derive_more::Debug, derive_more::Display)]
+pub enum Authorization<T> {
+    /// The initiator of the authorization is allowed to access the resource
+    Granted(T),
+    /// The initiator of the authorization is an admin and bypassed the authorization checks
+    Bypassed(T),
+    /// The initiator of the authorization is denied access to the resource
+    Denied { reason: &'static str },
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Unauthorized (reason: {reason})")]
+pub struct Unauthorized {
+    pub reason: &'static str,
+}
+
+impl<T> Authorization<T> {
+    pub fn allowed(self) -> Result<T, Unauthorized> {
+        match self {
+            Authorization::Granted(value) | Authorization::Bypassed(value) => Ok(value),
+            Authorization::Denied { reason } => Err(Unauthorized { reason }),
+        }
+    }
+}
+
+impl<T: Default> Authorization<T> {
+    #[inline]
+    fn from_privilege_check(allowed: bool) -> Self {
+        if allowed {
+            Authorization::Granted(T::default())
+        } else {
+            Authorization::Denied {
+                reason: "insufficient privileges",
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 /// The [fga::client::ConnectionSettings] to use for unit and doc tests
 ///

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -59,8 +59,6 @@ pub enum Error<StorageError: std::error::Error> {
     OpenFgaParsing(#[from] fga::model::ParsingError),
     #[error(transparent)]
     Storage(StorageError),
-    #[error("Unauthorized")]
-    Unauthorized,
 }
 
 impl<StorageError: std::error::Error> From<fga::client::QueryError> for Error<StorageError> {

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -96,6 +96,20 @@ impl<T> Authorization<T> {
             Authorization::Denied { reason } => Err(Unauthorized { reason }),
         }
     }
+
+    pub fn denied(&self) -> bool {
+        matches!(self, Self::Denied { .. })
+    }
+
+    pub async fn allowed_then_try<U, E>(
+        self,
+        f: impl AsyncFnOnce(T) -> Result<Authorization<U>, E>,
+    ) -> Result<Authorization<U>, E> {
+        match self {
+            Authorization::Granted(t) | Authorization::Bypassed(t) => f(t).await,
+            Authorization::Denied { reason } => Ok(Authorization::Denied { reason }),
+        }
+    }
 }
 
 impl<T: Default> Authorization<T> {

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -713,9 +713,8 @@ impl<S: StorageDriver> Regulator<S> {
         }
 
         // Remove other grants before to add the new one
-        self.revoke_infra_writer_unchecked(user_id, infra_id)
+        self.revoke_infra_grants_unchecked(user_id, infra_id)
             .await?;
-        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
 
         // Grant the new one
         self.openfga
@@ -775,9 +774,8 @@ impl<S: StorageDriver> Regulator<S> {
         }
 
         // Remove other grants before to add the new one
-        self.revoke_infra_reader_unchecked(user_id, infra_id)
+        self.revoke_infra_grants_unchecked(user_id, infra_id)
             .await?;
-        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
 
         // Grant the new one
         self.openfga
@@ -837,9 +835,7 @@ impl<S: StorageDriver> Regulator<S> {
         }
 
         // Remove other grants before to add the new one
-        self.revoke_infra_reader_unchecked(user_id, infra_id)
-            .await?;
-        self.revoke_infra_writer_unchecked(user_id, infra_id)
+        self.revoke_infra_grants_unchecked(user_id, infra_id)
             .await?;
 
         // Grant the new one
@@ -867,159 +863,64 @@ impl<S: StorageDriver> Regulator<S> {
             .await
     }
 
-    pub async fn revoke_infra_reader_unchecked(
-        &self,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra_id)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra_id));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user_id).await? {
-            return Err(Error::UnknownSubject(user_id));
-        }
-
-        // Check if the user has already the grant, if not, grant it
-        let has_grant = self.check_infra_grant_reader(user_id, infra_id).await?;
-        if has_grant {
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_deletes()
-                .delete(&Infra::reader().tuple(&user, &infra))
-                .execute()
-                .await?;
-        }
-
-        Ok(())
-    }
-
-    pub async fn revoke_infra_reader(
+    pub async fn revoke_infra_grants(
         &self,
         issuer_id: i64,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that the connected user has the right to remove the grants
-        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
-        if !is_owner {
-            return Err(Error::Unauthorized);
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        if !self
+            .openfga
+            .check(Infra::owner().check(&fga!(User:issuer_id), &fga!(Infra:infra_id)))
+            .await?
+        {
+            return Ok(Authorization::Denied {
+                reason: "only owners can revoke grants",
+            });
         }
-
-        // Revoke
-        self.revoke_infra_reader_unchecked(user_id, infra_id)
+        self.revoke_infra_grants_unchecked(user_id, infra_id)
             .await?;
-        Ok(())
+        Ok(Authorization::Granted(()))
     }
 
-    pub async fn revoke_infra_writer_unchecked(
+    pub async fn revoke_infra_grants_unchecked(
         &self,
         user_id: i64,
         infra_id: i64,
     ) -> Result<(), Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra_id)
-            .await
-            .map_err(Error::Storage)?
+        // No need to check if the infra exists. If it doesn't, there won't be any tuples in OpenFGA.
+        // And even if there is, we're about to remove them anyway.
+        // Likewise about both users.
+
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+        let mut delete = self.openfga.prepare_deletes();
+
+        if self
+            .openfga
+            .check(Infra::reader().check(&user, &infra))
+            .await?
         {
-            return Err(Error::UnknownResource(infra_id));
+            delete.push(&Infra::reader().tuple(&user, &infra));
         }
 
-        // Check if user exists
-        if !self.user_exists(user_id).await? {
-            return Err(Error::UnknownSubject(user_id));
-        }
-
-        let has_grant = self.check_infra_grant_writer(user_id, infra_id).await?;
-        if has_grant {
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_deletes()
-                .delete(&Infra::writer().tuple(&user, &infra))
-                .execute()
-                .await?;
-        }
-
-        Ok(())
-    }
-
-    pub async fn revoke_infra_writer(
-        &self,
-        issuer_id: i64,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that the connected user has the right to remove the grants
-        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
-        if !is_owner {
-            return Err(Error::Unauthorized);
-        }
-
-        // Revoke
-        self.revoke_infra_writer_unchecked(user_id, infra_id)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn revoke_infra_owner_unchecked(
-        &self,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra_id)
-            .await
-            .map_err(Error::Storage)?
+        if self
+            .openfga
+            .check(Infra::writer().check(&user, &infra))
+            .await?
         {
-            return Err(Error::UnknownResource(infra_id));
+            delete.push(&Infra::writer().tuple(&user, &infra));
         }
 
-        // Check if user exists
-        if !self.user_exists(user_id).await? {
-            return Err(Error::UnknownSubject(user_id));
+        if self
+            .openfga
+            .check(Infra::owner().check(&user, &infra))
+            .await?
+        {
+            delete.push(&Infra::owner().tuple(&user, &infra));
         }
 
-        let has_grant = self.check_infra_grant_owner(user_id, infra_id).await?;
-        if has_grant {
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_deletes()
-                .delete(&Infra::owner().tuple(&user, &infra))
-                .execute()
-                .await?;
-        }
-
-        Ok(())
-    }
-
-    pub async fn revoke_infra_owner(
-        &self,
-        issuer_id: i64,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that the connected user has the right to remove the grants
-        let is_owner = self.check_infra_grant_owner(issuer_id, infra_id).await?;
-        if !is_owner {
-            return Err(Error::Unauthorized);
-        }
-
-        // Revoke
-        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+        delete.execute().await?;
         Ok(())
     }
 }

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -344,6 +344,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(user_roles.contains(&Role::Admin))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_grant_reader(
         &self,
         user_id: i64,
@@ -374,6 +375,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(result)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_grant_writer(
         &self,
         user_id: i64,
@@ -404,6 +406,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(result)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_grant_owner(
         &self,
         user_id: i64,
@@ -434,6 +437,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(result)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn authorize_infra_read(
         &self,
         user_id: i64,
@@ -469,6 +473,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::from_privilege_check(check))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_privilege_can_share_read(
         &self,
         user_id: i64,
@@ -504,6 +509,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::from_privilege_check(result))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_privilege_can_share_write(
         &self,
         user_id: i64,
@@ -539,6 +545,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::from_privilege_check(result))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_privilege_can_share_ownership(
         &self,
         user_id: i64,
@@ -574,6 +581,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::from_privilege_check(result))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn get_infra_readers(
         &self,
         infra_id: i64,
@@ -598,6 +606,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(users)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn get_infra_writers(
         &self,
         infra_id: i64,
@@ -622,6 +631,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(users)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn get_infra_owners(
         &self,
         infra_id: i64,
@@ -680,6 +690,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(users)
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_reader_unchecked(
         &self,
         user_id: i64,
@@ -726,6 +737,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_reader(
         &self,
         issuer_id: i64,
@@ -741,6 +753,7 @@ impl<S: StorageDriver> Regulator<S> {
             .await
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_writer_unchecked(
         &self,
         user_id: i64,
@@ -787,6 +800,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_writer(
         &self,
         issuer_id: i64,
@@ -802,6 +816,7 @@ impl<S: StorageDriver> Regulator<S> {
             .await
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_owner_unchecked(
         &self,
         user_id: i64,
@@ -848,6 +863,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn grant_infra_owner(
         &self,
         issuer_id: i64,
@@ -863,6 +879,7 @@ impl<S: StorageDriver> Regulator<S> {
             .await
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn revoke_infra_grants(
         &self,
         issuer_id: i64,
@@ -883,6 +900,7 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(Authorization::Granted(()))
     }
 
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn revoke_infra_grants_unchecked(
         &self,
         user_id: i64,

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -498,41 +498,6 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(result)
     }
 
-    pub async fn check_infra_privilege_can_write(
-        &self,
-        user_id: i64,
-        infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
-        // Check if the infra exists
-        if !self
-            .driver
-            .infra_exists(infra_id)
-            .await
-            .map_err(Error::Storage)?
-        {
-            return Err(Error::UnknownResource(infra_id));
-        }
-
-        // Check if user exists
-        if !self.user_exists(user_id).await? {
-            return Err(Error::UnknownSubject(user_id));
-        }
-
-        // Bypass if user is an admin
-        if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
-        }
-
-        // Calling openfga
-        let user = fga!(User:user_id);
-        let infra = fga!(Infra:infra_id);
-        let result = self
-            .openfga
-            .check(model::Infra::can_write().check(&user, &infra))
-            .await?;
-        Ok(result)
-    }
-
     pub async fn check_infra_privilege_can_share_write(
         &self,
         user_id: i64,

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -473,7 +473,7 @@ impl<S: StorageDriver> Regulator<S> {
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         // Check if the infra exists
         if !self
             .driver
@@ -491,7 +491,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
+            return Ok(Authorization::Bypassed(()));
         }
 
         // Calling openfga
@@ -501,14 +501,14 @@ impl<S: StorageDriver> Regulator<S> {
             .openfga
             .check(model::Infra::can_share_read().check(&user, &infra))
             .await?;
-        Ok(result)
+        Ok(Authorization::from_privilege_check(result))
     }
 
     pub async fn check_infra_privilege_can_share_write(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         // Check if the infra exists
         if !self
             .driver
@@ -526,7 +526,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
+            return Ok(Authorization::Bypassed(()));
         }
 
         // Calling openfga
@@ -536,14 +536,14 @@ impl<S: StorageDriver> Regulator<S> {
             .openfga
             .check(model::Infra::can_share_write().check(&user, &infra))
             .await?;
-        Ok(result)
+        Ok(Authorization::from_privilege_check(result))
     }
 
     pub async fn check_infra_privilege_can_share_ownership(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         // Check if the infra exists
         if !self
             .driver
@@ -561,7 +561,7 @@ impl<S: StorageDriver> Regulator<S> {
 
         // Bypass if user is an admin
         if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
+            return Ok(Authorization::Bypassed(()));
         }
 
         // Calling openfga
@@ -571,7 +571,7 @@ impl<S: StorageDriver> Regulator<S> {
             .openfga
             .check(model::Infra::can_share_ownership().check(&user, &infra))
             .await?;
-        Ok(result)
+        Ok(Authorization::from_privilege_check(result))
     }
 
     pub async fn get_infra_readers(
@@ -700,21 +700,29 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user_id));
         }
 
-        let has_grant = self.check_infra_grant_reader(user_id, infra_id).await?;
-        if !has_grant {
-            // Remove other grants before to add the new one
-            self.revoke_infra_writer_unchecked(user_id, infra_id)
-                .await?;
-            self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
-            // Grant the new one
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_writes()
-                .write(&Infra::reader().tuple(&user, &infra))
-                .execute()
-                .await?;
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+
+        // Avoid creating an existing tuple
+        if self
+            .openfga
+            .check(Infra::reader().check(&user, &infra))
+            .await?
+        {
+            return Ok(());
         }
+
+        // Remove other grants before to add the new one
+        self.revoke_infra_writer_unchecked(user_id, infra_id)
+            .await?;
+        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+
+        // Grant the new one
+        self.openfga
+            .prepare_writes()
+            .write(&Infra::reader().tuple(&user, &infra))
+            .execute()
+            .await?;
 
         Ok(())
     }
@@ -724,18 +732,14 @@ impl<S: StorageDriver> Regulator<S> {
         issuer_id: i64,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that issuer has the right to add the grants
-        let can_share = self
-            .check_infra_privilege_can_share_read(issuer_id, infra_id)
-            .await?;
-        if !can_share {
-            return Err(Error::Unauthorized);
-        }
-
-        // Grant
-        self.grant_infra_reader_unchecked(user_id, infra_id).await?;
-        Ok(())
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        self.check_infra_privilege_can_share_read(issuer_id, infra_id)
+            .await?
+            .allowed_then_try(async |()| {
+                self.grant_infra_reader_unchecked(user_id, infra_id).await?;
+                Ok(Authorization::Granted(()))
+            })
+            .await
     }
 
     pub async fn grant_infra_writer_unchecked(
@@ -758,41 +762,46 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user_id));
         }
 
-        let has_grant = self.check_infra_grant_writer(user_id, infra_id).await?;
-        if !has_grant {
-            // Remove other grants before to add the new one
-            self.revoke_infra_reader_unchecked(user_id, infra_id)
-                .await?;
-            self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
-            // Grant the new one
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_writes()
-                .write(&Infra::writer().tuple(&user, &infra))
-                .execute()
-                .await?;
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+
+        // Avoid creating an existing tuple
+        if self
+            .openfga
+            .check(Infra::writer().check(&user, &infra))
+            .await?
+        {
+            return Ok(());
         }
+
+        // Remove other grants before to add the new one
+        self.revoke_infra_reader_unchecked(user_id, infra_id)
+            .await?;
+        self.revoke_infra_owner_unchecked(user_id, infra_id).await?;
+
+        // Grant the new one
+        self.openfga
+            .prepare_writes()
+            .write(&Infra::writer().tuple(&user, &infra))
+            .execute()
+            .await?;
 
         Ok(())
     }
+
     pub async fn grant_infra_writer(
         &self,
         issuer_id: i64,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that issuer has the right to add the grants
-        let can_share = self
-            .check_infra_privilege_can_share_write(issuer_id, infra_id)
-            .await?;
-        if !can_share {
-            return Err(Error::Unauthorized);
-        }
-
-        // Grant
-        self.grant_infra_writer_unchecked(user_id, infra_id).await?;
-        Ok(())
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        self.check_infra_privilege_can_share_write(issuer_id, infra_id)
+            .await?
+            .allowed_then_try(async |()| {
+                self.grant_infra_writer_unchecked(user_id, infra_id).await?;
+                Ok(Authorization::Granted(()))
+            })
+            .await
     }
 
     pub async fn grant_infra_owner_unchecked(
@@ -815,22 +824,30 @@ impl<S: StorageDriver> Regulator<S> {
             return Err(Error::UnknownSubject(user_id));
         }
 
-        let has_grant = self.check_infra_grant_owner(user_id, infra_id).await?;
-        if !has_grant {
-            // Remove other grants before to add the new one
-            self.revoke_infra_reader_unchecked(user_id, infra_id)
-                .await?;
-            self.revoke_infra_writer_unchecked(user_id, infra_id)
-                .await?;
-            // Grant the new one
-            let user = fga!(User:user_id);
-            let infra = fga!(Infra:infra_id);
-            self.openfga
-                .prepare_writes()
-                .write(&Infra::owner().tuple(&user, &infra))
-                .execute()
-                .await?;
+        let user = fga!(User:user_id);
+        let infra = fga!(Infra:infra_id);
+
+        // Avoid creating an existing tuple
+        if self
+            .openfga
+            .check(Infra::owner().check(&user, &infra))
+            .await?
+        {
+            return Ok(());
         }
+
+        // Remove other grants before to add the new one
+        self.revoke_infra_reader_unchecked(user_id, infra_id)
+            .await?;
+        self.revoke_infra_writer_unchecked(user_id, infra_id)
+            .await?;
+
+        // Grant the new one
+        self.openfga
+            .prepare_writes()
+            .write(&Infra::owner().tuple(&user, &infra))
+            .execute()
+            .await?;
 
         Ok(())
     }
@@ -840,18 +857,14 @@ impl<S: StorageDriver> Regulator<S> {
         issuer_id: i64,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<(), Error<S::Error>> {
-        // Check that issuer has the right to add the grants
-        let can_share = self
-            .check_infra_privilege_can_share_ownership(issuer_id, infra_id)
-            .await?;
-        if !can_share {
-            return Err(Error::Unauthorized);
-        }
-
-        // Grant
-        self.grant_infra_owner_unchecked(user_id, infra_id).await?;
-        Ok(())
+    ) -> Result<Authorization<()>, Error<S::Error>> {
+        self.check_infra_privilege_can_share_ownership(issuer_id, infra_id)
+            .await?
+            .allowed_then_try(async |()| {
+                self.grant_infra_owner_unchecked(user_id, infra_id).await?;
+                Ok(Authorization::Granted(()))
+            })
+            .await
     }
 
     pub async fn revoke_infra_reader_unchecked(

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -7,6 +7,7 @@ use fga::model::Relation;
 use futures::stream;
 use tracing::Level;
 
+use crate::Authorization;
 use crate::Error;
 use crate::Role;
 use crate::model;
@@ -338,6 +339,11 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(false)
     }
 
+    pub async fn is_admin(&self, user_id: i64) -> Result<bool, Error<S::Error>> {
+        let user_roles = self.user_roles(user_id).await?;
+        Ok(user_roles.contains(&Role::Admin))
+    }
+
     pub async fn check_infra_grant_reader(
         &self,
         user_id: i64,
@@ -428,11 +434,11 @@ impl<S: StorageDriver> Regulator<S> {
         Ok(result)
     }
 
-    pub async fn check_infra_privilege_can_read(
+    pub async fn authorize_infra_read(
         &self,
         user_id: i64,
         infra_id: i64,
-    ) -> Result<bool, Error<S::Error>> {
+    ) -> Result<Authorization<()>, Error<S::Error>> {
         // Check if the infra exists
         if !self
             .driver
@@ -449,18 +455,18 @@ impl<S: StorageDriver> Regulator<S> {
         }
 
         // Bypass if user is an admin
-        if self.check_roles(user_id, [Role::Admin].into()).await? {
-            return Ok(true);
+        if self.is_admin(user_id).await? {
+            return Ok(Authorization::Bypassed(()));
         }
 
         // Calling openfga
         let user = fga!(User:user_id);
         let infra = fga!(Infra:infra_id);
-        let result = self
+        let check = self
             .openfga
             .check(model::Infra::can_read().check(&user, &infra))
             .await?;
-        Ok(result)
+        Ok(Authorization::from_privilege_check(check))
     }
 
     pub async fn check_infra_privilege_can_share_read(

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -474,7 +474,7 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_privilege_can_share_read(
+    pub async fn authorize_infra_sharing_read(
         &self,
         user_id: i64,
         infra_id: i64,
@@ -510,7 +510,7 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_privilege_can_share_write(
+    pub async fn authorize_infra_sharing_write(
         &self,
         user_id: i64,
         infra_id: i64,
@@ -546,7 +546,7 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
-    pub async fn check_infra_privilege_can_share_ownership(
+    pub async fn authorize_infra_sharing_ownership(
         &self,
         user_id: i64,
         infra_id: i64,
@@ -744,7 +744,7 @@ impl<S: StorageDriver> Regulator<S> {
         user_id: i64,
         infra_id: i64,
     ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.check_infra_privilege_can_share_read(issuer_id, infra_id)
+        self.authorize_infra_sharing_read(issuer_id, infra_id)
             .await?
             .allowed_then_try(async |()| {
                 self.grant_infra_reader_unchecked(user_id, infra_id).await?;
@@ -807,7 +807,7 @@ impl<S: StorageDriver> Regulator<S> {
         user_id: i64,
         infra_id: i64,
     ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.check_infra_privilege_can_share_write(issuer_id, infra_id)
+        self.authorize_infra_sharing_write(issuer_id, infra_id)
             .await?
             .allowed_then_try(async |()| {
                 self.grant_infra_writer_unchecked(user_id, infra_id).await?;
@@ -870,7 +870,7 @@ impl<S: StorageDriver> Regulator<S> {
         user_id: i64,
         infra_id: i64,
     ) -> Result<Authorization<()>, Error<S::Error>> {
-        self.check_infra_privilege_can_share_ownership(issuer_id, infra_id)
+        self.authorize_infra_sharing_ownership(issuer_id, infra_id)
             .await?
             .allowed_then_try(async |()| {
                 self.grant_infra_owner_unchecked(user_id, infra_id).await?;

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4814,25 +4814,6 @@ components:
           type: string
           enum:
           - editoast:authz:SimultaneousGrantsAndRevokes
-    EditoastAuthzErrorUnauthorized:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 403
-        type:
-          type: string
-          enum:
-          - editoast:authz:Unauthorized
     EditoastAuthzErrorUnknownResource:
       type: object
       required:
@@ -5315,7 +5296,6 @@ components:
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthorizer'
       - $ref: '#/components/schemas/EditoastAuthzErrorAuthz'
       - $ref: '#/components/schemas/EditoastAuthzErrorSimultaneousGrantsAndRevokes'
-      - $ref: '#/components/schemas/EditoastAuthzErrorUnauthorized'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownResource'
       - $ref: '#/components/schemas/EditoastAuthzErrorUnknownSubject'
       - $ref: '#/components/schemas/EditoastAutoFixesEditoastErrorConflictingFixesOnSameObject'

--- a/editoast/src/error.rs
+++ b/editoast/src/error.rs
@@ -342,6 +342,19 @@ impl EditoastError for core::Error {
     }
 }
 
+impl From<editoast_authz::Unauthorized> for InternalError {
+    fn from(editoast_authz::Unauthorized { reason }: editoast_authz::Unauthorized) -> Self {
+        tracing::error!(reason, "Unauthorized operation");
+        crate::views::AuthorizationError::Forbidden.into()
+    }
+}
+
+impl From<crate::views::AuthorizerError> for InternalError {
+    fn from(value: crate::views::AuthorizerError) -> Self {
+        crate::views::AuthorizationError::from(value).into()
+    }
+}
+
 // error definition : uses by the macro EditoastError to generate
 // the list of error and share it with the openAPI generator
 #[derive(Debug)]

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -80,9 +80,6 @@ enum AuthzError {
     Authz(#[from] AuthorizationError),
     #[error("Grant and Revoke cannot be defined at the same time")]
     SimultaneousGrantsAndRevokes,
-    #[error("Unauthorized")]
-    #[editoast_error(status = 403)]
-    Unauthorized,
 }
 
 impl From<AuthorizerError> for AuthzError {
@@ -94,7 +91,6 @@ impl From<AuthorizerError> for AuthzError {
             AuthorizerError::UnknownSubject(subject_id) => {
                 AuthzError::UnknownSubject { subject_id }
             }
-            AuthorizerError::Unauthorized => AuthzError::Unauthorized,
             err => AuthzError::Authorizer(err),
         }
     }
@@ -490,23 +486,18 @@ async fn update_grants(
         }
     }
     if let Some(revoke) = revoke {
-        for grant in revoke {
-            match grant.resource_type {
+        for SubjectResource {
+            resource_type,
+            resource_id,
+            subject_id,
+        } in revoke
+        {
+            match resource_type {
                 Resource::Infra => {
                     authorizer
-                        .revoke_infra_reader(grant.subject_id, grant.resource_id)
-                        .await
-                        .map_err(AuthzError::from)?;
-
-                    authorizer
-                        .revoke_infra_writer(grant.subject_id, grant.resource_id)
-                        .await
-                        .map_err(AuthzError::from)?;
-
-                    authorizer
-                        .revoke_infra_owner(grant.subject_id, grant.resource_id)
-                        .await
-                        .map_err(AuthzError::from)?;
+                        .revoke_infra_grants(subject_id, resource_id)
+                        .await?
+                        .allowed()?;
                 }
             }
         }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -470,20 +470,20 @@ async fn update_grants(
                     InfraGrant::Reader => {
                         authorizer
                             .grant_infra_reader(grant.subject_id, grant.resource_id)
-                            .await
-                            .map_err(AuthzError::from)?;
+                            .await?
+                            .allowed()?;
                     }
                     InfraGrant::Writer => {
                         authorizer
                             .grant_infra_writer(grant.subject_id, grant.resource_id)
-                            .await
-                            .map_err(AuthzError::from)?;
+                            .await?
+                            .allowed()?;
                     }
                     InfraGrant::Owner => {
                         authorizer
                             .grant_infra_owner(grant.subject_id, grant.resource_id)
-                            .await
-                            .map_err(AuthzError::from)?;
+                            .await?
+                            .allowed()?;
                     }
                 },
             }

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -261,6 +261,7 @@ struct ResourceIdParam {
     ),
 )]
 async fn users_grants_for_resource_id(
+    Extension(authn): AuthenticationExt,
     State(AppState { regulator, .. }): State<AppState>,
     Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
     Path(ResourceIdParam { resource_id }): Path<ResourceIdParam>,
@@ -268,6 +269,14 @@ async fn users_grants_for_resource_id(
 ) -> Result<Json<Vec<SubjectGrant>>> {
     // Validate pagination params
     let mut skip = (page - 1) * page_size;
+
+    // One must be able to interact with the resource in order to
+    // consult who has access to it.
+    authn
+        .authorizer()?
+        .authorize_infra_read(resource_id)
+        .await?
+        .allowed()?;
 
     let mut result: Vec<SubjectGrant> = Vec::new();
 

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -316,7 +316,7 @@ async fn authentication_middleware(
     Ok(next.run(req).await)
 }
 
-type AuthorizerError =
+pub type AuthorizerError =
     editoast_authz::Error<<PgAuthDriver as editoast_authz::StorageDriver>::Error>;
 
 #[derive(Debug, Error, EditoastError)]


### PR DESCRIPTION
refs #11697

<details open id="prdesc">

- ce291c895 *editoast: remove unused Authorizer functions*
- 0a69767a3 *editoast: add Authorization response type for Regulator use*
    ```md
    Several advantages to this approach:
    
    1. It's obvious in the signature of the function that its result depends
       on an authorization check.
    2. It forces the caller to actually deal with the Unauthorized case
       instead of just forwarding it.  As always in Rust, "explicit better
       than implicit".  It also doesn't bury the Unauthorized variant in yet
       another error enum to be forgotten.
    3. Allows telling apart true permission and Admin role-overriden
       permission checks.
    4. Removes a buncb of superfluous `map_err` calls.
    ```
- 2a6610139 *editoast: simplify check and grant Authorizer interface*
- 93e4d131a *editoast: combine infra revocation functions in the Regulator*
- 8820ca455 *editoast: instrument Regulator infra functions*
- 9a75722bd *editoast: rename infra privilege check Regulator functions*

</details>