### PR TITLE
editoast: add `POST /authz/me/privileges` endpoint

### DIFF
--- a/editoast/editoast_authz/src/authorizer.rs
+++ b/editoast/editoast_authz/src/authorizer.rs
@@ -8,6 +8,7 @@ use crate::Infra;
 use crate::Regulator;
 use crate::Role;
 use crate::StorageDriver;
+use crate::model::InfraPrivilege;
 use crate::model::User;
 use crate::subject::UserIdentity;
 use crate::subject::UserInfo;
@@ -59,6 +60,15 @@ impl<S: StorageDriver> Authorizer<S> {
     #[tracing::instrument(skip_all, fields(user = %self.user, ?roles), ret(level = Level::DEBUG))]
     pub async fn check_roles(&self, roles: HashSet<Role>) -> Result<bool, Error<S::Error>> {
         self.regulator.check_roles(&User(self.user_id), roles).await
+    }
+
+    pub async fn infra_privileges(
+        &self,
+        infra: &Infra,
+    ) -> Result<HashSet<InfraPrivilege>, Error<S::Error>> {
+        self.regulator
+            .infra_privileges(&User(self.user_id), infra)
+            .await
     }
 
     pub async fn check_infra_grant_reader(&self, infra: &Infra) -> Result<bool, Error<S::Error>> {

--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -9,6 +9,7 @@ pub use regulator::StorageDriver;
 
 pub use model::Group;
 pub use model::Infra;
+pub use model::InfraPrivilege;
 pub use model::Role;
 pub use model::User;
 

--- a/editoast/editoast_authz/src/model.rs
+++ b/editoast/editoast_authz/src/model.rs
@@ -19,6 +19,20 @@ pub struct Group(pub i64);
 #[derive(fga::Type, fga::User, fga::Object, derive_more::FromStr, Debug, Clone)]
 pub struct Infra(pub i64);
 
+#[derive(Debug, Display, PartialEq, Eq, Hash, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize))]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+#[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
+pub enum InfraPrivilege {
+    CanRead,
+    CanShareRead,
+    CanWrite,
+    CanShareWrite,
+    CanDelete,
+    CanShareOwnership,
+}
+
 #[derive(
     fga::User,
     Debug,

--- a/editoast/editoast_authz/src/model.rs
+++ b/editoast/editoast_authz/src/model.rs
@@ -19,8 +19,7 @@ pub struct Group(pub i64);
 #[derive(fga::Type, fga::User, fga::Object, derive_more::FromStr, Debug, Clone)]
 pub struct Infra(pub i64);
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Serialize, ToSchema)]
-#[cfg_attr(test, derive(Deserialize))]
+#[derive(Debug, Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[allow(clippy::enum_variant_names)] // needed due to "Can" prefix

--- a/editoast/editoast_authz/src/regulator.rs
+++ b/editoast/editoast_authz/src/regulator.rs
@@ -317,6 +317,44 @@ impl<S: StorageDriver> Regulator<S> {
     }
 
     #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
