### PR TITLE
editoast: add fine error customization in Model

### DIFF
--- a/editoast/editoast_derive/src/model/args.rs
+++ b/editoast/editoast_derive/src/model/args.rs
@@ -22,7 +22,7 @@ pub(super) struct ModelArgs {
     #[darling(default)]
     pub(super) changeset: GeneratedTypeArgs,
     #[darling(default)]
-    pub(super) error: Option<syn::Path>,
+    pub(super) error: Option<ErrorArgs>,
     #[darling(multiple, rename = "identifier")]
     pub(super) identifiers: Vec<RawIdentifier>,
     #[darling(rename = "gen")]
@@ -43,6 +43,55 @@ pub(super) struct ImplPlan {
     pub(super) batch_ops: Crud,
     #[darling(default)]
     pub(super) list: bool,
+}
+
+#[derive(Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)] // yeah sure, but that's by design though...
+pub(super) enum ErrorArgs {
+    Single(syn::Path),
+    Rw(RwErrorArgs),
+    Detailed(DetailedErrorArgs),
+}
+
+impl darling::FromMeta for ErrorArgs {
+    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
+        let syn::Expr::Path(path) = expr else {
+            return Err(darling::Error::custom("expected a type").with_span(expr));
+        };
+        Ok(Self::Single(path.path.clone()))
+    }
+
+    fn from_list(items: &[ast::NestedMeta]) -> darling::Result<Self> {
+        match (
+            RwErrorArgs::from_list(items),
+            DetailedErrorArgs::from_list(items),
+        ) {
+            (Ok(rw), Err(_)) => Ok(ErrorArgs::Rw(rw)),
+            (Err(_), Ok(detail)) => Ok(ErrorArgs::Detailed(detail)),
+            (Ok(_), Ok(_)) => unreachable!(
+                "both branch cannot be parsed successfully at the same time since properties of each are disjoint sets"
+            ),
+            (Err(e), Err(f)) => Err(darling::Error::custom(format!(
+                "Model: error: expected either read/write xor create/retrieve/update/delete errors: {e}, {f}"
+            ))),
+        }
+    }
+}
+
+#[derive(FromMeta, Debug, PartialEq)]
+pub(super) struct RwErrorArgs {
+    /// retrieve and list
+    pub(super) read: Option<syn::Path>,
+    /// create, update and delete
+    pub(super) write: Option<syn::Path>,
+}
+
+#[derive(FromMeta, Debug, PartialEq)]
+pub(super) struct DetailedErrorArgs {
+    pub(super) create: Option<syn::Path>,
+    pub(super) retrieve: Option<syn::Path>,
+    pub(super) update: Option<syn::Path>,
+    pub(super) delete: Option<syn::Path>,
 }
 
 #[derive(FromMeta, Default, Debug, PartialEq)]

--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -138,7 +138,6 @@ impl ModelConfig {
             model: self.model.clone(),
             row: self.row.name.clone(),
             changeset: self.changeset.ident(),
-            error: self.error.clone(),
             table: self.table.clone(),
         }
     }
@@ -268,6 +267,7 @@ impl ModelConfig {
                     row: self.row.name.clone(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.read)
             })
@@ -283,6 +283,7 @@ impl ModelConfig {
                     table_name: self.table_name(),
                     table_mod: self.table.clone(),
                     identifier: identifier.clone(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.has_read())
             })
@@ -301,6 +302,7 @@ impl ModelConfig {
                     changeset: self.changeset.ident(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.update)
             })
@@ -316,6 +318,7 @@ impl ModelConfig {
                     table_name: self.table_name(),
                     table_mod: self.table.clone(),
                     identifier: identifier.clone(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.delete)
             })
@@ -330,6 +333,7 @@ impl ModelConfig {
             changeset: self.changeset.ident(),
             empty_changeset: self.changeset_fields().next().is_none(),
             columns: self.columns().cloned().collect(),
+            error: self.error.clone(),
         }
         .tokens_if(self.impl_plan.ops.create)
     }
@@ -339,6 +343,7 @@ impl ModelConfig {
             model: self.model.clone(),
             table_mod: self.table.clone(),
             primary_key: self.get_primary_field_ident(),
+            error: self.error.clone(),
         }
         .tokens_if(self.impl_plan.ops.delete)
     }
@@ -371,6 +376,7 @@ impl ModelConfig {
             changeset: self.changeset.ident(),
             field_count: self.changeset_fields().count(),
             columns: self.columns().cloned().collect(),
+            error: self.error.clone(),
         }
         .tokens_if(self.impl_plan.batch_ops.create)
     }
@@ -389,6 +395,7 @@ impl ModelConfig {
                     identifier: identifier.clone(),
                     field_count: self.changeset_fields().count(),
                     columns: self.columns().cloned().collect(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.create)
             })
@@ -407,6 +414,7 @@ impl ModelConfig {
                     row: self.row.name.clone(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.read)
             })
@@ -427,6 +435,7 @@ impl ModelConfig {
                     identifier: identifier.clone(),
                     primary_key_column: self.get_primary_field_column(),
                     columns: self.columns().cloned().collect(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.update)
             })
@@ -443,6 +452,7 @@ impl ModelConfig {
                     table_mod: self.table.clone(),
                     chunk_size_limit: self.batch_chunk_size_limit,
                     identifier: identifier.clone(),
+                    error: self.error.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.delete)
             })

--- a/editoast/editoast_derive/src/model/codegen.rs
+++ b/editoast/editoast_derive/src/model/codegen.rs
@@ -267,7 +267,7 @@ impl ModelConfig {
                     row: self.row.name.clone(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
-                    error: self.error.clone(),
+                    error: self.errors.retrieve.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.read)
             })
@@ -283,7 +283,7 @@ impl ModelConfig {
                     table_name: self.table_name(),
                     table_mod: self.table.clone(),
                     identifier: identifier.clone(),
-                    error: self.error.clone(),
+                    error: self.errors.retrieve.clone(),
                 }
                 .tokens_if(self.impl_plan.has_read())
             })
@@ -302,7 +302,7 @@ impl ModelConfig {
                     changeset: self.changeset.ident(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
-                    error: self.error.clone(),
+                    error: self.errors.update.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.update)
             })
@@ -318,7 +318,7 @@ impl ModelConfig {
                     table_name: self.table_name(),
                     table_mod: self.table.clone(),
                     identifier: identifier.clone(),
-                    error: self.error.clone(),
+                    error: self.errors.delete.clone(),
                 }
                 .tokens_if(self.impl_plan.ops.delete)
             })
