### PR TITLE
editoast: simplify lifetime management required by `fga` users

### DIFF
--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -499,7 +499,7 @@ impl Client {
 
     pub async fn list_objects<R: Relation, U: AsUser<User = R::User>>(
         &self,
-        QueryObjects(user, _): QueryObjects<'_, R, U>,
+        QueryObjects(user, _): QueryObjects<R, U>,
     ) -> Result<Vec<R::Object>, QueryError> {
         let objects = self
             .post_stores_list_objects(
@@ -932,7 +932,7 @@ impl<R: Relation, U: AsUser<User = R::User>> Request for Check<'_, R, U> {
     }
 }
 
-impl<R, U> Request for QueryObjects<'_, R, U>
+impl<R, U> Request for QueryObjects<R, U>
 where
     R: Relation,
     U: AsUser<User = R::User>,
@@ -1233,8 +1233,8 @@ mod tests {
         // Test batch_check with usersets
         let (friends_write_france, company_read_spain) = client
             .checks((
-                Infra::can_write().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
-                Infra::can_read().check(&fga!(Group:"company"#member), &fga!(Infra:"espagne")),
+                Infra::can_write().check(fga!(Group:"friends"#member), &fga!(Infra:"france")),
+                Infra::can_read().check(fga!(Group:"company"#member), &fga!(Infra:"espagne")),
             ))
             .await
             .unwrap();
@@ -1244,13 +1244,13 @@ mod tests {
         // Test check
         client
             .assert_check_not(
-                Infra::can_write().check(&fga!(Group:"company"#member), &fga!(Infra:"espagne")),
+                Infra::can_write().check(fga!(Group:"company"#member), &fga!(Infra:"espagne")),
             )
             .assert_check(
-                Infra::can_read().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
+                Infra::can_read().check(fga!(Group:"friends"#member), &fga!(Infra:"france")),
             )
             .assert_check(
-                Infra::can_write().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
+                Infra::can_write().check(fga!(Group:"friends"#member), &fga!(Infra:"france")),
             )
             .assert_check(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"espagne")))
             .assert_check_not(Infra::can_write().check(&fga!(User:"alice"), &fga!(Infra:"espagne")))
@@ -1432,7 +1432,7 @@ mod tests {
             .unwrap();
 
         let objects = client
-            .list_objects(Infra::can_read().query_objects(&fga!(User:*)))
+            .list_objects(Infra::can_read().query_objects(fga!(User:*)))
             .await
             .unwrap();
         assert_eq!(objects.as_slice(), &[fga!(Infra:"espagne")]);

--- a/editoast/fga/src/client.rs
+++ b/editoast/fga/src/client.rs
@@ -402,14 +402,18 @@ impl Client {
         }
     }
 
-    pub async fn check<R: Relation>(
+    pub async fn check<R, U>(
         &self,
-        Check { user, object }: Check<'_, R>,
-    ) -> Result<bool, RequestFailure> {
+        Check { user, object }: Check<'_, R, U>,
+    ) -> Result<bool, RequestFailure>
+    where
+        R: Relation,
+        U: AsUser<User = R::User>,
+    {
         self.post_stores_check(
             &self.store.id,
             RawTuple {
-                user: User::fga_user(user),
+                user: user.fga_user(),
                 relation: R::NAME.to_string(),
                 object: object.fga_object(),
             },
@@ -659,15 +663,23 @@ pub struct PreparedChecks<'a> {
 }
 
 impl PreparedChecks<'_> {
-    pub fn push<R: Relation>(&mut self, Check { user, object }: &Check<'_, R>) {
+    pub fn push<R, U>(&mut self, Check { user, object }: &Check<'_, R, U>)
+    where
+        R: Relation,
+        U: AsUser<User = R::User>,
+    {
         self.checks.push(RawTuple {
-            user: User::fga_user(*user),
+            user: user.fga_user(),
             relation: R::NAME.to_string(),
             object: object.fga_object(),
         });
     }
 
-    pub fn check<R: Relation>(mut self, check: &Check<'_, R>) -> Self {
+    pub fn check<R, U>(mut self, check: &Check<'_, R, U>) -> Self
+    where
+        R: Relation,
+        U: AsUser<User = R::User>,
+    {
         self.push(check);
         self
     }
@@ -742,8 +754,8 @@ pub trait StructuredChecks {
 }
 
 macro_rules! impl_structured_checks {
-    ($output:ty, $($relations:ident)+, $($idents:ident)+) => {
-        impl<$($relations: Relation),+> StructuredChecks for ($(Check<'_, $relations>),+) {
+    ($output:ty, $($relations:ident)+, $($users:ident)+, $($idents:ident)+) => {
+        impl<$($relations: Relation, $users: AsUser<User = $relations::User>),+> StructuredChecks for ($(Check<'_, $relations, $users>),+) {
             type Output = $output;
 
             fn prepare(self, client: &Client) -> PreparedChecks<'_> {
@@ -765,13 +777,13 @@ macro_rules! impl_structured_checks {
     };
 }
 
-impl_structured_checks!((bool, bool), R1 R2, a b);
-impl_structured_checks!((bool, bool, bool), R1 R2 R3, a b c);
-impl_structured_checks!((bool, bool, bool, bool), R1 R2 R3 R4, a b c d);
-impl_structured_checks!((bool, bool, bool, bool, bool), R1 R2 R3 R4 R5, a b c d e);
-impl_structured_checks!((bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6, a b c d e f);
-impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7, a b c d e f g);
-impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7 R8, a b c d e f g h);
+impl_structured_checks!((bool, bool), R1 R2, U1 U2, a b);
+impl_structured_checks!((bool, bool, bool), R1 R2 R3, U1 U2 U3, a b c);
+impl_structured_checks!((bool, bool, bool, bool), R1 R2 R3 R4, U1 U2 U3 U4, a b c d);
+impl_structured_checks!((bool, bool, bool, bool, bool), R1 R2 R3 R4 R5, U1 U2 U3 U4 U5, a b c d e);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6, U1 U2 U3 U4 U5 U6, a b c d e f);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7, U1 U2 U3 U4 U5 U6 U7, a b c d e f g);
+impl_structured_checks!((bool, bool, bool, bool, bool, bool, bool, bool), R1 R2 R3 R4 R5 R6 R7 R8, U1 U2 U3 U4 U5 U6 U7 U8, a b c d e f g h);
 
 pub struct PreparedWrites<'a> {
     writes: Vec<RawTuple>,
@@ -910,7 +922,7 @@ pub trait Request {
     ) -> impl future::Future<Output = Result<Self::Response, Self::Error>>;
 }
 
-impl<R: Relation> Request for Check<'_, R> {
+impl<R: Relation, U: AsUser<User = R::User>> Request for Check<'_, R, U> {
     type Response = bool;
 
     type Error = RequestFailure;
@@ -1052,6 +1064,7 @@ mod tests {
     use crate::compile_model;
     use crate::defs::*;
     use crate::fga;
+    use crate::model::AsUser;
     use crate::model::Check;
     use crate::model::Relation;
 
@@ -1114,7 +1127,11 @@ mod tests {
     impl Client {
         // TODO: comment about tokio::test
         #[track_caller]
-        fn assert_check<R: Relation>(&self, check: Check<'_, R>) -> &Self {
+        fn assert_check<R, U>(&self, check: Check<'_, R, U>) -> &Self
+        where
+            R: Relation,
+            U: AsUser<User = R::User> + std::fmt::Debug,
+        {
             let error = format!("{check:?} doesn't hold, WWWHHHHYYYYY???");
             let ok = futures::executor::block_on(check.fetch(self)).unwrap();
             assert!(ok, "{error}");
@@ -1122,7 +1139,11 @@ mod tests {
         }
 
         #[track_caller]
-        fn assert_check_not<R: Relation>(&self, check: Check<'_, R>) -> &Self {
+        fn assert_check_not<R, U>(&self, check: Check<'_, R, U>) -> &Self
+        where
+            R: Relation,
+            U: AsUser<User = R::User> + std::fmt::Debug,
+        {
             let error = format!("{check:?} does hold, it shouldn't tho");
             let ok = futures::executor::block_on(check.fetch(self)).unwrap();
             assert!(!ok, "{error}");
@@ -1190,6 +1211,52 @@ mod tests {
             assert!(bob);
             assert!(!alice);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn check_userset() {
+        setup_tracing();
+        let model = compile_model(MODEL);
+        let mut client = test_client!();
+        client.update_authorization_model(&model).await.unwrap();
+        client
+            .prepare_writes()
+            .write(&fga!(Infra:"france"#writer@Group:"friends"#member))
+            .write(&fga!(Infra:"espagne"#reader@Group:"company"#member))
+            .write(&fga!(Group:"friends"#member@User:"bob"))
+            .write(&fga!(Group:"company"#member@User:"bob"))
+            .write(&fga!(Group:"company"#member@User:"alice"))
+            .execute()
+            .await
+            .unwrap();
+
+        // Test batch_check with usersets
+        let (friends_write_france, company_read_spain) = client
+            .checks((
+                Infra::can_write().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
+                Infra::can_read().check(&fga!(Group:"company"#member), &fga!(Infra:"espagne")),
+            ))
+            .await
+            .unwrap();
+        assert!(friends_write_france);
+        assert!(company_read_spain);
+
+        // Test check
+        client
+            .assert_check_not(
+                Infra::can_write().check(&fga!(Group:"company"#member), &fga!(Infra:"espagne")),
+            )
+            .assert_check(
+                Infra::can_read().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
+            )
+            .assert_check(
+                Infra::can_write().check(&fga!(Group:"friends"#member), &fga!(Infra:"france")),
+            )
+            .assert_check(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"espagne")))
+            .assert_check_not(Infra::can_write().check(&fga!(User:"alice"), &fga!(Infra:"espagne")))
+            .assert_check_not(Infra::can_read().check(&fga!(User:"alice"), &fga!(Infra:"france")))
+            .assert_check(Infra::can_read().check(&fga!(User:"bob"), &fga!(Infra:"france")))
+            .assert_check(Infra::can_write().check(&fga!(User:"bob"), &fga!(Infra:"france")));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/editoast/fga/src/lib.rs
+++ b/editoast/fga/src/lib.rs
@@ -145,7 +145,7 @@
 //! // let wrong_tuple = DocumentReader.tuple(&doc, &bob);
 //!
 //! // type-bound public access support
-//! let public = DocumentReader.tuple(&User::wildcard(), &Document("public".to_string()));
+//! let public = DocumentReader.tuple(User::wildcard(), &Document("public".to_string()));
 //!
 //! // a check for permission
 //! let bob_can_read = DocumentCanRead.check(&bob, &doc);
@@ -360,7 +360,7 @@ pub fn compile_model(model: &str) -> serde_json::Value {
 /// assert_eq!(
 ///     fga!(Document:"2021-budget"#reader@Person:*),
 ///     Document::reader()
-///         .tuple(&Person::wildcard(), &Document("2021-budget".to_string()))
+///         .tuple(Person::wildcard(), &Document("2021-budget".to_string()))
 /// );
 ///
 /// // Tuples with usersets
@@ -368,7 +368,7 @@ pub fn compile_model(model: &str) -> serde_json::Value {
 ///     fga!(Document:"2021-budget"#reader@Document:"topsecret"#can_write),
 ///     Document::reader()
 ///         .tuple(
-///             &Document::can_write().userset(&Document("topsecret".to_string())),
+///             Document::can_write().userset(&Document("topsecret".to_string())),
 ///             &Document("2021-budget".to_string())
 ///         )
 /// );
@@ -407,17 +407,6 @@ pub fn compile_model(model: &str) -> serde_json::Value {
 /// // Simple tuples
 /// let alice = fga!(Person:"alice");
 /// let tuple = fga!(Document:secret # reader @ alice);
-/// println!("{tuple:?}");
-///
-/// // Tuples with type-bound public access
-/// let wildcard = fga!(Person:*);
-/// let tuple = fga!(Document:secret # reader @ wildcard);
-/// println!("{tuple:?}");
-///
-/// // Tuples with usersets
-/// let budget = fga!(Document:"2021-budget");
-/// let writers = fga!(Document:secret # can_write);
-/// let tuple = fga!(Document:budget # reader @ writers);
 /// println!("{tuple:?}");
 ///
 /// // Types with variables implementing ToString
@@ -466,12 +455,12 @@ macro_rules! fga {
 
     // fga!(group:id#member@user:*) => tuple syntax for public type access bounds
     ($object:ident : $object_id:literal # $relation:ident @ $user:ident : *) => {
-        $object::$relation().tuple(&fga!($user:*), &fga!($object:$object_id))
+        $object::$relation().tuple(fga!($user:*), &fga!($object:$object_id))
     };
 
     // fga!(doc:id#reader@group#member) => tuple syntax for user set
     ($object:ident : $object_id:literal # $relation:ident @ $user:ident : $user_id:literal # $user_relation:ident) => {
-        $object::$relation().tuple(&fga!($user:$user_id # $user_relation), &fga!($object:$object_id))
+        $object::$relation().tuple(fga!($user:$user_id # $user_relation), &fga!($object:$object_id))
     };
 
     ($object:ident : $object_var:ident # $relation:ident @ $user_var:ident) => {

--- a/editoast/fga/src/model.rs
+++ b/editoast/fga/src/model.rs
@@ -225,7 +225,7 @@ pub trait Relation: fmt::Debug + Sized {
     ///
     /// Can be used in [`Client::list_users`](crate::client::Client::list_users) to
     /// compute which users are related to `object` via `Self`.
-    fn query_users<'a>(&'a self, object: &'a Self::Object) -> QueryUsers<'a, Self> {
+    fn query_users<'a>(&self, object: &'a Self::Object) -> QueryUsers<'a, Self> {
         QueryUsers(object)
     }
 
@@ -234,7 +234,7 @@ pub trait Relation: fmt::Debug + Sized {
     /// Can be used in [`Client::list_usersets`](crate::client::Client::list_usersets) to
     /// compute which usersets are related to `object` via `Self`.
     fn query_usersets<'a, R: Relation>(
-        &'a self,
+        &self,
         _userset_relation: R,
         object: &'a Self::Object,
     ) -> QueryUsersets<'a, Self, R> {
@@ -246,7 +246,7 @@ pub trait Relation: fmt::Debug + Sized {
     /// Can be used in [`Client::list_objects`](crate::client::Client::list_objects) to
     /// compute which objects are related to `user` via `Self`.
     fn query_objects<'a, U: AsUser<User = Self::User>>(
-        &'a self,
+        &self,
         user: &'a U,
     ) -> QueryObjects<'a, Self, U> {
         QueryObjects::<Self, U>(user, std::marker::PhantomData)
@@ -254,14 +254,14 @@ pub trait Relation: fmt::Debug + Sized {
 
     // tuple_key = { user: user:bob, relation: reader, object: document: }
     /// NOT YET IMPLEMENTED
-    fn query_objects_stored<'a>(&'a self, user: &'a Self::User) -> QueryObjectsStored<'a, Self> {
+    fn query_objects_stored<'a>(&self, user: &'a Self::User) -> QueryObjectsStored<'a, Self> {
         let _ = user;
         todo!()
     }
 
     // tuple_key = { object: document:budget-2021, relation: reader }
     /// NOT YET IMPLEMENTED
-    fn query_users_stored<'a>(&'a self, object: &'a Self::Object) -> QueryUsersStored<'a, Self> {
+    fn query_users_stored<'a>(&self, object: &'a Self::Object) -> QueryUsersStored<'a, Self> {
         let _ = object;
         todo!()
     }

--- a/editoast/fga/src/model.rs
+++ b/editoast/fga/src/model.rs
@@ -213,11 +213,11 @@ pub trait Relation: fmt::Debug + Sized {
     ///
     /// Can be used in [`Client::check`](crate::client::Client::check) to check if `user`
     /// is related via `Self` to `object`.
-    fn check<'a: 'c, 'b: 'c, 'c>(
+    fn check<'a: 'c, 'b: 'c, 'c, U: AsUser<User = Self::User>>(
         &self,
-        user: &'a Self::User,
+        user: &'a U,
         object: &'b Self::Object,
-    ) -> Check<'c, Self> {
+    ) -> Check<'c, Self, U> {
         Check { user, object }
     }
 
@@ -365,8 +365,8 @@ impl<U: User> AsUser for U {
 ///
 /// <https://openfga.dev/docs/concepts#what-is-a-check-request>
 #[derive(Debug)]
-pub struct Check<'a, R: Relation> {
-    pub(crate) user: &'a R::User,
+pub struct Check<'a, R: Relation, U: AsUser<User = R::User>> {
+    pub(crate) user: &'a U,
     pub(crate) object: &'a R::Object,
 }
 

--- a/editoast/fga/src/model.rs
+++ b/editoast/fga/src/model.rs
@@ -192,11 +192,11 @@ pub trait Relation: fmt::Debug + Sized {
     /// [`Client::write_tuples`](crate::client::Client::write_tuples)
     /// or
     /// [`Client::prepare_writes`](crate::client::Client::prepare_writes).
-    fn tuple<'a: 'c, 'b: 'c, 'c, U: AsUser<User = Self::User>>(
+    fn tuple<'a, U: AsUser<User = Self::User>>(
         &self,
-        user: &'a U,
-        object: &'b Self::Object,
-    ) -> Tuple<'c, Self, U> {
+        user: U,
+        object: &'a Self::Object,
+    ) -> Tuple<'a, Self, U> {
         Tuple { user, object }
     }
 
@@ -213,11 +213,11 @@ pub trait Relation: fmt::Debug + Sized {
     ///
     /// Can be used in [`Client::check`](crate::client::Client::check) to check if `user`
     /// is related via `Self` to `object`.
-    fn check<'a: 'c, 'b: 'c, 'c, U: AsUser<User = Self::User>>(
+    fn check<'a, U: AsUser<User = Self::User>>(
         &self,
-        user: &'a U,
-        object: &'b Self::Object,
-    ) -> Check<'c, Self, U> {
+        user: U,
+        object: &'a Self::Object,
+    ) -> Check<'a, Self, U> {
         Check { user, object }
     }
 
@@ -245,10 +245,7 @@ pub trait Relation: fmt::Debug + Sized {
     ///
     /// Can be used in [`Client::list_objects`](crate::client::Client::list_objects) to
     /// compute which objects are related to `user` via `Self`.
-    fn query_objects<'a, U: AsUser<User = Self::User>>(
-        &self,
-        user: &'a U,
-    ) -> QueryObjects<'a, Self, U> {
+    fn query_objects<U: AsUser<User = Self::User>>(&self, user: U) -> QueryObjects<Self, U> {
         QueryObjects::<Self, U>(user, std::marker::PhantomData)
     }
 
@@ -351,7 +348,7 @@ pub trait AsUser {
     fn fga_user(&self) -> String;
 }
 
-impl<U: User> AsUser for U {
+impl<U: User> AsUser for &U {
     type User = U;
 
     fn fga_user(&self) -> String {
@@ -366,7 +363,7 @@ impl<U: User> AsUser for U {
 /// <https://openfga.dev/docs/concepts#what-is-a-check-request>
 #[derive(Debug)]
 pub struct Check<'a, R: Relation, U: AsUser<User = R::User>> {
-    pub(crate) user: &'a U,
+    pub(crate) user: U,
     pub(crate) object: &'a R::Object,
 }
 
@@ -376,8 +373,8 @@ pub struct Check<'a, R: Relation, U: AsUser<User = R::User>> {
 ///
 /// <https://openfga.dev/docs/concepts#what-is-a-list-objects-request>
 #[derive(Debug)]
-pub struct QueryObjects<'a, R: Relation, U: AsUser<User = R::User>>(
-    pub(crate) &'a U,
+pub struct QueryObjects<R: Relation, U: AsUser<User = R::User>>(
+    pub(crate) U,
     pub(crate) std::marker::PhantomData<R>,
 );
 
@@ -418,7 +415,7 @@ where
     R: Relation,
     U: AsUser<User = R::User>,
 {
-    pub(crate) user: &'a U,
+    pub(crate) user: U,
     pub(crate) object: &'a R::Object,
 }
 
@@ -437,7 +434,7 @@ where
 /// # OpenFGA concept
 ///
 /// <https://openfga.dev/docs/concepts#what-is-a-user>
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct UserSet<'a, R: Relation + 'static>(&'a R::Object);
 
 impl<R: Relation> AsUser for UserSet<'_, R> {
@@ -495,7 +492,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn public_access_injection_protection_user_asuser() {
-        let _ = AsUser::fga_user(&defs::User("*".to_owned()));
+        let _ = AsUser::fga_user(&&defs::User("*".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
refs #11697 

Some lifetime management required from the user of the `fga` API isn't really necessary.  The API user should only care about the lifetime of the data they put in their `impl Type`.

> [!TIP]
> For each commit, review the changes in `model.rs` first. 

<details open id="prdesc">

- 008eb3939 *editoast: fga: lift useless lifetime bound in `Regulator`*
- 7470aea07 *editoast: fga: support usersets in USER position of check queries*
- b8a66c875 *editoast: fga: transfer wildcards and userset ownership in `Relation`*
    ```md
    Less lifetime management required from API users.
    
    Wildcards and usersets expressions do not really own any data.
    Wildcards are just `PhantomData`, and usersets just embed a reference to
    an `impl Object`.  Therefore there is no need to force lifetime
    management on the API user for these objects, especially since they are both
    cheap to clone.
    
    From now on:
    
    * plain `impl User`: `Group("friends")` — no changes, only references,
      lifetime management required
    * wildcards: `Group::wildcard()` — ownership
    * usersets: `Group::member().userset(&Group("friends"))` — ownership,
      but the moved userset only references the user
    ```

</details>