### PR TITLE
editoast: replace derivative crate with educe

### DIFF
--- a/editoast/Cargo.lock
+++ b/editoast/Cargo.lock
@@ -904,9 +904,9 @@ dependencies = [
  "chrono",
  "core_client",
  "deadpool",
- "derivative",
  "editoast_common",
  "editoast_schemas",
+ "educe",
  "futures-util",
  "hostname",
  "http",
@@ -1128,17 +1128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1287,6 @@ dependencies = [
  "dashmap",
  "deadpool",
  "deadpool-redis",
- "derivative",
  "derive_more",
  "diesel",
  "diesel-async",
@@ -1310,6 +1298,7 @@ dependencies = [
  "editoast_osrdyne_client",
  "editoast_schemas",
  "editoast_search",
+ "educe",
  "enum-map",
  "enumset",
  "fga",
@@ -1464,9 +1453,9 @@ name = "editoast_schemas"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "derivative",
  "editoast_common",
  "editoast_derive",
+ "educe",
  "enum-map",
  "geojson",
  "iso8601",
@@ -1490,6 +1479,18 @@ dependencies = [
  "strum",
  "thiserror 2.0.12",
  "utoipa",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1527,6 +1528,26 @@ name = "enum-map-derive"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/editoast/Cargo.toml
+++ b/editoast/Cargo.toml
@@ -40,7 +40,6 @@ deadpool = { version = "0.12.2", features = [
   "rt_tokio_1",
   "unmanaged",
 ] }
-derivative = "2.2.0"
 derive_more = { version = "2.0.1", features = [
   "debug",
   "display",
@@ -65,6 +64,7 @@ editoast_models = { path = "./editoast_models" }
 editoast_osrdyne_client = { path = "./editoast_osrdyne_client" }
 editoast_schemas = { path = "./editoast_schemas" }
 editoast_search = { path = "./editoast_search" }
+educe = "0.6.0"
 enum-map = "2.7.3"
 fga = { path = "./fga" }
 futures = { version = "0.3.31" }
@@ -143,7 +143,6 @@ deadpool-redis = { version = "0.21.0", features = [
   "tokio-comp",
   "tokio-native-tls-comp",
 ] }
-derivative.workspace = true
 derive_more.workspace = true
 diesel.workspace = true
 diesel-async = { workspace = true }
@@ -155,6 +154,7 @@ editoast_models.workspace = true
 editoast_osrdyne_client.workspace = true
 editoast_schemas.workspace = true
 editoast_search = { workspace = true }
+educe.workspace = true
 enum-map.workspace = true
 enumset = "1.1.6"
 fga.workspace = true

--- a/editoast/core_client/Cargo.toml
+++ b/editoast/core_client/Cargo.toml
@@ -11,9 +11,9 @@ mocking_client = []
 approx.workspace = true
 chrono.workspace = true
 deadpool.workspace = true
-derivative.workspace = true
 editoast_common = { workspace = true }
 editoast_schemas = { workspace = true }
+educe.workspace = true
 futures-util.workspace = true
 hostname.workspace = true
 http = "1.3.1"

--- a/editoast/core_client/src/conflict_detection.rs
+++ b/editoast/core_client/src/conflict_detection.rs
@@ -1,6 +1,5 @@
 use chrono::DateTime;
 use chrono::Utc;
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -18,7 +17,7 @@ editoast_common::schemas! {
     ConflictRequirement,
 }
 
-#[derive(Debug, Derivative, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ConflictDetectionRequest {
     pub infra: i64,
     /// Infrastructure expected version

--- a/editoast/core_client/src/mq_client.rs
+++ b/editoast/core_client/src/mq_client.rs
@@ -3,7 +3,7 @@ use deadpool::managed::Metrics;
 use deadpool::managed::Pool;
 use deadpool::managed::RecycleError;
 use deadpool::managed::RecycleResult;
-use derivative::Derivative;
+use educe::Educe;
 use futures_util::StreamExt;
 use itertools::Itertools;
 use lapin::BasicProperties;
@@ -171,13 +171,13 @@ pub struct Options {
     pub num_channels: usize,
 }
 
-#[derive(Debug, Error, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Debug, Error, Educe)]
+#[educe(PartialEq)]
 pub enum MqClientError {
     #[error("AMQP error: {0}")]
     Lapin(#[from] lapin::Error),
     #[error("Cannot serialize request: {0}")]
-    Serialization(#[derivative(PartialEq = "ignore")] serde_json::Error),
+    Serialization(#[educe(PartialEq(ignore))] serde_json::Error),
     #[error("Cannot parse response status")]
     StatusParsing,
     #[error("Response timeout")]

--- a/editoast/core_client/src/simulation.rs
+++ b/editoast/core_client/src/simulation.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use derivative::Derivative;
 use editoast_common::units;
 use editoast_common::units::quantities::Acceleration;
 use editoast_common::units::quantities::Deceleration;
@@ -21,6 +20,7 @@ use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::MarginValue;
 use editoast_schemas::train_schedule::ReceptionSignal;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -40,44 +40,44 @@ editoast_common::schemas! {
     ReportTrain,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Educe, ToSchema)]
+#[educe(Hash)]
 pub struct PhysicsConsist {
     pub effort_curves: EffortCurves,
     pub base_power_class: Option<String>,
     /// Length of the rolling stock
-    #[derivative(Hash(hash_with = "units::millimeter::hash"))]
+    #[educe(Hash(method(units::millimeter::hash)))]
     #[serde(with = "units::millimeter::u64")]
     #[schema(value_type = u64)]
     pub length: Length,
     /// Maximum speed of the rolling stock
-    #[derivative(Hash(hash_with = "units::meter_per_second::hash"))]
+    #[educe(Hash(method(units::meter_per_second::hash)))]
     #[serde(with = "units::meter_per_second")]
     #[schema(value_type = f64)]
     pub max_speed: Velocity,
-    #[derivative(Hash(hash_with = "units::millisecond::hash"))]
+    #[educe(Hash(method(units::millisecond::hash)))]
     #[serde(with = "units::millisecond::u64")]
     #[schema(value_type = u64)]
     pub startup_time: Time,
-    #[derivative(Hash(hash_with = "units::meter_per_second_squared::hash"))]
+    #[educe(Hash(method(units::meter_per_second_squared::hash)))]
     #[serde(with = "units::meter_per_second_squared")]
     #[schema(value_type = f64)]
     pub startup_acceleration: Acceleration,
-    #[derivative(Hash(hash_with = "units::meter_per_second_squared::hash"))]
+    #[educe(Hash(method(units::meter_per_second_squared::hash)))]
     #[serde(with = "units::meter_per_second_squared")]
     #[schema(value_type = f64)]
     pub comfort_acceleration: Acceleration,
     /// The constant gamma braking coefficient used when NOT circulating
     /// under ETCS/ERTMS signaling system
-    #[derivative(Hash(hash_with = "units::meter_per_second_squared::hash"))]
+    #[educe(Hash(method(units::meter_per_second_squared::hash)))]
     #[serde(with = "units::meter_per_second_squared")]
     #[schema(value_type = f64)]
     pub const_gamma: Deceleration,
     pub etcs_brake_params: Option<EtcsBrakeParams>,
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<5,_>)))]
     pub inertia_coefficient: f64,
     /// Mass of the rolling stock
-    #[derivative(Hash(hash_with = "units::kilogram::hash"))]
+    #[educe(Hash(method(units::kilogram::hash)))]
     #[serde(with = "units::kilogram::u64")]
     #[schema(value_type = u64)]
     pub mass: Mass,
@@ -87,13 +87,13 @@ pub struct PhysicsConsist {
     pub power_restrictions: BTreeMap<String, String>,
     /// The time the train takes before actually using electrical power.
     /// Is null if the train is not electric or the value not specified.
-    #[derivative(Hash(hash_with = "units::millisecond::option::hash"))]
+    #[educe(Hash(method(units::millisecond::option::hash)))]
     #[serde(default, with = "units::millisecond::u64::option")]
     #[schema(value_type = Option<u64>)]
     pub electrical_power_startup_time: Option<Time>,
     /// The time it takes to raise this train's pantograph.
     /// Is null if the train is not electric or the value not specified.
-    #[derivative(Hash(hash_with = "units::millisecond::option::hash"))]
+    #[educe(Hash(method(units::millisecond::option::hash)))]
     #[serde(default, with = "units::millisecond::u64::option")]
     #[schema(value_type = Option<u64>)]
     pub raise_pantograph_time: Option<Time>,
@@ -456,15 +456,15 @@ pub struct SimulationPowerRestrictionRange {
     handled: bool,
 }
 
-#[derive(Debug, Serialize, Derivative)]
-#[derivative(Hash)]
+#[derive(Debug, Serialize, Educe)]
+#[educe(Hash)]
 pub struct Request {
     pub infra: i64,
     pub expected_version: i64,
     pub path: SimulationPath,
     pub schedule: Vec<SimulationScheduleItem>,
     pub margins: SimulationMargins,
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<3,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<3,_>)))]
     pub initial_speed: f64,
     pub comfort: Comfort,
     pub constraint_distribution: Distribution,

--- a/editoast/core_client/src/version.rs
+++ b/editoast/core_client/src/version.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use editoast_common::Version;
 use serde::Serialize;
 
@@ -6,8 +5,7 @@ use super::AsCoreRequest;
 use super::Json;
 
 /// A Core infra load request
-#[derive(Debug, Serialize, Derivative)]
-#[derivative(Default)]
+#[derive(Debug, Serialize, Default)]
 pub struct CoreVersionRequest {}
 
 impl AsCoreRequest<Json<Version>> for CoreVersionRequest {

--- a/editoast/editoast_common/src/units.rs
+++ b/editoast/editoast_common/src/units.rs
@@ -10,7 +10,7 @@
 //!
 //! ```ignore
 //! use editoast_model::units::*;
-//! #[derive(Debug, Serialize, Derivative)]
+//! #[derive(Debug, Serialize)]
 //! struct Train {
 //!     // This means that serde with read and write the velocity in meters per second
 //!     #[serde(with="meter_per_second")]

--- a/editoast/editoast_schemas/Cargo.toml
+++ b/editoast/editoast_schemas/Cargo.toml
@@ -9,9 +9,9 @@ testing = []
 
 [dependencies]
 chrono.workspace = true
-derivative.workspace = true
 editoast_common.workspace = true
 editoast_derive.workspace = true
+educe.workspace = true
 enum-map.workspace = true
 geojson.workspace = true
 iso8601 = "0.6.3"

--- a/editoast/editoast_schemas/src/infra/applicable_directions.rs
+++ b/editoast/editoast_schemas/src/infra/applicable_directions.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -7,12 +6,11 @@ editoast_common::schemas! {
     ApplicableDirections,
 }
 
-#[derive(Debug, Derivative, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
-#[derivative(Default)]
+#[derive(Debug, Default, Copy, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ApplicableDirections {
     StartToStop,
     StopToStart,
-    #[derivative(Default)]
+    #[default]
     Both,
 }

--- a/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
+++ b/editoast/editoast_schemas/src/infra/applicable_directions_track_range.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -10,15 +10,15 @@ editoast_common::schemas! {
     ApplicableDirectionsTrackRange,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct ApplicableDirectionsTrackRange {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub begin: f64,
-    #[derivative(Default(value = "100."))]
+    #[educe(Default = 100.)]
     pub end: f64,
     pub applicable_directions: ApplicableDirections,
 }

--- a/editoast/editoast_schemas/src/infra/buffer_stop.rs
+++ b/editoast/editoast_schemas/src/infra/buffer_stop.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -12,13 +12,13 @@ editoast_common::schemas! {
     BufferStop,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct BufferStop {
     #[schema(inline)]
     pub id: Identifier,
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,

--- a/editoast/editoast_schemas/src/infra/detector.rs
+++ b/editoast/editoast_schemas/src/infra/detector.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -12,13 +12,13 @@ editoast_common::schemas! {
     Detector,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct Detector {
     #[schema(inline)]
     pub id: Identifier,
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,

--- a/editoast/editoast_schemas/src/infra/directional_track_range.rs
+++ b/editoast/editoast_schemas/src/infra/directional_track_range.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -10,17 +10,17 @@ editoast_common::schemas! {
     DirectionalTrackRange,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct DirectionalTrackRange {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub begin: f64,
-    #[derivative(Default(value = "100."))]
+    #[educe(Default = 100.)]
     pub end: f64,
-    #[derivative(Default(value = "Direction::StartToStop"))]
+    #[educe(Default = Direction::StartToStop)]
     pub direction: Direction,
 }
 

--- a/editoast/editoast_schemas/src/infra/electrification.rs
+++ b/editoast/editoast_schemas/src/infra/electrification.rs
@@ -1,5 +1,4 @@
 use crate::primitives::NonBlankString;
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -14,9 +13,8 @@ editoast_common::schemas! {
     Electrification,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct Electrification {
     #[schema(inline)]
     pub id: Identifier,

--- a/editoast/editoast_schemas/src/infra/neutral_section.rs
+++ b/editoast/editoast_schemas/src/infra/neutral_section.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -19,9 +18,8 @@ editoast_common::schemas! {
 /// In practice, neutral sections are delimited by signs. In OSRD, neutral sections are directional to allow accounting for different sign placement depending on the direction.
 ///
 /// For more details see [the documentation](https://osrd.fr/en/docs/explanation/neutral_sections/).
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct NeutralSection {
     #[schema(inline)]
     pub id: Identifier,

--- a/editoast/editoast_schemas/src/infra/operational_point.rs
+++ b/editoast/editoast_schemas/src/infra/operational_point.rs
@@ -1,5 +1,5 @@
 use crate::primitives::NonBlankString;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -15,9 +15,8 @@ editoast_common::schemas! {
     OperationalPointPart,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct OperationalPoint {
     #[schema(inline)]
     pub id: Identifier,
@@ -29,11 +28,11 @@ pub struct OperationalPoint {
     pub weight: Option<u8>,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default, PartialEq)]
+#[educe(Default, PartialEq)]
 pub struct OperationalPointPart {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,

--- a/editoast/editoast_schemas/src/infra/railjson.rs
+++ b/editoast/editoast_schemas/src/infra/railjson.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -22,12 +22,12 @@ editoast_common::schemas! {
 }
 
 /// An infrastructure description in the RailJson format
-#[derive(Deserialize, Derivative, Serialize, Clone, Debug, ToSchema)]
-#[derivative(Default)]
+#[derive(Deserialize, Educe, Serialize, Clone, Debug, ToSchema)]
+#[educe(Default)]
 #[serde(deny_unknown_fields)]
 pub struct RailJson {
     /// The version of the RailJSON format. Defaults to the current version.
-    #[derivative(Default(value = r#"RAILJSON_VERSION.to_string()"#))]
+    #[educe(Default = RAILJSON_VERSION.to_string())]
     pub version: String,
     /// Operational point is also known in French as "Point Remarquable" (PR). One `OperationalPoint` is a **collection** of points (`OperationalPointParts`) of interest.
     pub operational_points: Vec<OperationalPoint>,

--- a/editoast/editoast_schemas/src/infra/route.rs
+++ b/editoast/editoast_schemas/src/infra/route.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::primitives::Identifier;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -19,14 +19,14 @@ editoast_common::schemas! {
     Waypoint,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct Route {
     #[schema(inline)]
     pub id: Identifier,
     pub entry_point: Waypoint,
-    #[derivative(Default(value = "Direction::StartToStop"))]
+    #[educe(Default = Direction::StartToStop)]
     pub entry_point_direction: Direction,
     pub exit_point: Waypoint,
     #[schema(inline)]

--- a/editoast/editoast_schemas/src/infra/side.rs
+++ b/editoast/editoast_schemas/src/infra/side.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -7,12 +6,11 @@ editoast_common::schemas! {
     Side,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
-#[derivative(Default)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Side {
     Left,
     Right,
-    #[derivative(Default)]
+    #[default]
     Center,
 }

--- a/editoast/editoast_schemas/src/infra/sign.rs
+++ b/editoast/editoast_schemas/src/infra/sign.rs
@@ -1,6 +1,6 @@
 use crate::primitives::Identifier;
 use crate::primitives::NonBlankString;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -12,16 +12,16 @@ editoast_common::schemas! {
     Sign,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
-#[derivative(Default)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[educe(Default)]
 #[serde(deny_unknown_fields)]
 pub struct Sign {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,
     pub side: Side,
-    #[derivative(Default(value = r#"Direction::StartToStop"#))]
+    #[educe(Default = Direction::StartToStop)]
     pub direction: Direction,
     #[serde(rename = "type")]
     #[schema(inline)]

--- a/editoast/editoast_schemas/src/infra/signal.rs
+++ b/editoast/editoast_schemas/src/infra/signal.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -17,19 +17,19 @@ editoast_common::schemas! {
     Signal,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct Signal {
     #[schema(inline)]
     pub id: Identifier,
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
     pub position: f64,
-    #[derivative(Default(value = "Direction::StartToStop"))]
+    #[educe(Default = Direction::StartToStop)]
     pub direction: Direction,
-    #[derivative(Default(value = "400."))]
+    #[educe(Default = 400.)]
     pub sight_distance: f64,
     #[serde(default)]
     #[schema(inline)]

--- a/editoast/editoast_schemas/src/infra/speed_section.rs
+++ b/editoast/editoast_schemas/src/infra/speed_section.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -17,16 +17,16 @@ editoast_common::schemas! {
     SpeedSection,
 }
 
-#[derive(Debug, Derivative, Clone, Serialize, PartialEq, Copy, ToSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, Copy, ToSchema)]
 pub struct Speed(pub f64);
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
-#[derivative(Default)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[educe(Default)]
 #[serde(deny_unknown_fields)]
 pub struct SpeedSection {
     #[schema(inline)]
     pub id: Identifier,
-    #[derivative(Default(value = "Some(Speed(80.))"))]
+    #[educe(Default = Some(Speed(80.)))]
     #[schema(inline)]
     pub speed_limit: Option<Speed>,
     #[schema(inline)]

--- a/editoast/editoast_schemas/src/infra/switch.rs
+++ b/editoast/editoast_schemas/src/infra/switch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -16,9 +15,8 @@ editoast_common::schemas! {
     Switch,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct Switch {
     #[schema(inline)]
     pub id: Identifier,

--- a/editoast/editoast_schemas/src/infra/switch_type.rs
+++ b/editoast/editoast_schemas/src/infra/switch_type.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -21,9 +20,8 @@ editoast_common::schemas! {
     SwitchPortConnection,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 #[schema(example = json!(
     {
         "id": "Point",
@@ -54,9 +52,8 @@ impl OSRDIdentified for SwitchType {
     }
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct SwitchPortConnection {
     #[schema(inline)]
     pub src: Identifier,

--- a/editoast/editoast_schemas/src/infra/track_endpoint.rs
+++ b/editoast/editoast_schemas/src/infra/track_endpoint.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -11,13 +11,13 @@ editoast_common::schemas! {
     TrackEndpoint,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
-#[derivative(Default)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, ToSchema)]
+#[educe(Default)]
 #[serde(deny_unknown_fields)]
 pub struct TrackEndpoint {
-    #[derivative(Default(value = "Endpoint::Begin"))]
+    #[educe(Default = Endpoint::Begin)]
     pub endpoint: Endpoint,
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     #[schema(inline)]
     pub track: Identifier,
 }

--- a/editoast/editoast_schemas/src/infra/track_range.rs
+++ b/editoast/editoast_schemas/src/infra/track_range.rs
@@ -1,5 +1,5 @@
 use crate::primitives::Identifier;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -8,15 +8,15 @@ editoast_common::schemas! {
     TrackRange,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct TrackRange {
     #[schema(value_type=String, example="01234567-89ab-cdef-0123-456789abcdef")]
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     pub track: Identifier,
     pub begin: f64,
-    #[derivative(Default(value = "100."))]
+    #[educe(Default = 100.)]
     pub end: f64,
 }
 

--- a/editoast/editoast_schemas/src/infra/track_section.rs
+++ b/editoast/editoast_schemas/src/infra/track_section.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use geojson::Geometry;
 use geojson::Value::LineString;
 use serde::Deserialize;
@@ -21,19 +21,19 @@ editoast_common::schemas! {
     Curve,
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct TrackSection {
     #[schema(inline)]
     pub id: Identifier,
-    #[derivative(Default(value = "100."))]
+    #[educe(Default = 100.)]
     pub length: f64,
     pub slopes: Vec<Slope>,
     pub curves: Vec<Curve>,
     #[serde(default)]
     pub loading_gauge_limits: Vec<LoadingGaugeLimit>,
-    #[derivative(Default(value = "Geometry::new(LineString(vec![]))"))]
+    #[educe(Default = Geometry::new(LineString(vec![])))]
     #[schema(value_type = GeoJsonLineString)]
     pub geo: Geometry,
     #[serde(default)]

--- a/editoast/editoast_schemas/src/infra/track_section_sncf_extension.rs
+++ b/editoast/editoast_schemas/src/infra/track_section_sncf_extension.rs
@@ -1,20 +1,20 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::primitives::NonBlankString;
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct TrackSectionSncfExtension {
     pub line_code: i32,
-    #[derivative(Default(value = r#""line_test".into()"#))]
+    #[educe(Default = "line_test".into())]
     #[schema(inline)]
     pub line_name: NonBlankString,
     pub track_number: i32,
-    #[derivative(Default(value = r#""track_test".into()"#))]
+    #[educe(Default = "track_test".into())]
     #[schema(inline)]
     pub track_name: NonBlankString,
 }

--- a/editoast/editoast_schemas/src/infra/track_section_source_extension.rs
+++ b/editoast/editoast_schemas/src/infra/track_section_source_extension.rs
@@ -1,13 +1,11 @@
-use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
 
 use crate::primitives::NonBlankString;
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
 pub struct TrackSectionSourceExtension {
     #[schema(inline)]
     pub name: NonBlankString,

--- a/editoast/editoast_schemas/src/primitives/object_ref.rs
+++ b/editoast/editoast_schemas/src/primitives/object_ref.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -9,14 +9,14 @@ editoast_common::schemas! {
     ObjectRef,
 }
 
-#[derive(Deserialize, Derivative, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
-#[derivative(Default)]
+#[derive(Deserialize, Educe, Serialize, Clone, Debug, PartialEq, Eq, Hash, ToSchema)]
+#[educe(Default)]
 #[serde(deny_unknown_fields)]
 pub struct ObjectRef {
     #[serde(rename = "type")]
-    #[derivative(Default(value = "ObjectType::TrackSection"))]
+    #[educe(Default = ObjectType::TrackSection)]
     pub obj_type: ObjectType,
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     pub obj_id: String,
 }
 

--- a/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/effort_curves.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -70,15 +70,15 @@ pub struct EffortCurveConditions {
     power_restriction_code: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, ToSchema, Derivative)]
-#[derivative(Hash)]
+#[derive(Clone, Debug, PartialEq, Serialize, ToSchema, Educe)]
+#[educe(Hash)]
 #[serde(deny_unknown_fields)]
 pub struct EffortCurve {
-    #[derivative(Hash(hash_with = "editoast_common::hash_float_slice::<3,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float_slice::<3,_>)))]
     #[schema(min_items = 2, example = json!([0.0, 2.958, 46.719]))]
     /// Speeds in m/s. Must contains the same number of elements as `max_efforts`
     speeds: Vec<f64>,
-    #[derivative(Hash(hash_with = "editoast_common::hash_float_slice::<3,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float_slice::<3,_>)))]
     #[schema(min_items = 2, example = json!([23500.0, 23200.0, 21200.0]))]
     /// Max efforts in N. Must contains the same number of elements as `speeds`.
     max_efforts: Vec<f64>,

--- a/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/etcs_brake_params.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -10,8 +10,8 @@ editoast_common::schemas! {
     SpeedIntervalValueCurve,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
-#[derivative(Hash)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
+#[educe(Hash)]
 #[serde(deny_unknown_fields)]
 /// Braking parameters for ERTMS ETCS Level 2
 /// Commented with their names in ETCS specification document `SUBSET-026-3 v400.pdf` from the
@@ -38,29 +38,29 @@ pub struct EtcsBrakeParams {
     /// Values (in m/s²) should be contained in [0, 10]
     pub k_n_neg: SpeedIntervalValueCurve,
     /// T_traction_cut_off: time delay in s from the traction cut-off command to the moment the acceleration due to traction is zero
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<5,_>)))]
     pub t_traction_cut_off: f64,
     /// T_bs1: time service break in s used for SBI1 computation
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<5,_>)))]
     pub t_bs1: f64,
     /// T_bs2: time service break in s used for SBI2 computation
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<5,_>)))]
     pub t_bs2: f64,
     /// T_be: safe brake build up time in s
-    #[derivative(Hash(hash_with = "editoast_common::hash_float::<5,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float::<5,_>)))]
     pub t_be: f64,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
-#[derivative(Hash)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
+#[educe(Hash)]
 #[serde(deny_unknown_fields, remote = "Self")]
 pub struct SpeedIntervalValueCurve {
-    #[derivative(Hash(hash_with = "editoast_common::hash_float_slice::<3,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float_slice::<3,_>)))]
     #[schema(example = json!([8.333333, 19.444444]))]
     /// Speed in m/s (sorted ascending)
     /// External bounds are implicit to [0, rolling_stock.max_speed]
     boundaries: Vec<f64>,
-    #[derivative(Hash(hash_with = "editoast_common::hash_float_slice::<3,_>"))]
+    #[educe(Hash(method(editoast_common::hash_float_slice::<3,_>)))]
     #[schema(min_items = 1, minimum = 0, example = json!([0.5, 0.6, 0.5]))]
     /// Interval values, must be >= 0 (unit to be made explicit at use)
     /// There must be one more value than boundaries

--- a/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
+++ b/editoast/editoast_schemas/src/rolling_stock/rolling_resistance.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use editoast_common::units;
 use editoast_common::units::quantities::AerodynamicDrag;
 use editoast_common::units::quantities::AerodynamicDragPerWeight;
@@ -6,6 +5,7 @@ use editoast_common::units::quantities::SolidFriction;
 use editoast_common::units::quantities::SolidFrictionPerWeight;
 use editoast_common::units::quantities::ViscosityFriction;
 use editoast_common::units::quantities::ViscosityFrictionPerWeight;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -16,45 +16,45 @@ editoast_common::schemas! {
 }
 
 #[editoast_derive::annotate_units]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
-#[derivative(Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
+#[educe(Hash)]
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 pub struct RollingResistance {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
     /// Solid friction
-    #[derivative(Hash(hash_with = "units::newton::hash"))]
+    #[educe(Hash(method(units::newton::hash)))]
     #[serde(with = "units::newton")]
     pub A: SolidFriction,
     /// Viscosity friction in N·(m/s)⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "units::kilogram_per_second::hash"))]
+    #[educe(Hash(method(units::kilogram_per_second::hash)))]
     #[serde(with = "units::kilogram_per_second")]
     pub B: ViscosityFriction,
     /// Aerodynamic drag in N·(m/s)⁻²; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "units::kilogram_per_meter::hash"))]
+    #[educe(Hash(method(units::kilogram_per_meter::hash)))]
     #[serde(with = "units::kilogram_per_meter")]
     pub C: AerodynamicDrag,
 }
 
 #[editoast_derive::annotate_units]
-#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Derivative)]
-#[derivative(Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize, ToSchema, Educe)]
+#[educe(Hash)]
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 pub struct RollingResistancePerWeight {
     #[serde(rename = "type")]
     pub rolling_resistance_type: String,
     /// Solid friction in N·kg⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "units::meter_per_second_squared::hash"))]
+    #[educe(Hash(method(units::meter_per_second_squared::hash)))]
     #[serde(with = "units::meter_per_second_squared")]
     pub A: SolidFrictionPerWeight,
     /// Viscosity friction in (N·kg⁻¹)·(m/s)⁻¹; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "units::hertz::hash"))]
+    #[educe(Hash(method(units::hertz::hash)))]
     #[serde(with = "units::hertz")]
     pub B: ViscosityFrictionPerWeight,
     /// Aerodynamic drag per kg in (N·kg⁻¹)·(m/s)⁻²; N = kg⋅m⋅s⁻²
-    #[derivative(Hash(hash_with = "units::per_meter::hash"))]
+    #[educe(Hash(method(units::per_meter::hash)))]
     #[serde(with = "units::per_meter")]
     pub C: AerodynamicDragPerWeight,
 }

--- a/editoast/editoast_schemas/src/train_schedule/margins.rs
+++ b/editoast/editoast_schemas/src/train_schedule/margins.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use crate::primitives::NonBlankString;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -10,13 +10,13 @@ editoast_common::schemas! {
     Margins,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Derivative, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Educe, ToSchema)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct Margins {
     #[schema(inline)]
     pub boundaries: Vec<NonBlankString>,
-    #[derivative(Default(value = "vec![MarginValue::default()]"))]
+    #[educe(Default = vec![MarginValue::default()])]
     /// The values of the margins. Must contains one more element than the boundaries
     /// Can be a percentage `X%` or a time in minutes per 100 kilometer `Xmin/100km`
     #[schema(value_type = Vec<String>, example = json!(["5%", "2min/100km"]))]
@@ -44,12 +44,12 @@ impl<'de> Deserialize<'de> for Margins {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Derivative, ToSchema)]
-#[derivative(Hash, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Educe, ToSchema)]
+#[educe(Hash, Default)]
 pub enum MarginValue {
-    #[derivative(Default)]
-    Percentage(#[derivative(Hash(hash_with = "editoast_common::hash_float::<3,_>"))] f64),
-    MinPer100Km(#[derivative(Hash(hash_with = "editoast_common::hash_float::<3,_>"))] f64),
+    #[educe(Default)]
+    Percentage(#[educe(Hash(method(editoast_common::hash_float::<3,_>)))] f64),
+    MinPer100Km(#[educe(Hash(method(editoast_common::hash_float::<3,_>)))] f64),
 }
 
 impl<'de> Deserialize<'de> for MarginValue {

--- a/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
+++ b/editoast/editoast_schemas/src/train_schedule/train_schedule_options.rs
@@ -1,4 +1,4 @@
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -7,14 +7,14 @@ editoast_common::schemas! {
     TrainScheduleOptions,
 }
 
-#[derive(Debug, Derivative, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Hash)]
+#[derive(Debug, Educe, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Hash)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct TrainScheduleOptions {
-    #[derivative(Default(value = "true"))]
+    #[educe(Default = true)]
     #[serde(default = "default_use_electrical_profiles")]
     use_electrical_profiles: bool,
-    #[derivative(Default(value = "true"))]
+    #[educe(Default = true)]
     #[serde(default = "default_use_speed_limits_for_simulation")]
     use_speed_limits_for_simulation: bool,
 }

--- a/editoast/src/client/mod.rs
+++ b/editoast/src/client/mod.rs
@@ -20,7 +20,6 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::Subcommand;
 use clap::ValueEnum;
-use derivative::Derivative;
 use editoast_derive::EditoastError;
 use group::GroupCommand;
 use import_rolling_stock::ImportRollingStockArgs;
@@ -60,12 +59,11 @@ pub struct Client {
     pub command: Commands,
 }
 
-#[derive(ValueEnum, Debug, Derivative, Clone)]
-#[derivative(Default)]
+#[derive(ValueEnum, Debug, Default, Clone)]
 pub enum Color {
     Never,
     Always,
-    #[derivative(Default)]
+    #[default]
     Auto,
 }
 

--- a/editoast/src/client/postgres_config.rs
+++ b/editoast/src/client/postgres_config.rs
@@ -1,22 +1,20 @@
 use clap::Args;
-use derivative::Derivative;
+use educe::Educe;
 use url::Url;
 
 use crate::views;
 
-#[derive(Args, Debug, Derivative, Clone)]
-#[derivative(Default)]
+#[derive(Args, Debug, Educe, Clone)]
+#[educe(Default)]
 pub struct PostgresConfig {
-    #[derivative(Default(
-        value = "Url::parse(\"postgres://osrd:password@localhost:5432/osrd\").unwrap()"
-    ))]
+    #[educe(Default = Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap())]
     #[arg(
         long,
         env,
         default_value_t = Url::parse("postgres://osrd:password@localhost:5432/osrd").unwrap()
     )]
     pub database_url: Url,
-    #[derivative(Default(value = "32"))]
+    #[educe(Default = 32)]
     #[arg(long, env, default_value_t = 32)]
     pub pool_size: usize,
 }

--- a/editoast/src/client/telemetry_config.rs
+++ b/editoast/src/client/telemetry_config.rs
@@ -1,18 +1,18 @@
 use clap::Args;
 use clap::ValueEnum;
-use derivative::Derivative;
+use educe::Educe;
 use url::Url;
 
-#[derive(Args, Debug, Derivative, Clone)]
-#[derivative(Default)]
+#[derive(Args, Debug, Educe, Clone)]
+#[educe(Default)]
 pub struct TelemetryConfig {
-    #[derivative(Default(value = "TelemetryKind::None"))]
+    #[educe(Default = TelemetryKind::None)]
     #[clap(long, env, default_value_t)]
     pub telemetry_kind: TelemetryKind,
-    #[derivative(Default(value = r#""osrd-editoast".into()"#))]
+    #[educe(Default = "osrd-editoast".into())]
     #[clap(long, env, default_value = "osrd-editoast")]
     pub service_name: String,
-    #[derivative(Default(value = r#"Url::parse("http://localhost:4317").unwrap()"#))]
+    #[educe(Default = Url::parse("http://localhost:4317").unwrap())]
     #[arg(long, env, default_value = "http://localhost:4317")]
     pub telemetry_endpoint: Url,
 }
@@ -26,7 +26,7 @@ impl From<TelemetryConfig> for editoast_common::tracing::Telemetry {
     }
 }
 
-#[derive(Default, ValueEnum, Debug, Derivative, Clone, strum::Display)]
+#[derive(Default, ValueEnum, Debug, Clone, strum::Display)]
 #[strum(serialize_all = "lowercase")]
 pub enum TelemetryKind {
     #[default]

--- a/editoast/src/client/valkey_config.rs
+++ b/editoast/src/client/valkey_config.rs
@@ -1,17 +1,16 @@
 use clap::Args;
-use derivative::Derivative;
+use educe::Educe;
 use url::Url;
 
 use crate::valkey_utils;
 
-#[derive(Args, Debug, Derivative, Clone)]
-#[derivative(Default)]
+#[derive(Args, Debug, Educe, Clone)]
+#[educe(Default)]
 pub struct ValkeyConfig {
     /// Disable cache. This should not be used in production.
-    #[derivative(Default(value = "false"))]
     #[clap(long, env, default_value_t = false)]
     pub no_cache: bool,
-    #[derivative(Default(value = r#"Url::parse("redis://localhost:6379").unwrap()"#))]
+    #[educe(Default = Url::parse("redis://localhost:6379").unwrap())]
     #[arg(long, env, default_value_t = Url::parse("redis://localhost:6379").unwrap())]
     /// Valkey url like `redis://[:PASSWORD@]HOST[:PORT][/DATABASE]`
     pub valkey_url: Url,

--- a/editoast/src/infra_cache/object_cache/buffer_stop_cache.rs
+++ b/editoast/src/infra_cache/object_cache/buffer_stop_cache.rs
@@ -1,23 +1,23 @@
-use derivative::Derivative;
 use diesel::sql_types::Double;
 use diesel::sql_types::Text;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::BufferStop;
 
-#[derive(QueryableByName, Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq)]
+#[derive(QueryableByName, Debug, Clone, Educe)]
+#[educe(Hash, PartialEq)]
 pub struct BufferStopCache {
     #[diesel(sql_type = Text)]
     pub obj_id: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Text)]
     pub track: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Double)]
     pub position: f64,
 }

--- a/editoast/src/infra_cache/object_cache/detector_cache.rs
+++ b/editoast/src/infra_cache/object_cache/detector_cache.rs
@@ -1,23 +1,23 @@
-use derivative::Derivative;
 use diesel::sql_types::Double;
 use diesel::sql_types::Text;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::Detector;
 
-#[derive(QueryableByName, Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq)]
+#[derive(QueryableByName, Debug, Clone, Educe)]
+#[educe(Hash, PartialEq)]
 pub struct DetectorCache {
     #[diesel(sql_type = Text)]
     pub obj_id: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Text)]
     pub track: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Double)]
     pub position: f64,
 }

--- a/editoast/src/infra_cache/object_cache/operational_point_cache.rs
+++ b/editoast/src/infra_cache/object_cache/operational_point_cache.rs
@@ -1,8 +1,8 @@
-use derivative::Derivative;
 use editoast_schemas::primitives::Identifier;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -11,11 +11,11 @@ use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::OperationalPoint;
 use editoast_schemas::infra::OperationalPointPart;
 
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq)]
+#[derive(Debug, Clone, Educe)]
+#[educe(Hash, PartialEq)]
 pub struct OperationalPointCache {
     pub obj_id: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub parts: Vec<OperationalPointPartCache>,
 }
 
@@ -54,11 +54,11 @@ impl Cache for OperationalPointCache {
     }
 }
 
-#[derive(Debug, Derivative, Clone, Deserialize, Serialize)]
+#[derive(Debug, Educe, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[derivative(Default, PartialEq)]
+#[educe(Default, PartialEq)]
 pub struct OperationalPointPartCache {
-    #[derivative(Default(value = r#""InvalidRef".into()"#))]
+    #[educe(Default = "InvalidRef".into())]
     pub track: Identifier,
     pub position: f64,
 }

--- a/editoast/src/infra_cache/object_cache/signal_cache.rs
+++ b/editoast/src/infra_cache/object_cache/signal_cache.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use diesel::sql_types::Double;
 use diesel::sql_types::Jsonb;
 use diesel::sql_types::Text;
@@ -6,24 +5,25 @@ use diesel_json::Json as DieselJson;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::LogicalSignal;
 use editoast_schemas::infra::Signal;
 
-#[derive(QueryableByName, Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq)]
+#[derive(QueryableByName, Debug, Clone, Educe)]
+#[educe(Hash, PartialEq)]
 pub struct SignalCache {
     #[diesel(sql_type = Text)]
     pub obj_id: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Text)]
     pub track: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Double)]
     pub position: f64,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     #[diesel(sql_type = Jsonb)]
     pub logical_signals: DieselJson<Vec<LogicalSignal>>,
 }

--- a/editoast/src/infra_cache/object_cache/switch_cache.rs
+++ b/editoast/src/infra_cache/object_cache/switch_cache.rs
@@ -1,20 +1,20 @@
-use derivative::Derivative;
 use editoast_schemas::infra::TrackEndpoint;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 use std::collections::HashMap;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::Switch;
 
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq)]
+#[derive(Debug, Clone, Educe)]
+#[educe(Hash, PartialEq)]
 pub struct SwitchCache {
     pub obj_id: String,
     pub switch_type: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub ports: HashMap<String, TrackEndpoint>,
 }
 

--- a/editoast/src/infra_cache/object_cache/track_section_cache.rs
+++ b/editoast/src/infra_cache/object_cache/track_section_cache.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use editoast_schemas::infra::Curve;
 use editoast_schemas::infra::Endpoint;
 use editoast_schemas::infra::Slope;
@@ -6,25 +5,26 @@ use editoast_schemas::infra::TrackEndpoint;
 use editoast_schemas::primitives::OSRDIdentified;
 use editoast_schemas::primitives::OSRDTyped;
 use editoast_schemas::primitives::ObjectType;
+use educe::Educe;
 
 use crate::infra_cache::Cache;
 use crate::infra_cache::ObjectCache;
 use editoast_schemas::infra::TrackSection;
 use editoast_schemas::primitives::BoundingBox;
 
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Hash, PartialEq, Default)]
+#[derive(Debug, Clone, Educe)]
+#[educe(Hash, PartialEq, Default)]
 pub struct TrackSectionCache {
     pub obj_id: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub line_code: Option<i32>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub length: f64,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub slopes: Vec<Slope>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub curves: Vec<Curve>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     pub bbox_geo: BoundingBox,
 }
 

--- a/editoast/src/models/infra.rs
+++ b/editoast/src/models/infra.rs
@@ -10,7 +10,6 @@ use std::ops::DerefMut;
 
 use chrono::DateTime;
 use chrono::Utc;
-use derivative::Derivative;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel::delete;
@@ -18,6 +17,7 @@ use diesel::sql_query;
 use diesel::sql_types::BigInt;
 use diesel_async::RunQueryDsl;
 use editoast_derive::Model;
+use educe::Educe;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
@@ -55,10 +55,10 @@ editoast_common::schemas! {
 #[cfg(test)]
 pub const DEFAULT_INFRA_VERSION: i64 = 0;
 
-#[derive(Debug, Clone, Derivative, Serialize, Deserialize, Model, utoipa::ToSchema)]
+#[derive(Debug, Clone, Educe, Serialize, Deserialize, Model, utoipa::ToSchema)]
 #[model(table = editoast_models::tables::infra)]
 #[model(gen(ops = crud, batch_ops = r, list))]
-#[derivative(Default)]
+#[educe(Default)]
 pub struct Infra {
     pub id: i64,
     pub name: String,
@@ -70,7 +70,7 @@ pub struct Infra {
     pub generated_version: Option<i64>,
     pub locked: bool,
     pub created: DateTime<Utc>,
-    #[derivative(Default(value = "Utc::now()"))]
+    #[educe(Default = Utc::now())]
     pub modified: DateTime<Utc>,
 }
 

--- a/editoast/src/models/rolling_stock_livery.rs
+++ b/editoast/src/models/rolling_stock_livery.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use editoast_derive::Model;
 
 use super::Document;
@@ -19,9 +18,8 @@ use serde::Deserialize;
 ///
 /// /!\ Its compound image is not deleted by cascade if the livery is removed.
 ///
-#[derive(Debug, Clone, Derivative, Model)]
+#[derive(Debug, Clone, Default, Model)]
 #[cfg_attr(test, derive(Deserialize))]
-#[derivative(Default)]
 #[model(table = editoast_models::tables::rolling_stock_livery)]
 #[model(gen(ops = crd, list))]
 pub struct RollingStockLivery {

--- a/editoast/src/views/infra/pathfinding.rs
+++ b/editoast/src/views/infra/pathfinding.rs
@@ -5,9 +5,9 @@ use axum::extract::Json;
 use axum::extract::Path;
 use axum::extract::Query;
 use axum::extract::State;
-use derivative::Derivative;
 use editoast_authz as authz;
 use editoast_derive::EditoastError;
+use educe::Educe;
 use pathfinding::prelude::yen;
 use serde::Deserialize;
 use serde::Serialize;
@@ -159,17 +159,17 @@ async fn pathfinding_view(
     Ok(Json(compute_path(&input, &infra_cache, &graph, number)))
 }
 
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Educe)]
+#[educe(Hash, Eq, PartialEq)]
 struct PathfindingStep {
     track: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     position: f64,
     direction: Direction,
     switch_direction: Option<(Identifier, Identifier)>,
     found: bool,
     starting_step: bool,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[educe(Hash(ignore), PartialEq(ignore))]
     previous: Option<Box<PathfindingStep>>,
     total_length: u64,
 }

--- a/editoast/src/views/path/pathfinding.rs
+++ b/editoast/src/views/path/pathfinding.rs
@@ -15,13 +15,13 @@ use core_client::pathfinding::PathfindingInputError;
 use core_client::pathfinding::PathfindingNotFound;
 use core_client::pathfinding::PathfindingRequest;
 use core_client::pathfinding::PathfindingResultSuccess;
-use derivative::Derivative;
 use editoast_authz as authz;
 use editoast_authz::Role;
 use editoast_common::units;
 use editoast_models::DbConnection;
 use editoast_schemas::rolling_stock::LoadingGaugeType;
 use editoast_schemas::train_schedule::PathItemLocation;
+use educe::Educe;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use serde::Deserialize;
@@ -163,12 +163,12 @@ impl From<PathfindingCoreResult> for PathfindingResult {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Derivative)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, ToSchema, Educe)]
+#[educe(Default)]
 #[serde(tag = "failed_status", rename_all = "snake_case")]
 pub enum PathfindingFailure {
     PathfindingInputError(PathfindingInputError),
-    #[derivative(Default)]
+    #[educe(Default)]
     PathfindingNotFound(PathfindingNotFound),
     InternalError {
         core_error: InternalError,

--- a/editoast/src/views/project.rs
+++ b/editoast/src/views/project.rs
@@ -5,7 +5,6 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use chrono::Utc;
-use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt as _;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
@@ -76,8 +75,7 @@ pub enum ProjectError {
 }
 
 /// Creation form for a project
-#[derive(Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 struct ProjectCreateForm {
     #[schema(max_length = 128)]
     pub name: String,

--- a/editoast/src/views/scenario.rs
+++ b/editoast/src/views/scenario.rs
@@ -7,7 +7,6 @@ use axum::extract::Query;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use chrono::Utc;
-use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
@@ -75,8 +74,7 @@ pub struct ScenarioIdParam {
 }
 
 /// This structure is used by the post endpoint to create a scenario
-#[derive(Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 struct ScenarioCreateForm {
     pub name: String,
     #[serde(default)]
@@ -288,8 +286,7 @@ async fn delete(
 }
 
 /// This structure is used by the patch endpoint to patch a scenario
-#[derive(Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 struct ScenarioPatchForm {
     pub name: Option<String>,
     pub description: Option<String>,

--- a/editoast/src/views/study.rs
+++ b/editoast/src/views/study.rs
@@ -6,7 +6,6 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use chrono::NaiveDate;
 use chrono::Utc;
-use derivative::Derivative;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
@@ -89,8 +88,7 @@ impl StudyResponse {
 }
 
 /// This structure is used by the post endpoint to create a study
-#[derive(Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 struct StudyCreateForm {
     pub name: String,
     pub description: Option<String>,
@@ -275,8 +273,7 @@ async fn get(
 }
 
 /// This structure is used by the patch endpoint to patch a study
-#[derive(Serialize, Deserialize, Derivative, ToSchema)]
-#[derivative(Default)]
+#[derive(Serialize, Deserialize, Default, ToSchema)]
 struct StudyPatchForm {
     pub name: Option<String>,
     #[serde(default, with = "double_option")]

--- a/editoast/src/views/timetable.rs
+++ b/editoast/src/views/timetable.rs
@@ -26,7 +26,6 @@ use core_client::conflict_detection::ConflictDetectionRequest;
 use core_client::conflict_detection::ConflictRequirement;
 use core_client::conflict_detection::ConflictType;
 use core_client::conflict_detection::TrainRequirements;
-use derivative::Derivative;
 use editoast_authz as authz;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnection;
@@ -114,7 +113,7 @@ enum TimetableError {
 }
 
 /// Creation result for a Timetable
-#[derive(Debug, Default, Serialize, Deserialize, Derivative, ToSchema)]
+#[derive(Debug, Default, Serialize, Deserialize, ToSchema)]
 #[cfg_attr(test, derive(PartialEq))]
 struct TimetableResult {
     pub timetable_id: i64,

--- a/editoast/src/views/work_schedules.rs
+++ b/editoast/src/views/work_schedules.rs
@@ -20,7 +20,6 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use chrono::DateTime;
 use chrono::Utc;
-use derivative::Derivative;
 use editoast_authz::Role;
 use editoast_derive::EditoastError;
 use editoast_models::DbConnectionPoolV2;
@@ -89,7 +88,7 @@ impl From<work_schedules::WsGroupError> for WorkScheduleError {
     }
 }
 
-#[derive(Serialize, Derivative, ToSchema)]
+#[derive(Serialize, ToSchema)]
 struct WorkScheduleItemForm {
     pub start_date_time: DateTime<Utc>,
     pub end_date_time: DateTime<Utc>,


### PR DESCRIPTION
Close #11071 
Replace the derivative crate with educe for trait derivation.