### PR TITLE
front: improve switch type display in infra editor

### DIFF
--- a/front/public/locales/en/translation.json
+++ b/front/public/locales/en/translation.json
@@ -392,6 +392,8 @@
           "pick-track-cancel": "Undo track selection",
           "save-switch": "Save the switch"
         },
+        "crossing": "Crossing",
+        "double_slip_switch": "Double slip switch",
         "duplicate-errors": "The track {{track}} is already used by the port {{port}}",
         "endpoint": "Endpoint:",
         "help": {
@@ -399,8 +401,13 @@
           "select-track": "Select a track on the map"
         },
         "label": "Switch tool",
+        "link": "Link",
         "no-track-picked-yet": "No track selected yet",
+        "point_switch": "Point switch",
+        "single_slip_switch": "Single slip switch",
         "switch-type": "Switch type",
+        "switch_type_w_port_count_one": "{{type}} ({{count}} port)",
+        "switch_type_w_port_count_other": "{{type}} ({{count}} ports)",
         "untitled-track": "Untitled track"
       },
       "track-edition": {

--- a/front/public/locales/fr/translation.json
+++ b/front/public/locales/fr/translation.json
@@ -390,6 +390,8 @@
           "pick-track-cancel": "Annuler la sélection d'une voie",
           "save-switch": "Sauvegarder l'aiguillage"
         },
+        "crossing": "Traversée oblique",
+        "double_slip_switch": "Traversée jonction double",
         "duplicate-errors": "La voie {{track}} est déjà utilisée par le port {{port}}",
         "endpoint": "Extrémité :",
         "help": {
@@ -397,8 +399,13 @@
           "select-track": "Sélectionnez une voie sur la carte"
         },
         "label": "Outil \"Aiguillage\"",
+        "link": "Lien",
         "no-track-picked-yet": "Aucune voie n'a encore été sélectionnée",
+        "point_switch": "Branchement 2 voies",
+        "single_slip_switch": "Traversée jonction simple",
         "switch-type": "Type d'aiguillage",
+        "switch_type_w_port_count_one": "{{type}} ({{count}} port)",
+        "switch_type_w_port_count_other": "{{type}} ({{count}} ports)",
         "untitled-track": "Voie sans nom"
       },
       "track-edition": {

--- a/front/src/applications/editor/components/EntitySumUp.tsx
+++ b/front/src/applications/editor/components/EntitySumUp.tsx
@@ -185,6 +185,7 @@ function getSumUpContent(
       } else {
         text = switchEntity.properties.id;
       }
+      subtexts.push(t(`Editor.tools.switch-edition.${switchEntity.properties.switch_type}`));
       if (trackNames.length) {
         subtexts.push(
           <>

--- a/front/src/applications/editor/tools/switchEdition/useSwitch.ts
+++ b/front/src/applications/editor/tools/switchEdition/useSwitch.ts
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from 'react';
 
 import { first, keyBy } from 'lodash';
+import { useTranslation } from 'react-i18next';
 
 import EditorContext from 'applications/editor/context';
 import { NEW_ENTITY_ID } from 'applications/editor/data/utils';
@@ -18,6 +19,7 @@ import { useInfraID } from 'common/osrdContext';
 
 // TODO : Rename all switch by tracknode when back renaming PR merged
 const useSwitch = () => {
+  const { t, i18n } = useTranslation();
   const { state, editorState } = useContext(
     EditorContext
   ) as ExtendedEditorContextType<SwitchEditionState>;
@@ -34,9 +36,12 @@ const useSwitch = () => {
     () =>
       switchTypes.map((type) => ({
         value: type.id,
-        label: `${type.id} (${type.ports.length} port${type.ports.length > 1 ? 's' : ''})`,
+        label: t('Editor.tools.switch-edition.switch_type_w_port_count_other', {
+          count: type.ports.length,
+          type: t(`Editor.tools.switch-edition.${type.id}`),
+        }),
       })),
-    [switchTypes]
+    [switchTypes, i18n.language]
   );
   const switchTypeOptionsDict = useMemo(
     () => keyBy(switchTypeOptions, 'value'),


### PR DESCRIPTION
- first commit translate switch types (so "Point switch" becomes "Branchement 2 voies" in French for example, its sncf name)
- second commit displays the switch type in the switch summary, which will make it much easier to know a switch type at a glance, and help us debug our infra

There's an mr in osrd-data (linked to issue [data:#773](https://github.com/osrd-project/osrd-data-issues/issues/773)) coming that will aditionally give us accurate gaia id and label (instead of "N/A" everywhere), and all in all our switches should be easier to work with now. 

These are possible enablers to [confidential-project:#1062](https://github.com/osrd-project/osrd-confidential/issues/1062), as they will help debug our nodes ^^