### PR TITLE
editoast: rename RollingStockSeparatedImageModel to RollingStockImage

### DIFF
--- a/editoast/src/models/mod.rs
+++ b/editoast/src/models/mod.rs
@@ -39,7 +39,7 @@ pub use infra_objects::*;
 pub use paced_train::PacedTrain;
 pub use project::Project;
 pub use rolling_stock::RollingStock;
-pub use rolling_stock_image::RollingStockSeparatedImageModel;
+pub use rolling_stock_image::RollingStockImage;
 pub use scenario::Scenario;
 pub use study::Study;
 pub use tags::Tags;

--- a/editoast/src/models/rolling_stock_image.rs
+++ b/editoast/src/models/rolling_stock_image.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize, Model)]
 #[model(table = editoast_models::tables::rolling_stock_separate_image)]
 #[model(gen(ops = c))]
-pub struct RollingStockSeparatedImageModel {
+pub struct RollingStockImage {
     pub id: i64,
     pub order: i32,
     pub image_id: i64, // FK to document

--- a/editoast/src/views/rolling_stock.rs
+++ b/editoast/src/views/rolling_stock.rs
@@ -36,7 +36,7 @@ use crate::error::InternalError;
 use crate::error::Result;
 use crate::models::Document;
 use crate::models::RollingStock;
-use crate::models::RollingStockSeparatedImageModel;
+use crate::models::RollingStockImage;
 use crate::models::prelude::*;
 use crate::models::rolling_stock;
 use crate::models::rolling_stock::ScenarioReference;
@@ -624,7 +624,7 @@ async fn create_livery(
             .create(conn)
             .await?;
 
-        let _ = RollingStockSeparatedImageModel::changeset()
+        let _ = RollingStockImage::changeset()
             .image_id(image.id)
             .livery_id(rolling_stock_livery.id)
             .order(index.try_into().unwrap())


### PR DESCRIPTION
The `Model` suffix was superfluous, and the `Separated` was removed to
match the module name.

> [!NOTE]
> I have *absolutely no idea* where the table `rolling_stock_separate_image` is read?? If it indeed isn't, it'd be probably best to remove the model...