+    pub async fn infra_privileges(
+        &self,
+        user: &User,
+        infra: &Infra,
+    ) -> Result<HashSet<InfraPrivilege>, Error<S::Error>> {
+        if self.is_admin(user).await? {
+            return Ok(HashSet::from([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+                InfraPrivilege::CanDelete,
+                InfraPrivilege::CanShareOwnership,
+            ]));
+        }
+
+        let (can_read, can_share_read, can_write, can_share_write, can_delete, can_share_ownership) =
+            self.openfga
+                .checks((
+                    Infra::can_read().check(user, infra),
+                    Infra::can_share_read().check(user, infra),
+                    Infra::can_write().check(user, infra),
+                    Infra::can_share_write().check(user, infra),
+                    Infra::can_delete().check(user, infra),
+                    Infra::can_share_ownership().check(user, infra),
+                ))
+                .await?;
+        let mut privileges = HashSet::new();
+        privileges.extend(can_read.then_some(InfraPrivilege::CanRead));
+        privileges.extend(can_share_read.then_some(InfraPrivilege::CanShareRead));
+        privileges.extend(can_write.then_some(InfraPrivilege::CanWrite));
+        privileges.extend(can_share_write.then_some(InfraPrivilege::CanShareWrite));
+        privileges.extend(can_delete.then_some(InfraPrivilege::CanDelete));
+        privileges.extend(can_share_ownership.then_some(InfraPrivilege::CanShareOwnership));
+        Ok(privileges)
+    }
+
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG), err)]
     pub async fn check_infra_grant_reader(
         &self,
         user: &User,

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -122,6 +122,45 @@ paths:
                       id:
                         type: integer
                         format: int64
+  /authz/me/privileges:
+    post:
+      tags:
+      - authz
+      requestBody:
+        description: The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted.
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+        required: true
+      responses:
+        '200':
+          description: The privileges of the user sending the request over each requested resource.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - resource_id
+                    - privileges
+                    properties:
+                      privileges:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/InfraPrivilege'
+                        uniqueItems: true
+                      resource_id:
+                        type: integer
+                        format: int64
   /authz/{resource_type}/{resource_id}:
     get:
       tags:

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -40,27 +40,6 @@ paths:
           description: Successful granting
         '204':
           description: Successful revoking
-  /authz/grants/{resource_type}:
-    get:
-      tags:
-      - authz
-      parameters:
-      - name: resource_type
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/ResourceType'
-      responses:
-        '200':
-          description: Get privileges for each grant associated to the resource type
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/InfraPrivilege'
   /authz/me:
     get:
       tags:
@@ -5441,7 +5420,6 @@ components:
       - $ref: '#/components/schemas/EditoastProjectErrorImageNotFound'
       - $ref: '#/components/schemas/EditoastProjectErrorNotFound'
       - $ref: '#/components/schemas/EditoastRailJsonErrorUnsupportedVersion'
-      - $ref: '#/components/schemas/EditoastResourceErrorUnknownResourceType'
       - $ref: '#/components/schemas/EditoastRollingStockErrorBasePowerClassEmpty'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotCreateCompoundImage'
       - $ref: '#/components/schemas/EditoastRollingStockErrorCannotReadImage'
@@ -6221,30 +6199,6 @@ components:
           type: string
           enum:
           - editoast:railjson:UnsupportedVersion
-    EditoastResourceErrorUnknownResourceType:
-      type: object
-      required:
-      - type
-      - status
-      - message
-      properties:
-        context:
-          type: object
-          required:
-          - resource_type
-          properties:
-            resource_type:
-              type: string
-        message:
-          type: string
-        status:
-          type: integer
-          enum:
-          - 404
-        type:
-          type: string
-          enum:
-          - editoast:authz:UnknownResourceType
     EditoastRollingStockErrorBasePowerClassEmpty:
       type: object
       required:

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -12,6 +12,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Json;
 use editoast_authz as authz;
+use editoast_authz::InfraPrivilege;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use itertools::Itertools;
@@ -320,20 +321,6 @@ async fn subjects_with_grant_on_resource(
         subjects: subjects_grant,
         stats,
     }))
-}
-
-#[derive(Display, Serialize, ToSchema)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-#[allow(clippy::enum_variant_names)] // needed due to "Can" prefix
-#[cfg_attr(test, derive(Debug, Deserialize))]
-pub enum InfraPrivilege {
-    CanRead,
-    CanShareRead,
-    CanWrite,
-    CanShareWrite,
-    CanDelete,
-    CanShareOwnership,
 }
 
 #[utoipa::path(

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::error::Result;
 use crate::models;
