### PR TITLE
editoast: paced train exceptions sim summary response

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -1785,7 +1785,7 @@ paths:
               schema:
                 type: object
                 additionalProperties:
-                  $ref: '#/components/schemas/SimulationSummaryResult'
+                  $ref: '#/components/schemas/PacedTrainSimulationSummaryResult'
   /paced_train/{id}:
     get:
       tags:
@@ -9107,6 +9107,19 @@ components:
           timetable_id:
             type: integer
             format: int64
+    PacedTrainSimulationSummaryResult:
+      type: object
+      required:
+      - paced_train
+      - exceptions
+      properties:
+        exceptions:
+          type: object
+          description: The key is the `exception_key`
+          additionalProperties:
+            $ref: '#/components/schemas/SimulationSummaryResult'
+        paced_train:
+          $ref: '#/components/schemas/SimulationSummaryResult'
     PaginationStats:
       type: object
       description: |-

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -61,6 +61,7 @@ editoast_common::schemas! {
     PacedTrain,
     OccupancyBlockForm,
     OccupancyBlocks,
+    PacedTrainSummaryResponse,
 }
 
 #[derive(Debug, Error, EditoastError)]
@@ -226,6 +227,17 @@ struct SimulationBatchForm {
     ids: HashSet<i64>,
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(test, derive(PartialEq, serde::Deserialize))]
+#[schema(as = PacedTrainSimulationSummaryResult)]
+struct PacedTrainSummaryResponse {
+    #[schema(value_type = SimulationSummaryResult)]
+    pub paced_train: SummaryResponse,
+    #[schema(value_type = HashMap<String, SimulationSummaryResult>)]
+    /// The key is the `exception_key`
+    pub exceptions: HashMap<String, SummaryResponse>,
+}
+
 /// Associate each paced train id with its simulation summaries response
 /// If the simulation fails, it associates the reason: pathfinding failed or running time failed
 #[utoipa::path(
@@ -233,7 +245,7 @@ struct SimulationBatchForm {
     tag = "paced_train",
     request_body = inline(SimulationBatchForm),
     responses(
-        (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, SimulationSummaryResult>),
+        (status = 200, description = "Associate each paced train id with its simulation summaries", body = HashMap<i64, PacedTrainSimulationSummaryResult>),
     ),
 )]
 async fn simulation_summary(
@@ -249,7 +261,7 @@ async fn simulation_summary(
         electrical_profile_set_id,
         ids: paced_train_ids,
     }): Json<SimulationBatchForm>,
-) -> Result<Json<HashMap<i64, SummaryResponse>>> {
+) -> Result<Json<HashMap<i64, PacedTrainSummaryResponse>>> {
     let authorized = auth
         .check_roles([Role::OperationalStudies].into())
         .await
@@ -293,7 +305,15 @@ async fn simulation_summary(
     let simulation_summaries = paced_trains
         .into_iter()
         .zip(simulations)
-        .map(|(paced_train, (sim, _))| (paced_train.id, SummaryResponse::from(sim)))
+        .map(|(paced_train, (sim, _))| {
+            (
+                paced_train.id,
+                PacedTrainSummaryResponse {
+                    paced_train: SummaryResponse::from(sim),
+                    exceptions: HashMap::new(), // TODO retreive paced train exceptions simulations
+                },
+            )
+        })
         .collect();
 
     Ok(Json(simulation_summaries))
@@ -592,6 +612,7 @@ mod tests {
     use crate::views::test_app::TestAppBuilder;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::paced_train::PacedTrainResponse;
+    use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
     use crate::views::timetable::simulation::SummaryResponse;
 
     #[rstest]
@@ -797,18 +818,22 @@ mod tests {
             "infra_id": infra_id,
             "ids": vec![paced_train_id],
         }));
-        let response: HashMap<i64, SummaryResponse> =
+
+        let response: HashMap<i64, PacedTrainSummaryResponse> =
             app.fetch(request).assert_status(StatusCode::OK).json_into();
         assert_eq!(response.len(), 1);
         assert_eq!(
             *response.get(&paced_train_id).unwrap(),
-            SummaryResponse::Success {
-                length: 0,
-                time: 0,
-                energy_consumption: 0.0,
-                path_item_times_final: vec![0, 1000, 2000, 3000],
-                path_item_times_provisional: vec![0, 1000, 2000, 3000],
-                path_item_times_base: vec![0, 1000, 2000, 3000]
+            PacedTrainSummaryResponse {
+                paced_train: SummaryResponse::Success {
+                    length: 0,
+                    time: 0,
+                    energy_consumption: 0.0,
+                    path_item_times_final: vec![0, 1000, 2000, 3000],
+                    path_item_times_provisional: vec![0, 1000, 2000, 3000],
+                    path_item_times_base: vec![0, 1000, 2000, 3000]
+                },
+                exceptions: HashMap::new()
             }
         );
     }

--- a/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
+++ b/front/src/applications/operationalStudies/helpers/TrainSimulationLazyLoader.ts
@@ -138,7 +138,8 @@ export default class TrainSimulationLazyLoader {
     }
     for (const [rawId, rawSummary] of Object.entries(rawPacedTrainSummaries)) {
       const id = formatEditoastIdToPacedTrainId(Number(rawId));
-      rawSummaries.set(id, rawSummary);
+      // TODO exceptions : adapt this to handle exceptions summaries
+      rawSummaries.set(id, rawSummary.paced_train);
     }
 
     this.options.onProgress(rawSummaries);

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -1677,7 +1677,7 @@ export type PostPacedTrainProjectPathApiArg = {
 };
 export type PostPacedTrainSimulationSummaryApiResponse =
   /** status 200 Associate each paced train id with its simulation summaries */ {
-    [key: string]: SimulationSummaryResult;
+    [key: string]: PacedTrainSimulationSummaryResult;
   };
 export type PostPacedTrainSimulationSummaryApiArg = {
   body: {
@@ -3340,6 +3340,13 @@ export type SimulationSummaryResult =
   | (PathfindingInputError & {
       status: 'pathfinding_input_error';
     });
+export type PacedTrainSimulationSummaryResult = {
+  /** The key is the `exception_key` */
+  exceptions: {
+    [key: string]: SimulationSummaryResult;
+  };
+  paced_train: SimulationSummaryResult;
+};
 export type Comfort = 'STANDARD' | 'AIR_CONDITIONING' | 'HEATING';
 export type Distribution = 'STANDARD' | 'MARECO';
 export type ReceptionSignal = 'OPEN' | 'STOP' | 'SHORT_SLIP_STOP';


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/11451 

- Refactor endpoint response `/paced_train/simulation_summary` (not implemented yet)


```json
{
  "train_42": {
    "paced_train": {
      "energy_consumption": 0,
      "length": 0,
      "path_item_times_base": [
        0
      ],
      "path_item_times_final": [
        0
      ],
      "path_item_times_provisional": [
        0
      ],
      "status": "success",
      "time": 0
    },
    "exceptions": {
      "42432-234234-243242-23434": {
        "energy_consumption": 0,
        "length": 0,
        "path_item_times_base": [
          0
        ],
        "path_item_times_final": [
          0
        ],
        "path_item_times_provisional": [
          0
        ],
        "status": "success",
        "time": 0
      }
    }
  }
}
```

The other endpoints will be handled in separate PRs