### PR TITLE
editoast: fga: support batch checking

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/editoast/fga/Cargo.toml
+++ b/editoast/fga/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 derive_more.workspace = true

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -369,6 +369,61 @@ impl Client {
         .await
     }
 
+    /// Performs multiple checks at once using OpenFGA `/batch-check` API
+    ///
+    /// Unlike [Client::prepare_checks] which ultimately returns a `Vec<bool>`,
+    /// this functions remembers the structure used to inject the checks.  This is
+    /// useful when you *statically* know the number of checks and want the individual
+    /// result afterwards instead of combining the `bool`s.
+    ///
+    /// You can provide this function a tuple from 2 to 8 checks, and it will return
+    /// a tuple from 2 to 8 `bool`s respectively.  Other structuring types can be supported
+    /// by implementing the [StructuredChecks] trait.
+    ///
+    /// # Which `check` function to use?
+    ///
+    /// As a rule of thumb:
+    ///
+    /// 1. If you only have one check to perform, use [Client::check].
+    /// 2. If you know which checks you want to perform at compile time and want the result
+    ///    of each check in its own binding, use [Client::checks].
+    /// 3. Otherwise (you dont know how many checks you will perform at compile time, or you
+    ///    don't care about each result individually), use [Client::prepare_checks].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # include!("doctest_setup.rs");
+    /// # use fga::fga;
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let mut client = fga::Client::try_new_store("doctest_checks".to_owned(), settings()).await.unwrap();
+    /// # client.update_authorization_model(&fga::compile_model(include_str!("../tests/doctest.fga"))).await.unwrap();
+    /// client
+    ///     .write_tuples(&[fga!(Document:"budget"#writer@Person:"alice")])
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let (alice_can_read, alice_can_write, bob_can_read) = client
+    ///     .checks((
+    ///         Document::can_read().check(&fga!(Person:"alice"), &fga!(Document:"budget")),
+    ///         Document::can_write().check(&fga!(Person:"alice"), &fga!(Document:"budget")),
+    ///         Document::can_read().check(&fga!(Person:"bob"), &fga!(Document:"budget")),
+    ///     ))
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// assert!(alice_can_read && alice_can_write && !bob_can_read);
+    /// # }
+    /// ```
+    pub async fn checks<S: StructuredChecks>(
+        &self,
+        checks: S,
+    ) -> Result<S::Output, RequestFailure> {
+        let results = checks.prepare(self).execute().await?;
+        Ok(S::from_check_results(results))
+    }
+
     /// Prepares multiple check requests to OpenFGA
     ///
     /// OpenFGA Check API do not accept more than 50 checks per request.
@@ -603,6 +658,45 @@ impl PreparedChecks<'_> {
         Ok(result)
     }
 }
+
+pub trait StructuredChecks {
+    type Output;
+
+    fn prepare(self, client: &Client) -> PreparedChecks<'_>;
+    fn from_check_results(results: Vec<bool>) -> Self::Output;
+}
+
+macro_rules! impl_structured_checks {
+    ($output:ty, $($relations:ident)+, $($idents:ident)+) => {
+        impl<$($relations: Relation),+> StructuredChecks for ($(Check<'_, $relations>),+) {
+            type Output = $output;
+
+            fn prepare(self, client: &Client) -> PreparedChecks<'_> {
+                let ($($idents,)+) = self;
+                PreparedChecks {
+                    checks: Vec::new(),
+                    client,
+                }
+                .$(check(&$idents)).+
+            }
+
+            fn from_check_results(results: Vec<bool>) -> Self::Output {
+                match &results[..] {
+                    [$($idents),+] => ($(*$idents),+),
+                    _ => unreachable!("OpenFGA always returns the same number of results as checks"),
+                }
+            }
+        }
+    };
+}
+
+impl_structured_checks!((bool, bool), R1 R2, a b);
+impl_structured_checks!((bool, bool, bool), R1 R2 R3, a b c);
+impl_structured_checks!((bool, bool, bool, bool), R1 R2 R3 R4, a b c d);
+impl_structured_checks!((bool, bool, bool, bool, bool), R1 R2 R3 R4 R5, a b c d e);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6, a b c d e f);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7, a b c d e f g);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7 R8, a b c d e f g h);
 
 pub struct PreparedWrites<'a> {
     writes: Vec<RawTuple>,
