### PR TITLE
front: reset searchResults only when needed

### DIFF
--- a/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
+++ b/front/src/applications/stdcm/components/StdcmForm/StdcmOperationalPoint.tsx
@@ -149,8 +149,10 @@ const StdcmOperationalPoint = ({
   };
 
   const resetSuggestions = () => {
-    setSearchResults([]);
-    setSearchTerm('');
+    if (searchTerm !== '' && !location) {
+      setSearchResults([]);
+      setSearchTerm('');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
Reset search results when focus is lost only if no op is selected and the search string is not empty.

closes #10315 