### PR TITLE
front: move path properties state into usePathfinding()

### DIFF
--- a/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
+++ b/front/src/applications/operationalStudies/hooks/useManageTrainScheduleContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, type ReactNode, useState } from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import { compact } from 'lodash';
 import { useSelector } from 'react-redux';
@@ -20,7 +20,6 @@ import type { ManageTrainSchedulePathProperties } from '../types';
 
 type ManageTrainScheduleContextType = {
   pathProperties?: ManageTrainSchedulePathProperties;
-  setPathProperties: (pathProperties?: ManageTrainSchedulePathProperties) => void;
   voltageRanges: RangedValue[];
   launchPathfinding: (
     steps: (PathStep | null)[],
@@ -42,11 +41,8 @@ export const ManageTrainScheduleContextProvider = ({
 }: ManageTrainScheduleContextProviderProps) => {
   const pathSteps = useSelector(getPathSteps);
 
-  const [pathProperties, setPathProperties] = useState<ManageTrainSchedulePathProperties>();
-
   const rollingStockId = useSelector(getOperationalStudiesRollingStockID);
-  const { launchPathfinding, pathfindingState, infraInfo } = usePathfinding({
-    setPathProperties,
+  const { launchPathfinding, pathfindingState, infraInfo, pathProperties } = usePathfinding({
     rollingStockId,
   });
 
@@ -63,7 +59,6 @@ export const ManageTrainScheduleContextProvider = ({
   const providedContext = useMemo(
     () => ({
       pathProperties,
-      setPathProperties,
       voltageRanges,
       launchPathfinding,
       pathfindingState,
@@ -72,7 +67,6 @@ export const ManageTrainScheduleContextProvider = ({
     }),
     [
       pathProperties,
-      setPathProperties,
       voltageRanges,
       launchPathfinding,
       pathfindingState,

--- a/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
+++ b/front/src/modules/pathfinding/components/Itinerary/Itinerary.tsx
@@ -42,7 +42,7 @@ const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) =
   const { t } = useTranslation('operationalStudies/manageTrainSchedule');
   const { openModal } = useModal();
 
-  const { pathProperties, setPathProperties, launchPathfinding, pathStepsAndSuggestedOPs } =
+  const { pathProperties, launchPathfinding, pathStepsAndSuggestedOPs } =
     useManageTrainScheduleContext();
 
   const zoomToFeaturePoint = (lngLat?: Position) => {
@@ -83,7 +83,6 @@ const Itinerary = ({ rollingStockId }: { rollingStockId: number | undefined }) =
   };
 
   const resetPathfinding = () => {
-    setPathProperties(undefined);
     notifyRestrictionResetWarning();
     launchPathfinding([null, null]);
   };

--- a/front/src/modules/pathfinding/hooks/usePathfinding.ts
+++ b/front/src/modules/pathfinding/hooks/usePathfinding.ts
@@ -46,10 +46,8 @@ const initialPathfindingState = {
 
 const usePathfinding = ({
   rollingStockId: currentRollingStockId,
-  setPathProperties,
 }: {
   rollingStockId: number | undefined;
-  setPathProperties: (pathProperties?: ManageTrainSchedulePathProperties) => void;
 }) => {
   const { t } = useTranslation(['operationalStudies/manageTrainSchedule']);
   const dispatch = useAppDispatch();
@@ -59,6 +57,7 @@ const usePathfinding = ({
   const { infra, reloadCount, setIsInfraError } = useInfraStatus({ infraId });
   const [pathfindingState, setPathfindingState] =
     useState<PathfindingState>(initialPathfindingState);
+  const [pathProperties, setPathProperties] = useState<ManageTrainSchedulePathProperties>();
 
   const [getRollingStockById] =
     osrdEditoastApi.endpoints.getRollingStockByRollingStockId.useLazyQuery();
@@ -329,6 +328,7 @@ const usePathfinding = ({
   return {
     launchPathfinding,
     pathfindingState,
+    pathProperties,
     infraInfo: {
       infra,
       reloadCount,


### PR DESCRIPTION
_See individual commits._

Right now, the path properties state is defined outside of
usePathfinding(), and the setter is passed around. This makes it
tricky to figure out the data flow: the setter can be called from
anywhere. Additionally, this makes it tempting to overwrite the
state outside of usePathfinding().

Move the state inside usePathfinding() and don't expose the setter.
Return the state so that a read-only view of the state is provided.
This ensures implementation details are kept inside usePathfinding().