### PR TITLE
front: fix and simplify imported train count translations

### DIFF
--- a/front/public/locales/en/operational-studies.json
+++ b/front/public/locales/en/operational-studies.json
@@ -1,6 +1,5 @@
 {
   "importTrains": {
-    "and": "and",
     "cancel": "Cancel",
     "date": "DATE",
     "datetime": "Date & time",
@@ -20,16 +19,10 @@
     "from": "Origin",
     "importTimetable": "Import a timetable",
     "inputPlaceholder": "Name, trigram",
-    "itemsFound_one": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) {{and}} $t(main.trainCount, {'count': {{trainsFound}}}) found",
-    "itemsFound_other": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) $t(main.trainCount, {'count': {{trainsFound}}}) found",
-    "itemsFound_zero": "No items found",
     "launchImport": "Start import",
     "noResults": "No results",
-    "pacedTrainCount_one": "1 service",
-    "pacedTrainCount_other": "{{count}} services",
-    "pacedTrainCount_zero": "",
     "pacedTrainsFound_one": "1 service found",
-    "pacedTrainsFound_other": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) found",
+    "pacedTrainsFound_other": "{{count}} services found",
     "searchTimetable": "Search timetable",
     "selectStation": "Select this station",
     "startTime": "START",
@@ -41,9 +34,9 @@
     },
     "success": "Operation successful",
     "to": "Destination",
-    "trainCount_one": "1 train",
-    "trainCount_other": "{{count}} trains",
-    "trainCount_zero": "",
+    "trainSchedulesAndPacedTrainsFound": "$t(main.pacedTrain, {'count': {{pacedTrainCount}}}) and $t(main.train, {'count': {{trainScheduleCount}}}) found",
+    "trainSchedulesFound_one": "1 train found",
+    "trainSchedulesFound_other": "{{count}} trains found",
     "warningMessages": {
       "warning": "Warning",
       "warningFilteredStepImport": "Some invalid steps had to be removed to allow import for trains: {{trainNumbers}}"

--- a/front/public/locales/fr/operational-studies.json
+++ b/front/public/locales/fr/operational-studies.json
@@ -1,6 +1,5 @@
 {
   "importTrains": {
-    "and": "et",
     "cancel": "Annuler",
     "date": "DATE",
     "datetime": "Date & horaires",
@@ -20,16 +19,10 @@
     "from": "Origine",
     "importTimetable": "Importer une grille horaire",
     "inputPlaceholder": "Nom, trigramme",
-    "itemsFound_one": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) $t(main.trainCount, {'count': {{trainsFound}}}) trouvé",
-    "itemsFound_other": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) {{and}} $t(main.trainCount, {'count': {{trainsFound}}}) trouvés",
-    "itemsFound_zero": "Aucun items trouvés",
     "launchImport": "Démarrer l'importation",
     "noResults": "Aucun résultat",
-    "pacedTrainCount_one": "1 mission",
-    "pacedTrainCount_other": "{{count}} missions",
-    "pacedTrainCount_zero": "",
     "pacedTrainsFound_one": "1 mission trouvée",
-    "pacedTrainsFound_other": "$t(main.pacedTrainCount, {'count': {{pacedTrainsFound}}}) trouvées",
+    "pacedTrainsFound_other": "{{count}} missions trouvées",
     "searchTimetable": "Rechercher la grille horaire",
     "selectStation": "Sélectionner cette station",
     "startTime": "DÉBUT",
@@ -41,9 +34,9 @@
     },
     "success": "Opération réussie",
     "to": "Destination",
-    "trainCount_one": "1 train",
-    "trainCount_other": "{{count}} trains",
-    "trainCount_zero": "",
+    "trainSchedulesAndPacedTrainsFound": "$t(main.pacedTrain, {'count': {{pacedTrainCount}}}) et $t(main.train, {'count': {{trainScheduleCount}}}) trouvés",
+    "trainSchedulesFound_one": "1 train trouvé",
+    "trainSchedulesFound_other": "{{count}} trains trouvés",
     "warningMessages": {
       "warning": "Attention",
       "warningFilteredStepImport": "Certaines étapes invalides ont dû être supprimées pour permettre l'importation pour les trains : {{trainNumbers}}"

--- a/front/scripts/i18n-checker.ts
+++ b/front/scripts/i18n-checker.ts
@@ -39,12 +39,6 @@ const IGNORE_UNUSED: RegExp[] = [
   /translation:mapKey.directCurrent/,
   /translation:mapSettings.layers\..*/,
 
-  // Import train schedule
-  /operational-studies:importTrains.and/,
-  /operational-studies:importTrains.errorMessages.errorEmptyFile/,
-  /operational-studies:importTrains.pacedTrainCount/,
-  /operational-studies:importTrains.trainCount/,
-
   // Manage train schedule
   /operational-studies:manageTrainSchedule.errorMessages\..*/,
   /operational-studies:manageTrainSchedule.incompatibleConstraints\..*/,

--- a/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
+++ b/front/src/modules/trainschedule/components/ImportTimetableItem/ImportTimetableItemTrainsList.tsx
@@ -163,30 +163,16 @@ const ImportTimetableItemTrainsList = ({
   }
 
   const computedItemImportLabel = () => {
-    if (
-      !trainSchedulesJsonData.length &&
-      !trainsList.length &&
-      (!!pacedTrainsJsonData.length || !!pacedTrainXmlData)
-    ) {
-      return t('pacedTrainsFound', {
-        count: pacedTrainsJsonData.length || pacedTrainXmlData.length,
-        pacedTrainsFound: pacedTrainsJsonData.length || pacedTrainXmlData.length,
-      });
-    }
+    const trainScheduleCount = trainsList.length || trainSchedulesJsonData.length;
+    const pacedTrainCount = pacedTrainsJsonData.length || pacedTrainXmlData.length;
 
-    return t('itemsFound', {
-      count:
-        trainsList.length ||
-        [...trainSchedulesJsonData, ...pacedTrainsJsonData, ...trainsXmlData, ...pacedTrainXmlData]
-          .length,
-      pacedTrainsFound: pacedTrainsJsonData.length || pacedTrainXmlData.length,
-      trainsFound: trainsList.length || trainSchedulesJsonData.length || trainsXmlData.length,
-      and:
-        (!!trainSchedulesJsonData.length && !!pacedTrainsJsonData.length) ||
-        (!!trainsXmlData.length && !!pacedTrainXmlData)
-          ? t('and')
-          : '',
-    });
+    if (trainScheduleCount > 0 && pacedTrainCount > 0) {
+      return t('trainSchedulesAndPacedTrainsFound', { trainScheduleCount, pacedTrainCount });
+    }
+    if (trainScheduleCount > 0) {
+      return t('trainSchedulesFound', { count: trainScheduleCount });
+    }
+    return t('pacedTrainsFound', { count: pacedTrainCount });
   };
 
   return trainsList.length > 0 ||


### PR DESCRIPTION
- The translations were misbehaving: some raw "/{{totalCount}}" strings were included in the final translation.
- The translations were more complicated than necessary: back-and-forth with variable interpolation for "and", unnecessary use of plurals and interpolation, empty strings making Weblate upset, unused keys.

This also lets us get rid of ignored patterns in i18n-checker.