### PR TITLE
front: adds opId into PathOperationalPoint

### DIFF
--- a/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
+++ b/front/src/applications/operationalStudies/__tests__/upsertMapWaypointsInOperationalPoints.spec.ts
@@ -79,6 +79,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 9246000, 26500000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+      'EditoastPathOperationalPoint',
       pathSteps,
       pathItemPositions,
       OPERATIONAL_POINTS,
@@ -170,6 +171,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 4198000, 4402000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+      'EditoastPathOperationalPoint',
       pathSteps,
       pathItemPositions,
       getOperationalPoints([
@@ -264,6 +266,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 1748000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+      'EditoastPathOperationalPoint',
       pathSteps,
       pathItemPositions,
       [],
@@ -325,6 +328,7 @@ describe('upsertMapWaypointsInOperationalPoints', () => {
     const pathItemPositions = [0, 12050000, 26500000];
 
     const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+      'EditoastPathOperationalPoint',
       pathSteps,
       pathItemPositions,
       OPERATIONAL_POINTS,

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -97,6 +97,7 @@ export function upsertMapWaypointsInOperationalPoints(
 
         return operationalPointsWithAllWaypoints;
       }
+
       return operationalPointsWithAllWaypoints;
     },
     [...operationalPoints]

--- a/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
+++ b/front/src/applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints.ts
@@ -2,20 +2,37 @@
 import type { TFunction } from 'i18next';
 
 import type { PathfindingResultSuccess, TrainSchedule } from 'common/api/osrdEditoastApi';
-
-import type { OperationalPoint } from '../types';
+import type {
+  PathOperationalPoint,
+  EditoastPathOperationalPoint,
+} from 'modules/simulationResult/types';
 
 const HIGHEST_PRIORITY_WEIGHT = 100;
 
 /**
  * Check if the train path used waypoints added by map click and add them to the operational points
  */
-export const upsertMapWaypointsInOperationalPoints = (
+export function upsertMapWaypointsInOperationalPoints(
+  type: 'PathOperationalPoint',
   path: TrainSchedule['path'],
   pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
-  operationalPoints: OperationalPoint[],
+  operationalPoints: PathOperationalPoint[],
   t: TFunction<'operational-studies'>
-): OperationalPoint[] => {
+): PathOperationalPoint[];
+export function upsertMapWaypointsInOperationalPoints(
+  type: 'EditoastPathOperationalPoint',
+  path: TrainSchedule['path'],
+  pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
+  operationalPoints: EditoastPathOperationalPoint[],
+  t: TFunction<'operational-studies'>
+): EditoastPathOperationalPoint[];
+export function upsertMapWaypointsInOperationalPoints(
+  type: 'PathOperationalPoint' | 'EditoastPathOperationalPoint',
+  path: TrainSchedule['path'],
+  pathItemsPositions: PathfindingResultSuccess['path_item_positions'],
+  operationalPoints: (PathOperationalPoint | EditoastPathOperationalPoint)[],
+  t: TFunction<'operational-studies'>
+): (PathOperationalPoint | EditoastPathOperationalPoint)[] {
   let waypointCounter = 1;
 
   return path.reduce(
@@ -46,8 +63,7 @@ export const upsertMapWaypointsInOperationalPoints = (
           (op) => op.position >= positionOnPath
         );
 
-        const formattedStep: OperationalPoint = {
-          id: step.id,
+        const baseFormattedStep = {
           extensions: {
             identifier: {
               name: t('simulationResults.requestedPoint', { count: waypointCounter }),
@@ -58,6 +74,17 @@ export const upsertMapWaypointsInOperationalPoints = (
           position: positionOnPath,
           weight: HIGHEST_PRIORITY_WEIGHT,
         };
+        const formattedStep =
+          type === 'PathOperationalPoint'
+            ? {
+                ...baseFormattedStep,
+                waypointId: step.id,
+                opId: null,
+              }
+            : {
+                ...baseFormattedStep,
+                id: step.id,
+              };
 
         waypointCounter += 1;
 
@@ -74,4 +101,4 @@ export const upsertMapWaypointsInOperationalPoints = (
     },
     [...operationalPoints]
   );
-};
+}

--- a/front/src/applications/operationalStudies/types.ts
+++ b/front/src/applications/operationalStudies/types.ts
@@ -10,6 +10,7 @@ import type {
   TrainSchedule,
 } from 'common/api/osrdEditoastApi';
 import type { RangedValue } from 'common/types';
+import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -69,11 +70,9 @@ export type CichDictValue = {
   chCode?: string;
 };
 
-export type OperationalPoint = NonNullable<PathProperties['operational_points']>[number];
-
 // Extraction of some required and non nullable properties from osrdEditoastApi's PathProperties type
 export type ManageTrainSchedulePathProperties = {
-  manchetteOperationalPoints?: OperationalPoint[];
+  manchetteOperationalPoints?: PathOperationalPoint[];
   electrifications: NonNullable<PathProperties['electrifications']>;
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
@@ -133,7 +132,7 @@ export type PathPropertiesFormatted = {
   electrifications: ElectrificationRange[];
   curves: PositionData<'radius'>[];
   slopes: PositionData<'gradient'>[];
-  operationalPoints: OperationalPoint[];
+  operationalPoints: NonNullable<PathProperties['operational_points']>;
   geometry: NonNullable<PathProperties['geometry']>;
   voltages: RangedValue[];
 };

--- a/front/src/applications/operationalStudies/utils.ts
+++ b/front/src/applications/operationalStudies/utils.ts
@@ -182,6 +182,7 @@ export const preparePathPropertiesData = (
   const voltageRanges = getPathVoltages(electrifications!, length);
 
   const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+    'EditoastPathOperationalPoint',
     trainSchedulePath,
     path_item_positions,
     operational_points!,

--- a/front/src/applications/stdcm/types.ts
+++ b/front/src/applications/stdcm/types.ts
@@ -10,7 +10,11 @@ import type {
   TowedRollingStock,
   PathProperties,
 } from 'common/api/osrdEditoastApi';
-import type { SpeedSpaceChartData, TrainSpaceTimeData } from 'modules/simulationResult/types';
+import type {
+  PathOperationalPoint,
+  SpeedSpaceChartData,
+  TrainSpaceTimeData,
+} from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { StdcmPathStep } from 'reducers/osrdconf/types';
 import type { Duration } from 'utils/duration';
@@ -44,10 +48,8 @@ export type StdcmConflictsResponse = Extract<
 
 export type StdcmResponse = StdcmConflictsResponse | StdcmSuccessResponse;
 
-export type OperationalPoint = NonNullable<PathProperties['operational_points']>[number];
-
 export type StdcmPathProperties = {
-  manchetteOperationalPoints?: OperationalPoint[];
+  manchetteOperationalPoints?: PathOperationalPoint[];
   geometry: NonNullable<PathProperties['geometry']>;
   suggestedOperationalPoints: SuggestedOP[];
   zones: NonNullable<PathProperties['zones']>;

--- a/front/src/applications/stdcm/utils/fetchPathProperties.ts
+++ b/front/src/applications/stdcm/utils/fetchPathProperties.ts
@@ -1,3 +1,5 @@
+import { omit } from 'lodash';
+
 import { getEntities } from 'applications/editor/data/api';
 import type { TrackSectionEntity } from 'applications/editor/tools/trackEdition/types';
 import type { StdcmPathProperties } from 'applications/stdcm/types';
@@ -7,6 +9,7 @@ import type {
 } from 'common/api/osrdEditoastApi';
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
 import { formatSuggestedOperationalPoints } from 'modules/pathfinding/utils';
+import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { SuggestedOP } from 'modules/trainschedule/components/ManageTrainSchedule/types';
 import type { AppDispatch } from 'store';
 
@@ -58,10 +61,13 @@ const fetchPathProperties = async (
       return { ...op, metadata };
     });
 
-    const operationalPointsWithUniqueIds = result.operational_points.map((op, index) => ({
-      ...op,
-      id: `${op.id}-${op.position}-${index}`,
-    }));
+    const operationalPointsWithUniqueIds: PathOperationalPoint[] = result.operational_points.map(
+      (op, index) => ({
+        ...omit(op, 'id'),
+        waypointId: `${op.id}-${op.position}-${index}`,
+        opId: op.id,
+      })
+    );
 
     const suggestedOperationalPoints: SuggestedOP[] = formatSuggestedOperationalPoints(
       operationalPointsWithMetadata,

--- a/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
+++ b/front/src/applications/stdcm/utils/stdcmComputeChartData.ts
@@ -15,6 +15,15 @@ const computeChartData = (
   pathProperties: StdcmPathProperties
 ): SpeedSpaceChartData => {
   const { simulation, path: pathfindingResult, departure_time: departureTime } = stdcmResponse;
+
+  /**
+   * TODO:
+   * Investigate the following fishy code:
+   * - pathProperties is of type **StdcmPathProperties**
+   * - preparePathPropertiesData requires a second argument of type **PathProperties**
+   * - TypeScript is fine with that, because all keys in PathProperties are optional
+   * - StdcmPathProperties and PathProperties have two keys in common (so this code might be on purpose)
+   */
   const formattedPathProperties = preparePathPropertiesData(
     simulation.electrical_profiles,
     pathProperties,

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -27,7 +27,7 @@ import { compact } from 'lodash';
 
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import type { PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
-import cutSpaceTimeRect from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
+import { cutSpaceTimeRect } from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
 import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
 import type {
   AspectLabel,

--- a/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
+++ b/front/src/modules/simulationResult/components/ManchetteWithSpaceTimeChart/ManchetteWithSpaceTimeChart.tsx
@@ -25,7 +25,6 @@ import cx from 'classnames';
 import dayjs from 'dayjs';
 import { compact } from 'lodash';
 
-import type { OperationalPoint } from 'applications/operationalStudies/types';
 import upward from 'assets/pictures/workSchedules/ScheduledMaintenanceUp.svg';
 import type { PostWorkSchedulesProjectPathApiResponse } from 'common/api/osrdEditoastApi';
 import cutSpaceTimeRect from 'modules/simulationResult/components/SpaceTimeChart/helpers/utils';
@@ -33,6 +32,7 @@ import { ASPECT_LABELS_COLORS } from 'modules/simulationResult/consts';
 import type {
   AspectLabel,
   LayerRangeData,
+  PathOperationalPoint,
   TrainSpaceTimeData,
   WaypointsPanelData,
 } from 'modules/simulationResult/types';
@@ -58,7 +58,7 @@ import useWaypointMenu from '../SpaceTimeChart/useWaypointMenu';
 import WaypointsPanel from '../SpaceTimeChart/WaypointsPanel';
 
 type ManchetteWithSpaceTimeChartProps = {
-  operationalPoints: OperationalPoint[];
+  operationalPoints: PathOperationalPoint[];
   projectPathTrainResult: TrainSpaceTimeData[];
   selectedTrainId?: TrainId;
   waypointsPanelData?: WaypointsPanelData;
@@ -222,7 +222,7 @@ const ManchetteWithSpaceTimeChartWrapper = ({
   const manchetteWaypoints = useMemo(() => {
     const rawWaypoints = waypointsPanelData?.filteredWaypoints ?? operationalPoints;
     return rawWaypoints.map((waypoint) => ({
-      id: waypoint.id,
+      id: waypoint.waypointId,
       position: waypoint.position,
       name: waypoint.extensions?.identifier?.name,
       secondaryCode: waypoint.extensions?.sncf?.ch,

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
@@ -6,15 +6,14 @@ import cx from 'classnames';
 import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import type { OperationalPoint } from 'applications/operationalStudies/types';
-import type { WaypointsPanelData } from 'modules/simulationResult/types';
+import type { PathOperationalPoint, WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mmToKm } from 'utils/physics';
 
 type WaypointsPanelProps = {
   waypointsPanelIsOpen: boolean;
   setWaypointsPanelIsOpen: (open: boolean) => void;
-  waypoints: OperationalPoint[];
+  waypoints: PathOperationalPoint[];
   waypointsPanelData: WaypointsPanelData;
 };
 
@@ -46,9 +45,9 @@ const WaypointsPanel = ({
 
   const openModal = () => {
     modalRef.current?.showModal();
-    const filteredWaypointsIds = filteredWaypoints.map((waypoint) => waypoint.id);
+    const filteredWaypointsIds = new Set(filteredWaypoints.map((waypoint) => waypoint.waypointId));
     const filteredWaypointsIndexes = waypoints
-      .map((waypoint, index) => (filteredWaypointsIds.includes(waypoint.id) ? index : -1))
+      .map((waypoint, index) => (filteredWaypointsIds.has(waypoint.waypointId) ? index : -1))
       .filter((index) => index !== -1);
 
     setSelectedWaypoints(new Set(filteredWaypointsIndexes));
@@ -148,7 +147,7 @@ const WaypointsPanel = ({
           />
         </div>
         {waypoints.map((waypoint, index) => (
-          <div className="waypoint-item" key={`${waypoint.id}-${index}`}>
+          <div className="waypoint-item" key={waypoint.waypointId}>
             <Checkbox
               small
               checked={selectedWaypoints.has(index)}

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/WaypointsPanel.tsx
@@ -3,12 +3,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Checkbox } from '@osrd-project/ui-core';
 import { Alert } from '@osrd-project/ui-icons';
 import cx from 'classnames';
-import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import type { PathOperationalPoint, WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
 import { mmToKm } from 'utils/physics';
+
+import { getWaypointsLocalStorageKey } from './helpers/utils';
 
 type WaypointsPanelProps = {
   waypointsPanelIsOpen: boolean;
@@ -68,13 +69,10 @@ const WaypointsPanel = ({
     const newFilteredWaypoints = waypoints.filter((_, i) => selectedWaypoints.has(i));
     setFilteredWaypoints(newFilteredWaypoints);
 
-    // We need to removed the id because it can change for waypoints added by map click
-    const simplifiedPath = projectionPath.map((waypoint) => omit(waypoint, ['id', 'deleted']));
-
     // TODO : when switching to the manchette back-end manager, remove all logic using
     // cleanScenarioLocalStorage from projet/study/scenario components (single/multi select)
     localStorage.setItem(
-      `${timetableId}-${JSON.stringify(simplifiedPath)}`,
+      getWaypointsLocalStorageKey(timetableId, projectionPath),
       JSON.stringify(newFilteredWaypoints)
     );
 

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/__tests__/utils.spec.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/__tests__/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import cutSpaceTimeRect from '../utils';
+import { cutSpaceTimeRect } from '../utils';
 
 describe('interpolateRange', () => {
   it('should return null if the interpolated range ends before the cut space', () => {

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/utils.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/helpers/utils.ts
@@ -1,6 +1,10 @@
+import { omit } from 'lodash';
+
+import type { TimetableItem } from 'reducers/osrdconf/types';
+
 import type { LayerRangeData } from '../../../types';
 
-const cutSpaceTimeRect = (
+export const cutSpaceTimeRect = (
   range: LayerRangeData,
   minSpace: number,
   maxSpace: number
@@ -31,4 +35,12 @@ const cutSpaceTimeRect = (
   };
 };
 
-export default cutSpaceTimeRect;
+export const getWaypointsLocalStorageKey = (
+  timetableId: number | undefined,
+  projectionPath: TimetableItem['path'] | undefined
+) => {
+  // We need to remove the id because it can change for waypoints added by map click
+  const simplifiedPath = projectionPath?.map((waypoint) => omit(waypoint, ['id', 'deleted']));
+
+  return `PathOperationalPoints-${timetableId}-${JSON.stringify(simplifiedPath)}`;
+};

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -4,13 +4,9 @@ import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { upsertMapWaypointsInOperationalPoints } from 'applications/operationalStudies/helpers/upsertMapWaypointsInOperationalPoints';
-import type { OperationalPoint } from 'applications/operationalStudies/types';
-import {
-  osrdEditoastApi,
-  type PathfindingResult,
-  type PathProperties,
-} from 'common/api/osrdEditoastApi';
+import { osrdEditoastApi, type PathfindingResult } from 'common/api/osrdEditoastApi';
 import { isStation } from 'modules/pathfinding/utils';
+import type { PathOperationalPoint } from 'modules/simulationResult/types';
 import type { TimetableItem } from 'reducers/osrdconf/types';
 import {
   extractEditoastIdFromPacedTrainId,
@@ -29,9 +25,9 @@ const useGetProjectedTrainOperationalPoints = ({
 }) => {
   const { t } = useTranslation('operational-studies');
 
-  const [operationalPoints, setOperationalPoints] = useState<OperationalPoint[]>([]);
+  const [operationalPoints, setOperationalPoints] = useState<PathOperationalPoint[]>([]);
   const [filteredOperationalPoints, setFilteredOperationalPoints] =
-    useState<OperationalPoint[]>(operationalPoints);
+    useState<PathOperationalPoint[]>(operationalPoints);
 
   const [getTrainSchedulePath] = osrdEditoastApi.endpoints.getTrainScheduleByIdPath.useLazyQuery();
   const [getPacedTrainPath] = osrdEditoastApi.endpoints.getPacedTrainByIdPath.useLazyQuery();
@@ -68,16 +64,20 @@ const useGetProjectedTrainOperationalPoints = ({
           },
         }).unwrap();
 
-        const operationalPointsWithAllWaypoints = upsertMapWaypointsInOperationalPoints(
+        let operationalPointsWithUniqueIds: PathOperationalPoint[] =
+          operational_points?.map((op, i) => ({
+            ...omit(op, 'id'),
+            waypointId: `${op.id}-${op.position}-${i}`,
+            opId: op.id,
+          })) || [];
+
+        operationalPointsWithUniqueIds = upsertMapWaypointsInOperationalPoints(
+          'PathOperationalPoint',
           timetableItemUsedForProjection.path,
           path.path_item_positions,
-          operational_points!,
+          operationalPointsWithUniqueIds,
           t
         );
-        let operationalPointsWithUniqueIds = operationalPointsWithAllWaypoints.map((op, i) => ({
-          ...op,
-          id: `${op.id}-${op.position}-${i}`,
-        }));
 
         setOperationalPoints(operationalPointsWithUniqueIds);
 
@@ -89,9 +89,9 @@ const useGetProjectedTrainOperationalPoints = ({
           `${timetableId}-${JSON.stringify(simplifiedPath)}`
         );
         if (stringifiedSavedWaypoints) {
-          operationalPointsWithUniqueIds = JSON.parse(stringifiedSavedWaypoints) as NonNullable<
-            PathProperties['operational_points']
-          >;
+          operationalPointsWithUniqueIds = JSON.parse(
+            stringifiedSavedWaypoints
+          ) as PathOperationalPoint[];
         } else {
           // If the manchette hasn't been saved, we want to display by default only
           // the waypoints with CH BV/00/'' and the path steps (origin, destination, vias)

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useGetProjectedTrainOperationalPoints.ts
@@ -14,6 +14,8 @@ import {
   isTrainScheduleId,
 } from 'utils/trainId';
 
+import { getWaypointsLocalStorageKey } from './helpers/utils';
+
 const useGetProjectedTrainOperationalPoints = ({
   infraId,
   timetableId,
@@ -81,12 +83,8 @@ const useGetProjectedTrainOperationalPoints = ({
 
         setOperationalPoints(operationalPointsWithUniqueIds);
 
-        // Check if there are saved manchettes in localStorage for the current timetable and path
-        const simplifiedPath = timetableItemUsedForProjection.path.map((waypoint) =>
-          omit(waypoint, ['id', 'deleted'])
-        );
         const stringifiedSavedWaypoints = localStorage.getItem(
-          `${timetableId}-${JSON.stringify(simplifiedPath)}`
+          getWaypointsLocalStorageKey(timetableId, timetableItemUsedForProjection.path)
         );
         if (stringifiedSavedWaypoints) {
           operationalPointsWithUniqueIds = JSON.parse(

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { EyeClosed } from '@osrd-project/ui-icons';
-import { omit } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import AnchoredMenu from 'common/AnchoredMenu';
@@ -9,6 +8,8 @@ import type { OSRDMenuItem } from 'common/OSRDMenu';
 import OSRDMenu from 'common/OSRDMenu';
 import type { WaypointsPanelData } from 'modules/simulationResult/types';
 import useModalFocusTrap from 'utils/hooks/useModalFocusTrap';
+
+import { getWaypointsLocalStorageKey } from './helpers/utils';
 
 const useWaypointMenu = (
   activeWaypointRef: React.RefObject<HTMLDivElement>,
@@ -60,15 +61,10 @@ const useWaypointMenu = (
             (waypoint) => waypoint.waypointId !== activeWaypointId
           );
 
-          // We need to remove the id because it can change for waypoints added by map click
-          const simplifiedPath = projectionPath?.map((waypoint) =>
-            omit(waypoint, ['id', 'deleted'])
-          );
-
           // TODO : when switching to the manchette back-end manager, remove all logic using
           // cleanScenarioLocalStorage from projet/study/scenario components (single/multi select)
           localStorage.setItem(
-            `${timetableId}-${JSON.stringify(simplifiedPath)}`,
+            getWaypointsLocalStorageKey(timetableId, projectionPath),
             JSON.stringify(newFilteredWaypoints)
           );
           return newFilteredWaypoints;

--- a/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
+++ b/front/src/modules/simulationResult/components/SpaceTimeChart/useWaypointMenu.tsx
@@ -57,7 +57,7 @@ const useWaypointMenu = (
         closeMenu();
         setFilteredWaypoints?.((prevFilteredWaypoints) => {
           const newFilteredWaypoints = prevFilteredWaypoints.filter(
-            (waypoint) => waypoint.id !== activeWaypointId
+            (waypoint) => waypoint.waypointId !== activeWaypointId
           );
 
           // We need to remove the id because it can change for waypoints added by map click

--- a/front/src/modules/simulationResult/types.ts
+++ b/front/src/modules/simulationResult/types.ts
@@ -3,7 +3,6 @@ import type { Dispatch, SetStateAction } from 'react';
 import type { LayerData, PowerRestrictionValues } from '@osrd-project/ui-charts';
 
 import type {
-  OperationalPoint,
   PathPropertiesFormatted,
   SimulationResponseSuccess,
 } from 'applications/operationalStudies/types';
@@ -17,6 +16,19 @@ import type {
 import type { PacedTrainWithDetails } from 'modules/trainschedule/components/Timetable/types';
 import type { OccurrenceId, TimetableItem, TrainScheduleId } from 'reducers/osrdconf/types';
 import type { ArrayElement } from 'utils/types';
+
+// This alias refers to an operational point, in the context of a given path, from Edistoast:
+export type EditoastPathOperationalPoint = NonNullable<
+  PathProperties['operational_points']
+>[number];
+
+// This type refers to an operational point, modified to carry its own unique ID (waypointId), and
+// optionally an actual opId, which can be repeated along a path when a train crosses multiple time
+// the same operational point:
+export type PathOperationalPoint = Omit<EditoastPathOperationalPoint, 'id'> & {
+  waypointId: string;
+  opId: string | null;
+};
 
 // Space Time Chart
 /**
@@ -57,8 +69,8 @@ export type ProjectionData = {
 
 export type WaypointsPanelData = {
   timetableId: number | undefined;
-  filteredWaypoints: OperationalPoint[];
-  setFilteredWaypoints: Dispatch<SetStateAction<OperationalPoint[]>>;
+  filteredWaypoints: PathOperationalPoint[];
+  setFilteredWaypoints: Dispatch<SetStateAction<PathOperationalPoint[]>>;
   projectionPath: TrainSchedule['path'];
 };
 


### PR DESCRIPTION
This commit aims at clarifying the `OperationalPoint` types (there are two identical types) that in practice have IDs that are not actual OP IDs, because the Manchette needs unique IDs, basically. It will help fetching track occupation data, when adding a track-occupancy diagram into the space-time chart (see [related ticket](https://github.com/osrd-project/osrd-confidential/issues/866)).

The solution is to also store the actual OP ID when it's possible, and get types with a slightly better naming, **`PathOperationalPoint`**, to highlight that these represent operational points, within the context of a given path.

#### Details:

- Replaces type `OperationalPoint` from both `operationalStudies/types` and `stdcm/types`, with **`EditoastPathOperationalPoint`** (exact data from Editoast) and **`PathOperationalPoint`** (with unique `waypointId` and optional `opId` instead of `id`) in `simulationResult/types`
- Switches to the relevant types in both STDCM and Operational Studies
- Stores the proper `opId` in the two places where the front generates unique IDs for the OPs for the Manchette
- Adapts `upsertMapWaypointsInOperationalPoints` so that it can both handles `PathOperationalPoint` or `EditoastPathOperationalPoint`
- Adds some comment about some fishy code in STDCM