### PR TITLE
front: update persistConfig to use whitelist instead of blacklist

### DIFF
--- a/front/src/reducers/index.ts
+++ b/front/src/reducers/index.ts
@@ -110,7 +110,13 @@ export const persistConfig = {
     operationalStudiesFilter,
     operationalStudiesDateTransform,
   ],
-  blacklist: [stdcmConfSlice.name],
+  whitelist: [
+    userSlice.name,
+    mapSlice.name,
+    mainSlice.name,
+    simulationResultsSlice.name,
+    mapViewerSlice.name,
+  ],
 };
 
 type AllActions = Action;


### PR DESCRIPTION
## Problem
When removing the whitelist from the persist config and keeping only the blacklist, several slices (editorSlice, gatewayApi, etc.) that were previously excluded by the whitelist were suddenly persisted in the store. This caused unexpected behaviors. For example, the infrastructure editor slice, which uses a Set to store layers, was persisted to localStorage. When retrieving this slice on page load, we got a white screen because there was no transform function to properly deserialize the Set data structure.

## Solution
Restored the original whitelist in the persist config to explicitly control which slices should be persisted:
- `userSlice`
- `mapSlice`
- `mainSlice`
- `simulationResultsSlice`
- `mapViewerSlice`

This ensures that only these specific slices are saved in localStorage while others are reset on page refresh.