### PR TITLE
ops, front: update nix flake nodejs and rust versions

### DIFF
--- a/.github/workflows/osrd-ui-publish.yml
+++ b/.github/workflows/osrd-ui-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: "24"
 
       - name: Authenticate with Registry
         run: |
@@ -29,7 +29,7 @@ jobs:
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Publish

--- a/.github/workflows/osrd-ui-website.yml
+++ b/.github/workflows/osrd-ui-website.yml
@@ -16,12 +16,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: "24"
 
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Build

--- a/.github/workflows/ui-icons-optimize.yml
+++ b/.github/workflows/ui-icons-optimize.yml
@@ -12,8 +12,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: "3.10"
+          cache: "pip"
       - run: pip install -r front/ui/ui-icons/requirements.txt
       - run: |
           for icon in front/ui/ui-icons/icons/*; do
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: "24"
       - run: |
           cd front/ui/ui-icons
           npm install
@@ -32,8 +32,8 @@ jobs:
 
       - uses: EndBug/add-and-commit@v9
         with:
-          add: 'front/ui/ui-icons/icons'
-          message: 'Optimize SVGs'
+          add: "front/ui/ui-icons/icons"
+          message: "Optimize SVGs"
           author_email: actions@github.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/editoast/Dockerfile
+++ b/editoast/Dockerfile
@@ -1,7 +1,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.85-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
 WORKDIR /editoast
 
 #######################

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1742452566,
-        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
+        "lastModified": 1747392669,
+        "narHash": "sha256-zky3+lndxKRu98PAwVK8kXPdg+Q1NVAhaI7YGrboKYA=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
+        "rev": "c3c27e603b0d9b5aac8a16236586696338856fbb",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1742296961,
-        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
+        "lastModified": 1747323949,
+        "narHash": "sha256-G4NwzhODScKnXqt2mEQtDFOnI0wU3L1WxsiHX3cID/0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
+        "rev": "f8e784353bde7cbf9a9046285c1caf41ac484ebe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           inherit system;
         };
 
-        fixedNode = pkgs.nodejs_23;
+        fixedNode = pkgs.nodejs_24;
         fixedNodePackages = pkgs.nodePackages.override {
           nodejs = fixedNode;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -62,9 +62,6 @@
               taplo
               uv
 
-              # API
-              ruff-lsp
-
               # Core
               gradle
               jdk17

--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -5,7 +5,7 @@ COPY docker/exec-as.c .
 RUN gcc -std=c99 -static -o /exec-as exec-as.c
 
 
-FROM node:24
+FROM node:24-alpine
 
 # Install dependencies
 RUN apt-get update -yqq && \

--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -5,7 +5,7 @@ COPY docker/exec-as.c .
 RUN gcc -std=c99 -static -o /exec-as exec-as.c
 
 
-FROM node:23
+FROM node:24
 
 # Install dependencies
 RUN apt-get update -yqq && \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.85-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
 WORKDIR /gateway
 
 #######################

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -59,7 +59,7 @@ CMD ["/usr/local/bin/osrd_gateway"]
 #####################
 # Build env : front #
 #####################
-FROM node:24-bookworm AS front_build
+FROM node:24-alpine AS front_build
 WORKDIR /app
 
 # Add build argument for skipping failed front

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -59,7 +59,7 @@ CMD ["/usr/local/bin/osrd_gateway"]
 #####################
 # Build env : front #
 #####################
-FROM node:23-bookworm AS front_build
+FROM node:24-bookworm AS front_build
 WORKDIR /app
 
 # Add build argument for skipping failed front

--- a/gateway/src/config.rs
+++ b/gateway/src/config.rs
@@ -204,9 +204,10 @@ impl Default for ProxyConfig {
     }
 }
 
-pub fn load() -> Result<ProxyConfig, figment::Error> {
+pub fn load() -> Result<ProxyConfig, Box<figment::Error>> {
     Figment::from(Serialized::defaults(ProxyConfig::default()))
         .merge(Toml::file("gateway.toml"))
         .merge(Env::prefixed("GATEWAY__").split("__"))
         .extract()
+        .map_err(Box::new)
 }

--- a/osrdyne/Dockerfile
+++ b/osrdyne/Dockerfile
@@ -3,7 +3,7 @@
 ##############
 # Cargo chef #
 ##############
-FROM lukemathwalker/cargo-chef:0.1.71-rust-1.85-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.87-alpine3.21 AS chef
 WORKDIR /osrdyne
 
 #######################

--- a/osrdyne/src/config.rs
+++ b/osrdyne/src/config.rs
@@ -18,7 +18,7 @@ use url::Url;
 pub enum WorkerDriverConfig {
     Noop,
     DockerDriver(DockerDriverOptions),
-    KubernetesDriver(KubernetesDriverOptions),
+    KubernetesDriver(Box<KubernetesDriverOptions>),
     ProcessComposeDriver(PCDriverOptions),
 }
 

--- a/osrdyne/src/main.rs
+++ b/osrdyne/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 info!("Using Kubernetes driver");
                 Box::new(
                     KubernetesDriver::new(
-                        opts,
+                        *opts,
                         config.amqp_uri.clone(),
                         config.max_msg_size,
                         config.pool_id.clone(),


### PR DESCRIPTION
- update nix flake lock
- ruff language server should be built in and is now depreciated, dropped from flake
- nodejs23 has been dropped from nix packages as node maintenance will cease in 2 weeks, we need to either revert to 22 (active version) or bump to 24 (current version, so compatibility is not yet guaranteed, nodejs doc states "Production applications should only use Active LTS or Maintenance LTS releases.").
- Rust bump to 1.87 (rustc bumped with the flake)

- We are trying out to switch from bookworm to alpine for the node image