@@ -1002,6 +1096,16 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(results, vec![true, false]);
+
+            let (bob, alice) = client
+                .checks((
+                    Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")),
+                    Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")),
+                ))
+                .await
+                .unwrap();
+            assert!(bob);
+            assert!(!alice);
         }
     }
 

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -7,15 +7,20 @@ mod tuples;
 pub use authorization_models::AuthorizationModel;
 pub use authorization_models::StoreAuthorizationModel;
 use itertools::Either;
+use queries::BatchCheckItem;
+use queries::BatchCheckSingleResult;
 use queries::RawUser;
 use queries::UserFilter;
 pub use stores::Store;
 
 use tracing::Instrument;
 use tuples::RawTuple;
+use uuid::Uuid;
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::future::{self};
+use std::str::FromStr as _;
 
 use futures::TryStreamExt as _;
 use futures::stream;
@@ -364,6 +369,25 @@ impl Client {
         .await
     }
 
+    /// Prepares multiple check requests to OpenFGA
+    ///
+    /// OpenFGA Check API do not accept more than 50 checks per request.
+    /// The [PreparedChecks] type returned by this function accepts any number
+    /// of checks through [PreparedChecks::push] and will chunk them into
+    /// requests of 50 checks each. The requests are sent concurrently when
+    /// [PreparedChecks::execute] is called.
+    ///
+    /// Beware that the checks injected into [PreparedChecks] cannot be accessed
+    /// after a [PreparedChecks::push]. So any form of post-processing is impossible.
+    /// Likewise, once a [Check] is injected into [PreparedChecks], all its typing information
+    /// is lost.
+    pub fn prepare_checks(&self) -> PreparedChecks<'_> {
+        PreparedChecks {
+            checks: Vec::new(),
+            client: self,
+        }
+    }
+
     pub async fn list_objects<R: Relation, U: AsUser<User = R::User>>(
         &self,
         QueryObjects(user, _): QueryObjects<'_, R, U>,
@@ -501,6 +525,83 @@ pub struct UserList<U: User> {
     pub users: Vec<U>,
     /// Whether the object has a user type `U` type-bound public access
     pub public_access: Option<Wildcard<U>>,
+}
+
+pub struct PreparedChecks<'a> {
+    checks: Vec<RawTuple>,
+    client: &'a Client,
+}
+
+impl PreparedChecks<'_> {
+    pub fn push<R: Relation>(&mut self, Check { user, object }: &Check<'_, R>) {
+        self.checks.push(RawTuple {
+            user: User::fga_user(*user),
+            relation: R::NAME.to_string(),
+            object: object.fga_object(),
+        });
+    }
+
+    pub fn check<R: Relation>(mut self, check: &Check<'_, R>) -> Self {
+        self.push(check);
+        self
+    }
+
+    /// Concurrently send batch-checks requests to OpenFGA in 50-check chunks
+    pub async fn execute(self) -> Result<Vec<bool>, RequestFailure> {
+        let count = self.checks.len();
+
+        // Prepare the request items
+        let (check_items, correlation_ids): (Vec<_>, HashMap<_, _>) = self
+            .checks
+            .into_iter()
+            .enumerate()
+            .map(|(check_index, tuple_key)| {
+                let correlation_id = Uuid::new_v4();
+                let item = BatchCheckItem {
+                    correlation_id: correlation_id.to_string(),
+                    tuple_key,
+                    contextual_tuples: None,
+                };
+                (item, (correlation_id, check_index))
+            })
+            .unzip();
+
+        // Prepare the requests
+        let futs = check_items.chunks(50).map(|checks| {
+            self.client
+                .post_stores_batch_check(
+                    &self.client.store.id,
+                    checks,
+                    self.client.authorization_model_id.as_deref(),
+                    None,
+                )
+                .in_current_span()
+        });
+
+        // Send the requests concurrently and combine all check results
+        let check_results = futures::future::try_join_all(futs)
+            .await?
+            .into_iter()
+            .flatten();
+
+        // Use the correlation IDs to find the index of the original checks in order to send the check results back
+        // in the same order as the checks
+        let mut result = vec![false; count];
+        for (correlation_id, BatchCheckSingleResult { allowed, error }) in check_results {
+            let Some(index) = Uuid::from_str(correlation_id.as_str())
+                .ok()
+                .and_then(|correlation_id| correlation_ids.get(&correlation_id))
+            else {
+                unreachable!("OpenFGA always returns correlation IDs we send it");
+            };
+            if let Some(error) = error {
+                tracing::error!(correlation_id, index, error = ?error.message, "batch check item failed");
+                // TODO: raise a proper error once OpenFGA errors are properly defined
+            }
+            result[*index] = allowed;
+        }
+        Ok(result)
+    }
 }
 
 pub struct PreparedWrites<'a> {
