### PR TITLE
editoast: paced train exceptions conflits endpoint

### DIFF
--- a/editoast/editoast_schemas/src/fixtures.rs
+++ b/editoast/editoast_schemas/src/fixtures.rs
@@ -1,8 +1,24 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
+use chrono::DateTime;
+use chrono::Utc;
 use editoast_common::units;
 
 use crate::RollingStock;
+use crate::paced_train::ConstraintDistributionChangeGroup;
+use crate::paced_train::ExceptionType;
+use crate::paced_train::InitialSpeedChangeGroup;
+use crate::paced_train::LabelsChangeGroup;
+use crate::paced_train::OptionsChangeGroup;
+use crate::paced_train::PacedTrainException;
+use crate::paced_train::PathAndScheduleChangeGroup;
+use crate::paced_train::RollingStockCategoryChangeGroup;
+use crate::paced_train::RollingStockChangeGroup;
+use crate::paced_train::SpeedLimitTagChangeGroup;
+use crate::paced_train::StartTimeChangeGroup;
+use crate::paced_train::TrainNameChangeGroup;
+use crate::primitives::NonBlankString;
 use crate::rolling_stock::EffortCurves;
 use crate::rolling_stock::LoadingGaugeType;
 use crate::rolling_stock::RollingResistance;
@@ -11,6 +27,11 @@ use crate::rolling_stock::RollingStockSupportedSignalingSystems;
 use crate::rolling_stock::TowedRollingStock;
 use crate::rolling_stock::TrainCategories;
 use crate::rolling_stock::TrainCategory;
