### PR TITLE
editoast: remove core-models dependency

### DIFF
--- a/editoast/editoast_schemas/src/fixtures.rs
+++ b/editoast/editoast_schemas/src/fixtures.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use editoast_common::units;
+
+use crate::RollingStock;
+use crate::rolling_stock::EffortCurves;
+use crate::rolling_stock::LoadingGaugeType;
+use crate::rolling_stock::RollingResistance;
+use crate::rolling_stock::RollingResistancePerWeight;
+use crate::rolling_stock::RollingStockSupportedSignalingSystems;
+use crate::rolling_stock::TowedRollingStock;
+use crate::rolling_stock::TrainCategories;
+use crate::rolling_stock::TrainCategory;
+
+pub fn simple_rolling_stock() -> RollingStock {
+    RollingStock {
+        name: "SIMPLE_ROLLING_STOCK".to_string(),
+        loading_gauge: LoadingGaugeType::G1,
+        supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
+        base_power_class: None,
+        comfort_acceleration: units::meter_per_second_squared::new(0.1),
+        inertia_coefficient: units::basis_point::new(1.10),
+        startup_acceleration: units::meter_per_second_squared::new(0.04),
+        startup_time: units::second::new(1.0),
+        effort_curves: EffortCurves::default(),
+        electrical_power_startup_time: None,
+        raise_pantograph_time: None,
+        energy_sources: vec![],
+        const_gamma: units::meter_per_second_squared::new(1.0),
+        etcs_brake_params: None,
+        locked: false,
+        metadata: None,
+        power_restrictions: HashMap::new(),
+        railjson_version: "12".to_string(),
+        rolling_resistance: RollingResistance {
+            rolling_resistance_type: "davis".to_string(),
+            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
+            // We should use more realistic values and fix the tests
+            A: units::newton::new(1.0),
+            B: units::kilogram_per_second::new(0.01),
+            C: units::kilogram_per_meter::new(0.0005),
+        },
+        length: units::meter::new(140.0),
+        mass: units::kilogram::new(15000.0),
+        max_speed: units::meter_per_second::new(20.0),
+        primary_category: TrainCategory::HighSpeedTrain,
+        other_categories: TrainCategories(vec![]),
+    }
+}
+
+pub fn towed_rolling_stock() -> TowedRollingStock {
+    TowedRollingStock {
+        name: "TOWED_ROLLING_STOCK".to_string(),
+        label: "towed".to_string(),
+        mass: units::kilogram::new(50000.0),
+        length: units::meter::new(30.0),
+        comfort_acceleration: units::meter_per_second_squared::new(0.2),
+        startup_acceleration: units::meter_per_second_squared::new(0.06),
+        inertia_coefficient: units::basis_point::new(1.05),
+        rolling_resistance: RollingResistancePerWeight {
+            rolling_resistance_type: "davis".to_string(),
+            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight
+            // We should use more realistic values and fix the tests
+            A: units::meter_per_second_squared::new(1.0),
+            B: units::hertz::new(0.01),
+            C: units::per_meter::new(0.0002),
+        },
+        const_gamma: units::meter_per_second_squared::new(0.5),
+        max_speed: Some(units::meter_per_second::new(35.0)),
+        railjson_version: "3.4".to_string(),
+    }
+}

--- a/editoast/editoast_schemas/src/lib.rs
+++ b/editoast/editoast_schemas/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod fixtures;
 pub mod infra;
 pub mod paced_train;
 pub mod primitives;

--- a/editoast/src/core/conflict_detection.rs
+++ b/editoast/src/core/conflict_detection.rs
@@ -41,31 +41,6 @@ pub struct WorkSchedulesRequest {
     pub start_time: DateTime<Utc>,
     pub work_schedule_requirements: HashMap<String, WorkSchedule>,
 }
-impl WorkSchedulesRequest {
-    pub fn new(
-        work_schedules: Vec<crate::models::work_schedules::WorkSchedule>,
-        earliest_departure_time: DateTime<Utc>,
-        latest_simulation_end: DateTime<Utc>,
-    ) -> Option<Self> {
-        if work_schedules.is_empty() {
-            return None;
-        }
-        // Filter the provided work schedules to find those that conflict with the given parameters
-        // This identifies any work schedules that may overlap with the earliest departure time and latest simulation end.
-        let work_schedule_requirements = work_schedules
-            .into_iter()
-            .filter_map(|ws| {
-                ws.as_core_work_schedule(earliest_departure_time, latest_simulation_end)
-                    .map(|core_ws| (ws.id.to_string(), core_ws))
-            })
-            .collect();
-
-        Some(Self {
-            start_time: earliest_departure_time,
-            work_schedule_requirements,
-        })
-    }
-}
 
 #[derive(Debug, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(Serialize))]

