### PR TITLE
front: reset simulations before updating stdcm env

### DIFF
--- a/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
+++ b/front/src/applications/stdcm/hooks/useStdcmEnv.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { osrdEditoastApi } from 'common/api/osrdEditoastApi';
-import { updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
+import { resetStdcmSimulations, updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
 
 export const NO_CONFIG_FOUND_MSG = 'No configuration found';
 
@@ -21,6 +21,7 @@ export default function useStdcmEnvironment() {
       setLoading(true);
       const { data } = await getStdcmSearchEnvironment();
       if (!data) throw new Error(NO_CONFIG_FOUND_MSG);
+      dispatch(resetStdcmSimulations());
       dispatch(
         updateStdcmEnvironment({
           infraID: data.infra_id,

--- a/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
+++ b/front/src/modules/scenario/components/ScenarioExplorer/MiniCards.tsx
@@ -10,7 +10,7 @@ import {
 } from 'common/api/osrdEditoastApi';
 import { ModalContext } from 'common/BootstrapSNCF/ModalSNCF/ModalProvider';
 import { getScenarioDatetimeWindow } from 'modules/scenario/helpers/utils';
-import { updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
+import { resetStdcmSimulations, updateStdcmEnvironment } from 'reducers/osrdconf/stdcmConf';
 import { useAppDispatch } from 'store';
 
 import Project2Image from './ScenarioExplorerProject2Image';
@@ -91,6 +91,7 @@ export const ScenarioMiniCard = ({
 
     const scenarioDateTimeWindow = getScenarioDatetimeWindow(trainSchedules);
 
+    dispatch(resetStdcmSimulations());
     dispatch(
       updateStdcmEnvironment({
         infraID: scenario.infra_id,

--- a/front/src/reducers/osrdconf/stdcmConf/index.ts
+++ b/front/src/reducers/osrdconf/stdcmConf/index.ts
@@ -99,6 +99,8 @@ export const stdcmConfSlice = createSlice({
       state.maxSpeed = stdcmConfInitialState.maxSpeed;
       state.speedLimitByTag = stdcmConfInitialState.speedLimitByTag;
       state.linkedTrains = stdcmConfInitialState.linkedTrains;
+      state.retainedSimulationIndex = stdcmConfInitialState.retainedSimulationIndex;
+      state.selectedSimulationIndex = stdcmConfInitialState.selectedSimulationIndex;
       state.simulations = stdcmConfInitialState.simulations;
     },
     restoreStdcmConfig(
@@ -297,6 +299,11 @@ export const stdcmConfSlice = createSlice({
     retainSimulation(state: Draft<OsrdStdcmConfState>, action: PayloadAction<number>) {
       state.retainedSimulationIndex = action.payload;
     },
+    resetStdcmSimulations(state: Draft<OsrdStdcmConfState>) {
+      state.retainedSimulationIndex = stdcmConfInitialState.retainedSimulationIndex;
+      state.selectedSimulationIndex = stdcmConfInitialState.selectedSimulationIndex;
+      state.simulations = stdcmConfInitialState.simulations;
+    },
   },
 });
 
@@ -321,6 +328,7 @@ export const {
   retainSimulation,
   updateStdcmLayers,
   addStdcmSimulations,
+  resetStdcmSimulations,
 } = stdcmConfSlice.actions;
 
 export type StdcmConfSlice = typeof stdcmConfSlice;


### PR DESCRIPTION
Deletes the already simulations whenever we change stdcm environment by selecting a new timetable in stdcm debug, or deactivating debug mode.

This avoid causing the crash that #11833 would fix in its second commit.


Optionally we could  : 
- instead directly call resetSimulations in the updateStdcmEnv reducer, or even inline it in the updateStdcmEnv reducer.
- also reset the path, and possibly previous train, possibly only if the infra changed