### PR TITLE
core: stdcm: trim edges that lead to nodes already visited

### DIFF
--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/STDCMHeuristic.kt
@@ -100,11 +100,10 @@ class STDCMHeuristicBuilder(
     private val maxRunningTime: Double,
     private val rollingStock: PhysicsRollingStock,
     private val temporarySpeedLimitManager: TemporarySpeedLimitManager =
-        TemporarySpeedLimitManager()
+        TemporarySpeedLimitManager(),
+    private val mrspBuilder: CachedBlockMRSPBuilder,
 ) {
     private val logger: Logger = LoggerFactory.getLogger("STDCMHeuristic")
-    private val mrspBuilder =
-        CachedBlockMRSPBuilder(rawInfra, blockInfra, rollingStock, temporarySpeedLimitManager)
 
     /** Runs all the pre-processing and initialize the STDCM A* heuristic. */
     @WithSpan(value = "Initializing STDCM heuristic", kind = SpanKind.SERVER)

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/STDCMGraph.kt
@@ -13,6 +13,7 @@ import fr.sncf.osrd.stdcm.STDCMStep
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorerWithEnvelope
 import fr.sncf.osrd.stdcm.preprocessing.interfaces.BlockAvailabilityInterface
 import fr.sncf.osrd.train.RollingStock
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.units.meters
 import java.lang.Double.isFinite
 import java.lang.Double.isNaN
@@ -46,12 +47,14 @@ class STDCMGraph(
         DelayManager(minScheduleTimeStart, maxRunTime, blockAvailability, this, timeStep)
     val allowanceManager: EngineeringAllowanceManager = EngineeringAllowanceManager(this)
     val backtrackingManager: BacktrackingManager = BacktrackingManager(this)
+    val mrspBuilder =
+        CachedBlockMRSPBuilder(rawInfra, blockInfra, rollingStock, temporarySpeedLimitManager)
 
     // min 30s between two edges, determined empirically
     // TODO: this value *should* reflect twice the min delay between two trains,
     // but it seems we need it to be as small as the smallest amount of time
     // a train can occupy a block. There's an issue somewhere.
-    private val visitedNodes = VisitedNodes(30.0)
+    private val visitedNodes = VisitedNodes(30.0, fullInfra, mrspBuilder)
 
     // A* heuristic
     val remainingTimeEstimator: STDCMAStarHeuristic
@@ -70,6 +73,7 @@ class STDCMGraph(
                     maxRunTime,
                     rollingStock,
                     temporarySpeedLimitManager,
+                    mrspBuilder,
                 )
                 .build()
         bestPossibleTime = remainingTimeEstimator.bestTravelTime
@@ -96,7 +100,7 @@ class STDCMGraph(
     override fun getAdjacentEdges(node: STDCMNode): Collection<STDCMEdge> {
         val res = ArrayList<STDCMEdge>()
         val maxMarginDuration = estimateMaxMarginDuration(node)
-        val visitedNodesParameters =
+        var visitedNodesParameters =
             VisitedNodes.Parameters(
                 null,
                 node.timeData,
@@ -126,6 +130,7 @@ class STDCMGraph(
                         node.infraExplorer.getStepTracker().nStepsExcludingLookahead,
                         0.meters
                     )
+                visitedNodesParameters = visitedNodesParameters.copy(explorer = newPath)
                 if (visitedNodes.isVisited(visitedNodesParameters)) return listOf()
                 visitedNodes.markAsVisited(visitedNodesParameters)
                 res.addAll(

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
@@ -172,30 +172,7 @@ data class VisitedNodes(val minDelay: Double) {
             return true
         }
         val visitedRanges = visitedRangesPerLocation[parameters.fingerprint] ?: return false
-        val timeData = parameters.timeData
-
-        val visitingRange =
-            Range.closedOpen(
-                timeData.earliestReachableTime,
-                timeData.earliestReachableTime + timeData.maxDepartureDelayingWithoutConflict
-            )
-        if (visitingRange.isEmpty) {
-            // Special case for empty range, `subRangeMap` returns an empty list
-            val value = visitedRanges.get(timeData.earliestReachableTime) ?: return false
-            return value.isVisited(visitingRange, parameters)
-        }
-        val subMap = visitedRanges.subRangeMap(visitingRange)
-
-        // Keep track of any range that isn't covered by the map
-        val uncovered = TreeRangeSet.create<Double>()
-        uncovered.add(visitingRange)
-        for (entry in subMap.asMapOfRanges()) {
-            uncovered.remove(entry.key)
-            // Value isn't visited: we can early return "false"
-            if (!entry.value.isVisited(entry.key, parameters)) return false
-        }
-        // If any area is left uncovered, we still return "false"
-        return uncovered.isEmpty
+        return isMapVisited(visitedRanges, parameters)
     }
 
     /** Marks the input as visited */
@@ -226,10 +203,34 @@ data class VisitedNodes(val minDelay: Double) {
             startTime + timeData.maxDepartureDelayingWithoutConflict + minDelay
         val endRangeExtraTravelTime = endRangeExtraStopTime + parameters.maxMarginDuration
 
+        markAsVisited(
+            visitedRanges,
+            startTime,
+            endRangeDepartureTimeChange,
+            endRangeExtraStopTime,
+            endRangeExtraTravelTime,
+            timeData.totalStopDuration,
+            parameters.nodeCost,
+        )
+    }
+
+    /**
+     * Marks the given time ranges as visited in the map. Adds 3 ranges: visited with added
+     * departure time, with extra stop duration, and with added travel time.
+     */
+    private fun markAsVisited(
+        map: RangeMap<Double, ConditionallyVisitedRange>,
+        startTime: Double,
+        endRangeDepartureTimeChange: Double,
+        endRangeExtraStopTime: Double,
+        endRangeExtraTravelTime: Double,
+        totalStopDuration: Double,
+        nodeCost: Double,
+    ) {
         fun putRange(start: Double, end: Double, value: ConditionallyVisitedRange) {
             if (start < end) {
                 val range = Range.closedOpen(start, end)
-                visitedRanges.merge(range, value) { a, b -> a.mergeWith(b) }
+                map.merge(range, value) { a, b -> a.mergeWith(b) }
             }
         }
 
@@ -245,16 +246,50 @@ data class VisitedNodes(val minDelay: Double) {
             endRangeDepartureTimeChange,
             endRangeExtraStopTime,
             VisitedWithAddedStopTime(
-                LinearFunction(timeData.totalStopDuration - endRangeDepartureTimeChange),
-                parameters.nodeCost,
+                LinearFunction(totalStopDuration - endRangeDepartureTimeChange),
+                nodeCost,
             )
         )
         // Visited with extra margins, starting from the end of the previous range
         putRange(
             endRangeExtraStopTime,
             endRangeExtraTravelTime,
-            VisitedWithAddedTravelTime(LinearFunction(parameters.nodeCost - endRangeExtraStopTime))
+            VisitedWithAddedTravelTime(LinearFunction(nodeCost - endRangeExtraStopTime))
         )
+    }
+
+    /**
+     * Returns true if the map already contains visited ranges for all new ranges from the given
+     * parameters.
+     */
+    private fun isMapVisited(
+        map: RangeMap<Double, ConditionallyVisitedRange>,
+        parameters: Parameters,
+    ): Boolean {
+        val timeData = parameters.timeData
+
+        val visitingRange =
+            Range.closedOpen(
+                timeData.earliestReachableTime,
+                timeData.earliestReachableTime + timeData.maxDepartureDelayingWithoutConflict
+            )
+        if (visitingRange.isEmpty) {
+            // Special case for empty range, `subRangeMap` returns an empty list
+            val value = map.get(timeData.earliestReachableTime) ?: return false
+            return value.isVisited(visitingRange, parameters)
+        }
+        val subMap = map.subRangeMap(visitingRange)
+
+        // Keep track of any range that isn't covered by the map
+        val uncovered = TreeRangeSet.create<Double>()
+        uncovered.add(visitingRange)
+        for (entry in subMap.asMapOfRanges()) {
+            uncovered.remove(entry.key)
+            // Value isn't visited: we can early return "false"
+            if (!entry.value.isVisited(entry.key, parameters)) return false
+        }
+        // If any area is left uncovered, we still return "false"
+        return uncovered.isEmpty
     }
 }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
@@ -137,7 +137,7 @@ data class VisitedNodes(val minDelay: Double) {
             range: Range<Double>,
             parameters: Parameters,
         ): Boolean {
-            val runningTimeForVisited = visitedWithTravelTime.apply(range.lowerEndpoint())
+            val runningTimeForVisited = visitedWithTravelTime.apply(range.upperEndpoint())
             return runningTimeForVisited <= parameters.nodeCost
         }
 

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/graph/VisitedNodes.kt
@@ -4,10 +4,16 @@ import com.google.common.collect.Range
 import com.google.common.collect.RangeMap
 import com.google.common.collect.TreeRangeMap
 import com.google.common.collect.TreeRangeSet
+import fr.sncf.osrd.api.FullInfra
 import fr.sncf.osrd.envelope_sim.TrainPhysicsIntegrator.areTimesEqual
 import fr.sncf.osrd.sim_infra.api.BlockId
+import fr.sncf.osrd.sim_infra.api.DirDetectorId
+import fr.sncf.osrd.sim_infra.utils.getBlockEntry
+import fr.sncf.osrd.sim_infra.utils.getBlockExit
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
 import fr.sncf.osrd.stdcm.infra_exploration.InfraExplorer
+import fr.sncf.osrd.stdcm.infra_exploration.getRemainingBlocks
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.units.Distance
 import fr.sncf.osrd.utils.units.meters
 import kotlin.math.min
@@ -38,7 +44,11 @@ import kotlin.math.min
  * Otherwise, we may consider that a range is visited despite being better according to the new
  * criteria.
  */
-data class VisitedNodes(val minDelay: Double) {
+data class VisitedNodes(
+    val minDelay: Double,
+    val infra: FullInfra? = null,
+    val mrspBuilder: CachedBlockMRSPBuilder? = null
+) {
 
     /** Data class representing a space location. Must be usable as map key. */
     data class Fingerprint(
@@ -160,6 +170,14 @@ data class VisitedNodes(val minDelay: Double) {
     // This also avoids exploring the same solutions several times with less passed steps.
     private val minPassedStepsForBlock = mutableMapOf<BlockId, Int>()
 
+    // For each detector, time ranges where it has been "reached" by a simulation,
+    // i.e. an edge ends there with these given time ranges. Ignores the lookahead.
+    // First key is the number of visited steps.
+    // Note: nodes are located at the *start* of blocks, so it's handled by accessing
+    // the start of the "current" block.
+    private val visitedAtDetector =
+        mutableMapOf<Int, MutableMap<DirDetectorId, RangeMap<Double, ConditionallyVisitedRange>>>()
+
     /** Returns true if the input has already been visited */
     fun isVisited(
         parameters: Parameters,
@@ -170,6 +188,44 @@ data class VisitedNodes(val minDelay: Double) {
         ) {
             // The block has already been seen with more passed steps
             return true
+        }
+
+        // Check if this node has a chance of opening new time ranges
+        // at the very end of the lookahead section.
+        if (parameters.explorer != null && infra != null) {
+            val lastLookaheadBlock = parameters.explorer.getLookahead().lastOrNull()
+            if (lastLookaheadBlock != null) {
+                val exitDet = infra.blockInfra.getBlockExit(infra.rawInfra, lastLookaheadBlock)
+                val mapAtStepIndex = visitedAtDetector[parameters.fingerprint!!.waypointIndex]
+                val mapAtDetector = mapAtStepIndex?.get(exitDet)
+
+                val minTravelTime =
+                    parameters.explorer.getRemainingBlocks().sumOf {
+                        mrspBuilder!!.getBlockTime(it, null)
+                    }
+                // We only check after adding the fastest travel time, and then add some extra
+                // margin at the end (in case engineering allowances are impossible there).
+                // TODO: we should compare possible "engineering allowances" in `isMapVisited`,
+                // with a large max allowance value here.
+                // The current margin (travel time) is a heuristic. Lowering it has a very large
+                // impact on the performance gain, but may block valid solutions when engineering
+                // allowances are impossible.
+                val newTimeData =
+                    parameters.timeData
+                        .withAddedTime(minTravelTime, null, null)
+                        .copy(
+                            maxDepartureDelayingWithoutConflict =
+                                parameters.timeData.maxDepartureDelayingWithoutConflict +
+                                    minTravelTime,
+                        )
+
+                if (
+                    mapAtDetector != null &&
+                        isMapVisited(mapAtDetector, parameters.copy(timeData = newTimeData))
+                ) {
+                    return true
+                }
+            }
         }
         val visitedRanges = visitedRangesPerLocation[parameters.fingerprint] ?: return false
         return isMapVisited(visitedRanges, parameters)
@@ -212,6 +268,33 @@ data class VisitedNodes(val minDelay: Double) {
             timeData.totalStopDuration,
             parameters.nodeCost,
         )
+
+        // Mark the visited time range at the start of the current block
+        if (parameters.explorer != null && infra != null && fingerprint.startOffset == 0.meters) {
+            val block = parameters.explorer.getCurrentBlock()
+            val mapAtStepIndex =
+                visitedAtDetector.getOrPut(parameters.fingerprint!!.waypointIndex) {
+                    mutableMapOf()
+                }
+            val visitedRangesAtStartOfBlock =
+                mapAtStepIndex.getOrPut(
+                    infra.blockInfra.getBlockEntry(
+                        infra.rawInfra,
+                        block,
+                    )
+                ) {
+                    TreeRangeMap.create()
+                }
+            markAsVisited(
+                visitedRangesAtStartOfBlock,
+                startTime,
+                endRangeDepartureTimeChange,
+                endRangeExtraStopTime,
+                endRangeExtraTravelTime,
+                timeData.totalStopDuration,
+                parameters.nodeCost,
+            )
+        }
     }
 
     /**

--- a/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
+++ b/core/src/main/kotlin/fr/sncf/osrd/stdcm/infra_exploration/InfraExplorer.kt
@@ -101,6 +101,13 @@ interface InfraExplorer {
     fun getStepTracker(): StepTracker
 }
 
+/** Returns the current block and the lookahead blocks */
+fun InfraExplorer.getRemainingBlocks(): List<BlockId> {
+    val res = mutableListOf(getCurrentBlock())
+    res.addAll(getLookahead())
+    return res
+}
+
 /** Used to identify an edge */
 interface EdgeIdentifier {
     override fun equals(other: Any?): Boolean
@@ -197,11 +204,7 @@ private class InfraExplorerImpl(
     }
 
     override fun getLastEdgeIdentifier(): EdgeIdentifier {
-        val currentAndRemainingBlocks = mutableStaticIdxArrayListOf<Block>()
-        for (i in currentIndex ..< blocks.size) {
-            currentAndRemainingBlocks.add(blocks[i])
-        }
-        return EdgeIdentifierImpl(currentAndRemainingBlocks)
+        return EdgeIdentifierImpl(getRemainingBlocks())
     }
 
     override fun cloneAndExtendLookahead(): Collection<InfraExplorer> {
@@ -376,7 +379,7 @@ private class InfraExplorerImpl(
     }
 }
 
-private class EdgeIdentifierImpl(private val blocks: StaticIdxList<Block>) : EdgeIdentifier {
+private class EdgeIdentifierImpl(private val blocks: List<BlockId>) : EdgeIdentifier {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         return if (other !is EdgeIdentifierImpl) false else this.blocks == other.blocks

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/VisitedNodesTests.kt
@@ -4,6 +4,8 @@ import fr.sncf.osrd.stdcm.graph.StopTimeData
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.graph.VisitedNodes
 import fr.sncf.osrd.stdcm.infra_exploration.EdgeIdentifier
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
+import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.units.meters
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -284,5 +286,73 @@ class VisitedNodesTests {
             )
         visitedNodes.markAsVisited(params1)
         assertEquals(increaseRemainingTime, visitedNodes.isVisited(params2))
+    }
+
+    @Test
+    fun testVisitedAtDetector() {
+        val infra = DummyInfra()
+        val blocks =
+            listOf(
+                infra.addBlock("a", "b"),
+                infra.addBlock("b", "c"),
+                infra.addBlock("c", "d"),
+                infra.addBlock("d", "e"),
+            )
+        val visitedNodes =
+            VisitedNodes(0.0, infra.fullInfra(), CachedBlockMRSPBuilder(infra, infra, null))
+
+        // d -> e
+        val lastExplorer = infraExplorerFromBlock(infra, infra, blocks.last())
+
+        // a -> b, lookahead: b -> c -> d
+        var explorerWithLookahead = infraExplorerFromBlock(infra, infra, blocks.first())
+        for (i in 0 ..< 2) explorerWithLookahead =
+            explorerWithLookahead.cloneAndExtendLookahead().first()
+
+        val timeData =
+            TimeData(
+                earliestReachableTime = 0.0,
+                maxDepartureDelayingWithoutConflict = 100.0,
+                timeOfNextConflictAtLocation = 100.0,
+                totalRunningTime = 0.0,
+                departureTime = 0.0,
+                stopTimeData = listOf(),
+                maxFirstDepartureDelaying = 100.0,
+            )
+        val visitingParams =
+            VisitedNodes.Parameters(
+                fingerprint = fingerprint,
+                timeData = timeData,
+                explorer = lastExplorer,
+                maxMarginDuration = 100.0,
+            )
+
+        val testParams = visitingParams.copy(explorer = explorerWithLookahead)
+
+        visitedNodes.markAsVisited(visitingParams)
+
+        // Identical parameters
+        assertTrue { visitedNodes.isVisited(testParams) }
+
+        // Arrival time is shifted later, the window isn't fully covered
+        assertFalse {
+            visitedNodes.isVisited(
+                testParams.copy(timeData = timeData.copy(earliestReachableTime = 50.0))
+            )
+        }
+
+        // Arrival time is shifted later, but the travel time is also longer.
+        // This doesn't actually open any better solution, it's considered visited.
+        assertTrue {
+            visitedNodes.isVisited(
+                testParams.copy(
+                    timeData =
+                        timeData.copy(
+                            earliestReachableTime = 50.0,
+                            totalRunningTime = 50.0,
+                        )
+                )
+            )
+        }
     }
 }

--- a/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
+++ b/core/src/test/kotlin/fr/sncf/osrd/stdcm/preprocessing/STDCMHeuristicTests.kt
@@ -11,6 +11,7 @@ import fr.sncf.osrd.stdcm.graph.STDCMEdge
 import fr.sncf.osrd.stdcm.graph.STDCMNode
 import fr.sncf.osrd.stdcm.graph.TimeData
 import fr.sncf.osrd.stdcm.infra_exploration.*
+import fr.sncf.osrd.utils.CachedBlockMRSPBuilder
 import fr.sncf.osrd.utils.DummyInfra
 import fr.sncf.osrd.utils.appendOnlyLinkedListOf
 import fr.sncf.osrd.utils.units.Distance
@@ -74,6 +75,7 @@ class STDCMHeuristicTests {
                     steps,
                     Double.POSITIVE_INFINITY,
                     STANDARD_TRAIN,
+                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                 )
                 .build()
 
@@ -151,6 +153,7 @@ class STDCMHeuristicTests {
                     steps,
                     Double.POSITIVE_INFINITY,
                     STANDARD_TRAIN,
+                    mrspBuilder = CachedBlockMRSPBuilder(infra, infra, null),
                 )
                 .build()
 


### PR DESCRIPTION
We mark visited time ranges at detectors, at places that have already been fully simulated (not just the lookahead).

We then check if new nodes open new time ranges at the very end of the lookahead. Otherwise we can discard the node and consider it "already visited".

By commit:

1. Minor bugfix on range comparaison
2. Reorganization: introduces a dedicated method to mark and check map ranges, no functional change
3. Add the extra maps and checks for detectors

There's a refacto to be done to *properly* handle engineering allowances there, but that's for a different PR : #12074 

---

Bench, reproduced on the last 32 requests logged, pandas' describe, everything in seconds:

 | | before | after | diff | relative_diff_% |
 |---|---|---|---|---|
 | count | 32.000000 | 32.000000 | 32.000000 | 32.000000 |
 | mean | 7.063562 | 5.274781 | -1.788781 | -15.305900 |
 | std | 13.796903 | 10.050358 | 4.012466 | 16.177562 |
 | min | 0.336000 | 0.335000 | -18.785000 | -55.257425 |
 | 25% | 0.954750 | 0.844000 | -1.250750 | -23.248328 |
 | 50% | 1.944500 | 1.793500 | -0.238000 | -10.807883 |
 | 75% | 7.184750 | 4.977750 | -0.093000 | -7.112761 |
 | max | 57.241000 | 43.364000 | 0.047000 | 6.491228 |