### PR TITLE
ui-charts: fixes issue with repeated waypoints

### DIFF
--- a/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
+++ b/front/ui/ui-charts/src/manchette/hooks/useManchetteWithSpaceTimeChart.tsx
@@ -459,7 +459,12 @@ const useManchetteWithSpaceTimeChart = ({
       });
     });
 
-    return sortBy(allScales, (scale) => scale.to + ('size' in scale ? Number.EPSILON : 0));
+    return sortBy(
+      allScales.filter((scale) =>
+        'coefficient' in scale ? scale.coefficient > 0 : isFinite(scale.size)
+      ),
+      (scale) => scale.to + ('size' in scale ? Number.EPSILON : 0)
+    );
   }, [
     waypoints,
     height,


### PR DESCRIPTION
This commit fixes #11868.

The ManchetteWithSpaceTimeChart was crashing when moving to the linear scale, and when there are are least two waypoints exactly at the same position.

This commit addresses that issue by fixing how spaceScales is computed in useManchetteWithSpaceTimeChart, ensuring there are no SpaceScale with a 0 coefficient or an infinite size.