### PR TITLE
tests: separate tests and comment them

### DIFF
--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -16,6 +16,97 @@ def test_get_timetable(
     assert "results" in json
 
 
+# A train schedule leaves on a top-branch of a 'Y' at 08:00.
+# A paced train (every 15 minutes for 2 hours) leave on the other top-branch of a 'Y' after the train schedule at:
+# 1. one second after the train schedule, expecting a spacing and a routing conflict
+# 2. ten minutes after the train schedule, expecting no conflict
+# 3. fifteen minutes and one second before, expecting the train schedule to arrive after the second occurrence with a spacing and a routing conflict
+@pytest.mark.parametrize(
+    ["paced_start_time", "expected_conflict_types"],
+    [
+        ("2024-05-22T08:00:01.000Z", {"Spacing", "Routing"}),
+        ("2024-05-22T08:10:00.000Z", set()),
+        ("2024-05-22T07:44:59.000Z", {"Spacing", "Routing"}),
+    ],
+)
+def test_conflicts_with_paced_trains(
+    small_infra: Infra,
+    timetable_id: int,
+    fast_rolling_stock: int,
+    paced_start_time: str,
+    expected_conflict_types: set[str],
+):
+    requests.post(f"{EDITOAST_URL}infra/{small_infra.id}/load").raise_for_status()
+    stopping_train_schedule_payload = [
+        {
+            "comfort": "STANDARD",
+            "constraint_distribution": "STANDARD",
+            "initial_speed": 0,
+            "labels": [],
+            "options": {"use_electrical_profiles": False},
+            "path": [
+                {"id": "start", "track": "TC0", "offset": 185000},
+                {"id": "stop", "track": "TC0", "offset": 685000},
+                {"id": "end", "track": "TD0", "offset": 24820000},
+            ],
+            "power_restrictions": [],
+            "rolling_stock_name": "fast_rolling_stock",
+            "schedule": [
+                {
+                    "at": "start",
+                },
+                {
+                    "at": "end",
+                },
+            ],
+            "speed_limit_tag": "MA100",
+            "start_time": "2024-05-22T08:00:00.000Z",
+            "train_name": "with_stop",
+        }
+    ]
+
+    stopping_train_schedule_response = requests.post(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
+        json=stopping_train_schedule_payload,
+    )
+    stopping_train_schedule_response.raise_for_status()
+
+    stopping_paced_train_payload = stopping_train_schedule_payload[0]
+    stopping_paced_train_payload["start_time"] = paced_start_time
+    stopping_paced_train_payload["paced"] = {"time_window": "PT2H", "interval": "PT15M"}
+    stopping_paced_train_payload["path"] = [
+        {"id": "start", "track": "TC1", "offset": 185000},
+        {"id": "end", "track": "TD0", "offset": 24820000},
+    ]
+
+    stopping_paced_train_response = requests.post(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/paced_trains",
+        json=[stopping_paced_train_payload],
+    )
+    stopping_paced_train_response.raise_for_status()
+
+    conflicts_response = requests.get(
+        f"{EDITOAST_URL}/timetable/{timetable_id}/conflicts/?infra_id={small_infra.id}"
+    )
+    conflicts_response.raise_for_status()
+    actual_conflicts = {
+        conflict["conflict_type"] for conflict in conflicts_response.json()
+    }
+    assert actual_conflicts == expected_conflict_types
+
+
+# Two train schedules are defined, one leaving at 08:00 and the second one
+# leaving a second after. Each train is on a different top-branch of a 'Y'
+# configuration and both train goes to the bottom branch of the 'Y'. The first
+# train is exposed to a signal before the node. The parametrization of this test
+# expose the three following scenarios:
+# 1. The signal is opened, the first train will not stop, and therefore reserve
+#    the block ahead of it. The second train will have both a spacing conflict (the
+#    block in front is reserved) and in routing (the node position is oriented
+#    for the first train).
+# 2/3. The signal is a stop (or a short slip stop), the first train has a
+#      reception on closed signal and does not reserve the block ahead,
+#      therefore, the second train has not spacing or routing conflict.
 @pytest.mark.parametrize(
     ["reception_signal", "expected_conflict_types"],
     [

--- a/tests/tests/test_timetable.py
+++ b/tests/tests/test_timetable.py
@@ -111,11 +111,11 @@ def test_conflicts_with_paced_trains(
     ["reception_signal", "expected_conflict_types"],
     [
         ("OPEN", {"Spacing", "Routing"}),
-        ("STOP", {"Spacing"}),
-        ("SHORT_SLIP_STOP", {"Spacing"}),
+        ("STOP", set()),
+        ("SHORT_SLIP_STOP", set()),
     ],
 )
-def test_conflicts(
+def test_conflicts_with_reception_on_closed_signal(
     small_infra: Infra,
     timetable_id: int,
     fast_rolling_stock: int,
@@ -160,16 +160,7 @@ def test_conflicts(
         f"{EDITOAST_URL}/timetable/{timetable_id}/train_schedules",
         json=stopping_train_schedule_payload,
     )
-
-    stopping_paced_train_payload = stopping_train_schedule_payload[0]
-    stopping_paced_train_payload["start_time"] = "2024-05-22T08:05:00.000Z"
-    stopping_paced_train_payload["paced"] = {"time_window": "PT2H", "interval": "PT15M"}
-
-    stopping_paced_train_response = requests.post(
-        f"{EDITOAST_URL}/timetable/{timetable_id}/paced_trains",
-        json=[stopping_paced_train_payload],
-    )
-    stopping_paced_train_response.raise_for_status()
+    stopping_train_schedule_response.raise_for_status()
 
     train_schedule_payload = [
         {


### PR DESCRIPTION
Should be merged after #11849.

The `test_conflicts` was a combination of testing conflicts on stop signals, and mixing train schedule and paced trains.

`test_conflicts` has been transformed into 2 different tests:
- `test_conflicts_with_paced_train` mixing up train schedule and paced trains and see if conflict behaviour is correct (see fbb30ec7525d4cf2a22282ffe61481cc237fc355).
- `test_conflicts_with_reception_on_closed_signal` testing opened, stop, and short slip stop configuration for signals (see 741562d17cd331f98a6c87d36860cff937e610a3)

Also add comments to the test to give more context.

Follow-up after #11216 that diverted original test