@@ -32,8 +33,11 @@ use super::pagination::PaginationStats;
 
 crate::routes! {
     "/authz" => {
-        "/me" => whoami,
-        "/me/grants" => user_authorizations,
+        "/me" => {
+            whoami,
+            "/privileges" => user_privileges,
+            "/grants" => user_authorizations,
+        },
         "/grants" => update_grants,
         "/{resource_type}/{resource_id}" => subjects_with_grant_on_resource,
         "/grants/{resource_type}"=> privileges_by_resource_type,
@@ -59,7 +63,7 @@ enum SubjectType {
     Group,
 }
 
-#[derive(Display, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Display, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[cfg_attr(test, derive(Debug))]
@@ -142,6 +146,62 @@ async fn whoami(Extension(auth): AuthenticationExt) -> Result<Json<WhoamiRespons
     }))
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(Deserialize, PartialEq, Eq))]
+struct ResourcePrivileges {
+    resource_id: i64,
+    privileges: HashSet<InfraPrivilege>,
+}
+
+#[utoipa::path(
+    post,
+    path = "",
+    tag = "authz",
+    request_body(
+        content = inline(HashMap<ResourceType, Vec<i64>>),
+        description = "The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted.",
+    ),
+    responses((
+        status = 200,
+        description = "The privileges of the user sending the request over each requested resource.",
+        body = inline(HashMap<ResourceType, Vec<ResourcePrivileges>>)
+    )),
+)]
+async fn user_privileges(
+    State(AppState { db_pool, .. }): State<AppState>,
+    Extension(auth): AuthenticationExt,
+    Json(body): Json<HashMap<ResourceType, Vec<i64>>>,
+) -> Result<Json<HashMap<ResourceType, Vec<ResourcePrivileges>>>> {
+    let authorizer = auth.authorizer()?;
+
+    let resources = body
+        .into_iter()
+        .flat_map(|(rtype, ids)| std::iter::repeat(rtype).zip(ids.into_iter()));
+
+    let mut result = HashMap::<_, Vec<_>>::new();
+    for (resource_type, resource_id) in resources {
+        match resource_type {
+            ResourceType::Infra => {
+                // check that the infra exists before to check the grants
+                if Infra::exists(&mut db_pool.get().await?, resource_id).await? {
+                    result
+                        .entry(ResourceType::Infra)
+                        .or_default()
+                        .push(ResourcePrivileges {
+                            resource_id,
+                            privileges: authorizer
+                                .infra_privileges(&authz::Infra(resource_id))
+                                .await
+                                .map_err(AuthzError::from)?,
+                        });
+                }
+            }
+        }
+    }
+
+    Ok(Json(result))
+}
+
 #[derive(Serialize, ToSchema)]
 #[cfg_attr(test, derive(Debug, Deserialize, PartialEq))]
 struct UserResourceGrant {
@@ -154,13 +214,13 @@ struct UserResourceGrant {
     path = "",
     tag = "authz",
     request_body(
-        content = inline(HashMap<Resource, Vec<i64>>),
+        content = inline(HashMap<ResourceType, Vec<i64>>),
         description = "HashMap of resource type with a list of resource id to get the grants for. If a resource doesn't exist, it will be omitted.",
     ),
     responses((
         status = 200,
         description = "Get grants info of the current user for the given resources in body",
-        body = inline(HashMap<Resource, Vec<UserResourceGrant>>)
+        body = inline(HashMap<ResourceType, Vec<UserResourceGrant>>)
     )),
 )]
 async fn user_authorizations(
@@ -475,8 +535,11 @@ async fn update_grants(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use axum::http::StatusCode;
 
+    use crate::models::fixtures::create_empty_infra;
     use crate::views::test_app::test_app;
 
     use super::*;
@@ -487,6 +550,132 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn me_privileges() {
+        let app = test_app!().enable_authorization(true).build();
+        let Infra { id: infra1, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra2, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra3, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra4, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra {
+            id: infra_unused, ..
+        } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let toto = app
+            .user("toto", "Toto")
+            .with_infra_grant(infra1, InfraGrant::Owner)
+            .with_infra_grant(infra2, InfraGrant::Writer)
+            .with_infra_grant(infra3, InfraGrant::Reader)
+            .create();
+
+        let mut privileges = app
+            .fetch(
+                app.post("/authz/me/privileges")
+                    .by_user(&toto)
+                    .json(&json!({
+                       "infra": [infra1, infra2, infra3, infra4]
+                    })),
+            )
+            .assert_status(StatusCode::OK)
+            .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .remove(&ResourceType::Infra)
+            .unwrap()
+            .into_iter()
+            .map(
+                |ResourcePrivileges {
+                     resource_id,
+                     privileges,
+                 }| (resource_id, privileges),
+            )
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            privileges.remove(&infra1).unwrap(),
+            HashSet::from([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+                InfraPrivilege::CanDelete,
+                InfraPrivilege::CanShareOwnership,
+            ])
+        );
+        assert_eq!(
+            privileges.remove(&infra2).unwrap(),
+            HashSet::from([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+            ])
+        );
+        assert_eq!(
+            privileges.remove(&infra3).unwrap(),
+            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+        );
+        assert_eq!(privileges.remove(&infra4).unwrap(), HashSet::from([]));
+        assert!(!privileges.contains_key(&infra_unused));
+    }
+
+    // TODO: merge with the previous test once test deadlocks are fixed
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn me_privileges_bis() {
+        let app = test_app!().enable_authorization(true).build();
+        let Infra { id: infra1, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra2, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra3, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra { id: infra4, .. } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let Infra {
+            id: infra_unused, ..
+        } = create_empty_infra(&mut app.db_pool().get_ok()).await;
+        let tata = app
+            .user("tata", "Tata")
+            .with_infra_grant(infra1, InfraGrant::Reader)
+            .with_infra_grant(infra3, InfraGrant::Reader)
+            .with_infra_grant(infra4, InfraGrant::Owner)
+            .create();
+
+        let mut privileges = app
+            .fetch(
+                app.post("/authz/me/privileges")
+                    .by_user(&tata)
+                    .json(&json!({
+                       "infra": [infra1, infra2, infra3, infra4]
+                    })),
+            )
+            .assert_status(StatusCode::OK)
+            .json_into::<HashMap<ResourceType, Vec<ResourcePrivileges>>>()
+            .remove(&ResourceType::Infra)
+            .unwrap()
+            .into_iter()
+            .map(
+                |ResourcePrivileges {
+                     resource_id,
+                     privileges,
+                 }| (resource_id, privileges),
+            )
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            privileges.remove(&infra1).unwrap(),
+            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead])
+        );
+        assert_eq!(privileges.remove(&infra2).unwrap(), HashSet::from([]));
+        assert_eq!(
+            privileges.remove(&infra3).unwrap(),
+            HashSet::from([InfraPrivilege::CanRead, InfraPrivilege::CanShareRead,])
+        );
+        assert_eq!(
+            privileges.remove(&infra4).unwrap(),
+            HashSet::from([
+                InfraPrivilege::CanRead,
+                InfraPrivilege::CanShareRead,
+                InfraPrivilege::CanWrite,
+                InfraPrivilege::CanShareWrite,
+                InfraPrivilege::CanDelete,
+                InfraPrivilege::CanShareOwnership
+            ])
+        );
+        assert!(!privileges.contains_key(&infra_unused));
+    }
 
     #[rstest]
     async fn user_authorizations_test() {

--- a/editoast/src/views/authz.rs
+++ b/editoast/src/views/authz.rs
@@ -40,7 +40,6 @@ crate::routes! {
         },
         "/grants" => update_grants,
         "/{resource_type}/{resource_id}" => subjects_with_grant_on_resource,
-        "/grants/{resource_type}"=> privileges_by_resource_type,
     },
 }
 
