### PR TITLE
editoast: send correct 'start_time' for paced train conflicts

### DIFF
--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -105,7 +105,7 @@ pub enum PathfindingCoreResult {
 }
 
 /// A successful pathfinding result. This is also used for STDCM response.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
 pub struct PathfindingResultSuccess {
     #[schema(inline)]
     /// Path description as block ids

--- a/editoast/src/core/pathfinding.rs
+++ b/editoast/src/core/pathfinding.rs
@@ -105,7 +105,8 @@ pub enum PathfindingCoreResult {
 }
 
 /// A successful pathfinding result. This is also used for STDCM response.
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema)]
+#[cfg_attr(test, derive(Default))]
 pub struct PathfindingResultSuccess {
     #[schema(inline)]
     /// Path description as block ids

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -19,8 +19,8 @@ use super::Tags;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
 
-#[derive(Debug, Default, Clone, Model)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, Model)]
+#[cfg_attr(test, derive(Default, PartialEq))]
 #[model(table = editoast_models::tables::paced_train)]
 #[model(gen(ops = crud, batch_ops = crd, list))]
 pub struct PacedTrain {

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -19,7 +19,7 @@ use super::Tags;
 use crate::models::prelude::*;
 use crate::models::train_schedule::TrainSchedule;
 
-#[derive(Debug, Clone, Model)]
+#[derive(Debug, Default, Clone, Model)]
 #[cfg_attr(test, derive(PartialEq))]
 #[model(table = editoast_models::tables::paced_train)]
 #[model(gen(ops = crud, batch_ops = crd, list))]

--- a/editoast/src/models/train_schedule.rs
+++ b/editoast/src/models/train_schedule.rs
@@ -13,7 +13,8 @@ use editoast_schemas::train_schedule::TrainScheduleOptions;
 
 use crate::models::prelude::*;
 
-#[derive(Debug, Default, Clone, Model)]
+#[derive(Debug, Clone, Model)]
+#[cfg_attr(test, derive(Default))]
 #[model(table = editoast_models::tables::train_schedule)]
 #[model(gen(ops = crud, batch_ops = crd, list))]
 #[model(row(derive(diesel::QueryableByName)))]

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -658,16 +658,16 @@ fn build_conflict_core_request(
     let mut it = paced_train_simulations.into_iter();
     for paced_train in paced_trains {
         let occurrences = &paced_train.num_occurrences();
-        let items: Vec<_> = it.by_ref().take(*occurrences).collect();
+        let simulations: Vec<_> = it.by_ref().take(*occurrences).collect();
 
-        if items.len() < *occurrences {
+        if simulations.len() < *occurrences {
             panic!(
                 "At least one simulation is missing for paced train {}",
                 paced_train.id
             );
         }
 
-        for (index, (sim, _)) in items.into_iter().enumerate() {
+        for (index, (sim, _)) in simulations.into_iter().enumerate() {
             let final_output = match sim {
                 simulation::Response::Success { final_output, .. } => final_output,
                 _ => continue,

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -657,10 +657,11 @@ fn build_conflict_core_request(
     // Build paced train requirements
     let mut it = paced_train_simulations.into_iter();
     for paced_train in paced_trains {
-        let occurrences_count = &paced_train.num_occurrences();
-        let simulations: Vec<_> = it.by_ref().take(*occurrences_count).collect();
+        let occurrences = paced_train.iter_occurrences().collect_vec();
+        let occurrences_count = occurrences.len();
+        let simulations: Vec<_> = it.by_ref().take(occurrences_count).collect();
 
-        if simulations.len() < *occurrences_count {
+        if simulations.len() < occurrences_count {
             panic!(
                 "At least one simulation is missing for paced train {}",
                 paced_train.id
@@ -681,7 +682,7 @@ fn build_conflict_core_request(
             trains_requirements.insert(
                 key,
                 TrainRequirements {
-                    start_time: paced_train.start_time,
+                    start_time: occurrences[index].start_time,
                     spacing_requirements: final_output.spacing_requirements,
                     routing_requirements: final_output.routing_requirements,
                 },
@@ -702,15 +703,26 @@ fn build_conflict_core_request(
 mod tests {
     use axum::http::StatusCode;
     use chrono::Duration;
+    use chrono::NaiveDate;
     use editoast_schemas::paced_train::ExceptionType;
     use editoast_schemas::paced_train::PacedTrainException;
     use editoast_schemas::paced_train::PathAndScheduleChangeGroup;
     use editoast_schemas::train_schedule::MarginValue;
     use editoast_schemas::train_schedule::Margins;
+    use models::PacedTrain;
+    use models::TrainSchedule;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
     use super::*;
+    use crate::core::pathfinding::PathfindingResultSuccess;
+    use crate::core::simulation::CompleteReportTrain;
+    use crate::core::simulation::ElectricalProfiles;
+    use crate::core::simulation::ReportTrain;
+    use crate::core::simulation::RoutingRequirement;
+    use crate::core::simulation::RoutingZoneRequirement;
+    use crate::core::simulation::SpacingRequirement;
+    use crate::core::simulation::SpeedLimitProperties;
     use crate::error::InternalError;
     use crate::models::fixtures::create_timetable;
     use crate::models::fixtures::simple_paced_train_base;
@@ -924,5 +936,153 @@ mod tests {
             .assert_status(StatusCode::NOT_FOUND)
             .json_into();
         assert_eq!(&response.error_type, "editoast:timetable:NotFound")
+    }
+
+    // Build one train schedule and one paced train with 2 occurrences
+    // then check that the function 'build_conflict_core_request'
+    // produce something coherent
+    #[test]
+    fn build_coherent_conflict_core_request() {
+        // Given
+        let infra = Infra::default();
+        let simple_id = 13;
+        let simple_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
+            .unwrap()
+            .and_hms_opt(8, 0, 0)
+            .unwrap()
+            .and_utc();
+        let train_schedule = TrainSchedule {
+            id: simple_id,
+            train_name: "simple".to_string(),
+            start_time: simple_start_time,
+            ..Default::default()
+        };
+        let trains = vec![train_schedule.clone()];
+        let spacing_requirement = SpacingRequirement {
+            zone: "ZONE_1".to_string(),
+            begin_time: 0,
+            end_time: 7,
+        };
+        let routing_requirement = RoutingRequirement {
+            route: "ZONE_2".to_string(),
+            begin_time: 12,
+            zones: vec![RoutingZoneRequirement {
+                zone: "ZONE_3".to_string(),
+                entry_detector: "D_1".to_string(),
+                exit_detector: "D_2".to_string(),
+                switches: {
+                    let mut map = HashMap::new();
+                    map.insert("S_1".to_string(), "S_2".to_string());
+                    map
+                },
+                end_time: 15,
+            }],
+        };
+        let train_simulations = vec![(
+            simulation::Response::Success {
+                base: ReportTrain::default(),
+                provisional: ReportTrain::default(),
+                final_output: CompleteReportTrain {
+                    spacing_requirements: vec![spacing_requirement.clone()],
+                    routing_requirements: vec![routing_requirement.clone()],
+                    ..Default::default()
+                },
+                mrsp: SpeedLimitProperties::default(),
+                electrical_profiles: ElectricalProfiles::default(),
+            },
+            PathfindingResult::Success(PathfindingResultSuccess::default()),
+        )];
+        let paced_id = 42;
+        let paced_start_time = NaiveDate::from_ymd_opt(2025, 1, 1)
+            .unwrap()
+            .and_hms_opt(9, 0, 0)
+            .unwrap()
+            .and_utc();
+        let paced_interval = chrono::Duration::try_hours(1).unwrap();
+        let paced_train = PacedTrain {
+            id: paced_id,
+            train_name: "paced".to_string(),
+            start_time: paced_start_time,
+            time_window: chrono::Duration::try_hours(2).unwrap(),
+            interval: paced_interval,
+            ..Default::default()
+        };
+        let paced_trains = vec![paced_train.clone()];
+        let paced_train_simulations = std::iter::repeat_n(
+            (
+                simulation::Response::Success {
+                    base: ReportTrain::default(),
+                    provisional: ReportTrain::default(),
+                    final_output: CompleteReportTrain {
+                        spacing_requirements: vec![spacing_requirement.clone()],
+                        routing_requirements: vec![routing_requirement.clone()],
+                        ..Default::default()
+                    },
+                    mrsp: SpeedLimitProperties::default(),
+                    electrical_profiles: ElectricalProfiles::default(),
+                },
+                PathfindingResult::Success(PathfindingResultSuccess::default()),
+            ),
+            2,
+        )
+        .collect();
+
+        // When
+        let conflict_core_request = build_conflict_core_request(
+            infra,
+            &trains,
+            train_simulations,
+            &paced_trains,
+            paced_train_simulations,
+        );
+
+        // Then (assert the train schedule)
+        assert_eq!(conflict_core_request.trains_requirements.len(), 3);
+        let simple_requirements = conflict_core_request
+            .trains_requirements
+            .get(&format!("{simple_id}"))
+            .unwrap();
+        assert_eq!(simple_requirements.start_time, simple_start_time);
+        assert_eq!(
+            simple_requirements.spacing_requirements,
+            vec![spacing_requirement.clone()]
+        );
+        assert_eq!(
+            simple_requirements.routing_requirements,
+            vec![routing_requirement.clone()]
+        );
+
+        // Then (assert the paced train, first occurrence)
+        let paced_0_requirements = conflict_core_request
+            .trains_requirements
+            .get(&format!("{paced_id}#0"))
+            .unwrap();
+        assert_eq!(paced_0_requirements.start_time, paced_start_time);
+        assert_eq!(
+            paced_0_requirements.spacing_requirements,
+            vec![spacing_requirement.clone()]
+        );
+        assert_eq!(
+            paced_0_requirements.routing_requirements,
+            vec![routing_requirement.clone()]
+        );
+
+        // Then (assert the paced train, second occurrence)
+        let paced_1_requirements = conflict_core_request
+            .trains_requirements
+            .get(&format!("{paced_id}#1"))
+            .unwrap();
+        assert_eq!(
+            paced_1_requirements.start_time,
+            paced_start_time + paced_interval
+        );
+        assert_eq!(
+            paced_1_requirements.spacing_requirements,
+            vec![spacing_requirement]
+        );
+        assert_eq!(
+            paced_1_requirements.routing_requirements,
+            vec![routing_requirement]
+        );
     }
 }

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -657,10 +657,10 @@ fn build_conflict_core_request(
     // Build paced train requirements
     let mut it = paced_train_simulations.into_iter();
     for paced_train in paced_trains {
-        let occurrences = &paced_train.num_occurrences();
-        let simulations: Vec<_> = it.by_ref().take(*occurrences).collect();
+        let occurrences_count = &paced_train.num_occurrences();
+        let simulations: Vec<_> = it.by_ref().take(*occurrences_count).collect();
 
-        if simulations.len() < *occurrences {
+        if simulations.len() < *occurrences_count {
             panic!(
                 "At least one simulation is missing for paced train {}",
                 paced_train.id

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -656,14 +656,14 @@ fn build_conflict_core_request(
 
     // Build paced train requirements
     let mut it = paced_train_simulations.into_iter();
-    for train in paced_trains {
-        let occurrences = &train.num_occurrences();
+    for paced_train in paced_trains {
+        let occurrences = &paced_train.num_occurrences();
         let items: Vec<_> = it.by_ref().take(*occurrences).collect();
 
         if items.len() < *occurrences {
             panic!(
                 "At least one simulation is missing for paced train {}",
-                train.id
+                paced_train.id
             );
         }
 
@@ -674,14 +674,14 @@ fn build_conflict_core_request(
             };
 
             let key = TrainId::PacedTrainOccurrence {
-                paced_train_id: train.id,
+                paced_train_id: paced_train.id,
                 index: index as u64,
             }
             .to_string();
             trains_requirements.insert(
                 key,
                 TrainRequirements {
-                    start_time: train.start_time,
+                    start_time: paced_train.start_time,
                     spacing_requirements: final_output.spacing_requirements,
                     routing_requirements: final_output.routing_requirements,
                 },

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -166,6 +166,68 @@ def test_conflicts(
     )
 
 
+@pytest.mark.parametrize(
+    ["paced_train_interval", "expected_conflict_types"],
+    [
+        ("PT15M", set()),  # Every half-hour, no conflict between each occurrences
+        (
+            "PT1M",
+            {"Spacing"},
+        ),  # Every minute, all occurrences will fight for space
+    ],
+)
+def test_paced_train_conflicts(
+    small_infra: Infra,
+    timetable_id: int,
+    fast_rolling_stock: int,
+    paced_train_interval: str,
+    expected_conflict_types: set[str],
+):
+    requests.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
+    paced_train_payload = {
+        "comfort": "STANDARD",
+        "constraint_distribution": "STANDARD",
+        "initial_speed": 0,
+        "labels": [],
+        "options": {"use_electrical_profiles": False},
+        "path": [
+            {"id": "start", "track": "TC1", "offset": 185000},
+            {"id": "end", "track": "TD0", "offset": 24820000},
+        ],
+        "power_restrictions": [],
+        "rolling_stock_name": "fast_rolling_stock",
+        "schedule": [
+            {
+                "at": "start",
+            },
+            {
+                "at": "end",
+            },
+        ],
+        "speed_limit_tag": "MA100",
+        "start_time": "2024-05-22T08:00:00.000Z",
+        "train_name": "paced train",
+        "paced": {"time_window": "PT1H", "interval": paced_train_interval},
+        "exceptions": [],
+    }
+
+    paced_train_response = requests.post(
+        f"{EDITOAST_URL}timetable/{timetable_id}/paced_trains",
+        json=[paced_train_payload],
+    )
+    paced_train_response.raise_for_status()
+
+    conflicts_response = requests.get(
+        f"{EDITOAST_URL}timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}"
+    )
+    conflicts_response.raise_for_status()
+
+    actual_conflicts = {
+        conflict["conflict_type"] for conflict in conflicts_response.json()
+    }
+    assert actual_conflicts == expected_conflict_types
+
+
 def test_scheduled_points_with_incompatible_margins(
     small_infra: Infra,
     timetable_id: int,


### PR DESCRIPTION
Fixes #11705 

When sending paced train occurrences to `core`, asking for conflicts, the `start_time` was always the one from the base occurrence. This PR calculates the correct `start_time` for each occurrence.

The fix is relatively simple (last commit), but I made 3 preliminary commits about renaming some variables. Most of the code is for adding tests:
- a test in `editoast` to check the construction of the `core` request for conflicts
- an integration test, checking that a paced train:
  - always have conflicts with its own occurrences if the interval is very small
  - never have conflicts with its own occurrences if the interval is big enough