--- a/editoast/src/core/simulation.rs
+++ b/editoast/src/core/simulation.rs
@@ -511,11 +511,10 @@ impl AsCoreRequest<Json<Response>> for Request {
 #[cfg(test)]
 mod tests {
     use editoast_common::units;
+    use editoast_schemas::fixtures::simple_rolling_stock;
+    use editoast_schemas::fixtures::towed_rolling_stock;
     use editoast_schemas::rolling_stock::RollingResistance;
     use pretty_assertions::assert_eq;
-
-    use crate::models::fixtures::create_simple_rolling_stock;
-    use crate::models::fixtures::create_towed_rolling_stock;
 
     use super::PhysicsConsistParameters;
 
@@ -524,8 +523,8 @@ mod tests {
             total_length: Some(units::meter::new(100.0)),
             total_mass: Some(units::kilogram::new(50000.0)),
             max_speed: Some(units::meter_per_second::new(22.0)),
-            towed_rolling_stock: Some(create_towed_rolling_stock()),
-            traction_engine: create_simple_rolling_stock(),
+            towed_rolling_stock: Some(towed_rolling_stock()),
+            traction_engine: simple_rolling_stock(),
         }
     }
 

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -259,65 +259,6 @@ pub async fn create_rolling_stock_livery(
         .expect("Failed to create rolling stock livery")
 }
 
-pub fn create_towed_rolling_stock() -> TowedRollingStock {
-    TowedRollingStock {
-        name: "TOWED_ROLLING_STOCK".to_string(),
-        label: "towed".to_string(),
-        mass: units::kilogram::new(50000.0),
-        length: units::meter::new(30.0),
-        comfort_acceleration: units::meter_per_second_squared::new(0.2),
-        startup_acceleration: units::meter_per_second_squared::new(0.06),
-        inertia_coefficient: units::basis_point::new(1.05),
-        rolling_resistance: RollingResistancePerWeight {
-            rolling_resistance_type: "davis".to_string(),
-            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)² per weight
-            // We should use more realistic values and fix the tests
-            A: units::meter_per_second_squared::new(1.0),
-            B: units::hertz::new(0.01),
-            C: units::per_meter::new(0.0002),
-        },
-        const_gamma: units::meter_per_second_squared::new(0.5),
-        max_speed: Some(units::meter_per_second::new(35.0)),
-        railjson_version: "3.4".to_string(),
-    }
-}
-
-pub fn create_simple_rolling_stock() -> editoast_schemas::RollingStock {
-    editoast_schemas::RollingStock {
-        name: "SIMPLE_ROLLING_STOCK".to_string(),
-        loading_gauge: LoadingGaugeType::G1,
-        supported_signaling_systems: RollingStockSupportedSignalingSystems(vec![]),
-        base_power_class: None,
-        comfort_acceleration: units::meter_per_second_squared::new(0.1),
-        inertia_coefficient: units::basis_point::new(1.10),
-        startup_acceleration: units::meter_per_second_squared::new(0.04),
-        startup_time: units::second::new(1.0),
-        effort_curves: EffortCurves::default(),
-        electrical_power_startup_time: None,
-        raise_pantograph_time: None,
-        energy_sources: vec![],
-        const_gamma: units::meter_per_second_squared::new(1.0),
-        etcs_brake_params: None,
-        locked: false,
-        metadata: None,
-        power_restrictions: HashMap::new(),
-        railjson_version: "12".to_string(),
-        rolling_resistance: RollingResistance {
-            rolling_resistance_type: "davis".to_string(),
-            // TODO those values are wrong, they correspond to daN/T, (daN/T)/(km/h), and (daN/T)/(km/h)²
-            // We should use more realistic values and fix the tests
-            A: units::newton::new(1.0),
-            B: units::kilogram_per_second::new(0.01),
-            C: units::kilogram_per_meter::new(0.0005),
-        },
-        length: units::meter::new(140.0),
-        mass: units::kilogram::new(15000.0),
-        max_speed: units::meter_per_second::new(20.0),
-        primary_category: TrainCategory::HighSpeedTrain,
-        other_categories: TrainCategories(vec![]),
-    }
-}
-
 pub async fn create_document_example(conn: &mut DbConnection) -> Document {
     let img = image::open("src/tests/example_rolling_stock_image_1.gif").unwrap();
     let mut img_bytes: Vec<u8> = Vec::new();

--- a/editoast/src/views/timetable/stdcm.rs
+++ b/editoast/src/views/timetable/stdcm.rs
@@ -548,6 +548,8 @@ mod tests {
     use chrono::DateTime;
     use editoast_common::units;
     use editoast_models::DbConnectionPoolV2;
+    use editoast_schemas::fixtures::simple_rolling_stock;
+    use editoast_schemas::fixtures::towed_rolling_stock;
     use editoast_schemas::rolling_stock::RollingResistance;
     use editoast_schemas::train_schedule::Comfort;
     use editoast_schemas::train_schedule::OperationalPointIdentifier;
@@ -575,10 +577,8 @@ mod tests {
     use crate::core::simulation::SpeedLimitProperties;
     use crate::error::InternalError;
     use crate::models::fixtures::create_fast_rolling_stock;
-    use crate::models::fixtures::create_simple_rolling_stock;
     use crate::models::fixtures::create_small_infra;
     use crate::models::fixtures::create_timetable;
-    use crate::models::fixtures::create_towed_rolling_stock;
     use crate::models::work_schedules::WorkSchedule;
     use crate::models::work_schedules::WorkScheduleGroup;
     use crate::models::work_schedules::WorkScheduleType;
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn simulation_with_towed_rolling_stock_parameters() {
-        let mut rolling_stock = create_simple_rolling_stock();
+        let mut rolling_stock = simple_rolling_stock();
         rolling_stock.mass = units::kilogram::new(100000.0);
         rolling_stock.length = units::meter::new(20.0);
         rolling_stock.inertia_coefficient = units::basis_point::new(1.10);
@@ -732,7 +732,7 @@ mod tests {
             C: units::kilogram_per_meter::new(0.0005),
         };
 
-        let towed_rolling_stock = create_towed_rolling_stock();
+        let towed_rolling_stock = towed_rolling_stock();
 
         let total_mass = units::kilogram::new(200000.0);
 
@@ -771,7 +771,7 @@ mod tests {
             total_length: Some(units::meter::new(455.0)),
             max_speed: Some(units::meter_per_second::new(10.0)),
             towed_rolling_stock: None,
-            traction_engine: create_simple_rolling_stock(),
+            traction_engine: simple_rolling_stock(),
         };
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn simulation_without_parameters() {
-        let rolling_stock = create_simple_rolling_stock();
+        let rolling_stock = simple_rolling_stock();
         let simulation_parameters = PhysicsConsistParameters::from_traction_engine(rolling_stock);
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();
@@ -801,8 +801,8 @@ mod tests {
 
     #[test]
     fn new_physics_rolling_stock_keeps_the_smallest_available_comfort_acceleration() {
-        let mut rolling_stock = create_simple_rolling_stock();
-        let mut towed_rolling_stock = create_towed_rolling_stock();
+        let mut rolling_stock = simple_rolling_stock();
+        let mut towed_rolling_stock = towed_rolling_stock();
         rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.2);
         towed_rolling_stock.comfort_acceleration = units::meter_per_second_squared::new(0.1);
 
@@ -840,8 +840,8 @@ mod tests {
             max_speed: None,
             total_length: None,
             total_mass: None,
-            towed_rolling_stock: Some(create_towed_rolling_stock()),
-            traction_engine: create_simple_rolling_stock(),
+            towed_rolling_stock: Some(towed_rolling_stock()),
+            traction_engine: simple_rolling_stock(),
         };
 
         simulation_parameters.traction_engine.startup_acceleration =
@@ -878,7 +878,7 @@ mod tests {
             total_length: None,
             max_speed: Some(units::meter_per_second::new(30.0)),
             towed_rolling_stock: None,
-            traction_engine: create_simple_rolling_stock(),
+            traction_engine: simple_rolling_stock(),
         };
 
         let physics_consist: PhysicsConsist = simulation_parameters.into();

--- a/editoast/src/views/timetable/stdcm/failure_handler.rs
+++ b/editoast/src/views/timetable/stdcm/failure_handler.rs
@@ -57,8 +57,24 @@ impl SimulationFailureHandler {
             .map(|ws| ws.start_date_time)
             .unwrap_or(earliest_departure_time);
         let virtual_train_id = train_schedule.id;
-        let work_schedules =
-            WorkSchedulesRequest::new(work_schedules, start_time, latest_simulation_end);
+        let work_schedules = if work_schedules.is_empty() {
+            None
+        } else {
+            // Filter the provided work schedules to find those that conflict with the given parameters
+            // This identifies any work schedules that may overlap with the earliest departure time and latest simulation end.
+            let work_schedule_requirements = work_schedules
+                .into_iter()
+                .filter_map(|ws| {
+                    ws.as_core_work_schedule(start_time, latest_simulation_end)
+                        .map(|core_ws| (ws.id.to_string(), core_ws))
+                })
+                .collect();
+
+            Some(WorkSchedulesRequest {
+                start_time,
+                work_schedule_requirements,
+            })
+        };
 
         // Combine the original train schedules with the virtual train schedule.
         train_schedules.push(train_schedule);


### PR DESCRIPTION
This PR inlines the creation of `WorkSchedulesRequest` in the `failure_handler` to simplify the code and remove the dependency on the `new()` method. It also moves two test fixtures to the `editoast_schemas` crate, eliminating the dependency between the `core` and `models` modules.