+use crate::train_schedule::Comfort;
+use crate::train_schedule::Distribution;
+use crate::train_schedule::MarginValue;
+use crate::train_schedule::Margins;
+use crate::train_schedule::TrainScheduleOptions;
 
 pub fn simple_rolling_stock() -> RollingStock {
     RollingStock {
@@ -69,4 +90,54 @@ pub fn towed_rolling_stock() -> TowedRollingStock {
         max_speed: Some(units::meter_per_second::new(35.0)),
         railjson_version: "3.4".to_string(),
     }
+}
+
+pub fn simple_created_exception_with_change_groups(key: &str) -> PacedTrainException {
+    PacedTrainException {
+        key: key.into(),
+        exception_type: ExceptionType::Created {},
+        disabled: false,
+        train_name: Some(TrainNameChangeGroup {
+            value: "exception_train_name".into(),
+        }),
+        constraint_distribution: Some(ConstraintDistributionChangeGroup {
+            value: Distribution::Mareco,
+        }),
+        initial_speed: Some(InitialSpeedChangeGroup { value: 10.0 }),
+        labels: Some(LabelsChangeGroup {
+            value: vec!["Label 1".to_string(), "Label 3".to_string()],
+        }),
+        options: Some(OptionsChangeGroup {
+            value: TrainScheduleOptions::default(),
+        }),
+        path_and_schedule: Some(PathAndScheduleChangeGroup {
+            power_restrictions: vec![],
+            schedule: vec![],
+            path: vec![],
+            margins: Margins {
+                boundaries: vec![],
+                values: vec![MarginValue::Percentage(5.0)],
+            },
+        }),
+        rolling_stock: Some(RollingStockChangeGroup {
+            rolling_stock_name: "TJV".into(),
+            comfort: Comfort::AirConditioning,
+        }),
+        rolling_stock_category: Some(RollingStockCategoryChangeGroup { value: None }),
+        speed_limit_tag: Some(SpeedLimitTagChangeGroup {
+            value: Some(NonBlankString("GB".into())),
+        }),
+        start_time: Some(StartTimeChangeGroup {
+            value: DateTime::<Utc>::from_str("2025-05-05T20:05:00+02:00").unwrap(),
+        }),
+    }
+}
+
+pub fn simple_modified_exception_with_change_groups(
+    key: &str,
+    occurrence_index: i32,
+) -> PacedTrainException {
+    let mut exception = simple_created_exception_with_change_groups(key);
+    exception.exception_type = ExceptionType::Modified { occurrence_index };
+    exception
 }

--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -4373,18 +4373,40 @@ components:
         paced_train_occurrence_ids:
           type: array
           items:
-            type: object
-            required:
-            - paced_train_id
-            - index
-            properties:
-              index:
-                type: integer
-                format: int64
-                minimum: 0
-              paced_train_id:
-                type: integer
-                format: int64
+            allOf:
+            - oneOf:
+              - type: object
+                required:
+                - index
+                properties:
+                  index:
+                    type: integer
+                    format: int64
+                    minimum: 0
+              - type: object
+                required:
+                - index
+                - exception_key
+                properties:
+                  exception_key:
+                    type: string
+                  index:
+                    type: integer
+                    format: int64
+                    minimum: 0
+              - type: object
+                required:
+                - exception_key
+                properties:
+                  exception_key:
+                    type: string
+            - type: object
+              required:
+              - paced_train_id
+              properties:
+                paced_train_id:
+                  type: integer
+                  format: int64
           description: |-
             List of paced train occurrences involved in the conflict.
             Each occurrence is identified by a `paced_train_id` and its `index`

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::ops::DerefMut;
+use std::str::FromStr;
 
 use chrono::DateTime;
 use chrono::Duration as ChronoDuration;
@@ -9,14 +10,27 @@ use editoast_models::DbConnection;
 
 use editoast_common::units;
 use editoast_models::DbConnectionPoolV2;
+use editoast_schemas::fixtures::simple_created_exception_with_change_groups;
+use editoast_schemas::fixtures::simple_modified_exception_with_change_groups;
 use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
 use editoast_schemas::infra::InfraObject;
 use editoast_schemas::infra::RailJson;
+use editoast_schemas::paced_train::ConstraintDistributionChangeGroup;
 use editoast_schemas::paced_train::ExceptionType;
+use editoast_schemas::paced_train::InitialSpeedChangeGroup;
+use editoast_schemas::paced_train::LabelsChangeGroup;
+use editoast_schemas::paced_train::OptionsChangeGroup;
 use editoast_schemas::paced_train::Paced;
 use editoast_schemas::paced_train::PacedTrain;
 use editoast_schemas::paced_train::PacedTrainException;
+use editoast_schemas::paced_train::PathAndScheduleChangeGroup;
+use editoast_schemas::paced_train::RollingStockCategoryChangeGroup;
+use editoast_schemas::paced_train::RollingStockChangeGroup;
+use editoast_schemas::paced_train::SpeedLimitTagChangeGroup;
+use editoast_schemas::paced_train::StartTimeChangeGroup;
+use editoast_schemas::paced_train::TrainNameChangeGroup;
+use editoast_schemas::primitives::NonBlankString;
 use editoast_schemas::primitives::OSRDObject;
 use editoast_schemas::rolling_stock::EffortCurves;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
@@ -26,7 +40,12 @@ use editoast_schemas::rolling_stock::RollingStockSupportedSignalingSystems;
 use editoast_schemas::rolling_stock::TowedRollingStock;
 use editoast_schemas::rolling_stock::TrainCategories;
 use editoast_schemas::rolling_stock::TrainCategory;
+use editoast_schemas::train_schedule::Comfort;
+use editoast_schemas::train_schedule::Distribution;
+use editoast_schemas::train_schedule::MarginValue;
+use editoast_schemas::train_schedule::Margins;
 use editoast_schemas::train_schedule::TrainSchedule;
+use editoast_schemas::train_schedule::TrainScheduleOptions;
 use postgis_diesel::types::LineString;
 use serde::Deserialize;
 use serde_json::Value;
@@ -103,21 +122,10 @@ pub fn simple_paced_train_base() -> PacedTrain {
             .expect("Unable to parse test train schedule");
     PacedTrain {
         train_schedule_base,
-        exceptions: vec![PacedTrainException {
-            key: "exception_key".into(),
-            exception_type: ExceptionType::Created {},
-            disabled: false,
-            constraint_distribution: None,
-            initial_speed: None,
-            labels: None,
-            options: None,
-            path_and_schedule: None,
-            rolling_stock: None,
-            rolling_stock_category: None,
-            speed_limit_tag: None,
-            start_time: None,
-            train_name: None,
-        }],
+        exceptions: vec![
+            simple_created_exception_with_change_groups("exception_key_1"),
+            simple_modified_exception_with_change_groups("exception_key_2", 0),
+        ],
         paced: Paced {
             time_window: ChronoDuration::hours(2).try_into().unwrap(),
             interval: ChronoDuration::minutes(15).try_into().unwrap(),

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -415,12 +415,30 @@ impl Conflict {
             .iter()
             .partition_map(|train_id| match train_id.parse() {
                 Ok(TrainId::TrainSchedule(id)) => Either::Left(id),
-                Ok(TrainId::PacedTrainOccurrence {
+                Ok(TrainId::PacedTrainBaseOccurrence {
                     paced_train_id,
                     index,
                 }) => Either::Right(PacedTrainOccurrenceId {
                     paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::BaseOccurrence { index },
+                }),
+                Ok(TrainId::PacedTrainCreatedException {
+                    paced_train_id,
+                    exception_key,
+                }) => Either::Right(PacedTrainOccurrenceId {
+                    paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::CreatedException { exception_key },
+                }),
+                Ok(TrainId::PacedTrainModifiedException {
+                    paced_train_id,
+                    exception_key,
                     index,
+                }) => Either::Right(PacedTrainOccurrenceId {
+                    paced_train_id,
+                    occurrence_ref: PacedTrainOccurrenceRef::ModifiedException {
+                        index,
+                        exception_key,
+                    },
                 }),
                 Err(_) => unreachable!("Unreachable case encountered while partitioning train IDs"),
             });
@@ -449,23 +467,55 @@ impl Conflict {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
 struct PacedTrainOccurrenceId {
     paced_train_id: i64,
-    index: u64,
+    #[schema(inline)]
+    #[serde(flatten)]
+    occurrence_ref: PacedTrainOccurrenceRef,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(untagged)]
+enum PacedTrainOccurrenceRef {
+    BaseOccurrence { index: u64 },
+    ModifiedException { index: u64, exception_key: String },
+    CreatedException { exception_key: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// This ID is used to identify paced train occurrences and exceptions when sending them to the core API for conflict detection.
 enum TrainId {
     TrainSchedule(i64),
-    PacedTrainOccurrence { paced_train_id: i64, index: u64 },
+    PacedTrainBaseOccurrence {
+        paced_train_id: i64,
+        index: u64,
+    },
+    PacedTrainModifiedException {
+        paced_train_id: i64,
+        index: u64,
+        exception_key: String,
+    },
+    PacedTrainCreatedException {
+        paced_train_id: i64,
+        exception_key: String,
+    },
 }
 
 impl Display for TrainId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::TrainSchedule(id) => write!(f, "{id}"),
-            Self::PacedTrainOccurrence {
+            Self::PacedTrainBaseOccurrence {
                 paced_train_id,
                 index,
             } => write!(f, "{paced_train_id}#{index}"),
+            Self::PacedTrainCreatedException {
+                paced_train_id,
+                exception_key,
+            } => write!(f, "{paced_train_id}@{exception_key}"),
+            Self::PacedTrainModifiedException {
+                paced_train_id,
+                exception_key,
+                index,
+            } => write!(f, "{paced_train_id}@{exception_key}#{index}"),
         }
     }
 }
@@ -474,23 +524,45 @@ impl FromStr for TrainId {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.contains('#') {
-            let parts: Vec<&str> = s.split('#').collect();
-            if parts.len() != 2 {
-                return Err("Invalid PacedTrainOccurrenceId format");
+        // Is it a paced train exception?
+        if let Some((train_id_str, exception_str)) = s.split_once('@') {
+            let paced_train_id = train_id_str
+                .parse::<i64>()
+                .map_err(|_| "Invalid train id")?;
+            // Is it a modified paced train exception?
+            if let Some((exception_key, index_str)) = exception_str.split_once('#') {
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid exception index")?;
+                Ok(TrainId::PacedTrainModifiedException {
+                    paced_train_id,
+                    exception_key: exception_key.to_string(),
+                    index,
+                })
+            } else {
+                let exception_key = exception_str.to_string();
+                Ok(TrainId::PacedTrainCreatedException {
+                    paced_train_id,
+                    exception_key,
+                })
             }
-
-            let paced_train_id = parts[0].parse::<i64>().map_err(|_| "Invalid train id")?;
-            let index = parts[1]
-                .parse::<u64>()
-                .map_err(|_| "Invalid occurence id")?;
-            Ok(TrainId::PacedTrainOccurrence {
-                paced_train_id,
-                index,
-            })
         } else {
-            let id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
-            Ok(TrainId::TrainSchedule(id))
+            // Is it a base paced train exception?
+            if let Some((train_id_str, index_str)) = s.split_once('#') {
+                let paced_train_id = train_id_str
+                    .parse::<i64>()
+                    .map_err(|_| "Invalid train id")?;
+                let index = index_str
+                    .parse::<u64>()
+                    .map_err(|_| "Invalid occurrence index")?;
+                Ok(TrainId::PacedTrainBaseOccurrence {
+                    paced_train_id,
+                    index,
+                })
+            } else {
+                let train_id = s.parse::<i64>().map_err(|_| "Invalid train id")?;
+                Ok(TrainId::TrainSchedule(train_id))
+            }
         }
     }
 }
@@ -680,7 +752,7 @@ fn build_conflict_core_request(
                 _ => continue,
             };
 
-            let key = TrainId::PacedTrainOccurrence {
+            let key = TrainId::PacedTrainBaseOccurrence {
                 paced_train_id: paced_train.id,
                 index: index as u64,
             }
@@ -718,6 +790,8 @@ mod tests {
     use core_client::simulation::RoutingZoneRequirement;
     use core_client::simulation::SpacingRequirement;
     use core_client::simulation::SpeedLimitProperties;
+    use editoast_schemas::fixtures::simple_created_exception_with_change_groups;
+    use editoast_schemas::fixtures::simple_modified_exception_with_change_groups;
     use editoast_schemas::paced_train::ExceptionType;
     use editoast_schemas::paced_train::PacedTrainException;
     use editoast_schemas::paced_train::PathAndScheduleChangeGroup;
@@ -1011,6 +1085,10 @@ mod tests {
             start_time: paced_start_time,
             time_window: chrono::Duration::try_hours(2).unwrap(),
             interval: paced_interval,
+            exceptions: vec![
+                simple_created_exception_with_change_groups("exception_key_1"),
+                simple_modified_exception_with_change_groups("exception_key_2", 0),
+            ],
             ..Default::default()
         };
         let paced_trains = vec![paced_train.clone()];
@@ -1090,5 +1168,32 @@ mod tests {
             paced_1_requirements.routing_requirements,
             vec![routing_requirement]
         );
+    }
+
+    #[rstest]
+    #[case("42")]
+    #[case("42#10")]
+    #[case("84@exception_21")]
+    #[case("84@exception_21#7")]
+    fn train_id_parse_and_to_string_roundtrip(#[case] id: &str) {
+        assert_eq!(id.parse::<TrainId>().unwrap().to_string(), id);
+    }
+
+    #[rstest]
+    #[case("", "Invalid train id")]
+    #[case("#", "Invalid train id")]
+    #[case("@", "Invalid train id")]
+    #[case("@#", "Invalid train id")]
+    #[case("22#", "Invalid occurrence index")]
+    #[case("22@#", "Invalid exception index")]
+    #[case("22@#zero", "Invalid exception index")]
+    #[case("zero#", "Invalid train id")]
+    #[case("zero@", "Invalid train id")]
+    #[case("zero@#", "Invalid train id")]
+    #[case("22#zero", "Invalid occurrence index")]
+    #[case("22@key#", "Invalid exception index")]
+    #[case("22@key#zero", "Invalid exception index")]
+    fn train_id_parse_fails(#[case] id: &str, #[case] err: &str) {
+        assert_eq!(&id.parse::<TrainId>().unwrap_err().to_string(), err);
     }
 }

--- a/front/src/common/api/generatedEditoastApi.ts
+++ b/front/src/common/api/generatedEditoastApi.ts
@@ -4137,10 +4137,20 @@ export type Conflict = {
   end_time: string;
   /** List of paced train occurrences involved in the conflict.
     Each occurrence is identified by a `paced_train_id` and its `index` */
-  paced_train_occurrence_ids: {
-    index: number;
+  paced_train_occurrence_ids: ((
+    | {
+        index: number;
+      }
+    | {
+        exception_key: string;
+        index: number;
+      }
+    | {
+        exception_key: string;
+      }
+  ) & {
     paced_train_id: number;
-  }[];
+  })[];
   /** List of requirements causing the conflict */
   requirements: ConflictRequirement[];
   /** Datetime of the start of the conflict */

--- a/front/src/modules/conflict/utils.ts
+++ b/front/src/modules/conflict/utils.ts
@@ -13,12 +13,18 @@ function getConflictTrainNames(
   const trainScheduleNames = conflict.train_schedule_ids.map((id) =>
     trainNameMap.get(formatEditoastIdToTrainScheduleId(id))
   );
-  const occurenceNames = conflict.paced_train_occurrence_ids.map(({ paced_train_id, index }) => {
-    const pacedTrainName = trainNameMap.get(formatEditoastIdToPacedTrainId(paced_train_id));
+  const occurrenceNames = conflict.paced_train_occurrence_ids.map((occurrence) => {
+    const pacedTrainName = trainNameMap.get(
+      formatEditoastIdToPacedTrainId(occurrence.paced_train_id)
+    );
     if (!pacedTrainName) return undefined;
-    return computeOccurrenceName(pacedTrainName, index);
+    if ('index' in occurrence) {
+      return computeOccurrenceName(pacedTrainName, occurrence.index);
+    }
+    // TODO handle paced train created exceptions
+    return undefined;
   });
-  return [...trainScheduleNames, ...occurenceNames].filter((name) => name !== undefined);
+  return [...trainScheduleNames, ...occurrenceNames].filter((name) => name !== undefined);
 }
 
 export default function addTrainNamesToConflicts(

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -248,6 +248,17 @@ def test_conflicts_with_reception_on_closed_signal(
     )
 
 
+def _create_paced_train_exception_payload(key: str = "exception_key_1"):
+    return {
+        "key": key,
+        "disabled": False,
+        "start_time": {
+            "value": "2024-05-22T08:16:00.000Z",
+        },
+        "train_name": {"value": "exception_train_name"},
+    }
+
+
 @pytest.mark.parametrize(
     ["paced_train_interval", "expected_conflict_types"],
     [
@@ -290,7 +301,7 @@ def test_paced_train_conflicts(
         "start_time": "2024-05-22T08:00:00.000Z",
         "train_name": "paced train",
         "paced": {"time_window": "PT1H", "interval": paced_train_interval},
-        "exceptions": [],
+        "exceptions": [_create_paced_train_exception_payload()],
     }
 
     paced_train_response = requests.post(


### PR DESCRIPTION
Part of https://github.com/OpenRailAssociation/osrd/issues/11451 
- Refactor PacedTrainId in `/timetable/id/conflicts` endpoint (not implemented yet)
- TrainId parsing method upgrade with exceptions keys
- Tests
- Change api response
```json
        "paced_train_occurrence_ids": [
            {
                "paced_train_id": 46,
                "index": 0
            },
            {
                "paced_train_id": 47,
                "index": 1,
                "exception_key": "<key>"
            },
            {
                "paced_train_id": 48,
                "exception_key": "<uuid>"
            }
        ],
```

The other endpoints will be handled in separate PRs