@@ -109,14 +108,6 @@ impl From<AuthorizerError> for AuthzError {
             err => AuthzError::Authorizer(err),
         }
     }
-}
-
-#[derive(Debug, thiserror::Error, EditoastError)]
-#[editoast_error(base_id = "authz")]
-enum ResourceError {
-    #[error("unknown resource type {resource_type}")]
-    #[editoast_error(status = 404)]
-    UnknownResourceType { resource_type: String },
 }
 
 #[derive(Serialize, ToSchema)]
@@ -381,53 +372,6 @@ async fn subjects_with_grant_on_resource(
         subjects: subjects_grant,
         stats,
     }))
-}
-
-#[utoipa::path(
-    get,
-    path = "",
-    tag = "authz",
-    params(ResourceTypeParam),
-    responses(
-        (status = 200, description = "Get privileges for each grant associated to the resource type", body = HashMap<InfraGrant, Vec<InfraPrivilege>>),
-    ),
-)]
-async fn privileges_by_resource_type(
-    Path(ResourceTypeParam { resource_type }): Path<ResourceTypeParam>,
-) -> Result<Json<HashMap<InfraGrant, Vec<InfraPrivilege>>>> {
-    if resource_type != ResourceType::Infra {
-        return Err(ResourceError::UnknownResourceType {
-            resource_type: resource_type.to_string(),
-        })?;
-    }
-
-    let mut infra_privileges: HashMap<InfraGrant, Vec<InfraPrivilege>> = HashMap::new();
-    infra_privileges.insert(
-        InfraGrant::Owner,
-        vec![
-            InfraPrivilege::CanRead,
-            InfraPrivilege::CanShareRead,
-            InfraPrivilege::CanWrite,
-            InfraPrivilege::CanShareWrite,
-            InfraPrivilege::CanDelete,
-            InfraPrivilege::CanShareOwnership,
-        ],
-    );
-    infra_privileges.insert(
-        InfraGrant::Writer,
-        vec![
-            InfraPrivilege::CanRead,
-            InfraPrivilege::CanShareRead,
-            InfraPrivilege::CanWrite,
-            InfraPrivilege::CanShareWrite,
-        ],
-    );
-    infra_privileges.insert(
-        InfraGrant::Reader,
-        vec![InfraPrivilege::CanRead, InfraPrivilege::CanShareRead],
-    );
-
-    Ok(Json(infra_privileges))
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -804,20 +748,6 @@ mod tests {
             .assert_status(StatusCode::NO_CONTENT);
         // Check that the new user has the good grant
         check_grant_on_resource(&app, &owner, infra.id, writer.id, None);
-    }
-
-    #[rstest]
-    async fn privileges_by_resource_type_test() {
-        let app = test_app!().enable_authorization(true).build();
-
-        let request = app.get(&format!("/authz/grants/{}", ResourceType::Infra));
-        let response: HashMap<InfraGrant, Vec<InfraPrivilege>> =
-            app.fetch(request).assert_status(StatusCode::OK).json_into();
-
-        // Checks
-        assert_eq!(response.get(&InfraGrant::Reader).unwrap().len(), 2);
-        assert_eq!(response.get(&InfraGrant::Writer).unwrap().len(), 4);
-        assert_eq!(response.get(&InfraGrant::Owner).unwrap().len(), 6);
     }
 
     #[rstest]

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -53,6 +53,13 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/authz/me/grants`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['authz'],
       }),
+      postAuthzMePrivileges: build.mutation<
+        PostAuthzMePrivilegesApiResponse,
+        PostAuthzMePrivilegesApiArg
+      >({
+        query: (queryArg) => ({ url: `/authz/me/privileges`, method: 'POST', body: queryArg.body }),
+        invalidatesTags: ['authz'],
+      }),
       getAuthzByResourceTypeAndResourceId: build.query<
         GetAuthzByResourceTypeAndResourceIdApiResponse,
         GetAuthzByResourceTypeAndResourceIdApiArg
@@ -1268,6 +1275,19 @@ export type PostAuthzMeGrantsApiResponse =
   };
 export type PostAuthzMeGrantsApiArg = {
   /** HashMap of resource type with a list of resource id to get the grants for. If a resource doesn't exist, it will be omitted. */
+  body: {
+    [key: string]: number[];
+  };
+};
+export type PostAuthzMePrivilegesApiResponse =
+  /** status 200 The privileges of the user sending the request over each requested resource. */ {
+    [key: string]: {
+      privileges: InfraPrivilege[];
+      resource_id: number;
+    }[];
+  };
+export type PostAuthzMePrivilegesApiArg = {
+  /** The resources of which to get the request sender's privileges. If a resource doesn't exist, it will be omitted. */
   body: {
     [key: string]: number[];
   };

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -38,13 +38,6 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/authz/grants`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['authz'],
       }),
