### PR TITLE
ops: remove useless dependency

### DIFF
--- a/front/docker/Dockerfile.devel
+++ b/front/docker/Dockerfile.devel
@@ -7,9 +7,6 @@ RUN gcc -std=c99 -static -o /exec-as exec-as.c
 
 FROM node:24-alpine
 
-# Install dependencies
-RUN apk add --no-cache xdg-utils
-
 COPY --from=exec_as_builder /exec-as /
 
 WORKDIR /app


### PR DESCRIPTION
The dependency `xdg-utils` was added in
727b03f942b633fd58fdefd22e7f0c0a2a8f669f, probably for `xdg-open` that was used in `front/scripts/start-dev.sh`. But this file was removed in 9f89ea4bcb8d3881c469322344fbd1988566bd83, and therefore, `xdg-utils` is not useful anymore.

See also https://github.com/OpenRailAssociation/osrd/pull/11881#issuecomment-2901553637.