### PR TITLE
editoast: simplify some error management in models

### DIFF
--- a/editoast/src/models/project.rs
+++ b/editoast/src/models/project.rs
@@ -24,7 +24,6 @@ editoast_common::schemas! {
 #[derive(Clone, Debug, Serialize, Deserialize, Model, ToSchema, PartialEq)]
 #[model(table = editoast_models::tables::project)]
 #[model(gen(ops = crud, list))]
-#[model(error = Error)]
 pub struct Project {
     pub id: i64,
     pub name: String,
@@ -40,17 +39,8 @@ pub struct Project {
     pub image: Option<i64>,
 }
 
-#[derive(Debug, thiserror::Error, derive_more::From)]
-pub enum Error {
-    #[error(transparent)]
-    #[from(forward)]
-    Database(model::Error),
-    #[error(transparent)]
-    Legacy(#[from] InternalError),
-}
-
 #[tracing::instrument(skip(conn), ret, err)]
-async fn try_delete_document(conn: &DbConnection, doc_id: i64) -> Result<(), Error> {
+async fn try_delete_document(conn: &DbConnection, doc_id: i64) -> Result<(), model::Error> {
     let res = conn
         .transaction(|mut conn| {
             async move {
@@ -79,13 +69,16 @@ async fn try_delete_document(conn: &DbConnection, doc_id: i64) -> Result<(), Err
         {
             Ok(())
         }
-        Err(e) => Err(self::Error::from(e)),
+        Err(e) => Err(e),
     }
 }
 
 impl Project {
     /// This function takes a filled project and update to now the last_modification field
-    pub async fn update_last_modified(&mut self, conn: &mut DbConnection) -> Result<(), Error> {
+    pub async fn update_last_modified(
+        &mut self,
+        conn: &mut DbConnection,
+    ) -> Result<(), model::Error> {
         self.last_modification = Utc::now().naive_utc();
         self.save(conn).await?;
         Ok(())
@@ -107,7 +100,7 @@ impl Project {
         &mut self,
         conn: &mut DbConnection,
         new_doc_id: Option<i64>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), model::Error> {
         conn.transaction(|mut conn| {
             async move {
                 let old_doc_id = self.image;
@@ -118,7 +111,7 @@ impl Project {
                         try_delete_document(&conn, old_doc_id).await?;
                     }
                 }
-                Ok::<_, Error>(())
+                Ok::<_, model::Error>(())
             }
             .scope_boxed()
         })
@@ -128,7 +121,10 @@ impl Project {
 
     /// Deletes a project and prunes the image if it is not used by another project
     #[tracing::instrument(skip(conn), ret, err)]
-    pub async fn delete_and_prune_document(self, conn: &mut DbConnection) -> Result<(), Error> {
+    pub async fn delete_and_prune_document(
+        self,
+        conn: &mut DbConnection,
+    ) -> Result<(), model::Error> {
         conn.transaction(|mut conn| {
             async move {
                 if !self.delete(&mut conn).await? {
@@ -164,8 +160,7 @@ impl Project {
     {
         conn.transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let mut project = Self::retrieve_or_fail(&mut conn, project_id, || {
+                let mut project = Self::retrieve_real_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
@@ -176,11 +171,7 @@ impl Project {
                     .patch()
                     .last_modification(Utc::now().naive_utc())
                     .apply(&mut conn)
-                    .await
-                    .map_err(|err| match err {
-                        Error::Database(e) => e.into(),
-                        Error::Legacy(e) => e,
-                    })?;
+                    .await?;
 
                 res.map(|t| (t, project)).map_err(Into::into)
             }

--- a/editoast/src/models/work_schedules.rs
+++ b/editoast/src/models/work_schedules.rs
@@ -54,7 +54,7 @@ pub enum WorkScheduleType {
 }
 
 #[derive(Debug, Default, Clone, Model, Serialize, Deserialize, ToSchema)]
-#[model(table = editoast_models::tables::work_schedule, error = Error)]
+#[model(table = editoast_models::tables::work_schedule)]
 #[model(gen(batch_ops = c, list))]
 pub struct WorkSchedule {
     pub id: i64,
@@ -67,10 +67,6 @@ pub struct WorkSchedule {
     pub work_schedule_type: WorkScheduleType,
     pub work_schedule_group_id: i64,
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct Error(#[from] model::Error);
 
 impl WorkSchedule {
     pub fn as_core_work_schedule(

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -11,6 +11,7 @@ use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
 use editoast_models::DbConnectionPoolV2;
+use editoast_models::model;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::rust::double_option;
@@ -32,7 +33,6 @@ use crate::models::Project;
 use crate::models::Retrieve;
 use crate::models::Tags;
 use crate::models::Update;
-use crate::models::project;
 use crate::views::AuthorizationError;
 use crate::views::pagination::PaginationQueryParams;
 
@@ -72,7 +72,7 @@ pub enum ProjectError {
     #[error(transparent)]
     #[from(forward)]
     #[editoast_error(status = 500)]
-    Database(project::Error),
+    Database(model::Error),
 }
 
 /// Creation form for a project
@@ -258,12 +258,14 @@ async fn get(
     if !authorized {
         return Err(AuthorizationError::Forbidden.into());
     }
-    let conn = &mut db_pool.get().await?;
-    #[expect(deprecated)]
-    let project =
-        Project::retrieve_or_fail(conn, project_id, || ProjectError::NotFound { project_id })
-            .await?;
-    Ok(Json(ProjectWithStudyCount::try_fetch(conn, project).await?))
+    let mut conn = db_pool.get().await?;
+    let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
+        ProjectError::NotFound { project_id }
+    })
+    .await?;
+    Ok(Json(
+        ProjectWithStudyCount::try_fetch(&mut conn, project).await?,
+    ))
 }
 
 /// Delete a project
@@ -294,15 +296,11 @@ async fn delete(
         .await?
         .transaction(|mut conn| {
             async move {
-                #[expect(deprecated)]
-                let project = Project::retrieve_or_fail(&mut conn, project_id, || {
+                let project = Project::retrieve_real_or_fail(conn.clone(), project_id, || {
                     ProjectError::NotFound { project_id }
                 })
                 .await?;
-                project
-                    .delete_and_prune_document(&mut conn)
-                    .await
-                    .map_err(ProjectError::from)?;
+                project.delete_and_prune_document(&mut conn).await?;
                 Ok::<_, ProjectError>(())
             }
             .scope_boxed()

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -29,7 +29,6 @@ use crate::models::Project;
 use crate::models::Study;
 use crate::models::Tags;
 use crate::models::prelude::*;
-use crate::models::project;
 use crate::views::pagination::PaginatedList as _;
 use crate::views::pagination::PaginationQueryParams;
 use crate::views::project::ProjectError;
@@ -425,8 +424,7 @@ async fn list(
     match Project::exists(&mut db_pool.get().await?, project_id).await {
         Ok(true) => (),
         Ok(false) => return Err(ProjectError::NotFound { project_id }.into()),
-        Err(project::Error::Legacy(err)) => return Err(err),
-        Err(project::Error::Database(err)) => return Err(err.into()),
+        Err(err) => return Err(err.into()),
     }
 
     let settings = pagination_params

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -27,7 +27,6 @@ use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::TrackRange;
-use itertools::Either;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as SerdeError;
@@ -65,7 +64,7 @@ struct WorkScheduleGroupIdParam {
     id: i64,
 }
 
-#[derive(Debug, Error, EditoastError)]
+#[derive(Debug, Error, EditoastError, derive_more::From)]
 #[editoast_error(base_id = "work_schedule")]
 enum WorkScheduleError {
     #[error("Name '{name}' already used")]
@@ -76,13 +75,8 @@ enum WorkScheduleError {
     WorkScheduleGroupNotFound { id: i64 },
     #[error(transparent)]
     #[editoast_error(status = 500)]
-    Database(Either<work_schedules::Error, work_schedules::WsGroupError>),
-}
-
-impl From<work_schedules::Error> for WorkScheduleError {
-    fn from(e: work_schedules::Error) -> Self {
-        WorkScheduleError::Database(Either::Left(e))
-    }
+    #[from(editoast_models::model::Error)]
+    Database(work_schedules::WsGroupError),
 }
 
 impl From<work_schedules::WsGroupError> for WorkScheduleError {
@@ -91,7 +85,7 @@ impl From<work_schedules::WsGroupError> for WorkScheduleError {
             work_schedules::WsGroupError::NameAlreadyUsed { name } => {
                 WorkScheduleError::NameAlreadyUsed { name }
             }
-            e => WorkScheduleError::Database(Either::Right(e)),
+            e => WorkScheduleError::Database(e),
         }
     }
 }
@@ -202,9 +196,8 @@ async fn create(
             work_schedule.into_work_schedule_changeset(work_schedule_group.work_schedule_group_id)
         })
         .collect::<Vec<_>>();
-    let _work_schedules: Vec<_> = WorkSchedule::create_batch(conn, work_schedules_changesets)
-        .await
-        .map_err(WorkScheduleError::from)?;
+    let _work_schedules: Vec<_> =
+        WorkSchedule::create_batch(conn, work_schedules_changesets).await?;
 
     Ok(Json(WorkScheduleCreateResponse {
         work_schedule_group_id: work_schedule_group.work_schedule_group_id,
@@ -456,9 +449,7 @@ async fn put_in_group(
                 .map(|work_schedule| work_schedule.into_work_schedule_changeset(group_id))
                 .collect::<Vec<_>>();
             let work_schedules =
-                WorkSchedule::create_batch(&mut conn.clone(), work_schedules_changesets)
-                    .await
-                    .map_err(WorkScheduleError::from)?;
+                WorkSchedule::create_batch(&mut conn.clone(), work_schedules_changesets).await?;
 
             Ok(Json(work_schedules))
         })


### PR DESCRIPTION
<details open id="prdesc">

- becaa1b78 *editoast: remove useless custom error of `models::WorkSchedule`*
- e35f02bd4 *editoast: simplify `model::Project` error management*
    ```md
    * The former `Error` type was useless at the model level
    * We can deal with `InternalError`s upstream
    * Removes a bunch of deprecated `retrieve` calls
    ```

</details>