### PR TITLE
front: fix rs editor mass conversions

### DIFF
--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
@@ -16,7 +16,13 @@ import {
   RollingStockEditorParameter,
   RS_REQUIRED_FIELDS,
 } from 'modules/rollingStock/consts';
-import { handleUnitValue, splitRollingStockProperties } from 'modules/rollingStock/helpers/utils';
+import {
+  handleUnitValue,
+  isMassDependentUnit,
+  isMultiUnitsParam,
+  splitRollingStockProperties,
+  rescaleMassDependentParam,
+} from 'modules/rollingStock/helpers/utils';
 import useCategoryOptions from 'modules/rollingStock/hooks/useCategoryOptions';
 import useCompleteRollingStockSchemasProperties from 'modules/rollingStock/hooks/useCompleteRollingStockSchemasProperties';
 import type {
@@ -139,12 +145,32 @@ const RollingStockEditorParameterFormColumn = ({
       unit: option.unit,
       value: handleUnitValue(option, selectedParam, lastNonZeroMass),
     } as MultiUnitsParameter;
+
+    // If the mass has changed, we need to update the min and max of parameters expressed in mass dependent units.
+    // Undefined or zero value for the mass however would render the conversion meaningless or lose information.
+    let massDependentParams: Partial<RollingStockParametersValues> = {};
     if (property.title === 'mass' && updatedSelectedParam.value) {
+      massDependentParams = Object.fromEntries(
+        Object.entries(rollingStockValues)
+          .filter(
+            ([_, curParam]) => isMultiUnitsParam(curParam) && isMassDependentUnit(curParam.unit)
+            // TODO : investigate how curParam.unit can be undefined at runtime despite being defined according to typing
+          )
+          .map(([curPropertyTitle, massDependentParam]) => [
+            curPropertyTitle,
+            rescaleMassDependentParam(
+              massDependentParam as MultiUnitsParameter,
+              lastNonZeroMass,
+              updatedSelectedParam
+            ),
+          ])
+      );
       setLastNonZeroMass(updatedSelectedParam);
     }
 
     setRollingStockValues({
       ...rollingStockValues,
+      ...massDependentParams,
       [property.title]: updatedSelectedParam,
     });
   };

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
@@ -122,7 +122,8 @@ const RollingStockEditorParameterFormColumn = ({
 }) => {
   const { t } = useTranslation();
 
-  const handleUnitChange = <U extends MultiUnit>(
+  /** Handle change in value or unit in a multiunit input */
+  const handleMultiUnitParamChange = <U extends MultiUnit>(
     option: InputGroupSNCFValue<U>,
     property: SchemaProperty
   ) => {
@@ -204,7 +205,7 @@ const RollingStockEditorParameterFormColumn = ({
                   id: unit,
                   label: unit,
                 }))}
-                onChange={(option) => handleUnitChange(option, property)}
+                onChange={(option) => handleMultiUnitParamChange(option, property)}
                 min={currentParam.min}
                 max={currentParam.max}
                 isInvalid={

--- a/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
+++ b/front/src/modules/rollingStock/components/RollingStockEditor/RollingStockEditorFormHelpers.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import cx from 'classnames';
 import { floor, isNil } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -121,6 +123,8 @@ const RollingStockEditorParameterFormColumn = ({
   propertiesList: SchemaProperty[];
 }) => {
   const { t } = useTranslation();
+  // The mass is sets by default to its min for a new rolling stock, so it should always be defined on first render
+  const [lastNonZeroMass, setLastNonZeroMass] = useState(rollingStockValues.mass!);
 
   /** Handle change in value or unit in a multiunit input */
   const handleMultiUnitParamChange = <U extends MultiUnit>(
@@ -129,14 +133,19 @@ const RollingStockEditorParameterFormColumn = ({
   ) => {
     const selectedParam = rollingStockValues[property.title] as MultiUnitsParameter;
 
+    const updatedSelectedParam = {
+      min: handleUnitValue(option, selectedParam, lastNonZeroMass, 'min'),
+      max: handleUnitValue(option, selectedParam, lastNonZeroMass, 'max'),
+      unit: option.unit,
+      value: handleUnitValue(option, selectedParam, lastNonZeroMass),
+    } as MultiUnitsParameter;
+    if (property.title === 'mass' && updatedSelectedParam.value) {
+      setLastNonZeroMass(updatedSelectedParam);
+    }
+
     setRollingStockValues({
       ...rollingStockValues,
-      [property.title]: {
-        min: handleUnitValue(option, selectedParam, rollingStockValues.mass, 'min'),
-        max: handleUnitValue(option, selectedParam, rollingStockValues.mass, 'max'),
-        unit: option.unit,
-        value: handleUnitValue(option, selectedParam, rollingStockValues.mass),
-      } as MultiUnitsParameter,
+      [property.title]: updatedSelectedParam,
     });
   };
 

--- a/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   convertUnits,
   convertUnitsWithMass,
   handleUnitValue,
+  isMassDependentUnit,
   makeEffortCurve,
 } from 'modules/rollingStock/helpers/utils';
 import type {
@@ -389,6 +390,24 @@ describe('multi units parameter conversion', () => {
         multiUnitsParams.mass
       );
       expect(convertedValue).toEqual(0.15);
+    });
+  });
+
+  describe('isMassDependentUnit', () => {
+    it('should return true for a mass dependent unit like "kN/t"', () => {
+      expect(isMassDependentUnit('kN/t')).toBe(true);
+    });
+
+    it('should return false for a non-mass dependent unit like "kN"', () => {
+      expect(isMassDependentUnit('kN')).toBe(false);
+    });
+
+    it('should return false for null or undefined', () => {
+      expect(isMassDependentUnit(undefined)).toBe(false);
+    });
+
+    it('should return false for tons themselves', () => {
+      expect(isMassDependentUnit('t')).toBe(false);
     });
   });
 });

--- a/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
@@ -209,7 +209,7 @@ describe('checkRollingStockFormValidity', () => {
 });
 
 describe('multi units parameter conversion', () => {
-  describe('unit converter', () => {
+  describe('convertUnits', () => {
     it('should convert kg to t', () => {
       const convertedUnit = convertUnits('kg', 't', 1000);
       expect(convertedUnit).toEqual(1);
@@ -283,7 +283,8 @@ describe('multi units parameter conversion', () => {
       expect(convertedUnit).toEqual(7);
     });
   });
-  describe('mass converter', () => {
+
+  describe('convertUnitsWithMass', () => {
     it('should divide the unit value by mass with current mass in t', () => {
       const convertedValue = convertUnitsWithMass('kN', 'kN/t', 40, 't', 20);
       expect(convertedValue).toEqual(0.5);
@@ -301,7 +302,8 @@ describe('multi units parameter conversion', () => {
       expect(convertedValue).toEqual(20);
     });
   });
-  describe('parameter unit convertor', () => {
+
+  describe('handleUnitValue', () => {
     const values: InputGroupSNCFValue<MultiUnit>[] = [
       {
         unit: 'kg',

--- a/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/rollingStock/helpers/__tests__/utils.spec.ts
@@ -11,6 +11,7 @@ import {
   handleUnitValue,
   isMassDependentUnit,
   makeEffortCurve,
+  rescaleMassDependentParam,
 } from 'modules/rollingStock/helpers/utils';
 import type {
   EffortCurveForms,
@@ -408,6 +409,32 @@ describe('multi units parameter conversion', () => {
 
     it('should return false for tons themselves', () => {
       expect(isMassDependentUnit('t')).toBe(false);
+    });
+  });
+
+  describe('updateMassDependentParam', () => {
+    it('should update min and max based on new mass values with different units', () => {
+      const previousMass: MultiUnitsParameter = { value: 20000, unit: 'kg', min: 0, max: 0 };
+      const newMass: MultiUnitsParameter = { value: 10, unit: 't', min: 0, max: 0 };
+      const param: MultiUnitsParameter = { unit: 'kN/t', value: 1, min: 0.1, max: 2 };
+
+      const updated = rescaleMassDependentParam(param, previousMass, newMass);
+      expect(updated.min).toBeCloseTo(0.2, 10);
+      expect(updated.max).toBeCloseTo(4, 10);
+      expect(updated.value).toEqual(1);
+      expect(updated.unit).toEqual('kN/t');
+    });
+
+    it('should update min and max based on new mass values with the same unit', () => {
+      const previousMass: MultiUnitsParameter = { value: 5, unit: 't', min: 0, max: 0 };
+      const newMass: MultiUnitsParameter = { value: 10, unit: 't', min: 0, max: 0 };
+      const param: MultiUnitsParameter = { unit: 'kN/t', value: 2, min: 0.1, max: 2 };
+
+      const updated = rescaleMassDependentParam(param, previousMass, newMass);
+      expect(updated.min).toBeCloseTo(0.05, 10);
+      expect(updated.max).toBeCloseTo(1, 10);
+      expect(updated.value).toEqual(2); // This value thus becomes out of the defined range
+      expect(updated.unit).toEqual('kN/t');
     });
   });
 });

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -508,3 +508,54 @@ export const handleUnitValue = <U extends MultiUnit>(
   }
   return +valueToConvert;
 };
+
+/**
+ * Updates a value expressed in a mass dependent unit when the mass change
+ * so that the value expressed in a mass independent value does not change.
+ * We assume mass dependent units only depend on the mass as 'MultiUnit/t'.
+ */
+const rescaleMassDependentValue = (
+  massDependentValue: number,
+  previousMassValue: number,
+  previousMassUnit: MultiUnit,
+  newMassValue: number,
+  newMassUnit: MultiUnit
+) => {
+  const previousMassInTons =
+    previousMassUnit !== 't'
+      ? convertUnits(previousMassUnit, 't', previousMassValue)
+      : previousMassValue;
+  const newMassInTons =
+    newMassUnit !== 't' ? convertUnits(newMassUnit, 't', newMassValue) : newMassValue;
+
+  return (massDependentValue * previousMassInTons) / newMassInTons;
+};
+
+/** Updates the min and max of a mass dependent parameter so that they remain unchanged
+ *  in their initial mass independent unit.
+ *
+ *  We may want to update the value of the parameter too in the future, but for now
+ *  we assume the user inputed mass dependent value was deliberate and should remain.
+ */
+export const rescaleMassDependentParam = (
+  massDependentParam: MultiUnitsParameter,
+  previousMass: MultiUnitsParameter,
+  newMass: MultiUnitsParameter
+): MultiUnitsParameter => ({
+  min: rescaleMassDependentValue(
+    massDependentParam.min,
+    previousMass.value,
+    previousMass.unit,
+    newMass.value,
+    newMass.unit
+  ),
+  max: rescaleMassDependentValue(
+    massDependentParam.max,
+    previousMass.value,
+    previousMass.unit,
+    newMass.value,
+    newMass.unit
+  ),
+  unit: massDependentParam.unit,
+  value: massDependentParam.value,
+});

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -209,10 +209,9 @@ export const rollingStockEditorQueryArg = (
 
 type Conditions = Record<string, (effortCurves: EffortCurveForms | null) => boolean>;
 
-const isMultiUnitsParam = (
+export const isMultiUnitsParam = (
   param: RollingStockParametersValues[keyof RollingStockParametersValues]
-): param is MultiUnitsParameter =>
-  param ? Object.keys(param as MultiUnitsParameter).includes('value') : false;
+): param is MultiUnitsParameter => (param ? Object.keys(param).includes('value') : false);
 
 export const isInvalidCurve = (curve: EffortCurve) =>
   curve.max_efforts.length < 2 ||

--- a/front/src/modules/rollingStock/helpers/utils.ts
+++ b/front/src/modules/rollingStock/helpers/utils.ts
@@ -436,8 +436,11 @@ export const convertUnits = (
   return maxDecimals ? floor(result, maxDecimals) : result;
 };
 
-export const isConversionWithTon = (previousUnit: string, newUnit: string) =>
-  previousUnit !== 't' && newUnit !== 't' && (previousUnit.endsWith('t') || newUnit.endsWith('t'));
+export const isMassDependentUnit = (unit?: string) =>
+  unit !== undefined && unit !== 't' && unit.endsWith('t');
+
+export const isConversionWithTon = (previousUnit: MultiUnit, newUnit: MultiUnit) =>
+  isMassDependentUnit(previousUnit) || isMassDependentUnit(newUnit);
 
 /**
  * For the rollingstock resistance (a, b or c), check if its unit
@@ -450,21 +453,19 @@ export const convertUnitsWithMass = (
   previousUnit: MultiUnit,
   newUnit: MultiUnit,
   currentMassValue: number,
-  currentMassUnit: string,
+  currentMassUnit: MultiUnit,
   previousValue: number
 ) => {
-  let convertedValue = previousValue;
-
   const massInTons =
     currentMassUnit === 'kg' ? convertUnits('kg', 't', currentMassValue) : currentMassValue;
-  if (isConversionWithTon(previousUnit, newUnit)) {
-    if (newUnit.endsWith('t')) {
-      convertedValue =
-        convertUnits(previousUnit, newUnit.slice(0, -2) as MultiUnit, previousValue) / massInTons;
-    } else {
-      convertedValue =
-        convertUnits(previousUnit.slice(0, -2) as MultiUnit, newUnit, previousValue) * massInTons;
-    }
+
+  let convertedValue = previousValue;
+  if (isMassDependentUnit(newUnit)) {
+    convertedValue =
+      convertUnits(previousUnit, newUnit.slice(0, -2) as MultiUnit, previousValue) / massInTons;
+  } else if (isMassDependentUnit(previousUnit)) {
+    convertedValue =
+      convertUnits(previousUnit.slice(0, -2) as MultiUnit, newUnit, previousValue) * massInTons;
   }
 
   return convertedValue;


### PR DESCRIPTION
Fix issue in the comment of #11574

First few commits are code quality refactoring and set up.

Fourth commit solves an issue with 0 or undefined mass making it impossible to properly do mass dependent conversions without either division by zero or loss of information, leading to min or max being set to NaN, undefined or 0. I have left a commented out code (with a TODO comment) that corresponded to my first solution, which was to prevent that value from ever being set to 0 or undefined, by I think the UX was bad, so instead I saved the last known non-zero value. I will remove it before merging, but left it in case you prefered that version.

Sixth commit solves the issue in the comment, which is that the min and max where not being rescaled when expressed in mass dependent units and we changed the mass, despite having absolute, non-mass dependent values that are not user set. Optionally we could also rescale the value of the input, but I believe that since the user when out of their way to input the value in a mass dependent way, they don't expect that value to get rescaled behind their back =p
