### PR TITLE
editoast, front : replace nextid in react keys with keys from data

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -11155,6 +11155,7 @@ components:
       description: |
         A search result item for a query with `object = "signal"`
       required:
+      - obj_id
       - infra_id
       - label
       - signaling_systems
@@ -11175,6 +11176,8 @@ components:
           format: int64
           minimum: 0
         line_name:
+          type: string
+        obj_id:
           type: string
         settings:
           type: array

--- a/editoast/src/views/search.rs
+++ b/editoast/src/views/search.rs
@@ -569,6 +569,8 @@ pub(super) struct SearchResultItemOperationalPointTrackSections {
 ///
 // **IMPORTANT**: Please note that any modification to this struct should be reflected in [crate::models::infra::Infra::clone]
 pub(super) struct SearchResultItemSignal {
+    #[search(sql = "sig.obj_id")]
+    obj_id: String,
     #[search(sql = "sig.infra_id")]
     infra_id: i64,
     #[search(sql = "sig.data->'extensions'->'sncf'->>'label'")]

--- a/front/src/applications/operationalStudies/views/Project.tsx
+++ b/front/src/applications/operationalStudies/views/Project.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { Pencil } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 import { BiTargetLock } from 'react-icons/bi';
-import nextId from 'react-id-generator';
 import ReactMarkdown from 'react-markdown';
 import { useParams } from 'react-router-dom';
 import remarkGfm from 'remark-gfm';
@@ -306,7 +305,7 @@ const Project = () => {
               )}
               <div className="project-details-tags">
                 {project.tags?.map((tag) => (
-                  <div className="project-details-tags-tag" key={nextId()}>
+                  <div className="project-details-tags-tag" key={tag}>
                     {tag}
                   </div>
                 ))}

--- a/front/src/applications/operationalStudies/views/Study.tsx
+++ b/front/src/applications/operationalStudies/views/Study.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Pencil } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useParams } from 'react-router-dom';
 
 import AddNewCard from 'applications/operationalStudies/components/AddNewCard';
