### PR TITLE
front: complete missing translation keys in 'en'

### DIFF
--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -166,7 +166,9 @@
     },
     "scenario": {
       "Database": "Internal error (database)",
-      "NotFound": "Scenario not found"
+      "InfraNotFound": "Infrastructure '{{infra_id}}' not found",
+      "NotFound": "Scenario not found",
+      "TimetableNotFound": "Timetable '{{timetable_id}}' not found"
     },
     "search": {
       "ArgMissing": "Expected argument of type {{expected}} at position {{arg_pos}} is missing",

--- a/front/public/locales/en/errors.json
+++ b/front/public/locales/en/errors.json
@@ -220,6 +220,7 @@
       "StartDateAfterEndDate": "The study start date must be before the end date"
     },
     "temporary_speed_limit": {
+      "Database": "Internal error (database)",
       "NameAlreadyUsed": "A group of temporary speed limits with '{{name}}' already exists"
     },
     "timetable": {

--- a/front/public/locales/fr/errors.json
+++ b/front/public/locales/fr/errors.json
@@ -166,7 +166,7 @@
     },
     "scenario": {
       "Database": "Erreur interne (base de données)",
-      "InfraNotFound": "Infrastructure {{infra_id}} non trouvée",
+      "InfraNotFound": "Infrastructure '{{infra_id}}' non trouvée",
       "NotFound": "Scénario non trouvé",
       "TimetableNotFound": "Grille horaire '{{timetable_id}}' non trouvée"
     },


### PR DESCRIPTION
As I was looking at translation keys, I realize the line number of one key in `fr` was not the same line number in `en` and I wonder why? Ended up finding (what I was expecting): missing translation keys.

See individual commits description to find the original commits that introduced the key only in `fr`.