-      getAuthzGrantsByResourceType: build.query<
-        GetAuthzGrantsByResourceTypeApiResponse,
-        GetAuthzGrantsByResourceTypeApiArg
-      >({
-        query: (queryArg) => ({ url: `/authz/grants/${queryArg.resourceType}` }),
-        providesTags: ['authz'],
-      }),
       getAuthzMe: build.query<GetAuthzMeApiResponse, GetAuthzMeApiArg>({
         query: () => ({ url: `/authz/me` }),
         providesTags: ['authz'],
@@ -1253,13 +1246,6 @@ export type PostAuthzGrantsApiArg = {
         revoke: RevokeBody[];
       };
 };
-export type GetAuthzGrantsByResourceTypeApiResponse =
-  /** status 200 Get privileges for each grant associated to the resource type */ {
-    [key: string]: InfraPrivilege[];
-  };
-export type GetAuthzGrantsByResourceTypeApiArg = {
-  resourceType: ResourceType;
-};
 export type GetAuthzMeApiResponse = /** status 200 Get the info of the current user */ {
   id: number;
   name: string;
@@ -2275,6 +2261,7 @@ export type RevokeBody = {
   resource_type: ResourceType;
   subject_id: number;
 };
+export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
 export type InfraPrivilege =
   | 'can_read'
   | 'can_share_read'
@@ -2282,7 +2269,6 @@ export type InfraPrivilege =
   | 'can_share_write'
   | 'can_delete'
   | 'can_share_ownership';
-export type Role = 'Admin' | 'Stdcm' | 'OperationalStudies';
 export type PaginationStats = {
   /** The total number of items */
   count: number;


### PR DESCRIPTION
closes https://github.com/OpenRailAssociation/osrd/issues/10579
refs #11697

<details open id="prdesc">

- 869d4cc87 *editoast: authz: add `infra_privileges` regulator function*
- 597e85f34 *editoast: add `POST /authz/me/privileges` endpoint*
- 10f6bc5d9 *editoast: remove `GET /authz/grants/{resource_type}`*
    ```md
    Not useful anymore as the frontend queries the privileges directly
    using `POST /authz/me/privileges`.
    ```

</details>