### PR TITLE
editoast: paced train path and simulation implementation

### DIFF
--- a/editoast/openapi.yaml
+++ b/editoast/openapi.yaml
@@ -5486,6 +5486,7 @@ components:
       - $ref: '#/components/schemas/EditoastOperationErrorObjectNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorBatchNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorDatabase'
+      - $ref: '#/components/schemas/EditoastPacedTrainErrorExceptionNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorInfraNotFound'
       - $ref: '#/components/schemas/EditoastPacedTrainErrorNotFound'
       - $ref: '#/components/schemas/EditoastPathfindingErrorInfraNotFound'
@@ -6021,6 +6022,30 @@ components:
           type: string
           enum:
           - editoast:paced_train:Database
+    EditoastPacedTrainErrorExceptionNotFound:
+      type: object
+      required:
+      - type
+      - status
+      - message
+      properties:
+        context:
+          type: object
+          required:
+          - exception_key
+          properties:
+            exception_key:
+              type: string
+        message:
+          type: string
+        status:
+          type: integer
+          enum:
+          - 404
+        type:
+          type: string
+          enum:
+          - editoast:paced_train:ExceptionNotFound
     EditoastPacedTrainErrorInfraNotFound:
       type: object
       required:

--- a/editoast/src/models/fixtures.rs
+++ b/editoast/src/models/fixtures.rs
@@ -16,6 +16,7 @@ use editoast_schemas::infra::Direction;
 use editoast_schemas::infra::DirectionalTrackRange;
 use editoast_schemas::infra::InfraObject;
 use editoast_schemas::infra::RailJson;
+use editoast_schemas::infra::TrackOffset;
 use editoast_schemas::paced_train::ConstraintDistributionChangeGroup;
 use editoast_schemas::paced_train::ExceptionType;
 use editoast_schemas::paced_train::InitialSpeedChangeGroup;
@@ -30,6 +31,7 @@ use editoast_schemas::paced_train::RollingStockChangeGroup;
 use editoast_schemas::paced_train::SpeedLimitTagChangeGroup;
 use editoast_schemas::paced_train::StartTimeChangeGroup;
 use editoast_schemas::paced_train::TrainNameChangeGroup;
+use editoast_schemas::primitives::Identifier;
 use editoast_schemas::primitives::NonBlankString;
 use editoast_schemas::primitives::OSRDObject;
 use editoast_schemas::rolling_stock::EffortCurves;
@@ -44,6 +46,11 @@ use editoast_schemas::train_schedule::Comfort;
 use editoast_schemas::train_schedule::Distribution;
 use editoast_schemas::train_schedule::MarginValue;
 use editoast_schemas::train_schedule::Margins;
+use editoast_schemas::train_schedule::OperationalPointIdentifier;
+use editoast_schemas::train_schedule::OperationalPointReference;
+use editoast_schemas::train_schedule::PathItem;
+use editoast_schemas::train_schedule::PathItemLocation;
+use editoast_schemas::train_schedule::ScheduleItem;
 use editoast_schemas::train_schedule::TrainSchedule;
 use editoast_schemas::train_schedule::TrainScheduleOptions;
 use postgis_diesel::types::LineString;
@@ -116,6 +123,110 @@ pub fn simple_train_schedule_base() -> TrainSchedule {
         .expect("Unable to parse test train schedule")
 }
 
