### PR TITLE
front: fix stdcm debug spacetimechart errors

### DIFF
--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -491,7 +491,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
           >
             {paths.map((path) => (
               <PathLayer
-                key={path.id}
+                key={`${path.id}-${path.points[0]?.position}`}
                 path={path}
                 {...getPathStyle(hoveredItem, path, !!draggingState, selectedTrainId)}
               />


### PR DESCRIPTION
 - First commit fix duplicate key, due to a single path being cut during partial projection and turned into multiple path fragments sharing the same id. I believe adding the position of the first element of each fragment should be enough and stable, although I'm open to other suggestions for the choice of key.

- Second commit fix an issue that occurs when we don't find the ids of trains to project in our timetable, and completely crash the page. The case where I encountered this was when switching from a simulation done on one timetable to another. 

We should probably be wiping the performed simulations when switching timetables though, unless there is some use case for keeping them?