### PR TITLE
ops: alpine uses 'apk', not 'apt-get'

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -8,9 +8,7 @@ RUN gcc -std=c99 -static -o /exec-as exec-as.c
 FROM node:24-alpine
 
 # Install dependencies
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends xdg-utils && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache xdg-utils
 
 COPY --from=exec_as_builder /exec-as /
 


### PR DESCRIPTION
After 03f2db385230b3c9538b85f18c82a2412a01df8f was published, the image of node was switch to alpine, but the package manager was not adapted.

⚠️ Should this file be associated with OPS maintainer in `CODEOWNER`?