### PR TITLE
editoast: paced train exception_key queries params

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1870,6 +1870,12 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: exception_key
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
       responses:
         '200':
           description: The path
@@ -1903,6 +1909,12 @@ paths:
         schema:
           type: integer
           format: int64
+          nullable: true
+      - name: exception_key
+        in: query
+        required: false
+        schema:
+          type: string
           nullable: true
       responses:
         '200':
@@ -7621,6 +7633,12 @@ components:
           format: double
           description: 'T_traction_cut_off: time delay in s from the traction cut-off command to the moment the acceleration due to traction is zero'
       additionalProperties: false
+    ExceptionQueryParam:
+      type: object
+      properties:
+        exception_key:
+          type: string
+          nullable: true
     GeoJson:
       oneOf:
       - $ref: '#/components/schemas/GeoJsonPoint'

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -62,6 +62,7 @@ editoast_common::schemas! {
     OccupancyBlockForm,
     OccupancyBlocks,
     PacedTrainSummaryResponse,
+    ExceptionQueryParam,
 }
 
 #[derive(Debug, Error, EditoastError)]
@@ -319,11 +320,17 @@ async fn simulation_summary(
     Ok(Json(simulation_summaries))
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+struct ExceptionQueryParam {
+    exception_key: Option<String>,
+}
+
 /// Get a path from a paced train given an infrastructure id and a paced train id
 #[utoipa::path(
     get, path = "",
     tag = "paced_train,pathfinding",
-    params(PacedTrainIdParam, InfraIdQueryParam),
+    params(PacedTrainIdParam, InfraIdQueryParam, ExceptionQueryParam),
     responses(
         (status = 200, description = "The path", body = PathfindingResult),
         (status = 404, description = "Infrastructure or Train schedule not found")
@@ -339,6 +346,9 @@ async fn get_path(
     Extension(auth): AuthenticationExt,
     Path(PacedTrainIdParam { id: paced_train_id }): Path<PacedTrainIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
+    Query(ExceptionQueryParam {
+        exception_key: _exception_key,
+    }): Query<ExceptionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies, Role::Stdcm].into())
@@ -382,7 +392,7 @@ pub struct ElectricalProfileSetIdQueryParam {
 #[utoipa::path(
     get, path = "",
     tag = "train_schedule",
-    params(PacedTrainIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam),
+    params(PacedTrainIdParam, InfraIdQueryParam, ElectricalProfileSetIdQueryParam, ExceptionQueryParam),
     responses(
         (status = 200, description = "Simulation Output", body = SimulationResponse),
     ),
@@ -400,6 +410,9 @@ async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
+    Query(ExceptionQueryParam {
+        exception_key: _exception_key,
+    }): Query<ExceptionQueryParam>,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -544,6 +544,7 @@ const injectedRtkApi = api
           url: `/paced_train/${queryArg.id}/path`,
           params: {
             infra_id: queryArg.infraId,
+            exception_key: queryArg.exceptionKey,
           },
         }),
         providesTags: ['paced_train', 'pathfinding'],
@@ -557,6 +558,7 @@ const injectedRtkApi = api
           params: {
             infra_id: queryArg.infraId,
             electrical_profile_set_id: queryArg.electricalProfileSetId,
+            exception_key: queryArg.exceptionKey,
           },
         }),
         providesTags: ['train_schedule'],
@@ -1708,6 +1710,7 @@ export type GetPacedTrainByIdPathApiResponse = /** status 200 The path */ Pathfi
 export type GetPacedTrainByIdPathApiArg = {
   id: number;
   infraId: number;
+  exceptionKey?: string | null;
 };
 export type GetPacedTrainByIdSimulationApiResponse =
   /** status 200 Simulation Output */ SimulationResponse;
@@ -1715,6 +1718,7 @@ export type GetPacedTrainByIdSimulationApiArg = {
   id: number;
   infraId: number;
   electricalProfileSetId?: number | null;
+  exceptionKey?: string | null;
 };
 export type GetProjectsApiResponse = /** status 200 The list of projects */ PaginationStats & {
   results: ProjectWithStudies[];


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/11451 and https://github.com/osrd-project/osrd-confidential/issues/980

- Add exception_key query parameter to the `/paced_train/:id/path` endpoint (not implemented yet)
- Add exception_key query parameter to the `/paced_train/:id/simulation` endpoint (not implemented yet)

The other endpoints will be handled in separate PRs