### PR TITLE
editoast: move `Version` struct to `editoast_common`

### DIFF
--- a/editoast/editoast_common/src/lib.rs
+++ b/editoast/editoast_common/src/lib.rs
@@ -8,8 +8,13 @@ pub mod units;
 pub use hash_rounded_float::hash_float;
 pub use hash_rounded_float::hash_float_slice;
 
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
 schemas! {
     geometry::schemas(),
+    Version,
 }
 
 pub fn setup_tracing_for_test() {
@@ -19,4 +24,10 @@ pub fn setup_tracing_for_test() {
         .pretty()
         .try_init()
         .ok();
+}
+
+#[derive(ToSchema, Serialize, Deserialize)]
+pub struct Version {
+    #[schema(required)] // Options are by default not required, but this one is
+    pub git_describe: Option<String>,
 }

--- a/editoast/src/core/version.rs
+++ b/editoast/src/core/version.rs
@@ -1,9 +1,9 @@
 use derivative::Derivative;
+use editoast_common::Version;
 use serde::Serialize;
 
 use super::AsCoreRequest;
 use super::Json;
-use crate::views::Version;
 
 /// A Core infra load request
 #[derive(Debug, Serialize, Derivative)]

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -25,6 +25,7 @@ pub mod work_schedules;
 #[cfg(test)]
 mod test_app;
 use editoast_authz::StorageDriver;
+use editoast_common::Version;
 #[cfg(test)]
 pub(crate) use test_app::test_app;
 
@@ -56,8 +57,6 @@ use axum::extract::State;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_models::db_connection_pool::ping_database;
-use serde::Deserialize;
-use serde::Serialize;
 use thiserror::Error;
 use tokio::time::timeout;
 use tower::Layer as _;
@@ -70,7 +69,6 @@ use tower_http::trace::TraceLayer;
 use tracing::info;
 use tracing::warn;
 use url::Url;
-use utoipa::ToSchema;
 
 use crate::ValkeyClient;
 use crate::client::get_app_version;
@@ -118,7 +116,6 @@ crate::routes! {
 }
 
 editoast_common::schemas! {
-    Version,
     editoast_common::schemas(),
     editoast_schemas::schemas(),
     models::schemas(),
@@ -415,12 +412,6 @@ pub async fn check_health(
         openfga_ping
     )?;
     Ok(())
-}
-
-#[derive(ToSchema, Serialize, Deserialize)]
-pub struct Version {
-    #[schema(required)] // Options are by default not required, but this one is
-    git_describe: Option<String>,
 }
 
 #[utoipa::path(


### PR DESCRIPTION
This PR moves the `Version` struct from the `views` module to `editoast_common` to remove the dependency between the `core` and `views` modules.