@@ -333,7 +333,7 @@ impl ModelConfig {
             changeset: self.changeset.ident(),
             empty_changeset: self.changeset_fields().next().is_none(),
             columns: self.columns().cloned().collect(),
-            error: self.error.clone(),
+            error: self.errors.create.clone(),
         }
         .tokens_if(self.impl_plan.ops.create)
     }
@@ -343,7 +343,7 @@ impl ModelConfig {
             model: self.model.clone(),
             table_mod: self.table.clone(),
             primary_key: self.get_primary_field_ident(),
-            error: self.error.clone(),
+            error: self.errors.delete.clone(),
         }
         .tokens_if(self.impl_plan.ops.delete)
     }
@@ -376,7 +376,7 @@ impl ModelConfig {
             changeset: self.changeset.ident(),
             field_count: self.changeset_fields().count(),
             columns: self.columns().cloned().collect(),
-            error: self.error.clone(),
+            error: self.errors.create.clone(),
         }
         .tokens_if(self.impl_plan.batch_ops.create)
     }
@@ -395,7 +395,7 @@ impl ModelConfig {
                     identifier: identifier.clone(),
                     field_count: self.changeset_fields().count(),
                     columns: self.columns().cloned().collect(),
-                    error: self.error.clone(),
+                    error: self.errors.create.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.create)
             })
@@ -414,7 +414,7 @@ impl ModelConfig {
                     row: self.row.name.clone(),
                     identifier: identifier.clone(),
                     columns: self.columns().cloned().collect(),
-                    error: self.error.clone(),
+                    error: self.errors.retrieve.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.read)
             })
@@ -435,7 +435,7 @@ impl ModelConfig {
                     identifier: identifier.clone(),
                     primary_key_column: self.get_primary_field_column(),
                     columns: self.columns().cloned().collect(),
-                    error: self.error.clone(),
+                    error: self.errors.update.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.update)
             })
@@ -452,7 +452,7 @@ impl ModelConfig {
                     table_mod: self.table.clone(),
                     chunk_size_limit: self.batch_chunk_size_limit,
                     identifier: identifier.clone(),
-                    error: self.error.clone(),
+                    error: self.errors.delete.clone(),
                 }
                 .tokens_if(self.impl_plan.batch_ops.delete)
             })