@@ -878,6 +979,30 @@ mod tests {
         client
             .assert_check(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")))
             .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn batch_check() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .write_tuples(&[fga!(Infra:"france"#reader@User:"bob")])
+            .await
+            .unwrap();
+
+        // we try the operation a few times to make sure that each bool matches with the correct check
+        for _ in 0..10 {
+            let results = client
+                .prepare_checks()
+                .check(&Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")))
+                .check(&Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
+                .execute()
+                .await
+                .unwrap();
+            assert_eq!(results, vec![true, false]);
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::model::AsUser;
 use crate::model::Relation;
 use crate::model::Tuple;
@@ -46,8 +48,74 @@ pub(super) enum RawUser {
     },
 }
 
+#[derive(Debug, serde::Serialize)]
+pub(super) struct BatchCheckItem {
+    pub(super) correlation_id: String,
+    pub(super) tuple_key: RawTuple,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) contextual_tuples: Option<ContextualTuples>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct BatchCheckSingleResult {
+    pub(super) allowed: bool,
+    pub(super) error: Option<CheckError>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct CheckError {
+    pub(super) message: String,
+    // other schema fields are left out (input_error and internal_error)
+}
+
 impl Client {
-    #[tracing::instrument(skip(self), ret(level = "debug") err)]
+    // TODO: make the maximum number of checks configurable in the client
+    #[tracing::instrument(skip(self, checks), ret(level = "debug"), err)]
+    pub(super) async fn post_stores_batch_check(
+        &self,
+        store_id: &str,
+        checks: &[BatchCheckItem],
+        authorization_model_id: Option<&str>,
+        consistency: Option<Consistency>,
+    ) -> Result<HashMap<String, BatchCheckSingleResult>, RequestFailure> {
+        assert!(
+            checks.len() <= 50,
+            "OpenFGA doesn't support more than 50 batched checks by default"
+        );
+
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            checks: &'a [BatchCheckItem],
+            #[serde(skip_serializing_if = "Option::is_none")]
+            authorization_model_id: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            consistency: Option<Consistency>,
+        }
+
+        let url = self
+            .base_url()
+            .join(format!("stores/{store_id}/batch-check").as_str())
+            .unwrap();
+        let response = self
+            .inner
+            .post(url)
+            .json(&Request {
+                checks,
+                authorization_model_id,
+                consistency,
+            })
+            .send()
+            .await?;
+
+        #[derive(serde::Deserialize)]
+        struct Response {
+            result: HashMap<String, BatchCheckSingleResult>,
+        }
+        let Response { result } = response.error_for_status()?.json().await?;
+        Ok(result)
+    }
+
+    #[tracing::instrument(skip(self), ret(level = "debug"), err)]
     pub(super) async fn post_stores_check(
         &self,
         store_id: &str,


### PR DESCRIPTION
refs #11697

The functions implemented here will be used in `editoast_authz` in a separate PR.

https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck

- **editoast: fga: add batch check support**
- **editoast: fga: add `Client::checks`**
