### PR TITLE
front: fix rs editor rounding

### DIFF
--- a/front/src/common/BootstrapSNCF/InputGroupSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/InputGroupSNCF.tsx
@@ -1,10 +1,9 @@
 import { type ChangeEvent, useCallback, useMemo, useState } from 'react';
 
 import cx from 'classnames';
-import { isNil } from 'lodash';
 
 import type { MultiUnit } from 'modules/rollingStock/types';
-import { isFloat, stripDecimalDigits } from 'utils/numbers';
+import { isFloat } from 'utils/numbers';
 
 type Option = {
   id: string;
@@ -29,13 +28,13 @@ type Props<U> = {
   max?: number;
   step?: number | string;
   disabled?: boolean;
-  limitDecimal?: number;
+  limitPrecision?: number;
   inputDataTestId?: string;
 };
 
-const isNeedStripDecimalDigits = (inputValue: string, limit: number) => {
+const isNeedLimitPrecision = (inputValue: string, limit?: number) => {
   const eventValue = Number(inputValue);
-  return !isNil(limit) && limit > 0 && inputValue !== '' && isFloat(eventValue);
+  return limit !== undefined && limit > 0 && inputValue !== '' && isFloat(eventValue);
 };
 
 export default function InputGroupSNCF<U extends string | MultiUnit>({
@@ -50,7 +49,7 @@ export default function InputGroupSNCF<U extends string | MultiUnit>({
   max,
   step = 'any',
   disabled = false,
-  limitDecimal = 10,
+  limitPrecision = 10,
   inputDataTestId,
 }: Props<U>) {
   const [isDropdownShown, setIsDropdownShown] = useState(false);
@@ -58,26 +57,28 @@ export default function InputGroupSNCF<U extends string | MultiUnit>({
   const handleValueChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const eventValue = Number(event.target.value);
-      let newValue: InputGroupSNCFValue<U>['value'] =
-        limitDecimal && isNeedStripDecimalDigits(event.target.value, limitDecimal)
-          ? stripDecimalDigits(eventValue, limitDecimal)
-          : eventValue;
+      let newValue: InputGroupSNCFValue<U>['value'] = isNeedLimitPrecision(
+        event.target.value,
+        limitPrecision
+      )
+        ? Number(eventValue.toPrecision(limitPrecision))
+        : eventValue;
       if (event.target.value === '') newValue = undefined;
       onChange({ unit: currentValue.unit, value: newValue });
     },
-    [onChange, currentValue.unit, limitDecimal]
+    [onChange, currentValue.unit, limitPrecision]
   );
 
   const inputValue = useMemo(() => {
     const { value } = currentValue;
     if (value !== undefined && !disabled) {
-      if (limitDecimal && isNeedStripDecimalDigits(value.toString(), limitDecimal)) {
-        return stripDecimalDigits(Number(value), limitDecimal);
+      if (isNeedLimitPrecision(value.toString(), limitPrecision)) {
+        return Number(value.toPrecision(limitPrecision));
       }
       return value;
     }
     return '';
-  }, [currentValue.value, limitDecimal, disabled]);
+  }, [currentValue.value, limitPrecision, disabled]);
 
   const inputField = (
     <div

--- a/front/src/utils/__tests__/numbers.spec.ts
+++ b/front/src/utils/__tests__/numbers.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { budgetFormat, isFloat, isInvalidFloatNumber, stripDecimalDigits } from 'utils/numbers';
+import { budgetFormat, isFloat, isInvalidFloatNumber } from 'utils/numbers';
 import { NARROW_NO_BREAK_SPACE, NO_BREAK_SPACE } from 'utils/strings';
 
 describe('budgetFormat', () => {
@@ -8,60 +8,6 @@ describe('budgetFormat', () => {
     expect(budgetFormat(45968493)).toBe(
       `45${NARROW_NO_BREAK_SPACE}968${NARROW_NO_BREAK_SPACE}493${NO_BREAK_SPACE}€`
     );
-  });
-});
-
-describe('stripDecimalDigits', () => {
-  it('should return the integer part of the number when decimalPlaces is 0', () => {
-    expect(stripDecimalDigits(123.456, 0)).toBe(123);
-  });
-
-  it('should return the same number when decimalPlaces is negative', () => {
-    expect(stripDecimalDigits(123.456, -1)).toBe(123.456);
-  });
-
-  it('should return the same number when decimalPlaces is NaN', () => {
-    expect(stripDecimalDigits(123.456, NaN)).toBe(123.456);
-  });
-
-  it('should return the same number when decimalPlaces is not an integer', () => {
-    expect(stripDecimalDigits(123.456, 1.5)).toBe(123.456);
-  });
-
-  it('should return the same number when decimalPlaces is infinite', () => {
-    expect(stripDecimalDigits(123.456, Infinity)).toBe(123.456);
-  });
-
-  it('should return the same number when the number is NaN', () => {
-    expect(stripDecimalDigits(NaN, 1)).toBe(NaN);
-  });
-
-  it('should return the same number when the number is infinite', () => {
-    expect(stripDecimalDigits(Infinity, 1)).toBe(Infinity);
-  });
-
-  it('should return the same number when the number is not finite', () => {
-    expect(stripDecimalDigits(1 / 0, 1)).toBe(Infinity);
-  });
-
-  it('should return the same number when the number is 0', () => {
-    expect(stripDecimalDigits(0, 1)).toBe(0);
-  });
-
-  it('should return the same number when the number has no decimal part', () => {
-    expect(stripDecimalDigits(123, 1)).toBe(123);
-  });
-
-  it('should return the same number when the number has less decimal digits than decimalPlaces', () => {
-    expect(stripDecimalDigits(123.4, 2)).toBe(123.4);
-  });
-
-  it('should return the same number when the number has the same decimal digits than decimalPlaces', () => {
-    expect(stripDecimalDigits(123.45, 2)).toBe(123.45);
-  });
-
-  it('should return the same number when the number has more decimal digits than decimalPlaces', () => {
-    expect(stripDecimalDigits(123.456, 2)).toBe(123.45);
   });
 });
 

--- a/front/src/utils/__tests__/numbers.spec.ts
+++ b/front/src/utils/__tests__/numbers.spec.ts
@@ -22,10 +22,16 @@ describe('isFloat', () => {
 
   it('should return false if the number is an integer', () => {
     expect(isFloat(1)).toBe(false);
+    expect(isFloat(2.0)).toBe(false);
   });
 
   it('should return false if the number is NaN', () => {
     expect(isFloat(NaN)).toBe(false);
+  });
+
+  it('should return false if the number is infinite', () => {
+    expect(isFloat(Infinity)).toBe(false);
+    expect(isFloat(-Infinity)).toBe(false);
   });
 });
 

--- a/front/src/utils/numbers.ts
+++ b/front/src/utils/numbers.ts
@@ -25,7 +25,7 @@ export function valueToInterval(value?: number, intervals?: number[]) {
 }
 
 export function isFloat(n: number) {
-  return Number(n) === n && n % 1 !== 0;
+  return Number.isFinite(n) && !Number.isInteger(n);
 }
 
 /**

--- a/front/src/utils/numbers.ts
+++ b/front/src/utils/numbers.ts
@@ -27,27 +27,6 @@ export function valueToInterval(value?: number, intervals?: number[]) {
 export function isFloat(n: number) {
   return Number(n) === n && n % 1 !== 0;
 }
-/**
- * If it a float number it will strip the decimal digits
- * @param value value to strip
- * @param decimalPlaces number of decimal places to keep
- * @returns stripped number
- */
-export function stripDecimalDigits(value: number, decimalPlaces: number): number {
-  if (!isFloat(value) || !Number.isInteger(decimalPlaces) || decimalPlaces < 0) {
-    return value;
-  }
-
-  const parts = value.toString().split('.');
-
-  if (parts.length !== 2) {
-    return value;
-  }
-
-  const stripedDecimal = parts[1].substring(0, decimalPlaces);
-  const result = Number(`${parts[0]}.${stripedDecimal}`);
-  return result;
-}
 
 /**
  * Checks if a floating-point number has more decimal places than specified.


### PR DESCRIPTION
Fix main issue of #11574

First commit fix rounding making our value greater when it is lower than 1e-10.  @emersion This is only applied for float values not integers, so no worry about mm ^^. Plus our precision is much bigger than what is required for all the fields we are using, but we could always set it on a case by case basis if we ever need more (though at some point we would start to attain float point limits, 1+1e-16===1 in js).

Second commit drops the now unused rounding function. Third commit changes isFloat to use built in functions instead of our custom implem, and makes its testing suite more exhaustive.



