### PR TITLE
front: fix stdcm combobox suggestion lists position

### DIFF
--- a/front/src/styles/scss/applications/stdcm/_card.scss
+++ b/front/src/styles/scss/applications/stdcm/_card.scss
@@ -98,7 +98,6 @@
       .suggestions-list {
         width: 99%;
         left: 0;
-        margin-top: 16px;
       }
     }
 


### PR DESCRIPTION
Close #11816 
Modification of margin-top on the .suggested-list class.

![image](https://github.com/user-attachments/assets/e3aef235-6a33-451a-8b74-6844f77a9c7c)
