### PR TITLE
docker: add a different managed_by_value for pr-test

### DIFF
--- a/docker/osrdyne-pr-tests.yml
+++ b/docker/osrdyne-pr-tests.yml
@@ -16,3 +16,4 @@ worker_driver:
 amqp_uri: "amqp://osrd:password@rabbitmq:5673/%2f"
 management_uri: "http://osrd:password@rabbitmq:15673"
 api_address: "0.0.0.0:4243"
+managed_by_value: "osrdyne-pr-test"

--- a/osrdyne/src/config.rs
+++ b/osrdyne/src/config.rs
@@ -34,6 +34,7 @@ pub struct OsrdyneConfig {
     pub max_length: Option<usize>,
     pub max_length_bytes: Option<usize>,
     pub api_address: String,
+    pub managed_by_value: String,
     pub extra_lifetime: Option<Duration>,
     pub opentelemetry: Option<OpentelemetryConfig>,
 }
@@ -64,6 +65,7 @@ impl Default for OsrdyneConfig {
             max_length: None,
             max_length_bytes: None,
             api_address: "0.0.0.0:4242".into(), // TODO: decide on the port
+            managed_by_value: "osrdyne".into(),
             extra_lifetime: None,
             opentelemetry: None,
         }

--- a/osrdyne/src/drivers.rs
+++ b/osrdyne/src/drivers.rs
@@ -9,5 +9,3 @@ const LABEL_WORKER_ID: &str = "osrd/worker_id";
 const LABEL_WORKER_KEY: &str = "osrd/worker_key";
 const LABEL_VERSION_IDENTIFIER: &str = "osrd/version_identifier";
 const LABEL_QUEUE_NAME: &str = "osrd/queue_name";
-
-const MANAGED_BY_VALUE: &str = "osrdyne";

--- a/osrdyne/src/drivers/docker.rs
+++ b/osrdyne/src/drivers/docker.rs
@@ -17,7 +17,6 @@ use crate::Key;
 
 use super::{
     LABEL_MANAGED_BY, LABEL_VERSION_IDENTIFIER, LABEL_WORKER_ID, LABEL_WORKER_KEY,
-    MANAGED_BY_VALUE,
     worker_driver::{DriverError, WorkerDriver, WorkerMetadata},
 };
 
@@ -44,6 +43,7 @@ pub struct DockerDriver {
     max_message_size: i64,
     worker_pool: String,
     version_identifier: String,
+    managed_by_value: String,
 }
 
 impl Debug for DockerDriver {
@@ -53,6 +53,7 @@ impl Debug for DockerDriver {
             .field("amqp_uri", &self.amqp_uri)
             .field("worker_pool", &self.worker_pool)
             .field("version_identifier", &self.version_identifier)
+            .field("managed_by_value", &self.managed_by_value)
             .finish()
     }
 }
@@ -63,6 +64,7 @@ impl DockerDriver {
         amqp_uri: String,
         max_message_size: i64,
         worker_pool: String,
+        managed_by_value: String,
     ) -> DockerDriver {
         let version_identifier = std::env::var("OSRD_GIT_DESCRIBE")
             .unwrap_or_else(|_| format!("run-{}", Uuid::new_v4()));
@@ -76,6 +78,7 @@ impl DockerDriver {
             max_message_size,
             worker_pool,
             version_identifier: hashed,
+            managed_by_value,
         }
     }
 }
