### PR TITLE
editoast: make fga client read/write tuple limit configurable

### DIFF
--- a/editoast/editoast_authz/src/lib.rs
+++ b/editoast/editoast_authz/src/lib.rs
@@ -121,15 +121,34 @@ impl<T: Default> Authorization<T> {
 #[cfg(test)]
 /// The [fga::client::ConnectionSettings] to use for unit and doc tests
 ///
-/// Configurable through the `OPENFGA_HOST` and `OPENFGA_PORT` environment variables.
-/// Defaults to `localhost` and `8091`.
+/// Configurable through the `OPENFGA_HOST`, `OPENFGA_PORT`, `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` and
+/// `OPENFGA_MAX_TUPLES_PER_WRITE` environment variables.
+/// Defaults to `localhost`, `8091` and OpenFGA default limits.
 fn connection_settings() -> fga::client::ConnectionSettings {
+    use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+    use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
+    use fga::client::Limits;
+
     let address = std::env::var("OPENFGA_HOST").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("OPENFGA_PORT")
         .unwrap_or_else(|_| "8091".to_string())
         .parse()
         .expect("invalid port");
-    fga::client::ConnectionSettings::new(address, port).reset_store()
+    let max_checks_per_batch_check = std::env::var("OPENFGA_MAX_CHECKS_PER_BATCH_CHECK")
+        .map(|tuple_reads| tuple_reads.parse::<u32>().expect("invalid max tuple reads"))
+        .unwrap_or(DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK);
+    let max_tuples_per_write = std::env::var("OPENFGA_MAX_TUPLES_PER_WRITE")
+        .map(|tuple_writes| {
+            tuple_writes
+                .parse::<u64>()
+                .expect("invalid max tuple reads")
+        })
+        .unwrap_or(DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE);
+    let limits = Limits {
+        max_checks_per_batch_check,
+        max_tuples_per_write,
+    };
+    fga::client::ConnectionSettings::new(address, port, limits).reset_store()
 }
 
 #[cfg(test)]

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -38,7 +38,8 @@ use crate::model::Type;
 use crate::model::User;
 use crate::model::Wildcard;
 
-const OPENFGA_WRITES_MAX_TUPLES: usize = 100;
+pub const DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK: u32 = 50;
+pub const DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE: u64 = 100;
 
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -52,6 +53,7 @@ pub struct Client {
 pub struct ConnectionSettings {
     address: String,
     port: u16,
+    limits: Limits,
 
     /// Whether to reset the store on initialization
     ///
@@ -62,11 +64,29 @@ pub struct ConnectionSettings {
     reset_store: bool,
 }
 
+/// Limits to the payloads sent to the authentication server. For more information about these limits,
+/// check [OpenFGA official documentation](https://openfga.dev/docs/getting-started/setup-openfga/configuration).
+#[derive(Debug, Clone)]
+pub struct Limits {
+    pub max_checks_per_batch_check: u32,
+    pub max_tuples_per_write: u64,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Limits {
+            max_checks_per_batch_check: DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK,
+            max_tuples_per_write: DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE,
+        }
+    }
+}
+
 impl ConnectionSettings {
-    pub fn new(address: String, port: u16) -> Self {
+    pub fn new(address: String, port: u16, limits: Limits) -> Self {
         Self {
             address,
             port,
+            limits,
             reset_store: false,
         }
     }
@@ -74,6 +94,10 @@ impl ConnectionSettings {
     pub fn reset_store(mut self) -> Self {
         self.reset_store = true;
         self
+    }
+
+    pub fn limit(&self) -> &Limits {
+        &self.limits
     }
 }
 
@@ -273,9 +297,10 @@ impl Client {
         Ok(model_id)
     }
 
-    /// Writes up to 100 tuples in OpenFGA
+    /// Writes up to `n` tuples in OpenFGA, with `n` the maximum number of tuple writes
+    /// configured in the [ConnectionSettings::limits]'s [Limits::max_tuples_per_write].
     ///
-    /// If the tuple slice is more than 100 elements, an error will be returned.
+    /// If the tuple slice is more than `n` elements, an error will be returned.
     /// If you want them to be chunked into several requests, or if your tuples cannot
     /// be monomorphized into a single type, use [Client::prepare_writes] instead.
     ///
@@ -285,9 +310,9 @@ impl Client {
         &self,
         tuples: &[Tuple<'_, R, U>],
     ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
-        if tuples.len() > OPENFGA_WRITES_MAX_TUPLES {
+        if tuples.len() > self.settings.limits.max_tuples_per_write as usize {
             return Err(Either::Right(TooManyTuples {
-                max: OPENFGA_WRITES_MAX_TUPLES,
+                max: self.settings.limits.max_tuples_per_write as usize,
                 provided_count: tuples.len(),
             }));
         }
@@ -303,11 +328,14 @@ impl Client {
 
     /// Prepares multiple write requests to OpenFGA
     ///
-    /// OpenFGA Writes API do not accept more than 100 tuples per request.
+    /// OpenFGA Writes API has a maximum number of tuples it accepts per request
+    /// (default value: [DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE]).
+    ///
     /// The [PreparedWrites] type returned by this function accepts any number
     /// of tuples through [PreparedWrites::push] and will chunk them into
-    /// requests of 100 tuples each. The requests are sent concurrently when
-    /// [PreparedWrites::execute] is called.
+    /// requests of `n` tuples each, with `n` the maximum number of tuple reads
+    /// configured in the [ConnectionSettings::limits]'s [Limits::max_checks_per_batch_check].
+    /// The requests are sent concurrently when [PreparedWrites::execute] is called.
     ///
     /// Beware that the tuples injected into [PreparedWrites] cannot be accessed
     /// after a [PreparedWrites::push]. So any form of post-processing is impossible.
@@ -322,9 +350,10 @@ impl Client {
         }
     }
 
-    /// Deletes up to 100 tuples in OpenFGA
+    /// Deletes up to `n` tuples in OpenFGA, with `n` the maximum number of tuple writes
+    /// configured in the [ConnectionSettings::limits]'s [Limits::max_tuples_per_write].
     ///
-    /// If the tuple slice is more than 100 elements, an error will be returned.
+    /// If the tuple slice is more than `n` elements, an error will be returned.
     /// If you want them to be chunked into several requests, or if your tuples cannot
     /// be monomorphized into a single type, use [Client::prepare_deletes] instead.
     ///
@@ -334,9 +363,9 @@ impl Client {
         &self,
         tuples: &[Tuple<'_, R, U>],
     ) -> Result<(), Either<RequestFailure, TooManyTuples>> {
-        if tuples.len() > OPENFGA_WRITES_MAX_TUPLES {
+        if tuples.len() > self.settings.limits.max_tuples_per_write as usize {
             return Err(Either::Right(TooManyTuples {
-                max: OPENFGA_WRITES_MAX_TUPLES,
+                max: self.settings.limits.max_tuples_per_write as usize,
                 provided_count: tuples.len(),
             }));
         }
@@ -352,11 +381,13 @@ impl Client {
 
     /// Prepares multiple delete requests to OpenFGA
     ///
-    /// OpenFGA Writes API do not accept more than 100 tuples per request.
+    /// OpenFGA Writes API has a maximum number of tuples it accepts per request
+    /// (default value: [DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE]).
     /// The [PreparedDeletes] type returned by this function accepts any number
     /// of tuples through [PreparedDeletes::push] and will chunk them into
-    /// requests of 100 tuples each. The requests are sent concurrently when
-    /// [PreparedDeletes::execute] is called.
+    /// requests of `n` tuples each, with `n` the tuples limit configured in
+    /// [ConnectionSettings::limits]'s [Limits::max_tuples_per_write].
+    /// The requests are sent concurrently when [PreparedDeletes::execute] is called.
     ///
     /// Beware that the tuples injected into [PreparedDeletes] cannot be accessed
     /// after a [PreparedDeletes::push]. So any form of post-processing is impossible.
@@ -445,10 +476,10 @@ impl Client {
 
     /// Prepares multiple check requests to OpenFGA
     ///
-    /// OpenFGA Check API do not accept more than 50 checks per request.
-    /// The [PreparedChecks] type returned by this function accepts any number
+    /// OpenFGA Check API do not accept more than a configurable maximum number of
+    /// checks per request. The [PreparedChecks] type returned by this function accepts any number
     /// of checks through [PreparedChecks::push] and will chunk them into
-    /// requests of 50 checks each. The requests are sent concurrently when
+    /// requests of `max_tuple_reads` checks each. The requests are sent concurrently when
     /// [PreparedChecks::execute] is called.
     ///
     /// Beware that the checks injected into [PreparedChecks] cannot be accessed
@@ -641,7 +672,9 @@ impl PreparedChecks<'_> {
         self
     }
 
-    /// Concurrently send batch-checks requests to OpenFGA in 50-check chunks
+    /// Concurrently send batch-checks requests to OpenFGA in chunks of `n` elements,
+    /// with `n` the maximum number of tuple reads configured in the
+    /// [ConnectionSettings::limits]'s [Limits::max_checks_per_batch_check].
     pub async fn execute(self) -> Result<Vec<bool>, RequestFailure> {
         let count = self.checks.len();
 
@@ -662,16 +695,18 @@ impl PreparedChecks<'_> {
             .unzip();
 
         // Prepare the requests
-        let futs = check_items.chunks(50).map(|checks| {
-            self.client
-                .post_stores_batch_check(
-                    &self.client.store.id,
-                    checks,
-                    self.client.authorization_model_id.as_deref(),
-                    None,
-                )
-                .in_current_span()
-        });
+        let futs = check_items
+            .chunks(self.client.settings.limits.max_checks_per_batch_check as usize)
+            .map(|checks| {
+                self.client
+                    .post_stores_batch_check(
+                        &self.client.store.id,
+                        checks,
+                        self.client.authorization_model_id.as_deref(),
+                        None,
+                    )
+                    .in_current_span()
+            });
 
         // Send the requests concurrently and combine all check results
         let check_results = futures::future::try_join_all(futs)
@@ -756,7 +791,9 @@ impl PreparedWrites<'_> {
         self
     }
 
-    /// Concurrently sends write requests to OpenFGA in 100-tuple chunks
+    /// Concurrently sends write requests to OpenFGA in chunks of `n` elements,
+    /// with `n` the maximum number of tuple reads configured in the [ConnectionSettings::limits]'s
+    /// [Limits::max_tuples_per_write].
     ///
     /// /!\ WARNING /!\ No transactional state is set up, so should any request fail,
     /// the tuples written by other successful requests will remain in OpenFGA.
@@ -765,7 +802,7 @@ impl PreparedWrites<'_> {
     pub async fn execute(self) -> Result<(), RequestFailure> {
         let futs = self
             .writes
-            .chunks(100)
+            .chunks(self.client.settings.limits.max_tuples_per_write as usize)
             .map(|chunk| {
                 self.client
                     .post_stores_write(
@@ -800,7 +837,9 @@ impl PreparedDeletes<'_> {
         self
     }
 
-    /// Concurrently sends delete requests to OpenFGA in 100-tuple chunks
+    /// Concurrently sends delete requests to OpenFGA in chunks of `n` elements,
+    /// with `n` the maximum number of tuple writes configured in the [ConnectionSettings::limits]'s
+    /// [Limits::max_tuples_per_write].
     ///
     /// /!\ WARNING /!\ No transactional state is set up, so should any request fail,
     /// the tuples deleted by other successful requests will remain deleted in OpenFGA.
@@ -809,7 +848,7 @@ impl PreparedDeletes<'_> {
     pub async fn execute(self) -> Result<(), RequestFailure> {
         let futs = self
             .deletes
-            .chunks(100)
+            .chunks(self.client.settings.limits.max_tuples_per_write as usize)
             .map(|chunk| {
                 self.client
                     .post_stores_write(
@@ -1003,7 +1042,11 @@ impl Continuation {
 
 #[cfg(test)]
 mod tests {
+    use reqwest::StatusCode;
+
     use crate::client::Client;
+    use crate::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+    use crate::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
     use crate::client::InitializationError;
     use crate::client::Request as _;
     use crate::compile_model;
@@ -1147,6 +1190,88 @@ mod tests {
             assert!(bob);
             assert!(!alice);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn batch_check_tuple_read_limit_success() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        let number_of_checks = DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK * 2;
+        let mut checks = client.prepare_checks();
+        for _ in 1..=number_of_checks {
+            checks.push(&Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")));
+        }
+        let results = checks.execute().await.unwrap();
+        assert_eq!(results, vec![false; number_of_checks as usize]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn batch_check_tuple_read_limit_fail() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client.settings.limits.max_checks_per_batch_check =
+            DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK + 1;
+        let number_of_checks = DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK * 2;
+        let mut checks = client.prepare_checks();
+        for _ in 1..=number_of_checks {
+            checks.push(&Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")));
+        }
+        let results = checks.execute().await;
+        assert!(results.is_err_and(|err| err.0.status().unwrap() == StatusCode::BAD_REQUEST));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn batch_check_tuple_write_limit_success() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        let mut writes = client.prepare_writes();
+        let mut infras: Vec<Infra> = vec![];
+        let mut users: Vec<User> = vec![];
+        for i in 1..=2 * DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE {
+            infras.push(Infra(format!("{i}")));
+            users.push(User(format!("{i}")));
+        }
+        let tuples = infras
+            .iter()
+            .zip(users.iter())
+            .map(|(infra, user)| Infra::reader().tuple(user, infra))
+            .collect::<Vec<_>>();
+        for tuple in tuples {
+            writes.push(&tuple);
+        }
+        writes.execute().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn batch_check_tuple_write_limit_fail() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.settings.limits.max_tuples_per_write = DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE + 1;
+        client.update_authorization_model(&model).await.unwrap();
+        let mut writes = client.prepare_writes();
+        let mut infras: Vec<Infra> = vec![];
+        let mut users: Vec<User> = vec![];
+        for i in 1..=2 * DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE {
+            infras.push(Infra(format!("{i}")));
+            users.push(User(format!("{i}")));
+        }
+        let tuples = infras
+            .iter()
+            .zip(users.iter())
+            .map(|(infra, user)| Infra::reader().tuple(user, infra))
+            .collect::<Vec<_>>();
+        for tuple in tuples {
+            writes.push(&tuple);
+        }
+        let response = writes.execute().await;
+        assert!(response.is_err_and(|err| err.0.status().unwrap() == StatusCode::BAD_REQUEST));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/fga/src/client/queries.rs
+++ b/editoast/fga/src/client/queries.rs
@@ -69,7 +69,6 @@ pub(super) struct CheckError {
 }
 
 impl Client {
-    // TODO: make the maximum number of checks configurable in the client
     #[tracing::instrument(skip(self, checks), ret(level = "debug"), err)]
     pub(super) async fn post_stores_batch_check(
         &self,
@@ -79,8 +78,9 @@ impl Client {
         consistency: Option<Consistency>,
     ) -> Result<HashMap<String, BatchCheckSingleResult>, RequestFailure> {
         assert!(
-            checks.len() <= 50,
-            "OpenFGA doesn't support more than 50 batched checks by default"
+            checks.len() as u32 <= self.settings.limits.max_checks_per_batch_check,
+            "OpenFGA client's checks limit per batch setting is set to {}",
+            self.settings.limits.max_checks_per_batch_check
         );
 
         #[derive(serde::Serialize)]

--- a/editoast/fga/src/doctest_setup.rs
+++ b/editoast/fga/src/doctest_setup.rs
@@ -1,4 +1,5 @@
 use fga::model::Relation as _;
+use fga::client::Limits;
 
 #[derive(Debug, PartialEq, Eq, fga::Type, fga::User, derive_more::FromStr)]
 struct Person(String);
@@ -23,5 +24,5 @@ fga::relations! {
 }
 
 fn settings() -> fga::client::ConnectionSettings {
-    fga::client::ConnectionSettings::new("localhost".to_string(), 8091).reset_store()
+    fga::client::ConnectionSettings::new("localhost".to_string(), 8091, Limits::default()).reset_store()
 }

--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -482,15 +482,39 @@ macro_rules! fga {
 #[cfg(test)]
 /// The [client::ConnectionSettings] to use for unit and doc tests
 ///
-/// Configurable through the `OPENFGA_HOST` and `OPENFGA_PORT` environment variables.
-/// Defaults to `localhost` and `8091` (as used by OSRD).
+/// Configurable through the `OPENFGA_HOST`, `OPENFGA_PORT`, `OPENFGA_MAX_CHECKS_PER_BATCH_CHECK` and
+/// `OPENFGA_MAX_TUPLES_PER_WRITE` environment variables.
+/// Defaults to `localhost`, `8091` and OpenFGA default settings.
 fn connection_settings() -> client::ConnectionSettings {
+    use client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+    use client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
+    use client::Limits;
+
     let address = std::env::var("OPENFGA_HOST").unwrap_or_else(|_| "localhost".to_string());
     let port = std::env::var("OPENFGA_PORT")
         .unwrap_or_else(|_| "8091".to_string())
         .parse()
         .expect("invalid port");
-    client::ConnectionSettings::new(address, port).reset_store()
+    let max_checks_per_batch_check = std::env::var("OPENFGA_MAX_CHECKS_PER_BATCH_CHECK")
+        .map(|tuple_reads| tuple_reads.parse::<u32>().expect("invalid max tuple reads"))
+        .unwrap_or(DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK);
+    let max_tuples_per_write = std::env::var("OPENFGA_MAX_TUPLES_PER_WRITE")
+        .map(|tuple_writes| {
+            tuple_writes
+                .parse::<u64>()
+                .expect("invalid max tuple reads")
+        })
+        .unwrap_or(DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE);
+
+    client::ConnectionSettings::new(
+        address,
+        port,
+        Limits {
+            max_checks_per_batch_check,
+            max_tuples_per_write,
+        },
+    )
+    .reset_store()
 }
 
 #[cfg(test)]

--- a/editoast/src/client/openfga_config.rs
+++ b/editoast/src/client/openfga_config.rs
@@ -4,6 +4,8 @@ use crate::models::PgAuthDriver;
 use crate::views;
 use clap::Args;
 use editoast_models::DbConnectionPoolV2;
+use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 use url::Url;
 
 #[derive(Args, Debug)]
@@ -12,6 +14,10 @@ pub struct OpenfgaConfig {
     pub(super) openfga_url: Url,
     #[clap(long, env = "EDITOAST_OPENFGA_STORE", default_value_t = String::from("osrd-editoast"))]
     pub(super) openfga_store: String,
+    #[clap(long, env = "OPENFGA_MAX_CHECKS_PER_BATCH_CHECK", default_value_t = DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK)]
+    pub(super) openfga_max_checks_per_batch_check: u32,
+    #[clap(long, env = "OPENFGA_MAX_TUPLES_PER_WRITE", default_value_t = DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE)]
+    pub(super) openfga_max_tuples_per_write: u64,
 }
 
 impl From<OpenfgaConfig> for views::OpenfgaConfig {
@@ -19,11 +25,15 @@ impl From<OpenfgaConfig> for views::OpenfgaConfig {
         OpenfgaConfig {
             openfga_url,
             openfga_store,
+            openfga_max_checks_per_batch_check,
+            openfga_max_tuples_per_write,
         }: OpenfgaConfig,
     ) -> Self {
         views::OpenfgaConfig {
             url: openfga_url,
             store: openfga_store,
+            max_checks_per_batch_check: openfga_max_checks_per_batch_check,
+            max_tuples_per_write: openfga_max_tuples_per_write,
         }
     }
 }

--- a/editoast/src/views/mod.rs
+++ b/editoast/src/views/mod.rs
@@ -28,6 +28,7 @@ use editoast_authz::Authorization;
 use editoast_authz::Infra;
 use editoast_authz::StorageDriver;
 use editoast_common::Version;
+use fga::client::Limits;
 #[cfg(test)]
 pub(crate) use test_app::test_app;
 
@@ -146,6 +147,9 @@ editoast_common::schemas! {
 /// Represents the bundle of information about the issuer of a request
 /// that can be extracted form recognized headers.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+// TODO wrap the OpenFGA client contained of the `Authenticated` variant in an Arc
+//      and remove the clippy ignore.
 pub enum Authentication {
     /// The issuer of the request did not provide any authentication information.
     Unauthenticated,
@@ -487,6 +491,8 @@ pub struct OsrdyneConfig {
 pub struct OpenfgaConfig {
     pub url: Url,
     pub store: String,
+    pub max_checks_per_batch_check: u32,
+    pub max_tuples_per_write: u64,
 }
 
 #[derive(Clone)]
@@ -713,6 +719,10 @@ impl OpenfgaConfig {
         Ok(fga::client::ConnectionSettings::new(
             address.to_owned(),
             port,
+            Limits {
+                max_checks_per_batch_check: self.max_checks_per_batch_check,
+                max_tuples_per_write: self.max_tuples_per_write,
+            },
         ))
     }
 }

--- a/editoast/src/views/test_app.rs
+++ b/editoast/src/views/test_app.rs
@@ -23,6 +23,7 @@ use editoast_common::tracing::TracingConfig;
 use editoast_common::tracing::create_tracing_subscriber;
 use editoast_models::DbConnectionPoolV2;
 use editoast_osrdyne_client::OsrdyneClient;
+use fga::client::Limits;
 use futures::executor::block_on;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::SpanData;
@@ -39,6 +40,8 @@ use crate::infra_cache::InfraCache;
 use crate::map::MapLayers;
 use crate::models::PgAuthDriver;
 use crate::valkey_utils::ValkeyConfig;
+use fga::client::DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK;
+use fga::client::DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE;
 
 use super::CoreConfig;
 use super::OpenfgaConfig;
@@ -178,6 +181,8 @@ impl TestAppBuilder {
             openfga_config: OpenfgaConfig {
                 url: Url::parse("http://localhost:8091").unwrap(),
                 store: self.test_name.clone(),
+                max_checks_per_batch_check: DEFAULT_OPENFGA_MAX_CHECKS_PER_BATCH_CHECK,
+                max_tuples_per_write: DEFAULT_OPENFGA_MAX_TUPLES_PER_WRITE,
             },
         };
 
@@ -245,7 +250,8 @@ impl TestAppBuilder {
         };
         let mut openfga = block_on(fga::Client::try_new_store(
             store_name,
-            fga::client::ConnectionSettings::new("localhost".to_owned(), 8091).reset_store(),
+            fga::client::ConnectionSettings::new("localhost".to_owned(), 8091, Limits::default())
+                .reset_store(),
         ))
         .expect("OpenFGA should be setup properly for testing");
         if let Some(model) = self.authorization_model {


### PR DESCRIPTION
Fixes https://github.com/OpenRailAssociation/osrd/issues/11842.

Introduce two new settings in the FGA configuration that allow to configure respectively the maximum number of tuples sent to the authentication server in read (resp. write) queries. If not explicitly set, they default to OpenFGA default values.