### PR TITLE
editoast: ignore auto-generated files from the review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # it's especially an issue for scripts copied to a docker container.
 # https://unix.stackexchange.com/questions/721844/linux-bash-shell-script-error-cannot-execute-required-file-not-found
 *.sh text eol=lf
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+editoast/openapi.yaml linguist-generated=true
+front/src/reducers/osrdconf/infra_schema.json linguist-generated=true


### PR DESCRIPTION
Usually, auto-generated files are not really useful to review. So having them auto-folded seems like a reasonable default (like it's already the case for `*.lock` files for example).