### PR TITLE
 ops: add '.gitattributes' under DevOps responsability 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # --- CI - CODEOWNERS - Dependabot - Template ---
+/.gitattributes                                          @openrailassociation/OSRD-DevOps
 /.github                                                 @openrailassociation/OSRD-DevOps
 /.github/CODEOWNERS                                      @openrailassociation/OSRD-Admins
 /*.md                                                    @openrailassociation/OSRD-Admins


### PR DESCRIPTION
This is a proposition, since I've made recent Pull Requests that didn't trigger automatic review from DevOps, which made me wonder why.