@@ -128,7 +131,7 @@ impl WorkerDriver for DockerDriver {
             };
 
             let labels = HashMap::from([
-                (LABEL_MANAGED_BY.to_owned(), MANAGED_BY_VALUE.to_owned()),
+                (LABEL_MANAGED_BY.to_owned(), self.managed_by_value.clone()),
                 (LABEL_WORKER_ID.to_owned(), new_id.to_string()),
                 (LABEL_WORKER_KEY.to_owned(), worker_key.to_string()),
                 (
@@ -235,7 +238,7 @@ impl WorkerDriver for DockerDriver {
                 .iter()
                 .filter_map(|container| {
                     container.labels.as_ref().and_then(|labels| {
-                        if labels.get(LABEL_MANAGED_BY) == Some(&MANAGED_BY_VALUE.to_string()) {
+                        if labels.get(LABEL_MANAGED_BY) == Some(&self.managed_by_value) {
                             let mut metadata = HashMap::new();
                             metadata.insert(
                                 LABEL_VERSION_IDENTIFIER.to_owned(),

--- a/osrdyne/src/drivers/kubernetes.rs
+++ b/osrdyne/src/drivers/kubernetes.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use super::{
-    LABEL_MANAGED_BY, LABEL_WORKER_ID, LABEL_WORKER_KEY, MANAGED_BY_VALUE,
+    LABEL_MANAGED_BY, LABEL_WORKER_ID, LABEL_WORKER_KEY,
     worker_driver::{DriverError, WorkerDriver, WorkerMetadata},
 };
 use k8s_openapi::{
@@ -144,6 +144,7 @@ pub struct KubernetesDriver {
     amqp_uri: String,
     max_message_size: i64,
     version_identifier: String,
+    managed_by_value: String,
 }
 
 impl Debug for KubernetesDriver {
@@ -153,6 +154,7 @@ impl Debug for KubernetesDriver {
             .field("options", &self.options)
             .field("amqp_uri", &self.amqp_uri)
             .field("version_identifier", &self.version_identifier)
+            .field("managed_by_value", &self.managed_by_value)
             .finish()
     }
 }
@@ -163,6 +165,7 @@ impl KubernetesDriver {
         amqp_uri: String,
         max_message_size: i64,
         pool_id: String,
+        managed_by_value: String,
     ) -> KubernetesDriver {
         let version_identifier = std::env::var("OSRD_GIT_DESCRIBE")
             .unwrap_or_else(|_| format!("run-{}", Uuid::new_v4()));
@@ -178,6 +181,7 @@ impl KubernetesDriver {
             max_message_size,
             pool_id,
             version_identifier: hashed,
+            managed_by_value,
         }
     }
 
@@ -197,7 +201,7 @@ impl KubernetesDriver {
                 namespace: Some(self.options.namespace.clone()),
                 labels: Some({
                     let mut labels = BTreeMap::new();
-                    labels.insert(LABEL_MANAGED_BY.to_owned(), MANAGED_BY_VALUE.to_owned());
+                    labels.insert(LABEL_MANAGED_BY.to_owned(), self.managed_by_value.clone());
                     labels.insert(LABEL_WORKER_ID.to_owned(), worker_id);
                     labels.insert(LABEL_WORKER_KEY.to_owned(), worker_key.to_string());
                     labels.insert(LABEL_QUEUE_NAME.to_owned(), queue_name.clone());
@@ -272,7 +276,7 @@ impl KubernetesDriver {
                 namespace: Some(self.options.namespace.clone()),
                 labels: Some({
                     let mut labels = BTreeMap::new();
-                    labels.insert(LABEL_MANAGED_BY.to_owned(), MANAGED_BY_VALUE.to_owned());
+                    labels.insert(LABEL_MANAGED_BY.to_owned(), self.managed_by_value.clone());
                     labels.insert(LABEL_WORKER_ID.to_owned(), worker_id);
                     labels.insert(LABEL_WORKER_KEY.to_owned(), worker_key.to_string());
                     labels.insert(LABEL_QUEUE_NAME.to_owned(), queue_name.clone());
@@ -438,7 +442,7 @@ impl WorkerDriver for KubernetesDriver {
 
             let match_labels = {
                 let mut labels = BTreeMap::new();
-                labels.insert(LABEL_MANAGED_BY.to_owned(), MANAGED_BY_VALUE.to_owned());
+                labels.insert(LABEL_MANAGED_BY.to_owned(), self.managed_by_value.clone());
                 labels.insert(LABEL_WORKER_ID.to_owned(), new_id.to_string());
                 labels.insert(LABEL_WORKER_KEY.to_owned(), worker_key.to_string());
                 labels
@@ -671,7 +675,7 @@ impl WorkerDriver for KubernetesDriver {
                 .iter()
                 .filter_map(|deployment| {
                     deployment.metadata.labels.as_ref().and_then(|labels| {
-                        if labels.get(LABEL_MANAGED_BY) == Some(&MANAGED_BY_VALUE.to_owned()) {
+                        if labels.get(LABEL_MANAGED_BY) == Some(&self.managed_by_value) {
                             let worker_id =
                                 labels.get(LABEL_WORKER_ID).expect("worker_id not found");
                             let worker_key =
@@ -748,7 +752,7 @@ impl WorkerDriver for KubernetesDriver {
                             .labels
                             .as_ref()
                             .and_then(|labels| labels.get(LABEL_MANAGED_BY))
-                            != Some(&MANAGED_BY_VALUE.to_owned())
+                            != Some(&self.managed_by_value)
                         {
                             continue;
                         }
@@ -794,7 +798,7 @@ impl WorkerDriver for KubernetesDriver {
                         // Check if managed by osrdyne otherwise ignore
                         if scaled_object.metadata.labels.as_ref().and_then(
                             |labels: &BTreeMap<String, String>| labels.get(LABEL_MANAGED_BY),
-                        ) != Some(&MANAGED_BY_VALUE.to_owned())
+                        ) != Some(&self.managed_by_value)
                         {
                             continue;
                         }

--- a/osrdyne/src/main.rs
+++ b/osrdyne/src/main.rs
@@ -139,6 +139,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     config.amqp_uri.clone(),
                     config.max_msg_size,
                     config.pool_id.clone(),
+                    config.managed_by_value.clone(),
                 ))
             }
 
@@ -150,6 +151,7 @@ async fn main() -> Result<(), anyhow::Error> {
                         config.amqp_uri.clone(),
                         config.max_msg_size,
                         config.pool_id.clone(),
+                        config.managed_by_value.clone(),
                     )
                     .await,
                 )


### PR DESCRIPTION
The osrdyne from the regular compose kills the workers of the osrdyne from pr-test when they don't manage the same infra. I changed the managed_by_value of pr-test so the osrdyne from the regular compose does not interact with the workers of pr-test

Related to issue #11871 