+pub fn create_created_exception_with_change_groups(key: &str) -> PacedTrainException {
+    PacedTrainException {
+        key: key.into(),
+        exception_type: ExceptionType::Created {},
+        disabled: false,
+        train_name: Some(TrainNameChangeGroup {
+            value: "exception_train_name".into(),
+        }),
+        constraint_distribution: Some(ConstraintDistributionChangeGroup {
+            value: Distribution::Mareco,
+        }),
+        initial_speed: Some(InitialSpeedChangeGroup { value: 10.0 }),
+        labels: Some(LabelsChangeGroup {
+            value: vec!["Label 1".to_string(), "Label 3".to_string()],
+        }),
+        options: Some(OptionsChangeGroup {
+            value: TrainScheduleOptions::default(),
+        }),
+        path_and_schedule: Some(PathAndScheduleChangeGroup {
+            power_restrictions: vec![],
+            schedule: vec![
+                ScheduleItem {
+                    at: NonBlankString("aa".to_string()),
+                    ..Default::default()
+                },
+                ScheduleItem {
+                    at: NonBlankString("bb".to_string()),
+                    ..Default::default()
+                },
+                ScheduleItem {
+                    at: NonBlankString("cc".to_string()),
+                    ..Default::default()
+                },
+                ScheduleItem {
+                    at: NonBlankString("dd".to_string()),
+                    ..Default::default()
+                },
+            ],
+            path: vec![
+                PathItem {
+                    id: "aa".into(),
+                    deleted: false,
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        offset: 300,
+                        track: Identifier("TC0".to_string()),
+                    }),
+                },
+                PathItem {
+                    id: "bb".into(),
+                    deleted: false,
+                    location: PathItemLocation::OperationalPointReference(
+                        OperationalPointReference {
+                            reference: OperationalPointIdentifier::OperationalPointId {
+                                operational_point: Identifier("Mid_East_station".to_string()),
+                            },
+                            track_reference: None,
+                        },
+                    ),
+                },
+                PathItem {
+                    id: "cc".into(),
+                    deleted: false,
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        offset: 300,
+                        track: Identifier("TC1".to_string()),
+                    }),
+                },
+                PathItem {
+                    id: "dd".into(),
+                    deleted: false,
+                    location: PathItemLocation::TrackOffset(TrackOffset {
+                        offset: 300,
+                        track: Identifier("TC2".to_string()),
+                    }),
+                },
+            ],
+            margins: Margins {
+                boundaries: vec![],
+                values: vec![MarginValue::Percentage(5.0)],
+            },
+        }),
+        rolling_stock: Some(RollingStockChangeGroup {
+            rolling_stock_name: "simulation_rolling_stock".into(),
+            comfort: Comfort::AirConditioning,
+        }),
+        rolling_stock_category: Some(RollingStockCategoryChangeGroup { value: None }),
+        speed_limit_tag: Some(SpeedLimitTagChangeGroup {
+            value: Some(NonBlankString("GB".into())),
+        }),
+        start_time: Some(StartTimeChangeGroup {
+            value: DateTime::<Utc>::from_str("2025-05-05T20:05:00+02:00").unwrap(),
+        }),
+    }
+}
+
+pub fn create_modified_exception_with_change_groups(
+    key: &str,
+    occurrence_index: i32,
+) -> PacedTrainException {
+    let mut exception = create_created_exception_with_change_groups(key);
+    exception.exception_type = ExceptionType::Modified { occurrence_index };
+    exception
+}
+
 pub fn simple_paced_train_base() -> PacedTrain {
     let train_schedule_base =
         serde_json::from_str(include_str!("../tests/train_schedules/simple.json"))
@@ -157,6 +268,18 @@ pub async fn create_simple_paced_train(
     timetable_id: i64,
 ) -> models::PacedTrain {
     simple_paced_train_changeset(timetable_id)
+        .create(conn)
+        .await
+        .expect("Failed to create paced train")
+}
+
+pub async fn create_paced_train_with_exceptions(
+    conn: &mut DbConnection,
+    timetable_id: i64,
+    exceptions: Vec<PacedTrainException>,
+) -> models::PacedTrain {
+    let paced_train = simple_paced_train_changeset(timetable_id).exceptions(exceptions);
+    paced_train
         .create(conn)
         .await
         .expect("Failed to create paced train")

--- a/editoast/src/models/paced_train.rs
+++ b/editoast/src/models/paced_train.rs
@@ -57,6 +57,54 @@ pub struct PacedTrain {
 }
 
 impl PacedTrain {
+    pub fn apply_exceptions(&self, exceptions: &[PacedTrainException]) -> Vec<TrainSchedule> {
+        exceptions
+            .iter()
+            .map(|exception| self.apply_exception(exception))
+            .collect()
+    }
+
+    pub fn apply_exception(&self, exception: &PacedTrainException) -> TrainSchedule {
+        let mut train_schedule = self.clone().into_first_occurrence();
+
+        if let Some(change_group) = &exception.train_name {
+            train_schedule.train_name = change_group.value.clone();
+        }
+        if let Some(change_group) = &exception.rolling_stock {
+            train_schedule.comfort = change_group.comfort;
+            train_schedule.rolling_stock_name = change_group.rolling_stock_name.clone();
+        }
+        if let Some(change_group) = &exception.rolling_stock_category {
+            train_schedule.category = change_group.value.clone().map(TrainCategory);
+        }
+        if let Some(change_group) = &exception.labels {
+            train_schedule.labels = change_group.value.iter().cloned().map(Some).collect();
+        }
+        if let Some(change_group) = &exception.speed_limit_tag {
+            train_schedule.speed_limit_tag = change_group.value.clone().map(|value| value.0);
+        }
+        if let Some(change_group) = &exception.start_time {
+            train_schedule.start_time = change_group.value
+        }
+        if let Some(change_group) = &exception.constraint_distribution {
+            train_schedule.constraint_distribution = change_group.value;
+        }
+        if let Some(change_group) = &exception.initial_speed {
+            train_schedule.initial_speed = change_group.value;
+        }
+        if let Some(change_group) = &exception.options {
+            train_schedule.options = change_group.value.clone();
+        }
+        if let Some(change_group) = &exception.path_and_schedule {
+            train_schedule.margins = change_group.margins.clone();
+            train_schedule.path = change_group.path.clone();
+            train_schedule.power_restrictions = change_group.power_restrictions.clone();
+            train_schedule.schedule = change_group.schedule.clone();
+        }
+
+        train_schedule
+    }
+
     pub fn into_first_occurrence(self) -> TrainSchedule {
         TrainSchedule {
             id: self.id,
@@ -146,5 +194,134 @@ impl From<PacedTrain> for paced_train::PacedTrain {
                 interval: paced_train.interval.try_into().unwrap(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use chrono::DateTime;
+    use chrono::Utc;
+    use editoast_models::rolling_stock::TrainCategory;
+    use editoast_schemas::paced_train::PacedTrainException;
+    use editoast_schemas::train_schedule::Comfort;
+    use editoast_schemas::train_schedule::Distribution;
+    use editoast_schemas::train_schedule::Margins;
+    use editoast_schemas::train_schedule::TrainScheduleOptions;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    use crate::models::PacedTrain;
+    use crate::models::Tags;
+    use crate::models::fixtures::create_created_exception_with_change_groups;
+    use crate::models::fixtures::create_modified_exception_with_change_groups;
+
+    pub fn create_paced_train(exceptions: Vec<PacedTrainException>) -> PacedTrain {
+        PacedTrain {
+            id: 1,
+            timetable_id: 1,
+            train_name: "train_name".to_string(),
+            rolling_stock_name: "R2D2".to_string(),
+            comfort: Comfort::Standard,
+            initial_speed: 25.0,
+            category: Some(TrainCategory(
+                editoast_schemas::rolling_stock::TrainCategory::HighSpeedTrain,
+            )),
+            constraint_distribution: Distribution::Standard,
+            labels: Tags::new(vec![]),
+            margins: Margins {
+                boundaries: vec![Default::default()],
+                ..Default::default()
+            },
+            path: vec![],
+            power_restrictions: vec![],
+            schedule: vec![],
+            speed_limit_tag: None,
+            options: TrainScheduleOptions::default(),
+            start_time: DateTime::<Utc>::from_str("2024-09-17T20:05:00+02:00").unwrap(),
+            time_window: chrono::Duration::try_hours(2).unwrap(),
+            interval: chrono::Duration::try_minutes(30).unwrap(),
+            exceptions,
+        }
+    }
+
+    #[rstest]
+    #[case::created(create_created_exception_with_change_groups("key_1"))]
+    #[case::modified(create_modified_exception_with_change_groups("key_2", 0))]
+    async fn paced_train_apply_exception(#[case] exception: PacedTrainException) {
+        let paced_train = create_paced_train(vec![exception.clone()]);
+        let paced_train_exception = paced_train.apply_exception(&exception);
+
+        assert_eq!(
+            paced_train_exception.train_name,
+            exception.train_name.unwrap().value
+        );
+        assert_eq!(
+            paced_train_exception.rolling_stock_name,
+            exception.rolling_stock.clone().unwrap().rolling_stock_name
+        );
+        assert_eq!(
+            paced_train_exception.comfort,
+            exception.rolling_stock.unwrap().comfort
+        );
+        assert_eq!(
+            paced_train_exception.initial_speed,
+            exception.initial_speed.unwrap().value
+        );
+        assert_eq!(
+            paced_train_exception.category,
+            exception
+                .rolling_stock_category
+                .unwrap()
+                .value
+                .map(TrainCategory)
+        );
+        assert_eq!(
+            paced_train_exception.constraint_distribution,
+            exception.constraint_distribution.unwrap().value
+        );
+        assert_eq!(
+            paced_train_exception.labels,
+            exception
+                .labels
+                .unwrap()
+                .value
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<Option<String>>>()
+        );
+        assert_eq!(
+            paced_train_exception.margins,
+            exception.path_and_schedule.clone().unwrap().margins
+        );
+        assert_eq!(
+            paced_train_exception.path,
+            exception.path_and_schedule.clone().unwrap().path
+        );
+        assert_eq!(
+            paced_train_exception.power_restrictions,
+            exception
+                .path_and_schedule
+                .clone()
+                .unwrap()
+                .power_restrictions
+        );
+        assert_eq!(
+            paced_train_exception.schedule,
+            exception.path_and_schedule.clone().unwrap().schedule
+        );
+        assert_eq!(
+            paced_train_exception.speed_limit_tag,
+            exception
+                .speed_limit_tag
+                .unwrap()
+                .value
+                .map(|v| v.to_string())
+        );
+        assert_eq!(
+            paced_train_exception.options,
+            exception.options.unwrap().value
+        );
     }
 }

--- a/editoast/src/views/timetable/paced_train.rs
+++ b/editoast/src/views/timetable/paced_train.rs
@@ -77,6 +77,9 @@ enum PacedTrainError {
     #[error("Infra '{infra_id}', could not be found")]
     #[editoast_error(status = 404)]
     InfraNotFound { infra_id: i64 },
+    #[error("Exception '{exception_key}', could not be found")]
+    #[editoast_error(status = 404)]
+    ExceptionNotFound { exception_key: String },
     #[error(transparent)]
     #[editoast_error(status = 500)]
     Database(#[from] editoast_models::model::Error),
@@ -354,9 +357,7 @@ async fn get_path(
     Extension(auth): AuthenticationExt,
     Path(PacedTrainIdParam { id: paced_train_id }): Path<PacedTrainIdParam>,
     Query(InfraIdQueryParam { infra_id }): Query<InfraIdQueryParam>,
-    Query(ExceptionQueryParam {
-        exception_key: _exception_key,
-    }): Query<ExceptionQueryParam>,
+    Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
 ) -> Result<Json<PathfindingResult>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies, authz::Role::Stdcm].into())
@@ -387,15 +388,24 @@ async fn get_path(
         PacedTrainError::NotFound { paced_train_id }
     })
     .await?;
+
+    let train_schedule = match exception_key {
+        Some(exception_key) => {
+            let exception = paced_train
+                .exceptions
+                .iter()
+                .find(|e| e.key == exception_key)
+                .ok_or_else(|| PacedTrainError::ExceptionNotFound {
+                    exception_key: exception_key.clone(),
+                })?;
+
+            paced_train.apply_exception(exception)
+        }
+        None => paced_train.into_first_occurrence(),
+    };
+
     Ok(Json(
-        pathfinding_from_train(
-            conn,
-            &mut valkey_conn,
-            core_client,
-            &infra,
-            paced_train.into_first_occurrence(),
-        )
-        .await?,
+        pathfinding_from_train(conn, &mut valkey_conn, core_client, &infra, train_schedule).await?,
     ))
 }
 
@@ -427,9 +437,7 @@ async fn simulation(
     Query(ElectricalProfileSetIdQueryParam {
         electrical_profile_set_id,
     }): Query<ElectricalProfileSetIdQueryParam>,
-    Query(ExceptionQueryParam {
-        exception_key: _exception_key,
-    }): Query<ExceptionQueryParam>,
+    Query(ExceptionQueryParam { exception_key }): Query<ExceptionQueryParam>,
 ) -> Result<Json<simulation::Response>> {
     let authorized = auth
         .check_roles([authz::Role::OperationalStudies].into())
@@ -462,12 +470,27 @@ async fn simulation(
         })
         .await?;
 
+    let train_schedule = match exception_key {
+        Some(exception_key) => {
+            let exception = paced_train
+                .exceptions
+                .iter()
+                .find(|e| e.key == exception_key)
+                .ok_or_else(|| PacedTrainError::ExceptionNotFound {
+                    exception_key: exception_key.clone(),
+                })?;
+
+            paced_train.apply_exception(exception)
+        }
+        None => paced_train.into_first_occurrence(),
+    };
+
     // Compute simulation of a paced_train
     let (simulation, _) = train_simulation_batch(
         &mut db_pool.get().await?,
         valkey_client,
         core_client,
-        &[paced_train.into_first_occurrence()],
+        &[train_schedule],
         &infra,
         electrical_profile_set_id,
     )
@@ -620,6 +643,7 @@ mod tests {
     use chrono::DateTime;
     use chrono::Duration;
     use core_client::mocking::MockingClient;
+    use core_client::pathfinding::PathfindingInputError;
     use core_client::pathfinding::PathfindingResultSuccess;
     use core_client::simulation::CompleteReportTrain;
     use core_client::simulation::ElectricalProfiles;
@@ -628,6 +652,8 @@ mod tests {
     use editoast_models::DbConnectionPoolV2;
     use editoast_schemas::paced_train::Paced;
     use editoast_schemas::paced_train::PacedTrain;
+    use editoast_schemas::paced_train::RollingStockChangeGroup;
+    use editoast_schemas::train_schedule::Comfort;
     use editoast_schemas::train_schedule::TrainSchedule;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -636,7 +662,9 @@ mod tests {
     use crate::error::InternalError;
     use crate::models;
     use crate::models::fixtures::PartialProjectPathTrainResult;
+    use crate::models::fixtures::create_created_exception_with_change_groups;
     use crate::models::fixtures::create_fast_rolling_stock;
+    use crate::models::fixtures::create_paced_train_with_exceptions;
     use crate::models::fixtures::create_simple_paced_train;
     use crate::models::fixtures::create_small_infra;
     use crate::models::fixtures::create_timetable;
@@ -644,12 +672,14 @@ mod tests {
     use crate::models::fixtures::simple_paced_train_changeset;
     use crate::models::paced_train::PacedTrainChangeset;
     use crate::models::prelude::*;
+    use crate::views::path::pathfinding::PathfindingFailure;
     use crate::views::path::pathfinding::PathfindingResult;
     use crate::views::test_app::TestApp;
     use crate::views::test_app::TestAppBuilder;
     use crate::views::tests::mocked_core_pathfinding_sim_and_proj;
     use crate::views::timetable::paced_train::PacedTrainResponse;
     use crate::views::timetable::paced_train::PacedTrainSummaryResponse;
+    use crate::views::timetable::simulation;
     use crate::views::timetable::simulation::SummaryResponse;
 
     #[rstest]
@@ -760,7 +790,9 @@ mod tests {
                 ..serde_json::from_str(include_str!("../../tests/train_schedules/simple.json"))
                     .expect("Unable to parse")
             },
-            exceptions: vec![],
+            exceptions: vec![create_created_exception_with_change_groups(
+                "created_exception_key",
+            )],
             paced: Paced {
                 time_window: Duration::hours(1).try_into().unwrap(),
                 interval: Duration::minutes(15).try_into().unwrap(),
@@ -828,6 +860,116 @@ mod tests {
                     boundaries: vec![],
                     values: vec![]
                 }
+            }
+        );
+    }
+
+    #[rstest]
+    async fn paced_train_exception_simulation_with_invalid_exception_key() {
+        let (app, infra_id, train_schedule_id) =
+            app_infra_id_paced_train_id_for_simulation_tests().await;
+        let request = app.get(
+            format!(
+                "/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=toto"
+            )
+            .as_str(),
+        );
+        let response: InternalError = app
+            .fetch(request)
+            .assert_status(StatusCode::NOT_FOUND)
+            .json_into();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:paced_train:ExceptionNotFound"
+        )
+    }
+
+    #[rstest]
+    async fn paced_train_exception_simulation() {
+        let (app, infra_id, train_schedule_id) =
+            app_infra_id_paced_train_id_for_simulation_tests().await;
+        let request = app.get(
+            format!("/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
+        );
+        let response: simulation::Response =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        assert_eq!(
+            response,
+            simulation::Response::Success {
+                base: ReportTrain {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1000, 2000, 3000]
+                },
+                provisional: ReportTrain {
+                    positions: vec![],
+                    times: vec![],
+                    speeds: vec![],
+                    energy_consumption: 0.0,
+                    path_item_times: vec![0, 1000, 2000, 3000]
+                },
+                final_output: CompleteReportTrain {
+                    report_train: ReportTrain {
+                        positions: vec![0],
+                        times: vec![0],
+                        speeds: vec![],
+                        energy_consumption: 0.0,
+                        path_item_times: vec![0, 1000, 2000, 3000]
+                    },
+                    signal_critical_positions: vec![],
+                    zone_updates: vec![],
+                    spacing_requirements: vec![],
+                    routing_requirements: vec![]
+                },
+                mrsp: SpeedLimitProperties {
+                    boundaries: vec![],
+                    values: vec![]
+                },
+                electrical_profiles: ElectricalProfiles {
+                    boundaries: vec![],
+                    values: vec![]
+                }
+            }
+        );
+    }
+
+    #[rstest]
+    async fn paced_train_exception_simulation_with_rolling_stock_not_found() {
+        // GIVEN
+        let (app, infra_id, train_schedule_id) =
+            app_infra_id_paced_train_id_for_simulation_tests().await;
+        let request = app.get(format!("/paced_train/{train_schedule_id}").as_str());
+        let mut paced_train_response: PacedTrainResponse =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+        paced_train_response.paced_train.exceptions[0].rolling_stock =
+            Some(RollingStockChangeGroup {
+                rolling_stock_name: "R2D2".into(),
+                comfort: Comfort::AirConditioning,
+            });
+        let request = app
+            .put(format!("/paced_train/{train_schedule_id}").as_str())
+            .json(&json!(paced_train_response.paced_train));
+        app.fetch(request).assert_status(StatusCode::NO_CONTENT);
+        // WHEN
+        let request = app.get(
+            format!("/paced_train/{train_schedule_id}/simulation/?infra_id={infra_id}&exception_key=created_exception_key").as_str(),
+        );
+        let response: simulation::Response =
+            app.fetch(request).assert_status(StatusCode::OK).json_into();
+
+        // THEN
+        assert_eq!(
+            response,
+            simulation::Response::PathfindingFailed {
+                pathfinding_failed: PathfindingFailure::PathfindingInputError(
+                    PathfindingInputError::RollingStockNotFound {
+                        rolling_stock_name: "R2D2".into()
+                    }
+                )
             }
         );
     }
@@ -931,6 +1073,31 @@ mod tests {
     }
 
     #[rstest]
+    async fn get_paced_train_path_with_invalid_exception_key() {
+        let app = TestAppBuilder::default_app();
+        let pool = app.db_pool();
+        let small_infra = create_small_infra(&mut pool.get_ok()).await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let paced_train = create_simple_paced_train(&mut pool.get_ok(), timetable.id).await;
+        let request = app.get(
+            format!(
+                "/paced_train/{}/path/?infra_id={}&exception_key=toto",
+                paced_train.id, small_infra.id
+            )
+            .as_str(),
+        );
+        let response: InternalError = app
+            .fetch(request)
+            .assert_status(StatusCode::NOT_FOUND)
+            .json_into();
+
+        assert_eq!(
+            &response.error_type,
+            "editoast:paced_train:ExceptionNotFound"
+        )
+    }
+
+    #[rstest]
     async fn get_paced_train_path() {
         let db_pool = DbConnectionPoolV2::for_tests();
         let mut core = MockingClient::new();
@@ -960,6 +1127,120 @@ mod tests {
         let request = app.get(&format!(
             "/paced_train/{}/path?infra_id={}",
             paced_train.id, small_infra.id
+        ));
+
+        let response = app
+            .fetch(request)
+            .assert_status(StatusCode::OK)
+            .json_into::<PathfindingResult>();
+
+        assert_eq!(
+            response,
+            PathfindingResult::Success(PathfindingResultSuccess {
+                blocks: vec![],
+                routes: vec![],
+                track_section_ranges: vec![],
+                path_item_positions: vec![],
+                length: 1
+            })
+        )
+    }
+
+    #[rstest]
+    async fn get_paced_train_exception_path_rolling_stock_not_found() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let mut core = MockingClient::new();
+        core.stub("/pathfinding/blocks")
+            .method(reqwest::Method::POST)
+            .response(StatusCode::OK)
+            .json(json!({
+                "blocks":[],
+                "routes": [],
+                "track_section_ranges": [],
+                "path_item_positions": [],
+                "length": 1,
+                "status": "success"
+            }))
+            .finish();
+        let app = TestAppBuilder::new()
+            .db_pool(db_pool.clone())
+            .core_client(core.into())
+            .build();
+        let pool = app.db_pool();
+
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "R2D2").await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let mut exception = create_created_exception_with_change_groups("exception_created_key");
+        exception.rolling_stock = Some(RollingStockChangeGroup {
+            rolling_stock_name: "exception_rolling_stock".into(),
+            comfort: Comfort::Standard,
+        });
+        let paced_train = create_paced_train_with_exceptions(
+            &mut pool.get_ok(),
+            timetable.id,
+            vec![exception.clone()],
+        )
+        .await;
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        let request = app.get(&format!(
+            "/paced_train/{}/path?infra_id={}&exception_key={}",
+            paced_train.id, small_infra.id, exception.key
+        ));
+
+        let response = app
+            .fetch(request)
+            .assert_status(StatusCode::OK)
+            .json_into::<PathfindingResult>();
+
+        assert_eq!(
+            response,
+            PathfindingResult::Failure(PathfindingFailure::PathfindingInputError(
+                PathfindingInputError::RollingStockNotFound {
+                    rolling_stock_name: "exception_rolling_stock".into()
+                }
+            ))
+        )
+    }
+
+    #[rstest]
+    async fn get_paced_train_exception_path() {
+        let db_pool = DbConnectionPoolV2::for_tests();
+        let mut core = MockingClient::new();
+        core.stub("/pathfinding/blocks")
+            .method(reqwest::Method::POST)
+            .response(StatusCode::OK)
+            .json(json!({
+                "blocks":[],
+                "routes": [],
+                "track_section_ranges": [],
+                "path_item_positions": [],
+                "length": 1,
+                "status": "success"
+            }))
+            .finish();
+        let app = TestAppBuilder::new()
+            .db_pool(db_pool.clone())
+            .core_client(core.into())
+            .build();
+        let pool = app.db_pool();
+
+        create_fast_rolling_stock(&mut db_pool.get_ok(), "simulation_rolling_stock").await;
+        let timetable = create_timetable(&mut pool.get_ok()).await;
+        let exception = create_created_exception_with_change_groups("exception_created_key");
+        let paced_train = create_paced_train_with_exceptions(
+            &mut pool.get_ok(),
+            timetable.id,
+            vec![exception.clone()],
+        )
+        .await;
+
+        let small_infra = create_small_infra(&mut db_pool.get_ok()).await;
+
+        let request = app.get(&format!(
+            "/paced_train/{}/path?infra_id={}&exception_key={}",
+            paced_train.id, small_infra.id, exception.key
         ));
 
         let response = app

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -126,6 +126,7 @@
     "paced_train": {
       "BatchNotFound": "'{{count}}' paced train(s) could not be found",
       "Database": "Internal error (database)",
+      "ExceptionNotFound": "Exception '{{exception_key}}' could not be found",
       "InfraNotFound": "Infrastructure '{{infra_id}}' could not be found",
       "NotFound": "Paced train '{{paced_train_id}}' could not be found"
     },

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -126,6 +126,7 @@
     "paced_train": {
       "BatchNotFound": "'{{count}}' mission(s) sont introuvable(s)",
       "Database": "Erreur interne (base de données)",
+      "ExceptionNotFound": "Exception '{{exception_key}}' non trouvée",
       "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Mission '{{paced_train_id}}' non trouvée"
     },


### PR DESCRIPTION
Part of #11456

Use exception_key in the /path and /simulation endpoints to apply an exception to the base paced train and compute the path or simulation.