--- a/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_impl.rs
@@ -12,6 +12,7 @@ pub(crate) struct CreateBatchImpl {
     pub(super) changeset: syn::Ident,
     pub(super) field_count: usize,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for CreateBatchImpl {
@@ -25,6 +26,7 @@ impl ToTokens for CreateBatchImpl {
             changeset,
             field_count,
             columns,
+            error,
         } = self;
         let span_name = format!("model:create_batch<{model}>");
 
@@ -42,17 +44,19 @@ impl ToTokens for CreateBatchImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                     .map_ok(<#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::CreateBatch for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch<
                     I: std::iter::IntoIterator<Item = #changeset> + Send,
@@ -60,7 +64,7 @@ impl ToTokens for CreateBatchImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     values: I,
-                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<C, Self::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;

--- a/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_batch_with_key_impl.rs
@@ -15,6 +15,7 @@ pub(crate) struct CreateBatchWithKeyImpl {
     pub(super) field_count: usize,
     pub(super) identifier: Identifier,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for CreateBatchWithKeyImpl {
@@ -29,6 +30,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
             field_count,
             identifier,
             columns,
+            error,
         } = self;
         let ty = identifier.get_type();
         let span_name = format!("model:create_batch_with_key<{model}>");
@@ -47,20 +49,22 @@ impl ToTokens for CreateBatchWithKeyImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                     .map_ok(|row| {
                         let model = <#model as Model>::from_row(row);
                         (model.get_id(), model)
                     })
                     .try_collect::<Vec<_>>()
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::CreateBatchWithKey<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create_batch_with_key<
                     I: std::iter::IntoIterator<Item = #changeset> + Send,
@@ -68,7 +72,7 @@ impl ToTokens for CreateBatchWithKeyImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     values: I,
-                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<C, Self::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use std::ops::DerefMut;

--- a/editoast/editoast_derive/src/model/codegen/create_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/create_impl.rs
@@ -8,6 +8,7 @@ pub(crate) struct CreateImpl {
     pub(super) changeset: syn::Ident,
     pub(super) empty_changeset: bool,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for CreateImpl {
@@ -19,6 +20,7 @@ impl ToTokens for CreateImpl {
             changeset,
             empty_changeset,
             columns,
+            error,
         } = self;
         let span_name = format!("model:create<{model}>");
 
@@ -32,11 +34,13 @@ impl ToTokens for CreateImpl {
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::Create<#model> for #changeset {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err)]
                 async fn create(
                     self,
                     conn: &mut editoast_models::DbConnection,
-                ) -> std::result::Result<#model, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<#model, Self::Error> {
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
                     use std::ops::DerefMut;
@@ -46,7 +50,7 @@ impl ToTokens for CreateImpl {
                         .get_result::<#row>(conn.write().await.deref_mut())
                         .await
                         .map(Into::into)
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/delete_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_batch_impl.rs
@@ -12,6 +12,7 @@ pub(crate) struct DeleteBatchImpl {
     pub(super) table_mod: syn::Path,
     pub(super) chunk_size_limit: usize,
     pub(super) identifier: Identifier,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for DeleteBatchImpl {
@@ -22,6 +23,7 @@ impl ToTokens for DeleteBatchImpl {
             table_mod,
             chunk_size_limit,
             identifier,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -43,18 +45,20 @@ impl ToTokens for DeleteBatchImpl {
                 query
                     .execute(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::DeleteBatch<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_ids))]
                 async fn delete_batch<I: std::iter::IntoIterator<Item = #ty> + Send>(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> std::result::Result<usize, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<usize, Self::Error> {
                     use #table_mod::dsl;
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;

--- a/editoast/editoast_derive/src/model/codegen/delete_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_impl.rs
@@ -5,6 +5,7 @@ pub(crate) struct DeleteImpl {
     pub(super) model: syn::Ident,
     pub(super) table_mod: syn::Path,
     pub(super) primary_key: syn::Ident,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for DeleteImpl {
@@ -13,17 +14,20 @@ impl ToTokens for DeleteImpl {
             model,
             table_mod,
             primary_key,
+            error,
         } = self;
         let span_name = format!("model:delete<{model}>");
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::Delete for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id = ?self.#primary_key))]
                 async fn delete(
                     &self,
                     conn: &mut editoast_models::DbConnection,
-                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<bool, Self::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
@@ -33,7 +37,7 @@ impl ToTokens for DeleteImpl {
                         .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/delete_static_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/delete_static_impl.rs
@@ -8,6 +8,7 @@ pub(crate) struct DeleteStaticImpl {
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
     pub(super) identifier: Identifier,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for DeleteStaticImpl {
@@ -17,6 +18,7 @@ impl ToTokens for DeleteStaticImpl {
             table_name,
             table_mod,
             identifier,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -27,11 +29,13 @@ impl ToTokens for DeleteStaticImpl {
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::DeleteStatic<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn delete_static(
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<bool, Self::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -41,7 +45,7 @@ impl ToTokens for DeleteStaticImpl {
                         .execute(conn.write().await.deref_mut())
                         .await
                         .map(|n| n == 1)
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/exists_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/exists_impl.rs
@@ -8,6 +8,7 @@ pub(crate) struct ExistsImpl {
     pub(super) table_name: syn::Ident,
     pub(super) table_mod: syn::Path,
     pub(super) identifier: Identifier,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for ExistsImpl {
@@ -17,6 +18,7 @@ impl ToTokens for ExistsImpl {
             table_name,
             table_mod,
             identifier,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -27,11 +29,13 @@ impl ToTokens for ExistsImpl {
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::Exists<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, ret, err, fields(query_id))]
                 async fn exists(
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> std::result::Result<bool, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<bool, Self::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -40,7 +44,7 @@ impl ToTokens for ExistsImpl {
                     diesel::select(diesel::dsl::exists(dsl::#table_name.#(filter(#eqs)).*))
                         .get_result(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/model_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/model_impl.rs
@@ -5,7 +5,6 @@ pub(crate) struct ModelImpl {
     pub(super) model: syn::Ident,
     pub(super) row: syn::Ident,
     pub(super) changeset: syn::Ident,
-    pub(super) error: syn::Path,
     pub(super) table: syn::Path,
 }
 
@@ -15,7 +14,6 @@ impl ToTokens for ModelImpl {
             model,
             row,
             changeset,
-            error,
             table,
         } = self;
         tokens.extend(quote! {
@@ -24,7 +22,6 @@ impl ToTokens for ModelImpl {
                 type Row = #row;
                 type Changeset = #changeset;
                 type Table = #table::table;
-                type Error = #error;
             }
         });
     }

--- a/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_batch_impl.rs
@@ -13,6 +13,7 @@ pub(crate) struct RetrieveBatchImpl {
     pub(super) row: syn::Ident,
     pub(super) identifier: Identifier,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for RetrieveBatchImpl {
@@ -25,6 +26,7 @@ impl ToTokens for RetrieveBatchImpl {
             row,
             identifier,
             columns,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -53,11 +55,11 @@ impl ToTokens for RetrieveBatchImpl {
                     .select((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                     .map_ok(<#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
@@ -70,19 +72,21 @@ impl ToTokens for RetrieveBatchImpl {
                 .select((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                 .map_ok(|row| {
                     let model = <#model as Model>::from_row(row);
                     (model.get_id(), model)
                 })
                 .try_collect::<Vec<_>>()
                 .await
-                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
         });
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::RetrieveBatchUnchecked<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send,
@@ -90,7 +94,7 @@ impl ToTokens for RetrieveBatchImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<C, Self::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use diesel::prelude::*;
@@ -109,7 +113,7 @@ impl ToTokens for RetrieveBatchImpl {
                 >(
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> std::result::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<C, Self::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use #table_mod::dsl;

--- a/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/retrieve_impl.rs
@@ -10,6 +10,7 @@ pub(crate) struct RetrieveImpl {
     pub(super) row: syn::Ident,
     pub(super) identifier: Identifier,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for RetrieveImpl {
@@ -21,6 +22,7 @@ impl ToTokens for RetrieveImpl {
             row,
             identifier,
             columns,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -31,11 +33,13 @@ impl ToTokens for RetrieveImpl {
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::Retrieve<#ty> for #model {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn retrieve_real(
                     conn: editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> std::result::Result<Option<#model>, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<Option<#model>, Self::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use #table_mod::dsl;
@@ -48,7 +52,7 @@ impl ToTokens for RetrieveImpl {
                         .await
                         .map(#model::from)
                         .optional()
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_batch_impl.rs
@@ -16,6 +16,7 @@ pub(crate) struct UpdateBatchImpl {
     pub(super) identifier: Identifier,
     pub(super) primary_key_column: syn::Ident,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for UpdateBatchImpl {
@@ -30,6 +31,7 @@ impl ToTokens for UpdateBatchImpl {
             changeset,
             primary_key_column,
             columns,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -60,11 +62,11 @@ impl ToTokens for UpdateBatchImpl {
                     .returning((#(dsl::#columns,)*))
                     .load_stream::<#row>(conn.write().await.deref_mut())
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                     .map_ok(<#model as Model>::from_row)
                     .try_collect::<Vec<_>>()
                     .await
-                    .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                    .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
             },
         };
 
@@ -79,19 +81,21 @@ impl ToTokens for UpdateBatchImpl {
                 .returning((#(dsl::#columns,)*))
                 .load_stream::<#row>(conn.write().await.deref_mut())
                 .await
-                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
                 .map_ok(|row| {
                     let model = <#model as Model>::from_row(row);
                     (model.get_id(), model)
                 })
                 .try_collect::<Vec<_>>()
                 .await
-                .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))?
+                .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))?
         });
 
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::UpdateBatchUnchecked<#model, #ty> for #changeset {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_ids))]
                 async fn update_batch_unchecked<
                     I: std::iter::IntoIterator<Item = #ty> + Send,
@@ -100,7 +104,7 @@ impl ToTokens for UpdateBatchImpl {
                     self,
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> crate::error::Result<C, Self::Error> {
                     use crate::models::Model;
                     use #table_mod::dsl;
                     use diesel::prelude::*;
@@ -121,7 +125,7 @@ impl ToTokens for UpdateBatchImpl {
                     self,
                     conn: &mut editoast_models::DbConnection,
                     ids: I,
-                ) -> crate::error::Result<C, <#model as crate::models::Model>::Error> {
+                ) -> crate::error::Result<C, Self::Error> {
                     use crate::models::Identifiable;
                     use crate::models::Model;
                     use #table_mod::dsl;

--- a/editoast/editoast_derive/src/model/codegen/update_impl.rs
+++ b/editoast/editoast_derive/src/model/codegen/update_impl.rs
@@ -11,6 +11,7 @@ pub(crate) struct UpdateImpl {
     pub(super) changeset: syn::Ident,
     pub(super) identifier: Identifier,
     pub(super) columns: Vec<syn::Ident>,
+    pub(super) error: syn::Path,
 }
 
 impl ToTokens for UpdateImpl {
@@ -23,6 +24,7 @@ impl ToTokens for UpdateImpl {
             changeset,
             identifier,
             columns,
+            error,
         } = self;
         let ty = identifier.get_type();
         let id_ident = identifier.get_lvalue();
@@ -33,12 +35,14 @@ impl ToTokens for UpdateImpl {
         tokens.extend(quote! {
             #[automatically_derived]
             impl crate::models::Update<#ty, #model> for #changeset {
+                type Error = #error;
+
                 #[tracing::instrument(name = #span_name, skip_all, err, fields(query_id))]
                 async fn update(
                     self,
                     conn: &mut editoast_models::DbConnection,
                     #id_ident: #ty,
-                ) -> std::result::Result<Option<#model>, <#model as crate::models::Model>::Error> {
+                ) -> std::result::Result<Option<#model>, Self::Error> {
                     use diesel::prelude::*;
                     use diesel_async::RunQueryDsl;
                     use std::ops::DerefMut;
@@ -51,7 +55,7 @@ impl ToTokens for UpdateImpl {
                         .await
                         .map(Into::into)
                         .optional()
-                        .map_err(|e| <#model as crate::models::Model>::Error::from(editoast_models::model::Error::from(e)))
+                        .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
                 }
             }
         });

--- a/editoast/editoast_derive/src/model/config.rs
+++ b/editoast/editoast_derive/src/model/config.rs
@@ -18,7 +18,7 @@ pub(crate) struct ModelConfig {
     pub(crate) fields: Fields,
     pub(crate) row: Row,
     pub(crate) changeset: Changeset,
-    pub(crate) error: syn::Path,
+    pub(crate) errors: Errors,
     pub(crate) identifiers: BTreeSet<Identifier>, // identifiers ⊆ fields
     pub(crate) preferred_identifier: Identifier,  // preferred_identifier ∈ identifiers
     pub(crate) primary_identifier: Identifier,    // primary_identifier ∈ identifiers
@@ -60,6 +60,14 @@ pub(crate) enum FieldTransformation {
     ToString,
     ToEnum(syn::Type),
     UomUnit(syn::Path),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct Errors {
+    pub(crate) create: syn::Path,
+    pub(crate) retrieve: syn::Path,
+    pub(crate) update: syn::Path,
+    pub(crate) delete: syn::Path,
 }
 
 #[derive(Debug, PartialEq)]

--- a/editoast/editoast_derive/src/model/parsing.rs
+++ b/editoast/editoast_derive/src/model/parsing.rs
@@ -9,11 +9,15 @@ use super::FieldTransformation;
 use super::Fields;
 use super::ModelConfig;
 use super::ModelField;
+use super::args::DetailedErrorArgs;
+use super::args::ErrorArgs;
 use super::args::GeneratedTypeArgs;
 use super::args::ImplPlan;
 use super::args::ModelArgs;
 use super::args::ModelFieldArgs;
+use super::args::RwErrorArgs;
 use super::config::Changeset;
+use super::config::Errors;
 use super::config::Row;
 use super::crud::Crud;
 use super::identifier::Identifier;
@@ -220,9 +224,10 @@ impl ModelConfig {
             fields,
             row,
             changeset,
-            error: options
+            errors: options
                 .error
-                .unwrap_or(syn::parse_quote! { editoast_models::model::Error }),
+                .map(Errors::from_args)
+                .unwrap_or_else(|| Ok(Errors::default()))?,
             identifiers: typed_identifiers,
             preferred_identifier: preferred_typed_identifier,
             primary_identifier: primary_typed_identifier,
@@ -289,6 +294,62 @@ impl FieldTransformation {
             _ => Err(Error::custom(
                 "Model: remote, json, geo, to_string, to_enum and uom_unit attributes are mutually exclusive",
             )),
+        }
+    }
+}
+
+impl Errors {
+    fn from_args(args: ErrorArgs) -> darling::Result<Self> {
+        match args {
+            ErrorArgs::Single(path) => Ok(Self {
+                create: path.clone(),
+                retrieve: path.clone(),
+                update: path.clone(),
+                delete: path,
+            }),
+            ErrorArgs::Rw(RwErrorArgs { read, write, .. }) => {
+                let Errors {
+                    retrieve, create, ..
+                } = Errors::default();
+                let read = read.unwrap_or(retrieve);
+                let write = write.unwrap_or(create);
+                Ok(Self {
+                    retrieve: read,
+                    create: write.clone(),
+                    update: write.clone(),
+                    delete: write,
+                })
+            }
+            ErrorArgs::Detailed(DetailedErrorArgs {
+                create,
+                retrieve,
+                update,
+                delete,
+            }) => {
+                let Errors {
+                    create: default_create,
+                    retrieve: default_retrieve,
+                    update: default_update,
+                    delete: default_delete,
+                } = Errors::default();
+                Ok(Self {
+                    retrieve: retrieve.unwrap_or(default_retrieve),
+                    create: create.unwrap_or(default_create),
+                    update: update.unwrap_or(default_update),
+                    delete: delete.unwrap_or(default_delete),
+                })
+            }
+        }
+    }
+}
+
+impl Default for Errors {
+    fn default() -> Self {
+        Self {
+            create: syn::parse_quote! { editoast_models::model::Error },
+            retrieve: syn::parse_quote! { editoast_models::model::Error },
+            update: syn::parse_quote! { editoast_models::model::Error },
+            delete: syn::parse_quote! { editoast_models::model::Error },
         }
     }
 }

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__construction.snap
@@ -25,7 +25,6 @@ impl crate::models::Model for Document {
     type Row = DocumentRow;
     type Changeset = DocumentChangeset;
     type Table = editoast_models::tables::osrd_infra_document::table;
-    type Error = editoast_models::model::Error;
 }
 paste::paste! {
     impl Document { pub const [< id_ : snake : upper >] : crate ::models::ModelField <
@@ -236,6 +235,7 @@ impl<'a> crate::models::Patch<'a, Document> {
 }
 #[automatically_derived]
 impl crate::models::Exists<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:exists<Document>",
         skip_all,
@@ -246,7 +246,7 @@ impl crate::models::Exists<(String)> for Document {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -260,13 +260,12 @@ impl crate::models::Exists<(String)> for Document {
             )
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Exists<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:exists<Document>",
         skip_all,
@@ -277,7 +276,7 @@ impl crate::models::Exists<(i64)> for Document {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -288,13 +287,12 @@ impl crate::models::Exists<(i64)> for Document {
             )
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Retrieve<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve<Document>",
         skip_all,
@@ -304,10 +302,7 @@ impl crate::models::Retrieve<(String)> for Document {
     async fn retrieve_real(
         conn: editoast_models::DbConnection,
         content_type: (String),
-    ) -> std::result::Result<
-        Option<Document>,
-        <Document as crate::models::Model>::Error,
-    > {
+    ) -> std::result::Result<Option<Document>, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -321,13 +316,12 @@ impl crate::models::Retrieve<(String)> for Document {
             .await
             .map(Document::from)
             .optional()
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Retrieve<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve<Document>",
         skip_all,
@@ -337,10 +331,7 @@ impl crate::models::Retrieve<(i64)> for Document {
     async fn retrieve_real(
         conn: editoast_models::DbConnection,
         id_: (i64),
-    ) -> std::result::Result<
-        Option<Document>,
-        <Document as crate::models::Model>::Error,
-    > {
+    ) -> std::result::Result<Option<Document>, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -353,13 +344,12 @@ impl crate::models::Retrieve<(i64)> for Document {
             .await
             .map(Document::from)
             .optional()
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Update<(String), Document> for DocumentChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:update<Document>",
         skip_all,
@@ -370,10 +360,7 @@ impl crate::models::Update<(String), Document> for DocumentChangeset {
         self,
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> std::result::Result<
-        Option<Document>,
-        <Document as crate::models::Model>::Error,
-    > {
+    ) -> std::result::Result<Option<Document>, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -389,13 +376,12 @@ impl crate::models::Update<(String), Document> for DocumentChangeset {
             .await
             .map(Into::into)
             .optional()
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Update<(i64), Document> for DocumentChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:update<Document>",
         skip_all,
@@ -406,10 +392,7 @@ impl crate::models::Update<(i64), Document> for DocumentChangeset {
         self,
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> std::result::Result<
-        Option<Document>,
-        <Document as crate::models::Model>::Error,
-    > {
+    ) -> std::result::Result<Option<Document>, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -422,13 +405,12 @@ impl crate::models::Update<(i64), Document> for DocumentChangeset {
             .await
             .map(Into::into)
             .optional()
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::DeleteStatic<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_static<Document>",
         skip_all,
@@ -439,7 +421,7 @@ impl crate::models::DeleteStatic<(String)> for Document {
     async fn delete_static(
         conn: &mut editoast_models::DbConnection,
         content_type: (String),
-    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -452,13 +434,12 @@ impl crate::models::DeleteStatic<(String)> for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::DeleteStatic<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_static<Document>",
         skip_all,
@@ -469,7 +450,7 @@ impl crate::models::DeleteStatic<(i64)> for Document {
     async fn delete_static(
         conn: &mut editoast_models::DbConnection,
         id_: (i64),
-    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -479,18 +460,17 @@ impl crate::models::DeleteStatic<(i64)> for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Create<Document> for DocumentChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(name = "model:create<Document>", skip_all, err)]
     async fn create(
         self,
         conn: &mut editoast_models::DbConnection,
-    ) -> std::result::Result<Document, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<Document, Self::Error> {
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
@@ -500,13 +480,12 @@ impl crate::models::Create<Document> for DocumentChangeset {
             .get_result::<DocumentRow>(conn.write().await.deref_mut())
             .await
             .map(Into::into)
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Delete for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete<Document>",
         skip_all,
@@ -517,7 +496,7 @@ impl crate::models::Delete for Document {
     async fn delete(
         &self,
         conn: &mut editoast_models::DbConnection,
-    ) -> std::result::Result<bool, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -527,9 +506,7 @@ impl crate::models::Delete for Document {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(|e| <Document as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
@@ -626,6 +603,7 @@ impl crate::models::prelude::Count for Document {
 }
 #[automatically_derived]
 impl crate::models::CreateBatch for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(name = "model:create_batch<Document>", skip_all, err)]
     async fn create_batch<
         I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
@@ -633,7 +611,7 @@ impl crate::models::CreateBatch for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         values: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use std::ops::DerefMut;
@@ -654,13 +632,13 @@ impl crate::models::CreateBatch for Document {
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Document as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -672,6 +650,7 @@ impl crate::models::CreateBatch for Document {
 }
 #[automatically_derived]
 impl crate::models::CreateBatchWithKey<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(name = "model:create_batch_with_key<Document>", skip_all, err)]
     async fn create_batch_with_key<
         I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
@@ -679,7 +658,7 @@ impl crate::models::CreateBatchWithKey<(String)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         values: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use std::ops::DerefMut;
@@ -701,7 +680,7 @@ impl crate::models::CreateBatchWithKey<(String)> for Document {
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -710,7 +689,7 @@ impl crate::models::CreateBatchWithKey<(String)> for Document {
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -722,6 +701,7 @@ impl crate::models::CreateBatchWithKey<(String)> for Document {
 }
 #[automatically_derived]
 impl crate::models::CreateBatchWithKey<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(name = "model:create_batch_with_key<Document>", skip_all, err)]
     async fn create_batch_with_key<
         I: std::iter::IntoIterator<Item = DocumentChangeset> + Send,
@@ -729,7 +709,7 @@ impl crate::models::CreateBatchWithKey<(i64)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         values: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use std::ops::DerefMut;
@@ -751,7 +731,7 @@ impl crate::models::CreateBatchWithKey<(i64)> for Document {
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -760,7 +740,7 @@ impl crate::models::CreateBatchWithKey<(i64)> for Document {
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -772,6 +752,7 @@ impl crate::models::CreateBatchWithKey<(i64)> for Document {
 }
 #[automatically_derived]
 impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Document>",
         skip_all,
@@ -784,7 +765,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -809,13 +790,13 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Document as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -836,7 +817,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -862,7 +843,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -871,7 +852,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -883,6 +864,7 @@ impl crate::models::RetrieveBatchUnchecked<(String)> for Document {
 }
 #[automatically_derived]
 impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Document>",
         skip_all,
@@ -895,7 +877,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -920,13 +902,13 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Document as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -947,7 +929,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -973,7 +955,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
                         .select((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -982,7 +964,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -994,6 +976,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Document {
 }
 #[automatically_derived]
 impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:update_batch_unchecked<Document>",
         skip_all,
@@ -1007,7 +990,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> crate::error::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -1037,13 +1020,13 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Document as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -1065,7 +1048,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> crate::error::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -1096,7 +1079,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -1105,7 +1088,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -1117,6 +1100,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (String)> for DocumentChanges
 }
 #[automatically_derived]
 impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:update_batch_unchecked<Document>",
         skip_all,
@@ -1130,7 +1114,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> crate::error::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
@@ -1160,13 +1144,13 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Document as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -1188,7 +1172,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
         self,
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> crate::error::Result<C, <Document as crate::models::Model>::Error> {
+    ) -> crate::error::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::osrd_infra_document::dsl;
@@ -1219,7 +1203,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
                         .returning((dsl::id, dsl::content_type, dsl::data))
                         .load_stream::<DocumentRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -1228,7 +1212,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -1240,6 +1224,7 @@ impl crate::models::UpdateBatchUnchecked<Document, (i64)> for DocumentChangeset 
 }
 #[automatically_derived]
 impl crate::models::DeleteBatch<(String)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_batch<Document>",
         skip_all,
@@ -1250,7 +1235,7 @@ impl crate::models::DeleteBatch<(String)> for Document {
     async fn delete_batch<I: std::iter::IntoIterator<Item = (String)> + Send>(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<usize, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<usize, Self::Error> {
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
@@ -1273,7 +1258,7 @@ impl crate::models::DeleteBatch<(String)> for Document {
                     query
                         .execute(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -1286,6 +1271,7 @@ impl crate::models::DeleteBatch<(String)> for Document {
 }
 #[automatically_derived]
 impl crate::models::DeleteBatch<(i64)> for Document {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_batch<Document>",
         skip_all,
@@ -1296,7 +1282,7 @@ impl crate::models::DeleteBatch<(i64)> for Document {
     async fn delete_batch<I: std::iter::IntoIterator<Item = (i64)> + Send>(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<usize, <Document as crate::models::Model>::Error> {
+    ) -> std::result::Result<usize, Self::Error> {
         use editoast_models::tables::osrd_infra_document::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
@@ -1319,7 +1305,7 @@ impl crate::models::DeleteBatch<(i64)> for Document {
                     query
                         .execute(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Document as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };

--- a/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
+++ b/editoast/editoast_derive/src/snapshots/editoast_derive__model__tests__single_pk_model.snap
@@ -19,7 +19,6 @@ impl crate::models::Model for Timetable {
     type Row = TimetableRow;
     type Changeset = TimetableChangeset;
     type Table = editoast_models::tables::timetable::table;
-    type Error = editoast_models::model::Error;
 }
 paste::paste! {
     impl Timetable { pub const [< id : snake : upper >] : crate ::models::ModelField <
@@ -90,6 +89,7 @@ impl From<Timetable> for TimetableChangeset {
 impl TimetableChangeset {}
 #[automatically_derived]
 impl crate::models::Exists<(i64)> for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:exists<Timetable>",
         skip_all,
@@ -100,7 +100,7 @@ impl crate::models::Exists<(i64)> for Timetable {
     async fn exists(
         conn: &mut editoast_models::DbConnection,
         id: (i64),
-    ) -> std::result::Result<bool, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -109,13 +109,12 @@ impl crate::models::Exists<(i64)> for Timetable {
         diesel::select(diesel::dsl::exists(dsl::timetable.filter(dsl::id.eq(id))))
             .get_result(conn.write().await.deref_mut())
             .await
-            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Retrieve<(i64)> for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve<Timetable>",
         skip_all,
@@ -125,10 +124,7 @@ impl crate::models::Retrieve<(i64)> for Timetable {
     async fn retrieve_real(
         conn: editoast_models::DbConnection,
         id: (i64),
-    ) -> std::result::Result<
-        Option<Timetable>,
-        <Timetable as crate::models::Model>::Error,
-    > {
+    ) -> std::result::Result<Option<Timetable>, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::timetable::dsl;
@@ -141,13 +137,12 @@ impl crate::models::Retrieve<(i64)> for Timetable {
             .await
             .map(Timetable::from)
             .optional()
-            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::DeleteStatic<(i64)> for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_static<Timetable>",
         skip_all,
@@ -158,7 +153,7 @@ impl crate::models::DeleteStatic<(i64)> for Timetable {
     async fn delete_static(
         conn: &mut editoast_models::DbConnection,
         id: (i64),
-    ) -> std::result::Result<bool, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use std::ops::DerefMut;
@@ -168,18 +163,17 @@ impl crate::models::DeleteStatic<(i64)> for Timetable {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Create<Timetable> for TimetableChangeset {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(name = "model:create<Timetable>", skip_all, err)]
     async fn create(
         self,
         conn: &mut editoast_models::DbConnection,
-    ) -> std::result::Result<Timetable, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<Timetable, Self::Error> {
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::timetable::dsl;
         use std::ops::DerefMut;
@@ -189,13 +183,12 @@ impl crate::models::Create<Timetable> for TimetableChangeset {
             .get_result::<TimetableRow>(conn.write().await.deref_mut())
             .await
             .map(Into::into)
-            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
 impl crate::models::Delete for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete<Timetable>",
         skip_all,
@@ -206,7 +199,7 @@ impl crate::models::Delete for Timetable {
     async fn delete(
         &self,
         conn: &mut editoast_models::DbConnection,
-    ) -> std::result::Result<bool, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<bool, Self::Error> {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
         use editoast_models::tables::timetable::dsl;
@@ -216,9 +209,7 @@ impl crate::models::Delete for Timetable {
             .execute(conn.write().await.deref_mut())
             .await
             .map(|n| n == 1)
-            .map_err(|e| <Timetable as crate::models::Model>::Error::from(
-                editoast_models::model::Error::from(e),
-            ))
+            .map_err(|e| Self::Error::from(editoast_models::model::Error::from(e)))
     }
 }
 #[automatically_derived]
@@ -315,6 +306,7 @@ impl crate::models::prelude::Count for Timetable {
 }
 #[automatically_derived]
 impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:retrieve_batch_unchecked<Timetable>",
         skip_all,
@@ -327,7 +319,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Model;
         use editoast_models::tables::timetable::dsl;
         use diesel::prelude::*;
@@ -352,13 +344,13 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(<Timetable as Model>::from_row)
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -379,7 +371,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
     >(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<C, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<C, Self::Error> {
         use crate::models::Identifiable;
         use crate::models::Model;
         use editoast_models::tables::timetable::dsl;
@@ -405,7 +397,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
                         .select((dsl::id,))
                         .load_stream::<TimetableRow>(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                         .map_ok(|row| {
@@ -414,7 +406,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
                         })
                         .try_collect::<Vec<_>>()
                         .await
-                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };
@@ -426,6 +418,7 @@ impl crate::models::RetrieveBatchUnchecked<(i64)> for Timetable {
 }
 #[automatically_derived]
 impl crate::models::DeleteBatch<(i64)> for Timetable {
+    type Error = editoast_models::model::Error;
     #[tracing::instrument(
         name = "model:delete_batch<Timetable>",
         skip_all,
@@ -436,7 +429,7 @@ impl crate::models::DeleteBatch<(i64)> for Timetable {
     async fn delete_batch<I: std::iter::IntoIterator<Item = (i64)> + Send>(
         conn: &mut editoast_models::DbConnection,
         ids: I,
-    ) -> std::result::Result<usize, <Timetable as crate::models::Model>::Error> {
+    ) -> std::result::Result<usize, Self::Error> {
         use editoast_models::tables::timetable::dsl;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
@@ -458,7 +451,7 @@ impl crate::models::DeleteBatch<(i64)> for Timetable {
                     query
                         .execute(conn.write().await.deref_mut())
                         .await
-                        .map_err(|e| <Timetable as crate::models::Model>::Error::from(
+                        .map_err(|e| Self::Error::from(
                             editoast_models::model::Error::from(e),
                         ))?
                 };

--- a/editoast/src/client/stdcm_search_env_commands.rs
+++ b/editoast/src/client/stdcm_search_env_commands.rs
@@ -48,7 +48,7 @@ async fn check_exists<T>(
 ) -> Result<(), Box<dyn Error + Send + Sync>>
 where
     T: Exists<i64>,
-    <T as Model>::Error: Sync + 'static,
+    <T as Exists<i64>>::Error: Sync + 'static,
 {
     if !T::exists(conn, object_id).await? {
         let err_msg = format!("❌ {readable_name} not found, id: {object_id}");

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -17,6 +17,7 @@ use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use editoast_models::model;
 use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
@@ -105,7 +106,7 @@ impl Infra {
             .collect()
     }
 
-    pub async fn bump_version(&mut self, conn: &mut DbConnection) -> Result<(), ModelError<Self>> {
+    pub async fn bump_version(&mut self, conn: &mut DbConnection) -> Result<(), model::Error> {
         self.version += 1;
         self.modified = Utc::now();
         self.save(conn).await
@@ -114,7 +115,7 @@ impl Infra {
     pub async fn bump_generated_version(
         &mut self,
         conn: &mut DbConnection,
-    ) -> Result<(), ModelError<Self>> {
+    ) -> Result<(), model::Error> {
         self.generated_version = Some(self.version);
         self.save(conn).await
     }

--- a/editoast/src/models/prelude/create.rs
+++ b/editoast/src/models/prelude/create.rs
@@ -13,12 +13,14 @@ use super::Model;
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
 pub trait Create<M: Model>: Sized {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Creates a new row in the database with the values of the changeset and
     /// returns the created model instance
-    async fn create(self, conn: &mut DbConnection) -> Result<M, M::Error>;
+    async fn create(self, conn: &mut DbConnection) -> Result<M, Self::Error>;
 
     /// Just like [Create::create] but discards the error if any and returns `Err(fail())` instead
-    async fn create_or_fail<E: From<M::Error>, F: FnOnce() -> E + Send>(
+    async fn create_or_fail<E: From<Self::Error>, F: FnOnce() -> E + Send>(
         self,
         conn: &mut DbConnection,
         fail: F,
@@ -35,6 +37,8 @@ pub trait Create<M: Model>: Sized {
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
 pub trait CreateBatch: Model {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Creates a batch of rows in the database given an iterator of changesets
     ///
     /// Returns a collection of the created rows.
@@ -68,6 +72,8 @@ pub trait CreateBatchWithKey<K>: Model
 where
     K: Send + Clone,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Just like [CreateBatch::create_batch] but the returned models are paired with their key
     async fn create_batch_with_key<
         I: IntoIterator<Item = Self::Changeset> + Send,

--- a/editoast/src/models/prelude/delete.rs
+++ b/editoast/src/models/prelude/delete.rs
@@ -12,6 +12,8 @@ use super::Model;
 /// You can implement this type manually but its recommended to use the `Model`
 /// derive macro instead.
 pub trait Delete: Model {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Deletes the row corresponding to this model instance
     ///
     /// Returns `true` if the row was deleted, `false` if it didn't exist
@@ -42,6 +44,8 @@ pub trait DeleteStatic<K>: Model
 where
     K: Send,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Deletes the row #`id` from the database
     async fn delete_static(
         conn: &mut DbConnection,
@@ -70,6 +74,8 @@ pub trait DeleteBatch<K>: Model
 where
     K: Send,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Deletes a batch of rows from the database given an iterator of keys
     ///
     /// Returns the number of rows deleted.

--- a/editoast/src/models/prelude/mod.rs
+++ b/editoast/src/models/prelude/mod.rs
@@ -31,7 +31,6 @@ pub trait Model: std::fmt::Debug + Clone + Sized + Send {
     type Row: Into<Self> + Send;
     type Changeset: Default + From<Self> + Send;
     type Table: diesel::Table + Send;
-    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
 
     /// Returns an empty changeset for this model
     fn changeset() -> Self::Changeset {
@@ -65,11 +64,6 @@ pub type Row<M> = <M as Model>::Row;
 ///
 /// Helps silent compiler errors about type ambiguity.
 pub type Changeset<M> = <M as Model>::Changeset;
-
-/// A type alias for the [Model::Error] associated type
-///
-/// Helps silent compiler errors about type ambiguity.
-pub type ModelError<M> = <M as Model>::Error;
 
 /// A struct persisting the column and type information of each model field
 ///

--- a/editoast/src/models/prelude/retrieve.rs
+++ b/editoast/src/models/prelude/retrieve.rs
@@ -18,6 +18,8 @@ where
     K: Send,
     Self: Send,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     #[deprecated = "use Retrieve::retrieve_real instead"]
     async fn retrieve(conn: &mut DbConnection, id: K) -> Result<Option<Self>> {
         match Self::retrieve_real(conn.clone(), id).await {
@@ -74,6 +76,8 @@ where
     K: Send,
     Self: Send,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Returns whether the row #`id` exists in the database
     async fn exists(conn: &mut DbConnection, id: K) -> Result<bool, Self::Error>;
 
@@ -103,6 +107,8 @@ where
     K: Send + Debug,
     Self: Send,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Retrieves a batch of rows from the database given an iterator of keys
     ///
     /// Returns a collection of the retrieved rows. That collection can contain

--- a/editoast/src/models/prelude/update.rs
+++ b/editoast/src/models/prelude/update.rs
@@ -6,7 +6,6 @@ use editoast_models::DbConnection;
 use crate::models::PreferredId;
 
 use super::Model;
-use super::ModelError;
 
 /// A couple ([Model] mutable reference, a [Model] changeset instance)
 ///
@@ -44,7 +43,10 @@ impl<M: Model> Patch<'_, M> {
     ///
     /// If this method is not implemented for your model for whatever reason, just
     /// use [Save::save].
-    pub async fn apply<K>(self, conn: &mut DbConnection) -> Result<(), M::Error>
+    pub async fn apply<K>(
+        self,
+        conn: &mut DbConnection,
+    ) -> Result<(), <<M as Model>::Changeset as Update<K, M>>::Error>
     where
         for<'b> K: Send + Clone + 'b,
         M: Model + PreferredId<K> + Send,
@@ -54,7 +56,9 @@ impl<M: Model> Patch<'_, M> {
         let updated: M = self
             .changeset
             .update_or_fail(conn, id, || {
-                M::Error::from(editoast_models::model::Error::from(NotFound))
+                <<M as Model>::Changeset as Update<K, M>>::Error::from(
+                    editoast_models::model::Error::from(NotFound),
+                )
             })
             .await?;
         *self.model = updated;
@@ -74,13 +78,15 @@ where
     K: Send,
     M: Model,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Updates the row #`id` with the changeset values and returns the updated model
-    async fn update(self, conn: &mut DbConnection, id: K) -> Result<Option<M>, M::Error>;
+    async fn update(self, conn: &mut DbConnection, id: K) -> Result<Option<M>, Self::Error>;
 
     /// Just like [Update::update] but returns `Err(fail())` if the row was not found
     async fn update_or_fail<E, F>(self, conn: &mut DbConnection, id: K, fail: F) -> Result<M, E>
     where
-        E: From<M::Error>,
+        E: From<Self::Error>,
         F: FnOnce() -> E + Send,
     {
         match self.update(conn, id).await {
@@ -96,6 +102,8 @@ where
 /// This trait is automatically implemented for all models that implement
 /// [Update].
 pub trait Save<K: Send>: Model {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Persists the model instance to the database
     ///
     /// # Example
@@ -115,12 +123,14 @@ where
     M: Model + PreferredId<K> + Clone + Send,
     <M as Model>::Changeset: Update<K, M> + Send,
 {
-    async fn save(&mut self, conn: &mut DbConnection) -> Result<(), M::Error> {
+    type Error = <<M as Model>::Changeset as Update<K, M>>::Error;
+
+    async fn save(&mut self, conn: &mut DbConnection) -> Result<(), Self::Error> {
         let id = self.get_id();
         let changeset = <M as Model>::Changeset::from(self.clone()); // FIXME: I don't like that clone, maybe a ChangesetOwned/Changeset pair would work?
         *self = changeset
             .update_or_fail(conn, id, || {
-                M::Error::from(editoast_models::model::Error::from(NotFound))
+                Self::Error::from(editoast_models::model::Error::from(NotFound))
             })
             .await?;
         Ok(())
@@ -139,6 +149,8 @@ where
     M: Model,
     K: Send + Clone,
 {
+    type Error: std::error::Error + From<editoast_models::model::Error> + Send;
+
     /// Updates a batch of rows in the database given an iterator of keys
     ///
     /// Returns a collection of the updated rows. That collection can contain
@@ -153,7 +165,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C, M::Error>;
+    ) -> Result<C, Self::Error>;
 
     /// Just like [UpdateBatchUnchecked::update_batch_unchecked] but the returned models are paired with their key
     ///
@@ -169,7 +181,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<C, M::Error>;
+    ) -> Result<C, Self::Error>;
 }
 
 /// Describes how a [Model] can be updated in the database given a batch of its changesets
@@ -206,7 +218,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>), M::Error>
+    ) -> Result<(C, std::collections::HashSet<K>), Self::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -243,7 +255,7 @@ where
         self,
         conn: &mut DbConnection,
         ids: I,
-    ) -> Result<(C, std::collections::HashSet<K>), M::Error>
+    ) -> Result<(C, std::collections::HashSet<K>), Self::Error>
     where
         I: Send + IntoIterator<Item = K>,
         C: Send
@@ -291,7 +303,7 @@ where
             + std::iter::Extend<M>
             + std::iter::FromIterator<M>
             + std::iter::IntoIterator<Item = M>,
-        E: From<M::Error>,
+        E: From<Self::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch::<_, C>(conn, ids).await?;
@@ -324,7 +336,7 @@ where
             + std::iter::Extend<(K, M)>
             + std::iter::FromIterator<(K, M)>
             + std::iter::IntoIterator<Item = (K, M)>,
-        E: From<M::Error>,
+        E: From<Self::Error>,
         F: FnOnce(std::collections::HashSet<K>) -> E + Send,
     {
         let (result, missing) = self.update_batch_with_key::<_, C>(conn, ids).await?;

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -12,8 +12,9 @@ use strum::FromRepr;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Model)]
-#[model(table = editoast_models::tables::work_schedule_group, error = WsGroupError)]
+#[model(table = editoast_models::tables::work_schedule_group)]
 #[model(gen(ops = crd, batch_ops = c, list))]
+#[model(error(create = WsGroupError, update = WsGroupError))]
 pub struct WorkScheduleGroup {
     pub id: i64,
     pub creation_date: DateTime<Utc>,


### PR DESCRIPTION
This PR is a solution to a problem I noticed while trying to change `List` and `Count` to use custom errors instead of `InternalError`.  Having a single error per model is annoying there because when we `MyModel::list`, we don't care about FK violations, check constraints not being held, etc.  Those can only happen when we create or update the row.  With a single error type, we still have to `match` on these variants when listing, even though *we know happen while listing*.  The same will happen for *every single `retrieve`* there is when  we'll try to remove the `deprecated` annotations.

A single error type is indeed easier to understand and manage at the `Model` level, but at usage its really not ergonomic.  (I was indeed "proved wrong" 👀 https://github.com/OpenRailAssociation/osrd/pull/10196#discussion_r1910293795.)

<details open id="prdesc">

- 8a2745d5d *editoast: move Error associated type to model operation traits*
    ```md
    Each operation can raise a different set of errors:
    
    * `Create` and `Update` can yield the most errors, from PK violations to
      `CHECK` constraints not being held.
    * `Delete` usually yield less errors, but there is still some custom
      behavior we may want to intercept and type properly.
    * `Retrieve` and `Exist` won't raise many custom errors since they just
      read data.
    
    Therefore having a single `type Model::Error` is problematic since we
    wanted that type to describe the full set of errors a model can have —
    that is the errors of `Create` and `Update`.  That forces us to deal
    with such impossible errors (e.g.: FK violations) while `Retrieve`-ing.
    That's especially annoying since `Retrieve` **is the most commonly**
    used operation.  In practice, we'll only care about the generic
    `model::Error` for `Retrieve`, the rest being just noise.
    
    This commit allows customizing the error type associated to each
    operation, enabling finer error control and propagation.
    ```
- 9c4e54c4a *editoast: derive: add finer Model error configuration*
- 2adec2767 *editoast: scope model WorkScheduleGroup's error more precisely*

</details>