@@ -283,7 +282,7 @@ const Study = () => {
                         study.id &&
                         study.state && (
                           <StateStep
-                            key={nextId()}
+                            key={state}
                             study={study}
                             number={idx + 1}
                             state={state}
@@ -331,7 +330,7 @@ const Study = () => {
               <div className="study-details-footer">
                 <div className="study-details-tags">
                   {study.tags?.map((tag) => (
-                    <div className="study-details-tags-tag" key={`${tag}`}>
+                    <div className="study-details-tags-tag" key={tag}>
                       {tag}
                     </div>
                   ))}

--- a/front/src/applications/operationalStudies/views/Study.tsx
+++ b/front/src/applications/operationalStudies/views/Study.tsx
@@ -331,7 +331,7 @@ const Study = () => {
               <div className="study-details-footer">
                 <div className="study-details-tags">
                   {study.tags?.map((tag) => (
-                    <div className="study-details-tags-tag" key={nextId()}>
+                    <div className="study-details-tags-tag" key={`${tag}`}>
                       {tag}
                     </div>
                   ))}

--- a/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/ChipsSNCF.tsx
@@ -1,7 +1,5 @@
 import { useId, useState } from 'react';
 
-import nextId from 'react-id-generator';
-
 enum colorClasses {
   primary = 'bg-primary',
   secondary = 'bg-secondary',
@@ -17,18 +15,24 @@ enum colorClasses {
 }
 
 type Props = {
-  addTag: (tag: string) => void;
   tags?: string[];
-  title?: JSX.Element | string;
+  addTag: (tag: string) => void;
   removeTag: (tagIdx: number) => void;
+  title?: JSX.Element | string;
   color?: string;
 };
 
+/**
+ * ChipsSNCF is a chip input component for an array of unique string tags (e.g., for trains, studies, scenarios, projects).
+ *
+ * The tags array is not directly mutated, only through provided addTag and removeTag callbacks.
+ * addTag is only called if the inputted tag is not already present in the tags array.
+ */
 export default function ChipsSNCF({
-  addTag,
   tags = [],
-  title,
+  addTag,
   removeTag,
+  title,
   color = 'primary',
 }: Props) {
   const [chipInputValue, setChipInputValue] = useState('');
@@ -36,7 +40,7 @@ export default function ChipsSNCF({
   const chip = (label: string, idx: number) => {
     const chipColor = colorClasses[color as keyof typeof colorClasses];
     return (
-      <div role="list" key={nextId()}>
+      <div role="list" key={label}>
         <div className="chips-group" role="listitem">
           <span
             data-testid="scenario-details-tag"
@@ -61,7 +65,7 @@ export default function ChipsSNCF({
     e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement }
   ) => {
     if (e.key === 'Enter' && e.target) {
-      addTag(e.target.value);
+      if (!tags.includes(e.target.value)) addTag(e.target.value);
       setChipInputValue('');
     }
   };

--- a/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/DropdownSNCF.tsx
@@ -1,6 +1,5 @@
 import { type LegacyRef, type ReactNode, useEffect, useRef, useState } from 'react';
 
-import nextId from 'react-id-generator';
 import TetherComponent from 'react-tether';
 
 export const DROPDOWN_STYLE_TYPES = {
@@ -10,7 +9,7 @@ export const DROPDOWN_STYLE_TYPES = {
 
 type DropdownSNCFProps = {
   titleContent: ReactNode;
-  items?: ReactNode[];
+  items?: { node: ReactNode; key: string }[];
   type?: string;
   className?: string;
   noArrow?: boolean;
@@ -25,17 +24,17 @@ const DropdownSNCF = ({
 }: DropdownSNCFProps) => {
   const [isDropdownShown, setIsDropdownShown] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
-  const itemNode = items.map((item) => (
+  const itemNode = items.map(({ node, key }) => (
     <li
       className="dropdown-item"
-      key={`item-${nextId()}`}
+      key={key}
       // Make it better some day :-/
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
       role="button"
       tabIndex={0}
       onClick={() => setIsDropdownShown(false)}
     >
-      {item}
+      {node}
     </li>
   ));
 

--- a/front/src/common/BootstrapSNCF/NavBarSNCF.tsx
+++ b/front/src/common/BootstrapSNCF/NavBarSNCF.tsx
@@ -116,57 +116,80 @@ const LegacyNavBarSNCF = ({ appName, showLogoWithName }: Props) => {
             type={DROPDOWN_STYLE_TYPES.transparent}
             items={[
               // Button to open modal displaying release version
-              <button
-                type="button"
-                className="btn-link text-reset"
-                onClick={() => openModal(<ReleaseInformations />, 'lg')}
-                key="release"
-              >
-                <span className="mr-2">
-                  <Info />
-                </span>
-                {t('nav-bar.about')}
-              </button>,
-              <button
-                type="button"
-                className="btn-link text-reset"
-                onClick={() => openModal(<HelpModalSNCF />, 'lg')}
-                key="help"
-              >
-                <span className="mr-2">
-                  <Report />
-                </span>
-                {t('nav-bar.help')}
-              </button>,
-              <button
-                type="button"
-                className="btn-link text-reset"
-                onClick={() => openModal(<ChangeLanguageModal />, 'sm')}
-                key="release"
-              >
-                <span className="mr-2">
-                  {i18n.language && getUnicodeFlagIcon(language2flag(i18n.language))}
-                </span>
-                <span data-testid="language-info">{t(`nav-bar.language.${i18n.language}`)} </span>
-              </button>,
-              <button
-                data-testid="user-settings-btn"
-                type="button"
-                className="user-settings-btn btn-link text-reset"
-                onClick={() => openModal(<UserSettings />)}
-                key="release"
-              >
-                <span className="mr-2">
-                  <Gear variant="fill" />
-                </span>
-                {t('nav-bar.userSettings')}
-              </button>,
-              <button type="button" className="btn-link text-reset" onClick={logout} key="logout">
-                <span className="mr-2">
-                  <SignOut />
-                </span>
-                {t('nav-bar.disconnect')}
-              </button>,
+              {
+                node: (
+                  <button
+                    type="button"
+                    className="btn-link text-reset"
+                    onClick={() => openModal(<ReleaseInformations />, 'lg')}
+                  >
+                    <span className="mr-2">
+                      <Info />
+                    </span>
+                    {t('nav-bar.about')}
+                  </button>
+                ),
+                key: 'about',
+              },
+              {
+                node: (
+                  <button
+                    type="button"
+                    className="btn-link text-reset"
+                    onClick={() => openModal(<HelpModalSNCF />, 'lg')}
+                  >
+                    <span className="mr-2">
+                      <Report />
+                    </span>
+                    {t('nav-bar.help')}
+                  </button>
+                ),
+                key: 'help',
+              },
+              {
+                node: (
+                  <button
+                    type="button"
+                    className="btn-link text-reset"
+                    onClick={() => openModal(<ChangeLanguageModal />, 'sm')}
+                  >
+                    <span className="mr-2">
+                      {i18n.language && getUnicodeFlagIcon(language2flag(i18n.language))}
+                    </span>
+                    <span data-testid="language-info">
+                      {t(`nav-bar.language.${i18n.language}`)}{' '}
+                    </span>
+                  </button>
+                ),
+                key: 'language',
+              },
+              {
+                node: (
+                  <button
+                    data-testid="user-settings-btn"
+                    type="button"
+                    className="user-settings-btn btn-link text-reset"
+                    onClick={() => openModal(<UserSettings />)}
+                  >
+                    <span className="mr-2">
+                      <Gear variant="fill" />
+                    </span>
+                    {t('nav-bar.userSettings')}
+                  </button>
+                ),
+                key: 'user-settings',
+              },
+              {
+                node: (
+                  <button type="button" className="btn-link text-reset" onClick={logout}>
+                    <span className="mr-2">
+                      <SignOut />
+                    </span>
+                    {t('nav-bar.disconnect')}
+                  </button>
+                ),
+                key: 'sign-out',
+              },
             ]}
           />
           {impersonatedUser && (

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -206,11 +206,7 @@ const MapSearchSignal = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchSi
   const formatSearchResults = () => (
     <div className="search-results">
       {searchResults.map((result) => (
-        <SignalCard
-          signalSearchResult={result}
-          onResultClick={onResultClick}
-          key={`${nextId()}-${result.line_name}`}
-        />
+        <SignalCard signalSearchResult={result} onResultClick={onResultClick} key={result.obj_id} />
       ))}
     </div>
   );
@@ -284,7 +280,7 @@ const MapSearchSignal = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchSi
           <datalist id="signal">
             {searchState &&
               searchResults.map((result) => (
-                <option value={result.label} key={`${nextId()}-${result.line_name}`}>
+                <option value={result.label} key={result.obj_id}>
                   {result.label}
                 </option>
               ))}

--- a/front/src/common/Map/Search/MapSearchSignal.tsx
+++ b/front/src/common/Map/Search/MapSearchSignal.tsx
@@ -4,7 +4,6 @@ import { ChevronDown, ChevronUp } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { sortBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useSelector } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
@@ -252,7 +251,7 @@ const MapSearchSignal = ({ updateExtViewport, closeMapSearchPopUp }: MapSearchSi
           <datalist id="line" className="overflow-hidden">
             {searchLineState &&
               autocompleteLineNames.map((lineName) => (
-                <option value={lineName} key={`${nextId()}-${lineName}`}>
+                <option value={lineName} key={lineName}>
                   {lineName}
                 </option>
               ))}

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -3913,6 +3913,7 @@ export type SearchResultItemSignal = {
   label: string;
   line_code: number;
   line_name: string;
+  obj_id: string;
   settings: string[];
   signaling_systems: string[];
   sprite?: string | null;

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyEdition.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { Search } from '@osrd-project/ui-icons';
 import { useTranslation } from 'react-i18next';
 import { VscJson } from 'react-icons/vsc';
-import nextId from 'react-id-generator';
 
 import { type Infra, osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import InputSNCF from 'common/BootstrapSNCF/InputSNCF';
@@ -109,7 +108,7 @@ const InfraSelectorModalBodyEdition = ({
           {infrasList.map((infra) => (
             <InfraSelectorEditionItem
               infra={infra}
-              key={nextId()}
+              key={infra.id}
               isFocused={isFocused}
               setIsFocused={setIsFocused}
             />

--- a/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
+++ b/front/src/modules/infra/components/InfraSelector/InfraSelectorModalBodyStandard.tsx
@@ -3,7 +3,6 @@ import { useCallback, useContext, useMemo } from 'react';
 import { Lock, Search } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useNavigate } from 'react-router-dom';
 
 import type { ResourceType } from 'common/api/mock/mockEditoastApi';
@@ -103,7 +102,7 @@ const InfraSelectorModalBodyStandard = ({
                 unlocked: !infra.locked,
                 active: infra.id === infraID,
               })}
-              key={nextId()}
+              key={infra.id}
             >
               <button
                 className="infraslist-item-choice-main"

--- a/front/src/modules/project/components/ProjectCard.tsx
+++ b/front/src/modules/project/components/ProjectCard.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { Calendar, CheckCircle, FileDirectory, FileDirectoryOpen } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
@@ -90,7 +89,7 @@ export default function ProjectCard({ setFilterChips, project, isSelected, toggl
           .map((tag) => (
             <div
               className="project-card-tags-tag"
-              key={nextId()}
+              key={tag}
               role="button"
               tabIndex={0}
               onClick={() => setFilterChips(tag)}

--- a/front/src/modules/scenario/components/ScenarioCard.tsx
+++ b/front/src/modules/scenario/components/ScenarioCard.tsx
@@ -3,7 +3,6 @@ import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { MdTrain } from 'react-icons/md';
 import { RiFolderChartLine } from 'react-icons/ri';
-import nextId from 'react-id-generator';
 import { useNavigate } from 'react-router-dom';
 
 import infraLogo from 'assets/pictures/components/tracks.svg';
@@ -72,7 +71,7 @@ export default function ScenarioCard({
           scenario.tags.map((tag) => (
             <div
               className="scenario-card-tags-tag"
-              key={nextId()}
+              key={tag}
               role="button"
               tabIndex={0}
               onClick={() => setFilterChips(tag)}

--- a/front/src/modules/study/components/StudyCard.tsx
+++ b/front/src/modules/study/components/StudyCard.tsx
@@ -1,7 +1,6 @@
 import { Calendar, CheckCircle, FileDirectory, FileDirectoryOpen } from '@osrd-project/ui-icons';
 import cx from 'classnames';
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 import { useNavigate } from 'react-router-dom';
 
 import studyLogo from 'assets/pictures/views/study.svg';
@@ -99,7 +98,7 @@ export default function StudyCard({
           study.tags.map((tag) => (
             <div
               className="study-card-tags-tag"
-              key={nextId()}
+              key={tag}
               role="button"
               tabIndex={0}
               onClick={() => setFilterChips(tag)}

--- a/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemStationSelector.tsx
+++ b/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemStationSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
-import nextId from 'react-id-generator';
 
 import type { ImportStation } from 'applications/operationalStudies/types';
 import { searchGraouStations } from 'common/api/graouApi';
@@ -66,7 +65,7 @@ const ImportTimetableItemStationSelector = ({
               aria-label={t('selectStation')}
               tabIndex={0}
               onClick={() => onSelect(station)}
-              key={nextId()}
+              key={`${station.name}-${station.uic}-${station.trigram}`}
             >
               <StationCard station={station} fixedHeight />
             </div>


### PR DESCRIPTION
First commit does what the title says. This will prevent keys from being reset every render. 

I tried to avoid using index when possible, but for some like tags, I had no other option has tags are not necessarily unique. It shouldn't be too costly to rerender them though =p

For the signal search items, we could almost avoid using index, but the "dépassement" lignes come with 101 identical signals, with some even sharing the exact same position.

I think most of my keys should be unique, but I'm not sure for the station one.

Second commit just memoize the sncf chip id to avoid resetting it every render.