### PR TITLE
front: fix turning a service into a train schedule from nge

### DIFF
--- a/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
+++ b/front/src/applications/operationalStudies/components/MacroEditor/ngeToOsrd.ts
@@ -381,6 +381,7 @@ const handleUpdateTimetableItem = async ({
     start_time: startDate.toISOString(),
     schedule,
     paced: undefined,
+    exceptions: undefined,
   };
 
   let updatedTimetableItem: TimetableItem;


### PR DESCRIPTION
The creation of the train schedule failed because the payload has a key exceptions, since it is created from the train service object, but it should not have this key.

Setting the key to undefined solves the bug.

closes #11873 