### PR TITLE
gateway: fix proxying of responses without a body

### DIFF
--- a/gateway/actix_proxy/src/lib.rs
+++ b/gateway/actix_proxy/src/lib.rs
@@ -511,8 +511,28 @@ impl InnerProxyService {
             }
         }
 
-        Ok(response.streaming(back_response))
+        // only attempt to stream the body for responses which can have one
+        if response_is_bodyless(req.method(), back_response.status().as_u16()) {
+            Ok(response.finish())
+        } else {
+            Ok(response.streaming(back_response))
+        }
     }
+}
+
+fn response_is_bodyless(req_method: &actix_web::http::Method, resp_status_code: u16) -> bool {
+    // Any response to a HEAD request and any response with a 1xx (Informational),
+    // 204 (No Content), or 304 (Not Modified) status code is always terminated
+    // by the first empty line after the header fields, regardless of the header
+    // fields present in the message, and thus cannot contain a message body or
+    // trailer section.
+    // https://httpwg.org/specs/rfc9112.html#message.body.length
+
+    if req_method == actix_web::http::Method::HEAD {
+        return true;
+    }
+
+    matches!(resp_status_code, 100..200 | 204 | 304)
 }
 
 impl ProxyService {


### PR DESCRIPTION
Some HTTP responses do not and cannot have a body, which is most http clients translate as an empty body. If we attempt to stream an empty body with a response code which cannot have a body, actix does not raise an error and fails to add the transfer-encoding header, but still transmits the content, which is not HTTP compliant.

Do not attempt to stream the body when the backend response does not have one.

I found this chatting with @Synar

Fixes  #11184